### PR TITLE
feat(constant-fold): fold Math.trunc / Math.sign on a numeric literal (0.108.0)

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.108.0] - 2026-07-22
+
+### Added - fold `Math.trunc(n)` and `Math.sign(n)` on a numeric literal
+
+Extended the existing single-argument `Math` fold (which already handled
+`abs`/`floor`/`ceil`/`round`) to two more static methods, verified byte-identical
+to the reference Closure Compiler (`closure-compiler-v20260712.jar`, SIMPLE):
+
+- `Math.trunc(4.9)` -> `4`, `Math.trunc(-4.9)` -> `-4` (round toward zero).
+- `Math.sign(7)` -> `1`, `Math.sign(-3)` -> `-1`, `Math.sign(0)` -> `0`.
+
+Both reuse the handler's existing safety gates: fold only when the single
+argument is a numeric literal, and DECLINE any result that is negative zero
+(`Math.trunc(-0.5)` === -0, `Math.sign(-0)` === -0) — the same conservative
+policy already applied to `Math.ceil(-0.5)`, since `-0` has no faithful
+numeric-literal spelling. `js_math_sign` implements the ECMAScript §21.3.2.34
+sign (which preserves signed zero and maps NaN to NaN) rather than Rust's
+`f64::signum`, whose `+-0 -> +-1` mapping would be wrong.
+
+The reference compiler does NOT fold the transcendental `Math` methods
+(`sqrt`/`cbrt`/`hypot`/`exp`/`log*`/`sin`/`cos`/`tan`/`atan`) even when the
+result is exact, so those remain declined and unchanged. `Math.pow`, `clz32`,
+`imul`, and the conditional `fround` are tracked separately.
+
 ## [0.107.0] - 2026-07-18
 
 ### Fixed — keep `a / b` unfolded past 7 fractional digits (match Closure)

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.107.0"
+version = "0.108.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -2720,7 +2720,10 @@ fn fold_call(c: &CallExpression, st: &mut FoldState) -> Expression {
                 // finite literal inputs produce finite outputs, so the
                 // `is_finite` check is defense-in-depth.
                 if obj.name == "Math"
