### PR TITLE
feat(spice): add BJT reverse beta

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **BJT reverse current gain** — BJT model cards now accept `BR`/`BETA_R` and
+  apply the reverse base-current branch in DC, transient, AC,
+  transfer-function, temperature, and noise paths, matching Rust and
+  TypeScript. `XTB` now scales both forward and reverse beta. The
+  supported-parameter catalog now contains 108 canonical rows.
+
 - **BJT forward-beta temperature exponent** — BJT model cards now accept `XTB`
   and scale forward beta by the analysis-to-nominal absolute temperature ratio,
   matching Rust and TypeScript. The supported-parameter catalog now contains

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -229,8 +229,12 @@ small-signal input conductance, and shot noise.
 `ISC` (default `0`, disabled) and `NC` (default `2`) add the mirrored Berkeley
 base-collector leakage branch to DC/transient current, small-signal
 base-collector conductance, and shot noise.
-`XTB` (default `0`) scales forward beta with the analysis-to-nominal absolute
-temperature ratio, preserving the nominal beta when omitted.
+`BR`/`BETA_R` (default `1` on model cards) controls reverse current gain and
+adds the base-collector reverse base-current branch. Direct `BJT` constructors
+default to infinite reverse beta to preserve their legacy behavior.
+`XTB` (default `0`) scales both forward and reverse beta with the
+analysis-to-nominal absolute temperature ratio, preserving nominal beta when
+omitted.
 `model_card_unsupported_parameter_issues()`,
 `format_model_card_unsupported_parameter_issue_table()`,
 `model_card_unsupported_parameter_issue_records()`,
@@ -256,7 +260,7 @@ catalog by model kind for compact release dashboards and Mosaic UI inventories.
 `model_card_supported_parameter_coverage_gate_issue_records()`,
 `format_model_card_supported_parameter_coverage_gate_issue_csv()`, and
 `format_model_card_supported_parameter_coverage_gate_issue_json()` validate the
-expected seven-kind, 106-row supported-parameter catalog and expose stable issue
+expected seven-kind, 108-row supported-parameter catalog and expose stable issue
 rows for release automation.
 `model_card_supported_parameter_coverage_dashboard()`,
 `format_model_card_supported_parameter_coverage_dashboard_table()`,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -604,7 +604,7 @@ class BJT:
     Nr:
         Reverse emission coefficient (default 1.0).
     Xtb:
