### PR TITLE
feat(sql): GROUP BY bare non-key column takes the group's first-row value

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.5.61 — GROUP BY bare column takes the group's first-row value
+
+`SELECT c FROM t GROUP BY x`, where `c` is neither a GROUP BY key nor inside an
+aggregate, now returns a value instead of NULL — SQLite reports such a bare
+column from the group's first row, and the VM now retains a representative row
+per group to do the same. Retires the `distinct_over_group_by_single_col` ledger
+entry.
+
+Verified against bundled real SQLite, including a multi-row group where the bare
+columns come from the first row (`v=10, tag='a'`) and a functionally-dependent
+bare column (deterministic regardless of which row is picked). The min/max-
+follows refinement (bare columns tracking a `min()`/`max()` row) stays out of
+scope — it needs an aggregate combined with bare columns, still ledgered.
+
 ## 0.5.60 — GROUP BY output follows the SELECT list
 
 `SELECT x, c FROM t GROUP BY c, x` now returns columns in SELECT-list order

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.60"
+version = "0.5.61"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1697,9 +1697,9 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT c || '!' AS d, c FROM t GROUP BY c ORDER BY c",
     },
-    // Still ledgered: a bare non-key column now projects under the RIGHT name
-    // (`c`, was the group key `x`) but as NULL, because the group retains no
-    // representative source row. See the LEDGER entry for details.
+    // A bare non-key column now projects a VALUE, not NULL: SQLite reports such a
+    // column from the group's FIRST row, and the VM now keeps that representative
+    // row. Here each x-group has one row (c='A'), so it's deterministic.
     Case {
         id: "distinct_over_group_by_single_col",
         setup: &[
@@ -1707,6 +1707,27 @@ const CASES: &[Case] = &[
             "INSERT INTO t VALUES('A','p'),('A','P')",
         ],
         query: "SELECT DISTINCT c FROM t GROUP BY x ORDER BY 1",
+    },
+    // Multi-row group: the bare columns `v` and `tag` come from the group's FIRST
+    // row (v=10, tag='a'), matching SQLite. Both engines scan an in-memory table
+    // in insertion/rowid order, so "first row of the group" is deterministic.
+    Case {
+        id: "group_by_bare_column_first_row",
+        setup: &[
+            "CREATE TABLE t (g INTEGER, v INTEGER, tag TEXT)",
+            "INSERT INTO t VALUES (1,10,'a'),(1,20,'b'),(1,30,'c'),(2,40,'d')",
+        ],
+        query: "SELECT g, v, tag FROM t GROUP BY g ORDER BY g",
+    },
+    // Bare column functionally dependent on the key (`c` constant within each
+    // `x`... here within `g`): deterministic regardless of which row is picked.
+    Case {
+        id: "group_by_bare_column_dependent",
+        setup: &[
+            "CREATE TABLE t (g INTEGER, label TEXT)",
+            "INSERT INTO t VALUES (1,'one'),(1,'one'),(2,'two')",
+        ],
+        query: "SELECT g, label FROM t GROUP BY g ORDER BY g",
     },
     // Still ledgered: an aggregate column reordered before a group key keeps the
     // fixed keys-then-aggregates layout (`[c, max(x)]` not `[max(x), c]`).
@@ -2205,18 +2226,6 @@ const LEDGER: &[(&str, &str)] = &[
     (
         "distinct_star_collate",
         "SELECT DISTINCT * does not expand the star into the table's columns (projection gap, not a collation gap)",
-    ),
-    // A GROUP BY over a BARE non-key column projects that column as NULL rather
-    // than a representative value from the group. The SELECT-list projection now
-    // fixes the column IDENTITY — `SELECT c ... GROUP BY x` returns a column
-    // named `c` (it used to return the group key `x`) — but the value is NULL
-    // because the group's fake row holds only the key columns, not a
-    // representative source row. Closing this needs the VM to retain a
-    // representative row per group (SQLite's "bare column in aggregate"
-    // extension); a tracked follow-up.
-    (
-        "distinct_over_group_by_single_col",
-        "GROUP BY over a bare non-key column projects it as NULL, not a representative row value (VM keeps no representative row per group)",
     ),
     // A GROUP BY with an AGGREGATE column still emits the fixed
     // group-keys-then-aggregates layout, so reordering an aggregate relative to

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.35] - Unreleased
+
+### Added
+
+- **A GROUP BY over a bare non-key column reports the group's first-row value,
+  not NULL.** `SELECT c FROM t GROUP BY x` (where `c` is neither a GROUP BY key
+  nor inside an aggregate) returned NULL; SQLite reports such a bare column from
+  the group's FIRST row. The GROUP BY state now keeps a representative row per
+  group — the first source row, snapshotted when the group is created — and the
+  Phase-2 fake row is built from it (via `build_group_fake_row`) with the
+  canonical key-column values overlaid on top, so a bare column resolves to a
+  value while a collated key still reports its original text. Both engines scan
+  an in-memory table in rowid order, so "first row of the group" is
+  deterministic. (The min/max-follows refinement — bare columns tracking the row
+  that holds a `min()`/`max()` — needs an aggregate present, which the projection
+  path does not yet combine with bare columns; a separate ledgered gap.)
+
 ## [0.4.34] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.34"
+version = "0.4.35"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -265,8 +265,20 @@ pub fn execute(program: &Program, backend: &mut dyn Backend) -> Result<QueryResu
     // deterministic (matches the scan order, i.e. the order of first
     // occurrence of each distinct group value in the table).
     let mut group_mode = false;
-    // Canonical string key → (original SqlValue list for the key columns, accumulators)
-    let mut group_data: HashMap<String, (Vec<SqlValue>, Vec<AggAccumulator>)> = HashMap::new();
+    // Canonical string key → (key-column values, accumulators, representative row).
+    //
+    // The representative row is the FIRST source row of the group, captured when
+    // the group is created. It lets a BARE non-key column (one that is neither a
+    // GROUP BY key nor inside an aggregate — e.g. `SELECT c FROM t GROUP BY x`)
+    // report a value instead of NULL, matching SQLite, which reports such a
+    // column from the group's first row. (The min/max-follows refinement — where
+    // bare columns track the row holding a min()/max() — needs an aggregate
+    // present, which the current projection path does not yet combine with bare
+    // columns; that is a separate ledgered gap.)
+    let mut group_data: HashMap<String, (Vec<SqlValue>, Vec<AggAccumulator>, Row)> = HashMap::new();
+    // Cumulative bytes of all stored representative rows, for the memory guard
+    // below (the group-COUNT cap alone doesn't bound bytes on a wide table).
+    let mut repr_bytes_total: usize = 0;
     let mut group_key_order: Vec<String> = Vec::new(); // insertion-order of distinct keys
     let mut current_group_key: String = String::new(); // set by SaveGroupKey each row
     // Names of the group-by columns (set by first SaveGroupKey call).
@@ -550,12 +562,9 @@ pub fn execute(program: &Program, backend: &mut dyn Backend) -> Result<QueryResu
                     group_mode = false; // disable so FinalizeAgg/LoadColumn run normally
                     // Load first group's data.
                     let key_str = group_key_order[0].clone();
-                    if let Some((key_vals, group_accs)) = group_data.get(&key_str) {
+                    if let Some((key_vals, group_accs, repr_row)) = group_data.get(&key_str) {
                         agg_accs = group_accs.clone();
-                        let mut fake_row: Row = Row::default();
-                        for (col_name, val) in group_col_names.iter().zip(key_vals.iter()) {
-                            fake_row.insert(col_name.clone(), val.clone());
-                        }
+                        let fake_row = build_group_fake_row(repr_row, &group_col_names, key_vals);
                         current_row.insert(alias, fake_row);
                     }
                 }
@@ -588,13 +597,11 @@ pub fn execute(program: &Program, backend: &mut dyn Backend) -> Result<QueryResu
                         // Load the next group's data so that LoadColumn /
                         // FinalizeAgg operate on the correct group.
                         let key_str = group_key_order[group_iter_idx].clone();
-                        if let Some((key_vals, group_accs)) = group_data.get(&key_str) {
+                        if let Some((key_vals, group_accs, repr_row)) = group_data.get(&key_str) {
                             agg_accs = group_accs.clone();
-                            // Repopulate current_row[None] with this group's key values.
-                            let mut fake_row: Row = Row::default();
-                            for (col_name, val) in group_col_names.iter().zip(key_vals.iter()) {
-                                fake_row.insert(col_name.clone(), val.clone());
-                            }
+                            // Repopulate current_row[None] with this group's key
+                            // values over its representative row.
+                            let fake_row = build_group_fake_row(repr_row, &group_col_names, key_vals);
                             // Use None as the cursor alias (no-alias scans store under None).
                             current_row.insert(None, fake_row);
                         }
@@ -664,7 +671,7 @@ pub fn execute(program: &Program, backend: &mut dyn Backend) -> Result<QueryResu
             Instruction::UpdateAgg(idx, fn_tag) => {
                 if group_mode {
                     // GROUP BY mode: update the accumulator for the current group.
-                    let (_, group_accs) = group_data
+                    let (_, group_accs, _) = group_data
                         .get_mut(&current_group_key)
                         .ok_or(VmError::AggIndexOutOfRange(idx))?;
                     if fn_tag == AggFn::CountStar {
@@ -771,7 +778,33 @@ pub fn execute(program: &Program, backend: &mut dyn Backend) -> Result<QueryResu
                     let fresh_accs = (0..num_agg_slots)
                         .map(|_| AggAccumulator { acc: None, count: 0, distinct_vals: None })
                         .collect();
-                    group_data.insert(key_str, (key_vals, fresh_accs));
+                    // Snapshot the group's FIRST row (the un-aliased cursor row)
+                    // as its representative, for bare non-key column projection —
+                    // but ONLY when the query has no aggregate columns. Bare
+                    // columns are projected solely on the no-aggregate GROUP BY
+                    // path; an aggregate query emits only keys + aggregates and
+                    // never reads a bare column from the fake row, so cloning full
+                    // rows there would be pure memory overhead.
+                    let repr_row = if num_agg_slots == 0 {
+                        let r = current_row.get(&None).cloned().unwrap_or_default();
+                        // DoS guard: `MAX_GROUP_KEYS` caps the NUMBER of groups but
+                        // not the BYTES retained. A wide table (many/large TEXT or
+                        // BLOB columns) with a high-cardinality key could hold far
+                        // more than the count implies. Cap cumulative representative
+                        // bytes at SQLite's default `SQLITE_MAX_LENGTH` order (~1 GB).
+                        const MAX_REPR_BYTES: usize = 1_000_000_000;
+                        repr_bytes_total = repr_bytes_total.saturating_add(row_bytes(&r));
+                        if repr_bytes_total > MAX_REPR_BYTES {
+                            return Err(VmError::ResourceLimit(format!(
+                                "GROUP BY representative rows exceeded maximum size ({} bytes)",
+                                MAX_REPR_BYTES
+                            )));
+                        }
+                        r
+                    } else {
+                        Row::default()
+                    };
+                    group_data.insert(key_str, (key_vals, fresh_accs, repr_row));
                 }
             }
 
@@ -822,12 +855,9 @@ pub fn execute(program: &Program, backend: &mut dyn Backend) -> Result<QueryResu
                         if group_iter_idx < group_key_order.len() {
                             // Load the next group's data.
                             let key_str = group_key_order[group_iter_idx].clone();
-                            if let Some((key_vals, group_accs)) = group_data.get(&key_str) {
+                            if let Some((key_vals, group_accs, repr_row)) = group_data.get(&key_str) {
                                 agg_accs = group_accs.clone();
-                                let mut fake_row: Row = Row::default();
-                                for (col_name, val) in group_col_names.iter().zip(key_vals.iter()) {
-                                    fake_row.insert(col_name.clone(), val.clone());
-                                }
+                                let fake_row = build_group_fake_row(repr_row, &group_col_names, key_vals);
                                 current_row.insert(None, fake_row);
                             }
                             // Clear row_buffer so that pre-BeginRow EmitColumn accumulations
@@ -3183,6 +3213,41 @@ fn parse_real_prefix(s: &str) -> f64 {
         }
     }
     t[..i].parse::<f64>().unwrap_or(0.0)
+}
+
+/// Approximate retained size of a `SqlValue`, in bytes, for the GROUP BY
+/// representative-row memory guard. Fixed-size scalars are counted at their
+/// storage width; TEXT/BLOB at their payload length (the dominant term).
+fn sql_value_bytes(v: &SqlValue) -> usize {
+    match v {
+        SqlValue::Null | SqlValue::Bool(_) => 1,
+        SqlValue::Int(_) | SqlValue::Float(_) => 8,
+        SqlValue::Text(s) => s.len(),
+        SqlValue::Blob(b) => b.len(),
+    }
+}
+
+/// Approximate retained size of a `Row` (column names + values), in bytes.
+fn row_bytes(row: &Row) -> usize {
+    row.iter().map(|(k, v)| k.len() + sql_value_bytes(v)).sum()
+}
+
+/// Build the "fake row" that Phase-2 GROUP BY emission reads columns from for one
+/// group. It starts from the group's representative (first) row — so a BARE
+/// non-key column (`SELECT c FROM t GROUP BY x`) resolves to a value rather than
+/// NULL, matching SQLite — then overlays the canonical key-column values on top.
+///
+/// The overlay matters for a collated key: the group is keyed case-insensitively
+/// but must REPORT its original text, and `key_vals` already holds the first
+/// row's original text for the key column (the representative row's value for that
+/// same column is identical here, so the overlay is a no-op for a plain key, but
+/// it keeps the two paths consistent and self-documenting).
+fn build_group_fake_row(repr_row: &Row, group_col_names: &[String], key_vals: &[SqlValue]) -> Row {
+    let mut fake_row = repr_row.clone();
+    for (col_name, val) in group_col_names.iter().zip(key_vals.iter()) {
+        fake_row.insert(col_name.clone(), val.clone());
+    }
+    fake_row
 }
 
 // ===========================================================================


### PR DESCRIPTION
The second of the two bugs the collation cluster uncovered — a bare non-key column in a GROUP BY now returns a value instead of NULL.

## What

`SELECT c FROM t GROUP BY x`, where `c` is neither a GROUP BY key nor inside an aggregate, returned NULL. SQLite reports such a bare column from the group's **first row**. The VM now retains a representative row per group (the first source row) and projects bare columns from it. Retires the `distinct_over_group_by_single_col` ledger entry.

Deterministic because both engines scan an in-memory table in rowid order, so "first row of the group" agrees. Verified against real `sqlite3` with a multi-row group (`SELECT g, v, tag GROUP BY g` → `v=10, tag='a'`, the first row) and a functionally-dependent bare column.

**Scope:** the no-aggregate GROUP BY path only. The min/max-follows refinement (bare columns tracking a `min()`/`max()` row) needs an aggregate combined with bare columns — a separate ledgered gap.

## Security review found and I fixed a real DoS

Naively storing a full representative `Row` per group turned the count-only group cap (`MAX_GROUP_KEYS` = 1M) into a **byte-unbounded** one on wide, high-cardinality tables — and paid the clone even for aggregate queries that never read a bare column. Fixed two ways:

- **capture only when `num_agg_slots == 0`** — bare-column projection happens only on the no-aggregate path, so aggregate queries store nothing extra and behave byte-for-byte as on main (bare column reads NULL — no regression; the re-review confirmed this specifically);
- **byte-aware cap** — cumulative representative-row bytes (new `row_bytes`/`sql_value_bytes`) capped at ~1 GB, returning `ResourceLimit` past it.

The inline re-review confirmed the fix resolves the finding with no new panic/overflow surface (`saturating_add`; exhaustive match over `SqlValue`).

## Tests

3 differential-oracle cases (retired case + multi-row-first-row + functionally-dependent) against bundled real SQLite. sql-vm 114, all mini-sqlite suites green; clippy clean.

Bumps: sql-vm 0.4.34→0.4.35, mini-sqlite 0.5.60→0.5.61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
