### PR TITLE
feat(spice): add BJT base-collector leakage

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **BJT base-collector leakage** — BJT model cards now accept `ISC`/`NC` and
+  apply the leakage branch in DC, transient, AC, transfer-function,
+  temperature, and noise paths, matching Rust and TypeScript. The
+  supported-parameter catalog now contains 104 canonical rows.
+
 - **BJT base-emitter leakage** — BJT model cards now accept `ISE`/`NE` and
   apply the leakage branch in DC, transient, AC, transfer-function,
   temperature, and noise paths, matching Rust and TypeScript. The

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -226,6 +226,9 @@ high-current base-charge modulation to collector transport and small-signal
 transconductance. `ISE` (default `0`, disabled) and `NE` (default `1`) add the
 Berkeley base-emitter leakage branch to DC/transient base current,
 small-signal input conductance, and shot noise.
+`ISC` (default `0`, disabled) and `NC` (default `2`) add the mirrored Berkeley
+base-collector leakage branch to DC/transient current, small-signal
+base-collector conductance, and shot noise.
 `model_card_unsupported_parameter_issues()`,
 `format_model_card_unsupported_parameter_issue_table()`,
 `model_card_unsupported_parameter_issue_records()`,
@@ -251,7 +254,7 @@ catalog by model kind for compact release dashboards and Mosaic UI inventories.
 `model_card_supported_parameter_coverage_gate_issue_records()`,
 `format_model_card_supported_parameter_coverage_gate_issue_csv()`, and
 `format_model_card_supported_parameter_coverage_gate_issue_json()` validate the
-expected seven-kind, 100-row supported-parameter catalog and expose stable issue
+expected seven-kind, 104-row supported-parameter catalog and expose stable issue
 rows for release automation.
 `model_card_supported_parameter_coverage_dashboard()`,
 `format_model_card_supported_parameter_coverage_dashboard_table()`,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -631,6 +631,8 @@ class BJT:
     Ikf: float = 0.0        # forward-beta roll-off current (A); 0 disables
     Ise: float = 0.0        # base-emitter leakage saturation current (A)
     Ne: float = 1.0         # base-emitter leakage emission coefficient
+    Isc: float = 0.0        # base-collector leakage saturation current (A)
+    Nc: float = 2.0         # base-collector leakage emission coefficient
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -358,6 +358,7 @@ def bjt_at_temperature(
         bjt,
         Is=bjt.Is * saturation_scale,
         Ise=bjt.Ise * saturation_scale,
+        Isc=bjt.Isc * saturation_scale,
         Vt=bjt.Vt * ratio,
     )
 
