### PR TITLE
feat(semantic-ir-to-ruby): sequences + ForRange, with total emitter (SIR16)

### DIFF
--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## 0.4.0 — sequences (SIR16)
+
+Accepts `Feature::Sequences`. Ruby has native arrays, so the SIR16 sequence
+nodes render directly — no runtime value-boxing like the Go/Rust backends'
+`_sir_seq_*`:
+
+- `Expr::SeqLit` (`[1, 2, 3]`) → a native array literal. Structural `Array#==`
+  makes `[1, 2] == [1, 2]` true, matching every backend that carries sequences.
+- `Expr::SeqIndex` (`a[i]`) → `(a)[i]`. Ruby's `Array#[]` already matches the
+  SIR reference exactly: a negative index counts from the end, an out-of-range
+  index returns `nil` (never raises — that is `fetch`).
+- `Expr::SeqLen` (`len a`) → `(a).length`.
+- `Stmt::SeqSet` (`a[i] = v`) → `sir_seq_set(a, i, v)`, a new runtime helper
+  that enforces the reference's bounds rule (RAISES on a negative or
+  out-of-range index, unlike Ruby's native `[]=` which pads with nils / counts
+  from the end) and returns the assigned value.
+- `Stmt::ForEach` (`for x in a`) → `(a).each { |x| … }` — reachable once
+  `Loops` is also accepted. A BLOCK, so `x` (and any body-local) is
+  block-scoped, matching the validator (which rewinds the loop body) and the
+  Go reference (`for _, x := range`, block-local via `:=`); a leaking `for …
+  in` would instead clobber an enclosing same-named local. `ForRange` is
+  block-scoped the same way, via a hoisted `->(x) { … }` body called from the
+  `while`. Safe as blocks because SIR loop bodies have no break/next/return.
+
+Also fixes a **pre-existing** panic surfaced while making the emitter total:
+`Stmt::ForRange` (`for i in 0...3`) is gated by `Feature::Loops` alone
+(accepted since 0.3.0) and is produced by the Ruby frontend, yet was sent to
+the same `unreachable!` — so a numeric `for` loop crashed the backend. It now
+desugars to a `while` mirroring the Go/Rust backends: bounds evaluated once
+into nesting-safe `sir_`-prefixed temporaries, a direction-aware exclusive stop
+(`step >= 0 ? i < stop : i > stop`, so a descending loop works), and a
+block-scoped loop var (the body runs inside a hoisted `->(i) { … }`, so `i`
+does not clobber an enclosing same-named local).
+
+Handling all five sequence nodes plus `ForRange` keeps the emitter TOTAL for
+its accepted feature set: no conforming producer (Ruby, C→SIR, Twig→SIR, …) can
+reach an `unreachable!`. **This was
+caught by security review** — an earlier revision handled only `SeqLit` on the
+false premise that it was the only `Sequences`-gated node; in fact `SeqIndex`/
+`SeqLen`/`SeqSet` are also gated by `Sequences` (the `NDArrays`-gated
+`IndexGet`/`IndexSet` are the different SIR22 nodes), and `ForEach` becomes
+reachable once `Loops` is accepted — all four would have panicked the emitter
+for a non-Ruby producer. Verified with hand-built modules (bypassing the Ruby
+frontend, which masks these nodes) for each of the five.
+
+Array *indexing via `Expr::IndexGet`* and slicing are a DIFFERENT feature
+(`NDArrays`, not accepted); array-*pattern* destructuring needs `ShortCircuit`
+(not accepted) — so those stay rejected at the feature gate.
+
+The `scan_expr`/`scan_stmt` unsupported-builtin pre-check recurses into the new
+nodes' sub-expressions too, so an unsupported builtin nested in `[foo()]`,
+`a[foo()]`, or `for x in [foo()]` is reported cleanly. It also gains a `While`
+arm — a pre-existing hole (also found by the review): an unsupported builtin in
+a `while` body previously escaped the pre-check and hit the emitter, so it now
+rejects cleanly instead of panicking.
+
 ## 0.3.0 — control flow & mutation (SIR16)
 
 Accepts `Feature::Loops` and `Feature::MutableBindings`, and renders the two

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/README.md
+++ b/code/packages/rust/semantic-ir-to-ruby/README.md
@@ -42,12 +42,19 @@ store, a display path, equality, and a builtin-as-value dispatcher).
 
 ## Capability declaration (v0)
 
