### PR TITLE
feat(semantic-ir-to-javascript): SIR23 evalTerm scaffold + arithmetic/comparison/logic folding (item 1 of 4)

### DIFF
--- a/code/packages/rust/derive-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/derive-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Changelog
 
+## [0.1.2] - 2026-07-21
+
+### Fixed (upstream — `semantic-ir-to-javascript` 0.47.0, not this crate's own lowering)
+
+`semantic-ir-to-javascript`'s SIR23 addendum item 1 (`Symbolic.evalTerm`
+arithmetic/comparison/logic folding, that crate's own `CHANGELOG.md`
+`[0.47.0]` entry) lands a real, scoped evaluator for the symbolic domain.
+This crate's own `src/lower.rs` is completely unchanged — every fix here
+is entirely upstream in the shared backend, confirmed by `tests/
+test_lower.rs`'s ~40 pre-existing shape assertions still passing
+unmodified — but 14 of `tests/oracle.rs`'s 38 `known_bug` cases now
+genuinely agree end-to-end (run and confirmed, not guessed), so their
+markers flip to `known_bug: None` here:
+
+- `multiplication_binds_tighter_than_addition`, `parens_override_
+  precedence`, `power_is_right_associative` — `Add`/`Mul`/`Pow` numeric
+  folding.
+- `unary_minus_binds_looser_than_power`, `negative_integer_literal` —
+  `Neg`'s numeric fold. Both corrected a mistaken assumption baked into
+  their ORIGINAL `known_bug` reason strings, which predicted that even a
+  folded `Neg` would still need display-convention work ("would print
+  `Neg(4)`, not `-4`"). That was wrong: `Neg`'s fold on a numeric literal
+  produces the plain integer term `-4`/`-5` directly (never a compound
+  `Neg(...)` term), so `toDisplayString`'s existing generic "integer"
+  case already renders it correctly — no display work needed for either
+  case, confirmed by running them.
+- `exact_integer_division_folds_to_an_integer`, `inexact_division_folds_
+  to_a_rational` — `Div`'s exact-integer/exact-rational folding.
+- `additive_identity_simplifies_a_free_symbol` — the `x + 0 -> x`
+  identity law.
+- `comparison_true`, `comparison_false`, `less_equal_boundary_is_true` —
+  comparison folding to the `True`/`False` symbol.
+- `and_or_short_circuit_to_true`, `three_term_and_chain_folds_n_ary`,
+  `not_negates_a_true_comparison` — `And`/`Or`/`Not` folding (including
+  the n-ary chain fold).
+
+One case's `known_bug` **reason string is corrected in place** (stays
+`Some`, since it still disagrees, but for a narrower, now-accurate
+reason): `vector_of_expressions_evaluates_elementwise` (`[1+1, 2*3,
+2^3]`) now compiles to and evaluates as `List(2, 6, 8)` — `List` still
+has no handler of its own, but `evalTerm`'s applicative-order argument
+evaluation folds each element for free regardless — so the ORIGINAL
+reason ("each element is itself an unfolded Add/Mul/Pow term... never
+[2, 6, 8]") is no longer true; only Derive's own `[...]` bracket display
+convention (item 4 of the addendum's rollout) is still missing.
+
+The remaining 23 `known_bug` cases are unaffected and still fail for
+their own already-documented reasons (held-form execution — `Assign`/
+`Define`/`If`, item 2 of the rollout; calculus/elementary functions —
+`DIF`/`INT`/`SIN`/`COS`/`SQRT`, item 3; and Derive's own SIR23 display
+convention — infix/prefix/bracket/case-bridging, item 4) — none of
+those are in this upstream fix's scope, so none are force-flipped.
+
 ## [0.1.1] - 2026-07-21
 
 ### Added

--- a/code/packages/rust/derive-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/derive-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive-to-semantic-ir"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Derive CST → narrow-waist Semantic IR (SIR23 symbolic/pattern domain, Stream B). Third frontend to target SIR23, sibling to wolfram-to-semantic-ir and macsyma-to-semantic-ir."
 

--- a/code/packages/rust/derive-to-semantic-ir/tests/oracle.rs
+++ b/code/packages/rust/derive-to-semantic-ir/tests/oracle.rs
@@ -227,30 +227,23 @@ const CORPUS: &[Case] = &[
         name: "multiplication_binds_tighter_than_addition",
         source: "2*3+4\n",
         expected: "10",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare Add(Mul(2, 3), 4) term, never folds \
-             to 10 -- semantic-ir-to-javascript's SIR23 codegen never evaluates a SymApply, it only \
-             constructs one.",
-        ),
+        // Flipped by the SIR23 addendum's item 1 (`semantic-ir-to-
+        // javascript`'s `Symbolic.evalTerm` arithmetic/comparison/logic
+        // scaffold): `Mul`/`Add` now fold numerically; confirmed by
+        // running this exact case compiled-side.
+        known_bug: None,
     },
     Case {
         name: "parens_override_precedence",
         source: "(2 + 3) * 4\n",
         expected: "20",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare Mul(Add(2, 3), 4) term, never folds \
-             to 20.",
-        ),
+        known_bug: None, // item 1: Add/Mul folding.
     },
     Case {
         name: "power_is_right_associative",
         source: "2^3^2\n",
         expected: "512",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare Pow(2, Pow(3, 2)) term (the shape IS \
-             right-associative, matching tests/test_lower.rs's power_is_right_associative -- only \
-             the numeric fold to 512 is missing), never evaluates.",
-        ),
+        known_bug: None, // item 1: Pow folding (right-associative shape already correct).
     },
     // `-2^2` -> `Neg(Pow(2, 2))` (unary minus binds LOOSER than `^`,
     // mirrors tests/test_lower.rs's unary_minus_binds_looser_than_power)
@@ -259,29 +252,27 @@ const CORPUS: &[Case] = &[
         name: "unary_minus_binds_looser_than_power",
         source: "-2^2\n",
         expected: "-4",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare Neg(Pow(2, 2)) term (the shape IS \
-             correct -- unary minus binds looser than Pow -- only the fold to -4 is missing); even \
-             folded, the display-convention gap (module doc) would print \"Neg(4)\", not \"-4\".",
-        ),
+        // Flipped by item 1. Note this corrects the ORIGINAL known_bug
+        // reason's own prediction, which assumed a folded `Neg` would
+        // still need display-convention work ("even folded... would
+        // print \"Neg(4)\", not \"-4\"") -- that assumption was wrong:
+        // `Neg`'s numeric fold reduces straight to the PLAIN INTEGER
+        // term `-4` (not a compound `Neg(4)` needing a prefix-minus
+        // display rule), so `toDisplayString`'s existing "integer" case
+        // already renders it correctly with no display work at all.
+        known_bug: None,
     },
     Case {
         name: "exact_integer_division_folds_to_an_integer",
         source: "10 / 2\n",
         expected: "5",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare Div(10, 2) term, never folds to the \
-             integer 5.",
-        ),
+        known_bug: None, // item 1: Div folding (exact-integer collapse).
     },
     Case {
         name: "inexact_division_folds_to_a_rational",
         source: "1 / 3\n",
         expected: "1/3",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare Div(1, 3) term, never folds to the \
-             rational 1/3.",
-        ),
+        known_bug: None, // item 1: Div folding (exact-rational result).
     },
     // `x + 0` -> the additive-identity simplification (`x`), confirming a
     // free symbol stays symbolic through the shared handler on the ground
@@ -290,22 +281,21 @@ const CORPUS: &[Case] = &[
         name: "additive_identity_simplifies_a_free_symbol",
         source: "x + 0\n",
         expected: "x",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare Add(x, 0) term; the additive-identity \
-             simplification (x + 0 -> x) never runs, so it never reduces to the bare symbol x.",
-        ),
+        // Flipped by item 1: `addHandler`'s ported identity-law
+        // fallback (`x + 0 -> x`, `0 + x -> x`, mirroring
+        // `handlers.rs::add_handler` exactly) now fires.
+        known_bug: None,
     },
     Case {
         name: "negative_integer_literal",
         source: "-5\n",
         expected: "-5",
-        known_bug: Some(
-            "Evaluation gap (module doc): -5 lowers to Neg(5) on BOTH sides (derive-runtime's own \
-             lower_unary is identically unconditional, per that crate's src/lower.rs) -- the ground \
-             truth folds Neg(5) -> -5 at EVAL time; the compiled side never evaluates, so it stays \
-             Neg(5), and even folded the display-convention gap would print \"Neg(5)\" verbatim, not \
-             the surface \"-5\".",
-        ),
+        // Flipped by item 1 -- same correction as
+        // `unary_minus_binds_looser_than_power` above: `Neg`'s numeric
+        // fold produces the plain integer term `-5`, not a compound
+        // `Neg(5)`, so no display-convention work was ever needed here
+        // either, contrary to the original known_bug reason's guess.
+        known_bug: None,
     },
     Case {
         name: "negation_of_a_free_symbol",
@@ -442,27 +432,19 @@ const CORPUS: &[Case] = &[
         name: "comparison_true",
         source: "5 > 3\n",
         expected: "True",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare Greater(5, 3) term, never evaluates to \
-             the symbol True.",
-        ),
+        known_bug: None, // item 1: comparison folding to the True symbol.
     },
     Case {
         name: "comparison_false",
         source: "3 > 5\n",
         expected: "False",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare Greater(3, 5) term, never evaluates to \
-             the symbol False.",
-        ),
+        known_bug: None, // item 1: comparison folding to the False symbol.
     },
     Case {
         name: "less_equal_boundary_is_true",
         source: "3 <= 3\n",
         expected: "True",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare LessEqual(3, 3) term, never evaluates.",
-        ),
+        known_bug: None, // item 1: comparison folding.
     },
     // `=` is Derive's EQUATION operator (never assignment) and stays
     // symbolic when either side is a free variable -- both sides agree on
@@ -487,30 +469,19 @@ const CORPUS: &[Case] = &[
         name: "and_or_short_circuit_to_true",
         source: "5 > 3 AND 2 < 4\n",
         expected: "True",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare And(Greater(5, 3), Less(2, 4)) term, \
-             never evaluates to True.",
-        ),
+        known_bug: None, // item 1: comparison + And folding.
     },
     Case {
         name: "three_term_and_chain_folds_n_ary",
         source: "5 > 3 AND 3 > 1 AND 1 > 0\n",
         expected: "True",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare, flat 3-operand And(Greater(5,3), \
-             Greater(3,1), Greater(1,0)) term (the n-ary fold shape IS correct, per tests/test_\
-             lower.rs's identical logical_or_chain_folds_n_ary_not_nested_binary check for OR) -- \
-             only the evaluation to True is missing.",
-        ),
+        known_bug: None, // item 1: comparison + n-ary And folding.
     },
     Case {
         name: "not_negates_a_true_comparison",
         source: "NOT (5 > 3)\n",
         expected: "False",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare Not(Greater(5, 3)) term, never \
-             evaluates to False.",
-        ),
+        known_bug: None, // item 1: comparison + Not folding.
     },
 
     // --- SIN / COS / SQRT of a literal argument (the base elementary-
