### PR TITLE
feat(gc-core-capi): __gc_register_stackmap_module — batch AOT registration (0.12.0)

### DIFF
--- a/code/packages/rust/gc-core-capi/CHANGELOG.md
+++ b/code/packages/rust/gc-core-capi/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this crate are documented here.
 
+## [0.12.0] — 2026-07-22
+
+### Added
+
+- **`__gc_register_stackmap_module(entries, n)` + `GcStackmapModuleEntry`** — the
+  batch registration entry a native-AOT image's start-up path invokes to register
+  **every** function's stack map in one call. It is a thin, allocation-free loop over
+  `__gc_register_stackmap`, one call per `#[repr(C)]` `GcStackmapModuleEntry` (each a
+  1:1 mirror of the `__gc_register_stackmap` arguments). This is what lets an image
+  emit its whole stack-map table as one `.rodata` array of entries plus a single
+  start-up `bl` — far cheaper to generate than an unrolled per-function call
+  sequence — so `__gc_collect_precise` can finally resolve real frames instead of
+  falling back to a conservative scan (`AOT00-T1-stackmap-emission.md`, the
+  registration half of the emission rung). Returns the total records registered; a
+  null table or `n <= 0` is a no-op. 2 unit tests (multi-function round-trip through
+  `resolve`, degenerate-input inertness) + a C `gc_core.h` declaration.
+
+
 ## [0.11.0] — 2026-07-18
 
 ### Added

--- a/code/packages/rust/gc-core-capi/Cargo.toml
+++ b/code/packages/rust/gc-core-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core-capi"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "C ABI for gc-core's flat-native heap — the gc_runtime_<target> archive linked into native-AOT output (LANG16 / AOT00 T1)."
 license = "MIT"

--- a/code/packages/rust/gc-core-capi/include/gc_core.h
+++ b/code/packages/rust/gc-core-capi/include/gc_core.h
@@ -141,6 +141,28 @@ int64_t __gc_register_stackmap(uint64_t func_start, uint64_t func_len,
  * __gc_collect. (For precision the image must be built with frame pointers.) */
 int64_t __gc_collect_precise(void);
 
+/* One compiled function's stack-map descriptor in a module table (see
+ * __gc_register_stackmap_module). Mirrors the __gc_register_stackmap arguments;
+ * frame_sizes / callee_masks may be NULL. Emitted into the image's read-only data,
+ * one per function, pointing at the per-function pc/count/slot arrays. */
+typedef struct {
+    uint64_t        func_start;
+    uint64_t        func_len;
+    int64_t         num_records;
+    const uint32_t *pc_offsets;
+    const uint32_t *frame_sizes;   /* nullable */
+    const uint16_t *callee_masks;  /* nullable */
+    const int32_t  *slot_counts;
+    const int32_t  *slots_flat;
+} GcStackmapModuleEntry;
+
+/* Register every function of a compiled module in one call — the entry an
+ * AOT image's start-up path invokes (a thin loop over __gc_register_stackmap).
+ * `entries` points to `n` descriptors; a NULL/`n<=0` call is a no-op. Returns the
+ * total records registered. This is what lets __gc_collect_precise resolve real
+ * frames instead of falling back to a conservative scan. */
+int64_t __gc_register_stackmap_module(const GcStackmapModuleEntry *entries, int64_t n);
+
 /* Number of functions currently registered via __gc_register_stackmap. */
 int64_t __gc_stackmap_count(void);
 

--- a/code/packages/rust/gc-core-capi/src/lib.rs
+++ b/code/packages/rust/gc-core-capi/src/lib.rs
@@ -279,6 +279,82 @@ pub unsafe extern "C" fn __gc_register_stackmap(
     )
 }
 
