### PR TITLE
feat(adj-formula-stdlib): speed library — distance–speed–time rates compose cited primitives

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/fl_speed_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/fl_speed_e2e.rs
@@ -1,0 +1,148 @@
+//! End-to-end tests for the `speed.adj` distance–speed–time rates library —
+//! driven through the built CLI binary against the SHIPPED stdlib. Each proves
+//! the composition invariant: the library COMPOSES the cited `arithmetic.adj`
+//! primitives (`quotient`, `product`) — it re-derives no arithmetic — computes
+//! the exact value on the CPU, and carries BOTH its own citation and the
+//! primitive's as a corroboration. The three formulas are the one relation
+//! v = d / t and its rearrangements d = v·t and t = d / v.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib")
+        .canonicalize()
+        .expect("shipped adj-formula-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_flspeed_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn place(dir: &Path, rel: &str) {
+    let src = stdlib().join(rel);
+    let name = Path::new(rel).file_name().unwrap();
+    std::fs::copy(&src, dir.join(name)).unwrap_or_else(|e| panic!("copy {rel}: {e}"));
+}
+
+fn with_lib(dir: &Path) {
+    place(dir, "arithmetic/arithmetic.adj");
+    place(dir, "arithmetic/speed.adj");
+}
+
+// ---------------------------------------------------------------------------
+// average_speed — distance over time, composing quotient.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn average_speed_composes_quotient_and_carries_both_citations() {
+    let dir = scratch("avg");
+    with_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"speed.adj\"\n\
+         observe distance(150)\n\
+         observe time(3)\n\
+         ? average_speed(distance, time)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 150 / 3 = 50, via the quotient primitive on the CPU.
+    assert!(
+        s.contains("\"name\":\"average_speed\"") && s.contains("\"value\":50"),
+        "average_speed(150, 3) = 50: {s}"
+    );
+    // BOTH citations: the speed definition (primary) AND the quotient primitive
+    // it composed (corroboration).
+    assert!(
+        s.contains("physics.info"),
+        "primary cites the speed definition: {s}"
+    );
+    assert!(
+        s.contains("mathworld.wolfram.com/Quotient.html"),
+        "corroboration cites the quotient primitive it composed: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// distance_travelled — speed times time (d = v·t), composing product.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn distance_travelled_composes_product() {
+    let dir = scratch("dist");
+    with_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"speed.adj\"\n\
+         observe speed(50)\n\
+         observe time(3)\n\
+         ? distance_travelled(speed, time)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 50 * 3 = 150, via the product primitive.
+    assert!(
+        s.contains("\"name\":\"distance_travelled\"") && s.contains("\"value\":150"),
+        "distance_travelled(50, 3) = 150: {s}"
+    );
+    assert!(
+        s.contains("mathworld.wolfram.com/Product.html"),
+        "corroboration cites the product primitive it composed: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// travel_time — distance over speed (t = d/v), composing quotient. The trace
+// bottoms out at the observed slots — no model arithmetic.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn travel_time_composes_quotient_and_names_its_leaves() {
+    let dir = scratch("time");
+    with_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"speed.adj\"\n\
+         observe distance(150)\n\
+         observe speed(50)\n\
+         ? travel_time(distance, speed)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 150 / 50 = 3, and the trace shows the division over the two observed
+    // leaves — reconstructable operand by operand, not asserted.
+    assert!(
+        s.contains("\"name\":\"travel_time\"") && s.contains("\"value\":3"),
+        "travel_time(150, 50) = 3: {s}"
+    );
+    assert!(
+        s.contains("\"node\":\"op\"") && s.contains("\"op\":\"/\""),
+        "the derivation names the quotient op: {s}"
+    );
+    assert!(
+        s.contains("\"slot\":\"distance\"") && s.contains("\"slot\":\"speed\""),
+        "the leaves name the observed slots the value was built from: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/arithmetic/speed.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/speed.adj
@@ -1,0 +1,83 @@
+% ============================================================================
+% speed.adj — the distance–speed–time rates library (ADJ-FORMULA-LIBRARIES).
+% ============================================================================
+% The most-taught elementary rate: average speed is distance divided by time,
+% and the two rearrangements that complete the distance–speed–time "triangle".
+% Built ENTIRELY by composing the cited primitives of `arithmetic.adj` — it
+% re-derives no arithmetic. Where `powers.adj` nests the cited `product`, this
+% APPLIES the cited `quotient` and `product`: a speed is a quotient, a distance
+% is a product, a time is a quotient, each cited as such.
+%
+%     import "speed.adj"                       % transitively imports arithmetic.adj
+%     observe distance(150)                    % "…150 km…"   (span cited by the model)
+%     observe time(3)                          % "…in 3 hours…" (span cited by the model)
+%     ? average_speed(distance, time)          % engine → 50, carrying every citation
+%
+% The engine expands `average_speed` → `quotient` (from arithmetic.adj) on the
+% CPU and composes the provenance chain, so the answer cites BOTH the speed
+% definition (primary) and the `quotient` primitive it builds on (corroboration).
+% The model performs zero arithmetic, and the audit trail names every formula
+% that participated.
+%
+% The three formulas are the one relation v = d / t and its algebraic
+% rearrangements d = v · t and t = d / v — the classic triangle. Each rests on
+% the SAME definitional relation among distance, speed and time, so each carries
+% that definition as its `source`; only the primitive it composes differs.
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% This library depends on two elementary primitives — `quotient` and `product`.
+% The import is RELATIVE to this file, so a consumer that imports `speed.adj`
+% gets those primitives transitively and the bodies below resolve.
+% ----------------------------------------------------------------------------
+import "arithmetic.adj"
+
+% ----------------------------------------------------------------------------
+% Vocabulary. The three quantities of the distance–speed–time relation, plus the
+% three results. Rung-0 types an observable slot as `finding`; the `surface`
+% synonyms let a decomposer map everyday phrasing ("how far", "how fast", "how
+% long") onto the canonical terms.
+% ----------------------------------------------------------------------------
+dictionary speed_vocab {
+    define distance : finding  surface "distance", "how far", "length travelled", "displacement"
+    define time     : finding  surface "time", "how long", "elapsed time", "duration"
+    define speed    : finding  surface "speed", "how fast", "average speed", "rate"
+
+    define average_speed     : finding  surface "average speed", "speed", "how fast"
+    define distance_travelled : finding  surface "distance travelled", "distance", "how far"
+    define travel_time       : finding  surface "travel time", "time taken", "how long"
+}
+
+% ----------------------------------------------------------------------------
+% The composed formulas. None writes a bare `/` or `*`: each APPLIES the cited
+% primitive from `arithmetic.adj`, so the rate is what it is BECAUSE of the
+% division (or multiplication) it composes, cited as such.
+%
+%   average_speed(distance, time)     = distance / time        (v = d / t)
+%   distance_travelled(speed, time)   = speed * time           (d = v · t)
+%   travel_time(distance, speed)      = distance / speed        (t = d / v)
+% ----------------------------------------------------------------------------
+formulabook speeds {
+    use speed_vocab
+
+    % Average speed — distance divided by time. Composes `quotient`: 150 km over
+    % 3 hours is 150 / 3 = 50 km/h.
+    formula average_speed(distance, time) = quotient(distance, time)
+        source "Average speed is the rate of change of distance with time."
+        locator "https://physics.info/velocity/"
+        trust authoritative
+
+    % Distance travelled — speed multiplied by time, the rearrangement d = v·t.
+    % Composes `product`: 50 km/h for 3 hours covers 50 * 3 = 150 km.
+    formula distance_travelled(speed, time) = product(speed, time)
+        source "Average speed is the rate of change of distance with time."
+        locator "https://physics.info/velocity/"
+        trust authoritative
+
+    % Travel time — distance divided by speed, the rearrangement t = d/v.
+    % Composes `quotient`: 150 km at 50 km/h takes 150 / 50 = 3 hours.
+    formula travel_time(distance, speed) = quotient(distance, speed)
+        source "Average speed is the rate of change of distance with time."
+        locator "https://physics.info/velocity/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/arithmetic/speed.query.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/speed.query.adj
@@ -1,0 +1,18 @@
+% ============================================================================
+% speed.query.adj — a worked example of the distance–speed–time rates library.
+% ============================================================================
+% Run against the shipped stdlib:
+%
+%   adj-lang-cli speed.query.adj
+%
+% "A car covers 150 km in 3 hours" → average speed 150 / 3 = 50 km/h, computed
+% on the CPU by composing the cited `quotient` primitive from arithmetic.adj. The
+% answer carries BOTH the speed definition (primary) and the quotient primitive
+% it built on (corroboration) — the model performs zero arithmetic.
+% ============================================================================
+import "speed.adj"
+
+observe distance(150)
+observe time(3)
+
+? average_speed(distance, time)


### PR DESCRIPTION
## Distance–speed–time rates [Libraries front]

Adds the most-taught elementary rate to the formula stdlib: **average speed is distance over time**, plus the two rearrangements that complete the distance–speed–time triangle. Built entirely by composing the cited primitives of `arithmetic.adj` — it re-derives no arithmetic:

```
import "speed.adj"
observe distance(150)
observe time(3)
? average_speed(distance, time)   % engine → 50, citing physics.info + Quotient
```

```
average_speed(distance, time)   = quotient(distance, time)   (v = d / t)
distance_travelled(speed, time) = product(speed, time)       (d = v · t)
travel_time(distance, speed)    = quotient(distance, speed)  (t = d / v)
```

Each answer carries **both** the speed definition (primary) and the arithmetic primitive it composed (corroboration). The definition is grounded to a **real fetched source** — the Physics Hypertextbook (physics.info): *"Average speed is the rate of change of distance with time."* The three formulas are the one relation and its algebraic rearrangements, so each carries that same definition; only the composed primitive (quotient vs product) differs.

### Placement note
Lives in `arithmetic/` (not `physics/`) because the import resolver **forbids `../` path-escapes** — a library composing `arithmetic.adj` must sit beside it, exactly as `ratio`/`fraction`/`percent`/`average`/`powers` do. (`physics/kinematics.adj` covers constant-acceleration velocity v=u+at and momentum, not average speed = d/t, so this is genuinely new — verified.)

### Ships
- `arithmetic/speed.adj` — the library (3 formulas).
- `arithmetic/speed.query.adj` — a worked example (a car covering 150 km in 3 h → 50 km/h).
- `adj-lang-cli/tests/fl_speed_e2e.rs` — 3 e2e tests through the built CLI against the shipped stdlib: `average_speed=50` with both citations; `distance_travelled=150` via product; `travel_time=3` with the derivation naming the `/` op over the observed slots.

Pure data + test — no crate code, no version bump. Independent of #8784 (D4b) and #8786 (SI base units).

### Verification
- `cargo test -p adj-lang-cli --test fl_speed_e2e` → 3 passed, 0 failed.
- Manually driven through the CLI (all three formulas; composed citations).
- Source fetched from the Physics Hypertextbook, not hand-authored.
- Security review passed (1 round — additive data + a harness-only test, no attacker-reachable surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)