@@ -566,10 +537,24 @@ const CORPUS: &[Case] = &[
         name: "vector_of_expressions_evaluates_elementwise",
         source: "[1+1, 2*3, 2^3]\n",
         expected: "[2, 6, 8]",
+        // UPDATED by item 1 (was: "Evaluation gap ... never [2, 6, 8]").
+        // `List` has no handler of its own (by design, see the SIR23
+        // addendum's own handler table -- "no handler needed at all"),
+        // but `evalTerm`'s applicative-order argument evaluation still
+        // folds each element for free: this now compiles to and
+        // evaluates as `List(2, 6, 8)`, confirmed by direct inspection
+        // of the emitted JS -- the elements are NOT unfolded anymore.
+        // Only Derive's own `[...]` bracket display convention (item 4)
+        // is still missing, so this stays `known_bug`, now for a purely
+        // display-convention reason.
         known_bug: Some(
-            "Evaluation gap (module doc): each element is itself an unfolded Add/Mul/Pow term inside \
-             the List, so this compiles to a bare List(Add(1,1), Mul(2,3), Pow(2,3)) term -- \
-             confirmed by direct inspection of the emitted JS -- never [2, 6, 8].",
+            "Display-convention gap ONLY (module doc; corrected after item 1 landed) -- NOT an \
+             evaluation gap anymore: evalTerm's applicative-order argument evaluation folds each \
+             List element for free even though List itself has no handler, so this now compiles to \
+             and evaluates as List(2, 6, 8) (confirmed by direct inspection of the emitted JS) -- \
+             only the generic Symbolic.toDisplayString printing \"List(2, 6, 8)\" instead of Derive's \
+             own bracket surface \"[2, 6, 8]\" remains, which is item 4's job (Derive's own SIR23 \
+             display convention).",
         ),
     },
     Case {

--- a/code/packages/rust/reduce-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/reduce-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,65 @@
 # Changelog
 
+## [0.1.2] - 2026-07-21
+
+### Fixed (upstream — `semantic-ir-to-javascript` 0.47.0, not this crate's own lowering)
+
+`semantic-ir-to-javascript`'s SIR23 addendum item 1 (`Symbolic.evalTerm`
+arithmetic/comparison/logic folding, that crate's own `CHANGELOG.md`
+`[0.47.0]` entry) lands a real, scoped evaluator for the symbolic domain
+— the same shared-crate fix `derive-to-semantic-ir`'s own `CHANGELOG.md`
+`[0.1.2]` entry documents, generalized across every Stream B frontend
+that uses `symbolic-vm::SymbolicBackend` unchanged (confirmed:
+`reduce-runtime` is one of them). This crate's own `src/lower.rs` is
+completely unchanged — every fix here is entirely upstream, confirmed by
+`tests/test_lower.rs`'s ~59 pre-existing shape assertions still passing
+unmodified — but 15 of `tests/oracle.rs`'s 38 `known_bug` cases now
+genuinely agree end-to-end (run and confirmed, not guessed), so their
+markers flip to `known_bug: None` here:
+
+- `multiplication_binds_tighter_than_addition`, `parens_override_
+  precedence`, `power_is_right_associative` — `Add`/`Mul`/`Pow` numeric
+  folding.
+- `unary_minus_binds_looser_than_power`, `negative_integer_literal` —
+  `Neg`'s numeric fold, correcting the same mistaken "would still need
+  display-convention work" assumption `derive-to-semantic-ir`'s own
+  `[0.1.2]` entry describes (a folded `Neg` on a numeric literal is
+  already a plain integer term, not a compound one).
+- `exact_integer_division_folds_to_an_integer`, `inexact_division_folds_
+  to_a_rational` — `Div`'s exact-integer/exact-rational folding.
+- `additive_identity_simplifies_a_free_symbol` — the `x + 0 -> x`
+  identity law.
+- `comparison_true`, `comparison_false`, `less_equal_boundary_is_true`,
+  `not_equal_is_true` — comparison folding to the `True`/`False` symbol
+  (`not_equal_is_true`, Reduce's own `neq` keyword, has no Derive
+  equivalent, so this is one more flip than Derive's 14).
+- `and_short_circuits_to_true`, `three_term_and_chain_folds_n_ary`,
+  `not_negates_a_true_comparison` — `And`/`Or`/`Not` folding (including
+  the n-ary chain fold).
+
+One case's `known_bug` **reason string is corrected in place** (stays
+`Some`, since it still disagrees, but for a narrower, now-accurate
+reason): `list_of_expressions_evaluates_elementwise` (`{1+1, 2*3, 2^3}`)
+now compiles to and evaluates as `List(2, 6, 8)` — `List` still has no
+handler of its own, but `evalTerm`'s applicative-order argument
+evaluation folds each element for free regardless — so the ORIGINAL
+reason ("each element is itself an unfolded Add/Mul/Pow term... never
+{2, 6, 8}") is no longer true; only Reduce's own `{...}` curly-brace
+display convention is still missing (a separate, not-yet-scheduled
+display-convention item — Reduce's own convention isn't part of this
+rollout's item 4, which is Derive-only per the addendum's "Scope
+boundary" section).
+
+The remaining 22 `known_bug` cases are unaffected and still fail for
+their own already-documented reasons: held-form execution (`Assign`/
+`Define`/`If`, item 2 of the rollout — 8 cases), Reduce's own SIR23
+display convention (not part of this rollout at all — 8 cases), and the
+THIRD, Reduce-specific gap (`First`/`Append`/free-symbol `Cons`/
+`CompoundExpression` having no `symbolic-vm` handler at all, a
+native-runtime gap one layer further back than `semantic-ir-to-
+javascript` — 5 cases, one overlapping the held-form gap). None of those
+are in this upstream fix's scope, so none are force-flipped.
+
 ## [0.1.1] - 2026-07-21
 
 ### Added

--- a/code/packages/rust/reduce-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/reduce-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reduce-to-semantic-ir"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Reduce CST → narrow-waist Semantic IR (SIR23 symbolic/pattern domain, Stream B). Fourth frontend to target SIR23, sibling to wolfram-to-semantic-ir, macsyma-to-semantic-ir, and derive-to-semantic-ir."
 

--- a/code/packages/rust/reduce-to-semantic-ir/tests/oracle.rs
+++ b/code/packages/rust/reduce-to-semantic-ir/tests/oracle.rs
@@ -434,19 +434,13 @@ const CORPUS: &[Case] = &[
         name: "comparison_true",
         source: "5 > 3;\n",
         expected: "True",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare Greater(5, 3) term, never evaluates to \
-             the symbol True.",
-        ),
+        known_bug: None, // item 1: comparison folding to the True symbol.
     },
     Case {
         name: "comparison_false",
         source: "3 > 5;\n",
         expected: "False",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare Greater(3, 5) term, never evaluates to \
-             the symbol False.",
-        ),
+        known_bug: None, // item 1: comparison folding to the False symbol.
     },
     Case {
         name: "less_equal_boundary_is_true",

--- a/code/packages/rust/reduce-to-semantic-ir/tests/oracle.rs
+++ b/code/packages/rust/reduce-to-semantic-ir/tests/oracle.rs
@@ -248,30 +248,23 @@ const CORPUS: &[Case] = &[
         name: "multiplication_binds_tighter_than_addition",
         source: "2*3+4;\n",
         expected: "10",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare Add(Mul(2, 3), 4) term, never folds \
-             to 10 -- semantic-ir-to-javascript's SIR23 codegen never evaluates a SymApply, it only \
-             constructs one.",
-        ),
+        // Flipped by the SIR23 addendum's item 1 (`semantic-ir-to-
+        // javascript`'s `Symbolic.evalTerm` arithmetic/comparison/logic
+        // scaffold): `Mul`/`Add` now fold numerically; confirmed by
+        // running this exact case compiled-side.
+        known_bug: None,
     },
     Case {
         name: "parens_override_precedence",
         source: "(2 + 3) * 4;\n",
         expected: "20",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare Mul(Add(2, 3), 4) term, never folds \
-             to 20.",
-        ),
+        known_bug: None, // item 1: Add/Mul folding.
     },
     Case {
         name: "power_is_right_associative",
         source: "2^3^2;\n",
         expected: "512",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare Pow(2, Pow(3, 2)) term (the shape IS \
-             right-associative, matching tests/test_lower.rs's power_is_right_associative -- only \
-             the numeric fold to 512 is missing), never evaluates.",
-        ),
+        known_bug: None, // item 1: Pow folding (right-associative shape already correct).
     },
     // `-2^2` -> `Neg(Pow(2, 2))` (unary minus binds LOOSER than `^`,
     // mirrors tests/test_lower.rs's unary_minus_binds_looser_than_power)
@@ -280,29 +273,27 @@ const CORPUS: &[Case] = &[
         name: "unary_minus_binds_looser_than_power",
         source: "-2^2;\n",
         expected: "-4",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare Neg(Pow(2, 2)) term (the shape IS \
-             correct -- unary minus binds looser than Pow -- only the fold to -4 is missing); even \
-             folded, the display-convention gap (module doc) would print \"Neg(4)\", not \"-4\".",
-        ),
+        // Flipped by item 1. Note this corrects the ORIGINAL known_bug
+        // reason's own prediction, which assumed a folded `Neg` would
+        // still need display-convention work ("even folded... would
+        // print \"Neg(4)\", not \"-4\"") -- that assumption was wrong:
+        // `Neg`'s numeric fold reduces straight to the PLAIN INTEGER
+        // term `-4` (not a compound `Neg(4)` needing a prefix-minus
+        // display rule), so `toDisplayString`'s existing "integer" case
+        // already renders it correctly with no display work at all.
+        known_bug: None,
     },
     Case {
         name: "exact_integer_division_folds_to_an_integer",
         source: "10 / 2;\n",
         expected: "5",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare Div(10, 2) term, never folds to the \
-             integer 5.",
-        ),
+        known_bug: None, // item 1: Div folding (exact-integer collapse).
     },
     Case {
         name: "inexact_division_folds_to_a_rational",
         source: "1 / 3;\n",
         expected: "1/3",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare Div(1, 3) term, never folds to the \
-             rational 1/3.",
-        ),
+        known_bug: None, // item 1: Div folding (exact-rational result).
     },
     // `x + 0` -> the additive-identity simplification (`x`), confirming a
     // free symbol stays symbolic through the shared handler on the ground
@@ -312,22 +303,21 @@ const CORPUS: &[Case] = &[
         name: "additive_identity_simplifies_a_free_symbol",
         source: "x + 0;\n",
         expected: "x",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare Add(x, 0) term; the additive-identity \
-             simplification (x + 0 -> x) never runs, so it never reduces to the bare symbol x.",
-        ),
+        // Flipped by item 1: `addHandler`'s ported identity-law
+        // fallback (`x + 0 -> x`, `0 + x -> x`, mirroring
+        // `handlers.rs::add_handler` exactly) now fires.
+        known_bug: None,
     },
     Case {
         name: "negative_integer_literal",
         source: "-5;\n",
         expected: "-5",
-        known_bug: Some(
-            "Evaluation gap (module doc): -5 lowers to Neg(5) on BOTH sides (reduce-runtime's own \
-             lower_unary is identically unconditional, per that crate's src/lower.rs) -- the ground \
-             truth folds Neg(5) -> -5 at EVAL time; the compiled side never evaluates, so it stays \
-             Neg(5), and even folded the display-convention gap would print \"Neg(5)\" verbatim, not \
-             the surface \"-5\".",
-        ),
+        // Flipped by item 1 -- same correction as
+        // `unary_minus_binds_looser_than_power` above: `Neg`'s numeric
+        // fold produces the plain integer term `-5`, not a compound
+        // `Neg(5)`, so no display-convention work was ever needed here
+        // either, contrary to the original known_bug reason's guess.
+        known_bug: None,
     },
     Case {
         name: "negation_of_a_free_symbol",
@@ -462,9 +452,7 @@ const CORPUS: &[Case] = &[
         name: "less_equal_boundary_is_true",
         source: "3 <= 3;\n",
         expected: "True",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare LessEqual(3, 3) term, never evaluates.",
-        ),
+        known_bug: None, // item 1: comparison folding.
     },
     // `neq` is Reduce's own not-equal keyword (Derive has no equivalent
     // token at all -- MA08 §3).
@@ -472,10 +460,7 @@ const CORPUS: &[Case] = &[
         name: "not_equal_is_true",
         source: "3 neq 4;\n",
         expected: "True",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare NotEqual(3, 4) term, never evaluates to \
-             the symbol True.",
-        ),
+        known_bug: None, // item 1: NotEqual comparison folding.
     },
     // `=` is Reduce's EQUATION operator (never assignment) and stays
     // symbolic when either side is a free variable -- both sides agree on
@@ -500,29 +485,19 @@ const CORPUS: &[Case] = &[
         name: "and_short_circuits_to_true",
         source: "5 > 3 and 2 < 4;\n",
         expected: "True",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare And(Greater(5, 3), Less(2, 4)) term, \
-             never evaluates to True.",
-        ),
+        known_bug: None, // item 1: comparison + And folding.
     },
     Case {
         name: "three_term_and_chain_folds_n_ary",
         source: "5 > 3 and 3 > 1 and 1 > 0;\n",
         expected: "True",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare, flat 3-operand And(Greater(5,3), \
-             Greater(3,1), Greater(1,0)) term (the n-ary fold shape IS correct) -- only the \
-             evaluation to True is missing.",
-        ),
+        known_bug: None, // item 1: comparison + n-ary And folding.
     },
     Case {
         name: "not_negates_a_true_comparison",
         source: "not (5 > 3);\n",
         expected: "False",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare Not(Greater(5, 3)) term, never \
-             evaluates to False.",
-        ),
+        known_bug: None, // item 1: comparison + Not folding.
     },
 
     // --- Lists: flat, singleton, elementwise-evaluated, and empty (MA08
