### PR TITLE
feat(spice): add BJT forward beta roll-off

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **BJT forward high-current beta roll-off** — BJT model cards now accept
+  `IKF`/`IK` and apply shared base-charge modulation in DC, transient, AC,
+  transfer-function, and noise paths, matching Rust and TypeScript. The
+  supported-parameter catalog now contains 96 canonical rows.
+
 - **BJT reverse Early voltage** — BJT model cards now accept `VAR`/`VB` and
   apply reverse Early-effect base-charge modulation in DC, transient, AC,
   transfer-function, and noise paths, matching Rust and TypeScript. The

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -221,7 +221,9 @@ base-collector diffusion capacitance in AC and transient analysis. `VJE`/`PE`
 depletion capacitance. `VJC`/`PC` (default `0.75 V`) and `MJC`/`MC` (default
 `0.33`) likewise shape `CJC` base-collector depletion capacitance. `FC`
 (default `0.5`) selects the shared Berkeley forward-bias continuation point for
-both junctions.
+both junctions. `IKF`/`IK` (default `0`, disabled) applies Berkeley forward
+high-current base-charge modulation to collector transport and small-signal
+transconductance.
 `model_card_unsupported_parameter_issues()`,
 `format_model_card_unsupported_parameter_issue_table()`,
 `model_card_unsupported_parameter_issue_records()`,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -628,6 +628,7 @@ class BJT:
     Mjc: float = 0.33       # base-collector grading coefficient
     Fc: float = 0.5         # forward-bias depletion coefficient
     Var: float = 0.0        # reverse Early voltage (V); 0 means infinite
