### PR TITLE
feat(adj-facts-stdlib): SI base units — grounded quantity→unit→symbol table (NIST)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_sibaseunits_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_sibaseunits_e2e.rs
@@ -1,0 +1,97 @@
+//! End-to-end test for the metrology SI-BASE-UNITS facts library
+//! (`adj-facts-stdlib/metrology/si-base-units.adj`) driven through the built CLI:
+//! a native `table` of base-quantity → unit → symbol resolves a binding-query
+//! recall with the NIST citation, runs the relation backwards (unit → quantity),
+//! and abstains on anything that is not one of the seven base quantities — 0
+//! model calls, never a fabricated unit.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factssi_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn with_case(dir: &Path, body: &str) -> PathBuf {
+    let src = facts_stdlib().join("metrology/si-base-units.adj");
+    std::fs::copy(&src, dir.join("si-base-units.adj")).expect("copy shipped si-base-units.adj");
+    let p = dir.join("case.adj");
+    std::fs::write(&p, format!("import \"si-base-units.adj\"\n{body}")).unwrap();
+    p
+}
+
+#[test]
+fn si_base_unit_forward_recall_binds_unit_and_symbol_with_citation() {
+    let dir = scratch("forward");
+    let p = with_case(
+        &dir,
+        "? si_base_unit(mass, $Unit, $Symbol)\n\
+         ? si_base_unit(temperature, $Unit, $Symbol)\n",
+    );
+
+    let (ok, out) = run(&p);
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Mass -> kilogram (kg); temperature -> kelvin (K).
+    assert!(
+        out.contains("\"Unit\":\"kilogram\""),
+        "mass binds the kilogram: {out}"
+    );
+    assert!(out.contains("kg"), "mass carries the symbol kg: {out}");
+    assert!(
+        out.contains("\"Unit\":\"kelvin\""),
+        "temperature binds the kelvin: {out}"
+    );
+    // The answer carries the NIST citation as its proof.
+    assert!(
+        out.contains("nist.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the NIST source citation: {out}"
+    );
+}
+
+#[test]
+fn si_base_unit_runs_backwards_from_unit_to_quantity() {
+    let dir = scratch("reverse");
+    // Given the unit `second`, recall the base quantity it measures — time.
+    let p = with_case(&dir, "? si_base_unit($Quantity, second, $Symbol)\n");
+
+    let (ok, out) = run(&p);
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"Quantity\":\"time\""),
+        "the second measures time (reverse lookup): {out}"
+    );
+}
+
+#[test]
+fn a_non_base_quantity_abstains_rather_than_inventing_a_unit() {
+    let dir = scratch("abstain");
+    // Luminance is a real photometric quantity but NOT one of the seven SI base
+    // quantities — the table must abstain, never fabricate a unit.
+    let p = with_case(&dir, "? si_base_unit(luminance, $Unit, $Symbol)\n");
+
+    let (ok, out) = run(&p);
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a non-base quantity abstains: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/metrology/si-base-units.adj
+++ b/code/specs/data/adj-facts-stdlib/metrology/si-base-units.adj
@@ -1,0 +1,66 @@
+% ============================================================================
+% si-base-units — each SI base quantity → its base unit (adj-facts-stdlib, METROLOGY).
+% ============================================================================
+% The foundation the whole metric system is built on: the seven base quantities
+% and the SI unit that measures each. "What is the SI unit of mass?" → the
+% kilogram. Recall is a binding query — you name a base quantity and get back its
+% unit (and the unit's symbol), WITH the citation:
+%
+%     ? si_base_unit(mass, $Unit, $Symbol)          % kilogram, "kg"
+%     ? si_base_unit(electric_current, $U, $S)       % ampere,   "A"
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `si_base_unit(quantity, unit, symbol)` carrying the table's citation,
+% so the lookup is the ordinary SLD binding query — the engine returns the unit
+% WITH its source, on the CPU, with zero model calls, and abstains on anything
+% that is not one of the seven base quantities (it never invents a unit). The
+% relation runs both ways: `? si_base_unit($Q, second, $S)` recalls the quantity
+% the SECOND measures — time.
+%
+% Why a `table` and NOT seven prose sentences: this is exactly the shape the
+% reference data ships in — a published list, one base quantity per row with its
+% unit and symbol. The citable artifact IS the NIST "SI Units" page at the
+% `locator` below, and each quantity→unit→symbol triple here is read straight off
+% it. The whole table is defended by one provenance envelope rather than repeating
+% source/locator/trust on every row.
+%
+% Why the symbol is a STRING and the unit an ATOM: unit names (`meter`,
+% `kilogram`) are lowercase atoms that bind and compose like any other recalled
+% token; unit *symbols* are case-sensitive (`A` for ampere, `K` for kelvin,
+% `cd` for candela) and several are uppercase, so they are carried as string
+% literals — an uppercase bare token would read as a variable, not an atom.
+%
+% Provenance: the seven quantity→unit→symbol triples are taken VERBATIM from the
+% NIST Office of Weights and Measures "SI Units" page. The per-row values:
+%
+%   length              → meter    "m"
+%   mass                → kilogram "kg"
+%   time                → second   "s"
+%   electric_current    → ampere   "A"
+%   temperature         → kelvin   "K"
+%   amount_of_substance → mole     "mol"
+%   luminous_intensity  → candela  "cd"
+%
+% The `source` span below is that page's sentence stating the SI is built from
+% seven base units. `trust authoritative` — a primary standards reference,
+% re-fetchable at the `locator`. Nothing here is asserted from memory: every
+% quantity→unit→symbol triple is a row of the cited list, and only the seven base
+% quantities the page names are included. (See ../README.md; ADJ-TABLES.md;
+% feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table si_base_unit {
+    columns quantity, unit, symbol
+
+    row (length, meter, "m")
+    row (mass, kilogram, "kg")
+    row (time, second, "s")
+    row (electric_current, ampere, "A")
+    row (temperature, kelvin, "K")
+    row (amount_of_substance, mole, "mol")
+    row (luminous_intensity, candela, "cd")
+
+    source "The SI is made up of 7 base units that define the 22 derived units with special names and symbols."
+    locator "https://www.nist.gov/pml/owm/metric-si/si-units"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/metrology/si-base-units.query.adj
+++ b/code/specs/data/adj-facts-stdlib/metrology/si-base-units.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% si-base-units.query.adj — a worked recall over the SI base-units library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what is the SI unit of
+% mass?": it states no metrology fact — it only `import`s the grounded table and
+% asks binding queries. The engine resolves each `?` against the `si_base_unit`
+% rows and returns the unit + symbol + the table's source/locator/trust. A
+% quantity that is not an SI base quantity abstains honestly — the engine never
+% invents a unit. The last query runs the relation BACKWARDS: given the unit
+% `second`, recall the quantity it measures.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli si-base-units.query.adj
+% ============================================================================
+
+import "si-base-units.adj"
+
+? si_base_unit(mass, $Unit, $Symbol)             % expect kilogram, "kg"
+? si_base_unit(temperature, $Unit, $Symbol)      % expect kelvin, "K"
+? si_base_unit($Quantity, second, $Symbol)       % expect time — reverse lookup by unit
+? si_base_unit(luminance, $Unit, $Symbol)        % expect abstain — not an SI base quantity


### PR DESCRIPTION
## SI base units — the metric system's foundation, grounded to NIST [Facts front]

Adds the foundational metrology table the whole metric system rests on: the **seven SI base quantities** and the unit (and symbol) that measures each. A new native `table` (ADJ-TABLES), grounded verbatim to NIST:

```
? si_base_unit(mass, $Unit, $Symbol)     % kilogram, "kg"
? si_base_unit($Q, second, $S)           % time — reverse lookup by unit
```

### The seven rows (verbatim from NIST OWM "SI Units")
| quantity | unit | symbol |
|----------|------|--------|
| length | meter | m |
| mass | kilogram | kg |
| time | second | s |
| electric_current | ampere | A |
| temperature | kelvin | K |
| amount_of_substance | mole | mol |
| luminous_intensity | candela | cd |

The envelope's `source` is that page's sentence — *"The SI is made up of 7 base units that define the 22 derived units with special names and symbols"* — with `locator` = the NIST page and `trust authoritative`. **Nothing is asserted from memory** — every triple is a row of the cited list, fetched from the source (`feedback_nothing_human_authored`).

**Symbols are STRING cells**: they're case-sensitive and several are uppercase (`A`, `K`), and an uppercase bare token would lex as a variable rather than an atom; units and quantities are lowercase atoms that bind and compose like any recalled token.

### Ships
- `metrology/si-base-units.adj` — the grounded table (in the existing `metrology/` domain, beside `metric-prefixes` and `time-units`).
- `metrology/si-base-units.query.adj` — worked recall: forward lookup, a **reverse** unit→quantity lookup, and an honest **abstention** on `luminance` (a real photometric quantity but not one of the seven base quantities).
- `adj-lang-cli/tests/facts_sibaseunits_e2e.rs` — 3 e2e tests through the built CLI against the shipped stdlib: forward recall binds unit+symbol with the NIST citation; reverse unit→quantity; a non-base quantity abstains (never a fabricated unit).

Pure data + test — no crate code, no version bump. Independent of the D4b PR (#8784).

### Verification
- `cargo test -p adj-lang-cli --test facts_sibaseunits_e2e` → 3 passed, 0 failed.
- Manually driven through the CLI (`mass → kilogram/"kg"` with NIST citation; reverse `second → time`; `luminance` abstains).
- Source fetched from NIST (`nist.gov/pml/owm/metric-si/si-units`), not hand-authored.
- Security review passed (1 round — additive data + a harness-only test, no attacker-reachable surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)