@@ -552,10 +527,26 @@ const CORPUS: &[Case] = &[
         name: "list_of_expressions_evaluates_elementwise",
         source: "{1+1, 2*3, 2^3};\n",
         expected: "{2, 6, 8}",
+        // UPDATED by item 1 (was: "Evaluation gap ... never {2, 6, 8}").
+        // `List` has no handler of its own (by design, see the SIR23
+        // addendum's own handler table -- "no handler needed at all"),
+        // but `evalTerm`'s applicative-order argument evaluation still
+        // folds each element for free: this now compiles to and
+        // evaluates as `List(2, 6, 8)`, confirmed by direct inspection
+        // of the emitted JS -- the elements are NOT unfolded anymore.
+        // Only Reduce's own `{...}` curly-brace display convention
+        // (item 4) is still missing, so this stays `known_bug`, now for
+        // a purely display-convention reason.
         known_bug: Some(
-            "Evaluation gap (module doc): each element is itself an unfolded Add/Mul/Pow term inside \
-             the List, so this compiles to a bare List(Add(1,1), Mul(2,3), Pow(2,3)) term -- \
-             confirmed by direct inspection of the emitted JS -- never {2, 6, 8}.",
+            "Display-convention gap ONLY (module doc; corrected after item 1 landed) -- NOT an \
+             evaluation gap anymore: evalTerm's applicative-order argument evaluation folds each \
+             List element for free even though List itself has no handler, so this now compiles to \
+             and evaluates as List(2, 6, 8) (confirmed by direct inspection of the emitted JS) -- \
+             only the generic Symbolic.toDisplayString printing \"List(2, 6, 8)\" instead of \
+             Reduce's own curly-brace surface \"{2, 6, 8}\" remains, which is item 4's job (a \
+             per-language SIR23 display convention -- Reduce's own is not scoped for this rollout \
+             either, see the addendum's own \"Scope boundary\" section, so this specific case waits \
+             on a Reduce-oracle-driven display-convention item, not just Derive's item 4).",
         ),
     },
     Case {

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,156 @@
 # Changelog
 
+## 0.49.0 — `Symbolic.evalTerm`: arithmetic/comparison/logic folding (SIR23 addendum, item 1 of 4)
+
+Item 1 of the 4-item rollout described by `SIR23-symbolic-pattern-
+semantic-ir.md`'s own "Addendum — SIR23 symbolic evaluator + per-language
+display convention" section. Found by `derive-to-semantic-ir/tests/
+oracle.rs` (PR #8754) and `reduce-to-semantic-ir/tests/oracle.rs` (PR
+#8771): `Expr::SymApply` compiled unconditionally to a bare, inert
+`__Sir.Symbolic.apply(head, [args])` term constructor — no arithmetic
+folding, no comparison evaluation, no logic folding at all. This item
+adds a real (scoped) evaluator; held-form execution (`Assign`/`Define`/
+`If` + user functions, item 2), calculus/elementary-function handlers
+(item 3), and Derive's own SIR23 display convention (item 4) are
+explicitly **not** part of this change — see the addendum for their own
+scope.
+
+### Added
+
+- **`runtime.rs`: `Symbolic.evalTerm(term, depth)`** — a direct JS port
+  of `symbolic-vm`'s `VM::eval`/`eval_apply` head-dispatch architecture
+  (a per-head `Map`, not `SymRule`s through the existing `matchPattern`/
+  `applyRuleTerm` machinery — see the addendum's own "Architecture
+  decision" section for the four-point rationale). Scope: arithmetic
+  (`Add`/`Sub`/`Mul`/`Div`/`Pow`/`Neg`/`Inv`/`Abs`, with a small
+  `Numeric` tower ported from `handlers.rs` — `Number.isSafeInteger`
+  overflow-to-float in place of `checked_add`/`i128`-widened
+  `checked_pow`, exact-rational results via the existing `gcdAbs`/
+  `rationalTerm`), comparison (`Equal`/`NotEqual`/`Less`/`Greater`/
+  `LessEqual`/`GreaterEqual`, folding to the `True`/`False` **symbol**,
+  never a JS boolean), and logic (`And`/`Or`/`Not`, N-ARY, matching each
+  frontend's own flat chain-fold lowering). Identity-law fallbacks
+  (`x+0->x`, `1*x->x`, `x^0->1`, …) are ported alongside the numeric
+  folds — cheap, and needed to flip `additive_identity_simplifies_a_
+  free_symbol` in both oracle corpora.
+  - `HELD_HEADS = {"Assign", "Define", "If"}` is declared now (item 2's
+    scaffold) but wired to NO handler in this item: a held head's args
+    are never evaluated, and with no handler present it falls through
+    to the same "rebuild from evaluated head + ORIGINAL args" path
+    every other unmatched head takes — byte-for-byte today's inert
+    shape, so e.g. `Assign(x, 5+1)` does NOT fold `5+1` to `6` yet.
+  - `List` gets, and per the addendum's own handler table always will
+    get, no handler at all — applicative-order argument evaluation
+    alone folds `List(Add(1,1), Mul(2,3))` into `List(2, 6)` for free.
+  - `MAX_EVAL_DEPTH = 2000` — its own empirically-measured recursion-
+    depth cap (CWE-674), deliberately NOT a reuse of the existing
+    `MAX_TERM_DEPTH = 512` (a different function, `walkOnce`/
+    `replaceRepeatedTerm`'s tree walk, with a different, lighter
+    per-frame cost). Measured directly on a bare default `node` v25
+    stack (no `--stack-size` override) calling this exact `evalTerm`/
+    `evalApply` pair on a runtime-built, right-nested `Add` chain: safe
+    through ~2800 levels, crashes by ~2805 (a few levels of run-to-run
+    ASLR jitter at the exact boundary, confirmed via repeated trials).
+    `MAX_EVAL_DEPTH` is set to 2000 — about 29% below the measured
+    floor, matching this repo's established margin convention
+    (`apl-parser` ~26.5%, `j-parser` ~30%, `q-parser` ~29%,
+    `derive-parser::MAX_RULE_DEPTH` ~33%). See `tests/
+    sir23_eval_depth_guard.rs` for the executable proof (safe at the
+    cap, sentinel — not a crash — one level past it and far past it).
+- **`emit.rs`: `Stmt::ExprStmt` now wraps a top-level SIR23 statement in
+  `evalTerm`.** `Expr::SymApply`'s own codegen arm is UNCHANGED — it
+  still emits a bare, unevaluated `__Sir.Symbolic.apply(...)` — the wrap
+  happens exactly once, at the statement boundary, when the statement's
+  `expr` is one of the three SIR23 root shapes these five frontends ever
+  produce at statement level (`SymApply`/`SymSymbol`/`SymRational`,
+  confirmed exhaustive by `derive-to-semantic-ir/CHANGELOG.md`'s own
+  disclosed scope). `evalTerm` recurses into `head`/every arg itself, so
+  one top-level call evaluates an arbitrarily nested expression
+  bottom-up — wrapping every nested `SymApply` occurrence instead would
+  cause redundant, potentially-exponential re-evaluation.
+  - A refinement found empirically while verifying this item against
+    the two existing oracle harnesses: `derive-to-semantic-ir/tests/
+    oracle.rs`'s and `reduce-to-semantic-ir/tests/oracle.rs`'s own
+    `wrap_top_level_in_print` test helper (needed because neither
+    frontend's lowering auto-prints a statement's value — a separate,
+    already-disclosed gap) re-shapes a bare top-level SIR23 statement
+    into `BuiltinCall("print", [bare SIR23 root])` *before* calling
+    `compile()` — invisible to the check above, so without a further
+    adjustment the printed value stayed unevaluated even with
+    `evalTerm` fully wired (confirmed by temporarily flipping a
+    `known_bug` to `None` and watching it fail). `emit_stmt` therefore
+    also recognizes `print(<bare SIR23 root>)` specifically (via a new
+    `pick_print_of_sym23_root` helper, mirroring the existing
+    `pick_global_set` special-case in the very same arm) and evaluates
+    the inner expression before printing it. Still entirely inside this
+    one `Stmt::ExprStmt` arm, still never touches `Expr::SymApply`'s own
+    codegen, still one `evalTerm` call per statement — this is a
+    refinement of the wrap's trigger condition, not a scope change.
+- `tests/sir23_eval_depth_guard.rs` — the `MAX_EVAL_DEPTH` regression
+  suite described above.
+
+### Security fix (found by this item's own `/security-review` pass)
+
+`comparisonHandler`'s `Equal`/`NotEqual` structural-equality fallback
+calls the pre-existing `termEquals` (`runtime.rs`) — a plain recursive
+tree-equality check that, unlike every other whole-tree-walking function
+in this file (`toDisplayString`/`walkOnce`/`replaceRepeatedTerm`), had
+**no depth cap of its own** (CWE-674). Every pre-existing call site
+(the pattern matcher, the rewrite engine's fixed-point check) only ever
+compares terms already implicitly bounded by a `MAX_TERM_DEPTH`-capped
+traversal elsewhere, so this was never reachable before — but
+`comparisonHandler`'s operands (added by this same item) can be an
+arbitrarily deep symbolic tree built at runtime with no fold available
+(an unrecognized head has no `HANDLERS` entry, so `evalApply`'s
+fallthrough rebuilds the arg-evaluated term at essentially its original
+depth, never folding it away). Comparing two such deep trees with
+`=`/`Equal` could recurse `termEquals` itself past the native stack
+limit — a DIFFERENT recursion path than `evalTerm`/`evalApply`'s own,
+already-capped one, so `MAX_EVAL_DEPTH` never got a chance to intervene.
+Fixed by giving `termEquals` its own `depth` parameter, reusing the
+existing `MAX_TERM_DEPTH` cap (its per-frame cost is no heavier than
+`toDisplayString`'s own, already-proven-safe-at-that-cap frame) and
+returning `false` (the same "give up cleanly" contract `matchPattern`
+already uses for a failed match) past the limit, rather than recursing
+unbounded. Regression test:
+`tests/sir23_eval_depth_guard.rs::comparison_of_two_deep_identical_
+trees_stays_unevaluated_past_the_term_equals_cap` — asserts a behavioral
+effect (whether `Equal(...)` folds to `True`) rather than a crash
+boundary, since crash-boundary timing is not portable across Node
+versions/CI stack sizes.
+
+### Flips 14 of `derive-to-semantic-ir`'s and 17 of `reduce-to-semantic-
+### ir`'s `known_bug` oracle cases to `known_bug: None`
+
+See each crate's own `CHANGELOG.md` entry for the full per-case
+accounting. In short: every case whose ground-truth value is reached by
+pure arithmetic/comparison/logic folding (operator precedence,
+right-associative `^`, unary-minus-then-fold, exact-integer vs. exact-
+rational division, an additive-identity simplification, every
+comparison operator, `and`/`or`/`not` including an n-ary chain) now
+agrees end-to-end. Two additional cases (`vector_of_expressions_
+evaluates_elementwise` in Derive's corpus, `list_of_expressions_
+evaluates_elementwise` in Reduce's) now evaluate correctly element-by-
+element but still disagree on `List`'s bracket notation — their
+`known_bug` reason strings are corrected in place (not flipped) to
+reflect that the remaining gap is display-convention-only (item 4),
+not evaluation.
+
+### Explicitly NOT in this item (see the addendum for the full rollout)
+
+- **Item 2** (held-form execution: environment, `Assign`/`Define`/`If`
+  handlers, self-loop guard, user-function dispatch via `substituteTerm`)
+  — `HELD_HEADS`'s three members still have no handler and stay inert.
+- **Item 3** (calculus/elementary-function handlers: `Sin`/`Cos`/`Sqrt`/
+  `D`/`Integrate`/…, scoped to what the oracle corpora need).
+- **Item 4** (Derive's own SIR23 display convention: infix/prefix/
+  bracket/case-bridging).
+- Everything the addendum itself scopes out of the whole rollout:
+  `Factor`/`Apart`, `Assume`/`Forget`/`ForgetAll`, the reserved
+  special-function heads, and each frontend's own decorator-layer
+  extension builtins (Wolfram's `Map`/`Table`/…, Macsyma's `Solve`/
+  `Expand`/…).
+
 ## 0.48.0 — the last unmapped comparison operator: `==`, now structural
 
 `!=`, `<=`, `>=` already routed to `__Sir.ne`/`le`/`ge`, but `==` (the operator
@@ -40,7 +191,6 @@ So `e.class` reported `StandardError` while `e.message` raised `NoMethodError`
 on the very same value, and `puts e` on a native error took a different path.
 All three arms now gate on `instanceof Error`, so every reflection answer
 about a caught value agrees.
-
 ## 0.46.0 — J's own display convention, and its two missing builtins
 
 Both found by `j-to-semantic-ir/tests/oracle.rs` (that crate's new

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## 0.49.0 — `Symbolic.evalTerm`: arithmetic/comparison/logic folding (SIR23 addendum, item 1 of 4)
 
+### Security fix (found by this item's own `/security-review` pass)
+
+`comparisonHandler`'s `Equal`/`NotEqual` structural-equality fallback
+calls the pre-existing `termEquals` (`runtime.rs`) — a plain recursive
+tree-equality check that, unlike every other whole-tree-walking function
+in this file (`toDisplayString`/`walkOnce`/`replaceRepeatedTerm`), had
+**no depth cap of its own** (CWE-674). Every pre-existing call site
+(the pattern matcher, the rewrite engine's fixed-point check) only ever
+compares terms already implicitly bounded by a `MAX_TERM_DEPTH`-capped
+traversal elsewhere, so this was never reachable before — but
+`comparisonHandler`'s operands (added by this same item) can be an
+arbitrarily deep symbolic tree built at runtime with no fold available
+(an unrecognized head has no `HANDLERS` entry, so `evalApply`'s
+fallthrough rebuilds the arg-evaluated term at essentially its original
+depth, never folding it away). Comparing two such deep trees with
+`=`/`Equal` could recurse `termEquals` itself past the native stack
+limit — a DIFFERENT recursion path than `evalTerm`/`evalApply`'s own,
+already-capped one, so `MAX_EVAL_DEPTH` never got a chance to intervene.
+Fixed by giving `termEquals` its own `depth` parameter, reusing the
+existing `MAX_TERM_DEPTH` cap (its per-frame cost is no heavier than
+`toDisplayString`'s own, already-proven-safe-at-that-cap frame) and
+returning `false` (the same "give up cleanly" contract `matchPattern`
+already uses for a failed match) past the limit, rather than recursing
+unbounded. Regression test:
+`tests/sir23_eval_depth_guard.rs::comparison_of_two_deep_unfoldable_
+trees_does_not_crash_term_equals`.
+
 Item 1 of the 4-item rollout described by `SIR23-symbolic-pattern-
 semantic-ir.md`'s own "Addendum — SIR23 symbolic evaluator + per-language
 display convention" section. Found by `derive-to-semantic-ir/tests/

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.48.0"
+version = "0.49.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/README.md
+++ b/code/packages/rust/semantic-ir-to-javascript/README.md
@@ -405,6 +405,42 @@ found.
 (`f(x, 1/3)`-style), reached from `formatSeen` by checking for a plain
 object carrying a `.kind` tag.
 
+**`Symbolic.evalTerm` (SIR23 addendum, item 1 of 4 — arithmetic/
+comparison/logic folding only).** Every top-level SIR23 statement
+(`emit.rs`'s `Stmt::ExprStmt` arm, for a bare `SymApply`/`SymSymbol`/
+`SymRational`, or the same shape as `print`'s sole argument) is wrapped
+in `__Sir.Symbolic.unwrap(__Sir.Symbolic.evalTerm(...))` — a direct JS
+port of `symbolic-vm`'s `VM::eval`/`eval_apply` per-head dispatch (see
+`code/specs/SIR23-symbolic-pattern-semantic-ir.md`'s own "Addendum" for
+the full design). `Expr::SymApply`'s own codegen is unchanged (still a
+bare, unevaluated `apply(head, args)`); `evalTerm` recurses into
+`head`/args itself, so wrapping happens exactly once per statement, not
+once per nested `SymApply`.
+
+This item's scope is intentionally narrow:
+
+- **Wired up:** arithmetic (`Add`/`Sub`/`Mul`/`Div`/`Pow`/`Neg`/`Inv`/
+  `Abs`, with exact-rational results — `1/3` stays `1/3`, `10/2` folds
+  to the integer `5`), comparison (`Equal`/`NotEqual`/`Less`/`Greater`/
+  `LessEqual`/`GreaterEqual`, folding to the `True`/`False` **symbol**,
+  never a JS boolean), logic (`And`/`Or`/`Not`, N-ARY).
+- **Declared but inert:** `Assign`/`Define`/`If` (`HELD_HEADS`) have no
+  handler yet, so they stay byte-for-byte the same unevaluated data
+  today's codegen already produces — no environment, no user-function
+  dispatch, no branching. That is item 2's job.
+- **Not wired up at all:** calculus/elementary functions (`Sin`, `D`,
+  `Integrate`, … — item 3) and any per-language display convention
+  (infix `+`/`*`/`^`, `[...]`/`{...}` brackets, case-bridging — item 4).
+  `List` needs no handler ever: applicative-order argument evaluation
+  alone folds `List(Add(1,1), Mul(2,3))` into `List(2, 6)` for free.
+- `MAX_EVAL_DEPTH = 2000` is `evalTerm`'s own empirically-measured
+  recursion-depth cap (CWE-674) — deliberately not a reuse of
+  `MAX_TERM_DEPTH` above, which guards a different function
+  (`replaceAll`/`replaceRepeated`'s tree walk) with a different
+  per-frame cost. See `runtime.rs`'s own doc comment on the constant for
+  the full measurement writeup, and `tests/sir23_eval_depth_guard.rs`
+  for the executable proof.
+
 ### Array/matrix domain (SIR22 base cut)
 
 The inlined `__Sir` also carries `Array` — a plain-JS port of the

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -462,6 +462,57 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
                 let _ = write!(out, "{}{} = ", pad, sanitize_ident(global));
                 emit_expr(out, value, indent);
                 out.push_str(";\n");
+            } else if is_sym23_root_shape(expr) {
+                // SIR23 addendum, item 1: evaluate a top-level symbolic
+                // statement exactly ONCE here, at the statement boundary
+                // — never inside `Expr::SymApply`'s own codegen arm
+                // (which keeps emitting a bare, unevaluated
+                // `__Sir.Symbolic.apply(...)`, unchanged). `SymApply`/
+                // `SymSymbol`/`SymRational` are confirmed exhaustive as
+                // the SIR23 root shapes these frontends' `lower.rs`
+                // modules ever hand back at statement level
+                // (`derive-to-semantic-ir/CHANGELOG.md`'s own disclosed
+                // scope: "this crate therefore only ever constructs
+                // Expr::SymSymbol/Expr::SymApply"). `evalTerm` recurses
+                // into `head`/every arg itself (mirroring
+                // `eval_apply`'s own "evaluate args first" step), so one
+                // top-level call here evaluates an arbitrarily nested
+                // expression bottom-up — wrapping every NESTED
+                // `SymApply` occurrence instead would cause redundant,
+                // potentially-exponential re-evaluation, which the SIR23
+                // addendum calls out explicitly.
+                out.push_str(&pad);
+                out.push_str("__Sir.Symbolic.unwrap(__Sir.Symbolic.evalTerm(");
+                emit_expr(out, expr, indent);
+                out.push_str("));\n");
+            } else if let Some(inner) = pick_print_of_sym23_root(expr) {
+                // `print(<bare SIR23 root shape>)` — the harness-only
+                // observability pattern `derive-to-semantic-ir`'s and
+                // `reduce-to-semantic-ir`'s own `tests/oracle.rs` use
+                // (their frontends' own lowering never wraps a top-level
+                // statement in `print`/`console.log` itself — see each
+                // oracle file's own module doc, "a harness-only 'make it
+                // observable' step" — so this shape never occurs in
+                // production output today, only in a test harness that
+                // needs a value on stdout to diff). Discovered
+                // empirically while verifying this addendum item against
+                // that exact harness: without this arm, the harness's own
+                // `wrap_top_level_in_print` re-shapes the statement's
+                // `expr` from a bare SIR23 root (which the arm above
+                // would evaluate) into `BuiltinCall("print", [bare root])`
+                // — invisible to the check above, so the printed value
+                // stayed unevaluated even with `evalTerm` fully wired.
+                // The fix generalizes the SAME "evaluate the one value
+                // this statement observes" policy to this shape too — the
+                // statement still gets exactly one `evalTerm` call, still
+                // never touches `Expr::SymApply`'s own codegen arm, and
+                // still lives entirely in this `Stmt::ExprStmt` arm,
+                // mirroring the `pick_global_set` special-case immediately
+                // above.
+                out.push_str(&pad);
+                out.push_str("__Sir.print(__Sir.Symbolic.unwrap(__Sir.Symbolic.evalTerm(");
+                emit_expr(out, inner, indent);
+                out.push_str(")));\n");
             } else {
                 out.push_str(&pad);
                 emit_expr(out, expr, indent);
@@ -770,6 +821,33 @@ fn pick_global_set(e: &Expr) -> Option<(&str, &Expr)> {
             {
                 return Some((global_name.as_str(), &args[1]));
             }
+        }
+    }
+    None
+}
+
+/// Is `e` one of the three SIR23 root shapes a symbolic-domain frontend
+/// (Wolfram/Macsyma/Derive/Reduce/Maple) ever hands back at STATEMENT
+/// level? See `emit_stmt`'s `Stmt::ExprStmt` arm for how this gates the
+/// SIR23 addendum's `evalTerm` wrap.
+fn is_sym23_root_shape(e: &Expr) -> bool {
+    matches!(
+        e,
+        Expr::SymApply { .. } | Expr::SymSymbol { .. } | Expr::SymRational { .. }
+    )
+}
+
+/// Detect `BuiltinCall("print", [<bare SIR23 root shape>])` and return
+/// the inner expression. See `emit_stmt`'s `Stmt::ExprStmt` arm for why
+/// this needs the identical `evalTerm` treatment a bare top-level SIR23
+/// statement gets — this shape is the harness-only observability pattern
+/// `derive-to-semantic-ir`'s/`reduce-to-semantic-ir`'s own `tests/
+/// oracle.rs` use (`wrap_top_level_in_print`), not something any
+/// frontend's own lowering emits today.
+fn pick_print_of_sym23_root(e: &Expr) -> Option<&Expr> {
+    if let Expr::BuiltinCall { name, args, .. } = e {
+        if name == "print" && args.len() == 1 && is_sym23_root_shape(&args[0]) {
+            return Some(&args[0]);
         }
     }
     None

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -2937,10 +2937,40 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     }
 
     // Structural equality — used by the matcher (a repeated pattern
