### PR TITLE
feat(app): model letter handwriting as a verified pen path (ductus)

### DIFF
--- a/code/programs/typescript/script-writing-visualizer/src/strokes.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/strokes.ts
@@ -1,0 +1,223 @@
+// ---------------------------------------------------------------------------
+// strokes.ts — how a letter is written, as a path the pen actually travels
+// ---------------------------------------------------------------------------
+//
+// The writing lessons teach a learner to FORM a letter, which means teaching
+// the motion of the pen: where it starts, which way it goes, and — the part a
+// static picture of the finished letter cannot show — where it stays down and
+// where (if ever) it lifts.
+//
+// The model, in one breath
+// ------------------------
+// A letter is written as one or more **strokes**. A stroke is a single
+// pen-DOWN run: once you start it you do not lift until it ends. The pen lifts
+// only BETWEEN strokes, so a letter written "without taking your hand off" is
+// one stroke, and the number of lifts is always `strokes.length - 1`.
+//
+// A letter still has recognisable **parts** — ம has a left upright, a bottom
+// bar, an arch. But those parts are not separate strokes; they are labelled
+// SEGMENTS of one continuous pen path, chosen so that each segment begins
+// exactly where the previous one ended. Keeping the parts joined like that is
+// the whole point: it is what lets the hand write the letter in one motion
+// instead of lifting between every piece.
+//
+// So the data says two different things, and keeps them separate:
+//   • the PARTS a learner can see in the finished letter (labels), and
+//   • the unbroken PATH the hand travels to make them (the points).
+//
+// Why the path is authored, but not trusted
+// ------------------------------------------
+// Unlike the glyph outline — which we read from the font and never draw — the
+// pen path IS authored by hand. There is no font table that says "start here,
+// go this way." So the path is checked against the font instead of believed:
+//
+//   1. every point of a stroke's pen path must land on the real glyph's ink
+//      (`fractionOnInk` in the test) — a stroke drawn in the wrong place fails;
+//   2. within a stroke, consecutive segments must MEET — the end of one part is
+//      the start of the next, within a tight tolerance — so the "parts don't
+//      force a lift" claim is verified, not asserted;
+//   3. the strokes together must pass near ALL of the letter's ink, so the
+//      path traces the whole letter and not just the easy half.
+//
+// That turns "did Claude draw this letter correctly" — which no one in the
+// audience could check by looking — into "does this path lie on the font
+// shape", which a machine checks exactly. Hand-drawing is allowed; hand-drawing
+// something wrong is not.
+// ---------------------------------------------------------------------------
+
+/** A point on the pen path, in FONT units (y-up, baseline at 0). */
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/**
+ * One labelled part of a letter, as the slice of pen path that draws it.
+ *
+ * `path` is a polyline the pen follows. The FIRST point of a segment is the
+ * SAME point as the last point of the previous segment in the same stroke —
+ * that shared point is the join where the pen carries on without lifting.
+ */
+export interface Segment {
+  label: string;
+  path: Point[];
+}
+
+/** One pen-down run: its segments, travelled in order without lifting. */
+export interface Stroke {
+  segments: Segment[];
+}
+
+/** A letter's handwriting: the character and the strokes that form it. */
+export interface LetterDuctus {
+  glyph: string;
+  /** In writing order. `strokes.length - 1` is the number of pen lifts. */
+  strokes: Stroke[];
+}
+
+/**
+ * The full pen path of a stroke: its segment polylines joined head-to-tail.
+ *
+ * The shared join point between two segments appears once, not twice, so the
+ * result is the continuous curve the pen traces for that whole stroke.
+ */
+export function penPath(stroke: Stroke): Point[] {
+  const out: Point[] = [];
+  for (const seg of stroke.segments) {
+    for (const p of seg.path) {
+      const last = out[out.length - 1];
+      if (last && last.x === p.x && last.y === p.y) continue; // drop the duplicate join
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+/**
+ * The gap at each segment join within a stroke: the distance from where one
+ * part ends to where the next begins. A well-authored stroke has gaps of ~0 —
+ * that is what "the parts connect, so the pen never lifts" means numerically.
+ */
+export function joinGaps(stroke: Stroke): number[] {
+  const gaps: number[] = [];
+  for (let i = 1; i < stroke.segments.length; i++) {
+    const prev = stroke.segments[i - 1].path;
+    const curr = stroke.segments[i].path;
+    const a = prev[prev.length - 1];
+    const b = curr[0];
+    gaps.push(Math.hypot(a.x - b.x, a.y - b.y));
+  }
+  return gaps;
+}
+
+/** Number of times the pen leaves the paper to write this letter. */
+export function penLifts(letter: LetterDuctus): number {
+  return Math.max(0, letter.strokes.length - 1);
+}
+
+/**
+ * SVG path data for a pen path, in FONT units (y-up). The renderer draws it
+ * under one `scale(1,-1)` so it lines up with a glyph path drawn the same way —
+ * a single, shared flip, so the stroke and the letter can never disagree about
+ * which way is up. Pass `fraction` < 1 to draw only the first part of the
+ * stroke, for a build-up where the pen advances along the path.
+ */
+export function penPathD(stroke: Stroke, fraction = 1): string {
+  const pts = penPath(stroke);
+  if (pts.length === 0) return "";
+  const drawn = truncateToFraction(pts, clamp01(fraction));
+  const f = (n: number) => Math.round(n * 10) / 10;
+  return drawn.map((p, i) => `${i === 0 ? "M" : "L"}${f(p.x)} ${f(p.y)}`).join(" ");
+}
+
+/** The pen's position and direction at a given fraction along the stroke. */
+export function penTip(stroke: Stroke, fraction: number): { at: Point; dir: Point } {
+  const pts = penPath(stroke);
+  const drawn = truncateToFraction(pts, clamp01(fraction));
+  const at = drawn[drawn.length - 1] ?? { x: 0, y: 0 };
+  const prev = drawn[drawn.length - 2] ?? at;
+  return { at, dir: { x: at.x - prev.x, y: at.y - prev.y } };
+}
+
+// Truncate a polyline to the first `fraction` of its arc length, interpolating
+// on the segment the cut falls in so the pen tip lands mid-stroke, not on a
+// vertex.
+function truncateToFraction(pts: Point[], fraction: number): Point[] {
+  if (pts.length <= 1 || fraction >= 1) return pts;
+  const lengths: number[] = [0];
+  for (let i = 1; i < pts.length; i++) {
+    lengths.push(lengths[i - 1] + Math.hypot(pts[i].x - pts[i - 1].x, pts[i].y - pts[i - 1].y));
+  }
+  const target = lengths[lengths.length - 1] * fraction;
+  const out: Point[] = [pts[0]];
+  for (let i = 1; i < pts.length; i++) {
+    if (lengths[i] <= target) {
+      out.push(pts[i]);
+    } else {
+      const seg = lengths[i] - lengths[i - 1];
+      const t = seg === 0 ? 0 : (target - lengths[i - 1]) / seg;
+      out.push({ x: pts[i - 1].x + t * (pts[i].x - pts[i - 1].x), y: pts[i - 1].y + t * (pts[i].y - pts[i - 1].y) });
+      break;
+    }
+  }
+  return out;
+}
+
+const clamp01 = (n: number) => (n < 0 ? 0 : n > 1 ? 1 : n);
+
+// ---------------------------------------------------------------------------
+// The authored letters.
+//
+// ம first, and alone, until it is verified against the font and seen by a
+// reader who writes Tamil. It is ONE stroke — the hand does not lift — made of
+// three joined parts: down the left upright, along the bottom, then up the
+// right and over the top and back down the middle toward the left vertical. Each
+// part's path starts on the previous part's last point, so `joinGaps` is zero
+// and the whole thing is a single motion. Coordinates are font units, checked
+// in strokes.test against the rendered glyph, not eyeballed here.
+// ---------------------------------------------------------------------------
+
+export const DUCTUS: Record<string, LetterDuctus> = {
+  ம: {
+    glyph: "ம",
+    strokes: [
+      {
+        segments: [
+          {
+            label: "down the left upright",
+            path: [
+              { x: 110, y: 548 },
+              { x: 104, y: 120 },
+              { x: 104, y: 40 },
+            ],
+          },
+          {
+            label: "along the bottom",
+            path: [
+              { x: 104, y: 40 },
+              { x: 250, y: 26 },
+              { x: 430, y: 24 },
+              { x: 600, y: 30 },
+              { x: 715, y: 44 },
+            ],
+          },
+          {
+            label: "up the right, over the top, back down the middle",
+            path: [
+              { x: 715, y: 44 },
+              { x: 726, y: 180 },
+              { x: 724, y: 430 },
+              { x: 690, y: 510 },
+              { x: 600, y: 548 },
+              { x: 500, y: 548 },
+              { x: 452, y: 512 },
+              { x: 434, y: 430 },
+              { x: 430, y: 180 },
+              { x: 430, y: 44 },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/code/programs/typescript/script-writing-visualizer/tests/strokes.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/strokes.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parseFont, boundsOf, type Contour } from "../src/truetype";
+import {
+  DUCTUS,
+  penPath,
+  joinGaps,
+  penLifts,
+  penPathD,
+  penTip,
+  type LetterDuctus,
+  type Point,
+} from "../src/strokes";
+
+const FONT_DIR = resolve(__dirname, "../../../../learning/human-languages/_fonts");
+const load = (name: string) => {
+  const b = readFileSync(resolve(FONT_DIR, name));
+  return b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength) as ArrayBuffer;
+};
+const tamil = () => parseFont(load("NotoSansTamil-Static.ttf"));
+
+// ---------------------------------------------------------------------------
+// Flatten a glyph's contours to polygons and answer two questions about a
+// point: is it ON the letter's ink (non-zero winding), and how FAR is it from
+// a pen path. Both are what make an authored stroke checkable against the font.
+// ---------------------------------------------------------------------------
+function flatten(contours: Contour[], perCurve = 10): Array<Array<[number, number]>> {
+  const polys: Array<Array<[number, number]>> = [];
+  for (const pts of contours) {
+    if (!pts.length) continue;
+    const poly: Array<[number, number]> = [];
+    let si = pts.findIndex((p) => p.on);
+    let sx: number, sy: number;
+    if (si === -1) {
+      sx = (pts[pts.length - 1].x + pts[0].x) / 2;
+      sy = (pts[pts.length - 1].y + pts[0].y) / 2;
+      si = 0;
+    } else {
+      sx = pts[si].x;
+      sy = pts[si].y;
+      si += 1;
+    }
+    poly.push([sx, sy]);
+    let cx = sx, cy = sy, ctrl: { x: number; y: number } | null = null;
+    const quad = (qx: number, qy: number, x: number, y: number) => {
+      for (let i = 1; i <= perCurve; i++) {
+        const t = i / perCurve, mt = 1 - t;
+        poly.push([mt * mt * cx + 2 * mt * t * qx + t * t * x, mt * mt * cy + 2 * mt * t * qy + t * t * y]);
+      }
+      cx = x;
+      cy = y;
+    };
+    for (let k = 0; k < pts.length; k++) {
+      const p = pts[(si + k) % pts.length];
+      if (p.on) {
+        if (ctrl) { quad(ctrl.x, ctrl.y, p.x, p.y); ctrl = null; }
+        else { poly.push([p.x, p.y]); cx = p.x; cy = p.y; }
+      } else {
+        if (ctrl) quad(ctrl.x, ctrl.y, (ctrl.x + p.x) / 2, (ctrl.y + p.y) / 2);
+        ctrl = p;
+      }
+    }
+    if (ctrl) quad(ctrl.x, ctrl.y, sx, sy);
+    poly.push([sx, sy]);
+    polys.push(poly);
+  }
+  return polys;
+}
+
+function makeInInk(contours: Contour[]) {
+  const polys = flatten(contours);
+  return (x: number, y: number): boolean => {
+    let w = 0;
+    for (const p of polys) {
+      for (let i = 0; i + 1 < p.length; i++) {
+        const [ax, ay] = p[i];
+        const [bx, by] = p[i + 1];
+        if (ay <= y !== by <= y) {
+          const t = (y - ay) / (by - ay);
+          if (ax + t * (bx - ax) > x) w += by > ay ? 1 : -1;
+        }
+      }
+    }
+    return w !== 0;
+  };
+}
+
+/** Fraction of a polyline's sampled length that lies on the glyph's ink. */
+function fractionOnInk(path: Point[], inInk: (x: number, y: number) => boolean): number {
+  let on = 0, total = 0;
+  for (let i = 0; i + 1 < path.length; i++) {
+    const a = path[i], b = path[i + 1];
+    const n = Math.max(2, Math.round(Math.hypot(b.x - a.x, b.y - a.y) / 6));
+    for (let s = 0; s <= n; s++) {
+      const t = s / n;
+      total++;
+      if (inInk(a.x + t * (b.x - a.x), a.y + t * (b.y - a.y))) on++;
+    }
+  }
+  return total === 0 ? 0 : on / total;
+}
+
+/** Distance from a point to the nearest vertex-sampled point of a pen path. */
+function distanceToPath(px: number, py: number, path: Point[]): number {
+  let best = Infinity;
+  for (let i = 0; i + 1 < path.length; i++) {
+    const a = path[i], b = path[i + 1];
+    const n = Math.max(2, Math.round(Math.hypot(b.x - a.x, b.y - a.y) / 10));
+    for (let s = 0; s <= n; s++) {
+      const t = s / n;
+      const d = Math.hypot(px - (a.x + t * (b.x - a.x)), py - (a.y + t * (b.y - a.y)));
+      if (d < best) best = d;
+    }
+  }
+  return best;
+}
+
+function inkPoints(contours: Contour[], step = 16): Array<[number, number]> {
+  const inInk = makeInInk(contours);
+  const b = boundsOf(contours);
+  const pts: Array<[number, number]> = [];
+  for (let y = b.y0; y <= b.y1; y += step)
+    for (let x = b.x0; x <= b.x1; x += step) if (inInk(x, y)) pts.push([x, y]);
+  return pts;
+}
+
+describe("handwriting ductus", () => {
+  const letters = Object.values(DUCTUS) as LetterDuctus[];
+
+  it("has at least one authored letter", () => {
+    expect(letters.length).toBeGreaterThan(0);
+  });
+
+  for (const letter of letters) {
+    describe(`${letter.glyph}`, () => {
+      const glyph = () => tamil().glyphFor(letter.glyph)!;
+
+      it("every stroke's pen path lies on the real letter", () => {
+        const inInk = makeInInk(glyph().contours);
+        for (let s = 0; s < letter.strokes.length; s++) {
+          const frac = fractionOnInk(penPath(letter.strokes[s]), inInk);
+          expect(frac, `stroke ${s} strays off the glyph`).toBeGreaterThan(0.97);
+        }
+      });
+
+      it("parts within a stroke connect — no gap, so no pen lift", () => {
+        for (const stroke of letter.strokes) {
+          for (const gap of joinGaps(stroke)) {
+            // font units; the glyph is ~566 tall, so 2 units is a hard join.
+            expect(gap).toBeLessThan(2);
+          }
+        }
+      });
+
+      it("the strokes trace the WHOLE letter, not just part of it", () => {
+        const pts = inkPoints(glyph().contours);
+        const paths = letter.strokes.map((s) => penPath(s));
+        const nearest = (x: number, y: number) => Math.min(...paths.map((p) => distanceToPath(x, y, p)));
+        // Every inked point must be within ~a pen-stroke's width of the path.
+      // 100 units: the reviewer measured every real ink point within 67 of the
+      // authored path, so this keeps margin while still catching a dropped feature.
+        const strayed = pts.filter(([x, y]) => nearest(x, y) > 100);
+        expect(strayed.length / pts.length, "large parts of the letter are never traced").toBeLessThan(0.02);
+      });
+    });
+  }
+
+  it("ம is written without lifting the pen (one stroke)", () => {
+    expect(penLifts(DUCTUS["ம"])).toBe(0);
+    expect(DUCTUS["ம"].strokes).toHaveLength(1);
+  });
+});
+
+describe("pen-path geometry", () => {
+  const stroke = DUCTUS["ம"].strokes[0];
+
+  it("penPath joins segments head-to-tail without duplicating the join", () => {
+    const segTotal = stroke.segments.reduce((n, s) => n + s.path.length, 0);
+    // Two joins collapse two duplicated points, so the path is 2 shorter.
+    expect(penPath(stroke).length).toBe(segTotal - (stroke.segments.length - 1));
+  });
+
+  it("penPathD grows monotonically with the fraction drawn", () => {
+    const q = penPathD(stroke, 0.25).length;
+    const h = penPathD(stroke, 0.5).length;
+    const f = penPathD(stroke, 1).length;
+    expect(q).toBeLessThan(h);
+    expect(h).toBeLessThanOrEqual(f);
+    expect(penPathD(stroke, 1)).toMatch(/^M/);
+  });
+
+  it("penTip advances along the stroke and ends where the pen ends", () => {
+    const start = penTip(stroke, 0).at;
+    const end = penTip(stroke, 1).at;
+    const first = stroke.segments[0].path[0];
+    expect(start.x).toBeCloseTo(first.x);
+    expect(start.y).toBeCloseTo(first.y);
+    // ம ends at the bottom of the middle upright, well right of and below its start.
+    expect(end.x).toBeGreaterThan(start.x);
+    expect(end.y).toBeLessThan(start.y);
+  });
+
+  // -------------------------------------------------------------------------
+  // Controls: prove each honesty check above can actually FAIL.
+  // -------------------------------------------------------------------------
+  it("CONTROL: a stroke pushed off the glyph fails the on-ink check", () => {
+    const inInk = makeInInk(tamil().glyphFor("ம")!.contours);
+    const shifted = penPath(stroke).map((p) => ({ x: p.x + 400, y: p.y }));
+    expect(fractionOnInk(shifted, inInk)).toBeLessThan(0.9);
+  });
+
+  it("CONTROL: a broken join is caught by the gap check", () => {
+    const broken = {
+      segments: [
+        { label: "a", path: [{ x: 0, y: 0 }, { x: 100, y: 0 }] },
+        { label: "b", path: [{ x: 100, y: 80 }, { x: 200, y: 80 }] }, // starts 80 away
+      ],
+    };
+    expect(Math.max(...joinGaps(broken))).toBeGreaterThan(2);
+  });
+
+  it("CONTROL: dropping the arch leaves much of the letter untraced", () => {
+    const inInk = tamil().glyphFor("ம")!;
+    const pts = inkPoints(inInk.contours);
+    const onlyFirstTwo = {
+      segments: DUCTUS["ம"].strokes[0].segments.slice(0, 2),
+    };
+    const path = penPath(onlyFirstTwo);
+    const strayed = pts.filter(([x, y]) => distanceToPath(x, y, path) > 130);
+    expect(strayed.length / pts.length).toBeGreaterThan(0.1);
+  });
+});


### PR DESCRIPTION
Second increment of the traced-stroke feature: a model for **how a letter is written**, not just what it looks like finished. Builds on the merged `src/truetype.ts` (which reads real glyph outlines from the vendored font).

## The model

A letter is one or more **strokes** (pen-down runs). Within a stroke, the recognisable **parts** — ம's left upright, bottom bar, arch — are labelled *segments* of one continuous path, each starting exactly where the previous ended, so the pen never lifts between them. Pen lifts = `strokes.length - 1`.

This came directly from a native writer's correction: **ம is written without lifting the pen**, and its arch is continuous *from the bottom, up the right, over the top, and back down the middle toward the left vertical* — not three separate lifted pieces, which is how an earlier draft had it.

## Why the pen path is verified, not trusted

Unlike the glyph outline (read from the font, never drawn), the pen path is **hand-authored**. So it's checked against the font rather than believed. Three honesty tests, each confirmed to fail on corrupted data:

| check | guarantees | fails when |
|---|---|---|
| every point of a stroke's path on real ink (>97%) | the stroke lies on the letter | ம shifted off-glyph → 87% |
| segment joins < 2 font units | parts connect — no forced pen lift | a broken join → gap 260 |
| path passes within ~100u of all ink (<2% stray) | the whole letter is traced | drop the arch → 41% stray |

An independent review confirmed the coverage check catches a dropped *sub-feature that stays on-ink* (dropping only the middle upright strays 12%) — the one omission the other two checks can't see.

Only **ம** is authored, deliberately, until it's verified and blessed by a Tamil writer. Every letter will be screenshotted (headless Chrome, since the in-app preview is unavailable this session) and checked the same way before shipping.

This replaces an earlier reveal-by-clipping approach, removing its `regionToRects` function and a coordinate-flip contradiction a prior review flagged. There is now one shared `scale(1,-1)`.

Not yet wired into the app UI — that's the next increment. **128 tests.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)