+    Ikf: float = 0.0        # forward-beta roll-off current (A); 0 disables
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -596,7 +596,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -9019,6 +9019,29 @@ def _bjt_forward_transconductance(
     return base_gm * early_factor - reverse_early_conductance
 
 
+def _bjt_forward_transport(
+    el: BJT,
+    base_collector_current: float,
+    base_gm: float,
+    early_factor: float,
+) -> tuple[float, float, float]:
+    low_current_gm = _bjt_forward_transconductance(
+        el, base_collector_current, base_gm, early_factor
+    )
+    if el.Ikf == 0.0 or base_collector_current <= 0.0:
+        return base_collector_current * early_factor, low_current_gm, 1.0
+    root = math.sqrt(1.0 + 4.0 * base_collector_current / el.Ikf)
+    charge_factor = 0.5 * (1.0 + root)
+    charge_derivative = base_gm / (el.Ikf * root)
+    collector_current = base_collector_current * early_factor / charge_factor
+    gm = (
+        low_current_gm / charge_factor
+        - base_collector_current * early_factor * charge_derivative
+        / charge_factor**2
+    )
+    return collector_current, gm, charge_factor
+
+
 def _stamp_bjt(
     G: list[list[float]],
     b: list[float],
@@ -9100,9 +9123,12 @@ def _stamp_bjt(
     base_gm = (el.Is / forward_thermal_voltage) * exp_term
     output_voltage = Vc - Ve if el.polarity == "NPN" else Ve - Vc
     early_factor = _bjt_early_factor(el, Vjunc, output_voltage)
-    output_conductance = 0.0 if el.Vaf == 0.0 else base_collector_current / el.Vaf
-    Ic0 = base_collector_current * early_factor
-    gm = _bjt_forward_transconductance(el, base_collector_current, base_gm, early_factor)
+    Ic0, gm, charge_factor = _bjt_forward_transport(
+        el, base_collector_current, base_gm, early_factor
+    )
+    output_conductance = (
+        0.0 if el.Vaf == 0.0 else base_collector_current / el.Vaf / charge_factor
+    )
     g_pi = base_gm / el.beta_f
     Ib0 = base_collector_current / el.beta_f
 
@@ -9194,6 +9220,10 @@ def _validate_bjt(el: BJT) -> None:
         raise ValueError(f"{el.name}: BJT forward Early voltage must be finite and non-negative")
     if not math.isfinite(el.Var) or el.Var < 0.0:
         raise ValueError(f"{el.name}: BJT reverse Early voltage must be finite and non-negative")
+    if not math.isfinite(el.Ikf) or el.Ikf < 0.0:
+        raise ValueError(
+            f"{el.name}: BJT forward beta roll-off current must be finite and non-negative"
+        )
     if not math.isfinite(el.Nf) or el.Nf <= 0.0:
         raise ValueError(f"{el.name}: BJT forward emission coefficient must be finite and positive")
     if not math.isfinite(el.Nr) or el.Nr <= 0.0:
@@ -12434,9 +12464,11 @@ def _stamp_ac(
         base_gm = (el.Is / forward_thermal_voltage) * exp_t
         output_voltage = Vc_dc - Ve_dc if el.polarity == "NPN" else Ve_dc - Vc_dc
         early_factor = _bjt_early_factor(el, Vjunc, output_voltage)
-        output_conductance = 0.0 if el.Vaf == 0.0 else base_collector_current / el.Vaf
-        gm_b: float = _bjt_forward_transconductance(
+        _, gm_b, charge_factor = _bjt_forward_transport(
             el, base_collector_current, base_gm, early_factor
+        )
+        output_conductance = (
+            0.0 if el.Vaf == 0.0 else base_collector_current / el.Vaf / charge_factor
         )
         gm_reverse: float = (el.Is / reverse_thermal_voltage) * exp_reverse
         g_pi: float = base_gm / el.beta_f
@@ -13053,9 +13085,11 @@ def _build_ss_matrix(
             base_gm = (el.Is / forward_thermal_voltage) * exp_t
             output_voltage = Vc_dc - Ve_dc if el.polarity == "NPN" else Ve_dc - Vc_dc
             early_factor = _bjt_early_factor(el, Vjunc, output_voltage)
-            output_conductance = 0.0 if el.Vaf == 0.0 else base_collector_current / el.Vaf
-            gm_b: float = _bjt_forward_transconductance(
+            _, gm_b, charge_factor = _bjt_forward_transport(
                 el, base_collector_current, base_gm, early_factor
+            )
+            output_conductance = (
+                0.0 if el.Vaf == 0.0 else base_collector_current / el.Vaf / charge_factor
             )
             g_pi: float = base_gm / el.beta_f
             _stamp_g(G, node_to_idx, el.collector, el.emitter, output_conductance)
@@ -13937,6 +13971,7 @@ def sens_dc(
                     Eg=el.Eg,
                     Vaf=el.Vaf,
                     Var=el.Var,
+                    Ikf=el.Ikf,
                     Nf=el.Nf,
                     Nr=el.Nr,
                     Vje=el.Vje,
@@ -13964,6 +13999,7 @@ def sens_dc(
                     Eg=el.Eg,
                     Vaf=el.Vaf,
                     Var=el.Var,
+                    Ikf=el.Ikf,
                     Nf=el.Nf,
                     Nr=el.Nr,
                     Vje=el.Vje,
@@ -14201,6 +14237,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             Eg=el.Eg,
             Vaf=el.Vaf,
             Var=el.Var,
+            Ikf=el.Ikf,
             Nf=el.Nf,
             Nr=el.Nr,
             Vje=el.Vje,
@@ -14650,7 +14687,12 @@ def _collect_noise_sources(
             )
             output_voltage = Vc - Ve if el.polarity == "NPN" else Ve - Vc
             early_factor = _bjt_early_factor(el, Vjunc, output_voltage)
-            I_C = el.Is * math.exp(Vjunc / (el.Vt * el.Nf)) * early_factor
+            exp_value = math.exp(Vjunc / (el.Vt * el.Nf))
+            base_collector_current = el.Is * (exp_value - 1.0)
+            base_gm = el.Is / (el.Vt * el.Nf) * exp_value
+            I_C, _, _ = _bjt_forward_transport(
+                el, base_collector_current, base_gm, early_factor
+            )
             psd = q2 * abs(I_C)
             n_b = None if _is_ground(el.base) else node_to_idx[el.base]
             n_e = None if _is_ground(el.emitter) else node_to_idx[el.emitter]

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (18, 32, 10, 4),
-    "PNP": (18, 32, 10, 4),
+    "NPN": (19, 34, 11, 4),
+    "PNP": (19, 34, 11, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -376,6 +376,8 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "VA": "VAF",
     "VAR": "VAR",
     "VB": "VAR",
+    "IKF": "IKF",
+    "IK": "IKF",
     "NF": "NF",
     "NR": "NR",
     "VJE": "VJE",
@@ -922,6 +924,7 @@ def bjt_from_model_card(
         Mjc=p.get("MJC", 0.33),
         Fc=p.get("FC", 0.5),
         Var=p.get("VAR", 0.0),
+        Ikf=p.get("IKF", 0.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 94
+    assert len(coverage) == 96
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 94
+    assert len(records) == 96
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,17 +501,17 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 94
-    assert report.expected_canonical_parameter_count == 94
-    assert report.accepted_name_count == 154
-    assert report.aliased_parameter_count == 47
+    assert report.canonical_parameter_count == 96
+    assert report.expected_canonical_parameter_count == 96
+    assert report.accepted_name_count == 158
+    assert report.aliased_parameter_count == 49
     assert report.max_alias_count == 4
     assert report.issues == ()
     assert format_model_card_supported_parameter_coverage_gate_report(report) == (
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t94\t94\t154\t47\t4\t0"
+        "true\t7\t7\t96\t96\t158\t49\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,9 +539,9 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 93
-    assert report.accepted_name_count == 151
-    assert report.aliased_parameter_count == 46
+    assert report.canonical_parameter_count == 95
+    assert report.accepted_name_count == 155
+    assert report.aliased_parameter_count == 48
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t93\t94\t151\t46\t4\t4\n"
+        "false\t7\t7\t95\t96\t155\t48\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,10 +647,10 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VA": 80.0, "VB": 120.0, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
+        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
+    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.Cje == pytest.approx(2.0e-12)
@@ -658,6 +658,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert bjt_model.Eg == pytest.approx(1.05)
     assert bjt_model.Vaf == pytest.approx(80.0)
     assert bjt_model.Var == pytest.approx(120.0)
+    assert bjt_model.Ikf == pytest.approx(2.0e-3)
     assert bjt_model.Nf == pytest.approx(1.2)
     assert bjt_model.Nr == pytest.approx(1.3)
     assert bjt_model.Vje == pytest.approx(0.8)
@@ -2295,7 +2296,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2313,6 +2314,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.Vjc == pytest.approx(0.7)
     assert expanded.Mjc == pytest.approx(0.45)
     assert expanded.Fc == pytest.approx(0.4)
+    assert expanded.Ikf == pytest.approx(2.0e-3)
 
 
 def test_branch_current_in_voltage_source():
@@ -2587,6 +2589,27 @@ def test_dc_rejects_invalid_bjt_reverse_early_voltage():
     circuit.add(BJT("Qbad", "c", "b", "0", Var=-1.0))
     with pytest.raises(
         ValueError, match="BJT reverse Early voltage must be finite and non-negative"
+    ):
+        dc_op(circuit)
+
+
+def test_bjt_forward_beta_rolloff_reduces_high_current_transport():
+    def collector_voltage(ikf: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vcc", "vcc", "0", 5.0))
+        circuit.add(VoltageSource("Vbase", "base", "0", 0.65))
+        circuit.add(Resistor("Rload", "vcc", "out", 1_000.0))
+        circuit.add(BJT("Q1", "out", "base", "0", Ikf=ikf))
+        return dc_op(circuit).node_voltages["out"]
+
+    assert collector_voltage(1.0e-4) > collector_voltage(0.0)
+
+
+def test_dc_rejects_invalid_bjt_forward_beta_rolloff_current():
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", Ikf=-1.0))
+    with pytest.raises(
+        ValueError, match="BJT forward beta roll-off current must be finite and non-negative"
     ):
         dc_op(circuit)
 
@@ -4272,6 +4295,20 @@ def test_ac_bjt_reverse_early_voltage_reduces_gain():
     assert gain(1.0) < gain(0.0)
 
 
+def test_ac_bjt_forward_beta_rolloff_reduces_gain():
+    def gain(ikf: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vin", "base", "0", 0.65, ac=AcSource(1.0)))
+        circuit.add(Resistor("Rload", "out", "0", 1_000.0))
+        circuit.add(BJT("Q1", "out", "base", "0", Ikf=ikf))
+        point = ac_sweep(
+            circuit, f_start=1_000.0, f_stop=1_000.0, n_points=1, sweep="lin"
+        ).points[0]
+        return abs(point.node_voltages["out"])
+
+    assert gain(1.0e-4) < gain(0.0)
+
+
 def test_ac_bjt_base_emitter_depletion_capacitance_falls_with_reverse_bias():
     """BJT Vje/Mje shape Cje under reverse base-emitter bias."""
     def base_amplitude(mje: float) -> float:
@@ -4754,6 +4791,17 @@ def test_tf_bjt_reverse_early_voltage_reduces_gain():
         return abs(tf(circuit, output_node="out", input_source="Vin").gain)
 
     assert gain(1.0) < gain(0.0)
+
+
+def test_tf_bjt_forward_beta_rolloff_reduces_gain():
+    def gain(ikf: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vin", "base", "0", 0.65))
+        circuit.add(Resistor("Rload", "out", "0", 1_000.0))
+        circuit.add(BJT("Q1", "out", "base", "0", Ikf=ikf))
+        return abs(tf(circuit, output_node="out", input_source="Vin").gain)
+
+    assert gain(1.0e-4) < gain(0.0)
 
 
 def test_tf_bjt_forward_emission_coefficient_reduces_gain_and_raises_input_impedance():
@@ -6682,6 +6730,23 @@ def test_noise_bjt_shot_noise_type_string() -> None:
     )
     assert bjt_entry is not None, "No entry for Q1"
     assert bjt_entry.noise_type == "shot"
+
+
+def test_noise_bjt_forward_beta_rolloff_reduces_shot_noise() -> None:
+    def source_psd(ikf: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vcc", "vcc", "0", 5.0))
+        circuit.add(VoltageSource("Vbase", "base", "0", 0.65))
+        circuit.add(Resistor("Rload", "vcc", "out", 1_000.0))
+        circuit.add(BJT("Q1", "out", "base", "0", Ikf=ikf))
+        result = noise_ac(circuit, "out", "Vbase", freqs=[1_000.0])
+        return next(
+            entry.source_psd
+            for entry in result.points[0].entries
+            if entry.element_name == "Q1"
+        )
+
+    assert source_psd(1.0e-4) < source_psd(0.0)
 
 
 def test_noise_mosfet_channel_thermal_noise() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add BJT model-card `IKF`/`IK` forward high-current beta roll-off support with
+  shared base-charge modulation in DC, transient, AC, transfer-function, and
+  noise paths, matching Python and TypeScript. The supported-parameter catalog
+  now contains 96 canonical rows.
 - Add BJT model-card `VAR`/`VB` reverse Early-voltage support with base-charge
   modulation in DC, transient, AC, transfer-function, and noise paths, matching
   Python and TypeScript. The supported-parameter catalog now contains 94

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -138,7 +138,9 @@ base-collector diffusion capacitance in AC and transient analysis. `VJE`/`PE`
 depletion capacitance. `VJC`/`PC` (default `0.75 V`) and `MJC`/`MC` (default
 `0.33`) likewise shape `CJC` base-collector depletion capacitance. `FC`
 (default `0.5`) selects the shared Berkeley forward-bias continuation point for
-both junctions.
+both junctions. `IKF`/`IK` (default `0`, disabled) applies Berkeley forward
+high-current base-charge modulation to collector transport and small-signal
+transconductance.
 `model_card_unsupported_parameter_issues`,
 `format_model_card_unsupported_parameter_issue_table`,
 `model_card_unsupported_parameter_issue_records`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -418,8 +418,8 @@ fn clone_subckt_element(
             element.gate_source_capacitance,
             element.gate_drain_capacitance,
         )),
-        Element::Bjt(element) => {
-            Element::Bjt(Bjt::with_model_temperature_depletion_and_early_parameters(
+        Element::Bjt(element) => Element::Bjt(
+            Bjt::with_model_temperature_depletion_early_and_rolloff_parameters(
                 format!("{instance_name}.{}", element.name),
                 map_subckt_node(&element.collector, instance_name, node_map),
                 map_subckt_node(&element.base, instance_name, node_map),
@@ -443,8 +443,9 @@ fn clone_subckt_element(
                 element.base_collector_grading_coefficient,
                 element.forward_bias_depletion_coefficient,
                 element.reverse_early_voltage,
-            ))
-        }
+                element.forward_beta_rolloff_current,
+            ),
+        ),
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
             format!("{instance_name}.{}", element.name),
             map_subckt_node(&element.drain, instance_name, node_map),
@@ -2857,6 +2858,7 @@ pub struct Bjt {
     pub base_collector_junction_potential: f64,
     pub base_collector_grading_coefficient: f64,
     pub forward_bias_depletion_coefficient: f64,
+    pub forward_beta_rolloff_current: f64,
 }
 
 impl Bjt {
@@ -3041,6 +3043,61 @@ impl Bjt {
         forward_bias_depletion_coefficient: f64,
         reverse_early_voltage: f64,
     ) -> Self {
+        Self::with_model_temperature_depletion_early_and_rolloff_parameters(
+            name,
+            collector,
+            base,
+            emitter,
+            polarity,
+            saturation_current,
+            forward_beta,
+            thermal_voltage,
+            base_emitter_capacitance,
+            base_collector_capacitance,
+            forward_transit_time,
+            reverse_transit_time,
+            saturation_current_temperature_exponent,
+            energy_gap_electron_volts,
+            forward_early_voltage,
+            forward_emission_coefficient,
+            reverse_emission_coefficient,
+            base_emitter_junction_potential,
+            base_emitter_grading_coefficient,
+            base_collector_junction_potential,
+            base_collector_grading_coefficient,
+            forward_bias_depletion_coefficient,
+            reverse_early_voltage,
+            0.0,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_model_temperature_depletion_early_and_rolloff_parameters(
+        name: impl Into<String>,
+        collector: impl Into<String>,
+        base: impl Into<String>,
+        emitter: impl Into<String>,
+        polarity: BjtPolarity,
+        saturation_current: f64,
+        forward_beta: f64,
+        thermal_voltage: f64,
+        base_emitter_capacitance: f64,
+        base_collector_capacitance: f64,
+        forward_transit_time: f64,
+        reverse_transit_time: f64,
+        saturation_current_temperature_exponent: f64,
+        energy_gap_electron_volts: f64,
+        forward_early_voltage: f64,
+        forward_emission_coefficient: f64,
+        reverse_emission_coefficient: f64,
+        base_emitter_junction_potential: f64,
+        base_emitter_grading_coefficient: f64,
+        base_collector_junction_potential: f64,
+        base_collector_grading_coefficient: f64,
+        forward_bias_depletion_coefficient: f64,
+        reverse_early_voltage: f64,
+        forward_beta_rolloff_current: f64,
+    ) -> Self {
         Self {
             name: name.into(),
             collector: collector.into(),
@@ -3065,6 +3122,7 @@ impl Bjt {
             base_collector_grading_coefficient,
             forward_bias_depletion_coefficient,
             reverse_early_voltage,
+            forward_beta_rolloff_current,
         }
     }
 }
@@ -3455,8 +3513,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 18, 32, 10, 4),
-    (ModelCardKind::Pnp, 18, 32, 10, 4),
+    (ModelCardKind::Npn, 19, 34, 11, 4),
+    (ModelCardKind::Pnp, 19, 34, 11, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3504,6 +3562,8 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("VA", "VAF"),
     ("VAR", "VAR"),
     ("VB", "VAR"),
+    ("IKF", "IKF"),
+    ("IK", "IKF"),
     ("NF", "NF"),
     ("NR", "NR"),
     ("VJE", "VJE"),
@@ -4154,31 +4214,34 @@ pub fn bjt_from_model_card(
         ModelCardKind::Pnp => BjtPolarity::Pnp,
         _ => return Err(model_card_kind_error(&name, "BJT", model.kind)),
     };
-    Ok(Bjt::with_model_temperature_depletion_and_early_parameters(
-        name,
-        collector,
-        base,
-        emitter,
-        polarity,
-        model_card_value(model, "IS", 1.0e-14),
-        model_card_value(model, "BF", 100.0),
-        model_card_value(model, "VT", 0.02585),
-        model_card_value(model, "CJE", 0.0),
-        model_card_value(model, "CJC", 0.0),
-        model_card_value(model, "TF", 0.0),
-        model_card_value(model, "TR", 0.0),
-        model_card_value(model, "XTI", 3.0),
-        model_card_value(model, "EG", 1.11),
-        model_card_value(model, "VAF", 0.0),
-        model_card_value(model, "NF", 1.0),
-        model_card_value(model, "NR", 1.0),
-        model_card_value(model, "VJE", 0.75),
-        model_card_value(model, "MJE", 0.33),
-        model_card_value(model, "VJC", 0.75),
-        model_card_value(model, "MJC", 0.33),
-        model_card_value(model, "FC", 0.5),
-        model_card_value(model, "VAR", 0.0),
-    ))
+    Ok(
+        Bjt::with_model_temperature_depletion_early_and_rolloff_parameters(
+            name,
+            collector,
+            base,
+            emitter,
+            polarity,
+            model_card_value(model, "IS", 1.0e-14),
+            model_card_value(model, "BF", 100.0),
+            model_card_value(model, "VT", 0.02585),
+            model_card_value(model, "CJE", 0.0),
+            model_card_value(model, "CJC", 0.0),
+            model_card_value(model, "TF", 0.0),
+            model_card_value(model, "TR", 0.0),
+            model_card_value(model, "XTI", 3.0),
+            model_card_value(model, "EG", 1.11),
+            model_card_value(model, "VAF", 0.0),
+            model_card_value(model, "NF", 1.0),
+            model_card_value(model, "NR", 1.0),
+            model_card_value(model, "VJE", 0.75),
+            model_card_value(model, "MJE", 0.33),
+            model_card_value(model, "VJC", 0.75),
+            model_card_value(model, "MJC", 0.33),
+            model_card_value(model, "FC", 0.5),
+            model_card_value(model, "VAR", 0.0),
+            model_card_value(model, "IKF", 0.0),
+        ),
+    )
 }
 
 pub fn jfet_from_model_card(
@@ -21834,8 +21897,11 @@ fn collect_noise_sources(
                     BjtPolarity::Pnp => emitter_voltage - collector_voltage,
                 };
                 let early_factor = bjt_early_factor(bjt, junction_voltage, output_voltage);
-                let collector_current =
-                    bjt.saturation_current * (exponent.exp() - 1.0) * early_factor;
+                let exp_value = exponent.exp();
+                let base_collector_current = bjt.saturation_current * (exp_value - 1.0);
+                let base_gm = bjt.saturation_current / forward_thermal_voltage * exp_value;
+                let (collector_current, _, _) =
+                    bjt_forward_transport(bjt, base_collector_current, base_gm, early_factor);
                 let (positive, negative) = match bjt.polarity {
                     BjtPolarity::Npn => (base, emitter),
                     BjtPolarity::Pnp => (emitter, base),
@@ -22304,6 +22370,26 @@ fn bjt_forward_transconductance(
     base_gm * early_factor - reverse_early_conductance
 }
 
+fn bjt_forward_transport(
+    bjt: &Bjt,
+    base_collector_current: f64,
+    base_gm: f64,
+    early_factor: f64,
+) -> (f64, f64, f64) {
+    let low_current_gm =
+        bjt_forward_transconductance(bjt, base_collector_current, base_gm, early_factor);
+    if bjt.forward_beta_rolloff_current == 0.0 || base_collector_current <= 0.0 {
+        return (base_collector_current * early_factor, low_current_gm, 1.0);
+    }
+    let root = (1.0 + 4.0 * base_collector_current / bjt.forward_beta_rolloff_current).sqrt();
+    let charge_factor = 0.5 * (1.0 + root);
+    let charge_derivative = base_gm / (bjt.forward_beta_rolloff_current * root);
+    let collector_current = base_collector_current * early_factor / charge_factor;
+    let gm = low_current_gm / charge_factor
+        - base_collector_current * early_factor * charge_derivative / charge_factor.powi(2);
+    (collector_current, gm, charge_factor)
+}
+
 fn stamp_bjt(
     bjt: &Bjt,
     capacitor_states: &[CapacitorState],
@@ -22333,13 +22419,13 @@ fn stamp_bjt(
         BjtPolarity::Pnp => emitter_voltage - collector_voltage,
     };
     let early_factor = bjt_early_factor(bjt, junction_voltage, output_voltage);
+    let (collector_current, gm, charge_factor) =
+        bjt_forward_transport(bjt, base_collector_current, base_gm, early_factor);
     let output_conductance = if bjt.forward_early_voltage == 0.0 {
         0.0
     } else {
-        base_collector_current / bjt.forward_early_voltage
+        base_collector_current / bjt.forward_early_voltage / charge_factor
     };
-    let collector_current = base_collector_current * early_factor;
-    let gm = bjt_forward_transconductance(bjt, base_collector_current, base_gm, early_factor);
     let gpi = base_gm / bjt.forward_beta;
     let base_current = base_collector_current / bjt.forward_beta;
     let equivalent_collector_current =
@@ -22451,12 +22537,13 @@ fn stamp_bjt_small_signal(
         BjtPolarity::Pnp => emitter_voltage - collector_voltage,
     };
     let early_factor = bjt_early_factor(bjt, junction_voltage, output_voltage);
+    let (_, gm, charge_factor) =
+        bjt_forward_transport(bjt, base_collector_current, base_gm, early_factor);
     let output_conductance = if bjt.forward_early_voltage == 0.0 {
         0.0
     } else {
-        base_collector_current / bjt.forward_early_voltage
+        base_collector_current / bjt.forward_early_voltage / charge_factor
     };
-    let gm = bjt_forward_transconductance(bjt, base_collector_current, base_gm, early_factor);
     let gpi = base_gm / bjt.forward_beta;
     stamp_conductance(matrix, collector, emitter, output_conductance);
     match bjt.polarity {
@@ -22506,15 +22593,14 @@ fn stamp_ac_bjt_small_signal(
         BjtPolarity::Pnp => emitter_voltage - collector_voltage,
     };
     let early_factor = bjt_early_factor(bjt, junction_voltage, output_voltage);
+    let (_, forward_gm, charge_factor) =
+        bjt_forward_transport(bjt, base_collector_current, base_gm, early_factor);
     let output_conductance = if bjt.forward_early_voltage == 0.0 {
         0.0
     } else {
-        base_collector_current / bjt.forward_early_voltage
+        base_collector_current / bjt.forward_early_voltage / charge_factor
     };
-    let gm = Complex::new(
-        bjt_forward_transconductance(bjt, base_collector_current, base_gm, early_factor),
-        0.0,
-    );
+    let gm = Complex::new(forward_gm, 0.0);
     let reverse_gm = bjt.saturation_current / reverse_thermal_voltage * reverse_exponent.exp();
     let diffusion_capacitance = bjt.forward_transit_time * gm.real;
     let reverse_diffusion_capacitance = bjt.reverse_transit_time * reverse_gm;
@@ -23523,6 +23609,12 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "reverse Early voltage must be finite and non-negative".to_string(),
+        });
+    }
+    if !bjt.forward_beta_rolloff_current.is_finite() || bjt.forward_beta_rolloff_current < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "forward beta roll-off current must be finite and non-negative".to_string(),
         });
     }
     if !bjt.forward_emission_coefficient.is_finite() || bjt.forward_emission_coefficient <= 0.0 {

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -889,6 +889,28 @@ fn ac_bjt_reverse_early_voltage_reduces_gain() {
 }
 
 #[test]
+fn ac_bjt_forward_beta_rolloff_reduces_gain() {
+    let gain = |rolloff_current: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vin", "base", "0", 0.65, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rload", "out", "0", 1_000.0,
+        )));
+        let mut transistor = Bjt::new("Q1", "out", "base", "0");
+        transistor.forward_beta_rolloff_current = rolloff_current;
+        circuit.add(Element::Bjt(transistor));
+        ac_sweep(&circuit, 1_000.0, 1_000.0, 1).unwrap()[0]
+            .voltage("out")
+            .unwrap()
+            .abs()
+    };
+
+    assert!(gain(1.0e-4) < gain(0.0));
+}
+
+#[test]
 fn ac_bjt_reverse_emission_coefficient_reduces_base_collector_diffusion_capacitance() {
     fn base_amplitude(reverse_emission_coefficient: f64) -> f64 {
         let mut circuit = Circuit::new();

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 94);
+    assert_eq!(coverage.len(), 96);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 94);
+    assert_eq!(records.len(), 96);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 94);
-    assert_eq!(report.expected_canonical_parameter_count, 94);
-    assert_eq!(report.accepted_name_count, 154);
-    assert_eq!(report.aliased_parameter_count, 47);
+    assert_eq!(report.canonical_parameter_count, 96);
+    assert_eq!(report.expected_canonical_parameter_count, 96);
+    assert_eq!(report.accepted_name_count, 158);
+    assert_eq!(report.aliased_parameter_count, 49);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t94\t94\t154\t47\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t96\t96\t158\t49\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,9 +235,9 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 93);
-    assert_eq!(report.accepted_name_count, 151);
-    assert_eq!(report.aliased_parameter_count, 46);
+    assert_eq!(report.canonical_parameter_count, 95);
+    assert_eq!(report.accepted_name_count, 155);
+    assert_eq!(report.aliased_parameter_count, 48);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
     assert_eq!(report.issues[0].kind, "NMOS");
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t93\t94\t151\t46\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t95\t96\t155\t48\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -432,6 +432,7 @@ fn model_card_aliases_build_device_instances() {
             ("EG", 1.05),
             ("VA", 80.0),
             ("VB", 120.0),
+            ("IK", 2.0e-3),
             ("NF", 1.2),
             ("NR", 1.3),
             ("PE", 0.8),
@@ -449,6 +450,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("EG").unwrap(), 1.05);
     assert_close(*bjt_card.parameters.get("VAF").unwrap(), 80.0);
     assert_close(*bjt_card.parameters.get("VAR").unwrap(), 120.0);
+    assert_close(*bjt_card.parameters.get("IKF").unwrap(), 2.0e-3);
     assert_close(*bjt_card.parameters.get("NF").unwrap(), 1.2);
     assert_close(*bjt_card.parameters.get("NR").unwrap(), 1.3);
     assert_close(*bjt_card.parameters.get("VJE").unwrap(), 0.8);
@@ -463,6 +465,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(bjt_model.energy_gap_electron_volts, 1.05);
     assert_close(bjt_model.forward_early_voltage, 80.0);
     assert_close(bjt_model.reverse_early_voltage, 120.0);
+    assert_close(bjt_model.forward_beta_rolloff_current, 2.0e-3);
     assert_close(bjt_model.forward_emission_coefficient, 1.2);
     assert_close(bjt_model.reverse_emission_coefficient, 1.3);
     assert_close(bjt_model.base_emitter_junction_potential, 0.8);
@@ -1366,7 +1369,7 @@ fn subcircuit_expansion_preserves_complete_diode_model() {
 
 #[test]
 fn subcircuit_expansion_preserves_complete_bjt_model() {
-    let bjt = Bjt::with_model_temperature_depletion_and_early_parameters(
+    let bjt = Bjt::with_model_temperature_depletion_early_and_rolloff_parameters(
         "Qcell",
         "c",
         "b",
@@ -1390,6 +1393,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
         0.45,
         0.4,
         120.0,
+        2.0e-3,
     );
     let mut circuit = Circuit::new();
     circuit
@@ -1426,6 +1430,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.base_collector_junction_potential, 0.7);
     assert_close(expanded.base_collector_grading_coefficient, 0.45);
     assert_close(expanded.forward_bias_depletion_coefficient, 0.4);
+    assert_close(expanded.forward_beta_rolloff_current, 2.0e-3);
 }
 
 #[test]
@@ -2078,6 +2083,40 @@ fn bjt_reverse_early_voltage_modulates_collector_current() {
     };
 
     assert!(collector_voltage(20.0) > collector_voltage(0.0));
+}
+
+#[test]
+fn bjt_forward_beta_rolloff_reduces_high_current_transport() {
+    let collector_voltage = |rolloff_current: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vcc", "vcc", "0", 5.0,
+        )));
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vbase", "base", "0", 0.65,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rload", "vcc", "out", 1_000.0,
+        )));
+        let mut transistor = Bjt::new("Q1", "out", "base", "0");
+        transistor.forward_beta_rolloff_current = rolloff_current;
+        circuit.add(Element::Bjt(transistor));
+        dc_op(&circuit).unwrap().voltage("out").unwrap()
+    };
+
+    assert!(collector_voltage(1.0e-4) > collector_voltage(0.0));
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_forward_beta_rolloff_current() {
+    let mut circuit = Circuit::new();
+    let mut transistor = Bjt::new("Qbad", "c", "b", "0");
+    transistor.forward_beta_rolloff_current = -1.0;
+    circuit.add(Element::Bjt(transistor));
+    let error = dc_op(&circuit).unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("forward beta roll-off current must be finite and non-negative"));
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -1,9 +1,38 @@
 use spice_engine::{
     device_model_noise_audit_fixtures, format_corner_noise_table, format_noise_table, noise_ac,
-    noise_ac_corners, noise_ac_corners_parallel, noise_ac_default, Capacitor, Circuit,
+    noise_ac_corners, noise_ac_corners_parallel, noise_ac_default, Bjt, Capacitor, Circuit,
     CornerOverride, CornerSpec, CurrentSource, Element, Mosfet, MosfetLevel1Params, MosfetType,
     NoiseType, Resistor, SpiceError, VoltageSource,
 };
+
+#[test]
+fn bjt_forward_beta_rolloff_reduces_shot_noise() {
+    let source_psd = |rolloff_current: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vcc", "vcc", "0", 5.0,
+        )));
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vbase", "base", "0", 0.65,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rload", "vcc", "out", 1_000.0,
+        )));
+        let mut transistor = Bjt::new("Q1", "out", "base", "0");
+        transistor.forward_beta_rolloff_current = rolloff_current;
+        circuit.add(Element::Bjt(transistor));
+        noise_ac(&circuit, "out", "Vbase", &[1_000.0], 300.0)
+            .unwrap()
+            .points[0]
+            .entries
+            .iter()
+            .find(|entry| entry.element_name == "Q1")
+            .unwrap()
+            .source_psd
+    };
+
+    assert!(source_psd(1.0e-4) < source_psd(0.0));
+}
 
 const BOLTZMANN: f64 = 1.380_649e-23;
 const MOSFET_CHANNEL_NOISE_GAMMA: f64 = 2.0 / 3.0;