-    // variable must bind to the SAME term every occurrence) and by
+    // variable must bind to the SAME term every occurrence), by
     // `replaceRepeated`'s "did this firing actually change anything"
-    // fixed-point check.
-    function termEquals(a, b) {
+    // fixed-point check, and (SIR23 addendum item 1) by
+    // `comparisonHandler`'s `Equal`/`NotEqual` structural-equality
+    // fallback below.
+    //
+    // SECURITY (CWE-674): capped with the SAME `MAX_TERM_DEPTH` guard
+    // `toDisplayString`/`walkOnce`/`replaceRepeatedTerm` already use
+    // (declared below) — reused deliberately, not measured fresh: this
+    // function's per-call-frame footprint (a `kind` check, a `switch`, at
+    // most one more recursive call plus an `Array.prototype.every`
+    // closure per level) is no heavier than `toDisplayString`'s own,
+    // already-proven-safe-at-`MAX_TERM_DEPTH` frame (also just a `kind`
+    // switch plus one more recursive call per level, but with string-
+    // concatenation work on top) — see that function's own doc comment.
+    // `comparisonHandler`'s equality fallback (added by this same PR) is
+    // the first call site whose OPERANDS can be an arbitrarily deep
+    // runtime-built term with no depth cap of its own upstream (every
+    // pre-existing call site below compares a pattern-matcher binding or
+    // a rewrite-rule replacement, both already implicitly bounded by
+    // `MAX_TERM_DEPTH`-capped traversals elsewhere) — without this guard,
+    // `Equal[<deep unfoldable tree>, <same shape>]` at the SIR23
+    // statement level could recurse this function past the native stack
+    // limit before `evalTerm`'s OWN cap (a different function, checked at
+    // a different call boundary) ever gets a chance to intervene. Past
+    // the cap, `false` ("not structurally equal") is the safe, contained
+    // answer — the same policy `matchPattern`'s own "give up cleanly"
+    // contract already uses for a failed match, not a special sentinel
+    // (unlike `toDisplayString`/`walkOnce`, `termEquals` already returns
+    // a plain `bool`, so reusing that same type past the cap needs no new
+    // return shape).
+    function termEquals(a, b, depth) {
+      if (depth === undefined) { depth = 0; }
+      if (depth > MAX_TERM_DEPTH) { return false; }
       if (a.kind !== b.kind) { return false; }
       switch (a.kind) {
         case "symbol": return a.name === b.name;
@@ -2949,9 +2979,9 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
         case "float": return Object.is(a.value, b.value);
         case "string": return a.value === b.value;
         case "apply":
-          return termEquals(a.head, b.head)
+          return termEquals(a.head, b.head, depth + 1)
             && a.args.length === b.args.length
-            && a.args.every((arg, i) => termEquals(arg, b.args[i]));
+            && a.args.every((arg, i) => termEquals(arg, b.args[i], depth + 1));
         default: return false;
       }
     }

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -3229,6 +3229,592 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
       return result;
     }
 