+/// One compiled function's stack-map descriptor in a **module table** — the flat,
+/// pointer-based layout a native-AOT image emits into its read-only data and hands
+/// to [`__gc_register_stackmap_module`] at start-up.
+///
+/// Each field mirrors a [`__gc_register_stackmap`] argument, so a module is just an
+/// array of these: the image lays down the per-function `pc_offsets` / `slot_counts`
+/// / `slots_flat` arrays in `.rodata`, then one `GcStackmapModuleEntry` per function
+/// pointing at them. `#[repr(C)]` fixes the layout so the code generator and the
+/// runtime agree byte-for-byte. `frame_sizes` / `callee_masks` may be null (read as
+/// zero) for the first-cut backend that spills every reference to the stack.
+#[repr(C)]
+pub struct GcStackmapModuleEntry {
+    /// Runtime start address of the function (a relocated code pointer).
+    pub func_start: u64,
+    /// Byte length of the function's machine code.
+    pub func_len: u64,
+    /// Number of safepoint records for this function.
+    pub num_records: i64,
+    /// `num_records` PC offsets (bytes from `func_start`).
+    pub pc_offsets: *const u32,
+    /// `num_records` frame sizes, or null.
+    pub frame_sizes: *const u32,
+    /// `num_records` callee-saved masks, or null.
+    pub callee_masks: *const u16,
+    /// `num_records` slot counts.
+    pub slot_counts: *const i32,
+    /// The concatenated slot arrays, read record-by-record through `slot_counts`.
+    pub slots_flat: *const i32,
+}
+
+/// Register **every** function in a compiled module in one call — the entry a
+/// native-AOT image's start-up path invokes so `__gc_collect_precise` can resolve
+/// real frames (`AOT00-T1-stackmap-emission.md`).
+///
+/// It is a thin, allocation-free loop over [`__gc_register_stackmap`], one call per
+/// [`GcStackmapModuleEntry`]. An image emits its whole stack-map table as a `.rodata`
+/// array of entries plus a single start-up call to this — far cheaper to generate
+/// (one relocation-filled table + one `bl`) than an unrolled `__gc_register_stackmap`
+/// call sequence per function. Returns the total number of records registered across
+/// all entries (the sum of each entry's accepted-record count; an entry rejected by
+/// `register` contributes 0, exactly as calling `__gc_register_stackmap` directly
+/// would).
+///
+/// # Safety
+///
+/// `entries` must point to `n` readable [`GcStackmapModuleEntry`] values, and every
+/// pointer inside each entry must satisfy the [`__gc_register_stackmap`] array
+/// contract for that entry's `num_records`. A null `entries` with `n == 0` is a
+/// no-op. The image's `.rodata` upholds all of this by construction.
+#[no_mangle]
+pub unsafe extern "C" fn __gc_register_stackmap_module(
+    entries: *const GcStackmapModuleEntry,
+    n: i64,
+) -> i64 {
+    if entries.is_null() || n <= 0 {
+        return 0;
+    }
+    let mut total = 0i64;
+    for i in 0..n {
+        // SAFETY: caller guarantees `entries[0..n]` are readable.
+        let e = &*entries.add(i as usize);
+        // SAFETY: each entry's inner pointers uphold the `register` contract.
+        total += stackmap_registry::register(
+            e.func_start,
+            e.func_len,
+            e.num_records,
+            e.pc_offsets,
+            e.frame_sizes,
+            e.callee_masks,
+            e.slot_counts,
+            e.slots_flat,
+        );
+    }
+    total
+}
+
 /// Number of functions currently registered via [`__gc_register_stackmap`].
 /// Introspection for diagnostics and tests.
 #[no_mangle]