-Accepts the SIR-v0 feature set: `Closures`, `Pairs`, `Symbols`, `Strings`,
-`DynamicTyping`, `OptionalTypeAnnotations`, `MutualRecursion`, `Globals`.
-Rejects `TailCalls`, `Intrinsics`, and every later feature (SIR16 sequences /
-maps / loops, params, the `Convert` node, collection methods, exceptions, OOP)
-until its cascade batch lands — each a clean, source-positioned
-`UnsupportedFeature`.
+Accepts `Closures`, `Pairs`, `Symbols`, `Strings`, `DynamicTyping`,
+`OptionalTypeAnnotations`, `MutualRecursion`, `Globals`; the SIR26 integer
+conversions (`Conversions`, `SizedIntegers`, `Unsigned`, `WrappingArithmetic`);
+SIR16 control flow and mutation (`Loops` — `While`, `ForRange` (numeric
+`for`, direction-aware), `ForEach`; and `MutableBindings`); and SIR16
+`Sequences` — native arrays for all five sequence nodes: `SeqLit` (`[1, 2, 3]`,
+structural `Array#==`), `SeqIndex` (`a[i]`, nil on OOB), `SeqLen` (`a.length`),
+`SeqSet` (`a[i] = v`, bounds-checked via `sir_seq_set`), and `ForEach`
+(`for x in a`).
+Rejects `TailCalls`, `Intrinsics`, and every not-yet-wired feature (array
+indexing / slicing via `IndexGet` — `NDArrays`; array-pattern destructuring —
+`ShortCircuit`; maps, collection methods, exceptions, OOP) until its cascade
+batch lands — each a clean, source-positioned `UnsupportedFeature`.
 
 ## Verification
 

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -8,10 +8,18 @@
 //! See [SIR25](../../../specs/SIR25-semantic-ir-to-ruby.md) for the design.
 
 use std::fmt::Write;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use semantic_ir::{Block, Expr, Function, Global, IntWidth, Module, Scope, Stmt};
 
 use crate::runtime::RUNTIME;
+
+/// Monotonic counter for unique loop-temporary names (`sir_for_i_N`, …). A
+/// `ForRange` desugars to a `while` with three temporaries that must not
+/// collide across NESTED range loops. The `sir_` prefix is guarded by
+/// [`sanitize_ident`] (a user variable spelled the same is renamed away), so
+/// these can never clash with a program's own names.
+static LOOP_TEMP_ID: AtomicUsize = AtomicUsize::new(0);
 
 /// Builtins the v0 backend lowers.  A `BuiltinCall` to anything else is
 /// rejected by [`first_unsupported_builtin`] (mirroring the C backend), so a
@@ -122,6 +130,29 @@ fn scan_stmt(s: &Stmt) -> Option<(String, semantic_ir::Span)> {
         | Stmt::LetStarBinding { value, .. }
         | Stmt::ExprStmt { expr: value, .. }
         | Stmt::Assign { value, .. } => scan_expr(value),
+        // A sequence write / iteration has sub-expressions that may themselves
+        // hide an unsupported builtin — scan them (and a ForEach body) so the
+        // graceful pre-check catches it rather than the emitter.
+        Stmt::SeqSet {
+            seq, index, value, ..
+        } => scan_expr(seq)
+            .or_else(|| scan_expr(index))
+            .or_else(|| scan_expr(value)),
+        // Compound-statement bodies must be scanned too, or an unsupported
+        // builtin hidden in a loop body survives the pre-check and reaches the
+        // emitter's `unreachable!`. (`While` was a pre-existing scan hole.)
+        Stmt::While { cond, body, .. } => scan_expr(cond).or_else(|| scan_block(body)),
+        Stmt::ForEach { iter, body, .. } => scan_expr(iter).or_else(|| scan_block(body)),
+        Stmt::ForRange {
+            start,
+            stop,
+            step,
+            body,
+            ..
+        } => scan_expr(start)
+            .or_else(|| scan_expr(stop))
+            .or_else(|| scan_expr(step))
+            .or_else(|| scan_block(body)),
         _ => None,
     }
 }