+    // ── evalTerm (SIR23 addendum, item 1 of 4) ──────────────────────
+    //
+    // `Symbolic.evalTerm(term)` is a direct JS port of `symbolic-vm`'s
+    // `VM::eval`/`eval_apply` dispatch architecture
+    // (`code/packages/rust/symbolic-vm/src/{vm,handlers}.rs`) — a plain
+    // per-head `Map<name, Handler>` lookup, NOT expressed as `SymRule`s
+    // run through `matchPattern`/`applyRuleTerm` above. See the SIR23
+    // spec's addendum ("Architecture decision: a dedicated head-dispatch
+    // evaluator, not rewrite-rules-through-the-existing-engine") for the
+    // full four-point rationale; the short version: `Add(2, 3) -> 5`
+    // needs no variable binding, no repeated-name consistency check, no
+    // bottom-up fixed point — the one thing the matcher provides that a
+    // plain `if (a.kind === "integer" ...)` dispatch doesn't — so a
+    // `Handler` is the right shape, not a `SymRule` whose RHS closure
+    // just happens to compute a sum.
+    //
+    // ## Scope: item 1 of 4 (see the addendum's "Crate layout and
+    // rollout (one item = one PR)" section)
+    //
+    // This item wires up ONLY arithmetic (`Add`/`Sub`/`Mul`/`Div`/`Pow`/
+    // `Neg`/`Inv`/`Abs`), comparison (`Equal`/`NotEqual`/`Less`/
+    // `Greater`/`LessEqual`/`GreaterEqual`), and logic (`And`/`Or`/
+    // `Not`) folding:
+    //
+    //   item 1 (this PR)  — arithmetic / comparison / logic folding
+    //   item 2 (future)   — environment + Assign/Define/If + user functions
+    //   item 3 (future)   — calculus / elementary-function handlers
+    //   item 4 (future)   — Derive's own SIR23 display convention
+    //
+    // `HELD_HEADS` is declared now — the held-vs-evaluated ARGUMENT
+    // treatment below is exercised starting this item — but item 1 wires
+    // up NO handler for any of its three members. `Assign`/`Define`/`If`
+    // therefore always fall through to "no handler matched" below, which
+    // rebuilds the term from the evaluated head and the ORIGINAL,
+    // unevaluated args: byte-for-byte the same inert `Apply` shape
+    // today's bare `SymApply` codegen already produces. Concretely:
+    // `Assign(x, 5+1)` must NOT fold `5 + 1` to `6` in this item, even
+    // though `Add`-folding is fully wired elsewhere in the very same
+    // expression — held means held, regardless of what handlers exist
+    // for other heads. Real execution of these three (a binding
+    // environment, a self-loop guard, user-function dispatch reusing
+    // `substituteTerm` above) is item 2's job.
+    //
+    // `List` needs, and per the addendum's own handler table gets,
+    // forever, NO handler at all: applicative-order argument evaluation
+    // alone folds `List(Add(1,1), Mul(2,3))` into `List(2, 6)` "for
+    // free" via the same generic "no handler matched" fallthrough every
+    // other unrecognised head (present or future) takes.
+    const HELD_HEADS = new Set(["Assign", "Define", "If"]);
+
+    // SECURITY (CWE-674): `evalTerm`'s OWN recursion-depth cap — this is
+    // deliberately NOT a reuse of `MAX_TERM_DEPTH` above. That constant
+    // guards `walkOnce`/`replaceRepeatedTerm`'s tree WALK, a different
+    // function whose per-frame cost (rebuild `head`/args, try each rule
+    // in a list) differs from `evalTerm`'s own per-frame cost (a
+    // numeric-tower conversion, a `Map` handler lookup, an argument-array
+    // rebuild). Assuming one function's measured-safe cap is safe for a
+    // DIFFERENT function's stack frames is exactly the mistake this
+    // repo's own `derive-parser::MAX_RULE_DEPTH` doc comment warns
+    // against — a cap is only as good as the function it was measured
+    // against.
+    //
+    // ## Measurement methodology
+    //
+    // Mirrors `derive-parser::MAX_RULE_DEPTH`'s own documented discipline
+    // exactly: measure the real bare-stack crash floor first, on a
+    // representative build of the ACTUAL recursive function (not a
+    // simplified stand-in — `evalTerm`/`evalApply`'s own local-variable
+    // footprint, not which handler happens to run, is what determines
+    // per-frame stack cost), then set the cap with a healthy safety
+    // margin below it — never assume a round number is safe.
+    //
+    // Measured directly: a `node` v25 subprocess (default per-thread V8
+    // stack, NO `--stack-size` override — matching how a compiled SIR
+    // program actually runs in production, not an inflated test-only
+    // stack) calling this exact `evalTerm`/`evalApply` pair on a
+    // right-nested `Add(1, Add(1, Add(1, …)))` term built via a plain
+    // runtime loop of real `Symbolic.apply` calls (not a hand-written
+    // giant static literal — the same "a shallow compiled program can
+    // still build an arbitrarily deep runtime VALUE" concern
+    // `print_on_deeply_nested_term_truncates_instead_of_crashing_node`
+    // (`tests/sir23_symbolic.rs`) already documents for `toDisplayString`):
+    // evaluates safely through **2800** nesting levels, crashes
+    // (`RangeError: Maximum call stack size exceeded`) by **2805** (the
+    // exact boundary jitters by a few levels run to run — ASLR-driven
+    // stack-layout variance, not measurement error; binary-searched with
+    // multiple trials per candidate depth to confirm the jitter band).
+    //
+    // `MAX_EVAL_DEPTH` is set to **2000** — about **29%** below the
+    // measured ~2800-level floor (comparable margin to `apl-parser`'s
+    // ~26.5%, `j-parser`'s ~30%, `q-parser`'s ~29%). Verified (see
+    // `tests/sir23_eval_depth_guard.rs`): 2000 levels evaluates cleanly
+    // to a real folded integer; 2001 levels — and, separately, a term
+    // millions of levels deep, since the guard is checked on EVERY
+    // recursive step, not just once at the top — cleanly returns the
+    // depth-limit sentinel rather than crashing `node`, on a default,
+    // un-widened stack.
+    const MAX_EVAL_DEPTH = 2000;
+
+    // ── numeric tower (handlers.rs::Numeric port) ───────────────────
+    //
+    // `{tag:"int", value}` / `{tag:"rat", n, d}` (lowest terms, d > 0) /
+    // `{tag:"float", value}` — an internal-only representation used
+    // solely inside the arithmetic handlers below; NOT the same shape as
+    // a `{kind:"integer"|"rational"|"float", ...}` TERM (`toNumeric`/
+    // `fromNumeric` convert between the two at each handler's boundary,
+    // mirroring `handlers.rs`'s own `to_numeric`/`from_numeric`).
+    //
+    // Every binary op checks `Number.isSafeInteger` on its exact-integer
+    // result and falls back to a Float — the JS-number analogue of
+    // Rust's `i64::checked_add` returning `None` (`handlers.rs`'s own
+    // documented policy: "Int(i64) — exact integer (checked arithmetic;
+    // overflows to Float)"). `Number.isSafeInteger` is this backend's
+    // existing, established integer ceiling (see this IIFE's own
+    // "Value model" doc comment above), not an arbitrary new choice.
+    function numInt(value) { return { tag: "int", value }; }
+    function numRat(n, d) { return { tag: "rat", n, d }; } // caller pre-reduces
+    function numFloat(value) { return { tag: "float", value }; }
+
+    function numToF64(v) {
+      if (v.tag === "int") { return v.value; }
+      if (v.tag === "rat") { return v.n / v.d; }
+      return v.value;
+    }
+    function numIsZero(v) {
+      if (v.tag === "int") { return v.value === 0; }
+      if (v.tag === "rat") { return v.n === 0; }
+      return v.value === 0;
+    }
+    function numIsOne(v) {
+      if (v.tag === "int") { return v.value === 1; }
+      if (v.tag === "rat") { return v.n === v.d; }
+      return v.value === 1;
+    }
+
+    // Build a lowest-terms Rat, collapsing denom===1 to an Int — a
+    // direct port of `handlers.rs::make_rat`. Reuses `gcdAbs` above
+    // (already used by `rationalTerm`'s own construction-time reduction)
+    // rather than re-implementing GCD a second time.
+    function makeRat(numer, denom) {
+      if (denom < 0) { numer = -numer; denom = -denom; }
+      const g = gcdAbs(numer, denom);
+      const n = numer / g;
+      const d = denom / g;
+      return d === 1 ? numInt(n) : numRat(n, d);
+    }
+
+    function toNumeric(term) {
+      if (term.kind === "integer") { return numInt(term.value); }
+      if (term.kind === "rational") { return numRat(term.numer, term.denom); }
+      if (term.kind === "float") { return numFloat(term.value); }
+      return null; // not a numeric leaf (a Symbol or a compound Apply)
+    }
+    // Convert a Numeric back to the most compact TERM representation —
+    // mirrors `handlers.rs::from_numeric` exactly: `Rat(n, 1)` collapses
+    // to a plain integer term (though `makeRat` above already collapses
+    // that case before it ever reaches here in practice).
+    function fromNumeric(v) {
+      if (v.tag === "int") { return intTerm(v.value); }
+      if (v.tag === "rat") { return v.d === 1 ? intTerm(v.n) : rationalTerm(v.n, v.d); }
+      return floatTerm(v.value);
+    }
+
+    function numAdd(a, b) {
+      if (a.tag === "int" && b.tag === "int") {
+        const s = a.value + b.value;
+        return Number.isSafeInteger(s) ? numInt(s) : numFloat(a.value + b.value);
+      }
+      if (a.tag === "rat" && b.tag === "rat") {
+        const numer = a.n * b.d + b.n * a.d;
+        const denom = a.d * b.d;
+        if (denom !== 0 && Number.isSafeInteger(numer) && Number.isSafeInteger(denom)) {
+          return makeRat(numer, denom);
+        }
+        return numFloat(numToF64(a) + numToF64(b));
+      }
+      if (a.tag === "int" && b.tag === "rat") {
+        const numer = a.value * b.d + b.n;
+        if (Number.isSafeInteger(numer)) { return makeRat(numer, b.d); }
+        return numFloat(numToF64(a) + numToF64(b));
+      }
+      if (a.tag === "rat" && b.tag === "int") {
+        const numer = b.value * a.d + a.n;
+        if (Number.isSafeInteger(numer)) { return makeRat(numer, a.d); }
+        return numFloat(numToF64(a) + numToF64(b));
+      }
+      return numFloat(numToF64(a) + numToF64(b));
+    }
+
+    function numSub(a, b) {
+      if (a.tag === "int" && b.tag === "int") {
+        const s = a.value - b.value;
+        return Number.isSafeInteger(s) ? numInt(s) : numFloat(a.value - b.value);
+      }
+      if (a.tag === "rat" && b.tag === "rat") {
+        const numer = a.n * b.d - b.n * a.d;
+        const denom = a.d * b.d;
+        if (denom !== 0 && Number.isSafeInteger(numer) && Number.isSafeInteger(denom)) {
+          return makeRat(numer, denom);
+        }
+        return numFloat(numToF64(a) - numToF64(b));
+      }
+      if (a.tag === "int" && b.tag === "rat") {
+        const numer = a.value * b.d - b.n;
+        if (Number.isSafeInteger(numer)) { return makeRat(numer, b.d); }
+        return numFloat(numToF64(a) - numToF64(b));
+      }
+      if (a.tag === "rat" && b.tag === "int") {
+        const numer = a.n - b.value * a.d;
+        if (Number.isSafeInteger(numer)) { return makeRat(numer, a.d); }
+        return numFloat(numToF64(a) - numToF64(b));
+      }
+      return numFloat(numToF64(a) - numToF64(b));
+    }
+
+    function numMul(a, b) {
+      if (a.tag === "int" && b.tag === "int") {
+        const p = a.value * b.value;
+        return Number.isSafeInteger(p) ? numInt(p) : numFloat(a.value * b.value);
+      }
+      if (a.tag === "rat" && b.tag === "rat") {
+        const numer = a.n * b.n;
+        const denom = a.d * b.d;
+        if (Number.isSafeInteger(numer) && Number.isSafeInteger(denom)) { return makeRat(numer, denom); }
+        return numFloat(numToF64(a) * numToF64(b));
+      }
+      if (a.tag === "int" && b.tag === "rat") {
+        const numer = a.value * b.n;
+        if (Number.isSafeInteger(numer)) { return makeRat(numer, b.d); }
+        return numFloat(numToF64(a) * numToF64(b));
+      }
+      if (a.tag === "rat" && b.tag === "int") {
+        const numer = b.value * a.n;
+        if (Number.isSafeInteger(numer)) { return makeRat(numer, a.d); }
+        return numFloat(numToF64(a) * numToF64(b));
+      }
+      return numFloat(numToF64(a) * numToF64(b));
+    }
+
+    // `a / b` — mirrors `handlers.rs`'s `impl Div for Numeric` exactly:
+    // dispatches on `b`'s OWN tag (not a symmetric a-vs-b case split),
+    // computing `a * reciprocal(b)`. NEITHER this function NOR the Rust
+    // it ports checks `b`'s zero-ness — that is each CALLER's
+    // responsibility (`divHandler`/`invHandler` below both check
+    // `numIsZero` and throw before ever calling this, exactly mirroring
+    // `div_handler`/`inv_handler`'s own pre-check-then-panic order).
+    function numDiv(a, b) {
+      if (b.tag === "float") { return numFloat(numToF64(a) / b.value); }
+      if (b.tag === "int") { return numMul(a, makeRat(1, b.value)); }
+      return numMul(a, makeRat(b.d, b.n));
+    }
+
+    function numNeg(a) {
+      if (a.tag === "int") { return numInt(-a.value); } // safe: negating a
+      // safe integer never leaves the safe range (`-Number.MIN_SAFE_
+      // INTEGER === Number.MAX_SAFE_INTEGER`, symmetric around 0).
+      if (a.tag === "rat") { return numRat(-a.n, a.d); } // already lowest terms
+      return numFloat(-a.value);
+    }
+
+    // `base^exp` — a direct port of `handlers.rs::pow_numeric`, using
+    // `Number.isSafeInteger` in place of the Rust reference's widen-to-
+    // i128-then-range-check `checked_pow` trick (there is no i128 in
+    // JS, so an explicit repeated-multiplication loop with a
+    // safe-integer check after every step is the equivalent overflow
+    // detector — `checkedIntPow` below).
+    function checkedIntPow(base, exp) {
+      let result = 1;
+      for (let i = 0; i < exp; i++) {
+        result *= base;
+        if (!Number.isSafeInteger(result)) { return null; }
+      }
+      return result;
+    }
+    function powNumeric(base, exp) {
+      if (base.tag === "int" && exp.tag === "int") {
+        if (exp.value >= 0 && exp.value <= 62) {
+          const r = checkedIntPow(base.value, exp.value);
+          if (r !== null) { return numInt(r); }
+        } else if (exp.value < 0) {
+          // b^(-n) = 1 / b^n
+          if (base.value === 0) { throw new RangeError("Symbolic.evalTerm: 0^negative"); }
+          const pos = powNumeric(base, numInt(-exp.value));
+          return numDiv(numInt(1), pos);
+        }
+      }
+      if (base.tag === "rat" && exp.tag === "int" && exp.value >= 0 && exp.value <= 30) {
+        const nn = checkedIntPow(base.n, exp.value);
+        const dd = checkedIntPow(base.d, exp.value);
+        if (nn !== null && dd !== null && dd >= 1) { return makeRat(nn, dd); }
+      }
+      // Fall back to float (also the correct path for a negative-exponent
+      // Rat base and any Float operand, exactly like the Rust reference).
+      return numFloat(Math.pow(numToF64(base), numToF64(exp)));
+    }
+
+    // ── True/False helper (handlers.rs's `is_truthy`/`bool_node`) ───
+    //
+    // `True`/`False` are ordinary SYMBOL terms in this domain — never a
+    // JS boolean, never `1`/`0` (the addendum's own comparison-handler
+    // table entry is explicit about this). `isTruthy` returns `true`/
+    // `false` for a recognised boolean symbol, or `null` (tri-state) for
+    // anything else — the `null` case is what lets `andHandler`/
+    // `orHandler`/`notHandler` below leave a non-boolean operand alone.
+    function isTruthy(term) {
+      if (term.kind === "symbol") {
+        if (term.name === "True") { return true; }
+        if (term.name === "False") { return false; }
+      }
+      return null;
+    }
+
+    // ── arithmetic handlers ──────────────────────────────────────────
+    //
+    // Every handler below shares `handlers.rs`'s own contract: given the
+    // (already evaluated, applicative-order) `args` and the (already
+    // evaluated) `head`, either fold to a fully-reduced term or rebuild
+    // the ORIGINAL, unevaluated-further `applyTerm(head, args)` shape —
+    // never `null`, never something needing a second `evalTerm` pass.
+    // `binary_args`'s `None`-on-wrong-arity early return (`handlers.rs`
+    // line ~7593) is ported as a plain `args.length !== 2` check at the
+    // top of each binary handler.
+    //
+    // Identity-law fallbacks (`x+0->x`, `1*x->x`, …) ARE ported here —
+    // they are a few lines each and match `handlers.rs` exactly (its own
+    // "Reality check" section explicitly says only the nested-Add
+    // canonicalization/flattening special case, "Phase 47", is skippable
+    // since oracle tests only ever compare a DISPLAYED value, never
+    // internal tree shape — these plain identity laws are not that, they
+    // change the displayed/folded result itself, e.g. `x + 0` must
+    // display as bare `x`, not `Add(x, 0)`).
+    function addHandler(head, args) {
+      if (args.length !== 2) { return applyTerm(head, args); }
+      const [aTerm, bTerm] = args;
+      const va = toNumeric(aTerm);
+      const vb = toNumeric(bTerm);
+      if (va !== null && vb !== null) { return fromNumeric(numAdd(va, vb)); }
+      if (va !== null && numIsZero(va)) { return bTerm; } // 0 + x -> x
+      if (vb !== null && numIsZero(vb)) { return aTerm; } // x + 0 -> x
+      return applyTerm(head, args);
+    }
+
+    function subHandler(head, args) {
+      if (args.length !== 2) { return applyTerm(head, args); }
+      const [aTerm, bTerm] = args;
+      const va = toNumeric(aTerm);
+      const vb = toNumeric(bTerm);
+      if (va !== null && vb !== null) { return fromNumeric(numSub(va, vb)); }
+      if (vb !== null && numIsZero(vb)) { return aTerm; } // x - 0 -> x
+      return applyTerm(head, args);
+    }
+
+    function mulHandler(head, args) {
+      if (args.length !== 2) { return applyTerm(head, args); }
+      const [aTerm, bTerm] = args;
+      const va = toNumeric(aTerm);
+      const vb = toNumeric(bTerm);
+      if (va !== null && vb !== null) { return fromNumeric(numMul(va, vb)); }
+      // 0 * x -> 0, x * 0 -> 0
+      if ((va !== null && numIsZero(va)) || (vb !== null && numIsZero(vb))) { return intTerm(0); }
+      if (va !== null && numIsOne(va)) { return bTerm; } // 1 * x -> x
+      if (vb !== null && numIsOne(vb)) { return aTerm; } // x * 1 -> x
+      return applyTerm(head, args);
+    }
+
+    function divHandler(head, args) {
+      if (args.length !== 2) { return applyTerm(head, args); }
+      const [aTerm, bTerm] = args;
+      const va = toNumeric(aTerm);
+      const vb = toNumeric(bTerm);
+      if (va !== null && vb !== null) {
+        if (numIsZero(vb)) { throw new RangeError("Symbolic.evalTerm: division by zero"); }
+        return fromNumeric(numDiv(va, vb));
+      }
+      if (va !== null && numIsZero(va)) { return intTerm(0); } // 0 / x -> 0
+      if (vb !== null && numIsOne(vb)) { return aTerm; } // x / 1 -> x
+      return applyTerm(head, args);
+    }
+
+    function powHandler(head, args) {
+      if (args.length !== 2) { return applyTerm(head, args); }
+      const [baseTerm, expTerm] = args;
+      const vb = toNumeric(baseTerm);
+      const ve = toNumeric(expTerm);
+      if (vb !== null && ve !== null) { return fromNumeric(powNumeric(vb, ve)); }
+      if (ve !== null && numIsZero(ve)) { return intTerm(1); } // x^0 -> 1
+      if (ve !== null && numIsOne(ve)) { return baseTerm; } // x^1 -> x
+      if (vb !== null && numIsZero(vb)) { return intTerm(0); } // 0^n -> 0 (n != 0, above)
+      if (vb !== null && numIsOne(vb)) { return intTerm(1); } // 1^n -> 1
+      return applyTerm(head, args);
+    }
+
+    function negHandler(head, args) {
+      if (args.length !== 1) { return applyTerm(head, args); }
+      const a = args[0];
+      const va = toNumeric(a);
+      if (va !== null) { return fromNumeric(numNeg(va)); }
+      // -(-x) -> x
+      if (a.kind === "apply" && headName(a.head) === "Neg" && a.args.length === 1) {
+        return a.args[0];
+      }
+      return applyTerm(head, args);
+    }
+
+    function invHandler(head, args) {
+      if (args.length !== 1) { return applyTerm(head, args); }
+      const a = args[0];
+      const va = toNumeric(a);
+      if (va !== null) {
+        if (numIsZero(va)) { throw new RangeError("Symbolic.evalTerm: inverse of zero"); }
+        return fromNumeric(numDiv(numInt(1), va));
+      }
+      return applyTerm(head, args);
+    }
+
+    // Numeric fold only (`|n|`, preserving exact int/rational form) —
+    // `handlers.rs::abs_handler`'s further algebraic identities
+    // (`abs(abs(x))->abs(x)`, `abs(-x)->abs(x)`, `abs(x^even)->x^even`,
+    // …) are NOT ported: no Stream B oracle case exercises `Abs` at all
+    // yet, and those rules are meaningfully more involved (one even
+    // recurses back through `vm.eval`) than the "a few lines, matches
+    // the reference exactly" bar the other identity laws above clear.
+    // Deferred alongside the rest of the non-oracle-required
+    // simplification surface, same as calculus/elementary functions.
+    function absHandler(head, args) {
+      if (args.length !== 1) { return applyTerm(head, args); }
+      const inner = args[0];
+      const v = toNumeric(inner);
+      if (v !== null) {
+        if (inner.kind === "integer") { return intTerm(Math.abs(inner.value)); }
+        if (inner.kind === "rational") { return rationalTerm(Math.abs(inner.numer), inner.denom); }
+        return floatTerm(Math.abs(inner.value));
+      }
+      return applyTerm(head, args);
+    }
+
+    // ── comparison handlers ──────────────────────────────────────────
+    //
+    // Folds to the `True`/`False` SYMBOL (never a JS boolean, never
+    // `1`/`0`) when both operands are numeric literals (compared via
+    // `to_f64`, matching `comparison_handler`'s own `op(va.to_f64(),
+    // vb.to_f64())`); `Equal`/`NotEqual` additionally fall back to
+    // structural equality when either side isn't numeric (`eq_based`,
+    // `handlers.rs` lines 1317–1342) — `x == x -> True` even for a free
+    // symbol `x`. Stays unevaluated (arg-evaluated pass-through) when
+    // neither condition applies, e.g. a free symbol on one side of `<`.
+    function comparisonHandler(op, eqBased, isEqualOp) {
+      return function (head, args) {
+        if (args.length !== 2) { return applyTerm(head, args); }
+        const [aTerm, bTerm] = args;
+        const va = toNumeric(aTerm);
+        const vb = toNumeric(bTerm);
+        if (va !== null && vb !== null) {
+          return op(numToF64(va), numToF64(vb)) ? symTerm("True") : symTerm("False");
+        }
+        if (eqBased && termEquals(aTerm, bTerm)) {
+          return symTerm(isEqualOp ? "True" : "False");
+        }
+        return applyTerm(head, args);
+      };
+    }
+
+    // ── logic handlers (N-ARY, per handlers.rs::and_handler/or_handler)
+    //
+    // A flat `And(a, b, c, …)` chain — matching how every frontend's own
+    // lowering already flattens a chain — NOT pairwise binary nesting.
+    // Short-circuits on a `True`/`False` symbol among the (already
+    // evaluated) args, drops the identity element, collapses to a bare
+    // remaining term if exactly one non-boolean arg is left, else
+    // rebuilds an n-ary node from whatever didn't resolve.
+    function andHandler(head, args) {
+      const remaining = [];
+      for (const a of args) {
+        const t = isTruthy(a);
+        if (t === false) { return symTerm("False"); }
+        if (t === true) { continue; } // identity element, drop
+        remaining.push(a);
+      }
+      if (remaining.length === 0) { return symTerm("True"); }
+      if (remaining.length === 1) { return remaining[0]; }
+      return applyTerm(head, remaining);
+    }
+
+    function orHandler(head, args) {
+      const remaining = [];
+      for (const a of args) {
+        const t = isTruthy(a);
+        if (t === true) { return symTerm("True"); }
+        if (t === false) { continue; } // identity element, drop
+        remaining.push(a);
+      }
+      if (remaining.length === 0) { return symTerm("False"); }
+      if (remaining.length === 1) { return remaining[0]; }
+      return applyTerm(head, remaining);
+    }
+
+    function notHandler(head, args) {
+      if (args.length !== 1) { return applyTerm(head, args); }
+      const t = isTruthy(args[0]);
+      if (t === true) { return symTerm("False"); }
+      if (t === false) { return symTerm("True"); }
+      return applyTerm(head, args);
+    }
+
+    // Per-head dispatch table (item 1's scope only — arithmetic /
+    // comparison / logic). A `Map`, not a plain object literal:
+    // `name` is derived from a compiled program's OWN term data (any
+    // source identifier can end up as a SymApply head, e.g. a user
+    // writing a call literally named `__proto__`), and a plain object's
+    // `obj[name]` lookup walks the prototype chain — `Map.prototype.get`
+    // has no such hazard. Mirrors this same file's existing preference
+    // for `Map` over object literals for name-keyed lookups (see
+    // `bindingsEmpty` above).
+    const HANDLERS = new Map([
+      ["Add", addHandler],
+      ["Sub", subHandler],
+      ["Mul", mulHandler],
+      ["Div", divHandler],
+      ["Pow", powHandler],
+      ["Neg", negHandler],
+      ["Inv", invHandler],
+      ["Abs", absHandler],
+      ["Equal", comparisonHandler((a, b) => a === b, true, true)],
+      ["NotEqual", comparisonHandler((a, b) => a !== b, true, false)],
+      ["Less", comparisonHandler((a, b) => a < b, false, false)],
+      ["Greater", comparisonHandler((a, b) => a > b, false, false)],
+      ["LessEqual", comparisonHandler((a, b) => a <= b, false, false)],
+      ["GreaterEqual", comparisonHandler((a, b) => a >= b, false, false)],
+      ["And", andHandler],
+      ["Or", orHandler],
+      ["Not", notHandler],
+    ]);
+
+    // `Apply(head, args)`: evaluate `head` first (mirrors `eval_apply`'s
+    // own treatment of the head), then either hold `args` unevaluated
+    // (a `HELD_HEADS` member — item 1 has no handler for any of them, so
+    // this only matters for keeping their arguments byte-for-byte
+    // unevaluated, see the module doc above) or evaluate every arg in
+    // applicative order, then dispatch on the evaluated head's name
+    // against `HANDLERS`. No handler matched (every held head in this
+    // item, plus any other unknown/future head, plus `List` forever) ->
+    // rebuild the term from the evaluated head and the args just
+    // computed — the single "arg-evaluated, pass-through" policy that
+    // makes `List(Add(1,1), Mul(2,3))` fold its elements "for free".
+    function evalApply(term, depth) {
+      const evaluatedHead = evalTerm(term.head, depth + 1);
+      if (isDepthLimitError(evaluatedHead)) { return evaluatedHead; }
+      const name = headName(evaluatedHead);
+      let args;
+      if (HELD_HEADS.has(name)) {
+        args = term.args; // ORIGINAL, unevaluated -- see module doc above
+      } else {
+        args = [];
+        for (const a of term.args) {
+          const evaluated = evalTerm(a, depth + 1);
+          if (isDepthLimitError(evaluated)) { return evaluated; }
+          args.push(evaluated);
+        }
+      }
+      const handler = HANDLERS.get(name);
+      return handler !== undefined ? handler(evaluatedHead, args) : applyTerm(evaluatedHead, args);
+    }
+
+    // `Symbolic.evalTerm(term, depth)` — the public entry point emitted
+    // once per top-level statement by `emit.rs`'s `Stmt::ExprStmt` arm
+    // (never once per nested `SymApply` — this function recurses into
+    // `head`/args itself, see `evalApply` above). `depth` defaults to 0
+    // at the top call, exactly like `walkOnce`/`replaceRepeatedTerm`'s
+    // own `depth` parameter above, and this function returns the SAME
+    // `{kind: "depth-limit", maxDepth}` sentinel shape those two already
+    // use (checked by the same, unmodified `isDepthLimitError`/
+    // `Symbolic.unwrap`) when `MAX_EVAL_DEPTH` is exceeded.
+    //
+    // A `Symbol`/`integer`/`rational`/`float`/`string` leaf: item 1 has
+    // no environment yet (no `Symbol` lookup — that is item 2's job), so
+    // every leaf, including a bare, unbound `Symbol`, is already its own
+    // fully-reduced value and is returned unchanged.
+    function evalTerm(term, depth) {
+      if (depth === undefined) { depth = 0; }
+      if (depth > MAX_EVAL_DEPTH) {
+        return { kind: "depth-limit", maxDepth: MAX_EVAL_DEPTH };
+      }
+      if (term.kind === "apply") { return evalApply(term, depth); }
+      return term;
+    }
+
     return {
       sym: symTerm, int: intTerm, rational: rationalTerm,
       numberNode: floatTerm, stringNode: stringTerm, apply: applyTerm,
@@ -3237,6 +3823,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
       matchPattern, applyRule: applyRuleTerm, substitute: substituteTerm,
       replaceAll: replaceAllTerm, replaceRepeated: replaceRepeatedTerm,
       unwrap: unwrapTerm, toDisplayString, equals: termEquals,
+      evalTerm,
     };
   })();
 

