### PR TITLE
feat(gc): precise roots load-bearing — GC-stress live_bytes differential (AOT00-T1 increment C)

### DIFF
--- a/code/packages/rust/aarch64-backend/CHANGELOG.md
+++ b/code/packages/rust/aarch64-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — `aarch64-backend`
 
+## 0.30.0 - 2026-07-21 — V1_BUILTINS: GC collection + observability (AOT00-T1 increment C)
+
+Four `call_builtin` entries the native GC-stress differential drives, resolving to the
+`__twig_gc_*` aliases in gc-core-capi: `gc_collect` (forced conservative full collect,
+void), `gc_collect_precise` (precise-roots frame walk, returns freed count),
+`gc_live_bytes` (live payload bytes), and `gc_stackmap_count` (registered-function
+count). No new lowering — the generic `call_builtin` marshaller emits the `BL`.
+
 ## 0.29.0 - 2026-07-20 — V1_BUILTINS: dyn_null_p (native `null?`)
 
 Part of the fix restoring McCarthy-lisp list programs on the native-AOT / LLVM backends (`lang-aot` `lang_matrix`). See the umbrella commit for the full story: `null?` was never routed to a runtime call on the tagged native/LLVM path (breaking every cons-walk helper), `list-ref`/`assoc` unboxed a raw-int index/key (→ wrong element), a top-level `(null? …)` predicate result was unboxed instead of truthy-coerced, and cons-cell field access failed the JVM verifier. Verified end-to-end: native list-ref/assoc/length/reverse/append/null? all correct.

--- a/code/packages/rust/aarch64-backend/Cargo.toml
+++ b/code/packages/rust/aarch64-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aarch64-backend"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 description = "ARM64 (AArch64) backend for jit-core / aot-core — lowers CIR to native machine code via aarch64-encoder."
 

--- a/code/packages/rust/aarch64-backend/src/lib.rs
+++ b/code/packages/rust/aarch64-backend/src/lib.rs
@@ -247,6 +247,17 @@ const V1_BUILTINS: &[BuiltinSig] = &[
     // adaptive threshold.  Used by IIR `safepoint` lowering.
     BuiltinSig { name: "gc_alloc",     n_args: 1, returns: true  },
     BuiltinSig { name: "gc_safepoint", n_args: 0, returns: false },
+    // AOT00-T1 increment C — the GC observability/collection entry points a native
+    // program uses to drive and measure a collection (→ `__twig_gc_*` aliases in
+    // gc-core-capi). `gc_collect` is a forced *conservative* full collect;
+    // `gc_collect_precise` is the precise-roots walk (returns objects freed);
+    // `gc_live_bytes` reports the live payload. Together they let the GC-stress
+    // differential show precise roots reclaiming a look-alike-pinned object that the
+    // conservative scan retains.
+    BuiltinSig { name: "gc_collect",         n_args: 0, returns: false },
+    BuiltinSig { name: "gc_collect_precise", n_args: 0, returns: true  },
+    BuiltinSig { name: "gc_live_bytes",      n_args: 0, returns: true  },
+    BuiltinSig { name: "gc_stackmap_count",  n_args: 0, returns: true  },
 ];
 
 fn lookup_builtin(name: &str) -> Option<BuiltinSig> {

--- a/code/packages/rust/gc-core-capi/CHANGELOG.md
+++ b/code/packages/rust/gc-core-capi/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this crate are documented here.
 
+## 0.13.0 - 2026-07-21 — twig-compat precise/observability aliases (AOT00-T1 increment C)
+
+Two `__twig_gc_*` aliases the native code generators emit for the GC-stress
+`live_bytes` differential that makes precise roots observable end to end:
+
+- **`__twig_gc_collect_precise()`** → `__gc_collect_precise` — a full collection
+  rooted **precisely** at the caller's stack via the frame-pointer walk (mapped
+  frames contribute exact reference slots, the rest conservative). Returns the freed
+  count. `#[inline(never)]`, same stack-ownership contract as `__gc_collect_precise`.
+- **`__twig_gc_stackmap_count()`** → `__gc_stackmap_count` — the number of registered
+  functions, a diagnostic that confirms an AOT image's `__gc_init_stackmaps` ran.
+
+Additive (`twig_compat` only); one new test. Enables the twig-aot `gc_collect_precise`
+/ `gc_stackmap_count` builtins.
+
 ## [0.12.0] — 2026-07-22
 
 ### Added

