### PR TITLE
feat(app): restore the stroke-order provenance gate (dropped from #8776's async merge)

### DIFF
--- a/code/programs/typescript/script-writing-visualizer/src/strokes.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/strokes.ts
@@ -68,11 +68,31 @@ export interface Stroke {
   segments: Segment[];
 }
 
+/**
+ * Where a letter's stroke ORDER came from.
+ *
+ * The pen path's SHAPE is checked against the font (see the test). Its ORDER
+ * cannot be — no font records it — so the order must trace to a real source:
+ * a handwriting primer, a stroke database, or a named native writer. There is
+ * no authoritative machine-readable stroke database for Tamil (or any Indic
+ * script, Arabic, or Hebrew), so the order is read from a cited teaching
+ * source, and `variation` records that Tamil is taught with school-to-school
+ * differences — this is one attested order, not the only one.
+ */
+export interface StrokeSource {
+  citation: string;
+  url: string;
+  /** How standardised the order is, and where it varies. */
+  variation?: string;
+}
+
 /** A letter's handwriting: the character and the strokes that form it. */
 export interface LetterDuctus {
   glyph: string;
   /** In writing order. `strokes.length - 1` is the number of pen lifts. */
   strokes: Stroke[];
+  /** Provenance of the stroke ORDER. Required — no letter enters uncited. */
+  source: StrokeSource;
 }
 
 /**
@@ -168,13 +188,13 @@ const clamp01 = (n: number) => (n < 0 ? 0 : n > 1 ? 1 : n);
 // ---------------------------------------------------------------------------
 // The authored letters.
 //
-// ம first, and alone, until it is verified against the font and seen by a
-// reader who writes Tamil. It is ONE stroke — the hand does not lift — made of
-// three joined parts: down the left upright, along the bottom, then up the
-// right and over the top and back down the middle toward the left vertical. Each
-// part's path starts on the previous part's last point, so `joinGaps` is zero
-// and the whole thing is a single motion. Coordinates are font units, checked
-// in strokes.test against the rendered glyph, not eyeballed here.
+// ம first, and alone, until every letter after it is sourced the same way. It
+// is ONE stroke — the hand does not lift — made of the FIVE joined parts the
+// cited primer numbers: down the left upright, along the bottom, up the right
+// side, over the top, and down the middle. Each part's path starts on the
+// previous part's last point, so `joinGaps` is zero and the whole thing is a
+// single motion. Coordinates are font units, checked in strokes.test against
+// the rendered glyph (shape) and against `source` (order), not eyeballed here.
 // ---------------------------------------------------------------------------
 
 export const DUCTUS: Record<string, LetterDuctus> = {
@@ -202,15 +222,27 @@ export const DUCTUS: Record<string, LetterDuctus> = {
             ],
           },
           {
-            label: "up the right, over the top, back down the middle",
+            label: "up the right side",
             path: [
               { x: 715, y: 44 },
               { x: 726, y: 180 },
+              { x: 724, y: 430 },
+            ],
+          },
+          {
+            label: "over the top",
+            path: [
               { x: 724, y: 430 },
               { x: 690, y: 510 },
               { x: 600, y: 548 },
               { x: 500, y: 548 },
               { x: 452, y: 512 },
+              { x: 434, y: 430 },
+            ],
+          },
+          {
+            label: "down the middle",
+            path: [
               { x: 434, y: 430 },
               { x: 430, y: 180 },
               { x: 430, y: 44 },
@@ -219,5 +251,15 @@ export const DUCTUS: Record<string, LetterDuctus> = {
         ],
       },
     ],
+    // Five movements, matching the numbered arrows in the cited primer's
+    // Frame 1 (down the left · along the bottom · up the right · over the top ·
+    // down the middle) — one unbroken pen path, exactly as authored.
+    source: {
+      citation:
+        "Sankaran Radhakrishnan, Tamil Script Learners Manual, Appendix I: Hand-movements, Frame 1 (Univ. of Texas at Austin)",
+      url: "https://sites.la.utexas.edu/tamilscript/files/2009/08/hw_lettersinstructions.pdf",
+      variation:
+        "Tamil handwriting is taught with school-to-school variation; there is no single national stroke-order standard. This is one attested order.",
+    },
   },
 };

--- a/code/programs/typescript/script-writing-visualizer/tests/strokes.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/strokes.test.ts
@@ -170,6 +170,26 @@ describe("handwriting ductus", () => {
     expect(penLifts(DUCTUS["ம"])).toBe(0);
     expect(DUCTUS["ம"].strokes).toHaveLength(1);
   });
+
+  // The PROVENANCE GATE. A stroke's SHAPE is checked against the font above;
+  // its ORDER cannot be — so it must trace to a cited source, or it does not
+  // ship. This is the counterpart, for hand-authored order, of "facts enter
+  // only through a source". Where no source exists, the letter is simply not
+  // authored rather than invented.
+  it("every letter cites a real source for its stroke order", () => {
+    for (const letter of letters) {
+      expect(letter.source, `${letter.glyph} has no source`).toBeDefined();
+      expect(letter.source.citation.length, `${letter.glyph} citation is empty`).toBeGreaterThan(10);
+      expect(letter.source.url, `${letter.glyph} source url is not a real link`).toMatch(/^https?:\/\/\S+$/);
+    }
+  });
+
+  it("ம's stroke order traces to the UT Austin primer, and records Tamil's variation", () => {
+    const src = DUCTUS["ம"].source;
+    expect(src.url).toContain("tamilscript");
+    expect(src.citation).toMatch(/Appendix I|Frame 1/);
+    expect(src.variation, "must not present one order as the only order").toMatch(/variation|no single/i);
+  });
 });
 
 describe("pen-path geometry", () => {


### PR DESCRIPTION
## Why this exists

PR #8776 was merged async at head `6ca081e` — the ductus-only commit — **before** its follow-up provenance commit (`67ffd5c`) landed on the branch. So the provenance work never reached `main`: `strokes.ts` on main has the pen-path model but **not** the required `source` field or the provenance-gate test. This restores it (cherry-picked, verified byte-identical to the already-reviewed commit via `git range-diff`).

## What it restores

A stroke's SHAPE is checked against the font, but its ORDER cannot be — no font records which way the pen travels. So the order must trace to a real source or it does not ship. This is the handwriting counterpart of the project's rule that facts enter only through a source.

- Each `LetterDuctus` carries a required `source` (citation, url, variation).
- A **provenance gate** test: every letter must cite a real `http(s)` source; ம's must name the primer and record Tamil's school-to-school variation. The gate fails if a letter's source is removed.
- ம's stroke order is sourced from **Sankaran Radhakrishnan, *Tamil Script Learners Manual*, Appendix I, Frame 1 (UT Austin)** — whose numbered arrows (down the left · along the bottom · up the right · over the top · down the middle) independently confirm the native writer's account. ம's segments were split from three to five to match the primer's numbering; the pen path is unchanged.

## Scope

This PR is **just the provenance recovery** — the same content already reviewed and approved on #8776, now targeted at the current main. Authoring the other ten Tamil letters (by the same fetch-the-primer, read-the-arrows, verify-shape-and-order method) is deliberately deferred to keep this focused on un-dropping what was lost.

**130 tests.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)