### PR TITLE
feat(spice): add BJT beta temperature exponent

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **BJT forward-beta temperature exponent** — BJT model cards now accept `XTB`
+  and scale forward beta by the analysis-to-nominal absolute temperature ratio,
+  matching Rust and TypeScript. The supported-parameter catalog now contains
+  106 canonical rows.
+
 - **BJT base-collector leakage** — BJT model cards now accept `ISC`/`NC` and
   apply the leakage branch in DC, transient, AC, transfer-function,
   temperature, and noise paths, matching Rust and TypeScript. The

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -229,6 +229,8 @@ small-signal input conductance, and shot noise.
 `ISC` (default `0`, disabled) and `NC` (default `2`) add the mirrored Berkeley
 base-collector leakage branch to DC/transient current, small-signal
 base-collector conductance, and shot noise.
+`XTB` (default `0`) scales forward beta with the analysis-to-nominal absolute
+temperature ratio, preserving the nominal beta when omitted.
 `model_card_unsupported_parameter_issues()`,
 `format_model_card_unsupported_parameter_issue_table()`,
 `model_card_unsupported_parameter_issue_records()`,
@@ -254,7 +256,7 @@ catalog by model kind for compact release dashboards and Mosaic UI inventories.
 `model_card_supported_parameter_coverage_gate_issue_records()`,
 `format_model_card_supported_parameter_coverage_gate_issue_csv()`, and
 `format_model_card_supported_parameter_coverage_gate_issue_json()` validate the
-expected seven-kind, 104-row supported-parameter catalog and expose stable issue
+expected seven-kind, 106-row supported-parameter catalog and expose stable issue
 rows for release automation.
 `model_card_supported_parameter_coverage_dashboard()`,
 `format_model_card_supported_parameter_coverage_dashboard_table()`,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -603,6 +603,8 @@ class BJT:
         Forward emission coefficient (default 1.0).
     Nr:
         Reverse emission coefficient (default 1.0).