--- a/code/packages/rust/gc-core-capi/Cargo.toml
+++ b/code/packages/rust/gc-core-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core-capi"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "C ABI for gc-core's flat-native heap — the gc_runtime_<target> archive linked into native-AOT output (LANG16 / AOT00 T1)."
 license = "MIT"

--- a/code/packages/rust/gc-core-capi/src/twig_compat.rs
+++ b/code/packages/rust/gc-core-capi/src/twig_compat.rs
@@ -26,7 +26,7 @@
 //! Once the code generators are migrated to emit the `__gc_*` names directly,
 //! this shim can be deleted.
 
-use crate::stack_scan::{__gc_collect, __gc_safepoint};
+use crate::stack_scan::{__gc_collect, __gc_collect_precise, __gc_safepoint};
 use crate::{__gc_alloc, __gc_collection_count, __gc_live_bytes};
 
 /// `__twig_gc_alloc(n)` → [`__gc_alloc`]. Called by the emitted code and by
@@ -63,6 +63,24 @@ pub unsafe extern "C" fn __twig_gc_safepoint() {
     let _ = __gc_safepoint();
 }
 
+/// `__twig_gc_collect_precise()` → [`__gc_collect_precise`]. A full collection
+/// rooted **precisely** at the caller's stack via the frame-pointer walk (mapped
+/// frames contribute exact reference slots; the rest are conservative). Returns the
+/// freed-object count. This is the `__twig_gc_*` name the native code generators
+/// emit for a precise collect (`gc_collect_precise` builtin), the AOT00-T1
+/// increment-C entry point that makes precise roots observable end to end.
+///
+/// # Safety
+///
+/// Same contract as [`__gc_collect_precise`]: the calling thread must own its stack.
+/// `#[inline(never)]` keeps it a real frame below the mutator so the walk starts at
+/// the caller.
+#[no_mangle]
+#[inline(never)]
+pub unsafe extern "C" fn __twig_gc_collect_precise() -> i64 {
+    __gc_collect_precise()
+}
+
 /// `__twig_gc_live_bytes()` → [`__gc_live_bytes`].
 #[no_mangle]
 pub extern "C" fn __twig_gc_live_bytes() -> i64 {
@@ -73,6 +91,14 @@ pub extern "C" fn __twig_gc_live_bytes() -> i64 {
 #[no_mangle]
 pub extern "C" fn __twig_gc_collection_count() -> i64 {
     __gc_collection_count()
+}
+
+/// `__twig_gc_stackmap_count()` → [`crate::__gc_stackmap_count`]. Number of functions
+/// whose stack maps are currently registered — a diagnostic the native `gc_stackmap_count`
+/// builtin exposes so a program can confirm `__gc_init_stackmaps` ran.
+#[no_mangle]
+pub extern "C" fn __twig_gc_stackmap_count() -> i64 {
+    crate::__gc_stackmap_count()
 }
 
 #[cfg(test)]
@@ -105,6 +131,30 @@ mod tests {
         unsafe { __twig_gc_collect() };
         assert_eq!(__twig_gc_collection_count(), 1);
         assert_eq!(unsafe { *(p as *const i64) }, 0x7161);
+        core::hint::black_box(p);
+
+        __gc_reset();
+    }
+
+    /// The increment-C aliases forward to the precise/observability entry points:
+    /// `__twig_gc_collect_precise` runs a (stack-rooted) collection and returns a
+    /// count, and `__twig_gc_stackmap_count` reports the stack-map registry size.
+    #[test]
+    fn twig_precise_and_count_aliases_forward() {
+        let _guard = crate::TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        __gc_reset();
+        crate::__gc_stackmap_reset();
+
+        // No functions registered yet → the count alias reads zero.
+        assert_eq!(__twig_gc_stackmap_count(), 0);
+
+        // A stack-rooted allocation survives a precise collect (no maps registered →
+        // the walk degrades to a conservative scan, which roots `p` on this stack).
+        let p = __twig_gc_alloc(16);
+        assert!(p != 0);
+        unsafe { *(p as *mut i64) = 0x5150 };
+        let _freed = unsafe { __twig_gc_collect_precise() };
+        assert_eq!(unsafe { *(p as *const i64) }, 0x5150, "precise collect kept the live root");
         core::hint::black_box(p);
 
         __gc_reset();

--- a/code/packages/rust/twig-aot/CHANGELOG.md
+++ b/code/packages/rust/twig-aot/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog — `twig-aot`
 
+## 0.41.0 - 2026-07-21 — precise roots load-bearing: register the entry wrapper (AOT00-T1 increment C)
+
+The GC-stress `live_bytes` differential — precise roots reclaiming a look-alike-pinned
+object that a conservative scan retains — now **passes end to end** on native AOT,
+proving the whole precise-roots chain (registration → `func_start` resolution → the map
+excluding non-reference slots) is load-bearing in production, not merely plumbed.
+
+Making it work required one fix: **the synthetic GC entry wrapper `__gc_aot_entry` is
+now itself registered** (with an empty ref-slot map). The wrapper is `main`'s caller
+and is live on the stack during every collection. The precise walk resolves a frame's
+map from the *return address* stored in its callee; when it reached `main` it resolved
+`main` precisely (no roots), but then — finding `main`'s own return address (into the
+*unmapped* wrapper) unmapped — fell back to conservatively re-scanning `main`'s whole
+frame, re-pinning exactly the non-reference look-alikes precise roots exist to reclaim.
+Mapping the wrapper keeps the entire generated call chain precise, so the conservative
+fallback only ever covers genuine runtime/libc frames (which hold no twig heap
+references in named slots). The wrapper's records are derived from its call-return
+offsets (a local `call_return_offsets`, mirroring the backend's own scan).
+
+Verified (`end_to_end_gc_stress_live_bytes_differential`): a program that keeps a
+64-byte allocation's address only in an `i64` slot exits with `live_bytes == 0` after a
+precise collect and `== 64` after a conservative one. Needs aarch64-backend 0.30.0
+(`gc_collect` / `gc_collect_precise` / `gc_live_bytes` / `gc_stackmap_count` builtins)
+and gc-core-capi 0.13.0 (`__twig_gc_collect_precise` / `__twig_gc_stackmap_count`).
+
 ## 0.40.0 - 2026-07-21 — GC stack-map registration (AOT00-T1 emission, increment B)
 
 `__gc_init_stackmaps` — the no-op start-up hook increment A landed — now **registers

--- a/code/packages/rust/twig-aot/Cargo.toml
+++ b/code/packages/rust/twig-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-aot"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 description = "Twig AOT compiler — produces native Mach-O / ELF executables from Twig source. v0.28.0 (E4d-4 fix): strip_dead_aot_string_allocs now keeps EVERY buffer bound to a live string alias — a branch-selected (multi-block) str var aliases several buffers, and the old alias-keyed map dropped all but the last, so a not-last branch read a freed/empty buffer at run time. v0.27.0 (E4-dyn E4d-4): runtime (branch-selected) strings on the native aarch64 + x86_64 columns — a str var assigned by str_const in >1 basic block is kept out of the compile-time literal map so print_str/str_len read the length from the [i64 len][bytes] buffer header at run time (field_load) instead of folding one branch's static length; the var's stack slot already carries the buffer address. v0.26.0 (E4-dyn E4d-1): runtime string helpers __twig_str_concat/_slice/_index/_len/_cmp in twig_runtime.c on the E5 length-prefixed heap block; bounds-trap on slice/index; C-driver unit tests."
 

--- a/code/packages/rust/twig-aot/src/lib.rs
+++ b/code/packages/rust/twig-aot/src/lib.rs
@@ -136,6 +136,25 @@ struct FnStackMap {
     records: Vec<(u32, Vec<i32>)>,
 }
 
+/// Byte offset of every return address in `code` — the byte just after each `BL` /
+/// `BLR`. These are the safepoint PCs a precise stack walk observes; the synthetic GC
+/// wrapper needs its own so its frame (live throughout the program) resolves precisely
+/// instead of forcing a conservative re-scan of its callee. Mirrors the aarch64
+/// backend's own scan (which is private to that crate); AArch64 is fixed-width and the
+/// wrapper carries no inline data, so every 4-byte word is a real instruction.
+fn call_return_offsets(code: &[u8]) -> Vec<u32> {
+    let mut out = Vec::new();
+    for (i, word) in code.chunks_exact(4).enumerate() {
+        let w = u32::from_le_bytes([word[0], word[1], word[2], word[3]]);
+        let is_bl = (w >> 26) == 0b100101; // BL imm26
+        let is_blr = (w & 0xFFFF_FC1F) == 0xD63F_0000; // BLR Rn
+        if is_bl || is_blr {
+            out.push(((i + 1) * 4) as u32);
+        }
+    }
+    out
+}
+
 /// Map an [`aarch64_encoder::EncodeError`] to an [`AotError`].
 fn gc_asm_err(e: aarch64_encoder::EncodeError) -> AotError {
     AotError::Linker { status: None, stderr: format!("twig-aot: GC entry codegen: {e:?}") }
@@ -2712,9 +2731,29 @@ fn compile_module_to_text_raw(
             });
         }
     }
+    // Build the wrapper first, then register IT too (with an empty ref-slot map).
+    // The wrapper is `main`'s caller and is live on the stack during every
+    // collection, so if it were unmapped the precise walk would resolve `main`
+    // precisely but then, finding `main`'s *return address* (into the unmapped
+    // wrapper) unmapped, fall back to conservatively re-scanning `main`'s whole
+    // frame — re-pinning exactly the non-reference look-alikes precise roots exist
+    // to reclaim. Mapping the wrapper (it holds no references, so its records name
+    // no slots) keeps the entire generated call chain precise; the conservative
+    // fallback then only ever covers genuine runtime/libc frames, which hold no
+    // twig heap references in named slots.
+    let (wrapper_bytes, wrapper_relocs) = build_gc_wrapper(user_entry)?;
+    let wrapper_records = call_return_offsets(&wrapper_bytes)
+        .into_iter()
+        .map(|pc| (pc, Vec::new()))
+        .collect();
+    fn_maps.push(FnStackMap {
+        name: GC_AOT_ENTRY.to_string(),
+        len: wrapper_bytes.len(),
+        records: wrapper_records,
+    });
+
     let (init_bytes, init_relocs, fn_addr_relocs) = build_gc_init_stackmaps(&fn_maps)?;
     fn_results.push((GC_INIT_STACKMAPS.to_string(), init_bytes, init_relocs, Vec::new()));
-    let (wrapper_bytes, wrapper_relocs) = build_gc_wrapper(user_entry)?;
     fn_results.push((GC_AOT_ENTRY.to_string(), wrapper_bytes, wrapper_relocs, Vec::new()));
 
     // ── LANG41: external symbols are resolved by the system linker ───────────
@@ -2939,6 +2978,7 @@ mod dynval_runtime_golden;
 #[cfg(test)]
 mod tests {
     use super::*;
+
 
     /// The GC entry wrapper is well-formed: the two `BL`s (→ init, → user entry)
     /// are recorded as relocations for the linker to patch intra-module, and it

--- a/code/packages/rust/twig-aot/tests/macos_arm64_smoke.rs
+++ b/code/packages/rust/twig-aot/tests/macos_arm64_smoke.rs
@@ -326,6 +326,124 @@ fn end_to_end_gc_init_registers_and_runs() {
     );
 }
 
+/// AOT00-T1 increment C — the **GC-stress `live_bytes` differential**: the headline
+/// proof that precise roots are load-bearing in production.
+///
+/// The program allocates one heap object and keeps its address **only in an `i64`
+/// slot** — a non-reference "look-alike" that holds a real heap pointer. Nothing else
+/// references the object, so it is garbage. Then it collects and reports
+/// `__gc_live_bytes` as its exit code:
+///
+/// ```text
+///   main() -> i64:
+///       a  = gc_alloc(64)        ; i64 slot — a heap-address look-alike (only ref)
+///       <collect>                ; gc_collect  (conservative) | gc_collect_precise
+///       lb = gc_live_bytes()
+///       ret lb                   ; exit code = live payload bytes
+/// ```
+///
+/// - **Conservative** (`__gc_collect`) scans the whole stack, sees the look-alike, and
+///   *pins* the object → `live_bytes == 64`.
+/// - **Precise** (`__gc_collect_precise`) walks `main`'s frame through its registered
+///   stack map, which names only *reference* slots — the `i64` look-alike is **not**
+///   among them — so the object is unrooted and reclaimed → `live_bytes == 0`.
+///
+/// The gap (64 → 0) is the whole precise-roots feature made observable: registration
+/// (increment B) fired, `func_start` resolved `main`'s return address to the right map,
+/// and the map correctly excluded the non-reference slot. If any link in that chain
+/// were wrong the two columns would be equal.
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn end_to_end_gc_stress_live_bytes_differential() {
+    use interpreter_ir::instr::{IIRInstr, Operand};
+
+    // Build `main` for a given collect builtin. `collect_returns` picks the dest shape
+    // the backend requires (a returning builtin needs a dest; a void one must not).
+    fn build(collect: &str, collect_returns: bool) -> IIRModule {
+        let mut body = vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(64)], "i64"),
+            // The allocation's address lives only here, in an i64 (non-ref) slot.
+            IIRInstr::new(
+                "call_builtin",
+                Some("a".into()),
+                vec![Operand::Var("gc_alloc".into()), Operand::Var("n".into())],
+                "i64",
+            ),
+        ];
+        body.push(if collect_returns {
+            IIRInstr::new(
+                "call_builtin",
+                Some("freed".into()),
+                vec![Operand::Var(collect.into())],
+                "i64",
+            )
+        } else {
+            IIRInstr::new("call_builtin", None, vec![Operand::Var(collect.into())], "void")
+        });
+        body.push(IIRInstr::new(
+            "call_builtin",
+            Some("lb".into()),
+            vec![Operand::Var("gc_live_bytes".into())],
+            "i64",
+        ));
+        body.push(IIRInstr::new("ret", None, vec![Operand::Var("lb".into())], "i64"));
+
+        let mut m = IIRModule::new("gc_stress", "twig");
+        m.add_or_replace(IIRFunction::new("main", vec![], "i64", body));
+        m.entry_point = Some("main".into());
+        m
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let run = |tag: &str, collect: &str, collect_returns: bool| -> i32 {
+        let m = build(collect, collect_returns);
+        let exe = dir.path().join(tag);
+        twig_aot::compile_module_to_macos_executable(&m, &exe)
+            .unwrap_or_else(|e| panic!("{tag} compiles+links: {e}"));
+        let out = Command::new(&exe).output().unwrap_or_else(|e| panic!("{tag} runs: {e}"));
+        out.status.code().unwrap_or_else(|| panic!("{tag} exited by signal: {out:?}"))
+    };
+
+    // Diagnostic: a program that just returns __gc_stackmap_count() — proves the
+    // start-up registration actually ran in the linked image (increment B).
+    {
+        let mut m = IIRModule::new("gc_count", "twig");
+        m.add_or_replace(IIRFunction::new(
+            "main", vec![], "i64",
+            vec![
+                IIRInstr::new(
+                    "call_builtin",
+                    Some("c".into()),
+                    vec![Operand::Var("gc_stackmap_count".into())],
+                    "i64",
+                ),
+                IIRInstr::new("ret", None, vec![Operand::Var("c".into())], "i64"),
+            ],
+        ));
+        m.entry_point = Some("main".into());
+        let exe = dir.path().join("gc_count");
+        twig_aot::compile_module_to_macos_executable(&m, &exe).expect("count compiles");
+        let code = Command::new(&exe).output().expect("count runs").status.code().unwrap();
+        eprintln!("DIAG __gc_stackmap_count() = {code}");
+        assert!(code > 0, "registration must have run at start-up (count={code})");
+    }
+
+    let conservative = run("gc_stress_cons", "gc_collect", false);
+    let precise = run("gc_stress_prec", "gc_collect_precise", true);
+
+    // Conservative pins the look-alike-referenced 64-byte object; precise reclaims it.
+    assert_eq!(
+        conservative, 64,
+        "conservative collect must retain the 64-byte look-alike-pinned object \
+         (live_bytes={conservative})",
+    );
+    assert_eq!(
+        precise, 0,
+        "precise collect must reclaim the object reachable only via a non-reference \
+         i64 slot (live_bytes={precise}); conservative kept {conservative}",
+    );
+}
+
 /// Sanity check that the AArch64Backend trait wiring goes end-to-end
 /// for a hand-built CIR-shaped function.
 #[test]