@@ -150,6 +181,12 @@ fn scan_expr(e: &Expr) -> Option<(String, semantic_ir::Span)> {
         }
         Expr::MakeClosure { captures, .. } => captures.iter().find_map(|c| scan_expr(&c.value)),
         Expr::Convert { value, .. } => scan_expr(value),
+        // A sequence literal's items are themselves expressions — scan each so
+        // an unsupported builtin nested in `[foo(), bar()]` is caught by the
+        // graceful pre-check rather than reaching the emitter.
+        Expr::SeqLit { items, .. } => items.iter().find_map(scan_expr),
+        Expr::SeqIndex { seq, index, .. } => scan_expr(seq).or_else(|| scan_expr(index)),
+        Expr::SeqLen { seq, .. } => scan_expr(seq),
         _ => None,
     }
 }
@@ -221,8 +258,94 @@ fn emit_stmt(s: &Stmt) -> String {
             s.push_str("end");
             s
         }
-        // Other SIR16+ statements (ForRange/ForEach/index-set/class/try) are not
-        // accepted; the capability check rejects such modules before emit.
+        // `a[i] = v` (indexed write). The SIR reference (`_sir_seq_set`) treats
+        // ONLY `0 <= i < len` as valid and RAISES on a negative or out-of-range
+        // index — unlike Ruby's native `[]=`, which silently extends the array
+        // with nils or counts negatives from the end. The `sir_seq_set` runtime
+        // helper enforces the reference rule and returns the assigned value.
+        Stmt::SeqSet {
+            seq, index, value, ..
+        } => format!(
+            "sir_seq_set({}, {}, {})",
+            emit_expr(seq),
+            emit_expr(index),
+            emit_expr(value)
+        ),
+        // `iter.each { |var| … }` — a BLOCK, so `var` and any body-local are
+        // block-scoped, matching the SIR validator (which `env.add_local`s the
+        // var then `env.rewind`s the whole loop body — body-scoped, NOT
+        // surrounding-scope) and the Go reference (`for _, x := range …`, whose
+        // `:=` var is block-local). A leaking `for … in` would instead clobber
+        // an enclosing local that shares the var's name. Safe as a block
+        // because SIR has no loop break/next/return that a block would reroute.
+        Stmt::ForEach {
+            var, iter, body, ..
+        } => {
+            let mut s = format!("({}).each do |{}|\n", emit_expr(iter), sanitize_ident(var));
+            for st in &body.stmts {
+                s.push_str(&emit_stmt(st));
+                s.push('\n');
+            }
+            s.push_str("end");
+            s
+        }
+        // `for var in start...stop step step`. Gated by `Feature::Loops` alone,
+        // so it is reachable whenever loops are accepted. Desugared to a
+        // `while` (rather than a Ruby Range, whose `step`/exclusivity is fiddly
+        // for a negative step) that mirrors the Go/Rust backends EXACTLY:
+        //   - `start`/`stop`/`step` are evaluated ONCE (they may have side
+        //     effects), into `sir_`-prefixed temporaries unique per loop
+        //     (nesting-safe, and collision-proof — `sanitize_ident` renames any
+        //     user variable out of the `sir_` namespace);
+        //   - the stop is EXCLUSIVE and the direction follows the step's sign
+        //     (`step >= 0 ? i < stop : i > stop`), so a descending loop works;
+        //   - `var` and any body-local are BLOCK-scoped: the body runs inside a
+        //     hoisted `->(var) { … }` lambda, so — like `ForEach`'s block and
+        //     the Go reference's `:=` counter — they never clobber an enclosing
+        //     same-named local (the validator rewinds the loop body).
+        Stmt::ForRange {
+            var,
+            start,
+            stop,
+            step,
+            body,
+            ..
+        } => {
+            let id = LOOP_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+            let v = sanitize_ident(var);
+            let mut s = String::new();
+            // The body runs inside a lambda taking `var`, so — like `ForEach`'s
+            // block and the Go reference's `:=` counter — `var` and any
+            // body-local are block-scoped (the validator rewinds them), never
+            // clobbering an enclosing same-named local. Hoisted once (not
+            // re-created per iteration). Safe because SIR loop bodies have no
+            // break/next/return a lambda would reroute.
+            let _ = writeln!(s, "sir_for_body_{id} = ->({v}) {{");
+            for st in &body.stmts {
+                s.push_str(&emit_stmt(st));
+                s.push('\n');
+            }
+            s.push_str("}\n");
+            // `start`/`stop`/`step` are evaluated ONCE, into `sir_`-namespaced
+            // temporaries (guarded from user names by `sanitize_ident`) unique
+            // per loop for nesting. Direction-aware EXCLUSIVE stop mirrors the
+            // Go/Rust backends: count up while `step >= 0` (`i < stop`), down
+            // otherwise (`i > stop`).
+            let _ = writeln!(s, "sir_for_i_{id} = ({})", emit_expr(start));
+            let _ = writeln!(s, "sir_for_stop_{id} = ({})", emit_expr(stop));
+            let _ = writeln!(s, "sir_for_step_{id} = ({})", emit_expr(step));
+            let _ = writeln!(
+                s,
+                "while (sir_for_step_{id} >= 0 ? sir_for_i_{id} < sir_for_stop_{id} : \
+                 sir_for_i_{id} > sir_for_stop_{id})"
+            );
+            let _ = writeln!(s, "sir_for_body_{id}.call(sir_for_i_{id})");
+            let _ = writeln!(s, "sir_for_i_{id} += sir_for_step_{id}");
+            s.push_str("end");
+            s
+        }
+        // Other SIR16+ statements (index-set/class/try) are not accepted; the
+        // capability check rejects such modules before emit.
         other => unreachable!("Ruby backend reached unsupported statement: {other:?}"),
     }
 }