-                    && matches!(prop.name.as_str(), "abs" | "floor" | "ceil" | "round")
+                    && matches!(
+                        prop.name.as_str(),
+                        "abs" | "floor" | "ceil" | "round" | "trunc" | "sign"
+                    )
                     && arguments.len() == 1
                 {
                     if let Expression::NumericLiteral(n) = &arguments[0] {
@@ -2730,6 +2733,18 @@ fn fold_call(c: &CallExpression, st: &mut FoldState) -> Expression {
                             "floor" => x.floor(),
                             "ceil" => x.ceil(),
                             "round" => js_math_round(x),
+                            // `Math.trunc(x)` (ECMAScript 21.3.2.38) removes the
+                            // fractional part, rounding toward zero. Rust's
+                            // `f64::trunc` has the identical rule, including
+                            // `trunc(-0.5) == -0.0` — which the shared negative-
+                            // zero gate below then DECLINES, matching how the
+                            // handler already declines `Math.ceil(-0.5)`.
+                            "trunc" => x.trunc(),
+                            // `Math.sign(x)` (ECMAScript 21.3.2.34) yields -1/-0/+0/+1
+                            // (and NaN for NaN). We can't spell Rust's `signum`
+                            // here because it maps +-0 to +-1; see `js_math_sign`.
+                            // A `-0` result is likewise declined by the gate.
+                            "sign" => js_math_sign(x),
                             _ => unreachable!("matches! guard limits the method set"),
                         };
                         let neg_zero_result = result == 0.0
@@ -6230,6 +6245,34 @@ fn js_math_round(x: f64) -> f64 {
         x.floor() + 1.0
     } else {
         x.round()
+    }
+}
+
+/// Evaluate `Math.sign(x)` per ECMAScript §21.3.2.34. The result preserves the
+/// SIGN of a zero input (`sign(+0) == +0`, `sign(-0) == -0`) and is `NaN` for
+/// `NaN`; otherwise it is `+1` for a positive input and `-1` for a negative one.
+///
+/// Rust's `f64::signum` is deliberately NOT used: it maps `+0.0`→`+1.0` and
+/// `-0.0`→`-1.0`, which would corrupt the zero cases. Our callers only pass
+/// finite numeric literals (never `NaN`), and the caller's shared negative-zero
+/// gate then declines the `sign(-0) == -0` result — matching how the same
+/// handler already declines `Math.ceil(-0.5)` — so this stays a faithful,
+/// standalone model.
+///
+/// | x        | Math.sign(x) |
+/// |----------|--------------|
+/// | NaN      | NaN          |
+/// | +0 / -0  | +0 / -0      |
+/// | x > 0    | +1           |
+/// | x < 0    | -1           |
+fn js_math_sign(x: f64) -> f64 {
+    if x.is_nan() || x == 0.0 {
+        // NaN and both zeroes map to themselves (preserving the signed zero).
+        x
+    } else if x > 0.0 {
+        1.0
+    } else {
+        -1.0
     }
 }
 
@@ -12629,8 +12672,9 @@ mod tests {
 
     #[test]
     fn math_other_methods_do_not_fold() {
-        // pow is not among the modelled methods (max/min/abs/floor/ceil/round);
-        // e.g. Math.pow(2, 3) is left alone.
+        // pow is not among the modelled methods
+        // (max/min/abs/floor/ceil/round/trunc/sign); e.g. Math.pow(2, 3) is
+        // left alone. (Modelling pow is tracked separately.)
         let c = math_call("pow", vec![num(2.0, None), num(3.0, None)]);
         let (out, _, changed, _) = run_pass(program_with_expr(c, true));
         assert!(!changed, "Math.pow(2, 3) is not modelled and must not fold");
@@ -12664,6 +12708,44 @@ mod tests {
     }
 
     #[test]
+    fn fold_math_trunc_basic() {
+        // Math.trunc removes the fractional part, rounding toward zero.
+        assert_eq!(folded_number(math_call("trunc", vec![num(4.9, None)])), 4.0);
+        assert_eq!(folded_number(math_call("trunc", vec![num(4.1, None)])), 4.0);
+        assert_eq!(folded_number(math_call("trunc", vec![num(-4.9, None)])), -4.0);
+        assert_eq!(folded_number(math_call("trunc", vec![num(-4.1, None)])), -4.0);
+        assert_eq!(folded_number(math_call("trunc", vec![num(7.0, None)])), 7.0);
+        // A positive fraction truncating to +0 is representable and folds.
+        assert_eq!(folded_number(math_call("trunc", vec![num(0.5, None)])), 0.0);
+    }
+
+    #[test]
+    fn fold_math_sign_basic() {
+        // Math.sign yields -1 / +1 for negative / positive, and preserves +0.
+        assert_eq!(folded_number(math_call("sign", vec![num(7.0, None)])), 1.0);
+        assert_eq!(folded_number(math_call("sign", vec![num(0.5, None)])), 1.0);
+        assert_eq!(folded_number(math_call("sign", vec![num(-3.0, None)])), -1.0);
+        assert_eq!(folded_number(math_call("sign", vec![num(-0.001, None)])), -1.0);
+        assert_eq!(folded_number(math_call("sign", vec![num(0.0, None)])), 0.0);
+    }
+
+    #[test]
+    fn math_trunc_sign_negative_zero_declines() {
+        // A -0 result has no faithful numeric-literal spelling, so both decline
+        // (consistent with the ceil/round -0 policy):
+        //   Math.trunc(-0.5) === -0   Math.sign(-0) === -0
+        let cases = [
+            math_call("trunc", vec![num(-0.5, None)]),
+            math_call("sign", vec![num(-0.0, None)]),
+        ];
+        for c in cases {
+            let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+            assert!(!changed, "a -0 result must not fold (no -0 literal spelling)");
+            assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+        }
+    }
+
+    #[test]
     fn math_unary_negative_zero_result_does_not_fold() {
         // Results that are (or, from a negative input, would be) -0 have no
         // faithful numeric-literal spelling, so they DECLINE:
@@ -12686,7 +12768,7 @@ mod tests {
 
     #[test]
     fn math_unary_non_literal_or_wrong_arity_does_not_fold() {
-        for method in ["abs", "floor", "ceil", "round"] {
+        for method in ["abs", "floor", "ceil", "round", "trunc", "sign"] {
             // Non-literal argument.
             let c = math_call(method, vec![ident("x")]);
             let (out, _, changed, _) = run_pass(program_with_expr(c, true));

--- a/code/programs/rust/closurec/tests/diff/simple-fold-math-trunc-sign/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-math-trunc-sign/README.md
@@ -1,0 +1,21 @@
+# simple-fold-math-trunc-sign
+
+Locks the byte output of SIMPLE-level static `Math.trunc(n)` / `Math.sign(n)`
+folding (`closure-pass-constant-fold`). When the single argument is a numeric
+literal the call collapses to the result as a numeric literal, verified
+byte-identical to the reference Closure Compiler
+(`closure-compiler-v20260712.jar`, SIMPLE, `--language_out NO_TRANSPILE`):
+
+- `Math.trunc(4.9)` -> `4`, `Math.trunc(-4.9)` -> `-4` (round toward zero)
+- `Math.sign(7)` -> `1`, `Math.sign(-3)` -> `-1`, `Math.sign(0)` -> `0`
+
+Declined (left intact), matching the reference:
+
+- `Math.trunc(x)` — non-literal argument
+- `Math.sqrt(16)` — the reference does not fold transcendental `Math` methods
+  even when the result is exact
+- `m.trunc(1.5)` — only the bare global `Math` folds
+- a `-0` result (`Math.trunc(-0.5)` === -0) — declined for lack of a faithful
+  `-0` literal spelling, the same policy as `Math.ceil(-0.5)` (unit-tested)
+
+See `input/a.js` for the source and `expected.stdout` for the locked output.

--- a/code/programs/rust/closurec/tests/diff/simple-fold-math-trunc-sign/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-math-trunc-sign/expected.stdout
@@ -1,0 +1,1 @@
+var a=4,b=-4,c=1,d=-1,e=0,f=Math.trunc(x),g=Math.sqrt(16),h=m.trunc(1.5);report(a,b,c,d,e,f,g,h);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-math-trunc-sign/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-math-trunc-sign/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-fold-math-trunc-sign/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-fold-math-trunc-sign/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-math-trunc-sign/input/a.js
@@ -1,0 +1,29 @@
+// SIMPLE-level static Math.trunc(n) / Math.sign(n) fold -> numeric literal.
+//
+// Math.trunc (ECMAScript 21.3.2.38) removes the fractional part, rounding
+// toward zero; Math.sign (21.3.2.34) yields -1 / -0 / +0 / +1 (and NaN for NaN).
+// When the single argument is a numeric literal the result is known at compile
+// time and the call collapses to a literal:
+//   * Math.trunc(4.9)  -> 4       Math.trunc(-4.9) -> -4
+//   * Math.sign(7)     -> 1       Math.sign(-3)    -> -1     Math.sign(0) -> 0
+//   * Math.trunc(x)    -> declined (x is a non-literal, runtime-unknown)
+//   * Math.sqrt(16)    -> declined (the reference compiler does NOT fold the
+//                         transcendental Math methods, even when exact)
+//   * m.trunc(1.5)     -> declined (only the bare global Math folds)
+//
+// A -0 result (e.g. Math.trunc(-0.5) === -0) is also DECLINED, matching how the
+// same handler already declines Math.ceil(-0.5): -0 has no faithful numeric-
+// literal spelling. (Covered by unit tests, not shown here so this fixture
+// stays byte-identical to the reference compiler.)
+//
+// Under WHITESPACE_ONLY every call survives; under SIMPLE the bare-global
+// numeric-literal calls collapse. Each value flows into report(...).
+var a = Math.trunc(4.9);
+var b = Math.trunc(-4.9);
+var c = Math.sign(7);
+var d = Math.sign(-3);
+var e = Math.sign(0);
+var f = Math.trunc(x);
+var g = Math.sqrt(16);
+var h = m.trunc(1.5);
+report(a, b, c, d, e, f, g, h);

--- a/code/programs/rust/closurec/tests/diff_simple_fold_math_trunc_sign.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_math_trunc_sign.rs
@@ -1,0 +1,52 @@
+//! Integration test for the `tests/diff/simple-fold-math-trunc-sign/` fixture.
+//!
+//! End-to-end oracle for static `Math.trunc(...)` / `Math.sign(...)` folding in
+//! `closure-pass-constant-fold`: when the single argument is a numeric literal
+//! the call collapses to the truncated / signed result as a numeric literal
+//! (ECMAScript 21.3.2.38 / 21.3.2.34). A non-literal argument (`Math.trunc(x)`),
+//! a transcendental method the reference never folds (`Math.sqrt(16)`), a
+//! non-global receiver (`m.trunc(1.5)`), and any `-0` result are all declined.
+//!
+//! At SIMPLE the fixture optimizes to:
+//!
+//! ```text
+//! var a=4,b=-4,c=1,d=-1,e=0,f=Math.trunc(x),g=Math.sqrt(16),h=m.trunc(1.5);report(a,b,c,d,e,f,g,h);
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-fold-math-trunc-sign/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_fold_math_trunc_sign_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-fold-math-trunc-sign/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}


### PR DESCRIPTION
## What

Fold `Math.trunc(n)` and `Math.sign(n)` on a numeric literal at SIMPLE/ADVANCED,
extending the existing single-argument Math fold (which already handled
`abs`/`floor`/`ceil`/`round`).

## Why

Oracle probing against the reference Closure Compiler
(`closure-compiler-v20260712.jar`, SIMPLE, `--language_out NO_TRANSPILE`) showed
closurec left these two calls un-folded where the reference collapses them:

- `Math.trunc(4.9)` -> `4`, `Math.trunc(-4.9)` -> `-4` (round toward zero)
- `Math.sign(7)` -> `1`, `Math.sign(-3)` -> `-1`, `Math.sign(0)` -> `0`

The reference does **not** fold the transcendental `Math` methods
(`sqrt`/`cbrt`/`hypot`/`exp`/`log*`/`sin`/`cos`/`tan`/`atan`) even when the
result is exact, so those stay declined (closurec already matched that).

## Changes

- **closure-pass-constant-fold 0.107.0 -> 0.108.0**: add `trunc`/`sign` to the
  unary Math `matches!` set and match; new `js_math_sign` helper implementing
  ECMAScript 21.3.2.34 (preserves signed zero, NaN -> NaN — Rust's `f64::signum`
  maps +-0 -> +-1, which would be wrong). Reuses the handler's existing gates:
  numeric-literal arg only, exactly 1 arg, and DECLINE any negative-zero result
  (`Math.trunc(-0.5)` === -0, `Math.sign(-0)` === -0), the same policy already
  applied to `Math.ceil(-0.5)` — `-0` has no faithful numeric-literal spelling.
  Unit tests for the folds, the `-0` decline, and non-literal/wrong-arity/
  non-global declines.
- **closurec**: new `tests/diff/simple-fold-math-trunc-sign` e2e fixture (input +
  `expected.stdout` byte-verified against the oracle) + its diff test harness.

## Verification

- `closure-pass-constant-fold` unit tests (404) pass, including 3 new.
- constant-fold consumer crates (dce, fold-control-flow, inline, inline-variables,
  collapse-properties) pass; full closurec suite (157 test targets) passes.
- `cargo clippy -- -D warnings` clean.
- The e2e fixture output is byte-identical to the reference compiler.
- Security review passed (no findings).

## Scope / follow-ups

`Math.pow` (general double results, needs number-format verification),
`Math.clz32`/`Math.imul` (32-bit coercion), and the conditional `Math.fround`
are tracked as a follow-up. Independent of the in-flight var-split PR (different
crate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