### PR DESCRIPTION
## Increment C — the precise-roots payoff, proven end to end

Builds on [#8782](https://github.com/adhithyan15/coding-adventures/pull/8782) (A: entry wrapper) and [#8787](https://github.com/adhithyan15/coding-adventures/pull/8787) (B: stack-map registration). Those made precise-roots registration *fire* in production. This PR proves it is **load-bearing**: the GC-stress `live_bytes` differential — precise roots reclaiming a look-alike-pinned object that a conservative scan retains — now **passes** on native AOT.

### The proof
`end_to_end_gc_stress_live_bytes_differential` (macOS/aarch64): a program keeps a 64-byte allocation's address **only in an `i64` slot** (a non-reference heap-address look-alike), then collects and returns `__gc_live_bytes` as its exit code.
- **Conservative** (`__gc_collect`) scans the whole stack, sees the look-alike, pins the object → `live_bytes == 64`.
- **Precise** (`__gc_collect_precise`) walks `main`'s registered stack map, which names only *reference* slots → the object is unrooted and reclaimed → `live_bytes == 0`.

The 64 → 0 gap is the entire feature made observable: registration fired, `func_start` resolved the return address to the right map, and the map correctly excluded the non-reference slot.

### The fix that made it work: register the entry wrapper too
The precise walk resolves each frame's map from the return address stored in its *callee*. It resolved `main` precisely (no roots) — but then, finding `main`'s **own** return address (into the previously-**unmapped** `__gc_aot_entry` wrapper) unmapped, fell back to conservatively re-scanning `main`'s whole frame, re-pinning exactly the non-reference look-alike precise roots exist to reclaim. **Registering the wrapper** (with an empty ref-slot map — it holds no references) keeps the entire generated call chain precise; the conservative fallback then only ever covers genuine runtime/libc frames, which hold no twig heap references in named slots. The wrapper's records are derived from its call-return offsets (`call_return_offsets`, mirroring the backend's own scan).

### Supporting builtins / aliases
So a native program can drive and measure a collection:
- **aarch64-backend 0.30.0**: `gc_collect` (forced conservative), `gc_collect_precise` (precise walk, returns freed), `gc_live_bytes`, `gc_stackmap_count`.
- **gc-core-capi 0.13.0**: `__twig_gc_collect_precise` + `__twig_gc_stackmap_count` aliases.

### Verification
- The differential passes; a `gc_stackmap_count` diagnostic confirms registration ran (count > 0) in the linked image.
- 51 twig-aot lib + 69 aarch64-backend + 28 gc-core-capi tests green; clippy clean across all three crates.
- Adversarial `/security-review`: **no exploitable defect** — the empty-map wrapper registration is safe (the wrapper never spills a heap pointer to a slot), `call_return_offsets` has no off-by-one, no range overlap.
- Confined to the aarch64/macOS path; x86_64 (linux/windows) untouched.

### Follow-up
- **Precision ladder is now: conservative → interior-precise → generational → precise-roots ✓ (load-bearing).** Remaining: `-Cforce-frame-pointers` on gc-core-capi for non-macOS portability (chip task_768a4dd1 — default-on on aarch64 macOS, hence this proof); then moving/compacting + incremental collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)