@@ -286,6 +409,27 @@ fn emit_expr(e: &Expr) -> String {
                 fixed.join(", ")
             )
         }
+        // SIR16 sequence literal (`[1, 2, 3]`).  Ruby has native arrays, so a
+        // `SeqLit` maps directly to an array-literal expression — no runtime
+        // helper (unlike the Go/Rust backends, whose tagged-value runtimes need
+        // `_sir_seq_lit` to box a heap sequence).  Each item is itself an
+        // expression, emitted recursively.  Structural `==` (Array#==) then
+        // makes `[1, 2] == [1, 2]` true, matching every other backend.
+        Expr::SeqLit { items, .. } => {
+            let elems: Vec<String> = items.iter().map(emit_expr).collect();
+            format!("[{}]", elems.join(", "))
+        }
+        // `a[i]` (read). Ruby's `Array#[]` matches the SIR reference EXACTLY:
+        // a negative index counts from the end (`a[-1]` is the last element),
+        // and an index outside `0 .. len-1` returns `nil` (it does not raise —
+        // that is `fetch`). This is the same rule `_sir_seq_index` documents on
+        // the Go/Rust/Python backends, so no helper is needed. The receiver is
+        // parenthesised so a compound `seq` expression indexes correctly.
+        Expr::SeqIndex { seq, index, .. } => {
+            format!("({})[{}]", emit_expr(seq), emit_expr(index))
+        }
+        // `a.length` — native `Array#length`, matching `_sir_seq_len`.
+        Expr::SeqLen { seq, .. } => format!("({}).length", emit_expr(seq)),
         // SIR26: integer conversion → a mask helper chosen by target width +
         // signedness.  A target width of `Arbitrary` is the identity (a widen
         // into Ruby's already-unbounded Integer), so no helper wraps it.

--- a/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
@@ -70,6 +70,23 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // `if`/`while`/`for` lower to these plus `Expr::If` (which needs no feature).
     Feature::Loops,
     Feature::MutableBindings,
