### PR TITLE
feat(adj-formula-stdlib): powers library — square/cube compose the cited product

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/fl4_powers_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/fl4_powers_e2e.rs
@@ -1,0 +1,152 @@
+//! End-to-end tests for ADJ-FORMULA-LIBRARIES FL-4 — the `powers.adj`
+//! elementary library — driven through the built CLI binary against the SHIPPED
+//! stdlib. Each proves the FL-4 invariant: the library COMPOSES the cited
+//! `product` primitive from `arithmetic.adj` (it re-derives no arithmetic),
+//! computes the exact value on the CPU, and carries BOTH its own citation and
+//! the `product` primitive's as a corroboration. `cube` additionally proves the
+//! RS-1 nesting case — one `product` feeding another — bottoming out at a single
+//! observed base.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib")
+        .canonicalize()
+        .expect("shipped adj-formula-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_fl4pow_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy a shipped `.adj` file (by relative path under the stdlib) into `dir`
+/// under its basename, so a consumer's relative `import` resolves.
+fn place(dir: &Path, rel: &str) {
+    let src = stdlib().join(rel);
+    let name = Path::new(rel).file_name().unwrap();
+    std::fs::copy(&src, dir.join(name)).unwrap_or_else(|e| panic!("copy {rel}: {e}"));
+}
+
+fn with_lib(dir: &Path) {
+    place(dir, "arithmetic/arithmetic.adj");
+    place(dir, "arithmetic/powers.adj");
+}
+
+// ---------------------------------------------------------------------------
+// square — a base multiplied by itself, composing product.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn square_composes_product_and_carries_both_citations() {
+    let dir = scratch("square");
+    with_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"powers.adj\"\n\
+         observe base(5)\n\
+         ? square(base)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 5 * 5 = 25, via the product primitive on the CPU.
+    assert!(
+        s.contains("\"name\":\"square\"") && s.contains("\"value\":25"),
+        "square(5) = 25: {s}"
+    );
+    // BOTH citations: square's own definition (primary) AND the product
+    // primitive it composed (corroboration).
+    assert!(
+        s.contains("mathworld.wolfram.com/Square.html"),
+        "primary cites the square definition: {s}"
+    );
+    assert!(
+        s.contains("mathworld.wolfram.com/Product.html"),
+        "corroboration cites the product primitive it composed: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// cube — a base multiplied by itself twice: product nested inside product.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cube_nests_product_inside_product() {
+    let dir = scratch("cube");
+    with_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"powers.adj\"\n\
+         observe base(3)\n\
+         ? cube(base)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (3 * 3) * 3 = 27, composing product twice.
+    assert!(
+        s.contains("\"name\":\"cube\"") && s.contains("\"value\":27"),
+        "cube(3) = 27: {s}"
+    );
+    assert!(
+        s.contains("mathworld.wolfram.com/Cube.html"),
+        "primary cites the cube definition: {s}"
+    );
+    assert!(
+        s.contains("mathworld.wolfram.com/Product.html"),
+        "corroboration cites the product primitive it composed: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The exact value is a rational, and the trace bottoms out at the observed base
+// through a chain of multiplications — no model arithmetic.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_derivation_tree_names_the_product_op_and_the_observed_base() {
+    let dir = scratch("tree");
+    with_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"powers.adj\"\n\
+         observe base(4)\n\
+         ? square(base)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    // 4 * 4 = 16, exact, and the trace shows the multiplication over the single
+    // observed base used twice — reconstructable operand by operand.
+    assert!(s.contains("\"value\":16"), "square(4) = 16: {s}");
+    assert!(
+        s.contains("\"num\":\"16\"") && s.contains("\"den\":\"1\""),
+        "the exact value is 16/1, not a lossy decimal: {s}"
+    );
+    assert!(
+        s.contains("\"node\":\"op\"") && s.contains("\"op\":\"*\""),
+        "the derivation names the product op: {s}"
+    );
+    assert!(
+        s.contains("\"slot\":\"base\""),
+        "the leaves name the observed base the value was built from: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/arithmetic/powers.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/powers.adj
@@ -1,0 +1,74 @@
+% ============================================================================
+% powers.adj — the elementary powers formula library (ADJ-FORMULA-LIBRARIES FL-4).
+% ============================================================================
+% The "raise to a small whole power" track of the compute standard library,
+% built ENTIRELY by composing the cited `product` primitive of `arithmetic.adj`
+% — it re-derives no arithmetic. A square is a number times itself; a cube is a
+% number times itself twice. Where `average.adj` nests the cited `sum`, this
+% nests the cited `product`: `cube` APPLIES `product` to the result of another
+% `product`, so the audit trail reads as a chain of multiplications bottoming out
+% at one observed quantity. Write-once-use-many: a consumer imports this file,
+% binds the base from its own byte-provenance decomposition, and asks the engine
+% to apply the cited formula on the CPU — the model performs zero arithmetic.
+%
+%     import "powers.adj"                     % transitively imports arithmetic.adj
+%     observe base(5)                         % "…a side of 5…"  (span cited by the model)
+%     ? square(base)                          % engine → 25, carrying every citation
+%
+% The engine expands `square` → `product` (from arithmetic.adj) on the CPU and
+% composes the provenance chain, so the answer cites BOTH the square definition
+% (primary) and the `product` primitive it builds on (corroboration). The audit
+% trail names every formula that participated.
+%
+% Note: `adj-lang` formula bodies compose the four leaf operators (+ − × ÷); the
+% `^` operator is NOT a body token, so a power is expressed as REPEATED
+% multiplication through the cited `product`, not as an exponent. Fractional and
+% symbolic powers (e.g. square roots) belong to a later rung that wires the
+% engine's `Pow` op into the surface — they are deliberately out of scope here.
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% This library depends on a single elementary primitive — `product`. The import
+% is RELATIVE to this file, so a consumer that imports `powers.adj` gets
+% `product` (and its siblings) transitively and the bodies below resolve.
+% ----------------------------------------------------------------------------
+import "arithmetic.adj"
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `square` and `cube` each range over a single base quantity. Rung-0
+% types an observable slot as `finding`; the `surface` synonyms let a decomposer
+% map everyday phrasing ("squared", "to the power of two", "cubed") onto the
+% canonical terms.
+% ----------------------------------------------------------------------------
+dictionary powers_vocab {
+    define base   : finding  surface "base", "number", "value", "the quantity"
+    define square : finding  surface "square", "squared", "second power", "to the power of two"
+    define cube   : finding  surface "cube", "cubed", "third power", "to the power of three"
+}
+
+% ----------------------------------------------------------------------------
+% The composed formulas. Neither writes a bare `*`: each APPLIES the cited
+% `product` primitive from `arithmetic.adj`, so the power is what it is BECAUSE
+% of the multiplication it composes, cited as such. `cube` nests `product` inside
+% `product` — the RS-1 composition core, one primitive feeding another.
+%
+%   square(base)  = base × base
+%   cube(base)    = (base × base) × base
+% ----------------------------------------------------------------------------
+formulabook powers {
+    use powers_vocab
+
+    % The square — the base multiplied by itself. Composes `product`: the square
+    % of 5 is 5 × 5 = 25.
+    formula square(base) = product(base, base)
+        source "The square of a number is that number multiplied by itself; the square of x is x^2 = x times x."
+        locator "https://mathworld.wolfram.com/Square.html"
+        trust authoritative
+
+    % The cube — the base multiplied by itself twice. Nests `product` inside
+    % `product`: the cube of 3 is (3 × 3) × 3 = 27.
+    formula cube(base) = product(product(base, base), base)
+        source "The cube of a number is that number raised to the third power; the cube of x is x^3 = x times x times x."
+        locator "https://mathworld.wolfram.com/Cube.html"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/arithmetic/powers.query.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/powers.query.adj
@@ -1,0 +1,17 @@
+% ============================================================================
+% powers.query.adj — a worked example of the powers formula library.
+% ============================================================================
+% Run against the shipped stdlib:
+%
+%   adj-lang-cli powers.query.adj
+%
+% "The area of a square tile with a 5-cm side" → 5 × 5 = 25, computed on the CPU
+% by composing the cited `product` primitive from arithmetic.adj. The answer
+% carries BOTH the square definition (primary) and the product primitive it built
+% on (corroboration) — the model performs zero arithmetic.
+% ============================================================================
+import "powers.adj"
+
+observe base(5)
+
+? square(base)


### PR DESCRIPTION
## Powers formula library (Libraries front)

Adds the **"raise to a small whole power"** track to the arithmetic formula stdlib, built entirely by composing the cited `product` primitive of `arithmetic.adj` — it re-derives no arithmetic:

```
import "powers.adj"
observe base(5)
? square(base)          % engine → 25, citing Square (primary) + Product (corroboration)
```

```
square(base) = product(base, base)
cube(base)   = product(product(base, base), base)   % product nested in product
```

`cube` exercises the RS-1 nesting case — one `product` feeding another — so the audit trail reads as a chain of multiplications bottoming out at a **single** observed base, and the answer carries both the power definition (primary, MathWorld) and the `product` primitive it composed (corroboration). Write-once-use-many all the way down.

### Scope note
adj-lang formula bodies compose the four leaf operators (`+ − × ÷`); `^` is **not** a body token (verified — the lexer rejects `^`), so a power is expressed as **repeated multiplication** through the cited `product`, not an exponent. Fractional/symbolic powers (square roots) are deliberately deferred to a later rung that wires the engine's `Pow` op into the surface.

### Ships
- `arithmetic/powers.adj` — the library (`square`, `cube`).
- `arithmetic/powers.query.adj` — a worked example (area of a square tile).
- `adj-lang-cli/tests/fl4_powers_e2e.rs` — 3 e2e tests through the built CLI against the shipped stdlib: `square(5)=25` with both citations; `cube(3)=27` with the nested product; and the exact-rational derivation tree naming the `*` op over the observed base.

Pure data + test — no crate code changes, no version bump. Independent of the RS-4 D4a PR (#8779).

### Verification
- `cargo test -p adj-lang-cli --test fl4_powers_e2e` → 3 passed, 0 failed.
- Manually driven through the CLI: `square(5)=25`, `cube(3)=27`, exact rationals, composed citations.
- Security review passed (1 round): additive data + a test that spawns the CLI on process-scoped temp files; no attacker-reachable surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)