--- a/code/packages/rust/spice-engine/tests/tf_tests.rs
+++ b/code/packages/rust/spice-engine/tests/tf_tests.rs
@@ -383,6 +383,25 @@ fn tf_bjt_reverse_early_voltage_reduces_gain() {
 }
 
 #[test]
+fn tf_bjt_forward_beta_rolloff_reduces_gain() {
+    let gain = |rolloff_current: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vin", "base", "0", 0.65,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rload", "out", "0", 1_000.0,
+        )));
+        let mut transistor = Bjt::new("Q1", "out", "base", "0");
+        transistor.forward_beta_rolloff_current = rolloff_current;
+        circuit.add(Element::Bjt(transistor));
+        tf(&circuit, "out", "Vin").unwrap().gain().abs()
+    };
+
+    assert!(gain(1.0e-4) < gain(0.0));
+}
+
+#[test]
 fn tf_bjt_forward_emission_coefficient_reduces_gain_and_raises_input_impedance() {
     let transfer = |forward_emission_coefficient: f64| {
         let mut circuit = Circuit::new();

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add BJT model-card `IKF`/`IK` forward high-current beta roll-off support with
+  shared base-charge modulation in DC, transient, AC, transfer-function, and
+  noise paths, matching Python and Rust. The supported-parameter catalog now
+  contains 96 canonical rows.
 - Add BJT model-card `VAR`/`VB` reverse Early-voltage support with base-charge
   modulation in DC, transient, AC, transfer-function, and noise paths, matching
   Python and Rust. The supported-parameter catalog now contains 94 canonical

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -208,7 +208,9 @@ base-collector diffusion capacitance in AC and transient analysis. `VJE`/`PE`
 depletion capacitance. `VJC`/`PC` (default `0.75 V`) and `MJC`/`MC` (default
 `0.33`) likewise shape `CJC` base-collector depletion capacitance. `FC`
 (default `0.5`) selects the shared Berkeley forward-bias continuation point for
-both junctions.
+both junctions. `IKF`/`IK` (default `0`, disabled) applies Berkeley forward
+high-current base-charge modulation to collector transport and small-signal
+transconductance.
 `modelCardUnsupportedParameterIssues`,
 `formatModelCardUnsupportedParameterIssueTable`,
 `modelCardUnsupportedParameterIssueRecords`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1721,6 +1721,7 @@ export interface Bjt {
   readonly baseCollectorJunctionPotential: number;
   readonly baseCollectorGradingCoefficient: number;
   readonly forwardBiasDepletionCoefficient: number;
+  readonly forwardBetaRolloffCurrent: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -1998,8 +1999,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [18, 32, 10, 4],
-  PNP: [18, 32, 10, 4],
+  NPN: [19, 34, 11, 4],
+  PNP: [19, 34, 11, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3589,7 +3590,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7753,6 +7754,7 @@ export function bjt(
   baseCollectorGradingCoefficient = 0.33,
   forwardBiasDepletionCoefficient = 0.5,
   reverseEarlyVoltage = 0.0,
+  forwardBetaRolloffCurrent = 0.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7779,6 +7781,7 @@ export function bjt(
     baseCollectorJunctionPotential,
     baseCollectorGradingCoefficient,
     forwardBiasDepletionCoefficient,
+    forwardBetaRolloffCurrent,
   };
 }
 
@@ -7886,6 +7889,8 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   VA: "VAF",
   VAR: "VAR",
   VB: "VAR",
+  IKF: "IKF",
+  IK: "IKF",
   NF: "NF",
   NR: "NR",
   VJE: "VJE",
@@ -8404,6 +8409,7 @@ export function bjtFromModelCard(
     p.MJC ?? 0.33,
     p.FC ?? 0.5,
     p.VAR ?? 0.0,
+    p.IKF ?? 0.0,
   );
 }
 
@@ -18338,7 +18344,16 @@ function collectNoiseSources(
         ? collectorVoltage - emitterVoltage
         : emitterVoltage - collectorVoltage;
       const earlyFactor = bjtEarlyFactor(element, junctionVoltage, outputVoltage);
-      const collectorCurrent = element.saturationCurrent * (Math.exp(exponent) - 1.0) * earlyFactor;
+      const expValue = Math.exp(exponent);
+      const baseCollectorCurrent = element.saturationCurrent * (expValue - 1.0);
+      const baseTransconductance =
+        element.saturationCurrent / forwardThermalVoltage * expValue;
+      const collectorCurrent = bjtForwardTransport(
+        element,
+        baseCollectorCurrent,
+        baseTransconductance,
+        earlyFactor,
+      ).collectorCurrent;
       sources.push({
         elementName: element.name,
         noiseType: "shot",
@@ -18814,6 +18829,40 @@ function bjtForwardTransconductance(
   return baseTransconductance * earlyFactor - reverseEarlyConductance;
 }
 
+function bjtForwardTransport(
+  element: Bjt,
+  baseCollectorCurrent: number,
+  baseTransconductance: number,
+  earlyFactor: number,
+): { collectorCurrent: number; transconductance: number; chargeFactor: number } {
+  const lowCurrentTransconductance = bjtForwardTransconductance(
+    element,
+    baseCollectorCurrent,
+    baseTransconductance,
+    earlyFactor,
+  );
+  if (element.forwardBetaRolloffCurrent === 0.0 || baseCollectorCurrent <= 0.0) {
+    return {
+      collectorCurrent: baseCollectorCurrent * earlyFactor,
+      transconductance: lowCurrentTransconductance,
+      chargeFactor: 1.0,
+    };
+  }
+  const root = Math.sqrt(
+    1.0 + 4.0 * baseCollectorCurrent / element.forwardBetaRolloffCurrent,
+  );
+  const chargeFactor = 0.5 * (1.0 + root);
+  const chargeDerivative =
+    baseTransconductance / (element.forwardBetaRolloffCurrent * root);
+  return {
+    collectorCurrent: baseCollectorCurrent * earlyFactor / chargeFactor,
+    transconductance:
+      lowCurrentTransconductance / chargeFactor
+      - baseCollectorCurrent * earlyFactor * chargeDerivative / chargeFactor ** 2,
+    chargeFactor,
+  };
+}
+
 function stampBjt(
   element: Bjt,
   capacitorStates: readonly CapacitorState[],
@@ -18843,16 +18892,17 @@ function stampBjt(
     ? collectorVoltage - emitterVoltage
     : emitterVoltage - collectorVoltage;
   const earlyFactor = bjtEarlyFactor(element, junctionVoltage, outputVoltage);
-  const outputConductance = element.forwardEarlyVoltage === 0.0
-    ? 0.0
-    : baseCollectorCurrent / element.forwardEarlyVoltage;
-  const collectorCurrent = baseCollectorCurrent * earlyFactor;
-  const transconductance = bjtForwardTransconductance(
+  const transport = bjtForwardTransport(
     element,
     baseCollectorCurrent,
     baseTransconductance,
     earlyFactor,
   );
+  const outputConductance = element.forwardEarlyVoltage === 0.0
+    ? 0.0
+    : baseCollectorCurrent / element.forwardEarlyVoltage / transport.chargeFactor;
+  const collectorCurrent = transport.collectorCurrent;
+  const transconductance = transport.transconductance;
   const junctionConductance = baseTransconductance / element.forwardBeta;
   const baseCurrent = baseCollectorCurrent / element.forwardBeta;
   const equivalentCollectorCurrent =
@@ -19691,6 +19741,9 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.reverseEarlyVoltage) || element.reverseEarlyVoltage < 0.0) {
     throw invalidElement(element.name, "reverse Early voltage must be finite and non-negative");
+  }
+  if (!Number.isFinite(element.forwardBetaRolloffCurrent) || element.forwardBetaRolloffCurrent < 0.0) {
+    throw invalidElement(element.name, "forward beta roll-off current must be finite and non-negative");
   }
   if (!Number.isFinite(element.forwardEmissionCoefficient) || element.forwardEmissionCoefficient <= 0.0) {
     throw invalidElement(element.name, "forward emission coefficient must be finite and positive");
@@ -21037,15 +21090,16 @@ function stampBjtSmallSignal(
     ? collectorVoltage - emitterVoltage
     : emitterVoltage - collectorVoltage;
   const earlyFactor = bjtEarlyFactor(element, junctionVoltage, outputVoltage);
-  const outputConductance = element.forwardEarlyVoltage === 0.0
-    ? 0.0
-    : baseCollectorCurrent / element.forwardEarlyVoltage;
-  const transconductance = bjtForwardTransconductance(
+  const transport = bjtForwardTransport(
     element,
     baseCollectorCurrent,
     baseTransconductance,
     earlyFactor,
   );
+  const outputConductance = element.forwardEarlyVoltage === 0.0
+    ? 0.0
+    : baseCollectorCurrent / element.forwardEarlyVoltage / transport.chargeFactor;
+  const transconductance = transport.transconductance;
   const junctionConductance = baseTransconductance / element.forwardBeta;
   stampConductance(matrix, collector, emitter, outputConductance);
   if (element.polarity === "NPN") {
@@ -21627,15 +21681,16 @@ function stampAcBjtSmallSignal(
     ? collectorVoltage - emitterVoltage
     : emitterVoltage - collectorVoltage;
   const earlyFactor = bjtEarlyFactor(element, junctionVoltage, outputVoltage);
-  const outputConductance = element.forwardEarlyVoltage === 0.0
-    ? 0.0
-    : baseCollectorCurrent / element.forwardEarlyVoltage;
-  const transconductance = bjtForwardTransconductance(
+  const transport = bjtForwardTransport(
     element,
     baseCollectorCurrent,
     baseTransconductance,
     earlyFactor,
   );
+  const outputConductance = element.forwardEarlyVoltage === 0.0
+    ? 0.0
+    : baseCollectorCurrent / element.forwardEarlyVoltage / transport.chargeFactor;
+  const transconductance = transport.transconductance;
   const junctionConductance = baseTransconductance / element.forwardBeta;
   const diffusionCapacitance = element.forwardTransitTime * transconductance;
   const reverseTransconductance =

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -617,6 +617,18 @@ describe("acSweep", () => {
     expect(gain(1.0)).toBeLessThan(gain(0.0));
   });
 
+  it("uses BJT forward beta roll-off to reduce AC gain", () => {
+    function gain(forwardBetaRolloffCurrent: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vin", "base", "0", 0.65, 1.0));
+      circuit.add(resistor("Rload", "out", "0", 1_000.0));
+      circuit.add({ ...bjt("Q1", "out", "base", "0"), forwardBetaRolloffCurrent });
+      return complexAbs(acSweep(circuit, 1_000.0, 1_000.0, 1, "lin")[0].voltage("out")!);
+    }
+
+    expect(gain(1.0e-4)).toBeLessThan(gain(0.0));
+  });
+
   it("shapes BJT base-emitter depletion capacitance under reverse bias", () => {
     function baseAmplitude(baseEmitterGradingCoefficient: number): number {
       const circuit = new Circuit();

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(94);
+    expect(coverage).toHaveLength(96);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(94);
+    expect(records).toHaveLength(96);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 94,
-      expectedCanonicalParameterCount: 94,
-      acceptedNameCount: 154,
-      aliasedParameterCount: 47,
+      canonicalParameterCount: 96,
+      expectedCanonicalParameterCount: 96,
+      acceptedNameCount: 158,
+      aliasedParameterCount: 49,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t94\t94\t154\t47\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t96\t96\t158\t49\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,9 +241,9 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(93);
-    expect(report.acceptedNameCount).toBe(151);
-    expect(report.aliasedParameterCount).toBe(46);
+    expect(report.canonicalParameterCount).toBe(95);
+    expect(report.acceptedNameCount).toBe(155);
+    expect(report.aliasedParameterCount).toBe(48);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t93\t94\t151\t46\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t95\t96\t155\t48\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -338,6 +338,7 @@ describe("dcOp", () => {
       EG: 1.05,
       VA: 80.0,
       VB: 120.0,
+      IK: 2.0e-3,
       NF: 1.2,
       NR: 1.3,
       PE: 0.8,
@@ -347,7 +348,7 @@ describe("dcOp", () => {
       FC: 0.4,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, EG: 1.05, VAF: 80.0, VAR: 120.0, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.baseEmitterCapacitance, 2.0e-12);
@@ -355,6 +356,7 @@ describe("dcOp", () => {
     expectClose(bjtModel.energyGapElectronVolts, 1.05);
     expectClose(bjtModel.forwardEarlyVoltage, 80.0);
     expectClose(bjtModel.reverseEarlyVoltage, 120.0);
+    expectClose(bjtModel.forwardBetaRolloffCurrent, 2.0e-3);
     expectClose(bjtModel.forwardEmissionCoefficient, 1.2);
     expectClose(bjtModel.reverseEmissionCoefficient, 1.3);
     expectClose(bjtModel.baseEmitterJunctionPotential, 0.8);
@@ -994,7 +996,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -1013,6 +1015,7 @@ describe("dcOp", () => {
       expectClose(expanded.baseCollectorJunctionPotential, 0.7);
       expectClose(expanded.baseCollectorGradingCoefficient, 0.45);
       expectClose(expanded.forwardBiasDepletionCoefficient, 0.4);
+      expectClose(expanded.forwardBetaRolloffCurrent, 2.0e-3);
     }
   });
 
@@ -1392,6 +1395,27 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.add({ ...bjt("Qbad", "c", "b", "0"), reverseEarlyVoltage: -1.0 });
     expect(() => dcOp(circuit)).toThrowError("reverse Early voltage must be finite and non-negative");
+  });
+
+  it("uses BJT forward beta roll-off to reduce high-current transport", () => {
+    const collectorVoltage = (forwardBetaRolloffCurrent: number): number => {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vcc", "vcc", "0", 5.0));
+      circuit.add(voltageSource("Vbase", "base", "0", 0.65));
+      circuit.add(resistor("Rload", "vcc", "out", 1_000.0));
+      circuit.add({ ...bjt("Q1", "out", "base", "0"), forwardBetaRolloffCurrent });
+      return dcOp(circuit).voltage("out");
+    };
+
+    expect(collectorVoltage(1.0e-4)).toBeGreaterThan(collectorVoltage(0.0));
+  });
+
+  it("rejects an invalid BJT forward beta roll-off current", () => {
+    const circuit = new Circuit();
+    circuit.add({ ...bjt("Qbad", "c", "b", "0"), forwardBetaRolloffCurrent: -1.0 });
+    expect(() => dcOp(circuit)).toThrowError(
+      "forward beta roll-off current must be finite and non-negative",
+    );
   });
 
   it("uses BJT forward emission coefficient to reduce collector current", () => {

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -3,6 +3,7 @@ import {
   Circuit,
   SpiceError,
   capacitor,
+  bjt,
   currentSource,
   deviceModelNoiseAuditFixtures,
   formatCornerNoiseTable,
@@ -18,6 +19,20 @@ const BOLTZMANN = 1.380_649e-23;
 const MOSFET_CHANNEL_NOISE_GAMMA = 2.0 / 3.0;
 
 describe("noiseAc", () => {
+  it("uses BJT forward beta roll-off to reduce shot noise", () => {
+    function sourcePsd(forwardBetaRolloffCurrent: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vcc", "vcc", "0", 5.0));
+      circuit.add(voltageSource("Vbase", "base", "0", 0.65));
+      circuit.add(resistor("Rload", "vcc", "out", 1_000.0));
+      circuit.add({ ...bjt("Q1", "out", "base", "0"), forwardBetaRolloffCurrent });
+      const entry = noiseAc(circuit, "out", "Vbase", [1_000.0], 300.0).points[0]?.entries
+        .find((candidate) => candidate.elementName === "Q1");
+      return entry!.sourcePsd;
+    }
+
+    expect(sourcePsd(1.0e-4)).toBeLessThan(sourcePsd(0.0));
+  });
   it("computes Johnson noise for a single grounded resistor", () => {
     const circuit = new Circuit();
     circuit.add(currentSource("Iin", "0", "out", 0.0));

--- a/code/packages/typescript/spice-engine/tests/tf.test.ts
+++ b/code/packages/typescript/spice-engine/tests/tf.test.ts
@@ -71,6 +71,18 @@ describe("tf", () => {
     expect(gain(1.0)).toBeLessThan(gain(0.0));
   });
 
+  it("uses BJT forward beta roll-off to reduce gain", () => {
+    function gain(forwardBetaRolloffCurrent: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vin", "base", "0", 0.65));
+      circuit.add(resistor("Rload", "out", "0", 1_000.0));
+      circuit.add({ ...bjt("Q1", "out", "base", "0"), forwardBetaRolloffCurrent });
+      return Math.abs(tf(circuit, "out", "Vin").gain());
+    }
+
+    expect(gain(1.0e-4)).toBeLessThan(gain(0.0));
+  });
+
   it("uses BJT forward emission coefficient to reduce gain and raise input impedance", () => {
     function transfer(forwardEmissionCoefficient: number) {
       const circuit = new Circuit();

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT reverse Early voltage.
+1. Cross-language BJT forward high-current beta roll-off.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `VAR` / `VB` reverse Early-voltage model-card support in
-     Rust, Python, and TypeScript with infinite behavior represented by the
-     existing zero default.
-   - Apply reverse Early-effect base-charge modulation in DC, transient, AC,
+   - Add Berkeley BJT `IKF` / `IK` forward beta roll-off model-card support in
+     Rust, Python, and TypeScript with disabled behavior represented by the
+     standard zero default.
+   - Apply forward high-current base-charge modulation in DC, transient, AC,
      transfer-function, and noise paths while preserving the complete BJT model
      through hierarchical subcircuits.
-   - Extend the supported-parameter coverage gate from 92 to 94 canonical rows
+   - Extend the supported-parameter coverage gate from 94 to 96 canonical rows
      and lock model-card aliases, behavior, validation, and hierarchy in all
      engines.
 
@@ -3055,6 +3055,14 @@ the Rust, Python, and TypeScript surfaces together.
      `CJE` and `CJC` in AC and transient analysis.
    - Hierarchical subcircuit expansion preserves the complete BJT model, and
      the supported-parameter release gate now covers 92 canonical rows.
+
+226. Cross-language BJT reverse Early voltage.
+   - Status: completed in PR 8762.
+   - Rust, Python, and TypeScript BJT model cards now accept `VAR` / `VB` and
+     apply reverse Early-effect base-charge modulation in DC, transient, AC,
+     transfer-function, and noise paths.
+   - Hierarchical subcircuit expansion preserves the complete BJT model, and
+     the supported-parameter release gate now covers 94 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- add Berkeley BJT `IKF` / `IK` model-card support in Rust, Python, and TypeScript
- apply forward high-current base-charge roll-off consistently in DC, transient, AC, transfer-function, and noise paths
- preserve the parameter through hierarchy/reconstruction paths and advance the supported-parameter gate from 94 to 96 canonical rows
- reconcile the SPICE completion plan after PR #8762

## Verification

- `cargo test -p spice-engine --tests` (337 passed)
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo fmt -p spice-engine -- --check`
- Python SPICE test suite (508 passed, 81.55% coverage)
- Ruff on touched Python sources/tests
- `pnpm test` (292 passed)
- `pnpm build`
- `git diff --check`