### PR TITLE
feat(sql): GROUP BY aggregate columns follow the SELECT list

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.5.62 — GROUP BY aggregate columns follow the SELECT list
+
+`SELECT max(x) AS mx, c FROM t GROUP BY c` now returns columns `[mx, c]` — the
+SELECT-list order — where before an aggregate column was always emitted after
+the group keys in a fixed layout (`[c, max(x)]`). This completes the GROUP BY
+projection work: non-aggregate columns already followed the SELECT list, and now
+aggregate columns do too, including `group_concat`.
+
+The enabler is reconciling `group_concat`'s representation: the planner now
+lowers it to `SqlExpr::Aggregate` like COUNT/SUM (it was previously a
+`FunctionCall` in the SELECT list), so codegen can re-compile any aggregate
+column in place. Retires the `group_by_reordered_with_aggregate` ledger entry.
+Verified against bundled real SQLite, including group_concat with a separator,
+count, and key all reordered. Spans sql-planner 0.2.29 and sql-codegen 0.6.11.
+
 ## 0.5.61 — GROUP BY bare column takes the group's first-row value
 
 `SELECT c FROM t GROUP BY x`, where `c` is neither a GROUP BY key nor inside an

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.61"
+version = "0.5.62"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1729,8 +1729,30 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT g, label FROM t GROUP BY g ORDER BY g",
     },