@@ -597,7 +598,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -9052,6 +9053,15 @@ def _bjt_base_emitter_leakage(el: BJT, junction_voltage: float) -> tuple[float, 
     return el.Ise * (exp_value - 1.0), el.Ise / thermal_voltage * exp_value
 
 
+def _bjt_base_collector_leakage(el: BJT, junction_voltage: float) -> tuple[float, float]:
+    if el.Isc == 0.0:
+        return 0.0, 0.0
+    thermal_voltage = el.Vt * el.Nc
+    exponent = max(-40.0, min(40.0, junction_voltage / thermal_voltage))
+    exp_value = math.exp(exponent)
+    return el.Isc * (exp_value - 1.0), el.Isc / thermal_voltage * exp_value
+
+
 def _stamp_bjt(
     G: list[list[float]],
     b: list[float],
@@ -9126,6 +9136,7 @@ def _stamp_bjt(
 
     # --- Controlling junction voltage (clamped to avoid exp overflow) --------
     Vjunc = min(Vb - Ve, 0.7) if el.polarity == "NPN" else min(Ve - Vb, 0.7)
+    Vreverse = Vb - Vc if el.polarity == "NPN" else Vc - Vb
 
     forward_thermal_voltage = el.Vt * el.Nf
     exp_term = math.exp(Vjunc / forward_thermal_voltage)
@@ -9145,8 +9156,15 @@ def _stamp_bjt(
 
     Ieq_junc = Ib0 - g_pi * Vjunc      # junction Norton offset
     Ieq_coll = Ic0 - gm * Vjunc - output_conductance * output_voltage
+    collector_leakage_current, collector_leakage_conductance = (
+        _bjt_base_collector_leakage(el, Vreverse)
+    )
+    Ieq_collector_leakage = (
+        collector_leakage_current - collector_leakage_conductance * Vreverse
+    )
 
     _stamp_g(G, node_to_idx, el.collector, el.emitter, output_conductance)
+    _stamp_g(G, node_to_idx, el.base, el.collector, collector_leakage_conductance)
 
     if el.polarity == "NPN":
         # --- Junction stamp: gπ between B and E ------------------------------
@@ -9174,6 +9192,10 @@ def _stamp_bjt(
             b[node_to_idx[el.collector]] -= Ieq_coll
         if not _is_ground(el.emitter):
             b[node_to_idx[el.emitter]] += Ieq_coll
+        if not _is_ground(el.base):
+            b[node_to_idx[el.base]] -= Ieq_collector_leakage
+        if not _is_ground(el.collector):
+            b[node_to_idx[el.collector]] += Ieq_collector_leakage
 
     else:
         # PNP: Vjunc = Ve - Vb; emitter injects, collector collects.
@@ -9202,6 +9224,10 @@ def _stamp_bjt(
             b[node_to_idx[el.emitter]] -= Ieq_coll
         if not _is_ground(el.collector):
             b[node_to_idx[el.collector]] += Ieq_coll
+        if not _is_ground(el.collector):
+            b[node_to_idx[el.collector]] -= Ieq_collector_leakage
+        if not _is_ground(el.base):
+            b[node_to_idx[el.base]] += Ieq_collector_leakage
 
 
 def _validate_bjt(el: BJT) -> None:
@@ -9242,6 +9268,14 @@ def _validate_bjt(el: BJT) -> None:
     if not math.isfinite(el.Ne) or el.Ne <= 0.0:
         raise ValueError(
             f"{el.name}: BJT base-emitter leakage emission coefficient must be finite and positive"
+        )
+    if not math.isfinite(el.Isc) or el.Isc < 0.0:
+        raise ValueError(
+            f"{el.name}: BJT base-collector leakage saturation current must be finite and non-negative"
+        )
+    if not math.isfinite(el.Nc) or el.Nc <= 0.0:
+        raise ValueError(
+            f"{el.name}: BJT base-collector leakage emission coefficient must be finite and positive"
         )
     if not math.isfinite(el.Nf) or el.Nf <= 0.0:
         raise ValueError(f"{el.name}: BJT forward emission coefficient must be finite and positive")
@@ -12475,6 +12509,10 @@ def _stamp_ac(
             min(Vb_dc - Vc_dc, 0.7) if el.polarity == "NPN"
             else min(Vc_dc - Vb_dc, 0.7)
         )
+        Vcollector_leakage = (
+            Vb_dc - Vc_dc if el.polarity == "NPN"
+            else Vc_dc - Vb_dc
+        )
         forward_thermal_voltage = el.Vt * el.Nf
         reverse_thermal_voltage = el.Vt * el.Nr
         exp_t = math.exp(Vjunc / forward_thermal_voltage)
@@ -12491,13 +12529,16 @@ def _stamp_ac(
         )
         gm_reverse: float = (el.Is / reverse_thermal_voltage) * exp_reverse
         _, leakage_conductance = _bjt_base_emitter_leakage(el, Vjunc)
+        _, collector_leakage_conductance = _bjt_base_collector_leakage(
+            el, Vcollector_leakage
+        )
         g_pi: float = base_gm / el.beta_f + leakage_conductance
         diffusion_capacitance = el.Tf * gm_b
         reverse_diffusion_capacitance = el.Tr * gm_reverse
         y_be = g_pi + 1j * omega * (
             _bjt_base_emitter_depletion_capacitance(el, Vjunc) + diffusion_capacitance
         )
-        y_bc = 1j * omega * (
+        y_bc = collector_leakage_conductance + 1j * omega * (
             _bjt_base_collector_depletion_capacitance(el, Vreverse)
             + reverse_diffusion_capacitance
         )
@@ -13099,6 +13140,7 @@ def _build_ss_matrix(
                 min(Vb_dc - Ve_dc, 0.7) if el.polarity == "NPN"
                 else min(Ve_dc - Vb_dc, 0.7)
             )
+            Vreverse = Vb_dc - Vc_dc if el.polarity == "NPN" else Vc_dc - Vb_dc
             forward_thermal_voltage = el.Vt * el.Nf
             exp_t = math.exp(Vjunc / forward_thermal_voltage)
             base_collector_current = el.Is * (exp_t - 1.0)
@@ -13112,8 +13154,10 @@ def _build_ss_matrix(
                 0.0 if el.Vaf == 0.0 else base_collector_current / el.Vaf / charge_factor
             )
             _, leakage_conductance = _bjt_base_emitter_leakage(el, Vjunc)
+            _, collector_leakage_conductance = _bjt_base_collector_leakage(el, Vreverse)
             g_pi: float = base_gm / el.beta_f + leakage_conductance
             _stamp_g(G, node_to_idx, el.collector, el.emitter, output_conductance)
+            _stamp_g(G, node_to_idx, el.base, el.collector, collector_leakage_conductance)
 
             if el.polarity == "NPN":
                 _stamp_g(G, node_to_idx, el.base, el.emitter, g_pi)
@@ -13995,6 +14039,8 @@ def sens_dc(
                     Ikf=el.Ikf,
                     Ise=el.Ise,
                     Ne=el.Ne,
+                    Isc=el.Isc,
+                    Nc=el.Nc,
                     Nf=el.Nf,
                     Nr=el.Nr,
                     Vje=el.Vje,
@@ -14025,6 +14071,8 @@ def sens_dc(
                     Ikf=el.Ikf,
                     Ise=el.Ise,
                     Ne=el.Ne,
+                    Isc=el.Isc,
+                    Nc=el.Nc,
                     Nf=el.Nf,
                     Nr=el.Nr,
                     Vje=el.Vje,
@@ -14265,6 +14313,8 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             Ikf=el.Ikf,
             Ise=el.Ise,
             Ne=el.Ne,
+            Isc=el.Isc,
+            Nc=el.Nc,
             Nf=el.Nf,
             Nr=el.Nr,
             Vje=el.Vje,
@@ -14712,6 +14762,7 @@ def _collect_noise_sources(
                 Vb - Ve if el.polarity == "NPN"
                 else Ve - Vb
             )
+            Vreverse = Vb - Vc if el.polarity == "NPN" else Vc - Vb
             output_voltage = Vc - Ve if el.polarity == "NPN" else Ve - Vc
             early_factor = _bjt_early_factor(el, Vjunc, output_voltage)
             exp_value = math.exp(Vjunc / (el.Vt * el.Nf))
@@ -14721,7 +14772,8 @@ def _collect_noise_sources(
                 el, base_collector_current, base_gm, early_factor
             )
             leakage_current, _ = _bjt_base_emitter_leakage(el, Vjunc)
-            psd = q2 * (abs(I_C) + abs(leakage_current))
+            collector_leakage_current, _ = _bjt_base_collector_leakage(el, Vreverse)
+            psd = q2 * (abs(I_C) + abs(leakage_current) + abs(collector_leakage_current))
             n_b = None if _is_ground(el.base) else node_to_idx[el.base]
             n_e = None if _is_ground(el.emitter) else node_to_idx[el.emitter]
             sources.append((el.name, "shot", n_b, n_e, psd))

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (21, 36, 11, 4),
-    "PNP": (21, 36, 11, 4),
+    "NPN": (23, 38, 11, 4),
+    "PNP": (23, 38, 11, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -380,6 +380,8 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "IK": "IKF",
     "ISE": "ISE",
     "NE": "NE",
+    "ISC": "ISC",
+    "NC": "NC",
     "NF": "NF",
     "NR": "NR",
     "VJE": "VJE",
@@ -929,6 +931,8 @@ def bjt_from_model_card(
         Ikf=p.get("IKF", 0.0),
         Ise=p.get("ISE", 0.0),
         Ne=p.get("NE", 1.0),
+        Isc=p.get("ISC", 0.0),
+        Nc=p.get("NC", 2.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 100
+    assert len(coverage) == 104
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 100
+    assert len(records) == 104
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,9 +501,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 100
-    assert report.expected_canonical_parameter_count == 100
-    assert report.accepted_name_count == 162
+    assert report.canonical_parameter_count == 104
+    assert report.expected_canonical_parameter_count == 104
+    assert report.accepted_name_count == 166
     assert report.aliased_parameter_count == 49
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -511,7 +511,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t100\t100\t162\t49\t4\t0"
+        "true\t7\t7\t104\t104\t166\t49\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,8 +539,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 99
-    assert report.accepted_name_count == 159
+    assert report.canonical_parameter_count == 103
+    assert report.accepted_name_count == 163
     assert report.aliased_parameter_count == 48
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t99\t100\t159\t48\t4\t4\n"
+        "false\t7\t7\t103\t104\t163\t48\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,10 +647,10 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "ISE": 3.0e-13, "NE": 1.7, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
+        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "ISE": 3.0e-13, "NE": 1.7, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
+    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.Cje == pytest.approx(2.0e-12)
@@ -661,6 +661,8 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert bjt_model.Ikf == pytest.approx(2.0e-3)
     assert bjt_model.Ise == pytest.approx(3.0e-13)
     assert bjt_model.Ne == pytest.approx(1.7)
+    assert bjt_model.Isc == pytest.approx(4.0e-13)
+    assert bjt_model.Nc == pytest.approx(1.8)
     assert bjt_model.Nf == pytest.approx(1.2)
     assert bjt_model.Nr == pytest.approx(1.3)
     assert bjt_model.Vje == pytest.approx(0.8)
@@ -2298,7 +2300,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2319,6 +2321,8 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.Ikf == pytest.approx(2.0e-3)
     assert expanded.Ise == pytest.approx(3.0e-13)
     assert expanded.Ne == pytest.approx(1.7)
+    assert expanded.Isc == pytest.approx(4.0e-13)
+    assert expanded.Nc == pytest.approx(1.8)
 
 
 def test_branch_current_in_voltage_source():
@@ -2544,6 +2548,12 @@ def test_bjt_temperature_scales_base_emitter_leakage_saturation_current():
     assert hot.Ise > transistor.Ise
 
 
+def test_bjt_temperature_scales_base_collector_leakage_saturation_current():
+    transistor = BJT("Q1", "c", "b", "e", Isc=2.0e-13)
+    hot = bjt_at_temperature(transistor, 350.0)
+    assert hot.Isc > transistor.Isc
+
+
 def test_bjt_temperature_scaling_uses_model_energy_gap():
     silicon = Circuit()
     silicon.add(BJT("Qsilicon", "c", "b", "e", Eg=1.11))
@@ -2643,6 +2653,28 @@ def test_dc_rejects_invalid_bjt_base_emitter_leakage_parameters():
     circuit = Circuit()
     circuit.add(BJT("Qbad", "c", "b", "0", Ne=0.0))
     with pytest.raises(ValueError, match="base-emitter leakage emission coefficient"):
+        dc_op(circuit)
+
+
+def test_bjt_base_collector_leakage_increases_base_current():
+    def base_current(isc: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vbase", "base", "0", 0.65))
+        circuit.add(BJT("Q1", "0", "base", "base", Isc=isc, Nc=1.5))
+        return abs(dc_op(circuit).branch_currents["I(Vbase)"])
+
+    assert base_current(1.0e-10) > base_current(0.0)
+
+
+def test_dc_rejects_invalid_bjt_base_collector_leakage_parameters():
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", Isc=-1.0))
+    with pytest.raises(ValueError, match="base-collector leakage saturation current"):
+        dc_op(circuit)
+
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", Nc=0.0))
+    with pytest.raises(ValueError, match="base-collector leakage emission coefficient"):
         dc_op(circuit)
 
 
@@ -4360,6 +4392,20 @@ def test_ac_bjt_base_emitter_leakage_reduces_gain_through_source_resistance():
     assert gain(1.0e-10) < gain(0.0)
 
 
+def test_ac_bjt_base_collector_leakage_loads_source_resistance():
+    def amplitude(isc: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vin", "in", "0", 0.65, ac=AcSource(1.0)))
+        circuit.add(Resistor("Rin", "in", "base", 1_000.0))
+        circuit.add(BJT("Q1", "0", "base", "base", Isc=isc, Nc=1.5))
+        point = ac_sweep(
+            circuit, f_start=1_000.0, f_stop=1_000.0, n_points=1, sweep="lin"
+        ).points[0]
+        return abs(point.node_voltages["base"])
+
+    assert amplitude(1.0e-10) < amplitude(0.0)
+
+
 def test_ac_bjt_base_emitter_depletion_capacitance_falls_with_reverse_bias():
     """BJT Vje/Mje shape Cje under reverse base-emitter bias."""
     def base_amplitude(mje: float) -> float:
@@ -4862,6 +4908,16 @@ def test_tf_bjt_base_emitter_leakage_reduces_input_impedance():
         circuit.add(Resistor("Rload", "out", "0", 1_000.0))
         circuit.add(BJT("Q1", "out", "base", "0", Ise=ise, Ne=1.5))
         return tf(circuit, output_node="out", input_source="Vin").input_impedance
+
+    assert input_impedance(1.0e-10) < input_impedance(0.0)
+
+
+def test_tf_bjt_base_collector_leakage_reduces_input_impedance():
+    def input_impedance(isc: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vin", "base", "0", 0.65))
+        circuit.add(BJT("Q1", "0", "base", "base", Isc=isc, Nc=1.5))
+        return tf(circuit, output_node="base", input_source="Vin").input_impedance
 
     assert input_impedance(1.0e-10) < input_impedance(0.0)
 
@@ -6817,6 +6873,22 @@ def test_noise_bjt_base_emitter_leakage_increases_shot_noise() -> None:
         circuit.add(VoltageSource("Vbase", "base", "0", 0.65))
         circuit.add(Resistor("Rload", "out", "0", 1_000.0))
         circuit.add(BJT("Q1", "out", "base", "0", Ise=ise, Ne=1.5))
+        result = noise_ac(circuit, "out", "Vbase", freqs=[1_000.0])
+        return next(
+            entry.source_psd
+            for entry in result.points[0].entries
+            if entry.element_name == "Q1"
+        )
+
+    assert source_psd(1.0e-10) > source_psd(0.0)
+
+
+def test_noise_bjt_base_collector_leakage_increases_shot_noise() -> None:
+    def source_psd(isc: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vbase", "base", "0", 0.65))
+        circuit.add(Resistor("Rload", "out", "0", 1_000.0))
+        circuit.add(BJT("Q1", "out", "base", "base", Isc=isc, Nc=1.5))
         result = noise_ac(circuit, "out", "Vbase", freqs=[1_000.0])
         return next(
             entry.source_psd

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add BJT model-card `ISC`/`NC` base-collector leakage support in DC,
+  transient, AC, transfer-function, temperature, and noise paths, matching
+  Python and TypeScript. The supported-parameter catalog now contains 104
+  canonical rows.
 - Add BJT model-card `ISE`/`NE` base-emitter leakage support in DC, transient,
   AC, transfer-function, temperature, and noise paths, matching Python and
   TypeScript. The supported-parameter catalog now contains 100 canonical rows.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -143,6 +143,9 @@ high-current base-charge modulation to collector transport and small-signal
 transconductance. `ISE` (default `0`, disabled) and `NE` (default `1`) add the
 Berkeley base-emitter leakage branch to DC/transient base current,
 small-signal input conductance, and shot noise.
+`ISC` (default `0`, disabled) and `NC` (default `2`) add the mirrored Berkeley
+base-collector leakage branch to DC/transient current, small-signal
+base-collector conductance, and shot noise.
 `model_card_unsupported_parameter_issues`,
 `format_model_card_unsupported_parameter_issue_table`,
 `model_card_unsupported_parameter_issue_records`,
@@ -168,7 +171,7 @@ catalog by model kind for compact release dashboards and Mosaic UI inventories.
 `model_card_supported_parameter_coverage_gate_issue_records`,
 `format_model_card_supported_parameter_coverage_gate_issue_csv`, and
 `format_model_card_supported_parameter_coverage_gate_issue_json` validate the
-expected seven-kind, 100-row supported-parameter catalog and expose stable issue
+expected seven-kind, 104-row supported-parameter catalog and expose stable issue
 rows for release automation.
 `model_card_supported_parameter_coverage_dashboard`,
 `format_model_card_supported_parameter_coverage_dashboard_table`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -419,7 +419,7 @@ fn clone_subckt_element(
             element.gate_drain_capacitance,
         )),
         Element::Bjt(element) => Element::Bjt(
-            Bjt::with_model_temperature_depletion_early_rolloff_and_leakage_parameters(
+            Bjt::with_model_temperature_depletion_early_rolloff_and_junction_leakage_parameters(
                 format!("{instance_name}.{}", element.name),
                 map_subckt_node(&element.collector, instance_name, node_map),
                 map_subckt_node(&element.base, instance_name, node_map),
@@ -446,6 +446,8 @@ fn clone_subckt_element(
                 element.forward_beta_rolloff_current,
                 element.base_emitter_leakage_saturation_current,
                 element.base_emitter_leakage_emission_coefficient,
+                element.base_collector_leakage_saturation_current,
+                element.base_collector_leakage_emission_coefficient,
             ),
         ),
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
@@ -2675,6 +2677,7 @@ pub fn bjt_at_temperature(
     let mut adjusted = bjt.clone();
     adjusted.saturation_current *= saturation_scale;
     adjusted.base_emitter_leakage_saturation_current *= saturation_scale;
+    adjusted.base_collector_leakage_saturation_current *= saturation_scale;
     adjusted.thermal_voltage *= ratio;
     Ok(adjusted)
 }
@@ -2864,6 +2867,8 @@ pub struct Bjt {
     pub forward_beta_rolloff_current: f64,
     pub base_emitter_leakage_saturation_current: f64,
     pub base_emitter_leakage_emission_coefficient: f64,
+    pub base_collector_leakage_saturation_current: f64,
+    pub base_collector_leakage_emission_coefficient: f64,
 }
 
 impl Bjt {
@@ -3162,6 +3167,69 @@ impl Bjt {
         base_emitter_leakage_saturation_current: f64,
         base_emitter_leakage_emission_coefficient: f64,
     ) -> Self {
+        Self::with_model_temperature_depletion_early_rolloff_and_junction_leakage_parameters(
+            name,
+            collector,
+            base,
+            emitter,
+            polarity,
+            saturation_current,
+            forward_beta,
+            thermal_voltage,
+            base_emitter_capacitance,
+            base_collector_capacitance,
+            forward_transit_time,
+            reverse_transit_time,
+            saturation_current_temperature_exponent,
+            energy_gap_electron_volts,
+            forward_early_voltage,
+            forward_emission_coefficient,
+            reverse_emission_coefficient,
+            base_emitter_junction_potential,
+            base_emitter_grading_coefficient,
+            base_collector_junction_potential,
+            base_collector_grading_coefficient,
+            forward_bias_depletion_coefficient,
+            reverse_early_voltage,
+            forward_beta_rolloff_current,
+            base_emitter_leakage_saturation_current,
+            base_emitter_leakage_emission_coefficient,
+            0.0,
+            2.0,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_model_temperature_depletion_early_rolloff_and_junction_leakage_parameters(
+        name: impl Into<String>,
+        collector: impl Into<String>,
+        base: impl Into<String>,
+        emitter: impl Into<String>,
+        polarity: BjtPolarity,
+        saturation_current: f64,
+        forward_beta: f64,
+        thermal_voltage: f64,
+        base_emitter_capacitance: f64,
+        base_collector_capacitance: f64,
+        forward_transit_time: f64,
+        reverse_transit_time: f64,
+        saturation_current_temperature_exponent: f64,
+        energy_gap_electron_volts: f64,
+        forward_early_voltage: f64,
+        forward_emission_coefficient: f64,
+        reverse_emission_coefficient: f64,
+        base_emitter_junction_potential: f64,
+        base_emitter_grading_coefficient: f64,
+        base_collector_junction_potential: f64,
+        base_collector_grading_coefficient: f64,
+        forward_bias_depletion_coefficient: f64,
+        reverse_early_voltage: f64,
+        forward_beta_rolloff_current: f64,
+        base_emitter_leakage_saturation_current: f64,
+        base_emitter_leakage_emission_coefficient: f64,
+        base_collector_leakage_saturation_current: f64,
+        base_collector_leakage_emission_coefficient: f64,
+    ) -> Self {
         Self {
             name: name.into(),
             collector: collector.into(),
@@ -3189,6 +3257,8 @@ impl Bjt {
             forward_beta_rolloff_current,
             base_emitter_leakage_saturation_current,
             base_emitter_leakage_emission_coefficient,
+            base_collector_leakage_saturation_current,
+            base_collector_leakage_emission_coefficient,
         }
     }
 }
@@ -3579,8 +3649,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 21, 36, 11, 4),
-    (ModelCardKind::Pnp, 21, 36, 11, 4),
+    (ModelCardKind::Npn, 23, 38, 11, 4),
+    (ModelCardKind::Pnp, 23, 38, 11, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3632,6 +3702,8 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IK", "IKF"),
     ("ISE", "ISE"),
     ("NE", "NE"),
+    ("ISC", "ISC"),
+    ("NC", "NC"),
     ("NF", "NF"),
     ("NR", "NR"),
     ("VJE", "VJE"),
@@ -4283,7 +4355,7 @@ pub fn bjt_from_model_card(
         _ => return Err(model_card_kind_error(&name, "BJT", model.kind)),
     };
     Ok(
-        Bjt::with_model_temperature_depletion_early_rolloff_and_leakage_parameters(
+        Bjt::with_model_temperature_depletion_early_rolloff_and_junction_leakage_parameters(
             name,
             collector,
             base,
@@ -4310,6 +4382,8 @@ pub fn bjt_from_model_card(
             model_card_value(model, "IKF", 0.0),
             model_card_value(model, "ISE", 0.0),
             model_card_value(model, "NE", 1.0),
+            model_card_value(model, "ISC", 0.0),
+            model_card_value(model, "NC", 2.0),
         ),
     )
 }
@@ -21959,6 +22033,10 @@ fn collect_noise_sources(
                     BjtPolarity::Npn => base_voltage - emitter_voltage,
                     BjtPolarity::Pnp => emitter_voltage - base_voltage,
                 };
+                let reverse_junction_voltage = match bjt.polarity {
+                    BjtPolarity::Npn => base_voltage - collector_voltage,
+                    BjtPolarity::Pnp => collector_voltage - base_voltage,
+                };
                 let forward_thermal_voltage =
                     bjt.thermal_voltage * bjt.forward_emission_coefficient;
                 let exponent = (junction_voltage / forward_thermal_voltage).clamp(-40.0, 40.0);
@@ -21973,6 +22051,8 @@ fn collect_noise_sources(
                 let (collector_current, _, _) =
                     bjt_forward_transport(bjt, base_collector_current, base_gm, early_factor);
                 let (leakage_current, _) = bjt_base_emitter_leakage(bjt, junction_voltage);
+                let (collector_leakage_current, _) =
+                    bjt_base_collector_leakage(bjt, reverse_junction_voltage);
                 let (positive, negative) = match bjt.polarity {
                     BjtPolarity::Npn => (base, emitter),
                     BjtPolarity::Pnp => (emitter, base),
@@ -21984,7 +22064,9 @@ fn collect_noise_sources(
                     negative,
                     source_psd: 2.0
                         * ELECTRON_CHARGE
-                        * (collector_current.abs() + leakage_current.abs()),
+                        * (collector_current.abs()
+                            + leakage_current.abs()
+                            + collector_leakage_current.abs()),
                 });
             }
             Element::Jfet(jfet) => {
@@ -22476,6 +22558,19 @@ fn bjt_base_emitter_leakage(bjt: &Bjt, junction_voltage: f64) -> (f64, f64) {
     )
 }
 
+fn bjt_base_collector_leakage(bjt: &Bjt, junction_voltage: f64) -> (f64, f64) {
+    if bjt.base_collector_leakage_saturation_current == 0.0 {
+        return (0.0, 0.0);
+    }
+    let thermal_voltage = bjt.thermal_voltage * bjt.base_collector_leakage_emission_coefficient;
+    let exponent = (junction_voltage / thermal_voltage).clamp(-40.0, 40.0);
+    let exp_value = exponent.exp();
+    (
+        bjt.base_collector_leakage_saturation_current * (exp_value - 1.0),
+        bjt.base_collector_leakage_saturation_current / thermal_voltage * exp_value,
+    )
+}
+
 fn stamp_bjt(
     bjt: &Bjt,
     capacitor_states: &[CapacitorState],
@@ -22494,6 +22589,10 @@ fn stamp_bjt(
     let junction_voltage = match bjt.polarity {
         BjtPolarity::Npn => base_voltage - emitter_voltage,
         BjtPolarity::Pnp => emitter_voltage - base_voltage,
+    };
+    let reverse_junction_voltage = match bjt.polarity {
+        BjtPolarity::Npn => base_voltage - collector_voltage,
+        BjtPolarity::Pnp => collector_voltage - base_voltage,
     };
     let forward_thermal_voltage = bjt.thermal_voltage * bjt.forward_emission_coefficient;
     let exponent = (junction_voltage / forward_thermal_voltage).clamp(-40.0, 40.0);
@@ -22518,8 +22617,13 @@ fn stamp_bjt(
     let equivalent_collector_current =
         collector_current - gm * junction_voltage - output_conductance * output_voltage;
     let equivalent_base_current = base_current - gpi * junction_voltage;
+    let (collector_leakage_current, collector_leakage_conductance) =
+        bjt_base_collector_leakage(bjt, reverse_junction_voltage);
+    let equivalent_collector_leakage_current =
+        collector_leakage_current - collector_leakage_conductance * reverse_junction_voltage;
 
     stamp_conductance(matrix, collector, emitter, output_conductance);
+    stamp_conductance(matrix, base, collector, collector_leakage_conductance);
 
     match bjt.polarity {
         BjtPolarity::Npn => {
@@ -22527,12 +22631,24 @@ fn stamp_bjt(
             stamp_transconductance(matrix, collector, emitter, base, emitter, gm);
             stamp_equivalent_current_source(rhs, base, emitter, equivalent_base_current);
             stamp_equivalent_current_source(rhs, collector, emitter, equivalent_collector_current);
+            stamp_equivalent_current_source(
+                rhs,
+                base,
+                collector,
+                equivalent_collector_leakage_current,
+            );
         }
         BjtPolarity::Pnp => {
             stamp_conductance(matrix, emitter, base, gpi);
             stamp_transconductance(matrix, emitter, collector, emitter, base, gm);
             stamp_equivalent_current_source(rhs, emitter, base, equivalent_base_current);
             stamp_equivalent_current_source(rhs, emitter, collector, equivalent_collector_current);
+            stamp_equivalent_current_source(
+                rhs,
+                collector,
+                base,
+                equivalent_collector_leakage_current,
+            );
         }
     }
     stamp_bjt_charge(bjt, capacitor_states, node_indices, matrix, rhs)?;
@@ -22614,6 +22730,10 @@ fn stamp_bjt_small_signal(
         BjtPolarity::Npn => base_voltage - emitter_voltage,
         BjtPolarity::Pnp => emitter_voltage - base_voltage,
     };
+    let reverse_junction_voltage = match bjt.polarity {
+        BjtPolarity::Npn => base_voltage - collector_voltage,
+        BjtPolarity::Pnp => collector_voltage - base_voltage,
+    };
     let forward_thermal_voltage = bjt.thermal_voltage * bjt.forward_emission_coefficient;
     let exponent = (junction_voltage / forward_thermal_voltage).clamp(-40.0, 40.0);
     let exp_value = exponent.exp();
@@ -22633,7 +22753,10 @@ fn stamp_bjt_small_signal(
     };
     let (_, leakage_conductance) = bjt_base_emitter_leakage(bjt, junction_voltage);
     let gpi = base_gm / bjt.forward_beta + leakage_conductance;
+    let (_, collector_leakage_conductance) =
+        bjt_base_collector_leakage(bjt, reverse_junction_voltage);
     stamp_conductance(matrix, collector, emitter, output_conductance);
+    stamp_conductance(matrix, base, collector, collector_leakage_conductance);
     match bjt.polarity {
         BjtPolarity::Npn => {
             stamp_conductance(matrix, base, emitter, gpi);
@@ -22693,6 +22816,8 @@ fn stamp_ac_bjt_small_signal(
     let diffusion_capacitance = bjt.forward_transit_time * gm.real;
     let reverse_diffusion_capacitance = bjt.reverse_transit_time * reverse_gm;
     let (_, leakage_conductance) = bjt_base_emitter_leakage(bjt, junction_voltage);
+    let (_, collector_leakage_conductance) =
+        bjt_base_collector_leakage(bjt, reverse_junction_voltage);
     let gpi = Complex::new(
         base_gm / bjt.forward_beta + leakage_conductance,
         omega
@@ -22700,7 +22825,7 @@ fn stamp_ac_bjt_small_signal(
                 + diffusion_capacitance),
     );
     let ybc = Complex::new(
-        0.0,
+        collector_leakage_conductance,
         omega
             * (bjt_base_collector_depletion_capacitance(bjt, reverse_junction_voltage)
                 + reverse_diffusion_capacitance),
@@ -23721,6 +23846,24 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "base-emitter leakage emission coefficient must be finite and positive"
+                .to_string(),
+        });
+    }
+    if !bjt.base_collector_leakage_saturation_current.is_finite()
+        || bjt.base_collector_leakage_saturation_current < 0.0
+    {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "base-collector leakage saturation current must be finite and non-negative"
+                .to_string(),
+        });
+    }
+    if !bjt.base_collector_leakage_emission_coefficient.is_finite()
+        || bjt.base_collector_leakage_emission_coefficient <= 0.0
+    {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "base-collector leakage emission coefficient must be finite and positive"
                 .to_string(),
         });
     }

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -937,6 +937,29 @@ fn ac_bjt_base_emitter_leakage_reduces_gain_through_source_resistance() {
 }
 
 #[test]
+fn ac_bjt_base_collector_leakage_loads_source_resistance() {
+    let amplitude = |leakage_current: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vin", "in", "0", 0.65, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "base", 1_000.0,
+        )));
+        let mut transistor = Bjt::new("Q1", "0", "base", "base");
+        transistor.base_collector_leakage_saturation_current = leakage_current;
+        transistor.base_collector_leakage_emission_coefficient = 1.5;
+        circuit.add(Element::Bjt(transistor));
+        ac_sweep(&circuit, 1_000.0, 1_000.0, 1).unwrap()[0]
+            .voltage("base")
+            .unwrap()
+            .abs()
+    };
+
+    assert!(amplitude(1.0e-10) < amplitude(0.0));
+}
+
+#[test]
 fn ac_bjt_reverse_emission_coefficient_reduces_base_collector_diffusion_capacitance() {
     fn base_amplitude(reverse_emission_coefficient: f64) -> f64 {
         let mut circuit = Circuit::new();

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 100);
+    assert_eq!(coverage.len(), 104);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 100);
+    assert_eq!(records.len(), 104);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 100);
-    assert_eq!(report.expected_canonical_parameter_count, 100);
-    assert_eq!(report.accepted_name_count, 162);
+    assert_eq!(report.canonical_parameter_count, 104);
+    assert_eq!(report.expected_canonical_parameter_count, 104);
+    assert_eq!(report.accepted_name_count, 166);
     assert_eq!(report.aliased_parameter_count, 49);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t100\t100\t162\t49\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t104\t104\t166\t49\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,8 +235,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 99);
-    assert_eq!(report.accepted_name_count, 159);
+    assert_eq!(report.canonical_parameter_count, 103);
+    assert_eq!(report.accepted_name_count, 163);
     assert_eq!(report.aliased_parameter_count, 48);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t99\t100\t159\t48\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t103\t104\t163\t48\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -435,6 +435,8 @@ fn model_card_aliases_build_device_instances() {
             ("IK", 2.0e-3),
             ("ISE", 3.0e-13),
             ("NE", 1.7),
+            ("ISC", 4.0e-13),
+            ("NC", 1.8),
             ("NF", 1.2),
             ("NR", 1.3),
             ("PE", 0.8),
@@ -455,6 +457,8 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("IKF").unwrap(), 2.0e-3);
     assert_close(*bjt_card.parameters.get("ISE").unwrap(), 3.0e-13);
     assert_close(*bjt_card.parameters.get("NE").unwrap(), 1.7);
+    assert_close(*bjt_card.parameters.get("ISC").unwrap(), 4.0e-13);
+    assert_close(*bjt_card.parameters.get("NC").unwrap(), 1.8);
     assert_close(*bjt_card.parameters.get("NF").unwrap(), 1.2);
     assert_close(*bjt_card.parameters.get("NR").unwrap(), 1.3);
     assert_close(*bjt_card.parameters.get("VJE").unwrap(), 0.8);
@@ -472,6 +476,8 @@ fn model_card_aliases_build_device_instances() {
     assert_close(bjt_model.forward_beta_rolloff_current, 2.0e-3);
     assert_close(bjt_model.base_emitter_leakage_saturation_current, 3.0e-13);
     assert_close(bjt_model.base_emitter_leakage_emission_coefficient, 1.7);
+    assert_close(bjt_model.base_collector_leakage_saturation_current, 4.0e-13);
+    assert_close(bjt_model.base_collector_leakage_emission_coefficient, 1.8);
     assert_close(bjt_model.forward_emission_coefficient, 1.2);
     assert_close(bjt_model.reverse_emission_coefficient, 1.3);
     assert_close(bjt_model.base_emitter_junction_potential, 0.8);
@@ -1375,7 +1381,7 @@ fn subcircuit_expansion_preserves_complete_diode_model() {
 
 #[test]
 fn subcircuit_expansion_preserves_complete_bjt_model() {
-    let bjt = Bjt::with_model_temperature_depletion_early_rolloff_and_leakage_parameters(
+    let bjt = Bjt::with_model_temperature_depletion_early_rolloff_and_junction_leakage_parameters(
         "Qcell",
         "c",
         "b",
@@ -1402,6 +1408,8 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
         2.0e-3,
         3.0e-13,
         1.7,
+        4.0e-13,
+        1.8,
     );
     let mut circuit = Circuit::new();
     circuit
@@ -1441,6 +1449,8 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.forward_beta_rolloff_current, 2.0e-3);
     assert_close(expanded.base_emitter_leakage_saturation_current, 3.0e-13);
     assert_close(expanded.base_emitter_leakage_emission_coefficient, 1.7);
+    assert_close(expanded.base_collector_leakage_saturation_current, 4.0e-13);
+    assert_close(expanded.base_collector_leakage_emission_coefficient, 1.8);
 }
 
 #[test]
@@ -1940,6 +1950,17 @@ fn bjt_temperature_scales_base_emitter_leakage_saturation_current() {
 }
 
 #[test]
+fn bjt_temperature_scales_base_collector_leakage_saturation_current() {
+    let mut transistor = Bjt::new("Q1", "c", "b", "e");
+    transistor.base_collector_leakage_saturation_current = 2.0e-13;
+    let hot = bjt_at_temperature(&transistor, 350.0, 300.15, 1.11).unwrap();
+    assert!(
+        hot.base_collector_leakage_saturation_current
+            > transistor.base_collector_leakage_saturation_current
+    );
+}
+
+#[test]
 fn bjt_temperature_scaling_uses_model_energy_gap() {
     let mut silicon = Circuit::new();
     silicon.add(Element::Bjt(Bjt::with_model_and_temperature_parameters(
@@ -2180,6 +2201,48 @@ fn dc_rejects_invalid_bjt_base_emitter_leakage_parameters() {
         .unwrap_err()
         .to_string()
         .contains("base-emitter leakage emission coefficient must be finite and positive"));
+}
+
+#[test]
+fn bjt_base_collector_leakage_increases_base_current() {
+    let base_current = |leakage_current: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vbase", "base", "0", 0.65,
+        )));
+        let mut transistor = Bjt::new("Q1", "0", "base", "base");
+        transistor.base_collector_leakage_saturation_current = leakage_current;
+        transistor.base_collector_leakage_emission_coefficient = 1.5;
+        circuit.add(Element::Bjt(transistor));
+        dc_op(&circuit)
+            .unwrap()
+            .branch_current("Vbase")
+            .unwrap()
+            .abs()
+    };
+
+    assert!(base_current(1.0e-10) > base_current(0.0));
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_base_collector_leakage_parameters() {
+    let mut circuit = Circuit::new();
+    let mut transistor = Bjt::new("Qbad", "c", "b", "0");
+    transistor.base_collector_leakage_saturation_current = -1.0;
+    circuit.add(Element::Bjt(transistor));
+    assert!(dc_op(&circuit)
+        .unwrap_err()
+        .to_string()
+        .contains("base-collector leakage saturation current must be finite and non-negative"));
+
+    let mut circuit = Circuit::new();
+    let mut transistor = Bjt::new("Qbad", "c", "b", "0");
+    transistor.base_collector_leakage_emission_coefficient = 0.0;
+    circuit.add(Element::Bjt(transistor));
+    assert!(dc_op(&circuit)
+        .unwrap_err()
+        .to_string()
+        .contains("base-collector leakage emission coefficient must be finite and positive"));
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -61,6 +61,33 @@ fn bjt_base_emitter_leakage_increases_shot_noise() {
     assert!(source_psd(1.0e-10) > source_psd(0.0));
 }
 
+#[test]
+fn bjt_base_collector_leakage_increases_shot_noise() {
+    let source_psd = |leakage_current: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vbase", "base", "0", 0.65,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rload", "out", "0", 1_000.0,
+        )));
+        let mut transistor = Bjt::new("Q1", "out", "base", "base");
+        transistor.base_collector_leakage_saturation_current = leakage_current;
+        transistor.base_collector_leakage_emission_coefficient = 1.5;
+        circuit.add(Element::Bjt(transistor));
+        noise_ac(&circuit, "out", "Vbase", &[1_000.0], 300.0)
+            .unwrap()
+            .points[0]
+            .entries
+            .iter()
+            .find(|entry| entry.element_name == "Q1")
+            .unwrap()
+            .source_psd
+    };
+
+    assert!(source_psd(1.0e-10) > source_psd(0.0));
+}
+
 const BOLTZMANN: f64 = 1.380_649e-23;
 const MOSFET_CHANNEL_NOISE_GAMMA: f64 = 2.0 / 3.0;
 

--- a/code/packages/rust/spice-engine/tests/tf_tests.rs
+++ b/code/packages/rust/spice-engine/tests/tf_tests.rs
@@ -422,6 +422,23 @@ fn tf_bjt_base_emitter_leakage_reduces_input_impedance() {
 }
 
 #[test]
+fn tf_bjt_base_collector_leakage_reduces_input_impedance() {
+    let input_impedance = |leakage_current: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vin", "base", "0", 0.65,
+        )));
+        let mut transistor = Bjt::new("Q1", "0", "base", "base");
+        transistor.base_collector_leakage_saturation_current = leakage_current;
+        transistor.base_collector_leakage_emission_coefficient = 1.5;
+        circuit.add(Element::Bjt(transistor));
+        tf(&circuit, "base", "Vin").unwrap().input_impedance_ohms
+    };
+
+    assert!(input_impedance(1.0e-10) < input_impedance(0.0));
+}
+
+#[test]
 fn tf_bjt_forward_emission_coefficient_reduces_gain_and_raises_input_impedance() {
     let transfer = |forward_emission_coefficient: f64| {
         let mut circuit = Circuit::new();

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add BJT model-card `ISC`/`NC` base-collector leakage support in DC,
+  transient, AC, transfer-function, temperature, and noise paths, matching
+  Rust and Python. The supported-parameter catalog now contains 104 canonical
+  rows.
 - Add BJT model-card `ISE`/`NE` base-emitter leakage support in DC, transient,
   AC, transfer-function, temperature, and noise paths, matching Rust and
   Python. The supported-parameter catalog now contains 100 canonical rows.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -213,6 +213,9 @@ high-current base-charge modulation to collector transport and small-signal
 transconductance. `ISE` (default `0`, disabled) and `NE` (default `1`) add the
 Berkeley base-emitter leakage branch to DC/transient base current,
 small-signal input conductance, and shot noise.
+`ISC` (default `0`, disabled) and `NC` (default `2`) add the mirrored Berkeley
+base-collector leakage branch to DC/transient current, small-signal
+base-collector conductance, and shot noise.
 `modelCardUnsupportedParameterIssues`,
 `formatModelCardUnsupportedParameterIssueTable`,
 `modelCardUnsupportedParameterIssueRecords`,
@@ -238,7 +241,7 @@ model kind for compact release dashboards and Mosaic UI inventories.
 `modelCardSupportedParameterCoverageGateIssueRecords`,
 `formatModelCardSupportedParameterCoverageGateIssueCsv`, and
 `formatModelCardSupportedParameterCoverageGateIssueJson` validate the expected
-seven-kind, 100-row supported-parameter catalog and expose stable issue rows for
+seven-kind, 104-row supported-parameter catalog and expose stable issue rows for
 release automation.
 `modelCardSupportedParameterCoverageDashboard`,
 `formatModelCardSupportedParameterCoverageDashboardTable`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1724,6 +1724,8 @@ export interface Bjt {
   readonly forwardBetaRolloffCurrent: number;
   readonly baseEmitterLeakageSaturationCurrent: number;
   readonly baseEmitterLeakageEmissionCoefficient: number;
+  readonly baseCollectorLeakageSaturationCurrent: number;
+  readonly baseCollectorLeakageEmissionCoefficient: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -2001,8 +2003,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [21, 36, 11, 4],
-  PNP: [21, 36, 11, 4],
+  NPN: [23, 38, 11, 4],
+  PNP: [23, 38, 11, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3592,7 +3594,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7641,6 +7643,8 @@ export function bjtAtTemperature(
     saturationCurrent: element.saturationCurrent * saturationScale,
     baseEmitterLeakageSaturationCurrent:
       element.baseEmitterLeakageSaturationCurrent * saturationScale,
+    baseCollectorLeakageSaturationCurrent:
+      element.baseCollectorLeakageSaturationCurrent * saturationScale,
     thermalVoltage: element.thermalVoltage * ratio,
   };
 }
@@ -7761,6 +7765,8 @@ export function bjt(
   forwardBetaRolloffCurrent = 0.0,
   baseEmitterLeakageSaturationCurrent = 0.0,
   baseEmitterLeakageEmissionCoefficient = 1.0,
+  baseCollectorLeakageSaturationCurrent = 0.0,
+  baseCollectorLeakageEmissionCoefficient = 2.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7790,6 +7796,8 @@ export function bjt(
     forwardBetaRolloffCurrent,
     baseEmitterLeakageSaturationCurrent,
     baseEmitterLeakageEmissionCoefficient,
+    baseCollectorLeakageSaturationCurrent,
+    baseCollectorLeakageEmissionCoefficient,
   };
 }
 
@@ -7901,6 +7909,8 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   IK: "IKF",
   ISE: "ISE",
   NE: "NE",
+  ISC: "ISC",
+  NC: "NC",
   NF: "NF",
   NR: "NR",
   VJE: "VJE",
@@ -8422,6 +8432,8 @@ export function bjtFromModelCard(
     p.IKF ?? 0.0,
     p.ISE ?? 0.0,
     p.NE ?? 1.0,
+    p.ISC ?? 0.0,
+    p.NC ?? 2.0,
   );
 }
 
@@ -18350,6 +18362,9 @@ function collectNoiseSources(
         element.polarity === "NPN"
           ? baseVoltage - emitterVoltage
           : emitterVoltage - baseVoltage;
+      const reverseJunctionVoltage = element.polarity === "NPN"
+        ? baseVoltage - collectorVoltage
+        : collectorVoltage - baseVoltage;
       const forwardThermalVoltage = element.thermalVoltage * element.forwardEmissionCoefficient;
       const exponent = Math.max(-40.0, Math.min(40.0, junctionVoltage / forwardThermalVoltage));
       const outputVoltage = element.polarity === "NPN"
@@ -18367,6 +18382,8 @@ function collectNoiseSources(
         earlyFactor,
       ).collectorCurrent;
       const leakageCurrent = bjtBaseEmitterLeakage(element, junctionVoltage).current;
+      const collectorLeakageCurrent =
+        bjtBaseCollectorLeakage(element, reverseJunctionVoltage).current;
       sources.push({
         elementName: element.name,
         noiseType: "shot",
@@ -18374,7 +18391,8 @@ function collectNoiseSources(
         negative: element.polarity === "NPN" ? emitter : base,
         sourcePsd:
           2.0 * ELECTRON_CHARGE *
-          (Math.abs(collectorCurrent) + Math.abs(leakageCurrent)),
+          (Math.abs(collectorCurrent) + Math.abs(leakageCurrent) +
+            Math.abs(collectorLeakageCurrent)),
       });
     } else if (element.kind === "jfet") {
       validateJfet(element);
@@ -18896,6 +18914,24 @@ function bjtBaseEmitterLeakage(
   };
 }
 
+function bjtBaseCollectorLeakage(
+  element: Bjt,
+  junctionVoltage: number,
+): { current: number; conductance: number } {
+  if (element.baseCollectorLeakageSaturationCurrent === 0.0) {
+    return { current: 0.0, conductance: 0.0 };
+  }
+  const thermalVoltage =
+    element.thermalVoltage * element.baseCollectorLeakageEmissionCoefficient;
+  const exponent = Math.max(-40.0, Math.min(40.0, junctionVoltage / thermalVoltage));
+  const expValue = Math.exp(exponent);
+  return {
+    current: element.baseCollectorLeakageSaturationCurrent * (expValue - 1.0),
+    conductance:
+      element.baseCollectorLeakageSaturationCurrent / thermalVoltage * expValue,
+  };
+}
+
 function stampBjt(
   element: Bjt,
   capacitorStates: readonly CapacitorState[],
@@ -18916,6 +18952,9 @@ function stampBjt(
     element.polarity === "NPN"
       ? baseVoltage - emitterVoltage
       : emitterVoltage - baseVoltage;
+  const reverseJunctionVoltage = element.polarity === "NPN"
+    ? baseVoltage - collectorVoltage
+    : collectorVoltage - baseVoltage;
   const forwardThermalVoltage = element.thermalVoltage * element.forwardEmissionCoefficient;
   const exponent = Math.max(-40.0, Math.min(40.0, junctionVoltage / forwardThermalVoltage));
   const expValue = Math.exp(exponent);
@@ -18944,18 +18983,24 @@ function stampBjt(
     collectorCurrent - transconductance * junctionVoltage - outputConductance * outputVoltage;
   const equivalentBaseCurrent =
     baseCurrent - junctionConductance * junctionVoltage;
+  const collectorLeakage = bjtBaseCollectorLeakage(element, reverseJunctionVoltage);
+  const equivalentCollectorLeakageCurrent =
+    collectorLeakage.current - collectorLeakage.conductance * reverseJunctionVoltage;
 
   stampConductance(matrix, collector, emitter, outputConductance);
+  stampConductance(matrix, base, collector, collectorLeakage.conductance);
   if (element.polarity === "NPN") {
     stampConductance(matrix, base, emitter, junctionConductance);
     stampTransconductance(matrix, collector, emitter, base, emitter, transconductance);
     stampCurrentSourceEquivalent(rhs, base, emitter, equivalentBaseCurrent);
     stampCurrentSourceEquivalent(rhs, collector, emitter, equivalentCollectorCurrent);
+    stampCurrentSourceEquivalent(rhs, base, collector, equivalentCollectorLeakageCurrent);
   } else {
     stampConductance(matrix, emitter, base, junctionConductance);
     stampTransconductance(matrix, emitter, collector, emitter, base, transconductance);
     stampCurrentSourceEquivalent(rhs, emitter, base, equivalentBaseCurrent);
     stampCurrentSourceEquivalent(rhs, emitter, collector, equivalentCollectorCurrent);
+    stampCurrentSourceEquivalent(rhs, collector, base, equivalentCollectorLeakageCurrent);
   }
   stampBjtCharge(element, capacitorStates, nodeIndices, matrix, rhs);
 }
@@ -19785,6 +19830,12 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.baseEmitterLeakageEmissionCoefficient) || element.baseEmitterLeakageEmissionCoefficient <= 0.0) {
     throw invalidElement(element.name, "base-emitter leakage emission coefficient must be finite and positive");
+  }
+  if (!Number.isFinite(element.baseCollectorLeakageSaturationCurrent) || element.baseCollectorLeakageSaturationCurrent < 0.0) {
+    throw invalidElement(element.name, "base-collector leakage saturation current must be finite and non-negative");
+  }
+  if (!Number.isFinite(element.baseCollectorLeakageEmissionCoefficient) || element.baseCollectorLeakageEmissionCoefficient <= 0.0) {
+    throw invalidElement(element.name, "base-collector leakage emission coefficient must be finite and positive");
   }
   if (!Number.isFinite(element.forwardEmissionCoefficient) || element.forwardEmissionCoefficient <= 0.0) {
     throw invalidElement(element.name, "forward emission coefficient must be finite and positive");
@@ -21122,6 +21173,9 @@ function stampBjtSmallSignal(
     element.polarity === "NPN"
       ? baseVoltage - emitterVoltage
       : emitterVoltage - baseVoltage;
+  const reverseJunctionVoltage = element.polarity === "NPN"
+    ? baseVoltage - collectorVoltage
+    : collectorVoltage - baseVoltage;
   const forwardThermalVoltage = element.thermalVoltage * element.forwardEmissionCoefficient;
   const exponent = Math.max(-40.0, Math.min(40.0, junctionVoltage / forwardThermalVoltage));
   const expValue = Math.exp(exponent);
@@ -21144,7 +21198,9 @@ function stampBjtSmallSignal(
   const leakage = bjtBaseEmitterLeakage(element, junctionVoltage);
   const junctionConductance =
     baseTransconductance / element.forwardBeta + leakage.conductance;
+  const collectorLeakage = bjtBaseCollectorLeakage(element, reverseJunctionVoltage);
   stampConductance(matrix, collector, emitter, outputConductance);
+  stampConductance(matrix, base, collector, collectorLeakage.conductance);
   if (element.polarity === "NPN") {
     stampConductance(matrix, base, emitter, junctionConductance);
     stampTransconductance(matrix, collector, emitter, base, emitter, transconductance);
@@ -21735,6 +21791,7 @@ function stampAcBjtSmallSignal(
     : baseCollectorCurrent / element.forwardEarlyVoltage / transport.chargeFactor;
   const transconductance = transport.transconductance;
   const leakage = bjtBaseEmitterLeakage(element, junctionVoltage);
+  const collectorLeakage = bjtBaseCollectorLeakage(element, reverseJunctionVoltage);
   const junctionConductance =
     baseTransconductance / element.forwardBeta + leakage.conductance;
   const diffusionCapacitance = element.forwardTransitTime * transconductance;
@@ -21748,7 +21805,7 @@ function stampAcBjtSmallSignal(
     ),
   );
   const baseCollectorAdmittance = complex(
-    0.0,
+    collectorLeakage.conductance,
     omega * (
       bjtBaseCollectorDepletionCapacitance(element, reverseJunctionVoltage) +
       reverseDiffusionCapacitance

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -646,6 +646,22 @@ describe("acSweep", () => {
     expect(gain(1.0e-10)).toBeLessThan(gain(0.0));
   });
 
+  it("uses BJT base-collector leakage to load source resistance", () => {
+    function amplitude(baseCollectorLeakageSaturationCurrent: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vin", "in", "0", 0.65, 1.0));
+      circuit.add(resistor("Rin", "in", "base", 1_000.0));
+      circuit.add({
+        ...bjt("Q1", "0", "base", "base"),
+        baseCollectorLeakageSaturationCurrent,
+        baseCollectorLeakageEmissionCoefficient: 1.5,
+      });
+      return complexAbs(acSweep(circuit, 1_000.0, 1_000.0, 1, "lin")[0].voltage("base")!);
+    }
+
+    expect(amplitude(1.0e-10)).toBeLessThan(amplitude(0.0));
+  });
+
   it("shapes BJT base-emitter depletion capacitance under reverse bias", () => {
     function baseAmplitude(baseEmitterGradingCoefficient: number): number {
       const circuit = new Circuit();

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(100);
+    expect(coverage).toHaveLength(104);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(100);
+    expect(records).toHaveLength(104);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 100,
-      expectedCanonicalParameterCount: 100,
-      acceptedNameCount: 162,
+      canonicalParameterCount: 104,
+      expectedCanonicalParameterCount: 104,
+      acceptedNameCount: 166,
       aliasedParameterCount: 49,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t100\t100\t162\t49\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t104\t104\t166\t49\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,8 +241,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(99);
-    expect(report.acceptedNameCount).toBe(159);
+    expect(report.canonicalParameterCount).toBe(103);
+    expect(report.acceptedNameCount).toBe(163);
     expect(report.aliasedParameterCount).toBe(48);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t99\t100\t159\t48\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t103\t104\t163\t48\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -341,6 +341,8 @@ describe("dcOp", () => {
       IK: 2.0e-3,
       ISE: 3.0e-13,
       NE: 1.7,
+      ISC: 4.0e-13,
+      NC: 1.8,
       NF: 1.2,
       NR: 1.3,
       PE: 0.8,
@@ -350,7 +352,7 @@ describe("dcOp", () => {
       FC: 0.4,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, ISE: 3.0e-13, NE: 1.7, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.baseEmitterCapacitance, 2.0e-12);
@@ -361,6 +363,8 @@ describe("dcOp", () => {
     expectClose(bjtModel.forwardBetaRolloffCurrent, 2.0e-3);
     expectClose(bjtModel.baseEmitterLeakageSaturationCurrent, 3.0e-13);
     expectClose(bjtModel.baseEmitterLeakageEmissionCoefficient, 1.7);
+    expectClose(bjtModel.baseCollectorLeakageSaturationCurrent, 4.0e-13);
+    expectClose(bjtModel.baseCollectorLeakageEmissionCoefficient, 1.8);
     expectClose(bjtModel.forwardEmissionCoefficient, 1.2);
     expectClose(bjtModel.reverseEmissionCoefficient, 1.3);
     expectClose(bjtModel.baseEmitterJunctionPotential, 0.8);
@@ -1000,7 +1004,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -1022,6 +1026,8 @@ describe("dcOp", () => {
       expectClose(expanded.forwardBetaRolloffCurrent, 2.0e-3);
       expectClose(expanded.baseEmitterLeakageSaturationCurrent, 3.0e-13);
       expectClose(expanded.baseEmitterLeakageEmissionCoefficient, 1.7);
+      expectClose(expanded.baseCollectorLeakageSaturationCurrent, 4.0e-13);
+      expectClose(expanded.baseCollectorLeakageEmissionCoefficient, 1.8);
     }
   });
 
@@ -1355,6 +1361,17 @@ describe("dcOp", () => {
     );
   });
 
+  it("scales BJT base-collector leakage saturation current with temperature", () => {
+    const transistor = {
+      ...bjt("Q1", "c", "b", "e"),
+      baseCollectorLeakageSaturationCurrent: 2.0e-13,
+    };
+    const hot = bjtAtTemperature(transistor, 350);
+    expect(hot.baseCollectorLeakageSaturationCurrent).toBeGreaterThan(
+      transistor.baseCollectorLeakageSaturationCurrent,
+    );
+  });
+
   it("uses the BJT model energy gap", () => {
     const silicon = new Circuit();
     silicon.add(bjt("Qsilicon", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 3, 1.11));
@@ -1458,6 +1475,31 @@ describe("dcOp", () => {
     const badCoefficient = new Circuit();
     badCoefficient.add({ ...bjt("Qbad", "c", "b", "0"), baseEmitterLeakageEmissionCoefficient: 0.0 });
     expect(() => dcOp(badCoefficient)).toThrowError("base-emitter leakage emission coefficient");
+  });
+
+  it("uses BJT base-collector leakage to increase base current", () => {
+    const baseCurrent = (baseCollectorLeakageSaturationCurrent: number): number => {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vbase", "base", "0", 0.65));
+      circuit.add({
+        ...bjt("Q1", "0", "base", "base"),
+        baseCollectorLeakageSaturationCurrent,
+        baseCollectorLeakageEmissionCoefficient: 1.5,
+      });
+      return Math.abs(dcOp(circuit).branchCurrent("Vbase")!);
+    };
+
+    expect(baseCurrent(1.0e-10)).toBeGreaterThan(baseCurrent(0.0));
+  });
+
+  it("rejects invalid BJT base-collector leakage parameters", () => {
+    const badCurrent = new Circuit();
+    badCurrent.add({ ...bjt("Qbad", "c", "b", "0"), baseCollectorLeakageSaturationCurrent: -1.0 });
+    expect(() => dcOp(badCurrent)).toThrowError("base-collector leakage saturation current");
+
+    const badCoefficient = new Circuit();
+    badCoefficient.add({ ...bjt("Qbad", "c", "b", "0"), baseCollectorLeakageEmissionCoefficient: 0.0 });
+    expect(() => dcOp(badCoefficient)).toThrowError("base-collector leakage emission coefficient");
   });
 
   it("uses BJT forward emission coefficient to reduce collector current", () => {

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -50,6 +50,23 @@ describe("noiseAc", () => {
 
     expect(sourcePsd(1.0e-10)).toBeGreaterThan(sourcePsd(0.0));
   });
+  it("uses BJT base-collector leakage to increase shot noise", () => {
+    function sourcePsd(baseCollectorLeakageSaturationCurrent: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vbase", "base", "0", 0.65));
+      circuit.add(resistor("Rload", "out", "0", 1_000.0));
+      circuit.add({
+        ...bjt("Q1", "out", "base", "base"),
+        baseCollectorLeakageSaturationCurrent,
+        baseCollectorLeakageEmissionCoefficient: 1.5,
+      });
+      const entry = noiseAc(circuit, "out", "Vbase", [1_000.0], 300.0).points[0]?.entries
+        .find((candidate) => candidate.elementName === "Q1");
+      return entry!.sourcePsd;
+    }
+
+    expect(sourcePsd(1.0e-10)).toBeGreaterThan(sourcePsd(0.0));
+  });
   it("computes Johnson noise for a single grounded resistor", () => {
     const circuit = new Circuit();
     circuit.add(currentSource("Iin", "0", "out", 0.0));

--- a/code/packages/typescript/spice-engine/tests/tf.test.ts
+++ b/code/packages/typescript/spice-engine/tests/tf.test.ts
@@ -99,6 +99,21 @@ describe("tf", () => {
     expect(inputImpedance(1.0e-10)).toBeLessThan(inputImpedance(0.0));
   });
 
+  it("uses BJT base-collector leakage to reduce input impedance", () => {
+    function inputImpedance(baseCollectorLeakageSaturationCurrent: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vin", "base", "0", 0.65));
+      circuit.add({
+        ...bjt("Q1", "0", "base", "base"),
+        baseCollectorLeakageSaturationCurrent,
+        baseCollectorLeakageEmissionCoefficient: 1.5,
+      });
+      return tf(circuit, "base", "Vin").inputImpedanceOhms;
+    }
+
+    expect(inputImpedance(1.0e-10)).toBeLessThan(inputImpedance(0.0));
+  });
+
   it("uses BJT forward emission coefficient to reduce gain and raise input impedance", () => {
     function transfer(forwardEmissionCoefficient: number) {
       const circuit = new Circuit();

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT base-emitter leakage.
+1. Cross-language BJT base-collector leakage.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `ISE` / `NE` base-emitter leakage model-card support in
+   - Add Berkeley BJT `ISC` / `NC` base-collector leakage model-card support in
      Rust, Python, and TypeScript with disabled behavior represented by the
-     standard zero `ISE` default.
+     standard zero `ISC` default.
    - Apply the leakage branch in DC, transient, AC, transfer-function,
      temperature, and noise paths while preserving the complete BJT model
      through hierarchical subcircuits.
-   - Extend the supported-parameter coverage gate from 96 to 100 canonical rows
+   - Extend the supported-parameter coverage gate from 100 to 104 canonical rows
      and lock model-card aliases, behavior, validation, and hierarchy in all
      engines.
 
@@ -3071,6 +3071,14 @@ the Rust, Python, and TypeScript surfaces together.
      transfer-function, and noise paths.
    - Hierarchical subcircuit expansion preserves the complete BJT model, and
      the supported-parameter release gate now covers 96 canonical rows.
+
+228. Cross-language BJT base-emitter leakage.
+   - Status: completed in PR 8778.
+   - Rust, Python, and TypeScript BJT model cards now accept `ISE` / `NE` and
+     apply the base-emitter leakage branch in DC, transient, AC,
+     transfer-function, temperature, and noise paths.
+   - Hierarchical subcircuit expansion preserves the complete BJT model, and
+     the supported-parameter release gate now covers 100 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley BJT `ISC`/`NC` base-collector leakage parameters in Rust, Python, and TypeScript
- apply the leakage branch across DC/transient, AC, transfer-function, temperature, hierarchy, and noise paths
- extend model-card coverage to 104 canonical parameters and reconcile the SPICE completion plan

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo test -p spice-engine`
- Python changed-file `ruff check`
- Python `pytest`: 546 passed, 88.65% coverage
- `npm run build`
- `npm test`: 304 passed