@@ -297,6 +373,81 @@ pub extern "C" fn __gc_stackmap_reset() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `__gc_register_stackmap_module` registers every function in one flat table —
+    /// the exact shape a native-AOT image emits into `.rodata`. Each entry must land
+    /// as if `__gc_register_stackmap` had been called for it, and a later
+    /// `resolve(func_start + pc_offset)` must recover that entry's slots.
+    #[test]
+    fn module_registration_registers_every_entry() {
+        // Serialise against every other registry-touching test (shared REGISTRY).
+        let _g = stackmap_registry::REG_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        __gc_stackmap_reset();
+        assert_eq!(__gc_stackmap_count(), 0);
+
+        // Two functions, at disjoint (fake) code ranges. Function 0 has one safepoint
+        // at pc 4 naming slots [-8, -16]; function 1 has one at pc 8 naming [16].
+        let pcs0 = [4u32];
+        let counts0 = [2i32];
+        let slots0 = [-8i32, -16];
+        let pcs1 = [8u32];
+        let counts1 = [1i32];
+        let slots1 = [16i32];
+
+        let entries = [
+            GcStackmapModuleEntry {
+                func_start: 0x1_0000,
+                func_len: 0x100,
+                num_records: 1,
+                pc_offsets: pcs0.as_ptr(),
+                frame_sizes: core::ptr::null(),
+                callee_masks: core::ptr::null(),
+                slot_counts: counts0.as_ptr(),
+                slots_flat: slots0.as_ptr(),
+            },
+            GcStackmapModuleEntry {
+                func_start: 0x2_0000,
+                func_len: 0x80,
+                num_records: 1,
+                pc_offsets: pcs1.as_ptr(),
+                frame_sizes: core::ptr::null(),
+                callee_masks: core::ptr::null(),
+                slot_counts: counts1.as_ptr(),
+                slots_flat: slots1.as_ptr(),
+            },
+        ];
+
+        let n = unsafe { __gc_register_stackmap_module(entries.as_ptr(), 2) };
+        assert_eq!(n, 2, "two records registered (one per function)");
+        assert_eq!(__gc_stackmap_count(), 2, "both functions are in the registry");
+
+        // Each function's record resolves at its own address.
+        let r0 = stackmap_registry::resolve(0x1_0000 + 4).expect("fn0 record");
+        assert_eq!(r0.slots, vec![-8, -16]);
+        let r1 = stackmap_registry::resolve(0x2_0000 + 8).expect("fn1 record");
+        assert_eq!(r1.slots, vec![16]);
+        // An address in neither range resolves to nothing.
+        assert!(stackmap_registry::resolve(0x9_9999).is_none());
+
+        __gc_stackmap_reset();
+    }
+
+    /// Degenerate inputs are inert: a null table or non-positive count is a no-op,
+    /// matching the "image upholds the contract" stance without trapping.
+    #[test]
+    fn module_registration_tolerates_degenerate_inputs() {
+        let _g = stackmap_registry::REG_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        __gc_stackmap_reset();
+        assert_eq!(unsafe { __gc_register_stackmap_module(core::ptr::null(), 0) }, 0);
+        assert_eq!(unsafe { __gc_register_stackmap_module(core::ptr::null(), 5) }, 0);
+        let empty: [GcStackmapModuleEntry; 0] = [];
+        assert_eq!(unsafe { __gc_register_stackmap_module(empty.as_ptr(), 0) }, 0);
+        assert_eq!(__gc_stackmap_count(), 0);
+    }
 
     // The exported functions share one process-wide `HEAP`, so the whole ABI
     // flow lives in a SINGLE test — cargo runs tests in parallel threads, and


### PR DESCRIPTION
The **registration half** of the stack-map emission rung (`AOT00-T1-stackmap-emission.md`): the entry a native-AOT image's start-up path invokes to register **every** function's stack map in one call.

`__gc_register_stackmap_module(entries, n)` is a thin, allocation-free loop over `__gc_register_stackmap`, one call per `#[repr(C)]` `GcStackmapModuleEntry` — each a 1:1 mirror of the `__gc_register_stackmap` arguments. So an image can emit its whole stack-map table as **one `.rodata` array of entries + a single start-up `bl`** (far cheaper to generate than an unrolled per-function call sequence), and `__gc_collect_precise` finally resolves real frames instead of falling back to a conservative scan.

- Returns the total records registered; a null table or `n <= 0` is a no-op (the image's `.rodata` upholds the array contract by construction).
- Bounds: the loop reads `entries[0..n]` only; each entry's inner pointers are forwarded verbatim to the already-reviewed `register`. `#[repr(C)]` fixes the layout so the code generator and runtime agree byte-for-byte.

## Tests

2 unit tests — a two-function round-trip (register a module table, assert both resolve at their own `func_start + pc_offset` with the right slots) and degenerate-input inertness (null / `n<=0` / empty). C `gc_core.h` gets the struct + prototype. 27 gc-core-capi tests pass; clippy clean. gc-core-capi only (4 files), purely additive.

## Where this sits

Precision ladder: … → registry (`__gc_register_stackmap`) → walk → `__gc_collect_precise` → `StackMapBuilder` → aarch64 emission (#8709) → **batch registration** (this).

**Next:** twig-aot serialises each compiled function's `StackMapRecord`s into a `.rodata` module table and calls this at start-up (Mach-O section + relocation + constructor work); then force frame pointers on this crate (the #8571 Q1b prerequisite); then the GC-stress `live_bytes` differential that **proves precise roots fire**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)