+    // ── SIR16 sequences ──────────────────────────────────────────────
+    // Ruby has native arrays, so the SIR16 sequence nodes render directly (no
+    // runtime value-boxing like the Go/Rust backends' `_sir_seq_*`). The
+    // emitter handles EVERY construct the `sequences` feature can surface:
+    //   `Expr::SeqLit`   → `[1, 2, 3]`      (structural `Array#==`)
+    //   `Expr::SeqIndex` → `(a)[i]`         (nil on OOB, negative-from-end)
+    //   `Expr::SeqLen`   → `(a).length`
+    //   `Stmt::SeqSet`   → `sir_seq_set(a, i, v)` (raises on OOB, per the ref)
+    //   `Stmt::ForEach`  → `(a).each { |x| … }` (also reachable once `Loops`
+    //                       is accepted — a block, so `x` is block-scoped,
+    //                       matching the validator's rewind and Go's `:=` var)
+    // handling all five keeps the emitter TOTAL for this feature (no
+    // `unreachable!` reachable from a conforming producer). Array *indexing
+    // via `Expr::IndexGet`* and slicing are a DIFFERENT feature (`NDArrays`,
+    // not accepted); array-*pattern* destructuring needs `ShortCircuit` (not
+    // accepted) — so those stay rejected at the feature gate.
+    Feature::Sequences,
 ];
 
 impl Backend for RubyBackend {

--- a/code/packages/rust/semantic-ir-to-ruby/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/runtime.rs
@@ -56,6 +56,18 @@ def sir_eq(a, b) = a == b
 # Call a closure value (a Ruby lambda) with the given arguments.
 def sir_apply(target, *args) = target.call(*args)
 
+# Indexed write `a[i] = v` with the SIR bounds rule.  The reference
+# (`_sir_seq_set`) treats ONLY `0 <= i < length` as valid and RAISES on a
+# negative or out-of-range index — whereas Ruby's native `a[i] = v` would
+# silently pad with nils (i past the end) or count from the end (negative i).
+# We enforce the reference rule so every backend agrees, and return the value
+# (an indexed assignment evaluates to its right-hand side).
+def sir_seq_set(a, i, v)
+  raise "sequence index out of range: #{i}" if i < 0 || i >= a.length
+  a[i] = v
+  v
+end
+
 # ── SIR26 integer conversions ──
 # Reduce an Integer to a fixed width by two's-complement reinterpretation — the
 # rendering of an Expr::Convert.  Ruby's Integer is arbitrary precision and its

--- a/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
@@ -313,3 +313,281 @@ fn e2e_convert_arbitrary_is_identity() {
         None => eprintln!("skip: no ruby on PATH"),
     }
 }