-        Forward-beta temperature exponent (default 0.0).
+        Forward- and reverse-beta temperature exponent (default 0.0).
     """
 
     name: str
@@ -636,6 +636,7 @@ class BJT:
     Isc: float = 0.0        # base-collector leakage saturation current (A)
     Nc: float = 2.0         # base-collector leakage emission coefficient
     Xtb: float = 0.0        # forward-beta temperature exponent
+    beta_r: float = float("inf")  # reverse current gain; infinity disables
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -354,7 +354,9 @@ def bjt_at_temperature(
             f"{bjt.name}: BJT saturation-current temperature exponent must be finite"
         )
     if not math.isfinite(bjt.Xtb):
-        raise ValueError(f"{bjt.name}: BJT forward-beta temperature exponent must be finite")
+        raise ValueError(f"{bjt.name}: BJT beta temperature exponent must be finite")
+    if math.isnan(bjt.beta_r) or bjt.beta_r <= 0.0:
+        raise ValueError(f"{bjt.name}: BJT reverse beta must be positive")
     saturation_scale = ratio**bjt.Xti * math.exp(max(-100.0, min(100.0, exponent)))
     return replace(
         bjt,
@@ -362,6 +364,7 @@ def bjt_at_temperature(
         Ise=bjt.Ise * saturation_scale,
         Isc=bjt.Isc * saturation_scale,
         beta_f=bjt.beta_f * ratio**bjt.Xtb,
+        beta_r=bjt.beta_r * ratio**bjt.Xtb,
         Vt=bjt.Vt * ratio,
     )
 
@@ -601,7 +604,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -9065,6 +9068,18 @@ def _bjt_base_collector_leakage(el: BJT, junction_voltage: float) -> tuple[float
     return el.Isc * (exp_value - 1.0), el.Isc / thermal_voltage * exp_value
 
 
+def _bjt_reverse_base_current(el: BJT, junction_voltage: float) -> tuple[float, float]:
+    if math.isinf(el.beta_r):
+        return 0.0, 0.0
+    thermal_voltage = el.Vt * el.Nr
+    exponent = max(-40.0, min(40.0, junction_voltage / thermal_voltage))
+    exp_value = math.exp(exponent)
+    return (
+        el.Is * (exp_value - 1.0) / el.beta_r,
+        el.Is / thermal_voltage * exp_value / el.beta_r,
+    )
+
+
 def _stamp_bjt(
     G: list[list[float]],
     b: list[float],
@@ -9162,12 +9177,19 @@ def _stamp_bjt(
     collector_leakage_current, collector_leakage_conductance = (
         _bjt_base_collector_leakage(el, Vreverse)
     )
+    reverse_base_current, reverse_base_conductance = _bjt_reverse_base_current(
+        el, Vreverse
+    )
+    base_collector_current = collector_leakage_current + reverse_base_current
+    base_collector_conductance = (
+        collector_leakage_conductance + reverse_base_conductance
+    )
     Ieq_collector_leakage = (
-        collector_leakage_current - collector_leakage_conductance * Vreverse
+        base_collector_current - base_collector_conductance * Vreverse
     )
 
     _stamp_g(G, node_to_idx, el.collector, el.emitter, output_conductance)
-    _stamp_g(G, node_to_idx, el.base, el.collector, collector_leakage_conductance)
+    _stamp_g(G, node_to_idx, el.base, el.collector, base_collector_conductance)
 
     if el.polarity == "NPN":
         # --- Junction stamp: gπ between B and E ------------------------------
@@ -9240,6 +9262,8 @@ def _validate_bjt(el: BJT) -> None:
         raise ValueError(f"{el.name}: BJT saturation current must be finite and positive")
     if not math.isfinite(el.beta_f) or el.beta_f <= 0.0:
         raise ValueError(f"{el.name}: BJT forward beta must be finite and positive")
+    if math.isnan(el.beta_r) or el.beta_r <= 0.0:
+        raise ValueError(f"{el.name}: BJT reverse beta must be positive")
     if not math.isfinite(el.Vt) or el.Vt <= 0.0:
         raise ValueError(f"{el.name}: BJT thermal voltage must be finite and positive")
     if not math.isfinite(el.Cje) or el.Cje < 0.0:
@@ -9255,7 +9279,7 @@ def _validate_bjt(el: BJT) -> None:
             f"{el.name}: BJT saturation-current temperature exponent must be finite"
         )
     if not math.isfinite(el.Xtb):
-        raise ValueError(f"{el.name}: BJT forward-beta temperature exponent must be finite")
+        raise ValueError(f"{el.name}: BJT beta temperature exponent must be finite")
     if not math.isfinite(el.Eg) or el.Eg <= 0.0:
         raise ValueError(f"{el.name}: BJT energy gap must be finite and positive")
     if not math.isfinite(el.Vaf) or el.Vaf < 0.0:
@@ -12537,13 +12561,16 @@ def _stamp_ac(
         _, collector_leakage_conductance = _bjt_base_collector_leakage(
             el, Vcollector_leakage
         )
+        _, reverse_base_conductance = _bjt_reverse_base_current(
+            el, Vcollector_leakage
+        )
         g_pi: float = base_gm / el.beta_f + leakage_conductance
         diffusion_capacitance = el.Tf * gm_b
         reverse_diffusion_capacitance = el.Tr * gm_reverse
         y_be = g_pi + 1j * omega * (
             _bjt_base_emitter_depletion_capacitance(el, Vjunc) + diffusion_capacitance
         )
-        y_bc = collector_leakage_conductance + 1j * omega * (
+        y_bc = collector_leakage_conductance + reverse_base_conductance + 1j * omega * (
             _bjt_base_collector_depletion_capacitance(el, Vreverse)
             + reverse_diffusion_capacitance
         )
@@ -13160,8 +13187,16 @@ def _build_ss_matrix(
             )
             _, leakage_conductance = _bjt_base_emitter_leakage(el, Vjunc)
             _, collector_leakage_conductance = _bjt_base_collector_leakage(el, Vreverse)
+            _, reverse_base_conductance = _bjt_reverse_base_current(el, Vreverse)
             g_pi: float = base_gm / el.beta_f + leakage_conductance
             _stamp_g(G, node_to_idx, el.collector, el.emitter, output_conductance)
+            _stamp_g(
+                G,
+                node_to_idx,
+                el.base,
+                el.collector,
+                collector_leakage_conductance + reverse_base_conductance,
+            )
             _stamp_g(G, node_to_idx, el.base, el.collector, collector_leakage_conductance)
 
             if el.polarity == "NPN":
@@ -14054,6 +14089,7 @@ def sens_dc(
                     Mjc=el.Mjc,
                     Fc=el.Fc,
                     Xtb=el.Xtb,
+                    beta_r=el.beta_r,
                 ),
             )
             delta_beta = max(abs(el.beta_f) * perturbation, abs_floor)
@@ -14087,6 +14123,7 @@ def sens_dc(
                     Mjc=el.Mjc,
                     Fc=el.Fc,
                     Xtb=el.Xtb,
+                    beta_r=el.beta_r,
                 ),
             )
 
@@ -14330,6 +14367,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             Mjc=el.Mjc,
             Fc=el.Fc,
             Xtb=el.Xtb,
+            beta_r=el.beta_r,
         )
 
     # Capacitor, Inductor, Mosfet — no tunable DC parameter; return unchanged.
@@ -14781,7 +14819,13 @@ def _collect_noise_sources(
             )
             leakage_current, _ = _bjt_base_emitter_leakage(el, Vjunc)
             collector_leakage_current, _ = _bjt_base_collector_leakage(el, Vreverse)
-            psd = q2 * (abs(I_C) + abs(leakage_current) + abs(collector_leakage_current))
+            reverse_base_current, _ = _bjt_reverse_base_current(el, Vreverse)
+            psd = q2 * (
+                abs(I_C)
+                + abs(leakage_current)
+                + abs(collector_leakage_current)
+                + abs(reverse_base_current)
+            )
             n_b = None if _is_ground(el.base) else node_to_idx[el.base]
             n_e = None if _is_ground(el.emitter) else node_to_idx[el.emitter]
             sources.append((el.name, "shot", n_b, n_e, psd))

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (24, 39, 11, 4),
-    "PNP": (24, 39, 11, 4),
+    "NPN": (25, 41, 12, 4),
+    "PNP": (25, 41, 12, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -383,6 +383,8 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "ISC": "ISC",
     "NC": "NC",
     "XTB": "XTB",
+    "BR": "BR",
+    "BETA_R": "BR",
     "NF": "NF",
     "NR": "NR",
     "VJE": "VJE",
@@ -935,6 +937,7 @@ def bjt_from_model_card(
         Isc=p.get("ISC", 0.0),
         Nc=p.get("NC", 2.0),
         Xtb=p.get("XTB", 0.0),
+        beta_r=p.get("BR", 1.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 106
+    assert len(coverage) == 108
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 106
+    assert len(records) == 108
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,17 +501,17 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 106
-    assert report.expected_canonical_parameter_count == 106
-    assert report.accepted_name_count == 168
-    assert report.aliased_parameter_count == 49
+    assert report.canonical_parameter_count == 108
+    assert report.expected_canonical_parameter_count == 108
+    assert report.accepted_name_count == 172
+    assert report.aliased_parameter_count == 51
     assert report.max_alias_count == 4
     assert report.issues == ()
     assert format_model_card_supported_parameter_coverage_gate_report(report) == (
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t106\t106\t168\t49\t4\t0"
+        "true\t7\t7\t108\t108\t172\t51\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,9 +539,9 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 105
-    assert report.accepted_name_count == 165
-    assert report.aliased_parameter_count == 48
+    assert report.canonical_parameter_count == 107
+    assert report.accepted_name_count == 169
+    assert report.aliased_parameter_count == 50
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t105\t106\t165\t48\t4\t4\n"
+        "false\t7\t7\t107\t108\t169\t50\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,12 +647,13 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
+        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
+    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
+    assert bjt_model.beta_r == pytest.approx(0.25)
     assert bjt_model.Cje == pytest.approx(2.0e-12)
     assert bjt_model.Xti == pytest.approx(2.4)
     assert bjt_model.Xtb == pytest.approx(1.5)
@@ -2301,7 +2302,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2325,6 +2326,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.Isc == pytest.approx(4.0e-13)
     assert expanded.Nc == pytest.approx(1.8)
     assert expanded.Xtb == pytest.approx(1.5)
+    assert expanded.beta_r == pytest.approx(0.25)
 
 
 def test_branch_current_in_voltage_source():
@@ -2544,16 +2546,17 @@ def test_bjt_temperature_scaling_uses_model_temperature_exponent():
     assert high.Is > low.Is
 
 
-def test_bjt_temperature_scaling_uses_forward_beta_temperature_exponent():
-    transistor = BJT("Q1", "c", "b", "e", beta_f=100.0, Xtb=2.0)
+def test_bjt_temperature_scaling_uses_beta_temperature_exponent():
+    transistor = BJT("Q1", "c", "b", "e", beta_f=100.0, beta_r=2.0, Xtb=2.0)
     hot = bjt_at_temperature(transistor, 350.0)
     assert hot.beta_f > transistor.beta_f
+    assert hot.beta_r > transistor.beta_r
 
 
-def test_dc_rejects_invalid_bjt_forward_beta_temperature_exponent():
+def test_dc_rejects_invalid_bjt_beta_temperature_exponent():
     circuit = Circuit()
     circuit.add(BJT("Qbad", "c", "b", "0", Xtb=math.nan))
-    with pytest.raises(ValueError, match="forward-beta temperature exponent must be finite"):
+    with pytest.raises(ValueError, match="beta temperature exponent must be finite"):
         dc_op(circuit)
 
 
@@ -2638,6 +2641,24 @@ def test_bjt_forward_beta_rolloff_reduces_high_current_transport():
         return dc_op(circuit).node_voltages["out"]
 
     assert collector_voltage(1.0e-4) > collector_voltage(0.0)
+
+
+def test_bjt_reverse_beta_controls_base_collector_junction_current():
+    def base_current(beta_r: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vbase", "base", "0", 0.65))
+        circuit.add(VoltageSource("Vemitter", "emitter", "0", 0.65))
+        circuit.add(BJT("Q1", "0", "base", "emitter", beta_r=beta_r))
+        return abs(dc_op(circuit).branch_currents["I(Vbase)"])
+
+    assert base_current(0.5) > base_current(5.0)
+
+
+def test_dc_rejects_invalid_bjt_reverse_beta():
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", beta_r=0.0))
+    with pytest.raises(ValueError, match="BJT reverse beta must be positive"):
+        dc_op(circuit)
 
 
 def test_dc_rejects_invalid_bjt_forward_beta_rolloff_current():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add BJT model-card `BR`/`BETA_R` reverse-current-gain support in DC,
+  transient, AC, transfer-function, temperature, and noise paths, matching
+  Python and TypeScript. `XTB` now scales both forward and reverse beta. The
+  supported-parameter catalog now contains 108 canonical rows.
 - Add BJT model-card `XTB` forward-beta temperature-exponent support, scaling
   forward beta by the analysis-to-nominal absolute temperature ratio, matching
   Python and TypeScript. The supported-parameter catalog now contains 106

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -146,8 +146,12 @@ small-signal input conductance, and shot noise.
 `ISC` (default `0`, disabled) and `NC` (default `2`) add the mirrored Berkeley
 base-collector leakage branch to DC/transient current, small-signal
 base-collector conductance, and shot noise.
-`XTB` (default `0`) scales forward beta with the analysis-to-nominal absolute
-temperature ratio, preserving the nominal beta when omitted.
+`BR`/`BETA_R` (default `1` on model cards) controls reverse current gain and
+adds the base-collector reverse base-current branch. Direct `Bjt` constructors
+default to infinite reverse beta to preserve their legacy behavior.
+`XTB` (default `0`) scales both forward and reverse beta with the
+analysis-to-nominal absolute temperature ratio, preserving nominal beta when
+omitted.
 `model_card_unsupported_parameter_issues`,
 `format_model_card_unsupported_parameter_issue_table`,
 `model_card_unsupported_parameter_issue_records`,
@@ -173,7 +177,7 @@ catalog by model kind for compact release dashboards and Mosaic UI inventories.
 `model_card_supported_parameter_coverage_gate_issue_records`,
 `format_model_card_supported_parameter_coverage_gate_issue_csv`, and
 `format_model_card_supported_parameter_coverage_gate_issue_json` validate the
-expected seven-kind, 106-row supported-parameter catalog and expose stable issue
+expected seven-kind, 108-row supported-parameter catalog and expose stable issue
 rows for release automation.
 `model_card_supported_parameter_coverage_dashboard`,
 `format_model_card_supported_parameter_coverage_dashboard_table`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -419,7 +419,7 @@ fn clone_subckt_element(
             element.gate_drain_capacitance,
         )),
         Element::Bjt(element) => Element::Bjt(
-            Bjt::with_model_temperature_depletion_early_rolloff_and_junction_leakage_parameters(
+            Bjt::with_model_temperature_depletion_early_rolloff_junction_leakage_and_reverse_beta_parameters(
                 format!("{instance_name}.{}", element.name),
                 map_subckt_node(&element.collector, instance_name, node_map),
                 map_subckt_node(&element.base, instance_name, node_map),
@@ -449,6 +449,7 @@ fn clone_subckt_element(
                 element.base_collector_leakage_saturation_current,
                 element.base_collector_leakage_emission_coefficient,
                 element.forward_beta_temperature_exponent,
+                element.reverse_beta,
             ),
         ),
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
@@ -2676,7 +2677,13 @@ pub fn bjt_at_temperature(
     if !bjt.forward_beta_temperature_exponent.is_finite() {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
-            reason: "forward-beta temperature exponent must be finite".to_string(),
+            reason: "beta temperature exponent must be finite".to_string(),
+        });
+    }
+    if bjt.reverse_beta.is_nan() || bjt.reverse_beta <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "reverse beta must be positive".to_string(),
         });
     }
     let saturation_scale = ratio.powf(bjt.saturation_current_temperature_exponent)
@@ -2686,6 +2693,7 @@ pub fn bjt_at_temperature(
     adjusted.base_emitter_leakage_saturation_current *= saturation_scale;
     adjusted.base_collector_leakage_saturation_current *= saturation_scale;
     adjusted.forward_beta *= ratio.powf(bjt.forward_beta_temperature_exponent);
+    adjusted.reverse_beta *= ratio.powf(bjt.forward_beta_temperature_exponent);
     adjusted.thermal_voltage *= ratio;
     Ok(adjusted)
 }
@@ -2878,6 +2886,7 @@ pub struct Bjt {
     pub base_collector_leakage_saturation_current: f64,
     pub base_collector_leakage_emission_coefficient: f64,
     pub forward_beta_temperature_exponent: f64,
+    pub reverse_beta: f64,
 }
 
 impl Bjt {
@@ -3241,6 +3250,73 @@ impl Bjt {
         base_collector_leakage_emission_coefficient: f64,
         forward_beta_temperature_exponent: f64,
     ) -> Self {
+        Self::with_model_temperature_depletion_early_rolloff_junction_leakage_and_reverse_beta_parameters(
+            name,
+            collector,
+            base,
+            emitter,
+            polarity,
+            saturation_current,
+            forward_beta,
+            thermal_voltage,
+            base_emitter_capacitance,
+            base_collector_capacitance,
+            forward_transit_time,
+            reverse_transit_time,
+            saturation_current_temperature_exponent,
+            energy_gap_electron_volts,
+            forward_early_voltage,
+            forward_emission_coefficient,
+            reverse_emission_coefficient,
+            base_emitter_junction_potential,
+            base_emitter_grading_coefficient,
+            base_collector_junction_potential,
+            base_collector_grading_coefficient,
+            forward_bias_depletion_coefficient,
+            reverse_early_voltage,
+            forward_beta_rolloff_current,
+            base_emitter_leakage_saturation_current,
+            base_emitter_leakage_emission_coefficient,
+            base_collector_leakage_saturation_current,
+            base_collector_leakage_emission_coefficient,
+            forward_beta_temperature_exponent,
+            f64::INFINITY,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_model_temperature_depletion_early_rolloff_junction_leakage_and_reverse_beta_parameters(
+        name: impl Into<String>,
+        collector: impl Into<String>,
+        base: impl Into<String>,
+        emitter: impl Into<String>,
+        polarity: BjtPolarity,
+        saturation_current: f64,
+        forward_beta: f64,
+        thermal_voltage: f64,
+        base_emitter_capacitance: f64,
+        base_collector_capacitance: f64,
+        forward_transit_time: f64,
+        reverse_transit_time: f64,
+        saturation_current_temperature_exponent: f64,
+        energy_gap_electron_volts: f64,
+        forward_early_voltage: f64,
+        forward_emission_coefficient: f64,
+        reverse_emission_coefficient: f64,
+        base_emitter_junction_potential: f64,
+        base_emitter_grading_coefficient: f64,
+        base_collector_junction_potential: f64,
+        base_collector_grading_coefficient: f64,
+        forward_bias_depletion_coefficient: f64,
+        reverse_early_voltage: f64,
+        forward_beta_rolloff_current: f64,
+        base_emitter_leakage_saturation_current: f64,
+        base_emitter_leakage_emission_coefficient: f64,
+        base_collector_leakage_saturation_current: f64,
+        base_collector_leakage_emission_coefficient: f64,
+        forward_beta_temperature_exponent: f64,
+        reverse_beta: f64,
+    ) -> Self {
         Self {
             name: name.into(),
             collector: collector.into(),
@@ -3271,6 +3347,7 @@ impl Bjt {
             base_collector_leakage_saturation_current,
             base_collector_leakage_emission_coefficient,
             forward_beta_temperature_exponent,
+            reverse_beta,
         }
     }
 }
@@ -3661,8 +3738,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 24, 39, 11, 4),
-    (ModelCardKind::Pnp, 24, 39, 11, 4),
+    (ModelCardKind::Npn, 25, 41, 12, 4),
+    (ModelCardKind::Pnp, 25, 41, 12, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3717,6 +3794,8 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("ISC", "ISC"),
     ("NC", "NC"),
     ("XTB", "XTB"),
+    ("BR", "BR"),
+    ("BETA_R", "BR"),
     ("NF", "NF"),
     ("NR", "NR"),
     ("VJE", "VJE"),
@@ -4368,7 +4447,7 @@ pub fn bjt_from_model_card(
         _ => return Err(model_card_kind_error(&name, "BJT", model.kind)),
     };
     Ok(
-        Bjt::with_model_temperature_depletion_early_rolloff_and_junction_leakage_parameters(
+        Bjt::with_model_temperature_depletion_early_rolloff_junction_leakage_and_reverse_beta_parameters(
             name,
             collector,
             base,
@@ -4398,6 +4477,7 @@ pub fn bjt_from_model_card(
             model_card_value(model, "ISC", 0.0),
             model_card_value(model, "NC", 2.0),
             model_card_value(model, "XTB", 0.0),
+            model_card_value(model, "BR", 1.0),
         ),
     )
 }
@@ -22067,6 +22147,8 @@ fn collect_noise_sources(
                 let (leakage_current, _) = bjt_base_emitter_leakage(bjt, junction_voltage);
                 let (collector_leakage_current, _) =
                     bjt_base_collector_leakage(bjt, reverse_junction_voltage);
+                let (reverse_base_current, _) =
+                    bjt_reverse_base_current(bjt, reverse_junction_voltage);
                 let (positive, negative) = match bjt.polarity {
                     BjtPolarity::Npn => (base, emitter),
                     BjtPolarity::Pnp => (emitter, base),
@@ -22080,7 +22162,8 @@ fn collect_noise_sources(
                         * ELECTRON_CHARGE
                         * (collector_current.abs()
                             + leakage_current.abs()
-                            + collector_leakage_current.abs()),
+                            + collector_leakage_current.abs()
+                            + reverse_base_current.abs()),
                 });
             }
             Element::Jfet(jfet) => {
@@ -22585,6 +22668,19 @@ fn bjt_base_collector_leakage(bjt: &Bjt, junction_voltage: f64) -> (f64, f64) {
     )
 }
 
+fn bjt_reverse_base_current(bjt: &Bjt, junction_voltage: f64) -> (f64, f64) {
+    if bjt.reverse_beta.is_infinite() {
+        return (0.0, 0.0);
+    }
+    let thermal_voltage = bjt.thermal_voltage * bjt.reverse_emission_coefficient;
+    let exponent = (junction_voltage / thermal_voltage).clamp(-40.0, 40.0);
+    let exp_value = exponent.exp();
+    (
+        bjt.saturation_current * (exp_value - 1.0) / bjt.reverse_beta,
+        bjt.saturation_current / thermal_voltage * exp_value / bjt.reverse_beta,
+    )
+}
+
 fn stamp_bjt(
     bjt: &Bjt,
     capacitor_states: &[CapacitorState],
@@ -22633,11 +22729,15 @@ fn stamp_bjt(
     let equivalent_base_current = base_current - gpi * junction_voltage;
     let (collector_leakage_current, collector_leakage_conductance) =
         bjt_base_collector_leakage(bjt, reverse_junction_voltage);
+    let (reverse_base_current, reverse_base_conductance) =
+        bjt_reverse_base_current(bjt, reverse_junction_voltage);
+    let base_collector_current = collector_leakage_current + reverse_base_current;
+    let base_collector_conductance = collector_leakage_conductance + reverse_base_conductance;
     let equivalent_collector_leakage_current =
-        collector_leakage_current - collector_leakage_conductance * reverse_junction_voltage;
+        base_collector_current - base_collector_conductance * reverse_junction_voltage;
 
     stamp_conductance(matrix, collector, emitter, output_conductance);
-    stamp_conductance(matrix, base, collector, collector_leakage_conductance);
+    stamp_conductance(matrix, base, collector, base_collector_conductance);
 
     match bjt.polarity {
         BjtPolarity::Npn => {
@@ -22769,8 +22869,14 @@ fn stamp_bjt_small_signal(
     let gpi = base_gm / bjt.forward_beta + leakage_conductance;
     let (_, collector_leakage_conductance) =
         bjt_base_collector_leakage(bjt, reverse_junction_voltage);
+    let (_, reverse_base_conductance) = bjt_reverse_base_current(bjt, reverse_junction_voltage);
     stamp_conductance(matrix, collector, emitter, output_conductance);
-    stamp_conductance(matrix, base, collector, collector_leakage_conductance);
+    stamp_conductance(
+        matrix,
+        base,
+        collector,
+        collector_leakage_conductance + reverse_base_conductance,
+    );
     match bjt.polarity {
         BjtPolarity::Npn => {
             stamp_conductance(matrix, base, emitter, gpi);
@@ -22832,6 +22938,7 @@ fn stamp_ac_bjt_small_signal(
     let (_, leakage_conductance) = bjt_base_emitter_leakage(bjt, junction_voltage);
     let (_, collector_leakage_conductance) =
         bjt_base_collector_leakage(bjt, reverse_junction_voltage);
+    let (_, reverse_base_conductance) = bjt_reverse_base_current(bjt, reverse_junction_voltage);
     let gpi = Complex::new(
         base_gm / bjt.forward_beta + leakage_conductance,
         omega
@@ -22839,7 +22946,7 @@ fn stamp_ac_bjt_small_signal(
                 + diffusion_capacitance),
     );
     let ybc = Complex::new(
-        collector_leakage_conductance,
+        collector_leakage_conductance + reverse_base_conductance,
         omega
             * (bjt_base_collector_depletion_capacitance(bjt, reverse_junction_voltage)
                 + reverse_diffusion_capacitance),
@@ -23785,6 +23892,12 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
             reason: "forward beta must be finite and positive".to_string(),
         });
     }
+    if bjt.reverse_beta.is_nan() || bjt.reverse_beta <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "reverse beta must be positive".to_string(),
+        });
+    }
     if !bjt.thermal_voltage.is_finite() || bjt.thermal_voltage <= 0.0 {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
@@ -23824,7 +23937,7 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
     if !bjt.forward_beta_temperature_exponent.is_finite() {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
-            reason: "forward-beta temperature exponent must be finite".to_string(),
+            reason: "beta temperature exponent must be finite".to_string(),
         });
     }
     if !bjt.energy_gap_electron_volts.is_finite() || bjt.energy_gap_electron_volts <= 0.0 {

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 106);
+    assert_eq!(coverage.len(), 108);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 106);
+    assert_eq!(records.len(), 108);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 106);
-    assert_eq!(report.expected_canonical_parameter_count, 106);
-    assert_eq!(report.accepted_name_count, 168);
-    assert_eq!(report.aliased_parameter_count, 49);
+    assert_eq!(report.canonical_parameter_count, 108);
+    assert_eq!(report.expected_canonical_parameter_count, 108);
+    assert_eq!(report.accepted_name_count, 172);
+    assert_eq!(report.aliased_parameter_count, 51);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t106\t106\t168\t49\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t108\t108\t172\t51\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,9 +235,9 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 105);
-    assert_eq!(report.accepted_name_count, 165);
-    assert_eq!(report.aliased_parameter_count, 48);
+    assert_eq!(report.canonical_parameter_count, 107);
+    assert_eq!(report.accepted_name_count, 169);
+    assert_eq!(report.aliased_parameter_count, 50);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
     assert_eq!(report.issues[0].kind, "NMOS");
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t105\t106\t165\t48\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t107\t108\t169\t50\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -430,6 +430,7 @@ fn model_card_aliases_build_device_instances() {
             ("CBE", 2.0e-12),
             ("XTI", 2.4),
             ("XTB", 1.5),
+            ("BETA_R", 0.25),
             ("EG", 1.05),
             ("VA", 80.0),
             ("VB", 120.0),
@@ -453,6 +454,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("CJE").unwrap(), 2.0e-12);
     assert_close(*bjt_card.parameters.get("XTI").unwrap(), 2.4);
     assert_close(*bjt_card.parameters.get("XTB").unwrap(), 1.5);
+    assert_close(*bjt_card.parameters.get("BR").unwrap(), 0.25);
     assert_close(*bjt_card.parameters.get("EG").unwrap(), 1.05);
     assert_close(*bjt_card.parameters.get("VAF").unwrap(), 80.0);
     assert_close(*bjt_card.parameters.get("VAR").unwrap(), 120.0);
@@ -473,6 +475,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(bjt_model.base_emitter_capacitance, 2.0e-12);
     assert_close(bjt_model.saturation_current_temperature_exponent, 2.4);
     assert_close(bjt_model.forward_beta_temperature_exponent, 1.5);
+    assert_close(bjt_model.reverse_beta, 0.25);
     assert_close(bjt_model.energy_gap_electron_volts, 1.05);
     assert_close(bjt_model.forward_early_voltage, 80.0);
     assert_close(bjt_model.reverse_early_voltage, 120.0);
@@ -1384,7 +1387,7 @@ fn subcircuit_expansion_preserves_complete_diode_model() {
 
 #[test]
 fn subcircuit_expansion_preserves_complete_bjt_model() {
-    let bjt = Bjt::with_model_temperature_depletion_early_rolloff_and_junction_leakage_parameters(
+    let bjt = Bjt::with_model_temperature_depletion_early_rolloff_junction_leakage_and_reverse_beta_parameters(
         "Qcell",
         "c",
         "b",
@@ -1414,6 +1417,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
         4.0e-13,
         1.8,
         1.5,
+        0.25,
     );
     let mut circuit = Circuit::new();
     circuit
@@ -1456,6 +1460,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.base_collector_leakage_saturation_current, 4.0e-13);
     assert_close(expanded.base_collector_leakage_emission_coefficient, 1.8);
     assert_close(expanded.forward_beta_temperature_exponent, 1.5);
+    assert_close(expanded.reverse_beta, 0.25);
 }
 
 #[test]
@@ -1944,15 +1949,17 @@ fn bjt_temperature_scaling_uses_model_temperature_exponent() {
 }
 
 #[test]
-fn bjt_temperature_scaling_uses_forward_beta_temperature_exponent() {
+fn bjt_temperature_scaling_uses_beta_temperature_exponent() {
     let mut transistor = Bjt::new("Q1", "c", "b", "e");
+    transistor.reverse_beta = 2.0;
     transistor.forward_beta_temperature_exponent = 2.0;
     let hot = bjt_at_temperature(&transistor, 350.0, 300.15, 1.11).unwrap();
     assert!(hot.forward_beta > transistor.forward_beta);
+    assert!(hot.reverse_beta > transistor.reverse_beta);
 }
 
 #[test]
-fn dc_rejects_invalid_bjt_forward_beta_temperature_exponent() {
+fn dc_rejects_invalid_bjt_beta_temperature_exponent() {
     let mut transistor = Bjt::new("Qbad", "c", "b", "0");
     transistor.forward_beta_temperature_exponent = f64::NAN;
     let mut circuit = Circuit::new();
@@ -1960,7 +1967,7 @@ fn dc_rejects_invalid_bjt_forward_beta_temperature_exponent() {
     let error = dc_op(&circuit).unwrap_err();
     assert!(error
         .to_string()
-        .contains("forward-beta temperature exponent must be finite"));
+        .contains("beta temperature exponent must be finite"));
 }
 
 #[test]
@@ -2172,6 +2179,39 @@ fn bjt_forward_beta_rolloff_reduces_high_current_transport() {
     };
 
     assert!(collector_voltage(1.0e-4) > collector_voltage(0.0));
+}
+
+#[test]
+fn bjt_reverse_beta_controls_base_collector_junction_current() {
+    let base_current = |reverse_beta: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vbase", "base", "0", 0.65,
+        )));
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vemitter", "emitter", "0", 0.65,
+        )));
+        let mut transistor = Bjt::new("Q1", "0", "base", "emitter");
+        transistor.reverse_beta = reverse_beta;
+        circuit.add(Element::Bjt(transistor));
+        dc_op(&circuit)
+            .unwrap()
+            .branch_current("Vbase")
+            .unwrap()
+            .abs()
+    };
+
+    assert!(base_current(0.5) > base_current(5.0));
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_reverse_beta() {
+    let mut circuit = Circuit::new();
+    let mut transistor = Bjt::new("Qbad", "c", "b", "0");
+    transistor.reverse_beta = 0.0;
+    circuit.add(Element::Bjt(transistor));
+    let error = dc_op(&circuit).unwrap_err();
+    assert!(error.to_string().contains("reverse beta must be positive"));
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add BJT model-card `BR`/`BETA_R` reverse-current-gain support in DC,
+  transient, AC, transfer-function, temperature, and noise paths, matching
+  Rust and Python. `XTB` now scales both forward and reverse beta. The
+  supported-parameter catalog now contains 108 canonical rows.
 - Add BJT model-card `XTB` forward-beta temperature-exponent support, scaling
   forward beta by the analysis-to-nominal absolute temperature ratio, matching
   Rust and Python. The supported-parameter catalog now contains 106 canonical

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -216,8 +216,12 @@ small-signal input conductance, and shot noise.
 `ISC` (default `0`, disabled) and `NC` (default `2`) add the mirrored Berkeley
 base-collector leakage branch to DC/transient current, small-signal
 base-collector conductance, and shot noise.
-`XTB` (default `0`) scales forward beta with the analysis-to-nominal absolute
-temperature ratio, preserving the nominal beta when omitted.
+`BR`/`BETA_R` (default `1` on model cards) controls reverse current gain and
+adds the base-collector reverse base-current branch. Direct `bjt` constructors
+default to infinite reverse beta to preserve their legacy behavior.
+`XTB` (default `0`) scales both forward and reverse beta with the
+analysis-to-nominal absolute temperature ratio, preserving nominal beta when
+omitted.
 `modelCardUnsupportedParameterIssues`,
 `formatModelCardUnsupportedParameterIssueTable`,
 `modelCardUnsupportedParameterIssueRecords`,
@@ -243,7 +247,7 @@ model kind for compact release dashboards and Mosaic UI inventories.
 `modelCardSupportedParameterCoverageGateIssueRecords`,
 `formatModelCardSupportedParameterCoverageGateIssueCsv`, and
 `formatModelCardSupportedParameterCoverageGateIssueJson` validate the expected
-seven-kind, 106-row supported-parameter catalog and expose stable issue rows for
+seven-kind, 108-row supported-parameter catalog and expose stable issue rows for
 release automation.
 `modelCardSupportedParameterCoverageDashboard`,
 `formatModelCardSupportedParameterCoverageDashboardTable`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1727,6 +1727,7 @@ export interface Bjt {
   readonly baseCollectorLeakageSaturationCurrent: number;
   readonly baseCollectorLeakageEmissionCoefficient: number;
   readonly forwardBetaTemperatureExponent: number;
+  readonly reverseBeta: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -2004,8 +2005,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [24, 39, 11, 4],
-  PNP: [24, 39, 11, 4],
+  NPN: [25, 41, 12, 4],
+  PNP: [25, 41, 12, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3595,7 +3596,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7637,7 +7638,10 @@ export function bjtAtTemperature(
     throw invalidElement(element.name, "saturation-current temperature exponent must be finite");
   }
   if (!Number.isFinite(element.forwardBetaTemperatureExponent)) {
-    throw invalidElement(element.name, "forward-beta temperature exponent must be finite");
+    throw invalidElement(element.name, "beta temperature exponent must be finite");
+  }
+  if (Number.isNaN(element.reverseBeta) || element.reverseBeta <= 0.0) {
+    throw invalidElement(element.name, "reverse beta must be positive");
   }
   const saturationScale =
     ratio ** element.saturationCurrentTemperatureExponent *
@@ -7650,6 +7654,7 @@ export function bjtAtTemperature(
     baseCollectorLeakageSaturationCurrent:
       element.baseCollectorLeakageSaturationCurrent * saturationScale,
     forwardBeta: element.forwardBeta * ratio ** element.forwardBetaTemperatureExponent,
+    reverseBeta: element.reverseBeta * ratio ** element.forwardBetaTemperatureExponent,
     thermalVoltage: element.thermalVoltage * ratio,
   };
 }
@@ -7773,6 +7778,7 @@ export function bjt(
   baseCollectorLeakageSaturationCurrent = 0.0,
   baseCollectorLeakageEmissionCoefficient = 2.0,
   forwardBetaTemperatureExponent = 0.0,
+  reverseBeta = Number.POSITIVE_INFINITY,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7805,6 +7811,7 @@ export function bjt(
     baseCollectorLeakageSaturationCurrent,
     baseCollectorLeakageEmissionCoefficient,
     forwardBetaTemperatureExponent,
+    reverseBeta,
   };
 }
 
@@ -7919,6 +7926,8 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   ISC: "ISC",
   NC: "NC",
   XTB: "XTB",
+  BR: "BR",
+  BETA_R: "BR",
   NF: "NF",
   NR: "NR",
   VJE: "VJE",
@@ -8443,6 +8452,7 @@ export function bjtFromModelCard(
     p.ISC ?? 0.0,
     p.NC ?? 2.0,
     p.XTB ?? 0.0,
+    p.BR ?? 1.0,
   );
 }
 
@@ -18393,6 +18403,8 @@ function collectNoiseSources(
       const leakageCurrent = bjtBaseEmitterLeakage(element, junctionVoltage).current;
       const collectorLeakageCurrent =
         bjtBaseCollectorLeakage(element, reverseJunctionVoltage).current;
+      const reverseBaseCurrent =
+        bjtReverseBaseCurrent(element, reverseJunctionVoltage).current;
       sources.push({
         elementName: element.name,
         noiseType: "shot",
@@ -18401,7 +18413,7 @@ function collectNoiseSources(
         sourcePsd:
           2.0 * ELECTRON_CHARGE *
           (Math.abs(collectorCurrent) + Math.abs(leakageCurrent) +
-            Math.abs(collectorLeakageCurrent)),
+            Math.abs(collectorLeakageCurrent) + Math.abs(reverseBaseCurrent)),
       });
     } else if (element.kind === "jfet") {
       validateJfet(element);
@@ -18941,6 +18953,23 @@ function bjtBaseCollectorLeakage(
   };
 }
 
+function bjtReverseBaseCurrent(
+  element: Bjt,
+  junctionVoltage: number,
+): { current: number; conductance: number } {
+  if (element.reverseBeta === Number.POSITIVE_INFINITY) {
+    return { current: 0.0, conductance: 0.0 };
+  }
+  const thermalVoltage = element.thermalVoltage * element.reverseEmissionCoefficient;
+  const exponent = Math.max(-40.0, Math.min(40.0, junctionVoltage / thermalVoltage));
+  const expValue = Math.exp(exponent);
+  return {
+    current: element.saturationCurrent * (expValue - 1.0) / element.reverseBeta,
+    conductance:
+      element.saturationCurrent / thermalVoltage * expValue / element.reverseBeta,
+  };
+}
+
 function stampBjt(
   element: Bjt,
   capacitorStates: readonly CapacitorState[],
@@ -18993,11 +19022,14 @@ function stampBjt(
   const equivalentBaseCurrent =
     baseCurrent - junctionConductance * junctionVoltage;
   const collectorLeakage = bjtBaseCollectorLeakage(element, reverseJunctionVoltage);
+  const reverseBase = bjtReverseBaseCurrent(element, reverseJunctionVoltage);
+  const baseCollectorJunctionCurrent = collectorLeakage.current + reverseBase.current;
+  const baseCollectorConductance = collectorLeakage.conductance + reverseBase.conductance;
   const equivalentCollectorLeakageCurrent =
-    collectorLeakage.current - collectorLeakage.conductance * reverseJunctionVoltage;
+    baseCollectorJunctionCurrent - baseCollectorConductance * reverseJunctionVoltage;
 
   stampConductance(matrix, collector, emitter, outputConductance);
-  stampConductance(matrix, base, collector, collectorLeakage.conductance);
+  stampConductance(matrix, base, collector, baseCollectorConductance);
   if (element.polarity === "NPN") {
     stampConductance(matrix, base, emitter, junctionConductance);
     stampTransconductance(matrix, collector, emitter, base, emitter, transconductance);
@@ -19803,6 +19835,9 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.forwardBeta) || element.forwardBeta <= 0.0) {
     throw invalidElement(element.name, "forward beta must be finite and positive");
+  }
+  if (Number.isNaN(element.reverseBeta) || element.reverseBeta <= 0.0) {
+    throw invalidElement(element.name, "reverse beta must be positive");
   }
   if (!Number.isFinite(element.thermalVoltage) || element.thermalVoltage <= 0.0) {
     throw invalidElement(element.name, "thermal voltage must be finite and positive");
@@ -21211,8 +21246,14 @@ function stampBjtSmallSignal(
   const junctionConductance =
     baseTransconductance / element.forwardBeta + leakage.conductance;
   const collectorLeakage = bjtBaseCollectorLeakage(element, reverseJunctionVoltage);
+  const reverseBase = bjtReverseBaseCurrent(element, reverseJunctionVoltage);
   stampConductance(matrix, collector, emitter, outputConductance);
-  stampConductance(matrix, base, collector, collectorLeakage.conductance);
+  stampConductance(
+    matrix,
+    base,
+    collector,
+    collectorLeakage.conductance + reverseBase.conductance,
+  );
   if (element.polarity === "NPN") {
     stampConductance(matrix, base, emitter, junctionConductance);
     stampTransconductance(matrix, collector, emitter, base, emitter, transconductance);
@@ -21804,6 +21845,7 @@ function stampAcBjtSmallSignal(
   const transconductance = transport.transconductance;
   const leakage = bjtBaseEmitterLeakage(element, junctionVoltage);
   const collectorLeakage = bjtBaseCollectorLeakage(element, reverseJunctionVoltage);
+  const reverseBase = bjtReverseBaseCurrent(element, reverseJunctionVoltage);
   const junctionConductance =
     baseTransconductance / element.forwardBeta + leakage.conductance;
   const diffusionCapacitance = element.forwardTransitTime * transconductance;
@@ -21817,7 +21859,7 @@ function stampAcBjtSmallSignal(
     ),
   );
   const baseCollectorAdmittance = complex(
-    collectorLeakage.conductance,
+    collectorLeakage.conductance + reverseBase.conductance,
     omega * (
       bjtBaseCollectorDepletionCapacitance(element, reverseJunctionVoltage) +
       reverseDiffusionCapacitance

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(106);
+    expect(coverage).toHaveLength(108);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(106);
+    expect(records).toHaveLength(108);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 106,
-      expectedCanonicalParameterCount: 106,
-      acceptedNameCount: 168,
-      aliasedParameterCount: 49,
+      canonicalParameterCount: 108,
+      expectedCanonicalParameterCount: 108,
+      acceptedNameCount: 172,
+      aliasedParameterCount: 51,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t106\t106\t168\t49\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t108\t108\t172\t51\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,9 +241,9 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(105);
-    expect(report.acceptedNameCount).toBe(165);
-    expect(report.aliasedParameterCount).toBe(48);
+    expect(report.canonicalParameterCount).toBe(107);
+    expect(report.acceptedNameCount).toBe(169);
+    expect(report.aliasedParameterCount).toBe(50);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t105\t106\t165\t48\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t107\t108\t169\t50\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -336,6 +336,7 @@ describe("dcOp", () => {
       CBE: 2.0e-12,
       XTI: 2.4,
       XTB: 1.5,
+      BETA_R: 0.25,
       EG: 1.05,
       VA: 80.0,
       VB: 120.0,
@@ -353,9 +354,10 @@ describe("dcOp", () => {
       FC: 0.4,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
+    expectClose(bjtModel.reverseBeta, 0.25);
     expectClose(bjtModel.baseEmitterCapacitance, 2.0e-12);
     expectClose(bjtModel.saturationCurrentTemperatureExponent, 2.4);
     expectClose(bjtModel.forwardBetaTemperatureExponent, 1.5);
@@ -1006,7 +1008,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -1031,6 +1033,7 @@ describe("dcOp", () => {
       expectClose(expanded.baseCollectorLeakageSaturationCurrent, 4.0e-13);
       expectClose(expanded.baseCollectorLeakageEmissionCoefficient, 1.8);
       expectClose(expanded.forwardBetaTemperatureExponent, 1.5);
+      expectClose(expanded.reverseBeta, 0.25);
     }
   });
 
@@ -1353,23 +1356,25 @@ describe("dcOp", () => {
     expect(high.saturationCurrent).toBeGreaterThan(low.saturationCurrent);
   });
 
-  it("uses the BJT forward-beta temperature exponent", () => {
+  it("uses the BJT beta temperature exponent", () => {
     const transistor = {
       ...bjt("Q1", "c", "b", "e"),
+      reverseBeta: 2.0,
       forwardBetaTemperatureExponent: 2.0,
     };
     const hot = bjtAtTemperature(transistor, 350);
     expect(hot.forwardBeta).toBeGreaterThan(transistor.forwardBeta);
+    expect(hot.reverseBeta).toBeGreaterThan(transistor.reverseBeta);
   });
 
-  it("rejects non-finite BJT forward-beta temperature exponents", () => {
+  it("rejects non-finite BJT beta temperature exponents", () => {
     const circuit = new Circuit();
     circuit.add({
       ...bjt("Qbad", "c", "b", "0"),
       forwardBetaTemperatureExponent: Number.NaN,
     });
     expect(() => dcOp(circuit)).toThrowError(
-      "forward-beta temperature exponent must be finite",
+      "beta temperature exponent must be finite",
     );
   });
 
@@ -1465,6 +1470,26 @@ describe("dcOp", () => {
     };
 
     expect(collectorVoltage(1.0e-4)).toBeGreaterThan(collectorVoltage(0.0));
+  });
+
+  it("uses BJT reverse beta to control base-collector junction current", () => {
+    const baseCurrent = (reverseBeta: number): number => {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vbase", "base", "0", 0.65));
+      circuit.add(voltageSource("Vemitter", "emitter", "0", 0.65));
+      circuit.add({ ...bjt("Q1", "0", "base", "emitter"), reverseBeta });
+      return Math.abs(dcOp(circuit).branchCurrent("Vbase")!);
+    };
+
+    expect(baseCurrent(0.5)).toBeGreaterThan(baseCurrent(5.0));
+  });
+
+  it("rejects invalid BJT reverse beta", () => {
+    const circuit = new Circuit();
+    circuit.add({ ...bjt("Qbad", "c", "b", "0"), reverseBeta: 0.0 });
+    expect(() => dcOp(circuit)).toThrowError(
+      "reverse beta must be positive",
+    );
   });
 
   it("rejects an invalid BJT forward beta roll-off current", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,13 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT forward-beta temperature exponent.
+1. Cross-language BJT reverse current gain.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `XTB` model-card support in Rust, Python, and TypeScript
-     with behavior-preserving zero-exponent defaults.
-   - Scale forward beta by the analysis-to-nominal absolute temperature ratio
-     while preserving the complete BJT model through hierarchical subcircuits.
-   - Extend the supported-parameter coverage gate from 104 to 106 canonical
+   - Add Berkeley BJT `BR` / `BETA_R` model-card support in Rust, Python, and
+     TypeScript with a model-card default of `1` and behavior-preserving direct
+     element defaults.
+   - Apply reverse base current in DC, transient, AC, transfer-function,
+     temperature, and noise paths, and scale both forward and reverse beta by
+     `XTB` while preserving the complete BJT model through subcircuits.
+   - Extend the supported-parameter coverage gate from 106 to 108 canonical
      rows and lock model-card aliases, behavior, validation, and hierarchy in
      all engines.
 
@@ -3085,6 +3087,13 @@ the Rust, Python, and TypeScript surfaces together.
      transfer-function, temperature, and noise paths.
    - Hierarchical subcircuit expansion preserves the complete BJT model, and
      the supported-parameter release gate now covers 104 canonical rows.
+
+230. Cross-language BJT beta temperature exponent.
+   - Status: completed in PR 8792.
+   - Rust, Python, and TypeScript BJT model cards now accept `XTB` and scale
+     forward beta by the analysis-to-nominal absolute temperature ratio.
+   - Hierarchical subcircuit expansion preserves the complete BJT model, and
+     the supported-parameter release gate now covers 106 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley BJT `BR` / `BETA_R` model-card support across Rust, Python, and TypeScript
- stamp reverse base current through DC, transient, AC, transfer-function, temperature, and noise paths while preserving direct-constructor compatibility
- scale forward and reverse beta with `XTB`, preserve hierarchy, and advance the supported-parameter gate to 108 rows
- reconcile the SPICE completion plan after merged PR #8792

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo test -p spice-engine`
- Python: `pytest -q` (550 passed, 88.77% coverage)
- Python: `ruff check` on all touched source and test files
- TypeScript: `npm run build && npm test` (308 passed)
- `git diff --check`