### PR TITLE
feat(spice): add BJT base-emitter leakage

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **BJT base-emitter leakage** — BJT model cards now accept `ISE`/`NE` and
+  apply the leakage branch in DC, transient, AC, transfer-function,
+  temperature, and noise paths, matching Rust and TypeScript. The
+  supported-parameter catalog now contains 100 canonical rows.
+
 - **BJT forward high-current beta roll-off** — BJT model cards now accept
   `IKF`/`IK` and apply shared base-charge modulation in DC, transient, AC,
   transfer-function, and noise paths, matching Rust and TypeScript. The

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -223,7 +223,9 @@ depletion capacitance. `VJC`/`PC` (default `0.75 V`) and `MJC`/`MC` (default
 (default `0.5`) selects the shared Berkeley forward-bias continuation point for
 both junctions. `IKF`/`IK` (default `0`, disabled) applies Berkeley forward
 high-current base-charge modulation to collector transport and small-signal
-transconductance.
+transconductance. `ISE` (default `0`, disabled) and `NE` (default `1`) add the
+Berkeley base-emitter leakage branch to DC/transient base current,
+small-signal input conductance, and shot noise.
 `model_card_unsupported_parameter_issues()`,
 `format_model_card_unsupported_parameter_issue_table()`,
 `model_card_unsupported_parameter_issue_records()`,
@@ -249,7 +251,7 @@ catalog by model kind for compact release dashboards and Mosaic UI inventories.
 `model_card_supported_parameter_coverage_gate_issue_records()`,
 `format_model_card_supported_parameter_coverage_gate_issue_csv()`, and
 `format_model_card_supported_parameter_coverage_gate_issue_json()` validate the
-expected seven-kind, 74-row supported-parameter catalog and expose stable issue
+expected seven-kind, 100-row supported-parameter catalog and expose stable issue
 rows for release automation.
 `model_card_supported_parameter_coverage_dashboard()`,
 `format_model_card_supported_parameter_coverage_dashboard_table()`,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -629,6 +629,8 @@ class BJT:
     Fc: float = 0.5         # forward-bias depletion coefficient
     Var: float = 0.0        # reverse Early voltage (V); 0 means infinite
     Ikf: float = 0.0        # forward-beta roll-off current (A); 0 disables
+    Ise: float = 0.0        # base-emitter leakage saturation current (A)
+    Ne: float = 1.0         # base-emitter leakage emission coefficient
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -357,6 +357,7 @@ def bjt_at_temperature(
     return replace(
         bjt,
         Is=bjt.Is * saturation_scale,
+        Ise=bjt.Ise * saturation_scale,
         Vt=bjt.Vt * ratio,
     )
 
@@ -596,7 +597,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -9042,6 +9043,15 @@ def _bjt_forward_transport(
     return collector_current, gm, charge_factor
 
 
+def _bjt_base_emitter_leakage(el: BJT, junction_voltage: float) -> tuple[float, float]:
+    if el.Ise == 0.0:
+        return 0.0, 0.0
+    thermal_voltage = el.Vt * el.Ne
+    exponent = max(-40.0, min(40.0, junction_voltage / thermal_voltage))
+    exp_value = math.exp(exponent)
+    return el.Ise * (exp_value - 1.0), el.Ise / thermal_voltage * exp_value
+
+
 def _stamp_bjt(
     G: list[list[float]],
     b: list[float],
@@ -9129,8 +9139,9 @@ def _stamp_bjt(
     output_conductance = (
         0.0 if el.Vaf == 0.0 else base_collector_current / el.Vaf / charge_factor
     )
-    g_pi = base_gm / el.beta_f
-    Ib0 = base_collector_current / el.beta_f
+    leakage_current, leakage_conductance = _bjt_base_emitter_leakage(el, Vjunc)
+    g_pi = base_gm / el.beta_f + leakage_conductance
+    Ib0 = base_collector_current / el.beta_f + leakage_current
 
     Ieq_junc = Ib0 - g_pi * Vjunc      # junction Norton offset
     Ieq_coll = Ic0 - gm * Vjunc - output_conductance * output_voltage
@@ -9223,6 +9234,14 @@ def _validate_bjt(el: BJT) -> None:
     if not math.isfinite(el.Ikf) or el.Ikf < 0.0:
         raise ValueError(
             f"{el.name}: BJT forward beta roll-off current must be finite and non-negative"
+        )
+    if not math.isfinite(el.Ise) or el.Ise < 0.0:
+        raise ValueError(
+            f"{el.name}: BJT base-emitter leakage saturation current must be finite and non-negative"
+        )
+    if not math.isfinite(el.Ne) or el.Ne <= 0.0:
+        raise ValueError(
+            f"{el.name}: BJT base-emitter leakage emission coefficient must be finite and positive"
         )
     if not math.isfinite(el.Nf) or el.Nf <= 0.0:
         raise ValueError(f"{el.name}: BJT forward emission coefficient must be finite and positive")
@@ -12471,7 +12490,8 @@ def _stamp_ac(
             0.0 if el.Vaf == 0.0 else base_collector_current / el.Vaf / charge_factor
         )
         gm_reverse: float = (el.Is / reverse_thermal_voltage) * exp_reverse
-        g_pi: float = base_gm / el.beta_f
+        _, leakage_conductance = _bjt_base_emitter_leakage(el, Vjunc)
+        g_pi: float = base_gm / el.beta_f + leakage_conductance
         diffusion_capacitance = el.Tf * gm_b
         reverse_diffusion_capacitance = el.Tr * gm_reverse
         y_be = g_pi + 1j * omega * (
@@ -13091,7 +13111,8 @@ def _build_ss_matrix(
             output_conductance = (
                 0.0 if el.Vaf == 0.0 else base_collector_current / el.Vaf / charge_factor
             )
-            g_pi: float = base_gm / el.beta_f
+            _, leakage_conductance = _bjt_base_emitter_leakage(el, Vjunc)
+            g_pi: float = base_gm / el.beta_f + leakage_conductance
             _stamp_g(G, node_to_idx, el.collector, el.emitter, output_conductance)
 
             if el.polarity == "NPN":
@@ -13972,6 +13993,8 @@ def sens_dc(
                     Vaf=el.Vaf,
                     Var=el.Var,
                     Ikf=el.Ikf,
+                    Ise=el.Ise,
+                    Ne=el.Ne,
                     Nf=el.Nf,
                     Nr=el.Nr,
                     Vje=el.Vje,
@@ -14000,6 +14023,8 @@ def sens_dc(
                     Vaf=el.Vaf,
                     Var=el.Var,
                     Ikf=el.Ikf,
+                    Ise=el.Ise,
+                    Ne=el.Ne,
                     Nf=el.Nf,
                     Nr=el.Nr,
                     Vje=el.Vje,
@@ -14238,6 +14263,8 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             Vaf=el.Vaf,
             Var=el.Var,
             Ikf=el.Ikf,
+            Ise=el.Ise,
+            Ne=el.Ne,
             Nf=el.Nf,
             Nr=el.Nr,
             Vje=el.Vje,
@@ -14693,7 +14720,8 @@ def _collect_noise_sources(
             I_C, _, _ = _bjt_forward_transport(
                 el, base_collector_current, base_gm, early_factor
             )
-            psd = q2 * abs(I_C)
+            leakage_current, _ = _bjt_base_emitter_leakage(el, Vjunc)
+            psd = q2 * (abs(I_C) + abs(leakage_current))
             n_b = None if _is_ground(el.base) else node_to_idx[el.base]
             n_e = None if _is_ground(el.emitter) else node_to_idx[el.emitter]
             sources.append((el.name, "shot", n_b, n_e, psd))

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (19, 34, 11, 4),
-    "PNP": (19, 34, 11, 4),
+    "NPN": (21, 36, 11, 4),
+    "PNP": (21, 36, 11, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -378,6 +378,8 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "VB": "VAR",
     "IKF": "IKF",
     "IK": "IKF",
+    "ISE": "ISE",
+    "NE": "NE",
     "NF": "NF",
     "NR": "NR",
     "VJE": "VJE",
@@ -925,6 +927,8 @@ def bjt_from_model_card(
         Fc=p.get("FC", 0.5),
         Var=p.get("VAR", 0.0),
         Ikf=p.get("IKF", 0.0),
+        Ise=p.get("ISE", 0.0),
+        Ne=p.get("NE", 1.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 96
+    assert len(coverage) == 100
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 96
+    assert len(records) == 100
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,9 +501,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 96
-    assert report.expected_canonical_parameter_count == 96
-    assert report.accepted_name_count == 158
+    assert report.canonical_parameter_count == 100
+    assert report.expected_canonical_parameter_count == 100
+    assert report.accepted_name_count == 162
     assert report.aliased_parameter_count == 49
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -511,7 +511,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t96\t96\t158\t49\t4\t0"
+        "true\t7\t7\t100\t100\t162\t49\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,8 +539,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 95
-    assert report.accepted_name_count == 155
+    assert report.canonical_parameter_count == 99
+    assert report.accepted_name_count == 159
     assert report.aliased_parameter_count == 48
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t95\t96\t155\t48\t4\t4\n"
+        "false\t7\t7\t99\t100\t159\t48\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,10 +647,10 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
+        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "ISE": 3.0e-13, "NE": 1.7, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
+    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "ISE": 3.0e-13, "NE": 1.7, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.Cje == pytest.approx(2.0e-12)
@@ -659,6 +659,8 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert bjt_model.Vaf == pytest.approx(80.0)
     assert bjt_model.Var == pytest.approx(120.0)
     assert bjt_model.Ikf == pytest.approx(2.0e-3)
+    assert bjt_model.Ise == pytest.approx(3.0e-13)
+    assert bjt_model.Ne == pytest.approx(1.7)
     assert bjt_model.Nf == pytest.approx(1.2)
     assert bjt_model.Nr == pytest.approx(1.3)
     assert bjt_model.Vje == pytest.approx(0.8)
@@ -2296,7 +2298,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2315,6 +2317,8 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.Mjc == pytest.approx(0.45)
     assert expanded.Fc == pytest.approx(0.4)
     assert expanded.Ikf == pytest.approx(2.0e-3)
+    assert expanded.Ise == pytest.approx(3.0e-13)
+    assert expanded.Ne == pytest.approx(1.7)
 
 
 def test_branch_current_in_voltage_source():
@@ -2534,6 +2538,12 @@ def test_bjt_temperature_scaling_uses_model_temperature_exponent():
     assert high.Is > low.Is
 
 
+def test_bjt_temperature_scales_base_emitter_leakage_saturation_current():
+    transistor = BJT("Q1", "c", "b", "e", Ise=2.0e-13)
+    hot = bjt_at_temperature(transistor, 350.0)
+    assert hot.Ise > transistor.Ise
+
+
 def test_bjt_temperature_scaling_uses_model_energy_gap():
     silicon = Circuit()
     silicon.add(BJT("Qsilicon", "c", "b", "e", Eg=1.11))
@@ -2611,6 +2621,28 @@ def test_dc_rejects_invalid_bjt_forward_beta_rolloff_current():
     with pytest.raises(
         ValueError, match="BJT forward beta roll-off current must be finite and non-negative"
     ):
+        dc_op(circuit)
+
+
+def test_bjt_base_emitter_leakage_increases_base_current():
+    def base_current(ise: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vbase", "base", "0", 0.65))
+        circuit.add(BJT("Q1", "0", "base", "0", Ise=ise, Ne=1.5))
+        return abs(dc_op(circuit).branch_currents["I(Vbase)"])
+
+    assert base_current(1.0e-10) > base_current(0.0)
+
+
+def test_dc_rejects_invalid_bjt_base_emitter_leakage_parameters():
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", Ise=-1.0))
+    with pytest.raises(ValueError, match="base-emitter leakage saturation current"):
+        dc_op(circuit)
+
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", Ne=0.0))
+    with pytest.raises(ValueError, match="base-emitter leakage emission coefficient"):
         dc_op(circuit)
 
 
@@ -4309,6 +4341,25 @@ def test_ac_bjt_forward_beta_rolloff_reduces_gain():
     assert gain(1.0e-4) < gain(0.0)
 
 
+def test_ac_bjt_base_emitter_leakage_reduces_gain_through_source_resistance():
+    def gain(ise: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vin", "in", "0", 0.65, ac=AcSource(1.0)))
+        circuit.add(Resistor("Rin", "in", "base", 1_000.0))
+        circuit.add(Resistor("Rload", "out", "0", 1_000.0))
+        circuit.add(BJT("Q1", "out", "base", "0", Ise=ise, Ne=1.5))
+        point = ac_sweep(
+            circuit,
+            f_start=1_000.0,
+            f_stop=1_000.0,
+            n_points=1,
+            sweep="lin",
+        ).points[0]
+        return abs(point.node_voltages["out"])
+
+    assert gain(1.0e-10) < gain(0.0)
+
+
 def test_ac_bjt_base_emitter_depletion_capacitance_falls_with_reverse_bias():
     """BJT Vje/Mje shape Cje under reverse base-emitter bias."""
     def base_amplitude(mje: float) -> float:
@@ -4802,6 +4853,17 @@ def test_tf_bjt_forward_beta_rolloff_reduces_gain():
         return abs(tf(circuit, output_node="out", input_source="Vin").gain)
 
     assert gain(1.0e-4) < gain(0.0)
+
+
+def test_tf_bjt_base_emitter_leakage_reduces_input_impedance():
+    def input_impedance(ise: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vin", "base", "0", 0.65))
+        circuit.add(Resistor("Rload", "out", "0", 1_000.0))
+        circuit.add(BJT("Q1", "out", "base", "0", Ise=ise, Ne=1.5))
+        return tf(circuit, output_node="out", input_source="Vin").input_impedance
+
+    assert input_impedance(1.0e-10) < input_impedance(0.0)
 
 
 def test_tf_bjt_forward_emission_coefficient_reduces_gain_and_raises_input_impedance():
@@ -6747,6 +6809,22 @@ def test_noise_bjt_forward_beta_rolloff_reduces_shot_noise() -> None:
         )
 
     assert source_psd(1.0e-4) < source_psd(0.0)
+
+
+def test_noise_bjt_base_emitter_leakage_increases_shot_noise() -> None:
+    def source_psd(ise: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vbase", "base", "0", 0.65))
+        circuit.add(Resistor("Rload", "out", "0", 1_000.0))
+        circuit.add(BJT("Q1", "out", "base", "0", Ise=ise, Ne=1.5))
+        result = noise_ac(circuit, "out", "Vbase", freqs=[1_000.0])
+        return next(
+            entry.source_psd
+            for entry in result.points[0].entries
+            if entry.element_name == "Q1"
+        )
+
+    assert source_psd(1.0e-10) > source_psd(0.0)
 
 
 def test_noise_mosfet_channel_thermal_noise() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add BJT model-card `ISE`/`NE` base-emitter leakage support in DC, transient,
+  AC, transfer-function, temperature, and noise paths, matching Python and
+  TypeScript. The supported-parameter catalog now contains 100 canonical rows.
 - Add BJT model-card `IKF`/`IK` forward high-current beta roll-off support with
   shared base-charge modulation in DC, transient, AC, transfer-function, and
   noise paths, matching Python and TypeScript. The supported-parameter catalog

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -140,7 +140,9 @@ depletion capacitance. `VJC`/`PC` (default `0.75 V`) and `MJC`/`MC` (default
 (default `0.5`) selects the shared Berkeley forward-bias continuation point for
 both junctions. `IKF`/`IK` (default `0`, disabled) applies Berkeley forward
 high-current base-charge modulation to collector transport and small-signal
-transconductance.
+transconductance. `ISE` (default `0`, disabled) and `NE` (default `1`) add the
+Berkeley base-emitter leakage branch to DC/transient base current,
+small-signal input conductance, and shot noise.
 `model_card_unsupported_parameter_issues`,
 `format_model_card_unsupported_parameter_issue_table`,
 `model_card_unsupported_parameter_issue_records`,
@@ -166,7 +168,7 @@ catalog by model kind for compact release dashboards and Mosaic UI inventories.
 `model_card_supported_parameter_coverage_gate_issue_records`,
 `format_model_card_supported_parameter_coverage_gate_issue_csv`, and
 `format_model_card_supported_parameter_coverage_gate_issue_json` validate the
-expected seven-kind, 74-row supported-parameter catalog and expose stable issue
+expected seven-kind, 100-row supported-parameter catalog and expose stable issue
 rows for release automation.
 `model_card_supported_parameter_coverage_dashboard`,
 `format_model_card_supported_parameter_coverage_dashboard_table`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -419,7 +419,7 @@ fn clone_subckt_element(
             element.gate_drain_capacitance,
         )),
         Element::Bjt(element) => Element::Bjt(
-            Bjt::with_model_temperature_depletion_early_and_rolloff_parameters(
+            Bjt::with_model_temperature_depletion_early_rolloff_and_leakage_parameters(
                 format!("{instance_name}.{}", element.name),
                 map_subckt_node(&element.collector, instance_name, node_map),
                 map_subckt_node(&element.base, instance_name, node_map),
@@ -444,6 +444,8 @@ fn clone_subckt_element(
                 element.forward_bias_depletion_coefficient,
                 element.reverse_early_voltage,
                 element.forward_beta_rolloff_current,
+                element.base_emitter_leakage_saturation_current,
+                element.base_emitter_leakage_emission_coefficient,
             ),
         ),
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
@@ -2672,6 +2674,7 @@ pub fn bjt_at_temperature(
         * exponent.clamp(-100.0, 100.0).exp();
     let mut adjusted = bjt.clone();
     adjusted.saturation_current *= saturation_scale;
+    adjusted.base_emitter_leakage_saturation_current *= saturation_scale;
     adjusted.thermal_voltage *= ratio;
     Ok(adjusted)
 }
@@ -2859,6 +2862,8 @@ pub struct Bjt {
     pub base_collector_grading_coefficient: f64,
     pub forward_bias_depletion_coefficient: f64,
     pub forward_beta_rolloff_current: f64,
+    pub base_emitter_leakage_saturation_current: f64,
+    pub base_emitter_leakage_emission_coefficient: f64,
 }
 
 impl Bjt {
@@ -3098,6 +3103,65 @@ impl Bjt {
         reverse_early_voltage: f64,
         forward_beta_rolloff_current: f64,
     ) -> Self {
+        Self::with_model_temperature_depletion_early_rolloff_and_leakage_parameters(
+            name,
+            collector,
+            base,
+            emitter,
+            polarity,
+            saturation_current,
+            forward_beta,
+            thermal_voltage,
+            base_emitter_capacitance,
+            base_collector_capacitance,
+            forward_transit_time,
+            reverse_transit_time,
+            saturation_current_temperature_exponent,
+            energy_gap_electron_volts,
+            forward_early_voltage,
+            forward_emission_coefficient,
+            reverse_emission_coefficient,
+            base_emitter_junction_potential,
+            base_emitter_grading_coefficient,
+            base_collector_junction_potential,
+            base_collector_grading_coefficient,
+            forward_bias_depletion_coefficient,
+            reverse_early_voltage,
+            forward_beta_rolloff_current,
+            0.0,
+            1.0,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_model_temperature_depletion_early_rolloff_and_leakage_parameters(
+        name: impl Into<String>,
+        collector: impl Into<String>,
+        base: impl Into<String>,
+        emitter: impl Into<String>,
+        polarity: BjtPolarity,
+        saturation_current: f64,
+        forward_beta: f64,
+        thermal_voltage: f64,
+        base_emitter_capacitance: f64,
+        base_collector_capacitance: f64,
+        forward_transit_time: f64,
+        reverse_transit_time: f64,
+        saturation_current_temperature_exponent: f64,
+        energy_gap_electron_volts: f64,
+        forward_early_voltage: f64,
+        forward_emission_coefficient: f64,
+        reverse_emission_coefficient: f64,
+        base_emitter_junction_potential: f64,
+        base_emitter_grading_coefficient: f64,
+        base_collector_junction_potential: f64,
+        base_collector_grading_coefficient: f64,
+        forward_bias_depletion_coefficient: f64,
+        reverse_early_voltage: f64,
+        forward_beta_rolloff_current: f64,
+        base_emitter_leakage_saturation_current: f64,
+        base_emitter_leakage_emission_coefficient: f64,
+    ) -> Self {
         Self {
             name: name.into(),
             collector: collector.into(),
@@ -3123,6 +3187,8 @@ impl Bjt {
             forward_bias_depletion_coefficient,
             reverse_early_voltage,
             forward_beta_rolloff_current,
+            base_emitter_leakage_saturation_current,
+            base_emitter_leakage_emission_coefficient,
         }
     }
 }
@@ -3513,8 +3579,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 19, 34, 11, 4),
-    (ModelCardKind::Pnp, 19, 34, 11, 4),
+    (ModelCardKind::Npn, 21, 36, 11, 4),
+    (ModelCardKind::Pnp, 21, 36, 11, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3564,6 +3630,8 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("VB", "VAR"),
     ("IKF", "IKF"),
     ("IK", "IKF"),
+    ("ISE", "ISE"),
+    ("NE", "NE"),
     ("NF", "NF"),
     ("NR", "NR"),
     ("VJE", "VJE"),
@@ -4215,7 +4283,7 @@ pub fn bjt_from_model_card(
         _ => return Err(model_card_kind_error(&name, "BJT", model.kind)),
     };
     Ok(
-        Bjt::with_model_temperature_depletion_early_and_rolloff_parameters(
+        Bjt::with_model_temperature_depletion_early_rolloff_and_leakage_parameters(
             name,
             collector,
             base,
@@ -4240,6 +4308,8 @@ pub fn bjt_from_model_card(
             model_card_value(model, "FC", 0.5),
             model_card_value(model, "VAR", 0.0),
             model_card_value(model, "IKF", 0.0),
+            model_card_value(model, "ISE", 0.0),
+            model_card_value(model, "NE", 1.0),
         ),
     )
 }
@@ -21902,6 +21972,7 @@ fn collect_noise_sources(
                 let base_gm = bjt.saturation_current / forward_thermal_voltage * exp_value;
                 let (collector_current, _, _) =
                     bjt_forward_transport(bjt, base_collector_current, base_gm, early_factor);
+                let (leakage_current, _) = bjt_base_emitter_leakage(bjt, junction_voltage);
                 let (positive, negative) = match bjt.polarity {
                     BjtPolarity::Npn => (base, emitter),
                     BjtPolarity::Pnp => (emitter, base),
@@ -21911,7 +21982,9 @@ fn collect_noise_sources(
                     noise_type: NoiseType::Shot,
                     positive,
                     negative,
-                    source_psd: 2.0 * ELECTRON_CHARGE * collector_current.abs(),
+                    source_psd: 2.0
+                        * ELECTRON_CHARGE
+                        * (collector_current.abs() + leakage_current.abs()),
                 });
             }
             Element::Jfet(jfet) => {
@@ -22390,6 +22463,19 @@ fn bjt_forward_transport(
     (collector_current, gm, charge_factor)
 }
 
+fn bjt_base_emitter_leakage(bjt: &Bjt, junction_voltage: f64) -> (f64, f64) {
+    if bjt.base_emitter_leakage_saturation_current == 0.0 {
+        return (0.0, 0.0);
+    }
+    let thermal_voltage = bjt.thermal_voltage * bjt.base_emitter_leakage_emission_coefficient;
+    let exponent = (junction_voltage / thermal_voltage).clamp(-40.0, 40.0);
+    let exp_value = exponent.exp();
+    (
+        bjt.base_emitter_leakage_saturation_current * (exp_value - 1.0),
+        bjt.base_emitter_leakage_saturation_current / thermal_voltage * exp_value,
+    )
+}
+
 fn stamp_bjt(
     bjt: &Bjt,
     capacitor_states: &[CapacitorState],
@@ -22426,8 +22512,9 @@ fn stamp_bjt(
     } else {
         base_collector_current / bjt.forward_early_voltage / charge_factor
     };
-    let gpi = base_gm / bjt.forward_beta;
-    let base_current = base_collector_current / bjt.forward_beta;
+    let (leakage_current, leakage_conductance) = bjt_base_emitter_leakage(bjt, junction_voltage);
+    let gpi = base_gm / bjt.forward_beta + leakage_conductance;
+    let base_current = base_collector_current / bjt.forward_beta + leakage_current;
     let equivalent_collector_current =
         collector_current - gm * junction_voltage - output_conductance * output_voltage;
     let equivalent_base_current = base_current - gpi * junction_voltage;
@@ -22544,7 +22631,8 @@ fn stamp_bjt_small_signal(
     } else {
         base_collector_current / bjt.forward_early_voltage / charge_factor
     };
-    let gpi = base_gm / bjt.forward_beta;
+    let (_, leakage_conductance) = bjt_base_emitter_leakage(bjt, junction_voltage);
+    let gpi = base_gm / bjt.forward_beta + leakage_conductance;
     stamp_conductance(matrix, collector, emitter, output_conductance);
     match bjt.polarity {
         BjtPolarity::Npn => {
@@ -22604,8 +22692,9 @@ fn stamp_ac_bjt_small_signal(
     let reverse_gm = bjt.saturation_current / reverse_thermal_voltage * reverse_exponent.exp();
     let diffusion_capacitance = bjt.forward_transit_time * gm.real;
     let reverse_diffusion_capacitance = bjt.reverse_transit_time * reverse_gm;
+    let (_, leakage_conductance) = bjt_base_emitter_leakage(bjt, junction_voltage);
     let gpi = Complex::new(
-        base_gm / bjt.forward_beta,
+        base_gm / bjt.forward_beta + leakage_conductance,
         omega
             * (bjt_base_emitter_depletion_capacitance(bjt, junction_voltage)
                 + diffusion_capacitance),
@@ -23615,6 +23704,24 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "forward beta roll-off current must be finite and non-negative".to_string(),
+        });
+    }
+    if !bjt.base_emitter_leakage_saturation_current.is_finite()
+        || bjt.base_emitter_leakage_saturation_current < 0.0
+    {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "base-emitter leakage saturation current must be finite and non-negative"
+                .to_string(),
+        });
+    }
+    if !bjt.base_emitter_leakage_emission_coefficient.is_finite()
+        || bjt.base_emitter_leakage_emission_coefficient <= 0.0
+    {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "base-emitter leakage emission coefficient must be finite and positive"
+                .to_string(),
         });
     }
     if !bjt.forward_emission_coefficient.is_finite() || bjt.forward_emission_coefficient <= 0.0 {

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -911,6 +911,32 @@ fn ac_bjt_forward_beta_rolloff_reduces_gain() {
 }
 
 #[test]
+fn ac_bjt_base_emitter_leakage_reduces_gain_through_source_resistance() {
+    let gain = |leakage_current: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vin", "in", "0", 0.65, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "base", 1_000.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rload", "out", "0", 1_000.0,
+        )));
+        let mut transistor = Bjt::new("Q1", "out", "base", "0");
+        transistor.base_emitter_leakage_saturation_current = leakage_current;
+        transistor.base_emitter_leakage_emission_coefficient = 1.5;
+        circuit.add(Element::Bjt(transistor));
+        ac_sweep(&circuit, 1_000.0, 1_000.0, 1).unwrap()[0]
+            .voltage("out")
+            .unwrap()
+            .abs()
+    };
+
+    assert!(gain(1.0e-10) < gain(0.0));
+}
+
+#[test]
 fn ac_bjt_reverse_emission_coefficient_reduces_base_collector_diffusion_capacitance() {
     fn base_amplitude(reverse_emission_coefficient: f64) -> f64 {
         let mut circuit = Circuit::new();

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 96);
+    assert_eq!(coverage.len(), 100);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 96);
+    assert_eq!(records.len(), 100);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 96);
-    assert_eq!(report.expected_canonical_parameter_count, 96);
-    assert_eq!(report.accepted_name_count, 158);
+    assert_eq!(report.canonical_parameter_count, 100);
+    assert_eq!(report.expected_canonical_parameter_count, 100);
+    assert_eq!(report.accepted_name_count, 162);
     assert_eq!(report.aliased_parameter_count, 49);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t96\t96\t158\t49\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t100\t100\t162\t49\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,8 +235,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 95);
-    assert_eq!(report.accepted_name_count, 155);
+    assert_eq!(report.canonical_parameter_count, 99);
+    assert_eq!(report.accepted_name_count, 159);
     assert_eq!(report.aliased_parameter_count, 48);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t95\t96\t155\t48\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t99\t100\t159\t48\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -433,6 +433,8 @@ fn model_card_aliases_build_device_instances() {
             ("VA", 80.0),
             ("VB", 120.0),
             ("IK", 2.0e-3),
+            ("ISE", 3.0e-13),
+            ("NE", 1.7),
             ("NF", 1.2),
             ("NR", 1.3),
             ("PE", 0.8),
@@ -451,6 +453,8 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("VAF").unwrap(), 80.0);
     assert_close(*bjt_card.parameters.get("VAR").unwrap(), 120.0);
     assert_close(*bjt_card.parameters.get("IKF").unwrap(), 2.0e-3);
+    assert_close(*bjt_card.parameters.get("ISE").unwrap(), 3.0e-13);
+    assert_close(*bjt_card.parameters.get("NE").unwrap(), 1.7);
     assert_close(*bjt_card.parameters.get("NF").unwrap(), 1.2);
     assert_close(*bjt_card.parameters.get("NR").unwrap(), 1.3);
     assert_close(*bjt_card.parameters.get("VJE").unwrap(), 0.8);
@@ -466,6 +470,8 @@ fn model_card_aliases_build_device_instances() {
     assert_close(bjt_model.forward_early_voltage, 80.0);
     assert_close(bjt_model.reverse_early_voltage, 120.0);
     assert_close(bjt_model.forward_beta_rolloff_current, 2.0e-3);
+    assert_close(bjt_model.base_emitter_leakage_saturation_current, 3.0e-13);
+    assert_close(bjt_model.base_emitter_leakage_emission_coefficient, 1.7);
     assert_close(bjt_model.forward_emission_coefficient, 1.2);
     assert_close(bjt_model.reverse_emission_coefficient, 1.3);
     assert_close(bjt_model.base_emitter_junction_potential, 0.8);
@@ -1369,7 +1375,7 @@ fn subcircuit_expansion_preserves_complete_diode_model() {
 
 #[test]
 fn subcircuit_expansion_preserves_complete_bjt_model() {
-    let bjt = Bjt::with_model_temperature_depletion_early_and_rolloff_parameters(
+    let bjt = Bjt::with_model_temperature_depletion_early_rolloff_and_leakage_parameters(
         "Qcell",
         "c",
         "b",
@@ -1394,6 +1400,8 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
         0.4,
         120.0,
         2.0e-3,
+        3.0e-13,
+        1.7,
     );
     let mut circuit = Circuit::new();
     circuit
@@ -1431,6 +1439,8 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.base_collector_grading_coefficient, 0.45);
     assert_close(expanded.forward_bias_depletion_coefficient, 0.4);
     assert_close(expanded.forward_beta_rolloff_current, 2.0e-3);
+    assert_close(expanded.base_emitter_leakage_saturation_current, 3.0e-13);
+    assert_close(expanded.base_emitter_leakage_emission_coefficient, 1.7);
 }
 
 #[test]
@@ -1919,6 +1929,17 @@ fn bjt_temperature_scaling_uses_model_temperature_exponent() {
 }
 
 #[test]
+fn bjt_temperature_scales_base_emitter_leakage_saturation_current() {
+    let mut transistor = Bjt::new("Q1", "c", "b", "e");
+    transistor.base_emitter_leakage_saturation_current = 2.0e-13;
+    let hot = bjt_at_temperature(&transistor, 350.0, 300.15, 1.11).unwrap();
+    assert!(
+        hot.base_emitter_leakage_saturation_current
+            > transistor.base_emitter_leakage_saturation_current
+    );
+}
+
+#[test]
 fn bjt_temperature_scaling_uses_model_energy_gap() {
     let mut silicon = Circuit::new();
     silicon.add(Element::Bjt(Bjt::with_model_and_temperature_parameters(
@@ -2117,6 +2138,48 @@ fn dc_rejects_invalid_bjt_forward_beta_rolloff_current() {
     assert!(error
         .to_string()
         .contains("forward beta roll-off current must be finite and non-negative"));
+}
+
+#[test]
+fn bjt_base_emitter_leakage_increases_base_current() {
+    let base_current = |leakage_current: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vbase", "base", "0", 0.65,
+        )));
+        let mut transistor = Bjt::new("Q1", "0", "base", "0");
+        transistor.base_emitter_leakage_saturation_current = leakage_current;
+        transistor.base_emitter_leakage_emission_coefficient = 1.5;
+        circuit.add(Element::Bjt(transistor));
+        dc_op(&circuit)
+            .unwrap()
+            .branch_current("Vbase")
+            .unwrap()
+            .abs()
+    };
+
+    assert!(base_current(1.0e-10) > base_current(0.0));
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_base_emitter_leakage_parameters() {
+    let mut circuit = Circuit::new();
+    let mut transistor = Bjt::new("Qbad", "c", "b", "0");
+    transistor.base_emitter_leakage_saturation_current = -1.0;
+    circuit.add(Element::Bjt(transistor));
+    assert!(dc_op(&circuit)
+        .unwrap_err()
+        .to_string()
+        .contains("base-emitter leakage saturation current must be finite and non-negative"));
+
+    let mut circuit = Circuit::new();
+    let mut transistor = Bjt::new("Qbad", "c", "b", "0");
+    transistor.base_emitter_leakage_emission_coefficient = 0.0;
+    circuit.add(Element::Bjt(transistor));
+    assert!(dc_op(&circuit)
+        .unwrap_err()
+        .to_string()
+        .contains("base-emitter leakage emission coefficient must be finite and positive"));
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -34,6 +34,33 @@ fn bjt_forward_beta_rolloff_reduces_shot_noise() {
     assert!(source_psd(1.0e-4) < source_psd(0.0));
 }
 
+#[test]
+fn bjt_base_emitter_leakage_increases_shot_noise() {
+    let source_psd = |leakage_current: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vbase", "base", "0", 0.65,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rload", "out", "0", 1_000.0,
+        )));
+        let mut transistor = Bjt::new("Q1", "out", "base", "0");
+        transistor.base_emitter_leakage_saturation_current = leakage_current;
+        transistor.base_emitter_leakage_emission_coefficient = 1.5;
+        circuit.add(Element::Bjt(transistor));
+        noise_ac(&circuit, "out", "Vbase", &[1_000.0], 300.0)
+            .unwrap()
+            .points[0]
+            .entries
+            .iter()
+            .find(|entry| entry.element_name == "Q1")
+            .unwrap()
+            .source_psd
+    };
+
+    assert!(source_psd(1.0e-10) > source_psd(0.0));
+}
+
 const BOLTZMANN: f64 = 1.380_649e-23;
 const MOSFET_CHANNEL_NOISE_GAMMA: f64 = 2.0 / 3.0;
 

--- a/code/packages/rust/spice-engine/tests/tf_tests.rs
+++ b/code/packages/rust/spice-engine/tests/tf_tests.rs
@@ -402,6 +402,26 @@ fn tf_bjt_forward_beta_rolloff_reduces_gain() {
 }
 
 #[test]
+fn tf_bjt_base_emitter_leakage_reduces_input_impedance() {
+    let input_impedance = |leakage_current: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vin", "base", "0", 0.65,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rload", "out", "0", 1_000.0,
+        )));
+        let mut transistor = Bjt::new("Q1", "out", "base", "0");
+        transistor.base_emitter_leakage_saturation_current = leakage_current;
+        transistor.base_emitter_leakage_emission_coefficient = 1.5;
+        circuit.add(Element::Bjt(transistor));
+        tf(&circuit, "out", "Vin").unwrap().input_impedance_ohms
+    };
+
+    assert!(input_impedance(1.0e-10) < input_impedance(0.0));
+}
+
+#[test]
 fn tf_bjt_forward_emission_coefficient_reduces_gain_and_raises_input_impedance() {
     let transfer = |forward_emission_coefficient: f64| {
         let mut circuit = Circuit::new();

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add BJT model-card `ISE`/`NE` base-emitter leakage support in DC, transient,
+  AC, transfer-function, temperature, and noise paths, matching Rust and
+  Python. The supported-parameter catalog now contains 100 canonical rows.
 - Add BJT model-card `IKF`/`IK` forward high-current beta roll-off support with
   shared base-charge modulation in DC, transient, AC, transfer-function, and
   noise paths, matching Python and Rust. The supported-parameter catalog now

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -210,7 +210,9 @@ depletion capacitance. `VJC`/`PC` (default `0.75 V`) and `MJC`/`MC` (default
 (default `0.5`) selects the shared Berkeley forward-bias continuation point for
 both junctions. `IKF`/`IK` (default `0`, disabled) applies Berkeley forward
 high-current base-charge modulation to collector transport and small-signal
-transconductance.
+transconductance. `ISE` (default `0`, disabled) and `NE` (default `1`) add the
+Berkeley base-emitter leakage branch to DC/transient base current,
+small-signal input conductance, and shot noise.
 `modelCardUnsupportedParameterIssues`,
 `formatModelCardUnsupportedParameterIssueTable`,
 `modelCardUnsupportedParameterIssueRecords`,
@@ -236,7 +238,7 @@ model kind for compact release dashboards and Mosaic UI inventories.
 `modelCardSupportedParameterCoverageGateIssueRecords`,
 `formatModelCardSupportedParameterCoverageGateIssueCsv`, and
 `formatModelCardSupportedParameterCoverageGateIssueJson` validate the expected
-seven-kind, 74-row supported-parameter catalog and expose stable issue rows for
+seven-kind, 100-row supported-parameter catalog and expose stable issue rows for
 release automation.
 `modelCardSupportedParameterCoverageDashboard`,
 `formatModelCardSupportedParameterCoverageDashboardTable`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1722,6 +1722,8 @@ export interface Bjt {
   readonly baseCollectorGradingCoefficient: number;
   readonly forwardBiasDepletionCoefficient: number;
   readonly forwardBetaRolloffCurrent: number;
+  readonly baseEmitterLeakageSaturationCurrent: number;
+  readonly baseEmitterLeakageEmissionCoefficient: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -1999,8 +2001,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [19, 34, 11, 4],
-  PNP: [19, 34, 11, 4],
+  NPN: [21, 36, 11, 4],
+  PNP: [21, 36, 11, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3590,7 +3592,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7637,6 +7639,8 @@ export function bjtAtTemperature(
   return {
     ...element,
     saturationCurrent: element.saturationCurrent * saturationScale,
+    baseEmitterLeakageSaturationCurrent:
+      element.baseEmitterLeakageSaturationCurrent * saturationScale,
     thermalVoltage: element.thermalVoltage * ratio,
   };
 }
@@ -7755,6 +7759,8 @@ export function bjt(
   forwardBiasDepletionCoefficient = 0.5,
   reverseEarlyVoltage = 0.0,
   forwardBetaRolloffCurrent = 0.0,
+  baseEmitterLeakageSaturationCurrent = 0.0,
+  baseEmitterLeakageEmissionCoefficient = 1.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7782,6 +7788,8 @@ export function bjt(
     baseCollectorGradingCoefficient,
     forwardBiasDepletionCoefficient,
     forwardBetaRolloffCurrent,
+    baseEmitterLeakageSaturationCurrent,
+    baseEmitterLeakageEmissionCoefficient,
   };
 }
 
@@ -7891,6 +7899,8 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   VB: "VAR",
   IKF: "IKF",
   IK: "IKF",
+  ISE: "ISE",
+  NE: "NE",
   NF: "NF",
   NR: "NR",
   VJE: "VJE",
@@ -8410,6 +8420,8 @@ export function bjtFromModelCard(
     p.FC ?? 0.5,
     p.VAR ?? 0.0,
     p.IKF ?? 0.0,
+    p.ISE ?? 0.0,
+    p.NE ?? 1.0,
   );
 }
 
@@ -18354,12 +18366,15 @@ function collectNoiseSources(
         baseTransconductance,
         earlyFactor,
       ).collectorCurrent;
+      const leakageCurrent = bjtBaseEmitterLeakage(element, junctionVoltage).current;
       sources.push({
         elementName: element.name,
         noiseType: "shot",
         positive: element.polarity === "NPN" ? base : emitter,
         negative: element.polarity === "NPN" ? emitter : base,
-        sourcePsd: 2.0 * ELECTRON_CHARGE * Math.abs(collectorCurrent),
+        sourcePsd:
+          2.0 * ELECTRON_CHARGE *
+          (Math.abs(collectorCurrent) + Math.abs(leakageCurrent)),
       });
     } else if (element.kind === "jfet") {
       validateJfet(element);
@@ -18863,6 +18878,24 @@ function bjtForwardTransport(
   };
 }
 
+function bjtBaseEmitterLeakage(
+  element: Bjt,
+  junctionVoltage: number,
+): { current: number; conductance: number } {
+  if (element.baseEmitterLeakageSaturationCurrent === 0.0) {
+    return { current: 0.0, conductance: 0.0 };
+  }
+  const thermalVoltage =
+    element.thermalVoltage * element.baseEmitterLeakageEmissionCoefficient;
+  const exponent = Math.max(-40.0, Math.min(40.0, junctionVoltage / thermalVoltage));
+  const expValue = Math.exp(exponent);
+  return {
+    current: element.baseEmitterLeakageSaturationCurrent * (expValue - 1.0),
+    conductance:
+      element.baseEmitterLeakageSaturationCurrent / thermalVoltage * expValue,
+  };
+}
+
 function stampBjt(
   element: Bjt,
   capacitorStates: readonly CapacitorState[],
@@ -18903,8 +18936,10 @@ function stampBjt(
     : baseCollectorCurrent / element.forwardEarlyVoltage / transport.chargeFactor;
   const collectorCurrent = transport.collectorCurrent;
   const transconductance = transport.transconductance;
-  const junctionConductance = baseTransconductance / element.forwardBeta;
-  const baseCurrent = baseCollectorCurrent / element.forwardBeta;
+  const leakage = bjtBaseEmitterLeakage(element, junctionVoltage);
+  const junctionConductance =
+    baseTransconductance / element.forwardBeta + leakage.conductance;
+  const baseCurrent = baseCollectorCurrent / element.forwardBeta + leakage.current;
   const equivalentCollectorCurrent =
     collectorCurrent - transconductance * junctionVoltage - outputConductance * outputVoltage;
   const equivalentBaseCurrent =
@@ -19744,6 +19779,12 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.forwardBetaRolloffCurrent) || element.forwardBetaRolloffCurrent < 0.0) {
     throw invalidElement(element.name, "forward beta roll-off current must be finite and non-negative");
+  }
+  if (!Number.isFinite(element.baseEmitterLeakageSaturationCurrent) || element.baseEmitterLeakageSaturationCurrent < 0.0) {
+    throw invalidElement(element.name, "base-emitter leakage saturation current must be finite and non-negative");
+  }
+  if (!Number.isFinite(element.baseEmitterLeakageEmissionCoefficient) || element.baseEmitterLeakageEmissionCoefficient <= 0.0) {
+    throw invalidElement(element.name, "base-emitter leakage emission coefficient must be finite and positive");
   }
   if (!Number.isFinite(element.forwardEmissionCoefficient) || element.forwardEmissionCoefficient <= 0.0) {
     throw invalidElement(element.name, "forward emission coefficient must be finite and positive");
@@ -21100,7 +21141,9 @@ function stampBjtSmallSignal(
     ? 0.0
     : baseCollectorCurrent / element.forwardEarlyVoltage / transport.chargeFactor;
   const transconductance = transport.transconductance;
-  const junctionConductance = baseTransconductance / element.forwardBeta;
+  const leakage = bjtBaseEmitterLeakage(element, junctionVoltage);
+  const junctionConductance =
+    baseTransconductance / element.forwardBeta + leakage.conductance;
   stampConductance(matrix, collector, emitter, outputConductance);
   if (element.polarity === "NPN") {
     stampConductance(matrix, base, emitter, junctionConductance);
@@ -21691,7 +21734,9 @@ function stampAcBjtSmallSignal(
     ? 0.0
     : baseCollectorCurrent / element.forwardEarlyVoltage / transport.chargeFactor;
   const transconductance = transport.transconductance;
-  const junctionConductance = baseTransconductance / element.forwardBeta;
+  const leakage = bjtBaseEmitterLeakage(element, junctionVoltage);
+  const junctionConductance =
+    baseTransconductance / element.forwardBeta + leakage.conductance;
   const diffusionCapacitance = element.forwardTransitTime * transconductance;
   const reverseTransconductance =
     element.saturationCurrent / reverseThermalVoltage * Math.exp(reverseExponent);

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -629,6 +629,23 @@ describe("acSweep", () => {
     expect(gain(1.0e-4)).toBeLessThan(gain(0.0));
   });
 
+  it("uses BJT base-emitter leakage to reduce gain through source resistance", () => {
+    function gain(baseEmitterLeakageSaturationCurrent: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vin", "in", "0", 0.65, 1.0));
+      circuit.add(resistor("Rin", "in", "base", 1_000.0));
+      circuit.add(resistor("Rload", "out", "0", 1_000.0));
+      circuit.add({
+        ...bjt("Q1", "out", "base", "0"),
+        baseEmitterLeakageSaturationCurrent,
+        baseEmitterLeakageEmissionCoefficient: 1.5,
+      });
+      return complexAbs(acSweep(circuit, 1_000.0, 1_000.0, 1, "lin")[0].voltage("out")!);
+    }
+
+    expect(gain(1.0e-10)).toBeLessThan(gain(0.0));
+  });
+
   it("shapes BJT base-emitter depletion capacitance under reverse bias", () => {
     function baseAmplitude(baseEmitterGradingCoefficient: number): number {
       const circuit = new Circuit();

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(96);
+    expect(coverage).toHaveLength(100);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(96);
+    expect(records).toHaveLength(100);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 96,
-      expectedCanonicalParameterCount: 96,
-      acceptedNameCount: 158,
+      canonicalParameterCount: 100,
+      expectedCanonicalParameterCount: 100,
+      acceptedNameCount: 162,
       aliasedParameterCount: 49,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t96\t96\t158\t49\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t100\t100\t162\t49\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,8 +241,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(95);
-    expect(report.acceptedNameCount).toBe(155);
+    expect(report.canonicalParameterCount).toBe(99);
+    expect(report.acceptedNameCount).toBe(159);
     expect(report.aliasedParameterCount).toBe(48);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t95\t96\t155\t48\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t99\t100\t159\t48\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -339,6 +339,8 @@ describe("dcOp", () => {
       VA: 80.0,
       VB: 120.0,
       IK: 2.0e-3,
+      ISE: 3.0e-13,
+      NE: 1.7,
       NF: 1.2,
       NR: 1.3,
       PE: 0.8,
@@ -348,7 +350,7 @@ describe("dcOp", () => {
       FC: 0.4,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, ISE: 3.0e-13, NE: 1.7, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.baseEmitterCapacitance, 2.0e-12);
@@ -357,6 +359,8 @@ describe("dcOp", () => {
     expectClose(bjtModel.forwardEarlyVoltage, 80.0);
     expectClose(bjtModel.reverseEarlyVoltage, 120.0);
     expectClose(bjtModel.forwardBetaRolloffCurrent, 2.0e-3);
+    expectClose(bjtModel.baseEmitterLeakageSaturationCurrent, 3.0e-13);
+    expectClose(bjtModel.baseEmitterLeakageEmissionCoefficient, 1.7);
     expectClose(bjtModel.forwardEmissionCoefficient, 1.2);
     expectClose(bjtModel.reverseEmissionCoefficient, 1.3);
     expectClose(bjtModel.baseEmitterJunctionPotential, 0.8);
@@ -996,7 +1000,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -1016,6 +1020,8 @@ describe("dcOp", () => {
       expectClose(expanded.baseCollectorGradingCoefficient, 0.45);
       expectClose(expanded.forwardBiasDepletionCoefficient, 0.4);
       expectClose(expanded.forwardBetaRolloffCurrent, 2.0e-3);
+      expectClose(expanded.baseEmitterLeakageSaturationCurrent, 3.0e-13);
+      expectClose(expanded.baseEmitterLeakageEmissionCoefficient, 1.7);
     }
   });
 
@@ -1338,6 +1344,17 @@ describe("dcOp", () => {
     expect(high.saturationCurrent).toBeGreaterThan(low.saturationCurrent);
   });
 
+  it("scales BJT base-emitter leakage saturation current with temperature", () => {
+    const transistor = {
+      ...bjt("Q1", "c", "b", "e"),
+      baseEmitterLeakageSaturationCurrent: 2.0e-13,
+    };
+    const hot = bjtAtTemperature(transistor, 350);
+    expect(hot.baseEmitterLeakageSaturationCurrent).toBeGreaterThan(
+      transistor.baseEmitterLeakageSaturationCurrent,
+    );
+  });
+
   it("uses the BJT model energy gap", () => {
     const silicon = new Circuit();
     silicon.add(bjt("Qsilicon", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 1.11));
@@ -1416,6 +1433,31 @@ describe("dcOp", () => {
     expect(() => dcOp(circuit)).toThrowError(
       "forward beta roll-off current must be finite and non-negative",
     );
+  });
+
+  it("uses BJT base-emitter leakage to increase base current", () => {
+    const baseCurrent = (baseEmitterLeakageSaturationCurrent: number): number => {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vbase", "base", "0", 0.65));
+      circuit.add({
+        ...bjt("Q1", "0", "base", "0"),
+        baseEmitterLeakageSaturationCurrent,
+        baseEmitterLeakageEmissionCoefficient: 1.5,
+      });
+      return Math.abs(dcOp(circuit).branchCurrent("Vbase")!);
+    };
+
+    expect(baseCurrent(1.0e-10)).toBeGreaterThan(baseCurrent(0.0));
+  });
+
+  it("rejects invalid BJT base-emitter leakage parameters", () => {
+    const badCurrent = new Circuit();
+    badCurrent.add({ ...bjt("Qbad", "c", "b", "0"), baseEmitterLeakageSaturationCurrent: -1.0 });
+    expect(() => dcOp(badCurrent)).toThrowError("base-emitter leakage saturation current");
+
+    const badCoefficient = new Circuit();
+    badCoefficient.add({ ...bjt("Qbad", "c", "b", "0"), baseEmitterLeakageEmissionCoefficient: 0.0 });
+    expect(() => dcOp(badCoefficient)).toThrowError("base-emitter leakage emission coefficient");
   });
 
   it("uses BJT forward emission coefficient to reduce collector current", () => {

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -33,6 +33,23 @@ describe("noiseAc", () => {
 
     expect(sourcePsd(1.0e-4)).toBeLessThan(sourcePsd(0.0));
   });
+  it("uses BJT base-emitter leakage to increase shot noise", () => {
+    function sourcePsd(baseEmitterLeakageSaturationCurrent: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vbase", "base", "0", 0.65));
+      circuit.add(resistor("Rload", "out", "0", 1_000.0));
+      circuit.add({
+        ...bjt("Q1", "out", "base", "0"),
+        baseEmitterLeakageSaturationCurrent,
+        baseEmitterLeakageEmissionCoefficient: 1.5,
+      });
+      const entry = noiseAc(circuit, "out", "Vbase", [1_000.0], 300.0).points[0]?.entries
+        .find((candidate) => candidate.elementName === "Q1");
+      return entry!.sourcePsd;
+    }
+
+    expect(sourcePsd(1.0e-10)).toBeGreaterThan(sourcePsd(0.0));
+  });
   it("computes Johnson noise for a single grounded resistor", () => {
     const circuit = new Circuit();
     circuit.add(currentSource("Iin", "0", "out", 0.0));

--- a/code/packages/typescript/spice-engine/tests/tf.test.ts
+++ b/code/packages/typescript/spice-engine/tests/tf.test.ts
@@ -83,6 +83,22 @@ describe("tf", () => {
     expect(gain(1.0e-4)).toBeLessThan(gain(0.0));
   });
 
+  it("uses BJT base-emitter leakage to reduce input impedance", () => {
+    function inputImpedance(baseEmitterLeakageSaturationCurrent: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vin", "base", "0", 0.65));
+      circuit.add(resistor("Rload", "out", "0", 1_000.0));
+      circuit.add({
+        ...bjt("Q1", "out", "base", "0"),
+        baseEmitterLeakageSaturationCurrent,
+        baseEmitterLeakageEmissionCoefficient: 1.5,
+      });
+      return tf(circuit, "out", "Vin").inputImpedanceOhms;
+    }
+
+    expect(inputImpedance(1.0e-10)).toBeLessThan(inputImpedance(0.0));
+  });
+
   it("uses BJT forward emission coefficient to reduce gain and raise input impedance", () => {
     function transfer(forwardEmissionCoefficient: number) {
       const circuit = new Circuit();

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT forward high-current beta roll-off.
+1. Cross-language BJT base-emitter leakage.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `IKF` / `IK` forward beta roll-off model-card support in
+   - Add Berkeley BJT `ISE` / `NE` base-emitter leakage model-card support in
      Rust, Python, and TypeScript with disabled behavior represented by the
-     standard zero default.
-   - Apply forward high-current base-charge modulation in DC, transient, AC,
-     transfer-function, and noise paths while preserving the complete BJT model
+     standard zero `ISE` default.
+   - Apply the leakage branch in DC, transient, AC, transfer-function,
+     temperature, and noise paths while preserving the complete BJT model
      through hierarchical subcircuits.
-   - Extend the supported-parameter coverage gate from 94 to 96 canonical rows
+   - Extend the supported-parameter coverage gate from 96 to 100 canonical rows
      and lock model-card aliases, behavior, validation, and hierarchy in all
      engines.
 
@@ -3063,6 +3063,14 @@ the Rust, Python, and TypeScript surfaces together.
      transfer-function, and noise paths.
    - Hierarchical subcircuit expansion preserves the complete BJT model, and
      the supported-parameter release gate now covers 94 canonical rows.
+
+227. Cross-language BJT forward high-current beta roll-off.
+   - Status: completed in PR 8770.
+   - Rust, Python, and TypeScript BJT model cards now accept `IKF` / `IK` and
+     apply forward high-current base-charge modulation in DC, transient, AC,
+     transfer-function, and noise paths.
+   - Hierarchical subcircuit expansion preserves the complete BJT model, and
+     the supported-parameter release gate now covers 96 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley BJT `ISE` / `NE` base-emitter leakage model parameters across Rust, Python, and TypeScript
- include leakage current and conductance in DC, transient, AC, TF, temperature, and noise behavior
- preserve the parameters through model cards and hierarchical expansion, and raise supported model coverage from 96 to 100 canonical rows
- reconcile the SPICE implementation plan after PR #8770

## Verification
- `cargo test -p spice-engine` (348 passed)
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo fmt -p spice-engine -- --check`
- Python: `pytest` (540 passed, 88.66% coverage)
- Python: `ruff check src/spice_engine/engine.py src/spice_engine/model_cards.py tests/test_engine.py`
- TypeScript: `pnpm test` (298 passed)
- TypeScript: `pnpm build`
- `git diff --check`