+    Xtb:
+        Forward-beta temperature exponent (default 0.0).
     """
 
     name: str
@@ -633,6 +635,7 @@ class BJT:
     Ne: float = 1.0         # base-emitter leakage emission coefficient
     Isc: float = 0.0        # base-collector leakage saturation current (A)
     Nc: float = 2.0         # base-collector leakage emission coefficient
+    Xtb: float = 0.0        # forward-beta temperature exponent
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -353,12 +353,15 @@ def bjt_at_temperature(
         raise ValueError(
             f"{bjt.name}: BJT saturation-current temperature exponent must be finite"
         )
+    if not math.isfinite(bjt.Xtb):
+        raise ValueError(f"{bjt.name}: BJT forward-beta temperature exponent must be finite")
     saturation_scale = ratio**bjt.Xti * math.exp(max(-100.0, min(100.0, exponent)))
     return replace(
         bjt,
         Is=bjt.Is * saturation_scale,
         Ise=bjt.Ise * saturation_scale,
         Isc=bjt.Isc * saturation_scale,
+        beta_f=bjt.beta_f * ratio**bjt.Xtb,
         Vt=bjt.Vt * ratio,
     )
 
@@ -598,7 +601,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -9251,6 +9254,8 @@ def _validate_bjt(el: BJT) -> None:
         raise ValueError(
             f"{el.name}: BJT saturation-current temperature exponent must be finite"
         )
+    if not math.isfinite(el.Xtb):
+        raise ValueError(f"{el.name}: BJT forward-beta temperature exponent must be finite")
     if not math.isfinite(el.Eg) or el.Eg <= 0.0:
         raise ValueError(f"{el.name}: BJT energy gap must be finite and positive")
     if not math.isfinite(el.Vaf) or el.Vaf < 0.0:
@@ -14048,6 +14053,7 @@ def sens_dc(
                     Vjc=el.Vjc,
                     Mjc=el.Mjc,
                     Fc=el.Fc,
+                    Xtb=el.Xtb,
                 ),
             )
             delta_beta = max(abs(el.beta_f) * perturbation, abs_floor)
@@ -14080,6 +14086,7 @@ def sens_dc(
                     Vjc=el.Vjc,
                     Mjc=el.Mjc,
                     Fc=el.Fc,
+                    Xtb=el.Xtb,
                 ),
             )
 
@@ -14322,6 +14329,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             Vjc=el.Vjc,
             Mjc=el.Mjc,
             Fc=el.Fc,
+            Xtb=el.Xtb,
         )
 
     # Capacitor, Inductor, Mosfet — no tunable DC parameter; return unchanged.

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (23, 38, 11, 4),
-    "PNP": (23, 38, 11, 4),
+    "NPN": (24, 39, 11, 4),
+    "PNP": (24, 39, 11, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -382,6 +382,7 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "NE": "NE",
     "ISC": "ISC",
     "NC": "NC",
+    "XTB": "XTB",
     "NF": "NF",
     "NR": "NR",
     "VJE": "VJE",
@@ -933,6 +934,7 @@ def bjt_from_model_card(
         Ne=p.get("NE", 1.0),
         Isc=p.get("ISC", 0.0),
         Nc=p.get("NC", 2.0),
+        Xtb=p.get("XTB", 0.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 104
+    assert len(coverage) == 106
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 104
+    assert len(records) == 106
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,9 +501,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 104
-    assert report.expected_canonical_parameter_count == 104
-    assert report.accepted_name_count == 166
+    assert report.canonical_parameter_count == 106
+    assert report.expected_canonical_parameter_count == 106
+    assert report.accepted_name_count == 168
     assert report.aliased_parameter_count == 49
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -511,7 +511,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t104\t104\t166\t49\t4\t0"
+        "true\t7\t7\t106\t106\t168\t49\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,8 +539,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 103
-    assert report.accepted_name_count == 163
+    assert report.canonical_parameter_count == 105
+    assert report.accepted_name_count == 165
     assert report.aliased_parameter_count == 48
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t103\t104\t163\t48\t4\t4\n"
+        "false\t7\t7\t105\t106\t165\t48\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,14 +647,15 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
+        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
+    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.Cje == pytest.approx(2.0e-12)
     assert bjt_model.Xti == pytest.approx(2.4)
+    assert bjt_model.Xtb == pytest.approx(1.5)
     assert bjt_model.Eg == pytest.approx(1.05)
     assert bjt_model.Vaf == pytest.approx(80.0)
     assert bjt_model.Var == pytest.approx(120.0)
@@ -2300,7 +2301,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2323,6 +2324,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.Ne == pytest.approx(1.7)
     assert expanded.Isc == pytest.approx(4.0e-13)
     assert expanded.Nc == pytest.approx(1.8)
+    assert expanded.Xtb == pytest.approx(1.5)
 
 
 def test_branch_current_in_voltage_source():
@@ -2540,6 +2542,19 @@ def test_bjt_temperature_scaling_uses_model_temperature_exponent():
     low = bjt_at_temperature(BJT("Qlow", "c", "b", "e", Xti=0.0), 350.0)
     high = bjt_at_temperature(BJT("Qhigh", "c", "b", "e", Xti=4.0), 350.0)
     assert high.Is > low.Is
+
+
+def test_bjt_temperature_scaling_uses_forward_beta_temperature_exponent():
+    transistor = BJT("Q1", "c", "b", "e", beta_f=100.0, Xtb=2.0)
+    hot = bjt_at_temperature(transistor, 350.0)
+    assert hot.beta_f > transistor.beta_f
+
+
+def test_dc_rejects_invalid_bjt_forward_beta_temperature_exponent():
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", Xtb=math.nan))
+    with pytest.raises(ValueError, match="forward-beta temperature exponent must be finite"):
+        dc_op(circuit)
 
 
 def test_bjt_temperature_scales_base_emitter_leakage_saturation_current():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add BJT model-card `XTB` forward-beta temperature-exponent support, scaling
+  forward beta by the analysis-to-nominal absolute temperature ratio, matching
+  Python and TypeScript. The supported-parameter catalog now contains 106
+  canonical rows.
 - Add BJT model-card `ISC`/`NC` base-collector leakage support in DC,
   transient, AC, transfer-function, temperature, and noise paths, matching
   Python and TypeScript. The supported-parameter catalog now contains 104

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -146,6 +146,8 @@ small-signal input conductance, and shot noise.
 `ISC` (default `0`, disabled) and `NC` (default `2`) add the mirrored Berkeley
 base-collector leakage branch to DC/transient current, small-signal
 base-collector conductance, and shot noise.
+`XTB` (default `0`) scales forward beta with the analysis-to-nominal absolute
+temperature ratio, preserving the nominal beta when omitted.
 `model_card_unsupported_parameter_issues`,
 `format_model_card_unsupported_parameter_issue_table`,
 `model_card_unsupported_parameter_issue_records`,
@@ -171,7 +173,7 @@ catalog by model kind for compact release dashboards and Mosaic UI inventories.
 `model_card_supported_parameter_coverage_gate_issue_records`,
 `format_model_card_supported_parameter_coverage_gate_issue_csv`, and
 `format_model_card_supported_parameter_coverage_gate_issue_json` validate the
-expected seven-kind, 104-row supported-parameter catalog and expose stable issue
+expected seven-kind, 106-row supported-parameter catalog and expose stable issue
 rows for release automation.
 `model_card_supported_parameter_coverage_dashboard`,
 `format_model_card_supported_parameter_coverage_dashboard_table`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -448,6 +448,7 @@ fn clone_subckt_element(
                 element.base_emitter_leakage_emission_coefficient,
                 element.base_collector_leakage_saturation_current,
                 element.base_collector_leakage_emission_coefficient,
+                element.forward_beta_temperature_exponent,
             ),
         ),
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
@@ -2672,12 +2673,19 @@ pub fn bjt_at_temperature(
             reason: "saturation-current temperature exponent must be finite".to_string(),
         });
     }
+    if !bjt.forward_beta_temperature_exponent.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "forward-beta temperature exponent must be finite".to_string(),
+        });
+    }
     let saturation_scale = ratio.powf(bjt.saturation_current_temperature_exponent)
         * exponent.clamp(-100.0, 100.0).exp();
     let mut adjusted = bjt.clone();
     adjusted.saturation_current *= saturation_scale;
     adjusted.base_emitter_leakage_saturation_current *= saturation_scale;
     adjusted.base_collector_leakage_saturation_current *= saturation_scale;
+    adjusted.forward_beta *= ratio.powf(bjt.forward_beta_temperature_exponent);
     adjusted.thermal_voltage *= ratio;
     Ok(adjusted)
 }
@@ -2869,6 +2877,7 @@ pub struct Bjt {
     pub base_emitter_leakage_emission_coefficient: f64,
     pub base_collector_leakage_saturation_current: f64,
     pub base_collector_leakage_emission_coefficient: f64,
+    pub forward_beta_temperature_exponent: f64,
 }
 
 impl Bjt {
@@ -3196,6 +3205,7 @@ impl Bjt {
             base_emitter_leakage_emission_coefficient,
             0.0,
             2.0,
+            0.0,
         )
     }
 
@@ -3229,6 +3239,7 @@ impl Bjt {
         base_emitter_leakage_emission_coefficient: f64,
         base_collector_leakage_saturation_current: f64,
         base_collector_leakage_emission_coefficient: f64,
+        forward_beta_temperature_exponent: f64,
     ) -> Self {
         Self {
             name: name.into(),
@@ -3259,6 +3270,7 @@ impl Bjt {
             base_emitter_leakage_emission_coefficient,
             base_collector_leakage_saturation_current,
             base_collector_leakage_emission_coefficient,
+            forward_beta_temperature_exponent,
         }
     }
 }
@@ -3649,8 +3661,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 23, 38, 11, 4),
-    (ModelCardKind::Pnp, 23, 38, 11, 4),
+    (ModelCardKind::Npn, 24, 39, 11, 4),
+    (ModelCardKind::Pnp, 24, 39, 11, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3704,6 +3716,7 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("NE", "NE"),
     ("ISC", "ISC"),
     ("NC", "NC"),
+    ("XTB", "XTB"),
     ("NF", "NF"),
     ("NR", "NR"),
     ("VJE", "VJE"),
@@ -4384,6 +4397,7 @@ pub fn bjt_from_model_card(
             model_card_value(model, "NE", 1.0),
             model_card_value(model, "ISC", 0.0),
             model_card_value(model, "NC", 2.0),
+            model_card_value(model, "XTB", 0.0),
         ),
     )
 }
@@ -23805,6 +23819,12 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "saturation-current temperature exponent must be finite".to_string(),
+        });
+    }
+    if !bjt.forward_beta_temperature_exponent.is_finite() {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "forward-beta temperature exponent must be finite".to_string(),
         });
     }
     if !bjt.energy_gap_electron_volts.is_finite() || bjt.energy_gap_electron_volts <= 0.0 {

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 104);
+    assert_eq!(coverage.len(), 106);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 104);
+    assert_eq!(records.len(), 106);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 104);
-    assert_eq!(report.expected_canonical_parameter_count, 104);
-    assert_eq!(report.accepted_name_count, 166);
+    assert_eq!(report.canonical_parameter_count, 106);
+    assert_eq!(report.expected_canonical_parameter_count, 106);
+    assert_eq!(report.accepted_name_count, 168);
     assert_eq!(report.aliased_parameter_count, 49);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t104\t104\t166\t49\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t106\t106\t168\t49\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,8 +235,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 103);
-    assert_eq!(report.accepted_name_count, 163);
+    assert_eq!(report.canonical_parameter_count, 105);
+    assert_eq!(report.accepted_name_count, 165);
     assert_eq!(report.aliased_parameter_count, 48);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t103\t104\t163\t48\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t105\t106\t165\t48\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -429,6 +429,7 @@ fn model_card_aliases_build_device_instances() {
             ("BETA", 125.0),
             ("CBE", 2.0e-12),
             ("XTI", 2.4),
+            ("XTB", 1.5),
             ("EG", 1.05),
             ("VA", 80.0),
             ("VB", 120.0),
@@ -451,6 +452,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("BF").unwrap(), 125.0);
     assert_close(*bjt_card.parameters.get("CJE").unwrap(), 2.0e-12);
     assert_close(*bjt_card.parameters.get("XTI").unwrap(), 2.4);
+    assert_close(*bjt_card.parameters.get("XTB").unwrap(), 1.5);
     assert_close(*bjt_card.parameters.get("EG").unwrap(), 1.05);
     assert_close(*bjt_card.parameters.get("VAF").unwrap(), 80.0);
     assert_close(*bjt_card.parameters.get("VAR").unwrap(), 120.0);
@@ -470,6 +472,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(bjt_model.forward_beta, 125.0);
     assert_close(bjt_model.base_emitter_capacitance, 2.0e-12);
     assert_close(bjt_model.saturation_current_temperature_exponent, 2.4);
+    assert_close(bjt_model.forward_beta_temperature_exponent, 1.5);
     assert_close(bjt_model.energy_gap_electron_volts, 1.05);
     assert_close(bjt_model.forward_early_voltage, 80.0);
     assert_close(bjt_model.reverse_early_voltage, 120.0);
@@ -1410,6 +1413,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
         1.7,
         4.0e-13,
         1.8,
+        1.5,
     );
     let mut circuit = Circuit::new();
     circuit
@@ -1451,6 +1455,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.base_emitter_leakage_emission_coefficient, 1.7);
     assert_close(expanded.base_collector_leakage_saturation_current, 4.0e-13);
     assert_close(expanded.base_collector_leakage_emission_coefficient, 1.8);
+    assert_close(expanded.forward_beta_temperature_exponent, 1.5);
 }
 
 #[test]
@@ -1936,6 +1941,26 @@ fn bjt_temperature_scaling_uses_model_temperature_exponent() {
     let low = bjt_at_temperature(&low_exponent, 350.0, 300.15, 1.11).unwrap();
     let high = bjt_at_temperature(&high_exponent, 350.0, 300.15, 1.11).unwrap();
     assert!(high.saturation_current > low.saturation_current);
+}
+
+#[test]
+fn bjt_temperature_scaling_uses_forward_beta_temperature_exponent() {
+    let mut transistor = Bjt::new("Q1", "c", "b", "e");
+    transistor.forward_beta_temperature_exponent = 2.0;
+    let hot = bjt_at_temperature(&transistor, 350.0, 300.15, 1.11).unwrap();
+    assert!(hot.forward_beta > transistor.forward_beta);
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_forward_beta_temperature_exponent() {
+    let mut transistor = Bjt::new("Qbad", "c", "b", "0");
+    transistor.forward_beta_temperature_exponent = f64::NAN;
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Bjt(transistor));
+    let error = dc_op(&circuit).unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("forward-beta temperature exponent must be finite"));
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add BJT model-card `XTB` forward-beta temperature-exponent support, scaling
+  forward beta by the analysis-to-nominal absolute temperature ratio, matching
+  Rust and Python. The supported-parameter catalog now contains 106 canonical
+  rows.
 - Add BJT model-card `ISC`/`NC` base-collector leakage support in DC,
   transient, AC, transfer-function, temperature, and noise paths, matching
   Rust and Python. The supported-parameter catalog now contains 104 canonical

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -216,6 +216,8 @@ small-signal input conductance, and shot noise.
 `ISC` (default `0`, disabled) and `NC` (default `2`) add the mirrored Berkeley
 base-collector leakage branch to DC/transient current, small-signal
 base-collector conductance, and shot noise.
+`XTB` (default `0`) scales forward beta with the analysis-to-nominal absolute
+temperature ratio, preserving the nominal beta when omitted.
 `modelCardUnsupportedParameterIssues`,
 `formatModelCardUnsupportedParameterIssueTable`,
 `modelCardUnsupportedParameterIssueRecords`,
@@ -241,7 +243,7 @@ model kind for compact release dashboards and Mosaic UI inventories.
 `modelCardSupportedParameterCoverageGateIssueRecords`,
 `formatModelCardSupportedParameterCoverageGateIssueCsv`, and
 `formatModelCardSupportedParameterCoverageGateIssueJson` validate the expected
-seven-kind, 104-row supported-parameter catalog and expose stable issue rows for
+seven-kind, 106-row supported-parameter catalog and expose stable issue rows for
 release automation.
 `modelCardSupportedParameterCoverageDashboard`,
 `formatModelCardSupportedParameterCoverageDashboardTable`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1726,6 +1726,7 @@ export interface Bjt {
   readonly baseEmitterLeakageEmissionCoefficient: number;
   readonly baseCollectorLeakageSaturationCurrent: number;
   readonly baseCollectorLeakageEmissionCoefficient: number;
+  readonly forwardBetaTemperatureExponent: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -2003,8 +2004,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [23, 38, 11, 4],
-  PNP: [23, 38, 11, 4],
+  NPN: [24, 39, 11, 4],
+  PNP: [24, 39, 11, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3594,7 +3595,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7635,6 +7636,9 @@ export function bjtAtTemperature(
   if (!Number.isFinite(element.saturationCurrentTemperatureExponent)) {
     throw invalidElement(element.name, "saturation-current temperature exponent must be finite");
   }
+  if (!Number.isFinite(element.forwardBetaTemperatureExponent)) {
+    throw invalidElement(element.name, "forward-beta temperature exponent must be finite");
+  }
   const saturationScale =
     ratio ** element.saturationCurrentTemperatureExponent *
     Math.exp(Math.max(-100.0, Math.min(100.0, exponent)));
@@ -7645,6 +7649,7 @@ export function bjtAtTemperature(
       element.baseEmitterLeakageSaturationCurrent * saturationScale,
     baseCollectorLeakageSaturationCurrent:
       element.baseCollectorLeakageSaturationCurrent * saturationScale,
+    forwardBeta: element.forwardBeta * ratio ** element.forwardBetaTemperatureExponent,
     thermalVoltage: element.thermalVoltage * ratio,
   };
 }
@@ -7767,6 +7772,7 @@ export function bjt(
   baseEmitterLeakageEmissionCoefficient = 1.0,
   baseCollectorLeakageSaturationCurrent = 0.0,
   baseCollectorLeakageEmissionCoefficient = 2.0,
+  forwardBetaTemperatureExponent = 0.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7798,6 +7804,7 @@ export function bjt(
     baseEmitterLeakageEmissionCoefficient,
     baseCollectorLeakageSaturationCurrent,
     baseCollectorLeakageEmissionCoefficient,
+    forwardBetaTemperatureExponent,
   };
 }
 
@@ -7911,6 +7918,7 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   NE: "NE",
   ISC: "ISC",
   NC: "NC",
+  XTB: "XTB",
   NF: "NF",
   NR: "NR",
   VJE: "VJE",
@@ -8434,6 +8442,7 @@ export function bjtFromModelCard(
     p.NE ?? 1.0,
     p.ISC ?? 0.0,
     p.NC ?? 2.0,
+    p.XTB ?? 0.0,
   );
 }
 
@@ -19812,6 +19821,9 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.saturationCurrentTemperatureExponent)) {
     throw invalidElement(element.name, "saturation-current temperature exponent must be finite");
+  }
+  if (!Number.isFinite(element.forwardBetaTemperatureExponent)) {
+    throw invalidElement(element.name, "forward-beta temperature exponent must be finite");
   }
   if (!Number.isFinite(element.energyGapElectronVolts) || element.energyGapElectronVolts <= 0.0) {
     throw invalidElement(element.name, "energy gap must be finite and positive");

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(104);
+    expect(coverage).toHaveLength(106);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(104);
+    expect(records).toHaveLength(106);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 104,
-      expectedCanonicalParameterCount: 104,
-      acceptedNameCount: 166,
+      canonicalParameterCount: 106,
+      expectedCanonicalParameterCount: 106,
+      acceptedNameCount: 168,
       aliasedParameterCount: 49,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t104\t104\t166\t49\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t106\t106\t168\t49\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,8 +241,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(103);
-    expect(report.acceptedNameCount).toBe(163);
+    expect(report.canonicalParameterCount).toBe(105);
+    expect(report.acceptedNameCount).toBe(165);
     expect(report.aliasedParameterCount).toBe(48);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t103\t104\t163\t48\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t105\t106\t165\t48\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -335,6 +335,7 @@ describe("dcOp", () => {
       BETA: 125.0,
       CBE: 2.0e-12,
       XTI: 2.4,
+      XTB: 1.5,
       EG: 1.05,
       VA: 80.0,
       VB: 120.0,
@@ -352,11 +353,12 @@ describe("dcOp", () => {
       FC: 0.4,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.baseEmitterCapacitance, 2.0e-12);
     expectClose(bjtModel.saturationCurrentTemperatureExponent, 2.4);
+    expectClose(bjtModel.forwardBetaTemperatureExponent, 1.5);
     expectClose(bjtModel.energyGapElectronVolts, 1.05);
     expectClose(bjtModel.forwardEarlyVoltage, 80.0);
     expectClose(bjtModel.reverseEarlyVoltage, 120.0);
@@ -1004,7 +1006,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -1028,6 +1030,7 @@ describe("dcOp", () => {
       expectClose(expanded.baseEmitterLeakageEmissionCoefficient, 1.7);
       expectClose(expanded.baseCollectorLeakageSaturationCurrent, 4.0e-13);
       expectClose(expanded.baseCollectorLeakageEmissionCoefficient, 1.8);
+      expectClose(expanded.forwardBetaTemperatureExponent, 1.5);
     }
   });
 
@@ -1348,6 +1351,26 @@ describe("dcOp", () => {
     const low = bjtAtTemperature(bjt("Qlow", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 0), 350);
     const high = bjtAtTemperature(bjt("Qhigh", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 4), 350);
     expect(high.saturationCurrent).toBeGreaterThan(low.saturationCurrent);
+  });
+
+  it("uses the BJT forward-beta temperature exponent", () => {
+    const transistor = {
+      ...bjt("Q1", "c", "b", "e"),
+      forwardBetaTemperatureExponent: 2.0,
+    };
+    const hot = bjtAtTemperature(transistor, 350);
+    expect(hot.forwardBeta).toBeGreaterThan(transistor.forwardBeta);
+  });
+
+  it("rejects non-finite BJT forward-beta temperature exponents", () => {
+    const circuit = new Circuit();
+    circuit.add({
+      ...bjt("Qbad", "c", "b", "0"),
+      forwardBetaTemperatureExponent: Number.NaN,
+    });
+    expect(() => dcOp(circuit)).toThrowError(
+      "forward-beta temperature exponent must be finite",
+    );
   });
 
   it("scales BJT base-emitter leakage saturation current with temperature", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,17 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT base-collector leakage.
+1. Cross-language BJT forward-beta temperature exponent.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `ISC` / `NC` base-collector leakage model-card support in
-     Rust, Python, and TypeScript with disabled behavior represented by the
-     standard zero `ISC` default.
-   - Apply the leakage branch in DC, transient, AC, transfer-function,
-     temperature, and noise paths while preserving the complete BJT model
-     through hierarchical subcircuits.
-   - Extend the supported-parameter coverage gate from 100 to 104 canonical rows
-     and lock model-card aliases, behavior, validation, and hierarchy in all
-     engines.
+   - Add Berkeley BJT `XTB` model-card support in Rust, Python, and TypeScript
+     with behavior-preserving zero-exponent defaults.
+   - Scale forward beta by the analysis-to-nominal absolute temperature ratio
+     while preserving the complete BJT model through hierarchical subcircuits.
+   - Extend the supported-parameter coverage gate from 104 to 106 canonical
+     rows and lock model-card aliases, behavior, validation, and hierarchy in
+     all engines.
 
 ## Completed Slices
 
@@ -3079,6 +3077,14 @@ the Rust, Python, and TypeScript surfaces together.
      transfer-function, temperature, and noise paths.
    - Hierarchical subcircuit expansion preserves the complete BJT model, and
      the supported-parameter release gate now covers 100 canonical rows.
+
+229. Cross-language BJT base-collector leakage.
+   - Status: completed in PR 8785.
+   - Rust, Python, and TypeScript BJT model cards now accept `ISC` / `NC` and
+     apply the base-collector leakage branch in DC, transient, AC,
+     transfer-function, temperature, and noise paths.
+   - Hierarchical subcircuit expansion preserves the complete BJT model, and
+     the supported-parameter release gate now covers 104 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley BJT `XTB` model-card support across Rust, Python, and TypeScript
- scale forward beta by the analysis-to-nominal absolute temperature ratio while preserving the zero-exponent default
- extend model-card coverage gates to 106 canonical rows and reconcile the SPICE completion plan

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo test -p spice-engine --test dc_tests` (108 passed)
- Python `ruff check` on touched source/tests
- Python `pytest` (548 passed, 88.76% coverage)
- `npm run build`
- `npm test` (306 passed)
- `git diff --check`