### PR TITLE
feat(adj-facts-stdlib): SI derived units — grounded quantity→symbol table (NIST)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_siderivedunits_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_siderivedunits_e2e.rs
@@ -1,0 +1,79 @@
+//! End-to-end test for the metrology SI-DERIVED-UNITS facts library
+//! (`adj-facts-stdlib/metrology/si-derived-units.adj`) driven through the built
+//! CLI: a native `table` of generic-derived-quantity → unit-symbol resolves a
+//! binding-query recall with the NIST citation, and abstains on a quantity the
+//! source sentence does not name — 0 model calls, never a fabricated unit.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsder_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+fn with_case(dir: &Path, body: &str) -> PathBuf {
+    let src = facts_stdlib().join("metrology/si-derived-units.adj");
+    std::fs::copy(&src, dir.join("si-derived-units.adj"))
+        .expect("copy shipped si-derived-units.adj");
+    let p = dir.join("case.adj");
+    std::fs::write(&p, format!("import \"si-derived-units.adj\"\n{body}")).unwrap();
+    p
+}
+
+#[test]
+fn si_derived_unit_recall_binds_symbol_with_citation() {
+    let dir = scratch("recall");
+    let p = with_case(
+        &dir,
+        "? si_derived_unit(velocity, $Symbol)\n\
+         ? si_derived_unit(acceleration, $Symbol)\n",
+    );
+
+    let (ok, out) = run(&p);
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Velocity -> m/s; acceleration -> m/s2 (verbatim symbols from the NIST page).
+    assert!(out.contains("m/s"), "velocity binds the m/s symbol: {out}");
+    assert!(
+        out.contains("m/s2"),
+        "acceleration binds the m/s2 symbol: {out}"
+    );
+    // The answer carries the NIST citation as its proof.
+    assert!(
+        out.contains("nist.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the NIST source citation: {out}"
+    );
+}
+
+#[test]
+fn an_unnamed_quantity_abstains_rather_than_inventing_a_unit() {
+    let dir = scratch("abstain");
+    // Luminance is a real photometric quantity, but the cited sentence does not
+    // name it among the generic derived units — the table must abstain.
+    let p = with_case(&dir, "? si_derived_unit(luminance, $Symbol)\n");
+
+    let (ok, out) = run(&p);
+    assert!(ok, "cli should succeed: {out}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a quantity the source doesn't name abstains: {out}"
+    );
+}

--- a/code/specs/data/adj-facts-stdlib/metrology/si-derived-units.adj
+++ b/code/specs/data/adj-facts-stdlib/metrology/si-derived-units.adj
@@ -1,0 +1,53 @@
+% ============================================================================
+% si-derived-units — each SI quantity → its generic derived-unit symbol
+% (adj-facts-stdlib, METROLOGY).
+% ============================================================================
+% One rung up from the seven base units: the SI *derived* units with generic
+% names, whose symbol reflects the quantity's mathematical derivation from the
+% base units. Speed is length over time, so its unit is the metre per second;
+% area is length squared, so its unit is the square metre. Recall is a binding
+% query — you name a quantity and get back its unit symbol, WITH the citation:
+%
+%     ? si_derived_unit(velocity, $Symbol)      % "m/s"
+%     ? si_derived_unit(area, $Symbol)          % "m2"
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `si_derived_unit(quantity, symbol)` carrying the table's citation, so
+% the lookup is the ordinary SLD binding query — the engine returns the symbol
+% WITH its source, on the CPU, with zero model calls, and abstains on a quantity
+% the page does not name (it never invents a unit). It pairs with the
+% `si_base_unit` table (the seven base quantities) in this same directory.
+%
+% Why the symbol is a STRING: the derived-unit symbols are compound expressions
+% over the base symbols (`m/s`, `m/s2`) with slashes and digits — not bare atoms.
+% They are carried verbatim as the source page writes them.
+%
+% Provenance: the four quantity→symbol pairs are taken VERBATIM from the sentence
+% on the NIST Office of Weights and Measures "SI Units" page that enumerates the
+% generic-name derived units. The `source` below IS that sentence; each row is a
+% pair read straight off it:
+%
+%   area         → "m2"     (area (m2))
+%   volume       → "m3"     (volume (m3))
+%   velocity     → "m/s"    (velocity (m/s))
+%   acceleration → "m/s2"   (acceleration (m/s2))
+%
+% `trust authoritative` — a primary standards reference, re-fetchable at the
+% `locator`. Nothing here is asserted from memory: every pair is a token of the
+% cited sentence, and only the four quantities the sentence names are included.
+% (See ../README.md; ADJ-TABLES.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table si_derived_unit {
+    columns quantity, symbol
+
+    row (area, "m2")
+    row (volume, "m3")
+    row (velocity, "m/s")
+    row (acceleration, "m/s2")
+
+    source "Derived units with generic names reflect their mathematical derivation, such as area (m2), volume (m3), velocity (m/s), and acceleration (m/s2)."
+    locator "https://www.nist.gov/pml/owm/metric-si/si-units"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/metrology/si-derived-units.query.adj
+++ b/code/specs/data/adj-facts-stdlib/metrology/si-derived-units.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% si-derived-units.query.adj — a worked recall over the SI derived-units library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what is the SI unit of
+% velocity?": it states no metrology fact — it only `import`s the grounded table
+% and asks binding queries. The engine resolves each `?` against the
+% `si_derived_unit` rows and returns the symbol + the table's source/locator/
+% trust. A quantity the source sentence does not name abstains honestly — the
+% engine never invents a unit.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli si-derived-units.query.adj
+% ============================================================================
+
+import "si-derived-units.adj"
+
+? si_derived_unit(velocity, $Symbol)         % expect "m/s"
+? si_derived_unit(area, $Symbol)             % expect "m2"
+? si_derived_unit(luminance, $Symbol)        % expect abstain — not a named generic derived unit here


### PR DESCRIPTION
## SI derived units — one rung up from the base units [Facts front]

Pairs with the `si_base_unit` table (the seven base quantities) shipped just before it: the SI **derived** units with generic names, whose symbol reflects the quantity's mathematical derivation from the base units. A new native `table` (ADJ-TABLES), grounded verbatim to NIST:

```
? si_derived_unit(velocity, $Symbol)      % "m/s"
? si_derived_unit(area, $Symbol)          % "m2"
```

### The four rows (verbatim from NIST OWM "SI Units")
| quantity | symbol |
|----------|--------|
| area | m2 |
| volume | m3 |
| velocity | m/s |
| acceleration | m/s2 |

The envelope's `source` **is** the exact sentence on the NIST page that enumerates these — *"Derived units with generic names reflect their mathematical derivation, such as area (m2), volume (m3), velocity (m/s), and acceleration (m/s2)."* — with `locator` = the NIST page and `trust authoritative`. Each row is a pair read straight off that sentence; **nothing is asserted from memory** (`feedback_nothing_human_authored`). Symbols are STRING cells (compound expressions over the base symbols — slashes, digits — carried exactly as the page writes them).

### Ships
- `metrology/si-derived-units.adj` — the grounded table (in `metrology/`, beside `si-base-units`, `metric-prefixes`, `time-units`).
- `metrology/si-derived-units.query.adj` — worked recall incl. an honest **abstention** on `luminance` (a real photometric quantity the sentence does not name).
- `adj-lang-cli/tests/facts_siderivedunits_e2e.rs` — 2 e2e tests through the built CLI against the shipped stdlib: recall binds the symbol with the NIST citation; an unnamed quantity abstains (never a fabricated unit).

Pure data + test — no crate code, no version bump. Independent; source fetched from NIST (`nist.gov/pml/owm/metric-si/si-units`), not hand-authored.

### Verification
- `cargo test -p adj-lang-cli --test facts_siderivedunits_e2e` → 2 passed, 0 failed.
- Manually driven through the CLI (`velocity → "m/s"` with NIST citation; `luminance` abstains).
- Security review passed (1 round — additive data + a harness-only test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)