-    // Still ledgered: an aggregate column reordered before a group key keeps the
-    // fixed keys-then-aggregates layout (`[c, max(x)]` not `[max(x), c]`).
+    // An aggregate column reordered before a group key now follows the SELECT
+    // list (`[mx, c]`, not the old `[c, max(x)]`) — every aggregate, including
+    // group_concat, lowers to SqlExpr::Aggregate so the projection can place it.
+    // group_concat reordered before the group key — exercises the reconcile:
+    // group_concat now lowers to SqlExpr::Aggregate, so the projection places it
+    // in SELECT-list order like any other aggregate.
+    Case {
+        id: "group_by_reordered_group_concat",
+        setup: &[
+            "CREATE TABLE t (g TEXT, v TEXT)",
+            "INSERT INTO t VALUES('a','1'),('a','2'),('b','3')",
+        ],
+        query: "SELECT group_concat(v) AS gc, g FROM t GROUP BY g ORDER BY g",
+    },
+    // group_concat (with separator) + count + key, all reordered relative to the
+    // group key, each named/placed per the SELECT list.
+    Case {
+        id: "group_by_reordered_mixed_aggregates",
+        setup: &[
+            "CREATE TABLE t (g TEXT, v TEXT)",
+            "INSERT INTO t VALUES('a','1'),('a','2'),('b','3')",
+        ],
+        query: "SELECT group_concat(v,'|') AS gc, count(*) AS n, g FROM t GROUP BY g ORDER BY g",
+    },
     Case {
         id: "group_by_reordered_with_aggregate",
         setup: &[
@@ -2226,18 +2248,6 @@ const LEDGER: &[(&str, &str)] = &[
     (
         "distinct_star_collate",
         "SELECT DISTINCT * does not expand the star into the table's columns (projection gap, not a collation gap)",
-    ),
-    // A GROUP BY with an AGGREGATE column still emits the fixed
-    // group-keys-then-aggregates layout, so reordering an aggregate relative to
-    // the key columns in the SELECT list is not yet honoured: `SELECT max(x), c
-    // ... GROUP BY c` comes back as `[c, max(x)]`. Non-aggregate GROUP BY output
-    // now follows the SELECT list; the aggregate case needs `group_concat` (a
-    // FunctionCall in the SELECT list, unlike COUNT/SUM/… which lower to
-    // SqlExpr::Aggregate) reconciled before an output column can be re-projected
-    // reliably. A tracked follow-up.
-    (
-        "group_by_reordered_with_aggregate",
-        "an aggregate column reordered before a group key in the SELECT list keeps the fixed keys-then-aggregates layout (aggregate output-expr representation not yet reconciled)",
     ),
     (
         "distinct_explicit_collate",

--- a/code/packages/rust/sql-codegen/CHANGELOG.md
+++ b/code/packages/rust/sql-codegen/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.6.11] - Unreleased
+
+### Fixed
+
+- **An aggregate column reordered in the SELECT list of a GROUP BY now follows
+  that order.** `emit_group_row`'s projected path is no longer restricted to
+  aggregate-free queries — it runs for every grouped query with a projection,
+  resolving each aggregate SELECT item through `agg_slots` (like HAVING) and each
+  group-key column from the group's fake row. So `SELECT max(x) AS mx, c FROM t
+  GROUP BY c` yields columns `[mx, c]`, not the old fixed `[c, max(x)]`. This
+  relies on the sql-planner 0.2.29 change lowering `group_concat` to
+  `SqlExpr::Aggregate` (so every aggregate is re-compilable) and on
+  `output_column_name` naming a `SqlExpr::Aggregate` via the new shared
+  `render_aggregate_name` (factored out of `aggregate_column_name`, so the
+  re-projected header matches the fixed-layout one). Retires the
+  `group_by_reordered_with_aggregate` oracle ledger entry.
+
 ## [0.6.10] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-codegen/Cargo.toml
+++ b/code/packages/rust/sql-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-codegen"
-version = "0.6.10"
+version = "0.6.11"
 edition = "2021"
 description = "Bytecode code generator for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-codegen/src/lib.rs
+++ b/code/packages/rust/sql-codegen/src/lib.rs
@@ -1276,28 +1276,25 @@ impl Compiler {
     /// This is the projection step — it runs after `FinalizeAgg` values are
     /// available and inside a `BeginRow`/`EmitRow` pair supplied by the caller.
     ///
-    /// **Projected path** — used when an enclosing `SELECT` list is available AND
-    /// the query has no aggregate columns (a pure `GROUP BY` producing only key
-    /// columns and expressions over them). The row then follows the SELECT list
-    /// exactly — order, count, and identity all come from what the user wrote,
-    /// each item compiled in the group's finalize context (a GROUP BY key column
-    /// reads its key value from the group's fake row, so a collated key still
-    /// reports its original text). So `SELECT x, c FROM t GROUP BY c, x` yields
-    /// columns `[x, c]`, not the internal group-key order `[c, x]` — the bug this
-    /// fixes (reordering the SELECT list used to change nothing).
+    /// **Projected path** — used whenever an enclosing `SELECT` list is available.
+    /// The row follows that list exactly — order, count, and identity all come
+    /// from what the user wrote — with each item compiled in the group's finalize
+    /// context: a GROUP BY key column reads its key value from the group's fake
+    /// row (so a collated key still reports its original text), and an aggregate
+    /// column resolves through `agg_slots` to its `FinalizeAgg` slot (the same
+    /// machinery HAVING uses). So `SELECT x, c FROM t GROUP BY c, x` yields
+    /// columns `[x, c]` (not the internal group-key order `[c, x]`), and
+    /// `SELECT max(x) AS mx, c FROM t GROUP BY c` yields `[mx, c]` (not
+    /// `[c, max(x)]`). This works for aggregate columns because the planner lowers
+    /// EVERY aggregate — including `group_concat` — to `SqlExpr::Aggregate`, so
+    /// `compile_expr` can resolve them, and `output_column_name` names them the
+    /// SQLite way.
     ///
-    /// **Fixed path** — used with no projection (an aggregate compiled outside a
-    /// `Project`; rare), OR whenever aggregate columns are present. It emits every
-    /// GROUP BY key (from its underlying column, so the group's original text and
-    /// name are reported) followed by every aggregate in declaration order.
-    ///
-    /// The aggregate case still takes the fixed layout on purpose: an aggregate
-    /// output column is not reliably re-compilable here — `group_concat(...)`
-    /// stays a `FunctionCall` in the SELECT list (unlike COUNT/SUM/… which the
-    /// planner lowers to `SqlExpr::Aggregate`), so routing it through
-    /// `compile_expr` would fail. Reordering aggregate columns to the SELECT
-    /// order needs that representation reconciled first, and is a tracked
-    /// follow-up (see the `group_by_reordered_with_aggregate` ledger entry).
+    /// **Fixed path** — used only with no projection (an aggregate compiled
+    /// outside a `Project`; rare, mostly defensive / subquery paths). It emits
+    /// every GROUP BY key (from its underlying column, so the group's original
+    /// text and name are reported) followed by every aggregate in declaration
+    /// order.
     fn emit_group_row(
         &mut self,
         projection: Option<&[OutputColumn]>,
@@ -1306,15 +1303,19 @@ impl Compiler {
         aggregates: &[AggregateItem],
     ) {
         match projection {
-            // Only re-project when there are no aggregate columns to place; with
-            // aggregates present we fall through to the fixed layout below.
-            Some(cols) if aggregates.is_empty() => {
+            Some(cols) => {
+                // Let `compile_expr` resolve an aggregate reference in the SELECT
+                // list to its accumulator slot (matched by func/arg/distinct); a
+                // bare column reference falls through to a `LoadColumn` against the
+                // group's fake row instead.
+                self.agg_slots = aggregates.iter().cloned().enumerate().collect();
                 for col in cols {
                     self.compile_expr(&col.expr);
                     self.emit(Instruction::EmitColumn(output_column_name(col)));
                 }
+                self.agg_slots.clear();
             }
-            _ => {
+            None => {
                 for e in group_by {
                     let e = strip_collate(e);
                     self.compile_expr(e);
@@ -2329,6 +2330,14 @@ fn output_column_name(col: &OutputColumn) -> String {
     match &col.expr {
         SqlExpr::Column { name, .. } => name.clone(),
         SqlExpr::FunctionCall { .. } => render_expr_label(&col.expr).unwrap_or_else(|| "?".to_string()),
+        // An un-aliased aggregate column is named after its call text (`SUM(n)`,
+        // `COUNT(*)`, `GROUP_CONCAT(x)`), matching SQLite — the same rule
+        // `aggregate_column_name` applies to the extracted `AggregateItem`. This
+        // is what lets the SELECT-list projection name an aggregate column
+        // correctly when it re-projects (instead of the old fixed layout).
+        SqlExpr::Aggregate { func, arg, distinct } => {
+            render_aggregate_name(func, arg.as_deref(), *distinct)
+        }
         _ => "?".to_string(),
     }
 }
@@ -2385,7 +2394,17 @@ fn aggregate_column_name(item: &AggregateItem) -> String {
     if let Some(alias) = &item.alias {
         return alias.clone();
     }
-    let func = match item.func {
+    render_aggregate_name(&item.func, item.arg.as_ref(), item.distinct)
+}
+
+/// Render an un-aliased aggregate's implicit column name from its parts — the
+/// call text SQLite uses: `COUNT(*)`, `SUM(n)`, `MIN(x)`, `GROUP_CONCAT(x)`,
+/// `COUNT(DISTINCT id)`. Shared by [`aggregate_column_name`] (which names an
+/// extracted `AggregateItem`) and [`output_column_name`] (which names a
+/// `SqlExpr::Aggregate` in the SELECT list); both must agree so a re-projected
+/// aggregate column keeps the same header as the fixed-layout one.
+fn render_aggregate_name(func: &AggFunc, arg: Option<&SqlExpr>, distinct: bool) -> String {
+    let func_name = match func {
         AggFunc::Count => "COUNT",
         AggFunc::Sum => "SUM",
         AggFunc::Avg => "AVG",
@@ -2393,18 +2412,18 @@ fn aggregate_column_name(item: &AggregateItem) -> String {
         AggFunc::Max => "MAX",
         AggFunc::GroupConcat { .. } => "GROUP_CONCAT",
     };
-    let inner = match &item.arg {
+    let inner = match arg {
         None => "*".to_string(),
         Some(expr) => {
             let base = render_expr_label(expr).unwrap_or_else(|| "?".to_string());
-            if item.distinct {
+            if distinct {
                 format!("DISTINCT {base}")
             } else {
                 base
             }
         }
     };
-    format!("{func}({inner})")
+    format!("{func_name}({inner})")
 }
 
 // ===========================================================================

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.29] - Unreleased
+
+### Changed
+
+- **`GROUP_CONCAT` lowers to `SqlExpr::Aggregate` in expression context.**
+  `plan_function_call` previously left `group_concat(...)` as a `SqlExpr::
+  FunctionCall` (while a separate path recognised it for accumulator
+  allocation), so an aggregate SELECT item had two representations. It now
+  produces `SqlExpr::Aggregate { func: GroupConcat { sep }, arg, distinct }` like
+  COUNT/SUM/…, so codegen's `compile_expr` can resolve it to its slot — which is
+  what lets a `group_concat` column be re-projected into SELECT-list order. The
+  separator is captured onto the func via the same `group_concat_separator`
+  helper the accumulator path uses, so the two stay consistent.
+
 ## [0.2.28] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.28"
+version = "0.2.29"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -3403,6 +3403,16 @@ fn plan_function_call(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
         "AVG" => Some(AggFunc::Avg),
         "MIN" => Some(AggFunc::Min),
         "MAX" => Some(AggFunc::Max),
+        // `GROUP_CONCAT(x [, sep])` is an aggregate too. Lowering it to
+        // `SqlExpr::Aggregate` here (rather than leaving it a `FunctionCall`, as
+        // it once was) means an aggregate SELECT item has ONE representation, so
+        // `compile_expr` can resolve it to its accumulator slot like COUNT/SUM —
+        // which is what lets a `group_concat` column be re-projected into
+        // SELECT-list order. The separator (the optional 2nd arg, default ",") is
+        // captured onto the func; `arg` below still resolves to the 1st argument.
+        "GROUP_CONCAT" => Some(AggFunc::GroupConcat {
+            sep: group_concat_separator(node),
+        }),
         _ => None,
     };
     // `MIN(a, b, …)` / `MAX(a, b, …)` with two-or-more arguments are the SCALAR


### PR DESCRIPTION
Round 1 of driving the four mini-sqlite streams to completion. Completes the GROUP BY projection work: aggregate columns now follow the SELECT list.

## What

`SELECT max(x) AS mx, c FROM t GROUP BY c` now returns columns `[mx, c]` — SELECT-list order — where before an aggregate column was always emitted after the group keys (`[c, max(x)]`). Non-aggregate columns already followed the SELECT list (#8774); this extends it to aggregates, including `group_concat`. Retires the `group_by_reordered_with_aggregate` ledger entry.

## How — the enabler is reconciling group_concat's representation

`group_concat` was the odd one out: the planner lowered COUNT/SUM/… to `SqlExpr::Aggregate` but left `group_concat(...)` a `FunctionCall` in the SELECT list (a dual representation — a separate path recognised it for accumulator allocation). Routing a `FunctionCall`-shaped aggregate through `compile_expr` fails, which is exactly why the previous PR had to scope its projection to aggregate-free queries.

- **sql-planner**: `plan_function_call` now lowers `group_concat` to `SqlExpr::Aggregate` too. One representation for every aggregate.
- **sql-codegen**: `output_column_name` names a `SqlExpr::Aggregate` via a new shared `render_aggregate_name` (factored out of `aggregate_column_name`, so the re-projected header is byte-identical to the fixed-layout one).
- **sql-codegen**: `emit_group_row`'s projected path drops its `aggregates.is_empty()` gate — it runs for every grouped query with a projection, resolving aggregate SELECT items through `agg_slots` (the same machinery HAVING uses) and group-key columns from the group's fake row.

## Tests

2 new positive oracle cases against bundled real SQLite — group_concat reordered before the key, and group_concat-with-separator + count + key all reordered — plus the retired case now passing. sql-planner 78, sql-codegen 81, sql-vm 114, mini-sqlite suites green; clippy clean.

## Security

Inline review: **clean**. The `agg_slots` slot match includes the separator (`AggFn::GroupConcat{sep,distinct}`), so `group_concat(x,'|')` and `group_concat(x,'-')` resolve to distinct slots — no collision, no fallback-to-0. The Phase-1 accumulator path and the SELECT-list expr derive `(func,arg,distinct,sep)` from the same AST node via the same helpers, so the slot lookup always matches. group_concat's DoS caps live in the unchanged VM accumulator, unaffected. Row-shape invariant holds; HAVING `agg_slots` hygiene intact.

Bumps: sql-planner 0.2.29, sql-codegen 0.6.11, mini-sqlite 0.5.62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