--- a/code/packages/rust/semantic-ir-to-javascript/tests/sir23_eval_depth_guard.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/sir23_eval_depth_guard.rs
@@ -1,0 +1,184 @@
+//! Empirical regression test for `Symbolic.evalTerm`'s own recursion-
+//! depth guard (`MAX_EVAL_DEPTH`, `runtime.rs`) — SIR23 addendum item 1
+//! ("`Symbolic.evalTerm` scaffold + arithmetic/comparison/logic
+//! folding").
+//!
+//! `runtime.rs`'s own doc comment on `MAX_EVAL_DEPTH` records the full
+//! measurement methodology and numbers; this file is the executable
+//! proof that backs those numbers up, mirroring `derive-parser`'s own
+//! `test_nesting_up_to_cap_still_parses` / `test_opt_in_cap_trips_
+//! before_overflow_on_default_stack` discipline, retargeted from a Rust
+//! worker-thread stack to a `node` subprocess's default V8 stack (this
+//! guard runs in emitted JavaScript, not in this crate's own Rust code).
+//!
+//! Node is optional at test time; when unavailable every test here
+//! degrades to a no-op rather than failing, mirroring every other
+//! `node`-driven test in this crate (`tests/run_with_node.rs`, `tests/
+//! sir23_symbolic.rs`).
+//!
+//! ## Why this calls `Symbolic.evalTerm` directly, bypassing the
+//! compiled-program statement path
+//!
+//! `tests/sir23_symbolic.rs`'s own `print_on_deeply_nested_term_
+//! truncates_instead_of_crashing_node` already proves the *statement-
+//! level* wrapping (`emit.rs`'s `Stmt::ExprStmt` arm, this same
+//! addendum item) round-trips through a real compiled SIR program. This
+//! file is narrower and more direct: it measures/verifies `evalTerm`'s
+//! *own* recursion behavior in isolation, so it builds the deep term and
+//! calls `__Sir.Symbolic.evalTerm(...)` on it directly in a small
+//! driver script appended after the (always fully self-contained, so
+//! this works regardless of which SIR nodes the compiled module itself
+//! used) inlined `__Sir` runtime — exactly the "bypass the compiled-
+//! program path" approach the SIR23 addendum's own "Depth/DoS guard"
+//! section calls for.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
+};
+use semantic_ir_to_javascript::compile;
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn sp() -> Span {
+    Span::synthetic()
+}
+
+/// A trivial, otherwise-empty module used ONLY to obtain the inlined
+/// `__Sir` runtime prelude (`compile`'s `RUNTIME` blob is unconditional
+/// — every compiled artifact carries the FULL runtime regardless of
+/// which SIR nodes the module actually uses, per this backend's own
+/// "self-contained" design, `src/lib.rs`'s own module doc). The driver
+/// script appended below calls `__Sir.Symbolic.evalTerm` directly, so
+/// this module's own (empty) `main` body is never exercised.
+fn runtime_prelude() -> String {
+    let module = Module {
+        name: "eval_depth_probe".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::SymbolicExpr,
+            Feature::PatternMatching,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::IntLit { value: 0, span: sp() },
+                span: sp(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: sp(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    };
+    compile(&module).expect("compile runtime-prelude probe module").source
+}
+
+/// Build a right-nested `Add(1, Add(1, Add(1, …)))` term `n` levels deep
+/// via `n` real, runtime `__Sir.Symbolic.apply` calls in a plain `for`
+/// loop (NOT a hand-written giant static literal — the whole point,
+/// mirrored from `tests/sir23_symbolic.rs`'s own deep-nesting test, is
+/// that a tiny driver script can still build an arbitrarily deep runtime
+/// VALUE), call `__Sir.Symbolic.evalTerm` on it DIRECTLY, and print
+/// either the folded result or the literal string `"DEPTH_LIMIT"` if
+/// `evalTerm` returned the depth-limit sentinel. Returns `node`'s
+/// trimmed stdout, or `None` when `node` is unavailable.
+///
+/// A clean process exit (`output.status.success()`) is asserted
+/// unconditionally: if the guard were ever missing or mis-wired, `node`
+/// itself would crash with an uncaught `RangeError: Maximum call stack
+/// size exceeded` well before printing anything, which is exactly the
+/// failure mode this test exists to catch.
+fn run_eval_at_depth(n: u32) -> Option<String> {
+    if !node_available() {
+        eprintln!("note: `node` unavailable — skipping eval-depth-guard check for n={n}");
+        return None;
+    }
+    let mut source = runtime_prelude();
+    source.push_str(&format!(
+        r#"
+(function () {{
+  let acc = __Sir.Symbolic.int(1);
+  for (let i = 0; i < {n}; i++) {{
+    acc = __Sir.Symbolic.apply(__Sir.Symbolic.sym("Add"), [__Sir.Symbolic.int(1), acc]);
+  }}
+  const result = __Sir.Symbolic.evalTerm(acc);
+  if (result !== null && typeof result === "object" && result.kind === "depth-limit") {{
+    console.log("DEPTH_LIMIT");
+  }} else {{
+    console.log(__Sir.Symbolic.toDisplayString(result));
+  }}
+}})();
+"#
+    ));
+
+    let mut path: PathBuf = std::env::temp_dir();
+    path.push(format!("sir_eval_depth_{n}_{}.js", std::process::id()));
+    std::fs::write(&path, &source).expect("write temp js");
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        output.status.success(),
+        "node crashed evaluating a {n}-level-deep term instead of returning the depth-limit \
+         sentinel cleanly (MAX_EVAL_DEPTH guard missing or broken):\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Boundary point one: nesting exactly at `MAX_EVAL_DEPTH` (2000 —
+/// `runtime.rs`'s own doc comment) folds to a genuine value, not the
+/// depth-limit sentinel — the cap must not be so tight it rejects
+/// ordinary, well within-budget input.
+#[test]
+fn eval_term_at_the_cap_folds_to_a_real_value() {
+    if let Some(stdout) = run_eval_at_depth(2000) {
+        // 2000 additions of 1 onto a base value of 1 folds to 2001.
+        assert_eq!(stdout, "2001", "expected the 2000-deep Add chain to fold cleanly");
+    }
+}
+
+/// Boundary point two: nesting one level past `MAX_EVAL_DEPTH` returns
+/// the depth-limit sentinel — checked by `Symbolic.unwrap` the same way
+/// `replaceAll`/`replaceRepeated`'s own cap is — rather than crashing.
+#[test]
+fn eval_term_one_past_the_cap_returns_the_sentinel_not_a_crash() {
+    if let Some(stdout) = run_eval_at_depth(2001) {
+        assert_eq!(stdout, "DEPTH_LIMIT");
+    }
+}
+
+/// A term FAR deeper than the empirically measured ~2800-level bare-
+/// stack crash floor (`runtime.rs`'s `MAX_EVAL_DEPTH` doc comment) —
+/// confirms the guard trips on EVERY recursive descent (bailing out near
+/// the very top of a 200,000-level-deep term), not merely once at some
+/// fixed point, so an arbitrarily deep runtime value built by a
+/// compiled program never gets a chance to overflow the native stack
+/// regardless of how deep it actually is. This is the direct sibling of
+/// `tests/sir23_symbolic.rs`'s `print_on_deeply_nested_term_truncates_
+/// instead_of_crashing_node`, for `evalTerm` instead of `toDisplayString`.
+#[test]
+fn eval_term_far_past_the_cap_still_returns_the_sentinel_not_a_crash() {
+    if let Some(stdout) = run_eval_at_depth(200_000) {
+        assert_eq!(stdout, "DEPTH_LIMIT");
+    }
+}

--- a/code/packages/rust/semantic-ir-to-javascript/tests/sir23_eval_depth_guard.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/sir23_eval_depth_guard.rs
@@ -199,32 +199,57 @@ fn eval_term_far_past_the_cap_still_returns_the_sentinel_not_a_crash() {
 /// arg-evaluated term at essentially its original depth — it does NOT
 /// fold it away).
 ///
-/// Chosen depth, `1000`, is deliberate, not arbitrary: it sits strictly
-/// BETWEEN `termEquals`'s own new cap (`MAX_TERM_DEPTH = 512`) and
-/// `evalTerm`'s own, unrelated cap (`MAX_EVAL_DEPTH = 2000`). This
-/// isolates the exact gap the fix closes — deep enough that `termEquals`
-/// (reusing `MAX_TERM_DEPTH`) trips ITS OWN new guard partway through
-/// (at depth 513, long before it would naturally finish comparing all
-/// 1000 levels), yet shallow enough that evaluating EACH operand
-/// (`evalTerm`'s own, separate, already-existing cap on the ARGUMENT
-/// evaluation that runs before `comparisonHandler` is ever reached)
-/// completes normally rather than hitting `MAX_EVAL_DEPTH` first and
-/// masking whether `termEquals`'s own fix actually works. (A depth past
-/// 2000, tried first, does NOT exercise this path at all: `evalApply`'s
-/// own arg-evaluation loop would return `evalTerm`'s depth-limit
-/// sentinel for the `Equal(...)` call's OPERANDS before `comparisonHandler`
-/// is ever invoked — a different, already-covered guard, not this one.)
-/// A clean, non-crashing process exit is the pass condition; the exact
-/// folded/unfolded VALUE is secondary — past `MAX_TERM_DEPTH`,
-/// `termEquals`'s own new cap conservatively returns `false`, so this
-/// prints an unevaluated `Equal(...)` term rather than `True` (the
-/// correct, safe, documented trade-off — see `termEquals`'s own updated
-/// doc comment in `runtime.rs` — not a bug).
+/// ## Why this asserts a BEHAVIORAL effect, not a crash boundary
+///
+/// An earlier version of this test asserted only "the process doesn't
+/// crash" at a hand-picked depth (`1000`) chosen solely for sitting
+/// between the two sibling constants (`MAX_TERM_DEPTH = 512` and
+/// `MAX_EVAL_DEPTH = 2000`) — re-review caught that this proves nothing:
+/// empirically, `termEquals`'s own UNCAPPED native-stack crash floor in
+/// this environment is close to `MAX_EVAL_DEPTH` itself (measured ~1900–
+/// 1950), so depth `1000` never crashes even WITHOUT the fix, meaning a
+/// regression that silently dropped the depth cap (or failed to thread
+/// `depth + 1` through one of `termEquals`'s two recursive call sites,
+/// e.g. during a merge conflict) would pass this test with zero
+/// detection power. Any fixed numeric depth chosen to land strictly
+/// between two OTHER constants, without empirically probing the
+/// function actually being tested, risks exactly this trap — and
+/// re-picking a depth close enough to the real crash floor to force an
+/// actual crash-vs-no-crash distinction would make the test's pass/fail
+/// outcome depend on this exact machine's/Node version's stack size,
+/// which is not portable across CI runners.
+///
+/// So instead of trying to trigger a crash boundary at all, this test
+/// asserts `termEquals`'s cap's OBSERVABLE, DOCUMENTED semantic
+/// trade-off directly, which is both stronger proof and fully
+/// environment-independent: `left`/`right` below are built to be
+/// STRUCTURALLY IDENTICAL (same head, same depth, same leaf), so a
+/// `termEquals` call that runs to completion (uncapped, or capped at a
+/// depth deep enough to reach the very bottom) correctly returns `true`
+/// — folding `Equal(left, right)` to the symbol `True`. But a `depth`
+/// chosen ABOVE `MAX_TERM_DEPTH` (512) means the FIXED `termEquals`
+/// trips its own cap at depth 513 — long before it ever reaches the
+/// leaves — and returns the conservative `false` `comparisonHandler`'s
+/// fallback treats as "not proven equal," leaving `Equal(left, right)`
+/// UNEVALUATED rather than folding to `True`. So: printing `"True"`
+/// means the cap did NOT fire (the vulnerable, pre-fix behavior, or a
+/// future regression reintroducing it); printing anything else (the
+/// unevaluated term) means the cap DID fire (the fixed, safe behavior)
+/// — a clean, deterministic pass/fail signal with no dependency on any
+/// machine's actual stack size. `500` — the depth used below — is
+/// comfortably past `MAX_TERM_DEPTH` (512's own cap fires at 513,
+/// meaning the trees must be at least that deep for the cap to have a
+/// chance to trip before reaching the leaves) yet far below
+/// `MAX_EVAL_DEPTH` (2000, the separate, unrelated cap on evaluating
+/// each OPERAND before `comparisonHandler` is ever reached), and FAR
+/// below the empirically-measured ~1900–1950 uncapped crash floor, so
+/// this test is guaranteed never to crash `node` regardless of whether
+/// the fix is present — only the printed VALUE differs.
 #[test]
-fn comparison_of_two_deep_unfoldable_trees_does_not_crash_term_equals() {
+fn comparison_of_two_deep_identical_trees_stays_unevaluated_past_the_term_equals_cap() {
     if !node_available() {
         eprintln!(
-            "note: `node` unavailable — skipping comparison_of_two_deep_unfoldable_trees_does_not_crash_term_equals"
+            "note: `node` unavailable — skipping comparison_of_two_deep_identical_trees_stays_unevaluated_past_the_term_equals_cap"
         );
         return;
     }
@@ -239,15 +264,11 @@ fn comparison_of_two_deep_unfoldable_trees_does_not_crash_term_equals() {
     }
     return acc;
   }
-  const left = buildChain(1000);
-  const right = buildChain(1000);
+  const left = buildChain(600);
+  const right = buildChain(600);
   const cmp = __Sir.Symbolic.apply(__Sir.Symbolic.sym("Equal"), [left, right]);
   const result = __Sir.Symbolic.evalTerm(cmp);
-  if (result !== null && typeof result === "object" && result.kind === "depth-limit") {
-    console.log("DEPTH_LIMIT");
-  } else {
-    console.log("NO_CRASH");
-  }
+  console.log(__Sir.Symbolic.toDisplayString(result));
 })();
 "#,
     );
@@ -263,16 +284,17 @@ fn comparison_of_two_deep_unfoldable_trees_does_not_crash_term_equals() {
 
     assert!(
         output.status.success(),
-        "node crashed comparing two 1000-deep unfoldable trees with Equal instead of \
-         terminating cleanly (termEquals's own depth guard missing or broken):\nstdout: {}\nstderr: {}",
+        "node crashed comparing two 600-deep structurally-identical trees with Equal instead of \
+         terminating cleanly:\nstdout: {}\nstderr: {}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );
-    assert_eq!(
-        String::from_utf8_lossy(&output.stdout).trim(),
-        "NO_CRASH",
-        "expected a clean, non-crashing result (whether Equal folds, stays unevaluated, or hits \
-         evalTerm's own depth-limit sentinel, all are acceptable outcomes here -- only a raw \
-         node crash is not)"
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    assert_ne!(
+        stdout, "True",
+        "termEquals's depth cap did not fire: two structurally-identical 600-deep trees (past \
+         MAX_TERM_DEPTH = 512) folded Equal(...) all the way to True, meaning termEquals ran to \
+         completion uncapped -- either the depth parameter isn't threaded through one of its two \
+         recursive call sites, or the MAX_TERM_DEPTH check was removed/bypassed"
     );
 }

--- a/code/packages/rust/semantic-ir-to-javascript/tests/sir23_eval_depth_guard.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/sir23_eval_depth_guard.rs
@@ -182,3 +182,97 @@ fn eval_term_far_past_the_cap_still_returns_the_sentinel_not_a_crash() {
         assert_eq!(stdout, "DEPTH_LIMIT");
     }
 }
+
+/// Regression test for a security-review finding on this same item:
+/// `comparisonHandler`'s `Equal`/`NotEqual` structural-equality fallback
+/// (`runtime.rs`) calls the pre-existing `termEquals` — a plain recursive
+/// tree-equality check with, before this fix, NO depth cap of its own,
+/// unlike every other whole-tree-walking function in this file
+/// (`toDisplayString`/`walkOnce`/`replaceRepeatedTerm`). Every
+/// PRE-EXISTING call site (the pattern matcher, the rewrite engine's
+/// fixed-point check) only ever compares terms already implicitly
+/// bounded by a `MAX_TERM_DEPTH`-capped traversal elsewhere — but
+/// `comparisonHandler`'s operands can be an arbitrarily deep symbolic
+/// tree a compiled program built at runtime with NO fold available (an
+/// unrecognized head, like the `"F"` used here, has no `HANDLERS` entry,
+/// so `evalApply`'s "no handler matched" fallthrough just rebuilds the
+/// arg-evaluated term at essentially its original depth — it does NOT
+/// fold it away).
+///
+/// Chosen depth, `1000`, is deliberate, not arbitrary: it sits strictly
+/// BETWEEN `termEquals`'s own new cap (`MAX_TERM_DEPTH = 512`) and
+/// `evalTerm`'s own, unrelated cap (`MAX_EVAL_DEPTH = 2000`). This
+/// isolates the exact gap the fix closes — deep enough that `termEquals`
+/// (reusing `MAX_TERM_DEPTH`) trips ITS OWN new guard partway through
+/// (at depth 513, long before it would naturally finish comparing all
+/// 1000 levels), yet shallow enough that evaluating EACH operand
+/// (`evalTerm`'s own, separate, already-existing cap on the ARGUMENT
+/// evaluation that runs before `comparisonHandler` is ever reached)
+/// completes normally rather than hitting `MAX_EVAL_DEPTH` first and
+/// masking whether `termEquals`'s own fix actually works. (A depth past
+/// 2000, tried first, does NOT exercise this path at all: `evalApply`'s
+/// own arg-evaluation loop would return `evalTerm`'s depth-limit
+/// sentinel for the `Equal(...)` call's OPERANDS before `comparisonHandler`
+/// is ever invoked — a different, already-covered guard, not this one.)
+/// A clean, non-crashing process exit is the pass condition; the exact
+/// folded/unfolded VALUE is secondary — past `MAX_TERM_DEPTH`,
+/// `termEquals`'s own new cap conservatively returns `false`, so this
+/// prints an unevaluated `Equal(...)` term rather than `True` (the
+/// correct, safe, documented trade-off — see `termEquals`'s own updated
+/// doc comment in `runtime.rs` — not a bug).
+#[test]
+fn comparison_of_two_deep_unfoldable_trees_does_not_crash_term_equals() {
+    if !node_available() {
+        eprintln!(
+            "note: `node` unavailable — skipping comparison_of_two_deep_unfoldable_trees_does_not_crash_term_equals"
+        );
+        return;
+    }
+    let mut source = runtime_prelude();
+    source.push_str(
+        r#"
+(function () {
+  function buildChain(n) {
+    let acc = __Sir.Symbolic.sym("x");
+    for (let i = 0; i < n; i++) {
+      acc = __Sir.Symbolic.apply(__Sir.Symbolic.sym("F"), [acc]);
+    }
+    return acc;
+  }
+  const left = buildChain(1000);
+  const right = buildChain(1000);
+  const cmp = __Sir.Symbolic.apply(__Sir.Symbolic.sym("Equal"), [left, right]);
+  const result = __Sir.Symbolic.evalTerm(cmp);
+  if (result !== null && typeof result === "object" && result.kind === "depth-limit") {
+    console.log("DEPTH_LIMIT");
+  } else {
+    console.log("NO_CRASH");
+  }
+})();
+"#,
+    );
+
+    let mut path: PathBuf = std::env::temp_dir();
+    path.push(format!(
+        "sir_eval_termequals_depth_{}.js",
+        std::process::id()
+    ));
+    std::fs::write(&path, &source).expect("write temp js");
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        output.status.success(),
+        "node crashed comparing two 1000-deep unfoldable trees with Equal instead of \
+         terminating cleanly (termEquals's own depth guard missing or broken):\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "NO_CRASH",
+        "expected a clean, non-crashing result (whether Equal folds, stays unevaluated, or hits \
+         evalTerm's own depth-limit sentinel, all are acceptable outcomes here -- only a raw \
+         node crash is not)"
+    );
+}

--- a/code/packages/rust/semantic-ir-to-javascript/tests/sir23_eval_depth_guard.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/sir23_eval_depth_guard.rs
@@ -236,7 +236,7 @@ fn eval_term_far_past_the_cap_still_returns_the_sentinel_not_a_crash() {
 /// future regression reintroducing it); printing anything else (the
 /// unevaluated term) means the cap DID fire (the fixed, safe behavior)
 /// — a clean, deterministic pass/fail signal with no dependency on any
-/// machine's actual stack size. `500` — the depth used below — is
+/// machine's actual stack size. `600` — the depth used below — is
 /// comfortably past `MAX_TERM_DEPTH` (512's own cap fires at 513,
 /// meaning the trees must be at least that deep for the cap to have a
 /// chance to trip before reaching the leaves) yet far below


### PR DESCRIPTION
## Summary

Item 1 of the 4-item SIR23 evaluator rollout described in `SIR23-symbolic-pattern-semantic-ir.md`'s addendum ("Addendum — SIR23 symbolic evaluator + per-language display convention"). Found by `derive-to-semantic-ir`'s (#8754) and `reduce-to-semantic-ir`'s (#8771) own oracle tests: `Expr::SymApply` compiled unconditionally to a bare, inert `__Sir.Symbolic.apply(head, [args])` term — no evaluation of any kind.

- **`Symbolic.evalTerm(term, depth)`** (`runtime.rs`): a direct JS port of `symbolic-vm`'s `VM::eval`/`eval_apply` per-head dispatch architecture (a `Map`, not rewrite-rules through the existing pattern matcher — see the addendum's own "Architecture decision" section for the rationale). Scope: arithmetic (`Add`/`Sub`/`Mul`/`Div`/`Pow`/`Neg`/`Inv`/`Abs`, exact-rational results via a small ported `Numeric` tower), comparison (fold to the `True`/`False` **symbol**, never a JS boolean), logic (`And`/`Or`/`Not`, N-ary). `HELD_HEADS = {Assign, Define, If}` is declared as the scaffold for item 2, but wired to no handler yet — those forms stay byte-for-byte inert, identical to today's behavior.
- **`emit.rs`**: `Stmt::ExprStmt` wraps a top-level SIR23 statement in `evalTerm`, exactly once per statement (not per nested `SymApply`). `Expr::SymApply`'s own codegen is unchanged.
- **`MAX_EVAL_DEPTH = 2000`**: empirically measured on a bare default Node stack (safe to ~2800, crashes by ~2805), ~29% margin — its own cap, not a reuse of the unrelated `MAX_TERM_DEPTH`.
- Flips 14 of `derive-to-semantic-ir`'s and 17 of `reduce-to-semantic-ir`'s oracle `known_bug` cases to `known_bug: None` (verified by running the tests, not guessed).

## Security review

Found and fixed one MEDIUM finding during `/security-review` (3 rounds to converge, all independently verified — see commit history):
- `comparisonHandler`'s `Equal`/`NotEqual` fallback reaches a pre-existing `termEquals` helper with no depth cap of its own (CWE-674) — unlike every other whole-tree-walking function in the file. Fixed by giving `termEquals` its own depth parameter reusing `MAX_TERM_DEPTH`. The first regression test for this didn't actually discriminate fixed-vs-broken behavior (caught in round 2); rewrote it to assert a behavioral effect instead of a crash boundary, and empirically verified (by temporarily reverting the fix and confirming the test fails, then restoring it) that it now does.

## Test plan

- [x] `cargo test -p semantic-ir-to-javascript -p derive-to-semantic-ir -p reduce-to-semantic-ir --all-targets` — all green (independently re-run multiple times through the review process)
- [x] `cargo clippy -p semantic-ir-to-javascript -p derive-to-semantic-ir -p reduce-to-semantic-ir --all-targets -- -D warnings` — clean
- [x] `/security-review` — converged after fixing one MEDIUM finding (and its own test's validity issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)