+
+// ── SIR16 sequences (Expr::SeqLit) ──────────────────────────────────────────
+
+#[test]
+fn seq_literal_emits_a_native_ruby_array() {
+    // `[1, 2, 3]` maps to a native array literal — no runtime helper, since
+    // Ruby arrays ARE the value (unlike the Go/Rust tagged-value backends).
+    let rb = ruby_to_ruby("puts([1, 2, 3])");
+    assert!(rb.contains("[1, 2, 3]"), "SeqLit should be a native array:\n{rb}");
+}
+
+#[test]
+fn e2e_seq_literal_displays_as_an_array() {
+    // Ruby's `puts` of an array prints the array (`[1, 2, 3]`) — a
+    // convention-independent check (no boolean display involved).
+    let rb = ruby_to_ruby("puts([1, 2, 3])");
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "[1, 2, 3]"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn e2e_seq_structural_equality_drives_control_flow() {
+    // The point of sequences on this backend: `Array#==` is STRUCTURAL, so
+    // `[1, 2] == [1, 2]` is true even for distinct array objects — matching
+    // the Python/Go/Rust backends that carry sequences. Driven through an
+    // `if` (printing a string) so the assertion does not depend on the
+    // boolean display convention. Also exercises a NEGATIVE and a NESTED case.
+    let rb = ruby_to_ruby(
+        "if [1, 2] == [1, 2]\n  puts \"same\"\nelse\n  puts \"diff\"\nend\n\
+         if [1, 2] == [1, 3]\n  puts \"same\"\nelse\n  puts \"diff\"\nend\n\
+         if [[1, 2], [3]] == [[1, 2], [3]]\n  puts \"same\"\nelse\n  puts \"diff\"\nend",
+    );
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "same\ndiff\nsame"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+// ── SIR16 sequences: HAND-BUILT modules (producer-agnostic) ─────────────────
+//
+// The bundled Ruby frontend cannot yet PRODUCE `SeqIndex`/`SeqLen`/`SeqSet`/
+// `ForEach` (its parser drops `a[i]`, `.length` needs a deferred builtin, etc.),
+// so a source-driven test would MASK them. But SIR is producer-agnostic — a
+// C→SIR or Twig→SIR module can carry these nodes with a `{Sequences, Loops}`
+// manifest that this backend now accepts. These tests build such modules
+// directly and prove the emitter is TOTAL for the feature (no `unreachable!`)
+// and matches the reference semantics.
+
+use semantic_ir::{Effect, Scope, Stmt};
+
+fn s2() -> Span {
+    Span::synthetic()
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s2() }
+}
+fn seq(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s2() }
+}
+fn local(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Local, span: s2() }
+}
+fn puts(arg: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "puts".into(),
+            args: vec![arg],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s2(),
+        },
+        span: s2(),
+    }
+}
+/// A `main` module carrying the given statements, declaring Sequences + Loops.
+fn seq_module(stmts: Vec<Stmt>) -> Module {
+    Module {
+        name: "seqprog".into(),
+        manifest: FeatureManifest::from_features(&[Feature::Sequences, Feature::Loops]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s2() }, span: s2() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s2(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(CURRENT_SIR_VERSION),
+        span: s2(),
+    }
+}
+fn emit_seq_module(stmts: Vec<Stmt>) -> String {
+    compile(&seq_module(stmts)).expect("seq module must compile, not panic").source
+}
+
+#[test]
+fn seq_index_matches_ruby_bracket_semantics() {
+    // `a[i]`: in-range, negative-from-end, and OOB→nil (never raises).
+    let rb = emit_seq_module(vec![
+        puts(Expr::SeqIndex { seq: Box::new(seq(vec![ilit(10), ilit(20), ilit(30)])), index: Box::new(ilit(1)), span: s2() }),
+        puts(Expr::SeqIndex { seq: Box::new(seq(vec![ilit(10), ilit(20), ilit(30)])), index: Box::new(ilit(-1)), span: s2() }),
+        puts(Expr::SeqIndex { seq: Box::new(seq(vec![ilit(10), ilit(20), ilit(30)])), index: Box::new(ilit(9)), span: s2() }),
+    ]);
+    assert!(rb.contains("[10, 20, 30])[1]"), "SeqIndex should be native []:\n{rb}");
+    match run_ruby(&rb) {
+        // `a[1]`→20, `a[-1]`→30 (from the end), `a[9]`→nil (OOB never raises).
+        // `sir_puts(nil)` renders nil as "nil" in this backend's convention.
+        Some(out) => assert_eq!(out, "20\n30\nnil"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn seq_len_is_native_length() {
+    let rb = emit_seq_module(vec![puts(Expr::SeqLen {
+        seq: Box::new(seq(vec![ilit(1), ilit(2), ilit(3)])),
+        span: s2(),
+    })]);
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "3"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn seq_set_writes_in_bounds_and_returns_the_value() {
+    // `a = [1,2,3]; a[1] = 99; puts a` → `[1, 99, 3]`.
+    let rb = emit_seq_module(vec![
+        Stmt::LetBinding {
+            name: "a".into(),
+            sir_type: None,
+            value: seq(vec![ilit(1), ilit(2), ilit(3)]),
+            span: s2(),
+        },
+        Stmt::SeqSet { seq: local("a"), index: ilit(1), value: ilit(99), span: s2() },
+        puts(local("a")),
+    ]);
+    assert!(rb.contains("sir_seq_set(a, 1, 99)"), "SeqSet should use the guarded helper:\n{rb}");
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "[1, 99, 3]"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn for_each_iterates_via_each_block() {
+    // `for x in [1,2,3]: puts x` → `1\n2\n3`, emitted as `(…).each { |x| … }`
+    // so the loop var is block-scoped (see `for_each_var_is_block_scoped…`).
+    let rb = emit_seq_module(vec![Stmt::ForEach {
+        var: "x".into(),
+        iter: seq(vec![ilit(1), ilit(2), ilit(3)]),
+        body: Block { stmts: vec![puts(local("x"))], value: Expr::NilLit { span: s2() }, span: s2() },
+        span: s2(),
+    }]);
+    assert!(rb.contains("([1, 2, 3]).each do |x|"), "ForEach should be a .each block:\n{rb}");
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "1\n2\n3"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn for_each_var_is_block_scoped_not_leaking() {
+    // A loop var that SHADOWS an enclosing local must NOT clobber it — the
+    // validator rewinds the loop var (body-scoped), and the Go backend
+    // block-scopes it too. `x = 99; for x in [1,2,3]; end; puts x` → 99.
+    let rb = emit_seq_module(vec![
+        Stmt::LetBinding { name: "x".into(), sir_type: None, value: ilit(99), span: s2() },
+        Stmt::ForEach {
+            var: "x".into(),
+            iter: seq(vec![ilit(1), ilit(2), ilit(3)]),
+            body: Block { stmts: vec![], value: Expr::NilLit { span: s2() }, span: s2() },
+            span: s2(),
+        },
+        puts(local("x")),
+    ]);
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "99"), // block-scoped: enclosing x survives
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+// ── SIR16 ForRange (numeric `for` loop, gated by Loops) ─────────────────────
+//
+// ForRange requires ONLY `Feature::Loops` (accepted since 0.3.0), so it is
+// reachable from the Ruby frontend (`for i in 0...3`) — yet the emitter used to
+// send it to `unreachable!`, a pre-existing panic. Now desugared to a `while`
+// matching the Go/Rust backends: evaluate-once bounds, direction-aware
+// exclusive stop, the loop var leaking to the enclosing scope.
+
+fn forrange(var: &str, start: i64, stop: i64, step: i64, body: Vec<Stmt>) -> Stmt {
+    Stmt::ForRange {
+        var: var.into(),
+        start: ilit(start),
+        stop: ilit(stop),
+        step: ilit(step),
+        body: Block { stmts: body, value: Expr::NilLit { span: s2() }, span: s2() },
+        span: s2(),
+    }
+}
+
+/// A ForRange module needs only Loops; build one so the manifest is minimal.
+fn loops_module(stmts: Vec<Stmt>) -> Module {
+    let mut m = seq_module(stmts);
+    m.manifest = FeatureManifest::from_features(&[Feature::Loops]);
+    m
+}
+
+#[test]
+fn for_range_counts_up_exclusive() {
+    // `for i in 0, 3, 1: puts i` → 0,1,2 (stop is exclusive).
+    let rb = compile(&loops_module(vec![forrange("i", 0, 3, 1, vec![puts(local("i"))])]))
+        .expect("ForRange must compile, not panic")
+        .source;
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "0\n1\n2"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn for_range_counts_down_with_negative_step() {
+    // `for i in 3, 0, -1: puts i` → 3,2,1 (descending, exclusive of 0).
+    let rb = compile(&loops_module(vec![forrange("i", 3, 0, -1, vec![puts(local("i"))])]))
+        .expect("ForRange must compile")
+        .source;
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "3\n2\n1"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn for_range_nested_uses_distinct_temporaries() {
+    // Nested range loops must not clobber each other's temporaries.
+    let inner = forrange("j", 0, 2, 1, vec![puts(local("j"))]);
+    let rb = compile(&loops_module(vec![forrange("i", 0, 2, 1, vec![inner])]))
+        .expect("nested ForRange must compile")
+        .source;
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "0\n1\n0\n1"), // i=0:{j0,j1}, i=1:{j0,j1}
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn unsupported_builtin_in_while_body_is_rejected_not_panicked() {
+    // Gap B (security review): a `While` body was not scanned by the
+    // unsupported-builtin pre-check, so an unknown builtin hidden there
+    // survived validation and hit the emitter's `unreachable!`. It must now be
+    // rejected CLEANLY (a `BackendError`), never panic.
+    let bad_call = Expr::BuiltinCall {
+        name: "totally_unsupported_xyz".into(),
+        args: vec![],
+        effects: EffectSet::PURE,
+        span: s2(),
+    };
+    let while_stmt = Stmt::While {
+        cond: Expr::BoolLit { value: false, span: s2() },
+        body: Block {
+            stmts: vec![Stmt::ExprStmt { expr: bad_call, span: s2() }],
+            value: Expr::NilLit { span: s2() },
+            span: s2(),
+        },
+        span: s2(),
+    };
+    // `compile` must return an Err (clean rejection), not unwind/panic.
+    let result = compile(&loops_module(vec![while_stmt]));
+    assert!(result.is_err(), "an unsupported builtin in a while body must be rejected cleanly");
+}


### PR DESCRIPTION
## What

The Ruby source-emitting backend rejected any array-literal program (it didn't accept `Feature::Sequences`), so sequence programs every other backend runs were **skipped** on Ruby, and the cross-backend composite-equality conformance case couldn't assert on Ruby.

This accepts `Feature::Sequences` and renders every SIR16 sequence node as **native Ruby** (no runtime value-boxing, unlike the Go/Rust `_sir_seq_*`):

| node | Ruby | note |
|---|---|---|
| `SeqLit` | `[1, 2, 3]` | structural `Array#==` → `[1,2] == [1,2]` is true |
| `SeqIndex` | `(a)[i]` | nil on OOB, negative-from-end — matches the reference exactly |
| `SeqLen` | `(a).length` | |
| `SeqSet` | `sir_seq_set(a, i, v)` | helper enforcing the ref bounds rule (RAISES on OOB/negative) |
| `ForEach` | `(a).each { \|x\| … }` | a block → loop var block-scoped |

## Two review rounds → a TOTAL emitter

The goal is composite equality (`SeqLit`), but accepting a feature means handling **everything** it can surface, or the emitter's `unreachable!` panics for a non-Ruby producer (C→SIR, Twig→SIR). Two security-review rounds caught that a naive `SeqLit`-only version was unsound:

- `SeqIndex`/`SeqLen`/`SeqSet` are **also** `Sequences`-gated (the `NDArrays`-gated `IndexGet`/`IndexSet` are different SIR22 nodes) — all three were unhandled.
- `ForEach` becomes reachable once `Loops` is accepted — unhandled.
- **`Stmt::ForRange`** (`for i in 0...3`) is `Loops`-gated (accepted since 0.3.0) and frontend-produced, yet was **also** unhandled — a **pre-existing panic**. Now a `while` desugaring matching Go's `_sir_range_cont` byte-for-byte: evaluate-once bounds in nesting-safe temporaries, direction-aware exclusive stop, a hoisted `->(i){…}` body so the counter is block-scoped.
- **`scan_stmt` had no `While` arm** (pre-existing hole): an unsupported builtin in a `while` body escaped the pre-check and panicked. Now scans While/ForEach/ForRange/SeqSet bodies.

Loop vars are block-scoped (via `.each` blocks / a body lambda) to match the validator (which rewinds the loop body) and Go's block-local counters — a leaking `for … in`/`while` would clobber an enclosing same-named local.

## Tests

Every node verified by **hand-built modules** (bypassing the Ruby frontend, which *masks* these nodes — the exact blind spot that let the first revision look complete): `SeqIndex` OOB/negative, `SeqSet` in-bounds, `ForEach`/`ForRange` up/down/nested, loop-var block-scoping (a shadowed enclosing local survives), and a `while`-body unsupported builtin rejecting cleanly. 28 backend tests green (real `ruby`).

## Scope

`IndexGet`/slicing (`NDArrays`) and array-pattern destructuring (`ShortCircuit`) remain rejected at the feature gate. No cross-backend conformance case is added here — on `main` the comparison operators aren't yet lowered on Python/JS/Rust, so a composite-`==` case would fail there; once that lands, the existing conformance case runs on Ruby too instead of skipping. README capability list corrected (it wrongly still listed `Loops` as rejected).

Version: `semantic-ir-to-ruby` 0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
