### PR TITLE
feat(q-runtime,q-repl): tree-walking evaluator + REPL for Q (MA11 D-4)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -277,6 +277,8 @@ members = [
     "scilab-to-semantic-ir",
     "q-lexer",
     "q-parser",
+    "q-runtime",
+    "q-repl",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/q-repl/BUILD
+++ b/code/packages/rust/q-repl/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-q-repl -- --nocapture

--- a/code/packages/rust/q-repl/BUILD_windows
+++ b/code/packages/rust/q-repl/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-q-repl -- --nocapture

--- a/code/packages/rust/q-repl/CHANGELOG.md
+++ b/code/packages/rust/q-repl/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **(HIGH) A `/`-comment opened on one physical line of a still-open
+  continuation silently swallowed every subsequently-typed line, forever.**
+  The previous scanner tokenized the *whole accumulated, space-joined*
+  `self.buffer` on every call — but `q-lexer`'s comment rule blanks from `/`
+  through the next **real** `'\n'` or end of input, and this REPL joins
+  continuation lines with a single **space**, never a real `'\n'`. A
+  comment opened on one physical line therefore had no real `'\n'` left to
+  stop at once joined, and silently erased every following line — including
+  whatever closing bracket was supposed to complete the statement — leaving
+  the session stuck reporting `NeedMore` forever (until the 64 KiB
+  continuation cap eventually fired and discarded the whole thing,
+  including legitimately-typed program text). `quit`/`exit` couldn't escape
+  it either, since those are only recognized when the buffer is empty.
+  Concrete repro: `feed("(1 / comment")` then `feed("+2)")` never
+  evaluated to `3`. Fixed by [`blank_line_comment`]: each physical line's
+  own trailing comment is now blanked to spaces **before** it is folded
+  into `self.buffer` at all (not merely accounted for when checking
+  completeness) — a comment's real extent is only knowable one physical
+  line at a time, before the lossy space-join loses track of where each
+  line ended.
+- **(MEDIUM) O(n²) cumulative CPU cost from re-tokenizing the whole
+  buffer on every fed line.** The previous `is_incomplete` re-tokenized the
+  entire accumulated buffer from scratch on every physical line fed while a
+  bracket remained open — cost per call scaled with the buffer's current
+  length, so cumulative cost across a continuation that grows one short
+  line at a time was O(n²) in the number of lines. `QRepl` now tracks
+  running `(parens, braces, brackets)` counts as instance state and
+  tokenizes only the newly-appended (already comment-blanked) line
+  fragment on each call, folding its own delta into the running totals —
+  O(line length) per call, O(buffer length) total per continuation, not
+  O(buffer length²). Sound because no token in this cut's grammar can span
+  a line-fragment boundary (no multi-line string/number literal, MA11 §4).
+  Solving both findings with the same per-line pre-processing step (rather
+  than two separate patches) falls out naturally: once each line's own
+  comment is blanked and tokenized independently, a comment on one line can
+  no longer reach past that line's own end, by construction.
+- Added regression tests: `a_comment_opened_mid_continuation_does_not_swallow_the_rest_of_the_statement`
+  and `a_comment_inside_a_multi_line_function_literal_does_not_swallow_the_closing_brace`
+  (Finding 1), and `per_line_scanning_cost_does_not_scale_with_the_existing_buffer_size`
+  (Finding 2 — a comparative timing measurement: the same number of
+  trivial filler lines against a small vs. a ~60 KiB pre-existing buffer
+  must cost approximately the same, not scale with the existing buffer
+  size).
+- Corrects this file's own earlier (now inaccurate) claim that "comments
+  need zero REPL-level handling of their own" — see above; this crate now
+  does its own narrow, documented, single-physical-line-scoped comment
+  blanking, precisely because whole-buffer delegation to `q-lexer` turned
+  out to be unsound for a REPL that joins lines with spaces rather than
+  real newlines.
+
 ## [0.1.0] - 2026-07-22
 
 ### Added

--- a/code/packages/rust/q-repl/CHANGELOG.md
+++ b/code/packages/rust/q-repl/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-07-22
+
+### Added
+
+- Initial release — the interactive REPL and the **`q` binary** (item
+  MA-11d, spec [`MA11`](../../../specs/MA11-q-language.md)), a sibling of
+  `j-repl`/`apl-repl`/`matlab-repl`/`s-repl`/`r-repl` over the `q-runtime`
+  interpreter.
+- `QRepl` with a persistent workspace, `>> `/`... ` prompts, and `quit`/
+  `exit`/EOF handling; `run()` drives a full stdio session.
+- **Brace/bracket/paren continuation scanning — the one genuinely new
+  concern beyond `j-repl`'s plain paren-balance scanner.** Q has a real
+  user-defined block construct (`{[x;y] stmt; stmt}`, MA11 §2/§3 bullet 1)
+  that J/APL never had, so a statement can legitimately still be "in
+  progress" across a still-open `{`/`[` too, not just `(`. `is_incomplete`
+  tracks three *independent* running depths (a mismatched `{)` correctly
+  stays incomplete on the strength of the still-open brace, rather than
+  two mismatched counts cancelling out in a single combined tally) by
+  tokenizing the accumulated buffer with the *real* `q-lexer`
+  (`coding_adventures_q_lexer::try_tokenize_q`) — delegating comment-
+  awareness to the lexer's own already-correct pre-tokenize hook, rather
+  than re-deriving Q's whitespace-sensitive `/`-comment rule a second time
+  by hand (which would risk drifting out of sync with `q-lexer`'s own
+  rule). Verified by hand-tracing the exact multi-line function-literal
+  scenario this crate's own module doc comment describes (`{[x;y]` on one
+  line, ` x+y}` on the next), a split parameter-list case (`{[x;` /
+  `y] ...}`), a complete one-line statement never spuriously waiting, and a
+  stray unbalanced `(` sitting inside a comment not fooling the scanner.
+- Continuation lines are joined with a space rather than a real newline
+  (mirrors `j-repl`'s identical rationale, generalized to Q's own
+  significant `NEWLINE` token between top-level statements).
+- `/`-to-end-of-line comments need zero REPL-level handling of their own —
+  they're stripped entirely by `q-lexer`'s pre-tokenize hook before this
+  crate's scanner ever sees a token for them (see above).
+- Errors are surfaced (`Error: …`) without ending the session.
+- `MAX_CONTINUATION_BUFFER` (64 KiB) caps the pending-continuation buffer
+  while any bracket type is still unbalanced, and `MAX_LINE_LEN` (64 KiB)
+  caps a single physical line read from the input stream — both ported
+  forward from `j-repl`'s own already-security-reviewed guards (task #80,
+  PRs already merged), **including the fixed push-order**: the size cap is
+  checked *before* `self.buffer` is grown, never after, so the cap cannot
+  be exceeded by up to one line's worth of bytes the way an earlier
+  (already-fixed-elsewhere) ordering bug in every sibling REPL once allowed
+  — this crate never reintroduces that bug class, it starts from the
+  already-corrected ordering.
+- `read_bounded_line` is `j-repl`'s own already-reviewed byte-oriented line
+  reader (multibyte-boundary-safe, "oversized decided by all three
+  conditions" discipline, full-drain-the-oversized-line loop), replicated
+  here verbatim — this repl's own line-reading concern is identical to
+  J's/APL's; only the bracket-balance scanner above is genuinely new to Q.

--- a/code/packages/rust/q-repl/CHANGELOG.md
+++ b/code/packages/rust/q-repl/CHANGELOG.md
@@ -6,6 +6,32 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **(MEDIUM, round 2) `apply_line_bracket_tokens` (formerly
+  `line_bracket_delta`) computed one net delta per line and clamped the
+  running total only once, instead of clamping per token against the
+  persisted running state as the original whole-buffer algorithm did.**
+  These diverge whenever a line's own tokens, combined with the count
+  already open, dip a counter below zero *mid-line* before a later,
+  genuinely-unmatched open of the same type — an excess close must be
+  "forgiven" (clamped to 0) at the exact point it occurs, not allowed to
+  arithmetically cancel a later open within the same line. Concrete
+  counterexample: `")("` as a lone first line — per-token clamping
+  correctly reports "incomplete" (the `)` is forgiven, then the `(`
+  opens); the net-delta approach computed `-1 + 1 = 0` and wrongly
+  reported "complete". A realistic multi-line sequence
+  (`feed("(1")`, `feed("))+((2")`, `feed(")")`) triggers the same
+  divergence one line early. Fixed by threading `&mut i32` references to
+  the three running counters straight into the token loop and clamping
+  each one immediately after every token that touches it — mathematically
+  identical to replaying the whole-buffer algorithm from scratch, since a
+  per-token-clamped walk's end state is fully determined by its starting
+  value and remaining tokens regardless of where that starting value came
+  from. Added two regression tests for the counterexamples above.
+- **(LOW/INFO) `blank_line_comment`'s soundness depends on an unenforced
+  precondition** (every line reaching `feed` has no embedded `'\n'`) —
+  added a `debug_assert!` at the top of `feed` so a future direct caller
+  violating it fails loudly in tests/debug builds instead of silently
+  reintroducing a scoped version of the comment-swallowing bug below.
 - **(HIGH) A `/`-comment opened on one physical line of a still-open
   continuation silently swallowed every subsequently-typed line, forever.**
   The previous scanner tokenized the *whole accumulated, space-joined*

--- a/code/packages/rust/q-repl/Cargo.toml
+++ b/code/packages/rust/q-repl/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "coding-adventures-q-repl"
+version = "0.1.0"
+edition = "2021"
+description = "Interactive REPL and `q` binary for the Q (kdb+) language"
+
+[dependencies]
+coding-adventures-q-runtime = { path = "../q-runtime" }
+coding-adventures-q-lexer = { path = "../q-lexer" }
+
+[[bin]]
+name = "q"
+path = "src/main.rs"

--- a/code/packages/rust/q-repl/README.md
+++ b/code/packages/rust/q-repl/README.md
@@ -1,0 +1,64 @@
+# Q REPL
+
+The interactive REPL and the **`q` binary** for the Q language. Wraps a
+persistent [`q-runtime`](../q-runtime) `Interpreter` and adds console
+behaviours. Item **MA-11d**; sibling of `j-repl`/`apl-repl`/`matlab-repl`/
+`s-repl`/`r-repl`.
+
+## Usage
+
+```sh
+cargo run -p coding-adventures-q-repl --bin q
+```
+
+```
+Q (on array-runtime) — type quit to exit.
+>> f:{[x;y] x+y}
+>> f 2 3
+5
+>> +/1 2 3 4
+10
+>> !5
+0 1 2 3 4
+>> 2*3+4
+14
+>> quit
+```
+
+A multi-line function literal is typed one line at a time, exactly the way
+a real interactive session works:
+
+```
+>> f:{[x;y]
+...  x+y}
+>> 2 f 3
+5
+```
+
+## Lines continue across an open `(`, `{`, or `[` — the one genuinely new
+## concern beyond J's/APL's plain paren-balance scanner
+
+Read `j-repl`'s own module doc comment first: J/APL have no user-defined
+block construct at all, so their continuation scanner reduces to plain
+paren-balance tracking. Q is different — it has a real one, the function
+literal `{[x;y] stmt; stmt}` (MA11 §2/§3 bullet 1) — which can legitimately
+span several physical lines in an interactive session. This crate's
+scanner tracks three *independent* running depths (parens, braces,
+brackets), so a mismatched `{)` correctly stays "incomplete" on the
+strength of the still-open brace rather than two mismatched counts
+happening to cancel out. It delegates to the *real* Q lexer
+(`coding_adventures_q_lexer::try_tokenize_q`) to count bracket tokens,
+rather than hand-rolling a character scan — Q's `/`-comment marker (MA11
+§3 bullet 2) is an ordinary character that could contain an unbalanced
+bracket inside comment text, and the real lexer's own pre-tokenize hook
+already strips comments correctly, so a stray `(` inside a comment can
+never fool this scanner.
+
+`quit`/`exit` (or Ctrl-D) leaves. Errors are shown, not fatal — the session
+continues.
+
+## Testing
+
+```sh
+cargo test -p coding-adventures-q-repl
+```

--- a/code/packages/rust/q-repl/README.md
+++ b/code/packages/rust/q-repl/README.md
@@ -43,16 +43,25 @@ block construct at all, so their continuation scanner reduces to plain
 paren-balance tracking. Q is different — it has a real one, the function
 literal `{[x;y] stmt; stmt}` (MA11 §2/§3 bullet 1) — which can legitimately
 span several physical lines in an interactive session. This crate's
-scanner tracks three *independent* running depths (parens, braces,
-brackets), so a mismatched `{)` correctly stays "incomplete" on the
-strength of the still-open brace rather than two mismatched counts
-happening to cancel out. It delegates to the *real* Q lexer
-(`coding_adventures_q_lexer::try_tokenize_q`) to count bracket tokens,
-rather than hand-rolling a character scan — Q's `/`-comment marker (MA11
-§3 bullet 2) is an ordinary character that could contain an unbalanced
-bracket inside comment text, and the real lexer's own pre-tokenize hook
-already strips comments correctly, so a stray `(` inside a comment can
-never fool this scanner.
+scanner tracks three *independent* **running** depths (parens, braces,
+brackets) as instance state, updated incrementally: each physical line is
+first comment-blanked (`blank_line_comment`, a narrow, documented
+re-derivation of `q-lexer`'s own comment rule, scoped to a single line —
+see that function's own doc comment for why this is sound rather than a
+duplication hazard) and then tokenized on its own with the *real* Q lexer
+(`coding_adventures_q_lexer::try_tokenize_q`) to compute that one line's
+own bracket delta, which is folded into the running totals — never by
+re-tokenizing the whole accumulated buffer from scratch on every call (an
+earlier version did exactly that, and paid for it twice over: an O(n²)
+cumulative cost across a long continuation, *and* a real bug where a
+comment opened on one physical line — having no real `'\n'` left to stop
+at once space-joined into the buffer — silently swallowed every
+subsequent line forever; see `CHANGELOG.md` for the full incident). A
+mismatched `{)` still correctly stays "incomplete" on the strength of the
+still-open brace rather than two mismatched counts happening to cancel
+out, and a stray `(` inside a comment still can never fool this scanner —
+now true both *within* a single line and *across* a continuation's
+several lines.
 
 `quit`/`exit` (or Ctrl-D) leaves. Errors are shown, not fatal — the session
 continues.

--- a/code/packages/rust/q-repl/required_capabilities.json
+++ b/code/packages/rust/q-repl/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/q-repl",
+  "capabilities": ["stdio"],
+  "justification": "An interactive console: the `q` binary reads Q source from stdin and writes results to stdout. No filesystem, network, or process access beyond standard streams."
+}

--- a/code/packages/rust/q-repl/src/lib.rs
+++ b/code/packages/rust/q-repl/src/lib.rs
@@ -1,0 +1,546 @@
+//! # Q REPL — an interactive Read-Eval-Print loop for Q.
+//!
+//! [`QRepl`] wraps a persistent [`Interpreter`] and adds the interactive
+//! behaviours a console needs: line continuation across an open bracket,
+//! and echoing of auto-printed results. It is the sibling of `j-repl`/
+//! `apl-repl`/`matlab-repl`/`s-repl`/`r-repl`; only the interpreter (and
+//! the continuation scanner) differ. See
+//! `code/specs/MA11-q-language.md`.
+//!
+//! ## Why this scanner needs brace/bracket balance, not just paren balance
+//!
+//! Read `j-repl`'s own module doc comment (`code/packages/rust/j-repl/src/lib.rs`)
+//! first: it explains that J's/APL's continuation scanner reduces to plain
+//! `(`-balance tracking because those languages (this repo's own cuts of
+//! them) have no control flow, no user-defined blocks, and no string/char
+//! literal type — the *only* grouping construct is parenthesised, so an
+//! unbalanced `(` is the *only* way a statement can still be "in progress".
+//!
+//! Q is genuinely different: it has a real user-defined block construct
+//! now — the function literal `{[x;y] stmt; stmt}` (MA11 §2/§3 bullet 1) —
+//! which can legitimately span multiple physical lines in an interactive
+//! session (a user typing a multi-statement lambda body one line at a
+//! time, e.g. `{[x;y]` on one line and ` x+y}` on the next). So this
+//! scanner needs **brace** balance (`{`/`}`) in addition to **paren**
+//! balance (`(`/`)`, needed here for exactly the same reason it is in
+//! J/APL: ordinary grouping and the explicit list-literal form both use
+//! parens) — and, since a function literal's optional parameter list is
+//! itself bracketed (`{[x;y] ...}`), **bracket** balance (`[`/`]`) too,
+//! even though splitting a parameter list across a line break would be
+//! unusual style. This module does **not** just copy `j-repl`'s scanner
+//! verbatim and assume it is sufficient — see [`is_incomplete`]'s own doc
+//! comment for the verification this claim rests on.
+//!
+//! ## Delegating to the real Q lexer, not a hand-rolled character scan
+//!
+//! Unlike J/APL's scanner (a raw character count, safe because neither
+//! language's comment marker can contain an unbalanced paren that would
+//! fool a naive scan), Q's comment marker (`/`, MA11 §3 bullet 2) is a
+//! plain ASCII character that could easily appear unbalanced-looking
+//! bracket characters *inside* comment text (e.g. `2+3 / a stray ( here`).
+//! A naive character-level scan of the raw buffer would be fooled by that
+//! stray `(` inside the comment and wait forever for a `)` that will never
+//! come. Rather than re-deriving `q-lexer`'s own whitespace-sensitive
+//! comment-stripping rule a second time by hand here (which this repo's
+//! "no hand-written lexers" discipline warns against duplicating), this
+//! scanner tokenizes the accumulated buffer with the *real*
+//! `coding_adventures_q_lexer::try_tokenize_q` (which already strips
+//! comments via its own pre-tokenize hook) and counts only genuine
+//! `LPAREN`/`RPAREN`/`LBRACE`/`RBRACE`/`LBRACKET`/`RBRACKET` *tokens* — a
+//! bracket character sitting inside a comment is never even tokenized as
+//! one, so it can never be miscounted. Tokenizing a syntactically
+//! incomplete-but-not-yet-closed buffer is always safe here: Q's lexer has
+//! no notion of an "unterminated" token that could fail on partial input
+//! (no multi-line string/char literal in this cut's alphabet at all,
+//! MA11 §4), so a `try_tokenize_q` failure here can only mean a genuinely
+//! unrecognized character — in that case this scanner reports "not
+//! incomplete" (falls through to evaluation) so the *real* lex/parse error
+//! surfaces through [`Interpreter::feed`]'s own `Result`, rather than
+//! silently waiting for more input forever.
+//!
+//! Hand-rolled rather than built on the generic `repl` crate, mirroring
+//! `j-repl`'s own rationale: the interpreter is single-threaded, and a
+//! console session is sequential anyway.
+
+use coding_adventures_q_runtime::Interpreter;
+use std::io::{BufRead, Write};
+
+/// What the REPL should do after being fed one physical line.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ReplResponse {
+    /// Text to display (may be empty — e.g. after a silent assignment).
+    Output(String),
+    /// The current statement is incomplete; read another line (`... ` prompt).
+    NeedMore,
+    /// End the session.
+    Quit,
+}
+
+/// Upper bound on the pending-continuation buffer (while a bracket of any
+/// kind is still unbalanced). Without this, a source that never closes its
+/// brackets/braces/parens grows `buffer` without bound before anything is
+/// ever parsed — mirrors `j-repl::MAX_CONTINUATION_BUFFER`'s identical
+/// "generous but bounded" convention and value.
+const MAX_CONTINUATION_BUFFER: usize = 64 * 1024;
+
+/// Upper bound on a single *physical* line read from the input stream,
+/// applied in [`read_bounded_line`] before [`MAX_CONTINUATION_BUFFER`]'s
+/// own check ever runs. Mirrors `j-repl::MAX_LINE_LEN` exactly (see that
+/// module's own doc comment for the full rationale — `BufRead::read_line`
+/// has no length bound of its own, so without this a single, arbitrarily
+/// long physical line would be fully buffered in memory regardless of
+/// `MAX_CONTINUATION_BUFFER`).
+const MAX_LINE_LEN: u64 = 64 * 1024;
+
+/// Read one physical line, bounded to [`MAX_LINE_LEN`] bytes. Byte-for-byte
+/// identical algorithm to `j-repl::read_bounded_line` (see that function's
+/// own extensive doc comment for the full rationale of every design
+/// decision here — the byte-oriented multibyte-boundary handling, the
+/// "oversized decided by all three conditions" rule, and the
+/// fully-drain-the-oversized-line loop) — this repl's own line-reading
+/// concern is identical to J's/APL's; only the *bracket-balance* scanner
+/// below is genuinely new to Q.
+fn read_bounded_line<R: BufRead>(reader: &mut R) -> std::io::Result<Option<Result<String, ()>>> {
+    let mut buf: Vec<u8> = Vec::new();
+    let mut limited: std::io::Take<&mut R> = std::io::Read::take(&mut *reader, MAX_LINE_LEN);
+    let read = limited.read_until(b'\n', &mut buf)?;
+    if read == 0 {
+        return Ok(None);
+    }
+    let hit_cap = buf.len() as u64 == MAX_LINE_LEN && buf.last() != Some(&b'\n');
+    if hit_cap {
+        let mut saw_more_data = false;
+        loop {
+            let mut chunk: Vec<u8> = Vec::new();
+            let mut limited: std::io::Take<&mut R> = std::io::Read::take(&mut *reader, MAX_LINE_LEN);
+            let n = limited.read_until(b'\n', &mut chunk)?;
+            if n == 0 {
+                if !saw_more_data {
+                    return match String::from_utf8(buf) {
+                        Ok(line) => Ok(Some(Ok(line))),
+                        Err(e) => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+                    };
+                }
+                break;
+            }
+            saw_more_data = true;
+            if chunk.last() == Some(&b'\n') {
+                break;
+            }
+        }
+        return Ok(Some(Err(())));
+    }
+    match String::from_utf8(buf) {
+        Ok(line) => Ok(Some(Ok(line))),
+        Err(e) => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+    }
+}
+
+/// Whether `src` (the accumulated continuation buffer) still has an
+/// unbalanced `(`, `{`, or `[` -- i.e. whether the REPL should keep reading
+/// more physical lines before handing `src` to the interpreter.
+///
+/// Tokenizes `src` with the *real* Q lexer (see this module's own top doc
+/// comment for why: comment-awareness comes for free this way, with no
+/// risk of a stray bracket character *inside* a comment fooling a naive
+/// character scan) and counts three *independent* running depths — a
+/// bracket type is "still open" only by its *own* count, so `{)` (a brace
+/// opened, then a paren closed with no matching open) correctly stays
+/// "incomplete" on the strength of the still-unbalanced brace, rather than
+/// two mismatched counts happening to cancel out in a combined tally.
+///
+/// If tokenizing `src` itself fails (a genuinely unrecognized character —
+/// the only way `try_tokenize_q` can fail, since this cut's lexer has no
+/// literal type that could be "unterminated" on partial input, MA11 §4),
+/// this returns `false` (not incomplete) rather than looping forever: the
+/// real lex error will surface cleanly through [`Interpreter::feed`]'s own
+/// `Result` once this buffer is hu to evaluation, exactly like any other
+/// runtime error this REPL already displays without crashing.
+///
+/// # Verified by hand-tracing exactly the scenario this module's doc
+/// comment describes (not just asserted)
+///
+/// - `{[x;y]` alone: tokenizes to `LBRACE LBRACKET NAME SEMICOLON NAME
+///   RBRACKET` -- braces=1, brackets=0 (opened then closed) -- still
+///   "incomplete" (`braces > 0`), correctly waiting for the rest of the
+///   body and the closing `}`.
+/// - Continuing with ` x+y}`: the *combined*, space-joined buffer
+///   `{[x;y] x+y}` now tokenizes with braces returning to 0 -- no longer
+///   incomplete, handed off to the interpreter as one complete statement.
+/// - A complete one-line statement, e.g. `2+2`, has no bracket tokens at
+///   all -- all three counters stay `0` -- never spuriously waits.
+/// - `(1+2` (open paren, J's/APL's own classic case): `parens = 1`,
+///   `braces = 0`, `brackets = 0` -- incomplete on the strength of `parens`
+///   alone, exactly like `j-repl`'s own scanner.
+/// - `{)`  (mismatched: a brace opened, then a *paren* closed with nothing
+///   open): `braces = 1` (LBRACE, never decremented -- the RPAREN only
+///   touches the `parens` counter, whose own decrement is clamped at 0 by
+///   `.max(0)` since no LPAREN preceded it) -- correctly still
+///   "incomplete", unlike a single combined depth counter, which would
+///   have let the mismatched close cancel the open out to `0` and stopped
+///   waiting prematurely.
+fn is_incomplete(src: &str) -> bool {
+    let tokens = match coding_adventures_q_lexer::try_tokenize_q(src) {
+        Ok(tokens) => tokens,
+        Err(_) => return false,
+    };
+    let mut parens = 0i32;
+    let mut braces = 0i32;
+    let mut brackets = 0i32;
+    for t in &tokens {
+        match t.effective_type_name() {
+            "LPAREN" => parens += 1,
+            "RPAREN" => parens = (parens - 1).max(0),
+            "LBRACE" => braces += 1,
+            "RBRACE" => braces = (braces - 1).max(0),
+            "LBRACKET" => brackets += 1,
+            "RBRACKET" => brackets = (brackets - 1).max(0),
+            _ => {}
+        }
+    }
+    parens > 0 || braces > 0 || brackets > 0
+}
+
+/// A persistent interactive Q session.
+pub struct QRepl {
+    interp: Interpreter,
+    buffer: String,
+}
+
+impl Default for QRepl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl QRepl {
+    pub fn new() -> Self {
+        QRepl {
+            interp: Interpreter::new(),
+            buffer: String::new(),
+        }
+    }
+
+    /// `>> ` for a fresh statement, `... ` while continuing an incomplete
+    /// one (an open `(`/`{`/`[`).
+    pub fn prompt(&self) -> &'static str {
+        if self.buffer.is_empty() {
+            ">> "
+        } else {
+            "... "
+        }
+    }
+
+    /// Feed one physical input line (without its trailing newline).
+    ///
+    /// # The buffer-size-cap ordering (checked BEFORE appending, not after)
+    ///
+    /// This repo already paid down the "push-before-size-check" bug class
+    /// once, across every sibling REPL (task #80, PRs already merged) — the
+    /// continuation buffer's own cap must be checked *before* the new line
+    /// is appended, or the cap can still be exceeded by up to one whole
+    /// line's worth of bytes (the ordering `j-repl::JRepl::feed` already
+    /// fixed, and mirrored here verbatim: compute `separator_len` first,
+    /// check the *prospective* total size, and only `push_str` after that
+    /// check passes).
+    pub fn feed(&mut self, line: &str) -> ReplResponse {
+        if self.buffer.is_empty() {
+            match line.trim() {
+                "quit" | "exit" | "quit()" | "exit()" => return ReplResponse::Quit,
+                _ => {}
+            }
+        }
+
+        // Bound the accumulation buffer BEFORE growing it -- see this
+        // method's own doc comment. `separator_len` accounts for the
+        // joining space this method adds below when the buffer already
+        // holds a still-open continuation.
+        let separator_len = if self.buffer.is_empty() { 0 } else { 1 };
+        if self
+            .buffer
+            .len()
+            .saturating_add(separator_len)
+            .saturating_add(line.len())
+            > MAX_CONTINUATION_BUFFER
+        {
+            self.buffer.clear();
+            return ReplResponse::Output(format!(
+                "Error: statement exceeds the {MAX_CONTINUATION_BUFFER}-byte continuation limit; discarded\n"
+            ));
+        }
+
+        if separator_len == 0 {
+            self.buffer.push_str(line);
+        } else {
+            // Joining with a single space (not a real '\n') keeps a still-
+            // open `{...}`/`(...)`/`[...]` on one logical line -- Q's own
+            // NEWLINE token is significant between top-level statements
+            // (`q.grammar`'s `line = statement NEWLINE | statement |
+            // NEWLINE`), and injecting one *inside* a still-open bracket
+            // would hand the parser a genuinely broken program, exactly
+            // mirroring `j-repl`'s identical rationale for its own simpler
+            // (paren-only) case.
+            self.buffer.push(' ');
+            self.buffer.push_str(line);
+        }
+
+        if is_incomplete(&self.buffer) {
+            return ReplResponse::NeedMore;
+        }
+
+        let src = std::mem::take(&mut self.buffer);
+        if src.trim().is_empty() {
+            return ReplResponse::Output(String::new());
+        }
+        match self.interp.feed(&format!("{src}\n")) {
+            Ok(text) => ReplResponse::Output(text),
+            Err(e) => ReplResponse::Output(format!("Error: {e}\n")),
+        }
+    }
+
+    pub fn is_continuing(&self) -> bool {
+        !self.buffer.is_empty()
+    }
+}
+
+/// Drive a full interactive Q session over the given reader and writer.
+pub fn run<R: BufRead, W: Write>(mut reader: R, mut writer: W) -> std::io::Result<()> {
+    let mut repl = QRepl::new();
+    writeln!(writer, "Q (on array-runtime) — type quit to exit.")?;
+
+    loop {
+        write!(writer, "{}", repl.prompt())?;
+        writer.flush()?;
+
+        let line = match read_bounded_line(&mut reader)? {
+            None => {
+                writeln!(writer)?;
+                break;
+            }
+            Some(Err(())) => {
+                writeln!(
+                    writer,
+                    "Error: line exceeds the {MAX_LINE_LEN}-byte limit; discarded"
+                )?;
+                writer.flush()?;
+                continue;
+            }
+            Some(Ok(line)) => line,
+        };
+        let line = line.strip_suffix('\n').unwrap_or(&line);
+        let line = line.strip_suffix('\r').unwrap_or(line);
+
+        match repl.feed(line) {
+            ReplResponse::Output(text) => {
+                write!(writer, "{text}")?;
+                writer.flush()?;
+            }
+            ReplResponse::NeedMore => {}
+            ReplResponse::Quit => break,
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_expression_prints_assignment_is_silent() {
+        let mut r = QRepl::new();
+        assert!(matches!(r.feed("2+2"), ReplResponse::Output(t) if t.trim() == "4"));
+        assert_eq!(r.feed("a:5"), ReplResponse::Output(String::new()));
+    }
+
+    // ── The genuinely new concern: brace/bracket continuation ─────────────
+
+    #[test]
+    fn continues_across_an_open_paren_exactly_like_j_repl() {
+        let mut r = QRepl::new();
+        assert_eq!(r.feed("(1+2"), ReplResponse::NeedMore);
+        assert!(r.is_continuing());
+        assert!(matches!(r.feed("+3)"), ReplResponse::Output(t) if t.trim() == "6"));
+        assert!(!r.is_continuing());
+    }
+
+    #[test]
+    fn continues_across_a_multi_line_function_literal_body() {
+        // The scenario this crate's own module doc comment hand-traces:
+        // `{[x;y]` on one line, ` x+y}` on the next -- a genuinely new
+        // continuation shape with no J/APL precedent (neither has a
+        // user-defined block construct at all).
+        let mut r = QRepl::new();
+        assert_eq!(r.feed("f:{[x;y]"), ReplResponse::NeedMore);
+        assert!(r.is_continuing());
+        assert_eq!(r.feed(" x+y}"), ReplResponse::Output(String::new()));
+        assert!(!r.is_continuing());
+        // Confirm the function was actually captured correctly (not just
+        // that the scanner stopped waiting) by calling it in a follow-up
+        // line.
+        assert!(matches!(r.feed("2 f 3"), ReplResponse::Output(t) if t.trim() == "5"));
+    }
+
+    #[test]
+    fn continues_across_a_split_bracketed_parameter_list() {
+        // The optional parameter list's own `[`/`]` -- a real, if unusual,
+        // way to split a line, and the reason this scanner needs bracket
+        // balance too, not just brace balance.
+        let mut r = QRepl::new();
+        assert_eq!(r.feed("f:{[x;"), ReplResponse::NeedMore);
+        assert_eq!(r.feed("y] x*y}"), ReplResponse::Output(String::new()));
+        assert!(matches!(r.feed("2 f 3"), ReplResponse::Output(t) if t.trim() == "6"));
+    }
+
+    #[test]
+    fn a_complete_one_line_statement_never_spuriously_waits() {
+        let mut r = QRepl::new();
+        // Every kind of complete-on-one-line statement this language has:
+        // a function literal fully closed, a list literal fully closed,
+        // and plain grouping fully closed.
+        assert!(matches!(r.feed("f:{x+y}"), ReplResponse::Output(t) if t.is_empty()));
+        assert!(matches!(r.feed("(1;2;3)"), ReplResponse::Output(_)));
+        assert!(matches!(r.feed("(1+2)*3"), ReplResponse::Output(t) if t.trim() == "9"));
+    }
+
+    #[test]
+    fn a_stray_bracket_character_inside_a_comment_does_not_fool_the_scanner() {
+        // The real risk a naive character-level scan would have: `/` opens
+        // a Q comment (MA11 §3 bullet 2), and the comment text below
+        // contains an unbalanced `(` that must NOT be counted, since
+        // `q-lexer`'s own pre-tokenize hook already blanks it out before
+        // this scanner ever sees a token for it.
+        let mut r = QRepl::new();
+        match r.feed("1+1 / a stray ( in a comment") {
+            ReplResponse::Output(t) => assert_eq!(t.trim(), "2"),
+            other => panic!("expected an immediate result, not NeedMore -- got {other:?}"),
+        }
+        assert!(!r.is_continuing());
+    }
+
+    #[test]
+    fn mismatched_bracket_types_stay_incomplete_on_their_own_open_count() {
+        // `{)`-shaped input: a brace opened, then a paren "closed" with
+        // nothing open -- must stay incomplete on the strength of the
+        // still-open BRACE, not have the mismatched close cancel it out
+        // (see `is_incomplete`'s own doc comment for the full rationale).
+        assert!(is_incomplete("{)"));
+    }
+
+    #[test]
+    fn an_unbounded_continuation_is_discarded_not_grown_forever() {
+        let mut r = QRepl::new();
+        assert_eq!(r.feed("(1"), ReplResponse::NeedMore);
+        let filler = "+1".repeat(MAX_CONTINUATION_BUFFER / 2 + 10);
+        match r.feed(&filler) {
+            ReplResponse::Output(t) => assert!(t.contains("Error")),
+            other => panic!("expected an Error output once the cap is exceeded, got {other:?}"),
+        }
+        assert!(!r.is_continuing());
+        assert!(matches!(r.feed("1+1"), ReplResponse::Output(t) if t.trim() == "2"));
+    }
+
+    #[test]
+    fn buffer_cap_is_checked_before_appending_not_after() {
+        // A direct regression test for the exact bug class this repo
+        // already paid down once (task #80): feed a single line whose
+        // length ALONE already exceeds the cap (never mind any
+        // accumulation) -- if the size check ran AFTER appending, this
+        // single `push_str` would already have grown `buffer` past the
+        // cap before the check ever fired, but the cap would still
+        // (eventually) catch it on a LATER call once the accumulated
+        // total was inspected again; checking BEFORE means it is caught
+        // on THIS very call, with the buffer never having held the
+        // oversized content at all. We confirm the stronger property: the
+        // buffer is fully cleared and empty immediately after this single
+        // call, not left holding a too-large-but-not-yet-noticed value.
+        let mut r = QRepl::new();
+        let _ = r.feed("(");
+        let oversized = "+1".repeat(MAX_CONTINUATION_BUFFER);
+        let response = r.feed(&oversized);
+        assert!(matches!(response, ReplResponse::Output(t) if t.contains("Error")));
+        assert!(!r.is_continuing(), "buffer must be cleared, not left oversized");
+    }
+
+    #[test]
+    fn quit_commands() {
+        assert_eq!(QRepl::new().feed("quit"), ReplResponse::Quit);
+        assert_eq!(QRepl::new().feed("exit"), ReplResponse::Quit);
+    }
+
+    #[test]
+    fn errors_are_shown_not_fatal() {
+        let mut r = QRepl::new();
+        assert!(matches!(r.feed("undefined_var"), ReplResponse::Output(t) if t.contains("Error")));
+        assert!(matches!(r.feed("1+1"), ReplResponse::Output(t) if t.trim() == "2"));
+    }
+
+    #[test]
+    fn session_persists_across_lines() {
+        let mut r = QRepl::new();
+        r.feed("a:10");
+        assert!(matches!(r.feed("a+5"), ReplResponse::Output(t) if t.trim() == "15"));
+    }
+
+    #[test]
+    fn zero_based_til_survives_a_real_repl_session() {
+        let mut r = QRepl::new();
+        assert!(matches!(r.feed("!5"), ReplResponse::Output(t) if t.trim() == "0 1 2 3 4"));
+    }
+
+    #[test]
+    fn run_drives_a_session_to_eof() {
+        let input = "a:3\na*2\nquit\n".as_bytes();
+        let mut output = Vec::new();
+        run(input, &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(text.contains('6'));
+    }
+
+    #[test]
+    fn run_handles_a_multi_line_function_literal_end_to_end() {
+        let input = "f:{[x;y]\n x+y}\n2 f 3\nquit\n".as_bytes();
+        let mut output = Vec::new();
+        run(input, &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(text.contains('5'), "expected 2 f 3 == 5 in output, got: {text}");
+    }
+
+    #[test]
+    fn read_bounded_line_returns_a_final_line_without_a_trailing_newline() {
+        let mut input = "quit".as_bytes();
+        assert_eq!(
+            read_bounded_line(&mut input).unwrap(),
+            Some(Ok("quit".to_string()))
+        );
+        assert_eq!(read_bounded_line(&mut input).unwrap(), None);
+    }
+
+    #[test]
+    fn run_quits_cleanly_on_a_final_line_without_a_trailing_newline() {
+        let input = "quit".as_bytes();
+        let mut output = Vec::new();
+        run(input, &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(!text.contains("exceeds"));
+    }
+
+    #[test]
+    fn read_bounded_line_rejects_a_line_exceeding_the_cap_without_buffering_it_whole() {
+        let oversized = "+".repeat(MAX_LINE_LEN as usize * 3);
+        let mut input = oversized.as_bytes();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Err(())));
+        let _ = read_bounded_line(&mut input);
+    }
+
+    #[test]
+    fn run_reports_an_oversized_line_cleanly_and_keeps_the_session_alive() {
+        let oversized = "+".repeat(MAX_LINE_LEN as usize * 2);
+        let input = format!("{oversized}\n1+1\nquit\n");
+        let mut output = Vec::new();
+        run(input.as_bytes(), &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(text.contains("exceeds"), "expected an oversized-line error, got: {text}");
+        assert!(text.contains('2'), "session must keep working after an oversized line, got: {text}");
+    }
+}

--- a/code/packages/rust/q-repl/src/lib.rs
+++ b/code/packages/rust/q-repl/src/lib.rs
@@ -29,8 +29,8 @@
 //! even though splitting a parameter list across a line break would be
 //! unusual style. This module does **not** just copy `j-repl`'s scanner
 //! verbatim and assume it is sufficient — see [`QRepl::feed`]'s and
-//! [`line_bracket_delta`]'s own doc comments for the verification this
-//! claim rests on.
+//! [`apply_line_bracket_tokens`]'s own doc comments for the verification
+//! this claim rests on.
 //!
 //! ## Delegating to the real Q lexer, not a hand-rolled character scan
 //!
@@ -91,13 +91,20 @@
 //! is O(n²) in the number of lines. [`QRepl`] instead tracks **running**
 //! `(parens, braces, brackets)` counts as instance state and, on each
 //! `feed()` call, tokenizes only the *newly appended* (comment-blanked)
-//! line fragment, folding its own delta into the running totals — O(line
+//! line fragment, applying that fragment's own tokens to the running
+//! counts **one token at a time** ([`apply_line_bracket_tokens`]), clamping
+//! each counter at 0 immediately after every token that touches it — O(line
 //! length) per call, O(buffer length) total across an entire continuation,
 //! not O(buffer length²). This is sound because no token in this cut's
 //! grammar can span a line-fragment boundary (no multi-line string/number
-//! literal, MA11 §4) — tokenizing one fragment at a time and summing
-//! deltas gives the identical bracket counts whole-buffer tokenization
-//! would have, every time.
+//! literal, MA11 §4) — tokenizing one fragment at a time and replaying its
+//! tokens against the *persisted* running state gives the identical bracket
+//! counts whole-buffer tokenization would have, every time. **Critically,
+//! this must clamp per token against the persisted state, not compute an
+//! independent net delta for the whole fragment and clamp once** — see
+//! `apply_line_bracket_tokens`'s own doc comment for a concrete case where
+//! the two diverge (a security-review finding from an earlier version of
+//! this function that computed net deltas).
 //!
 //! Tokenizing a syntactically incomplete-but-not-yet-closed fragment is
 //! always safe here: Q's lexer has no notion of an "unterminated" token
@@ -244,38 +251,72 @@ fn blank_line_comment(line: &str) -> String {
     out
 }
 
-/// The net change in open-`(`/open-`{`/open-`[` counts contributed by one
-/// already-comment-blanked line fragment, as `(parens, braces, brackets)`
-/// deltas (each may be negative, e.g. a continuation line that is just a
-/// closing `)`) — the incremental building block [`QRepl::feed`] folds
-/// into its own running totals on every call, replacing whole-buffer
-/// re-tokenization (see this module's own top doc comment, "Incremental,
-/// not whole-buffer, bracket counting").
+/// Apply one already-comment-blanked line fragment's own bracket tokens to
+/// the running `(*parens, *braces, *brackets)` counts **one token at a
+/// time**, clamping each counter at 0 immediately after every single token
+/// that touches it — exactly mirroring the original whole-buffer
+/// algorithm's own per-token clamp (`(count - 1).max(0)` applied at each
+/// closing bracket as it is encountered), just replayed over one fragment
+/// at a time instead of the whole buffer from position 0.
 ///
-/// `Ok(None)` means tokenizing `line` itself failed (a genuinely
+/// # Why this must clamp per token, not compute one net delta and clamp once
+///
+/// An earlier version of this function computed a single **net** delta for
+/// the whole line (summing every token's +1/-1 contribution) and let the
+/// caller clamp the *running total* only once, after folding that delta
+/// in. That diverges from the original whole-buffer algorithm whenever a
+/// line's own tokens dip a counter below zero **mid-line** before a later,
+/// genuinely-unmatched open of the same type: an excess close must be
+/// "forgiven" (clamped to 0) at the exact point it occurs, so it can never
+/// later be arithmetically cancelled out by a subsequent open within the
+/// same line. Concretely, `")("` as a lone first line: per-token clamping
+/// gives `RPAREN` -> clamped to 0, then `LPAREN` -> 1 (still incomplete,
+/// matching the original algorithm); a net-delta-then-clamp-once approach
+/// computes `-1 + 1 = 0` and reports "complete" instead — silently wrong.
+/// (Found and confirmed by a second security-review round; see this
+/// module's own regression tests for both this single-line case and a
+/// realistic multi-line sequence with the identical shape.)
+///
+/// This per-token-clamped walk over just the new fragment is mathematically
+/// identical to replaying the *entire* whole-buffer algorithm from
+/// scratch: a per-token-clamped walk's end state is fully determined by its
+/// starting value and its remaining tokens, regardless of whether that
+/// starting value came from replaying from 0 or from resuming a prior
+/// clamped walk that already processed everything before it — which is
+/// exactly what makes tokenizing only the new fragment (not the whole
+/// buffer) a sound, O(line length) replacement for O(buffer length)
+/// whole-buffer re-tokenization on every call.
+///
+/// Returns `false` if tokenizing `line` itself failed (a genuinely
 /// unrecognized character — the only way `try_tokenize_q` can fail, since
 /// this cut's lexer has no literal type that could be "unterminated" on
-/// partial input, MA11 §4); the caller treats this the same way the
-/// previous whole-buffer version did — proceed to evaluation immediately
-/// rather than waiting forever, letting the real lex/parse error surface
-/// through [`Interpreter::feed`]'s own `Result`.
-fn line_bracket_delta(line: &str) -> Option<(i32, i32, i32)> {
-    let tokens = coding_adventures_q_lexer::try_tokenize_q(line).ok()?;
-    let mut parens = 0i32;
-    let mut braces = 0i32;
-    let mut brackets = 0i32;
+/// partial input, MA11 §4) **without touching any of the three counters**;
+/// the caller treats this the same way the original whole-buffer version
+/// did — proceed to evaluation immediately rather than waiting forever,
+/// letting the real lex/parse error surface through [`Interpreter::feed`]'s
+/// own `Result`.
+fn apply_line_bracket_tokens(
+    line: &str,
+    parens: &mut i32,
+    braces: &mut i32,
+    brackets: &mut i32,
+) -> bool {
+    let tokens = match coding_adventures_q_lexer::try_tokenize_q(line) {
+        Ok(tokens) => tokens,
+        Err(_) => return false,
+    };
     for t in &tokens {
         match t.effective_type_name() {
-            "LPAREN" => parens += 1,
-            "RPAREN" => parens -= 1,
-            "LBRACE" => braces += 1,
-            "RBRACE" => braces -= 1,
-            "LBRACKET" => brackets += 1,
-            "RBRACKET" => brackets -= 1,
+            "LPAREN" => *parens += 1,
+            "RPAREN" => *parens = (*parens - 1).max(0),
+            "LBRACE" => *braces += 1,
+            "RBRACE" => *braces = (*braces - 1).max(0),
+            "LBRACKET" => *brackets += 1,
+            "RBRACKET" => *brackets = (*brackets - 1).max(0),
             _ => {}
         }
     }
-    Some((parens, braces, brackets))
+    true
 }
 
 /// A persistent interactive Q session.
@@ -342,7 +383,24 @@ impl QRepl {
     /// construction) keeps the incremental bracket count correct. Blanking
     /// only replaces characters with spaces (same length), so the size
     /// check's byte-count math is unaffected either way.
+    ///
+    /// # Precondition: `line` is a single physical line (no embedded `'\n'`)
+    ///
+    /// [`blank_line_comment`]'s own soundness (see its doc comment) relies
+    /// on `line` never containing an embedded `'\n'` — true by construction
+    /// at this crate's own sole call site ([`run`], which always strips a
+    /// physical line's own trailing newline before calling `feed`), but
+    /// `feed`/`QRepl` are public API: a future direct caller passing a
+    /// string with an embedded `'\n'` would silently reintroduce a scoped
+    /// version of the exact comment-swallowing bug this module's own
+    /// `CHANGELOG.md` documents. Asserted here (debug-only, zero release
+    /// cost) so a violation fails loudly in tests/debug builds rather than
+    /// silently misbehaving.
     pub fn feed(&mut self, line: &str) -> ReplResponse {
+        debug_assert!(
+            !line.contains('\n'),
+            "QRepl::feed expects a single physical line without an embedded newline"
+        );
         if self.buffer.is_empty() {
             match line.trim() {
                 "quit" | "exit" | "quit()" | "exit()" => return ReplResponse::Quit,
@@ -388,23 +446,26 @@ impl QRepl {
             self.buffer.push_str(&line);
         }
 
-        // Incremental bracket-delta update (see this module's own top doc
-        // comment, "Incremental, not whole-buffer, bracket counting") --
-        // tokenizes only the just-appended (already comment-blanked) line,
-        // not the whole accumulated buffer. A tokenize failure on this one
-        // fragment forces an immediate attempt at evaluation (matching the
-        // previous whole-buffer version's identical "don't wait forever on
-        // a genuinely bad character" behavior), regardless of the running
+        // Incremental, per-token-clamped bracket update (see this module's
+        // own top doc comment, "Incremental, not whole-buffer, bracket
+        // counting", and `apply_line_bracket_tokens`'s own doc comment for
+        // exactly why this must clamp per token against the PERSISTED
+        // running state, not compute an independent net delta for the
+        // whole line and clamp once) -- tokenizes only the just-appended
+        // (already comment-blanked) line, not the whole accumulated
+        // buffer. A tokenize failure on this one fragment forces an
+        // immediate attempt at evaluation (matching the previous
+        // whole-buffer version's identical "don't wait forever on a
+        // genuinely bad character" behavior), regardless of the running
         // counts.
-        let still_incomplete = match line_bracket_delta(&line) {
-            Some((dp, db, dk)) => {
-                self.open_parens = (self.open_parens + dp).max(0);
-                self.open_braces = (self.open_braces + db).max(0);
-                self.open_brackets = (self.open_brackets + dk).max(0);
-                self.open_parens > 0 || self.open_braces > 0 || self.open_brackets > 0
-            }
-            None => false,
-        };
+        let tokenized_ok = apply_line_bracket_tokens(
+            &line,
+            &mut self.open_parens,
+            &mut self.open_braces,
+            &mut self.open_brackets,
+        );
+        let still_incomplete = tokenized_ok
+            && (self.open_parens > 0 || self.open_braces > 0 || self.open_brackets > 0);
         if still_incomplete {
             return ReplResponse::NeedMore;
         }
@@ -655,13 +716,56 @@ mod tests {
         // `{)`-shaped input: a brace opened, then a paren "closed" with
         // nothing open -- must stay incomplete on the strength of the
         // still-open BRACE, not have the mismatched close cancel it out
-        // (see `line_bracket_delta`'s own doc comment for the full
-        // rationale).
-        let (parens, braces, brackets) = line_bracket_delta("{)").unwrap();
-        assert_eq!((parens, braces, brackets), (-1, 1, 0));
+        // (see `apply_line_bracket_tokens`'s own doc comment for the full
+        // rationale). The stray RPAREN clamps `parens` to 0 immediately
+        // (not -1) -- it is "forgiven", not carried as a negative value.
+        let (mut parens, mut braces, mut brackets) = (0i32, 0i32, 0i32);
+        assert!(apply_line_bracket_tokens("{)", &mut parens, &mut braces, &mut brackets));
+        assert_eq!((parens, braces, brackets), (0, 1, 0));
 
         let mut r = QRepl::new();
         assert_eq!(r.feed("{)"), ReplResponse::NeedMore);
+    }
+
+    /// Security-review round 2 regression: the simplest counterexample
+    /// where clamping a whole-line NET delta once (an earlier, incorrect
+    /// version of `apply_line_bracket_tokens`) diverges from clamping PER
+    /// TOKEN as the original whole-buffer algorithm did. `")("` as a lone
+    /// first line: per-token clamping gives `RPAREN` -> forgiven (clamped
+    /// to 0), then `LPAREN` -> 1 (still incomplete); a net-delta approach
+    /// computes `-1 + 1 = 0` and would (wrongly) report "complete".
+    #[test]
+    fn a_line_with_more_closes_than_opens_forgives_the_excess_rather_than_cancelling_a_later_open() {
+        let (mut parens, mut braces, mut brackets) = (0i32, 0i32, 0i32);
+        assert!(apply_line_bracket_tokens(")(", &mut parens, &mut braces, &mut brackets));
+        assert_eq!((parens, braces, brackets), (1, 0, 0));
+
+        let mut r = QRepl::new();
+        assert_eq!(r.feed(")("), ReplResponse::NeedMore);
+    }
+
+    /// The same counterexample, at the full `QRepl` session level with a
+    /// realistic multi-line shape: `feed("(1")`, `feed("))+((2")`,
+    /// `feed(")")`. One real `(` from the first line remains unmatched
+    /// throughout (the middle line's first close matches it, its second
+    /// close is forgiven, then it opens two MORE parens; the final line's
+    /// lone close only accounts for one of those two). A net-delta-per-line
+    /// approach would let the middle line's own `-2 + 2 = 0` net delta
+    /// erase all memory that one of its closes was already spurious,
+    /// making the final `")"` look (wrongly) like it completes the
+    /// statement one line early.
+    #[test]
+    fn a_realistic_multi_line_sequence_with_excess_closes_still_waits_for_the_real_unmatched_open() {
+        let mut r = QRepl::new();
+        assert_eq!(r.feed("(1"), ReplResponse::NeedMore);
+        assert_eq!(r.feed("))+((2"), ReplResponse::NeedMore);
+        assert_eq!(
+            r.feed(")"),
+            ReplResponse::NeedMore,
+            "one real unmatched '(' remains open from the very first line -- \
+             must still wait for '... ', not prematurely declare the statement complete"
+        );
+        assert!(r.is_continuing());
     }
 
     #[test]

--- a/code/packages/rust/q-repl/src/lib.rs
+++ b/code/packages/rust/q-repl/src/lib.rs
@@ -28,8 +28,9 @@
 //! itself bracketed (`{[x;y] ...}`), **bracket** balance (`[`/`]`) too,
 //! even though splitting a parameter list across a line break would be
 //! unusual style. This module does **not** just copy `j-repl`'s scanner
-//! verbatim and assume it is sufficient — see [`is_incomplete`]'s own doc
-//! comment for the verification this claim rests on.
+//! verbatim and assume it is sufficient — see [`QRepl::feed`]'s and
+//! [`line_bracket_delta`]'s own doc comments for the verification this
+//! claim rests on.
 //!
 //! ## Delegating to the real Q lexer, not a hand-rolled character scan
 //!
@@ -41,22 +42,71 @@
 //! A naive character-level scan of the raw buffer would be fooled by that
 //! stray `(` inside the comment and wait forever for a `)` that will never
 //! come. Rather than re-deriving `q-lexer`'s own whitespace-sensitive
-//! comment-stripping rule a second time by hand here (which this repo's
-//! "no hand-written lexers" discipline warns against duplicating), this
-//! scanner tokenizes the accumulated buffer with the *real*
-//! `coding_adventures_q_lexer::try_tokenize_q` (which already strips
+//! comment-stripping rule a second time by hand here for *tokenizing*
+//! purposes (which this repo's "no hand-written lexers" discipline warns
+//! against duplicating), this scanner tokenizes each physical line with the
+//! *real* `coding_adventures_q_lexer::try_tokenize_q` (which already strips
 //! comments via its own pre-tokenize hook) and counts only genuine
 //! `LPAREN`/`RPAREN`/`LBRACE`/`RBRACE`/`LBRACKET`/`RBRACKET` *tokens* — a
 //! bracket character sitting inside a comment is never even tokenized as
-//! one, so it can never be miscounted. Tokenizing a syntactically
-//! incomplete-but-not-yet-closed buffer is always safe here: Q's lexer has
-//! no notion of an "unterminated" token that could fail on partial input
-//! (no multi-line string/char literal in this cut's alphabet at all,
-//! MA11 §4), so a `try_tokenize_q` failure here can only mean a genuinely
-//! unrecognized character — in that case this scanner reports "not
-//! incomplete" (falls through to evaluation) so the *real* lex/parse error
-//! surfaces through [`Interpreter::feed`]'s own `Result`, rather than
-//! silently waiting for more input forever.
+//! one, so it can never be miscounted.
+//!
+//! ## Why comments must be pre-blanked *per physical line*, before the join
+//! (not just accounted for when checking completeness)
+//!
+//! An earlier version of this scanner tokenized the *whole accumulated,
+//! space-joined* `self.buffer` on every call. That has a real bug: `/`
+//! blanks from itself through the next **real** `'\n'` or end of input, but
+//! this REPL joins continuation lines with a single **space** (never a
+//! real `'\n'`, see [`QRepl::feed`]'s own doc comment for why) — so a
+//! comment opened on one physical line, once joined into the single-line
+//! buffer, has no real `'\n'` left to stop at and silently blanks *every
+//! subsequent physical line* too, including whatever closing bracket was
+//! supposed to complete the statement. The session would then wait for
+//! more input forever (the "closing" text was erased before it could be
+//! counted), and — just as badly — even if completeness were somehow
+//! detected some other way, hand raw `self.buffer` to [`Interpreter::feed`]
+//! and the identical problem recurs there: tokenizing the whole
+//! (still-comment-bearing, still-`'\n'`-free) buffer at evaluation time
+//! would blank the exact same "rest of the statement" a second time.
+//!
+//! The fix ([`blank_line_comment`]) blanks each physical line's own
+//! trailing comment (if any) to spaces **before** it is ever appended to
+//! `self.buffer` or tokenized for bracket-counting — both problems have the
+//! same root cause (a comment's real extent is only known one physical
+//! line at a time, before the lossy space-join), so both are fixed by the
+//! same per-line pre-processing step, not two separate patches. This is a
+//! narrow, deliberate, *documented* duplication of `q-lexer`'s comment rule
+//! (that crate's own `strip_slash_comments` is private and built for a
+//! whole, possibly-multi-line source, not a single line) — see
+//! `blank_line_comment`'s own doc comment for why this narrower scope
+//! makes the duplication sound rather than a maintenance hazard.
+//!
+//! ## Incremental, not whole-buffer, bracket counting (avoiding O(n²) cost)
+//!
+//! Tokenizing the *entire* accumulated buffer from scratch on every single
+//! physical line fed (the earlier version's approach) costs O(buffer
+//! length) per call; summed over a continuation that grows to the full
+//! `MAX_CONTINUATION_BUFFER` one short line at a time, the cumulative cost
+//! is O(n²) in the number of lines. [`QRepl`] instead tracks **running**
+//! `(parens, braces, brackets)` counts as instance state and, on each
+//! `feed()` call, tokenizes only the *newly appended* (comment-blanked)
+//! line fragment, folding its own delta into the running totals — O(line
+//! length) per call, O(buffer length) total across an entire continuation,
+//! not O(buffer length²). This is sound because no token in this cut's
+//! grammar can span a line-fragment boundary (no multi-line string/number
+//! literal, MA11 §4) — tokenizing one fragment at a time and summing
+//! deltas gives the identical bracket counts whole-buffer tokenization
+//! would have, every time.
+//!
+//! Tokenizing a syntactically incomplete-but-not-yet-closed fragment is
+//! always safe here: Q's lexer has no notion of an "unterminated" token
+//! that could fail on partial input (no multi-line string/char literal in
+//! this cut's alphabet at all, MA11 §4), so a `try_tokenize_q` failure here
+//! can only mean a genuinely unrecognized character — in that case this
+//! scanner reports "not incomplete" (falls through to evaluation) so the
+//! *real* lex/parse error surfaces through [`Interpreter::feed`]'s own
+//! `Result`, rather than silently waiting for more input forever.
 //!
 //! Hand-rolled rather than built on the generic `repl` crate, mirroring
 //! `j-repl`'s own rationale: the interpreter is single-threaded, and a
@@ -136,75 +186,110 @@ fn read_bounded_line<R: BufRead>(reader: &mut R) -> std::io::Result<Option<Resul
     }
 }
 
-/// Whether `src` (the accumulated continuation buffer) still has an
-/// unbalanced `(`, `{`, or `[` -- i.e. whether the REPL should keep reading
-/// more physical lines before handing `src` to the interpreter.
+/// Blank out a `/`-to-end-of-line comment on a **single physical line**
+/// (never containing an embedded `'\n'` — every line reaching [`QRepl::feed`]
+/// has already had its own trailing newline stripped by [`run`]'s caller
+/// logic before `feed` ever sees it).
 ///
-/// Tokenizes `src` with the *real* Q lexer (see this module's own top doc
-/// comment for why: comment-awareness comes for free this way, with no
-/// risk of a stray bracket character *inside* a comment fooling a naive
-/// character scan) and counts three *independent* running depths — a
-/// bracket type is "still open" only by its *own* count, so `{)` (a brace
-/// opened, then a paren closed with no matching open) correctly stays
-/// "incomplete" on the strength of the still-unbalanced brace, rather than
-/// two mismatched counts happening to cancel out in a combined tally.
+/// Mirrors `q-lexer`'s own (private) `strip_slash_comments` pre-tokenize
+/// hook exactly (MA11 §3 bullet 2's rule: a `/` preceded by whitespace, or
+/// at the very start of the line, opens a comment that runs to the next
+/// real `'\n'` or end of input) — necessarily re-derived here, since that
+/// function is private to `q-lexer` and is built to scan a whole,
+/// potentially multi-line source, tracking whitespace-adjacency across
+/// real embedded newlines. This is **sound to duplicate at this narrower
+/// scope**, not a maintenance hazard, specifically because a single
+/// physical line never contains an embedded `'\n'` at all: the full rule
+/// ("blank until the next real `'\n'` or end of input") degenerates
+/// exactly to "blank to the end of this line", with no multi-line state to
+/// track — and because a real, previously-processed physical line always
+/// had a real `'\n'` (itself whitespace-like) immediately before the next
+/// one in genuine multi-line source, treating "start of this line" as
+/// whitespace-like (this function's own initial state, matching
+/// `q-lexer`'s identical "start of input counts as whitespace-like" rule)
+/// reproduces the exact same decision the real, whole-source algorithm
+/// would have made at that position.
 ///
-/// If tokenizing `src` itself fails (a genuinely unrecognized character —
-/// the only way `try_tokenize_q` can fail, since this cut's lexer has no
-/// literal type that could be "unterminated" on partial input, MA11 §4),
-/// this returns `false` (not incomplete) rather than looping forever: the
-/// real lex error will surface cleanly through [`Interpreter::feed`]'s own
-/// `Result` once this buffer is hu to evaluation, exactly like any other
-/// runtime error this REPL already displays without crashing.
+/// See this module's own top doc comment ("Why comments must be
+/// pre-blanked *per physical line*") for why this must happen **before**
+/// a line is folded into `self.buffer` at all, not merely accounted for
+/// when checking completeness: this REPL joins continuation lines with a
+/// single space, never a real `'\n'` (MA11's own significant-`NEWLINE`
+/// grammar rule forbids injecting one mid-expression), so a comment that
+/// is not blanked here would have no real `'\n'` left anywhere in the
+/// joined buffer to stop at — silently erasing every subsequent line, at
+/// both the completeness-check stage and, just as importantly, at the
+/// final evaluation stage (`Interpreter::feed` tokenizes the very same
+/// joined buffer and would hit the identical problem).
+fn blank_line_comment(line: &str) -> String {
+    let chars: Vec<char> = line.chars().collect();
+    let n = chars.len();
+    let mut out = String::with_capacity(n);
+    let mut prev_is_whitespace_like = true; // start of line counts as whitespace-like
+    let mut i = 0;
+    while i < n {
+        let c = chars[i];
+        if c == '/' && prev_is_whitespace_like {
+            // Comment: blank through to the end of this line -- there is
+            // no embedded '\n' to stop at any earlier.
+            for _ in i..n {
+                out.push(' ');
+            }
+            break;
+        }
+        out.push(c);
+        prev_is_whitespace_like = matches!(c, ' ' | '\t' | '\r' | '\n');
+        i += 1;
+    }
+    out
+}
+
+/// The net change in open-`(`/open-`{`/open-`[` counts contributed by one
+/// already-comment-blanked line fragment, as `(parens, braces, brackets)`
+/// deltas (each may be negative, e.g. a continuation line that is just a
+/// closing `)`) — the incremental building block [`QRepl::feed`] folds
+/// into its own running totals on every call, replacing whole-buffer
+/// re-tokenization (see this module's own top doc comment, "Incremental,
+/// not whole-buffer, bracket counting").
 ///
-/// # Verified by hand-tracing exactly the scenario this module's doc
-/// comment describes (not just asserted)
-///
-/// - `{[x;y]` alone: tokenizes to `LBRACE LBRACKET NAME SEMICOLON NAME
-///   RBRACKET` -- braces=1, brackets=0 (opened then closed) -- still
-///   "incomplete" (`braces > 0`), correctly waiting for the rest of the
-///   body and the closing `}`.
-/// - Continuing with ` x+y}`: the *combined*, space-joined buffer
-///   `{[x;y] x+y}` now tokenizes with braces returning to 0 -- no longer
-///   incomplete, handed off to the interpreter as one complete statement.
-/// - A complete one-line statement, e.g. `2+2`, has no bracket tokens at
-///   all -- all three counters stay `0` -- never spuriously waits.
-/// - `(1+2` (open paren, J's/APL's own classic case): `parens = 1`,
-///   `braces = 0`, `brackets = 0` -- incomplete on the strength of `parens`
-///   alone, exactly like `j-repl`'s own scanner.
-/// - `{)`  (mismatched: a brace opened, then a *paren* closed with nothing
-///   open): `braces = 1` (LBRACE, never decremented -- the RPAREN only
-///   touches the `parens` counter, whose own decrement is clamped at 0 by
-///   `.max(0)` since no LPAREN preceded it) -- correctly still
-///   "incomplete", unlike a single combined depth counter, which would
-///   have let the mismatched close cancel the open out to `0` and stopped
-///   waiting prematurely.
-fn is_incomplete(src: &str) -> bool {
-    let tokens = match coding_adventures_q_lexer::try_tokenize_q(src) {
-        Ok(tokens) => tokens,
-        Err(_) => return false,
-    };
+/// `Ok(None)` means tokenizing `line` itself failed (a genuinely
+/// unrecognized character — the only way `try_tokenize_q` can fail, since
+/// this cut's lexer has no literal type that could be "unterminated" on
+/// partial input, MA11 §4); the caller treats this the same way the
+/// previous whole-buffer version did — proceed to evaluation immediately
+/// rather than waiting forever, letting the real lex/parse error surface
+/// through [`Interpreter::feed`]'s own `Result`.
+fn line_bracket_delta(line: &str) -> Option<(i32, i32, i32)> {
+    let tokens = coding_adventures_q_lexer::try_tokenize_q(line).ok()?;
     let mut parens = 0i32;
     let mut braces = 0i32;
     let mut brackets = 0i32;
     for t in &tokens {
         match t.effective_type_name() {
             "LPAREN" => parens += 1,
-            "RPAREN" => parens = (parens - 1).max(0),
+            "RPAREN" => parens -= 1,
             "LBRACE" => braces += 1,
-            "RBRACE" => braces = (braces - 1).max(0),
+            "RBRACE" => braces -= 1,
             "LBRACKET" => brackets += 1,
-            "RBRACKET" => brackets = (brackets - 1).max(0),
+            "RBRACKET" => brackets -= 1,
             _ => {}
         }
     }
-    parens > 0 || braces > 0 || brackets > 0
+    Some((parens, braces, brackets))
 }
 
 /// A persistent interactive Q session.
 pub struct QRepl {
     interp: Interpreter,
     buffer: String,
+    /// Running open-bracket counts for the CURRENT continuation, updated
+    /// incrementally (one line's own delta at a time) rather than
+    /// recomputed by re-tokenizing all of `buffer` on every call — see this
+    /// module's own top doc comment, "Incremental, not whole-buffer,
+    /// bracket counting".
+    open_parens: i32,
+    open_braces: i32,
+    open_brackets: i32,
 }
 
 impl Default for QRepl {
@@ -218,6 +303,9 @@ impl QRepl {
         QRepl {
             interp: Interpreter::new(),
             buffer: String::new(),
+            open_parens: 0,
+            open_braces: 0,
+            open_brackets: 0,
         }
     }
 
@@ -243,6 +331,17 @@ impl QRepl {
     /// fixed, and mirrored here verbatim: compute `separator_len` first,
     /// check the *prospective* total size, and only `push_str` after that
     /// check passes).
+    ///
+    /// # Comment blanking happens first, before anything else touches `line`
+    ///
+    /// `line` is comment-blanked ([`blank_line_comment`]) *before* it is
+    /// measured for the size cap, appended to `self.buffer`, or tokenized
+    /// for its own bracket delta — see this module's own top doc comment,
+    /// "Why comments must be pre-blanked per physical line", for why this
+    /// single step is what fixes both the comment-swallowing bug and (by
+    /// construction) keeps the incremental bracket count correct. Blanking
+    /// only replaces characters with spaces (same length), so the size
+    /// check's byte-count math is unaffected either way.
     pub fn feed(&mut self, line: &str) -> ReplResponse {
         if self.buffer.is_empty() {
             match line.trim() {
@@ -250,6 +349,8 @@ impl QRepl {
                 _ => {}
             }
         }
+
+        let line = blank_line_comment(line);
 
         // Bound the accumulation buffer BEFORE growing it -- see this
         // method's own doc comment. `separator_len` accounts for the
@@ -264,13 +365,16 @@ impl QRepl {
             > MAX_CONTINUATION_BUFFER
         {
             self.buffer.clear();
+            self.open_parens = 0;
+            self.open_braces = 0;
+            self.open_brackets = 0;
             return ReplResponse::Output(format!(
                 "Error: statement exceeds the {MAX_CONTINUATION_BUFFER}-byte continuation limit; discarded\n"
             ));
         }
 
         if separator_len == 0 {
-            self.buffer.push_str(line);
+            self.buffer.push_str(&line);
         } else {
             // Joining with a single space (not a real '\n') keeps a still-
             // open `{...}`/`(...)`/`[...]` on one logical line -- Q's own
@@ -281,13 +385,33 @@ impl QRepl {
             // mirroring `j-repl`'s identical rationale for its own simpler
             // (paren-only) case.
             self.buffer.push(' ');
-            self.buffer.push_str(line);
+            self.buffer.push_str(&line);
         }
 
-        if is_incomplete(&self.buffer) {
+        // Incremental bracket-delta update (see this module's own top doc
+        // comment, "Incremental, not whole-buffer, bracket counting") --
+        // tokenizes only the just-appended (already comment-blanked) line,
+        // not the whole accumulated buffer. A tokenize failure on this one
+        // fragment forces an immediate attempt at evaluation (matching the
+        // previous whole-buffer version's identical "don't wait forever on
+        // a genuinely bad character" behavior), regardless of the running
+        // counts.
+        let still_incomplete = match line_bracket_delta(&line) {
+            Some((dp, db, dk)) => {
+                self.open_parens = (self.open_parens + dp).max(0);
+                self.open_braces = (self.open_braces + db).max(0);
+                self.open_brackets = (self.open_brackets + dk).max(0);
+                self.open_parens > 0 || self.open_braces > 0 || self.open_brackets > 0
+            }
+            None => false,
+        };
+        if still_incomplete {
             return ReplResponse::NeedMore;
         }
 
+        self.open_parens = 0;
+        self.open_braces = 0;
+        self.open_brackets = 0;
         let src = std::mem::take(&mut self.buffer);
         if src.trim().is_empty() {
             return ReplResponse::Output(String::new());
@@ -418,13 +542,126 @@ mod tests {
         assert!(!r.is_continuing());
     }
 
+    /// Security-review regression (Finding 1, HIGH): a `/`-comment opened on
+    /// one physical line of a still-open continuation must NOT swallow
+    /// every subsequently-typed line. Before the per-line comment-blanking
+    /// fix, the second `feed()` call below returned `NeedMore` forever (the
+    /// combined space-joined buffer has no real `'\n'` for the comment to
+    /// stop at, so it erased `"+2)"` along with the comment) instead of
+    /// completing the statement and evaluating it to `3`.
+    #[test]
+    fn a_comment_opened_mid_continuation_does_not_swallow_the_rest_of_the_statement() {
+        let mut r = QRepl::new();
+        assert_eq!(r.feed("(1 / comment"), ReplResponse::NeedMore);
+        assert!(r.is_continuing());
+        match r.feed("+2)") {
+            ReplResponse::Output(t) => assert_eq!(t.trim(), "3"),
+            other => panic!(
+                "expected the statement to complete and evaluate to 3, got {other:?} \
+                 (a comment on the first line must not swallow the second line)"
+            ),
+        }
+        assert!(!r.is_continuing());
+    }
+
+    /// The same scenario, but with the comment-opening line ending in an
+    /// otherwise-legitimate trailing space before the continuation, and
+    /// with a brace/bracket continuation instead of a paren -- confirms the
+    /// fix isn't accidentally specific to the exact repro shape above.
+    #[test]
+    fn a_comment_inside_a_multi_line_function_literal_does_not_swallow_the_closing_brace() {
+        let mut r = QRepl::new();
+        assert_eq!(r.feed("f:{[x;y] / defines add"), ReplResponse::NeedMore);
+        match r.feed("x+y}") {
+            ReplResponse::Output(t) => assert_eq!(t, ""),
+            other => panic!("expected the function definition to complete silently, got {other:?}"),
+        }
+        assert!(matches!(r.feed("2 f 3"), ReplResponse::Output(t) if t.trim() == "5"));
+    }
+
+    /// Security-review regression (Finding 2, MEDIUM): re-tokenizing the
+    /// *entire* accumulated buffer on every fed line costs O(buffer length)
+    /// per call, summing to O(n²) over a continuation that grows one short
+    /// line at a time.
+    ///
+    /// A pure "N lines must complete within X seconds" bound would be
+    /// confounded by `try_tokenize_q`'s own fixed per-call cost (rebuilding
+    /// ~30 token patterns from `_grammar::token_grammar()` every call,
+    /// independent of input length) — that fixed cost is paid by both the
+    /// old whole-buffer approach and this one, and could easily dominate at
+    /// small N regardless of which is used, telling us nothing about
+    /// *scaling*. Instead this is a **comparative** measurement: feed the
+    /// exact same `n` trivial filler lines twice — once against a small
+    /// starting buffer, once against a buffer already pre-grown to just
+    /// under the continuation cap — and confirm the timing is
+    /// approximately the same either way. Every filler line here is an
+    /// all-comment line (`"/"`, blanked to a single space by
+    /// `blank_line_comment`) specifically so it never adds any real parse-
+    /// tree depth (avoiding `q-parser`'s own `MAX_RULE_DEPTH`, which caps a
+    /// genuine nested/chained expression at only ~13-26 terms — far too
+    /// shallow to build a meaningfully large N through real expression
+    /// content). If the whole-buffer-re-tokenization bug were still
+    /// present, the "large starting buffer" run would take dramatically
+    /// longer, since each of its `n` calls would re-scan the *entire*
+    /// (large) buffer instead of just its own tiny new fragment.
+    #[test]
+    fn per_line_scanning_cost_does_not_scale_with_the_existing_buffer_size() {
+        fn time_n_filler_lines(r: &mut QRepl, n: usize) -> std::time::Duration {
+            let start = std::time::Instant::now();
+            for _ in 0..n {
+                assert_eq!(r.feed("/"), ReplResponse::NeedMore);
+            }
+            start.elapsed()
+        }
+
+        let n = 500;
+
+        // Scenario A: small starting buffer.
+        let mut small = QRepl::new();
+        assert_eq!(small.feed("(0"), ReplResponse::NeedMore);
+        let small_time = time_n_filler_lines(&mut small, n);
+
+        // Scenario B: buffer already grown to just under the 64 KiB
+        // continuation cap via a single long all-comment padding line (one
+        // `feed()` call, not timed) -- still trivially shallow to parse
+        // (it's all blanked to whitespace), so no recursion-depth risk.
+        let mut large = QRepl::new();
+        assert_eq!(large.feed("(0"), ReplResponse::NeedMore);
+        let padding = format!("/{}", "x".repeat(60_000));
+        assert_eq!(large.feed(&padding), ReplResponse::NeedMore);
+        let large_time = time_n_filler_lines(&mut large, n);
+
+        let ratio = large_time.as_secs_f64() / small_time.as_secs_f64().max(1e-6);
+        assert!(
+            ratio < 5.0,
+            "feeding {n} trivial filler lines took {large_time:?} against a ~60 KiB \
+             pre-existing buffer vs {small_time:?} against a small one ({ratio:.1}x) -- \
+             per-line cost should not scale with the EXISTING buffer size (O(1) \
+             amortized per line, not O(buffer length))"
+        );
+
+        // Sanity check the fast path didn't corrupt anything: closing
+        // `small`'s continuation (untouched by all this comment filler,
+        // which contributes zero real tokens) must still evaluate to
+        // plain `0`.
+        match small.feed(")") {
+            ReplResponse::Output(t) => assert_eq!(t.trim(), "0"),
+            other => panic!("expected the statement to close cleanly to 0, got {other:?}"),
+        }
+    }
+
     #[test]
     fn mismatched_bracket_types_stay_incomplete_on_their_own_open_count() {
         // `{)`-shaped input: a brace opened, then a paren "closed" with
         // nothing open -- must stay incomplete on the strength of the
         // still-open BRACE, not have the mismatched close cancel it out
-        // (see `is_incomplete`'s own doc comment for the full rationale).
-        assert!(is_incomplete("{)"));
+        // (see `line_bracket_delta`'s own doc comment for the full
+        // rationale).
+        let (parens, braces, brackets) = line_bracket_delta("{)").unwrap();
+        assert_eq!((parens, braces, brackets), (-1, 1, 0));
+
+        let mut r = QRepl::new();
+        assert_eq!(r.feed("{)"), ReplResponse::NeedMore);
     }
 
     #[test]

--- a/code/packages/rust/q-repl/src/main.rs
+++ b/code/packages/rust/q-repl/src/main.rs
@@ -1,0 +1,17 @@
+//! The `q` binary — an interactive prompt for the Q language.
+//!
+//! Reads one line at a time (continuing across an open `(`, `{`, or `[`),
+//! evaluates over `array-runtime`, and prints the auto-printed result. Type
+//! `quit` / `exit` (or send EOF with Ctrl-D) to leave. All logic lives in
+//! [`coding_adventures_q_repl::run`].
+
+use std::io;
+
+fn main() {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    if let Err(e) = coding_adventures_q_repl::run(stdin.lock(), stdout.lock()) {
+        eprintln!("q: I/O error: {e}");
+        std::process::exit(1);
+    }
+}

--- a/code/packages/rust/q-runtime/BUILD
+++ b/code/packages/rust/q-runtime/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-q-runtime -- --nocapture

--- a/code/packages/rust/q-runtime/BUILD_windows
+++ b/code/packages/rust/q-runtime/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-q-runtime -- --nocapture

--- a/code/packages/rust/q-runtime/CHANGELOG.md
+++ b/code/packages/rust/q-runtime/CHANGELOG.md
@@ -1,0 +1,121 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-07-22
+
+### Added
+
+- Initial release — **MA-11d** of the Q frontend (spec
+  [`MA11`](../../../specs/MA11-q-language.md)): a tree-walking evaluator over
+  `array-runtime`, making the Q lexer/parser (`q-lexer`/`q-parser`,
+  MA-11b/MA-11c) executable.
+- `Interpreter` (persistent workspace) + `feed`/`eval` entry points.
+  Auto-print semantics: an assignment is silent, a bare `noun_expr` result
+  auto-prints (mirrors `j-runtime`'s/`apl-runtime`'s own real-session
+  convention, and real Q's own console behavior).
+- **`QValue`** — this crate's value type: `Arr(Array)` or `Fn(Rc<Lambda>)`.
+  Unlike `j-runtime`/`apl-runtime` (whose evaluators only ever produce a
+  bare `Array`), Q's function literal is itself an ordinary noun value
+  (MA11 §2/§3 bullet 1), so a bare array is not enough — this is the direct
+  consequence of that headline novelty flowing through the whole evaluator.
+- **`QFn::Lambda`** — the one genuinely new evaluator concept MA11 §2
+  flags: a user-defined function literal (`{[x;y] stmt; stmt; ...}`), with
+  named parameters, a multi-statement body, and (implicitly) whatever
+  global bindings are visible at call time.
+  - The bracket-omitted implicit `x`/`y`/`z` parameter names when no
+    `[x;y]` list is present at all (a real Q convenience, MA11 §3 bullet 1
+    / §4). `q.grammar` simply omits the `param_list` child in this case, so
+    an *absent* node (not an empty one) is the signal `build_lambda` reads.
+  - Calling a function value uses the **same** juxtaposition dispatch site
+    (`Interpreter::apply_monadic`/`apply_dyadic`) as every primitive verb —
+    no separate "call a lambda" code path (MA11 §3 bullet 1: "no new
+    application production, only a new way to produce a callable value").
+  - Assignment inside a function body is local to that call only
+    (MA11 §4): a call-local frame is pushed onto an environment *stack*
+    (`RefCell<Vec<HashMap<String, QValue>>>`) for the duration of the call
+    and popped again via an RAII `FrameGuard`, mirroring
+    `j-runtime::eval::DepthGuard`'s "guard owns the undo" pattern.
+  - **Nested function literals are a clean, explicit error** (MA11 §4: "no
+    nested function literals to begin with"), checked at the moment a
+    `function_literal` node is evaluated while already inside an active
+    call — not just when the inner literal happens to be invoked, since
+    even a merely-constructed-and-returned nested literal would need real
+    lexical closure capture (which this crate deliberately does not
+    implement) to behave correctly if later called independently.
+  - First-class functions: a parameter bound to a `Fn` value can itself be
+    applied inside the callee's body (`apply:{[g] g 5}`) — a natural,
+    disclosed generalization of "a function literal is an ordinary noun
+    value... assignable, passable" (MA11 §3 bullet 1), distinct from the
+    explicitly-deferred nested-*definition* case above.
+- **16 primitive verbs** (MA11 §4's full table): `+` flip/add, `-`
+  negate/subtract, `*` first/multiply, `%` reciprocal/divide (always
+  true/float division, no integer-division special case), `!` til
+  (monadic-only, **0-based** — matches J's `i.`, never APL's 1-based `⍳`;
+  dyadic `!` is a clean, explicit "not yet implemented" error, MA11 §4's
+  own deferral), `,` enlist/join, `#` count/take, `_` floor/drop, `&`
+  where/min, `|` reverse/max, `~` not/match (deep equality, producing a
+  scalar — the one primitive in this crate whose dyadic meaning is *not*
+  elementwise), `=` `<` `>` `<=` `>=` `<>` comparison (Q's own not-equal
+  spelling, never `~=`/`#`).
+  - Exactly 12 of the 16 map onto `array_runtime::ops::BinOp` for their
+    *dyadic* meaning (`Prim::to_binop`); the remaining 5 (`!` `,` `#` `_`
+    `~`) get hand-rolled logic in `builtins.rs` — the same count and
+    structural split as `j-runtime`'s own 5 bespoke primitives (`$` `i.`
+    `,` `#` `^`).
+  - Genuinely new relative to J: several `BinOp`-mappable primitives (`+`
+    `*` `&` `|`) have a *monadic* meaning that is not itself an elementwise
+    scalar map (flip/transpose, first, where, reverse) — J's own 12
+    `BinOp`-mappable atoms were all uniformly elementwise monadically, so
+    this asymmetry falls straight out of Q's own primitive table rather
+    than being invented here.
+- **Adverbs**: `'` (each), `/` (reduce), `\` (scan) — reduce/scan are
+  restricted to the 12 `BinOp`-mappable primitives exactly like
+  `j-runtime::eval::require_scalar_binop`; each has a well-defined,
+  non-redundant meaning only for the primitives whose direct application
+  is *not already* elementwise scalar (this cut's flat, dense-array-only
+  value model has no nested/boxed list type, so "apply per element" is
+  never distinguishable from "apply directly" for the primitives where the
+  direct form is already elementwise) — everything else is a clean,
+  disclosed "no well-defined per-element meaning for this primitive" error.
+  `q.grammar` only ever attaches an adverb to a bare `verb_primitive`
+  (confirmed directly against the grammar file), so none of the three ever
+  need to handle a user-defined `Lambda`.
+- **Dual list-literal syntax** (MA11 §3 bullet 3 / §4): adjacent-numeric
+  stranding (`1 2 3`) and explicit `(a; b; c)` both lower to the same
+  vector value when every element is a plain scalar. A list literal
+  containing a non-scalar (itself a vector/matrix) or function-valued
+  element is a clean, disclosed error — this cut's `array_runtime::Array`
+  value model has no nested/heterogeneous representation at all (MA11 §4:
+  "arrays only, dense and numeric"), so such an element genuinely cannot be
+  represented, rather than being silently flattened or truncated.
+- Q-style display (`value.rs`): a plain ASCII `-` for negatives (unlike
+  J's leading underscore) — Q spells a negative *literal* with an ordinary
+  `-`, disambiguated from subtraction by whitespace (MA11 §3 bullet 2), so
+  printing with plain `-` round-trips correctly through `q-lexer`'s own
+  negative-literal fold hook, unlike J (whose lexer reserves ASCII `-`
+  exclusively for the `MINUS` token).
+- DoS guards: an independent recursion-depth guard in the evaluator
+  (`eval.rs::MAX_DEPTH`, 512) — **genuinely reachable** through a
+  legitimate, sufficiently long chain of already-defined-function calls
+  across many separate top-level lines (unlike `j-runtime`'s identical
+  guard, which per that crate's own doc comment is "never actually
+  reachable through genuine parsed input" since J has no user-defined
+  functions to chain calls through) — plus `builtins::MAX_ARRAY_LENGTH`
+  (1,000,000) capping every primitive whose output size or work scales
+  with a runtime-computed value (`!n`, take, join, and the flat
+  stranded-literal/list-literal element counts), each checked *before*
+  allocating or scanning.
+
+### Notes
+
+- No `array-runtime` substrate changes were needed (MA11 §2's own "zero new
+  substrate" finding, confirmed directly against `ops.rs`'s current public
+  API) — every primitive here is either `ops::elementwise`/`reduce`/`scan`
+  wearing a new glyph, or hand-rolled logic local to this crate.
+- `QFn` has **no** train-shaped variants (`Compose`/`Hook`/`Fork`) — Q has
+  no trains and no `@` compose in this cut at all (MA11 §3/§4), so unlike
+  `j-runtime::eval::JFn` (which needed a hand-rolled iterative `Drop` to
+  avoid a native-stack overflow tearing down a deeply-boxed train), `QFn`'s
+  variants are all leaf dispatches with no self-referential recursion —
+  nothing here needed (or got) that treatment.

--- a/code/packages/rust/q-runtime/CHANGELOG.md
+++ b/code/packages/rust/q-runtime/CHANGELOG.md
@@ -96,12 +96,16 @@ All notable changes to this project will be documented in this file.
   negative-literal fold hook, unlike J (whose lexer reserves ASCII `-`
   exclusively for the `MINUS` token).
 - DoS guards: an independent recursion-depth guard in the evaluator
-  (`eval.rs::MAX_DEPTH`, 512) — **genuinely reachable** through a
-  legitimate, sufficiently long chain of already-defined-function calls
-  across many separate top-level lines (unlike `j-runtime`'s identical
-  guard, which per that crate's own doc comment is "never actually
-  reachable through genuine parsed input" since J has no user-defined
-  functions to chain calls through) — plus `builtins::MAX_ARRAY_LENGTH`
+  (`eval.rs::MAX_DEPTH`, 760 — empirically measured against this
+  evaluator's own `call_lambda`-driven recursion on a known 2 MiB stack,
+  not copied from `j-runtime`'s unrelated constant; see that constant's
+  own doc comment for the full binary-search methodology) —
+  **genuinely reachable** through a legitimate, sufficiently long chain
+  of already-defined-function calls across many separate top-level lines
+  (unlike `j-runtime`'s identical guard, which per that crate's own doc
+  comment is "never actually reachable through genuine parsed input"
+  since J has no user-defined functions to chain calls through) — plus
+  `builtins::MAX_ARRAY_LENGTH`
   (1,000,000) capping every primitive whose output size or work scales
   with a runtime-computed value (`!n`, take, join, and the flat
   stranded-literal/list-literal element counts), each checked *before*

--- a/code/packages/rust/q-runtime/Cargo.toml
+++ b/code/packages/rust/q-runtime/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "coding-adventures-q-runtime"
+version = "0.1.0"
+edition = "2021"
+description = "Tree-walking evaluator for the Q (kdb+) language over array-runtime"
+
+[dependencies]
+coding-adventures-q-parser = { path = "../q-parser" }
+array-runtime = { package = "coding-adventures-array-runtime", path = "../array-runtime" }
+parser = { path = "../parser" }
+
+[dev-dependencies]
+# Only used by value.rs's own round-trip regression test (confirming this
+# crate's negative-number display re-tokenizes back into a single negative
+# NUMBER, not MINUS) -- the evaluator itself never needs the lexer directly,
+# only `q-parser` (which already depends on it internally).
+coding-adventures-q-lexer = { path = "../q-lexer" }

--- a/code/packages/rust/q-runtime/README.md
+++ b/code/packages/rust/q-runtime/README.md
@@ -120,11 +120,12 @@ everything else (`+` `*` `!` `,` `#` `&` `|` monadically; `!` `,` `#` `_`
 ## DoS guards
 
 - An independent recursion-depth guard in the evaluator
-  (`eval.rs::MAX_DEPTH`, 512) — **genuinely reachable**, unlike
-  `j-runtime`'s identical guard, through a legitimate (if unusual) long
-  chain of already-defined-function calls spread across many separate
-  top-level lines, since Q (unlike J) has real function calls to chain at
-  all.
+  (`eval.rs::MAX_DEPTH`, 760 — empirically measured against this crate's
+  own `call_lambda`-driven recursion, not copied from `j-runtime`'s
+  unrelated constant) — **genuinely reachable**, unlike `j-runtime`'s
+  identical guard, through a legitimate (if unusual) long chain of
+  already-defined-function calls spread across many separate top-level
+  lines, since Q (unlike J) has real function calls to chain at all.
 - `builtins::MAX_ARRAY_LENGTH` (1,000,000) bounds every primitive whose
   output size or work scales with a runtime-computed value (`!n`, take,
   join) and the flat stranded-literal/list-literal element counts, each

--- a/code/packages/rust/q-runtime/README.md
+++ b/code/packages/rust/q-runtime/README.md
@@ -1,0 +1,137 @@
+# Q Runtime
+
+A tree-walking evaluator for [Q](https://en.wikipedia.org/wiki/Q_(programming_language_from_Kx_Systems)),
+kdb+'s scripting language, over [`array-runtime`](../array-runtime). Item
+**MA-11d** of the Q frontend (spec
+[`MA11`](../../../specs/MA11-q-language.md)): the piece that makes the Q
+lexer/parser (`q-lexer`/`q-parser`) executable.
+
+## Why Q needed its own runtime, not a reused one
+
+Q is APL/J's second-generation descendant (MA11 §1) and reuses their exact
+two-nonterminal, right-to-left, no-precedence grammar shape (MA11 §3) — but
+one property has no APL/J precedent at all: **a genuine user-defined
+function literal**. `{[x;y] stmt; stmt; ...}` is a real callable value with
+named parameters, a multi-statement body, and (implicit) access to
+whatever's visible at the top level when it's called. Neither
+`apl-runtime::eval::AplFn` nor `j-runtime::eval::JFn` has ever needed to
+represent this, because APL's/J's in-scope grammars are expression-only —
+trains *recombine* existing primitives, they never introduce a brand-new
+parameter name a body can reference. This is why `QValue` (this crate's
+own value type) is `Arr(Array)` **or** `Fn(Rc<Lambda>)`, not just a bare
+`Array` the way `j-runtime`'s evaluator gets away with.
+
+```rust
+use coding_adventures_q_runtime::eval;
+
+// `!` (til) is 0-based, matching J's `i.` -- never APL's 1-based `⍳`.
+assert_eq!(eval("!5\n").unwrap().trim(), "0 1 2 3 4");
+
+// `%` is always true/float division -- no integer-division special case.
+assert_eq!(eval("6%4\n").unwrap().trim(), "1.5");
+
+// A function literal: bracket-omitted implicit x/y, applied by
+// juxtaposition exactly like a primitive verb.
+assert_eq!(eval("f:{x+y}\n2 f 3\n").unwrap().trim(), "5");
+
+// Assignment is silent; a bare expression auto-prints.
+assert_eq!(eval("a:5\n").unwrap(), "");
+assert_eq!(eval("a:5\na\n").unwrap().trim(), "5");
+```
+
+## What it evaluates
+
+- **Arrays only** (MA11 §4): dense, numeric, rank <= 2. A scalar is a
+  rank-0 array. No booleans, no symbols, no strings, no temporal literals,
+  no tables.
+- **16 primitive verbs** (monadic / dyadic meaning): `+` (flip / add), `-`
+  (negate / subtract), `*` (first / multiply — a completely different
+  monadic pairing from J's "sign / multiply"), `%` (reciprocal / divide,
+  always true/float), `!` (til, **0-based** monadic-only — dyadic is a
+  clean, explicit "not yet implemented" error), `,` (enlist / join), `#`
+  (count / take — Q's `#` is *take*, genuinely different from J's dyadic
+  `#`, which is *replicate*), `_` (floor / drop), `&` (where — indices of
+  nonzero elements — / min), `|` (reverse / max), `~` (not / match — deep
+  equality, producing a scalar, the one primitive here whose dyadic
+  meaning is *not* elementwise), `=` `<` `>` `<=` `>=` `<>` (dyadic-only
+  comparison; Q's own not-equal spelling is `<>`, never `~=`/`#`).
+- **Adverbs**: `'` (each), `/` (reduce), `\` (scan) — lowered onto
+  `array_runtime::ops::{reduce, scan}` (item AR-2), same kernels APL/J
+  already reuse. Reduce/scan are restricted to the 12 primitives that map
+  onto a `BinOp`; each has a well-defined, non-redundant meaning only for
+  the primitives whose direct application isn't already elementwise (see
+  "Each degenerates to direct application" below).
+- **Function literals**: `{[x;y] ...}` and the bracket-omitted implicit
+  `x`/`y`/`z` form. Assignable without being called, passable as an
+  argument (including to another function, which can then apply it), and
+  applied via the *same* juxtaposition mechanism as a primitive verb — no
+  separate "call a lambda" code path. No recursion, no nested function
+  literals (both explicitly out of scope, MA11 §4).
+- **Dual list-literal syntax**: adjacent stranding (`1 2 3`) and explicit
+  `(a; b; c)` both lower to the identical vector value, for the case this
+  cut's value model can actually represent (every element a plain scalar).
+- **Assignment** `name:expr`, right-associative chaining (`a:b:3` sets
+  both), local to the enclosing function call when used inside one.
+- **Comments** `/`-to-end-of-line (a lexer-level concern, confirmed here by
+  an end-to-end evaluation test) and parenthesised grouping.
+
+### Deferred (documented, MA11 §4)
+
+Booleans, symbols, strings, temporal literals, dictionaries and tables
+(the flagship Q/kdb+ feature — q-SQL is by far the largest deferred
+surface), `?`/`.`/`@` (all heavily overloaded, deferred whole), each-prior/
+each-right/each-left adverbs, recursion, and nested function-literal
+definitions. Each of these that the grammar happens to still parse (a few
+do, since `q-lexer`/`q-parser` were built slightly ahead of this crate's
+own semantic scope) is a clean, specific "not yet implemented" error here —
+never silently misinterpreted as something else.
+
+## `QFn::Lambda` — the one genuinely new evaluator concept
+
+`QFn` (this crate's own representation of "which verb, and with which
+adverb applied", generalizing `j-runtime::eval::JFn` per MA11 §2's own
+instruction) has **no** train-shaped variants at all — Q has no trains and
+no `@` compose in this cut (MA11 §3/§4), so every `QFn` variant here is a
+leaf dispatch with no self-referential recursion, unlike `JFn` (which
+needed a hand-rolled iterative `Drop` specifically because `Compose`/
+`Hook`/`Fork` box their own operands).
+
+`Lambda { params: Vec<String>, body: Vec<GrammarASTNode> }` stores no
+captured environment at all: since nested function *definitions* are
+explicitly out of scope, every `Lambda` is always defined at the top
+level, so its body only ever needs its own parameters plus whatever's in
+the *global* frame at call time — resolved via this evaluator's ordinary
+two-tier lookup (call-local frame first, global frame beneath it), not a
+snapshot taken at definition time.
+
+### Each degenerates to direct application (a disclosed design choice)
+
+This cut's value model is flat, dense arrays only — no nested/boxed list
+type at all. Real Q's `'` (each) earns its keep by applying a function to
+each *item* of a possibly-nested list; without nesting, "apply per
+element" and "apply directly" are indistinguishable for every primitive
+whose direct meaning is already elementwise (`-` `%` `_` `~` monadically;
+all 12 `BinOp`-mappable primitives dyadically). `each` is therefore
+well-defined but redundant for those, and a clean, disclosed error for
+everything else (`+` `*` `!` `,` `#` `&` `|` monadically; `!` `,` `#` `_`
+`~` dyadically) — see `builtins.rs`'s own `each_monadic_supported`/
+`each_dyadic_supported` for the exact rationale.
+
+## DoS guards
+
+- An independent recursion-depth guard in the evaluator
+  (`eval.rs::MAX_DEPTH`, 512) — **genuinely reachable**, unlike
+  `j-runtime`'s identical guard, through a legitimate (if unusual) long
+  chain of already-defined-function calls spread across many separate
+  top-level lines, since Q (unlike J) has real function calls to chain at
+  all.
+- `builtins::MAX_ARRAY_LENGTH` (1,000,000) bounds every primitive whose
+  output size or work scales with a runtime-computed value (`!n`, take,
+  join) and the flat stranded-literal/list-literal element counts, each
+  checked *before* allocating or scanning.
+
+## Testing
+
+```sh
+cargo test -p coding-adventures-q-runtime
+```

--- a/code/packages/rust/q-runtime/required_capabilities.json
+++ b/code/packages/rust/q-runtime/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/q-runtime",
+  "capabilities": [],
+  "justification": "Pure computation: a tree-walking evaluator over the in-memory array-runtime value model. No filesystem, network, or process access (the REPL crate owns stdio)."
+}

--- a/code/packages/rust/q-runtime/src/builtins.rs
+++ b/code/packages/rust/q-runtime/src/builtins.rs
@@ -1,0 +1,837 @@
+//! Q's 16 primitive verbs (MA11 §4), split the same way `j-runtime`'s own
+//! `builtins.rs` splits J's: the ones whose *dyadic* meaning is an ordinary
+//! elementwise scalar function reuse `array_runtime::ops::BinOp` directly
+//! (see [`Prim::to_binop`] in `eval.rs`); the rest (`!` `,` `#` `_` `~` --
+//! **exactly five**, the same count as J's own five bespoke primitives
+//! `$`/`i.`/`,`/`#`/`^`, a pleasant structural echo of MA11 §2's own framing
+//! that Q "maps directly onto the kernels APL/J already reused") get
+//! hand-rolled monadic+dyadic logic here.
+//!
+//! Unlike J, several of Q's *BinOp-mappable* primitives (`+`, `*`, `&`, `|`)
+//! have a **monadic** meaning that is *not* itself an elementwise scalar
+//! map (flip/transpose, first, where, reverse) -- so this module also grows
+//! bespoke monadic-only implementations for those four, even though their
+//! *dyadic* meaning is plain `ops::elementwise`. This is a genuine
+//! structural difference from J (whose 12 `BinOp`-mappable atoms all had
+//! *uniformly* elementwise monadic meanings, MA06 §4) that falls straight
+//! out of Q's own primitive table (MA11 §4) rather than being invented
+//! here.
+
+use array_runtime::{ops, ops::BinOp, Array};
+
+/// Upper bound on any array this crate allocates from a **runtime-computed**
+/// size, or any work whose cost scales with a runtime-computed value --
+/// monadic `!n`'s `n`, dyadic `#`'s (take) target element count, dyadic
+/// `,`'s (join) combined output length -- checked *before* allocating or
+/// scanning, so a crafted `!2000000` is a clean `Err` instead of a
+/// 2-million-element allocation. Same value, and the same "check before the
+/// expensive work" discipline, as `j-runtime::builtins::MAX_ARRAY_LENGTH`/
+/// `apl-runtime::builtins::MAX_ARRAY_LENGTH` (this repo's established cap
+/// for a user-controlled array length/work product).
+pub const MAX_ARRAY_LENGTH: usize = 1_000_000;
+
+/// One of Q's 16 primitive verb glyphs (MA11 §4's full table). Kept as a
+/// small `Copy` enum (not the raw token) so error messages can name the
+/// actual glyph (`"!"`, not `"BANG"`) via [`glyph`], mirroring
+/// `j-runtime::eval::NonScalarAtom`'s identical role.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Prim {
+    Plus,
+    Minus,
+    Star,
+    Percent,
+    Bang,
+    Comma,
+    Hash,
+    Underscore,
+    Amp,
+    Pipe,
+    Tilde,
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Ge,
+    Gt,
+}
+
+impl Prim {
+    /// The ASCII spelling of this glyph, for error messages. `Ne` spells
+    /// `<>` -- Q's own not-equal (MA11 §4), never `~=`/`#`.
+    pub fn glyph(self) -> &'static str {
+        match self {
+            Prim::Plus => "+",
+            Prim::Minus => "-",
+            Prim::Star => "*",
+            Prim::Percent => "%",
+            Prim::Bang => "!",
+            Prim::Comma => ",",
+            Prim::Hash => "#",
+            Prim::Underscore => "_",
+            Prim::Amp => "&",
+            Prim::Pipe => "|",
+            Prim::Tilde => "~",
+            Prim::Eq => "=",
+            Prim::Ne => "<>",
+            Prim::Lt => "<",
+            Prim::Le => "<=",
+            Prim::Ge => ">=",
+            Prim::Gt => ">",
+        }
+    }
+
+    /// The `array_runtime::ops::BinOp` this primitive's **dyadic** meaning
+    /// maps onto, if any. Exactly 12 of the 16 primitives map onto one of
+    /// `BinOp`'s 12 variants (one glyph per variant, a happy 1:1
+    /// correspondence): `+ - * % & | = <> < <= >= >`. The remaining 5
+    /// (`! , # _ ~`) have no elementwise-scalar dyadic meaning at all --
+    /// `None` here, dispatched to bespoke logic instead (see
+    /// [`apply_dyadic_prim`]).
+    pub fn to_binop(self) -> Option<BinOp> {
+        match self {
+            Prim::Plus => Some(BinOp::Add),
+            Prim::Minus => Some(BinOp::Sub),
+            Prim::Star => Some(BinOp::Mul),
+            Prim::Percent => Some(BinOp::Div),
+            Prim::Amp => Some(BinOp::Min),
+            Prim::Pipe => Some(BinOp::Max),
+            Prim::Eq => Some(BinOp::Eq),
+            Prim::Ne => Some(BinOp::Ne),
+            Prim::Lt => Some(BinOp::Lt),
+            Prim::Le => Some(BinOp::Le),
+            Prim::Ge => Some(BinOp::Ge),
+            Prim::Gt => Some(BinOp::Gt),
+            Prim::Bang | Prim::Comma | Prim::Hash | Prim::Underscore | Prim::Tilde => None,
+        }
+    }
+
+    /// Whether **monadic** `f'x` (each) has a well-defined, non-redundant
+    /// meaning for this primitive in this cut's flat, dense-numeric-only
+    /// value model -- true only for the four primitives whose *monadic*
+    /// meaning is itself an ordinary per-element scalar map (`-` negate,
+    /// `%` reciprocal, `_` floor, `~` not). See this module's own top doc
+    /// comment and [`crate::eval`]'s `QFn::Each` doc comment for the full
+    /// rationale: this repo's value model has no nested/boxed list type, so
+    /// "apply per element" only has a meaning distinct from "apply
+    /// directly" when the direct application *isn't already* elementwise --
+    /// which, for every other primitive here (`+` flip, `*` first, `!` til,
+    /// `,` enlist, `#` tally, `&` where, `|` reverse -- monadically -- and
+    /// `!` `,` `#` `_` `~` dyadically), is never the case.
+    pub fn each_monadic_supported(self) -> bool {
+        matches!(self, Prim::Minus | Prim::Percent | Prim::Underscore | Prim::Tilde)
+    }
+
+    /// Whether **dyadic** `x f'y` (each) has a well-defined, non-redundant
+    /// meaning -- true exactly for the `BinOp`-mappable primitives, whose
+    /// ordinary dyadic meaning (`ops::elementwise`) is *already* per-element,
+    /// making `each` degenerate to the identical computation as plain
+    /// dyadic application. See [`each_monadic_supported`](Self::each_monadic_supported)'s
+    /// doc comment for the shared rationale.
+    pub fn each_dyadic_supported(self) -> bool {
+        self.to_binop().is_some()
+    }
+}
+
+// ── Monadic dispatch ────────────────────────────────────────────────────────
+
+/// Apply `p` monadically. `Eq`/`Ne`/`Lt`/`Le`/`Ge`/`Gt` have no monadic
+/// meaning in Q either (MA11 §4 lists them as dyadic-only comparisons) --
+/// a clean, explicit error rather than silently picking a behavior, mirroring
+/// `j-runtime::eval::apply_monadic_scalar`'s identical treatment of its own
+/// six comparison atoms.
+pub fn apply_monadic_prim(p: Prim, a: &Array) -> Result<Array, String> {
+    match p {
+        Prim::Plus => Ok(flip(a)),
+        Prim::Minus => Ok(negate(a)),
+        Prim::Star => first(a),
+        Prim::Percent => Ok(reciprocal(a)),
+        Prim::Bang => til(a),
+        Prim::Comma => Ok(enlist(a)),
+        Prim::Hash => Ok(tally(a)),
+        Prim::Underscore => Ok(floor_monadic(a)),
+        Prim::Amp => where_indices(a),
+        Prim::Pipe => reverse(a),
+        Prim::Tilde => Ok(not_(a)),
+        Prim::Eq | Prim::Ne | Prim::Lt | Prim::Le | Prim::Ge | Prim::Gt => {
+            Err(format!("q-runtime: no monadic form for {}", p.glyph()))
+        }
+    }
+}
+
+/// Apply `p` dyadically.
+pub fn apply_dyadic_prim(p: Prim, a: &Array, b: &Array) -> Result<Array, String> {
+    match p {
+        Prim::Plus => ops::elementwise(BinOp::Add, a, b),
+        Prim::Minus => ops::elementwise(BinOp::Sub, a, b),
+        Prim::Star => ops::elementwise(BinOp::Mul, a, b),
+        Prim::Percent => ops::elementwise(BinOp::Div, a, b),
+        Prim::Amp => ops::elementwise(BinOp::Min, a, b),
+        Prim::Pipe => ops::elementwise(BinOp::Max, a, b),
+        Prim::Eq => ops::elementwise(BinOp::Eq, a, b),
+        Prim::Ne => ops::elementwise(BinOp::Ne, a, b),
+        Prim::Lt => ops::elementwise(BinOp::Lt, a, b),
+        Prim::Le => ops::elementwise(BinOp::Le, a, b),
+        Prim::Ge => ops::elementwise(BinOp::Ge, a, b),
+        Prim::Gt => ops::elementwise(BinOp::Gt, a, b),
+        // MA11 §4: "dyadic `!` (dict creation, and its other real overloads)
+        // is deferred" -- explicitly out of scope, never silently
+        // misinterpreted as something else.
+        Prim::Bang => Err(
+            "q-runtime: dyadic ! (dict creation) is not yet implemented -- explicitly deferred, MA11 §4".to_string(),
+        ),
+        Prim::Comma => join(a, b),
+        Prim::Hash => take(a, b),
+        Prim::Underscore => drop_(a, b),
+        Prim::Tilde => Ok(match_(a, b)),
+    }
+}
+
+// ── + flip ───────────────────────────────────────────────────────────────
+
+/// Monadic `+` (flip): transposes a matrix (rank 2); identity for a scalar
+/// or vector (rank <= 1). Real Q's monadic `+` is really about flipping a
+/// column-dictionary/table into row-major orientation (and vice versa) --
+/// this cut's value model has no tables (MA11 §4 defers them wholesale), so
+/// "transpose the rank-2 case, identity otherwise" is this crate's own
+/// considered, disclosed reading of "flip" restricted to the dense-numeric
+/// subset actually in scope, reusing `array_runtime::ops::transpose`
+/// directly (the *same* AR-2 kernel APL/J already share, per MA11 §2's own
+/// "zero new substrate" finding).
+pub fn flip(a: &Array) -> Array {
+    if a.ndims() == 2 {
+        ops::transpose(a)
+    } else {
+        a.clone()
+    }
+}
+
+// ── - negate / % reciprocal / _ floor (elementwise monadic maps) ──────────
+
+pub fn negate(a: &Array) -> Array {
+    map_elementwise(a, |v| -v)
+}
+
+pub fn reciprocal(a: &Array) -> Array {
+    map_elementwise(a, |v| 1.0 / v)
+}
+
+pub fn floor_monadic(a: &Array) -> Array {
+    map_elementwise(a, f64::floor)
+}
+
+/// Not (monadic `~`): `1` for `0`, `0` for anything nonzero -- matching
+/// MA11 §4's "comparisons/logic produce/accept plain 0/1 numerics" (no
+/// native boolean type in this cut).
+pub fn not_(a: &Array) -> Array {
+    map_elementwise(a, |v| if v == 0.0 { 1.0 } else { 0.0 })
+}
+
+fn map_elementwise(a: &Array, f: impl Fn(f64) -> f64) -> Array {
+    Array::from_shape(a.data().iter().map(|&v| f(v)).collect(), a.shape().to_vec())
+        .expect("elementwise map preserves shape/length")
+}
+
+// ── * first ──────────────────────────────────────────────────────────────
+
+/// Monadic `*` (first): the first item along the leading axis -- a scalar's
+/// first item is itself; a vector's first item is its element 0 (a scalar
+/// result); a matrix's first item is its row 0 (a vector result). Deferring
+/// to Q's own real "first item of a list" semantics rather than APL/J's
+/// unrelated monadic `*` (sign) -- MA11 §4 is explicit that Q's `*` is
+/// "first / multiply", a completely different pairing from J's
+/// "sign / multiply".
+pub fn first(a: &Array) -> Result<Array, String> {
+    match *a.shape() {
+        [] => Ok(a.clone()),
+        [n] => {
+            if n == 0 {
+                return Err("*: first of an empty vector is undefined".to_string());
+            }
+            Ok(Array::scalar(a.data()[0]))
+        }
+        [r, c] => {
+            if r == 0 {
+                return Err("*: first of an empty matrix is undefined".to_string());
+            }
+            let row: Vec<f64> = (0..c).map(|col| a.get(0, col).expect("in bounds")).collect();
+            Ok(Array::from_vec(row))
+        }
+        _ => Err("*: first is only supported for rank <= 2".to_string()),
+    }
+}
+
+// ── ! til ────────────────────────────────────────────────────────────────
+
+/// Monadic `!` (til): the **0-based** vector `[0, 1, ..., n-1]` -- matches
+/// J's own `i.`, NOT APL's 1-based `⍳` (MA11 §4's own explicit callout).
+/// `n` must be a non-negative-integer-valued scalar; the result length is
+/// capped at [`MAX_ARRAY_LENGTH`] *before* allocating.
+pub fn til(a: &Array) -> Result<Array, String> {
+    if !a.is_scalar() {
+        return Err("!: monadic argument (til) must be a scalar".to_string());
+    }
+    let x = a.data()[0];
+    if x < 0.0 || x.fract() != 0.0 {
+        return Err(format!(
+            "!: monadic argument must be a non-negative integer, got {x}"
+        ));
+    }
+    let n = x as usize;
+    if n > MAX_ARRAY_LENGTH {
+        return Err(format!("!: {n} exceeds the cap of {MAX_ARRAY_LENGTH} elements"));
+    }
+    Ok(Array::from_vec((0..n).map(|i| i as f64).collect()))
+}
+
+// ── , enlist / join ──────────────────────────────────────────────────────
+
+/// Monadic `,` (enlist): "ensure this value is list-shaped." A scalar
+/// (rank 0) is wrapped into a length-1 vector; a value already at rank >= 1
+/// is returned unchanged.
+///
+/// **Disclosed simplification**: real Q's enlist always wraps its argument
+/// in exactly *one more* level of list nesting, even when the argument is
+/// already a list (`,1 2 3` produces a 1-item list *containing* the
+/// 3-element list `1 2 3` -- a strictly deeper nesting than `1 2 3` itself,
+/// distinguishable by `count each`). This cut's value model
+/// (`array_runtime::Array`, dense and *flat* -- MA11 §4: "arrays only") has
+/// no boxed/nested representation at all, so that extra nesting level
+/// simply cannot be represented here. "Ensure rank >= 1, otherwise
+/// identity" is the closest sound approximation available within this
+/// value model, and is exact for enlist's single most common use (wrapping
+/// a bare scalar into a 1-element list, e.g. `,5` == `1#5`).
+pub fn enlist(a: &Array) -> Array {
+    if a.is_scalar() {
+        Array::from_vec(vec![a.data()[0]])
+    } else {
+        a.clone()
+    }
+}
+
+/// Dyadic `,` (join/catenate): supports scalar-scalar, scalar-vector,
+/// vector-scalar, vector-vector (all producing a vector), and
+/// matrix-matrix-with-equal-row-counts (column catenate, producing
+/// `[r, c1 + c2]`) -- re-derived fresh here (not shared with `j-runtime`,
+/// whose identical-shaped `catenate` is private to that crate), but kept
+/// behaviourally consistent across the two frontends by design, mirroring
+/// the same "same substrate, same natural convention" reasoning MA11 §2
+/// gives for reusing AR-2's kernels. Any other rank combination is a clean
+/// "not yet supported" error.
+pub fn join(a: &Array, b: &Array) -> Result<Array, String> {
+    match a.len().checked_add(b.len()) {
+        Some(total) if total <= MAX_ARRAY_LENGTH => {}
+        _ => {
+            return Err(format!(
+                ",: join of {} and {} elements exceeds the cap of {MAX_ARRAY_LENGTH} elements",
+                a.len(),
+                b.len()
+            ));
+        }
+    }
+    match (a.ndims(), b.ndims()) {
+        (0, 0) => Ok(Array::from_vec(vec![a.data()[0], b.data()[0]])),
+        (0, 1) => {
+            let mut out = vec![a.data()[0]];
+            out.extend_from_slice(b.data());
+            Ok(Array::from_vec(out))
+        }
+        (1, 0) => {
+            let mut out = a.data().to_vec();
+            out.push(b.data()[0]);
+            Ok(Array::from_vec(out))
+        }
+        (1, 1) => {
+            let mut out = a.data().to_vec();
+            out.extend_from_slice(b.data());
+            Ok(Array::from_vec(out))
+        }
+        (2, 2) => {
+            if a.nrows() != b.nrows() {
+                return Err(format!(
+                    ",: matrix join needs equal row counts ({} vs {})",
+                    a.nrows(),
+                    b.nrows()
+                ));
+            }
+            let (r, ca, cb) = (a.nrows(), a.ncols(), b.ncols());
+            let mut data = vec![0.0; r * (ca + cb)];
+            for row in 0..r {
+                for col in 0..ca {
+                    data[col * r + row] = a.get(row, col).expect("in bounds");
+                }
+                for col in 0..cb {
+                    data[(ca + col) * r + row] = b.get(row, col).expect("in bounds");
+                }
+            }
+            Array::from_shape(data, vec![r, ca + cb])
+        }
+        (ra, rb) => Err(format!(",: join of rank {ra} and rank {rb} is not yet supported")),
+    }
+}
+
+// ── # tally / take ───────────────────────────────────────────────────────
+
+/// Monadic `#` (count/tally): the item count along the leading axis --
+/// scalar has exactly **one** item, a vector `[n]` has `n`, and a matrix
+/// `[r, c]` has `r` (one per row).
+pub fn tally(a: &Array) -> Array {
+    let n = match *a.shape() {
+        [] => 1,
+        [n] => n,
+        [r, _] => r,
+        ref dims => dims.first().copied().unwrap_or(1),
+    };
+    Array::scalar(n as f64)
+}
+
+/// Dyadic `#` (take): `x#y` takes `|x|` items from `y`, **cycling** if `y`
+/// is shorter than needed -- from the front if `x >= 0`, from the *end* if
+/// `x < 0` (real Q's actual take semantics; a genuinely different meaning
+/// from J's dyadic `#`, which is *replicate*, not take -- MA11 §4 is
+/// explicit that Q's `#` is "count / take").
+///
+/// `y` is scoped to rank <= 1 (a scalar or vector), mirroring
+/// `j-runtime::builtins::replicate`'s identical rank-limiting convention
+/// for its own dyadic right operand.
+pub fn take(x: &Array, y: &Array) -> Result<Array, String> {
+    if !x.is_scalar() {
+        return Err("#: dyadic left argument (take count) must be a scalar".to_string());
+    }
+    if y.ndims() > 1 {
+        return Err(format!(
+            "#: dyadic right argument must be a scalar or vector (rank <= 1), got rank {}",
+            y.ndims()
+        ));
+    }
+    let n = x.data()[0];
+    if n.fract() != 0.0 {
+        return Err(format!("#: take count must be an integer, got {n}"));
+    }
+    let count = n.abs() as usize;
+    if count > MAX_ARRAY_LENGTH {
+        return Err(format!(
+            "#: take of {count} elements exceeds the cap of {MAX_ARRAY_LENGTH}"
+        ));
+    }
+    let src = y.data();
+    if count == 0 {
+        return Ok(Array::from_vec(vec![]));
+    }
+    if src.is_empty() {
+        return Err("#: cannot take a nonzero count from an empty array".to_string());
+    }
+    let out: Vec<f64> = if n >= 0.0 {
+        (0..count).map(|i| src[i % src.len()]).collect()
+    } else {
+        // Negative count: the last `count` items of the infinite cyclic
+        // repetition of `y`, ending exactly at `y`'s own last element --
+        // equivalent to taking `count` from the front of the *reversed*
+        // source, then reversing that result back.
+        let mut rev = src.to_vec();
+        rev.reverse();
+        let mut out: Vec<f64> = (0..count).map(|i| rev[i % rev.len()]).collect();
+        out.reverse();
+        out
+    };
+    Ok(Array::from_vec(out))
+}
+
+// ── _ floor (monadic, above) / drop (dyadic) ────────────────────────────
+
+/// Dyadic `_` (drop): `x _ y` drops `|x|` items from `y` -- from the front
+/// if `x >= 0`, from the end if `x < 0` -- with **no** cycling (unlike take
+/// above): dropping more items than `y` has simply empties it. `y` is
+/// scoped to rank <= 1, mirroring [`take`]'s identical restriction.
+pub fn drop_(x: &Array, y: &Array) -> Result<Array, String> {
+    if !x.is_scalar() {
+        return Err("_: dyadic left argument (drop count) must be a scalar".to_string());
+    }
+    if y.ndims() > 1 {
+        return Err(format!(
+            "_: dyadic right argument must be a scalar or vector (rank <= 1), got rank {}",
+            y.ndims()
+        ));
+    }
+    let n = x.data()[0];
+    if n.fract() != 0.0 {
+        return Err(format!("_: drop count must be an integer, got {n}"));
+    }
+    let src = y.data();
+    let len = src.len();
+    let k = (n.abs() as usize).min(len);
+    let out: Vec<f64> = if n >= 0.0 {
+        src[k..].to_vec()
+    } else {
+        src[..len - k].to_vec()
+    };
+    Ok(Array::from_vec(out))
+}
+
+// ── & where / min ────────────────────────────────────────────────────────
+
+/// Monadic `&` (where): the indices (0-based) of every nonzero element, per
+/// MA11 §4's own literal wording ("monadic: indices of nonzero elements").
+/// Scoped to rank <= 1 (scalar or vector), mirroring this crate's other
+/// rank-limited bespoke primitives.
+///
+/// **Disclosed simplification**: real Q's monadic `&` actually generalizes
+/// this to non-boolean non-negative-integer *counts* (`&2 0 3` produces
+/// `0 0 1 1 1`, replicating index `i` exactly `x[i]` times, of which
+/// "indices of nonzero elements" is only the special case where every count
+/// is 0 or 1). This crate follows MA11 §4's own literal spec text rather
+/// than real Q's fuller generalization, since the spec explicitly commits
+/// to the narrower reading.
+pub fn where_indices(a: &Array) -> Result<Array, String> {
+    if a.ndims() > 1 {
+        return Err(format!(
+            "&: monadic argument (where) must be a scalar or vector, got rank {}",
+            a.ndims()
+        ));
+    }
+    let idx: Vec<f64> = a
+        .data()
+        .iter()
+        .enumerate()
+        .filter(|(_, &v)| v != 0.0)
+        .map(|(i, _)| i as f64)
+        .collect();
+    Ok(Array::from_vec(idx))
+}
+
+// ── | reverse / max ──────────────────────────────────────────────────────
+
+/// Monadic `|` (reverse): reverses element order for a vector; reverses row
+/// order (each row's own column order stays intact) for a matrix; a scalar
+/// reverses to itself.
+pub fn reverse(a: &Array) -> Result<Array, String> {
+    match *a.shape() {
+        [] => Ok(a.clone()),
+        [_] => {
+            let mut d = a.data().to_vec();
+            d.reverse();
+            Ok(Array::from_vec(d))
+        }
+        [r, c] => {
+            let mut data = vec![0.0; r * c];
+            for row in 0..r {
+                let src_row = r - 1 - row;
+                for col in 0..c {
+                    data[col * r + row] = a.get(src_row, col).expect("in bounds");
+                }
+            }
+            Array::from_shape(data, vec![r, c])
+        }
+        _ => Err("|: reverse is only supported for rank <= 2".to_string()),
+    }
+}
+
+// ── ~ not (monadic, above) / match (dyadic) ─────────────────────────────
+
+/// Dyadic `~` (match): deep equality -- same shape *and* every element
+/// exactly equal (plain `f64 ==`, no floating-point tolerance, matching
+/// every other comparison in this crate) -- producing a single scalar `1`
+/// or `0`, **not** an elementwise array (a genuine, deliberate difference
+/// from every other dyadic primitive in this crate, which are all
+/// elementwise: match answers one yes/no question about the whole pair of
+/// values, exactly mirroring real Q's own `~` semantics).
+pub fn match_(a: &Array, b: &Array) -> Array {
+    let eq = a.shape() == b.shape() && a.data() == b.data();
+    Array::scalar(if eq { 1.0 } else { 0.0 })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- + flip --------------------------------------------------------
+
+    #[test]
+    fn flip_transposes_a_matrix() {
+        let m = Array::from_rows(vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]]).unwrap();
+        let t = flip(&m);
+        assert_eq!(t.shape(), &[3, 2]);
+        assert_eq!(t.get(0, 0), Some(1.0));
+        assert_eq!(t.get(2, 1), Some(6.0));
+    }
+
+    #[test]
+    fn flip_is_identity_for_scalar_and_vector() {
+        assert_eq!(flip(&Array::scalar(5.0)).data(), &[5.0]);
+        let v = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        assert_eq!(flip(&v).data(), v.data());
+    }
+
+    // --- - negate / % reciprocal / _ floor ------------------------------
+
+    #[test]
+    fn negate_flips_sign_elementwise() {
+        assert_eq!(negate(&Array::from_vec(vec![1.0, -2.0, 0.0])).data(), &[-1.0, 2.0, -0.0]);
+    }
+
+    #[test]
+    fn reciprocal_is_elementwise() {
+        assert_eq!(reciprocal(&Array::from_vec(vec![1.0, 2.0, 4.0])).data(), &[1.0, 0.5, 0.25]);
+    }
+
+    #[test]
+    fn floor_monadic_rounds_down() {
+        assert_eq!(floor_monadic(&Array::scalar(3.8)).data(), &[3.0]);
+        assert_eq!(floor_monadic(&Array::scalar(-3.2)).data(), &[-4.0]);
+    }
+
+    // --- ~ not -----------------------------------------------------------
+
+    #[test]
+    fn not_flips_zero_and_nonzero() {
+        assert_eq!(not_(&Array::from_vec(vec![0.0, 1.0, 5.0, -1.0])).data(), &[1.0, 0.0, 0.0, 0.0]);
+    }
+
+    // --- * first -----------------------------------------------------------
+
+    #[test]
+    fn first_of_scalar_vector_and_matrix() {
+        assert_eq!(first(&Array::scalar(9.0)).unwrap().data(), &[9.0]);
+        assert_eq!(
+            first(&Array::from_vec(vec![7.0, 8.0, 9.0])).unwrap().data(),
+            &[7.0]
+        );
+        let m = Array::from_rows(vec![vec![1.0, 2.0], vec![3.0, 4.0]]).unwrap();
+        assert_eq!(first(&m).unwrap().data(), &[1.0, 2.0]);
+    }
+
+    #[test]
+    fn first_of_empty_is_an_error() {
+        assert!(first(&Array::from_vec(vec![])).is_err());
+    }
+
+    // --- ! til -------------------------------------------------------------
+
+    #[test]
+    fn til_is_zero_based_not_one_based() {
+        // THE single most safety-critical assertion for this primitive
+        // (MA11 §4): `!5` is `[0,1,2,3,4]`, never APL's 1-based `[1..5]`.
+        assert_eq!(til(&Array::scalar(5.0)).unwrap().data(), &[0.0, 1.0, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn til_of_zero_is_empty() {
+        assert!(til(&Array::scalar(0.0)).unwrap().is_empty());
+    }
+
+    #[test]
+    fn til_rejects_negative_and_noninteger() {
+        assert!(til(&Array::scalar(-1.0)).is_err());
+        assert!(til(&Array::scalar(2.5)).is_err());
+    }
+
+    #[test]
+    fn til_caps_n_before_allocating() {
+        let huge = Array::scalar((MAX_ARRAY_LENGTH + 1) as f64);
+        assert!(til(&huge).is_err());
+    }
+
+    // --- , enlist / join -----------------------------------------------------
+
+    #[test]
+    fn enlist_wraps_a_scalar_into_a_one_element_vector() {
+        assert_eq!(enlist(&Array::scalar(5.0)).data(), &[5.0]);
+        assert_eq!(enlist(&Array::scalar(5.0)).shape(), &[1]);
+    }
+
+    #[test]
+    fn enlist_of_an_already_list_shaped_value_is_unchanged() {
+        let v = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        assert_eq!(enlist(&v).data(), v.data());
+    }
+
+    #[test]
+    fn join_scalar_and_vector_combinations() {
+        assert_eq!(join(&Array::scalar(1.0), &Array::scalar(2.0)).unwrap().data(), &[1.0, 2.0]);
+        let v = Array::from_vec(vec![2.0, 3.0]);
+        assert_eq!(join(&Array::scalar(1.0), &v).unwrap().data(), &[1.0, 2.0, 3.0]);
+        assert_eq!(join(&v, &Array::scalar(4.0)).unwrap().data(), &[2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn join_matrices_with_equal_rows_concatenates_columns() {
+        let a = Array::from_rows(vec![vec![1.0, 2.0], vec![3.0, 4.0]]).unwrap();
+        let b = Array::from_rows(vec![vec![5.0], vec![6.0]]).unwrap();
+        let r = join(&a, &b).unwrap();
+        assert_eq!(r.shape(), &[2, 3]);
+        assert_eq!(r.get(0, 2), Some(5.0));
+        assert_eq!(r.get(1, 2), Some(6.0));
+    }
+
+    #[test]
+    fn join_rejects_mismatched_matrix_row_counts() {
+        let a = Array::from_rows(vec![vec![1.0, 2.0]]).unwrap();
+        let b = Array::from_rows(vec![vec![1.0, 2.0], vec![3.0, 4.0]]).unwrap();
+        assert!(join(&a, &b).is_err());
+    }
+
+    #[test]
+    fn join_caps_combined_length_before_allocating() {
+        let half = MAX_ARRAY_LENGTH / 2 + 1;
+        let a = Array::from_vec(vec![0.0; half]);
+        let b = Array::from_vec(vec![0.0; half]);
+        assert!(join(&a, &b).is_err());
+    }
+
+    // --- # tally / take -------------------------------------------------
+
+    #[test]
+    fn tally_of_scalar_vector_and_matrix() {
+        assert_eq!(tally(&Array::scalar(7.0)).data(), &[1.0]);
+        assert_eq!(tally(&Array::from_vec(vec![1.0, 2.0, 3.0])).data(), &[3.0]);
+        let m = Array::from_rows(vec![vec![1.0, 2.0], vec![3.0, 4.0], vec![5.0, 6.0]]).unwrap();
+        assert_eq!(tally(&m).data(), &[3.0]);
+    }
+
+    #[test]
+    fn take_positive_count_cycles_a_shorter_source() {
+        // 5#1 2 3 -> [1,2,3,1,2] (cycled).
+        let y = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        let r = take(&Array::scalar(5.0), &y).unwrap();
+        assert_eq!(r.data(), &[1.0, 2.0, 3.0, 1.0, 2.0]);
+    }
+
+    #[test]
+    fn take_positive_count_truncates_a_longer_source() {
+        let y = Array::from_vec(vec![1.0, 2.0, 3.0, 4.0]);
+        let r = take(&Array::scalar(2.0), &y).unwrap();
+        assert_eq!(r.data(), &[1.0, 2.0]);
+    }
+
+    #[test]
+    fn take_negative_count_takes_from_the_end_and_cycles() {
+        // -2#1 2 3 -> last 2 elements -> [2,3].
+        let y = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        assert_eq!(take(&Array::scalar(-2.0), &y).unwrap().data(), &[2.0, 3.0]);
+        // -5#1 2 3 -> cycled from the end -> [2,3,1,2,3].
+        assert_eq!(
+            take(&Array::scalar(-5.0), &y).unwrap().data(),
+            &[2.0, 3.0, 1.0, 2.0, 3.0]
+        );
+    }
+
+    #[test]
+    fn take_zero_count_is_empty_even_from_an_empty_source() {
+        let empty = Array::from_vec(vec![]);
+        assert_eq!(take(&Array::scalar(0.0), &empty).unwrap().data(), &[] as &[f64]);
+    }
+
+    #[test]
+    fn take_rejects_nonzero_count_from_empty_source() {
+        let empty = Array::from_vec(vec![]);
+        assert!(take(&Array::scalar(3.0), &empty).is_err());
+    }
+
+    #[test]
+    fn take_caps_count_before_allocating() {
+        let y = Array::from_vec(vec![1.0]);
+        assert!(take(&Array::scalar((MAX_ARRAY_LENGTH + 1) as f64), &y).is_err());
+    }
+
+    #[test]
+    fn take_rejects_rank_2_source() {
+        let m = Array::from_rows(vec![vec![1.0, 2.0], vec![3.0, 4.0]]).unwrap();
+        assert!(take(&Array::scalar(2.0), &m).is_err());
+    }
+
+    // --- _ drop ------------------------------------------------------------
+
+    #[test]
+    fn drop_positive_count_drops_from_the_front() {
+        let y = Array::from_vec(vec![1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(drop_(&Array::scalar(2.0), &y).unwrap().data(), &[3.0, 4.0]);
+    }
+
+    #[test]
+    fn drop_negative_count_drops_from_the_end() {
+        let y = Array::from_vec(vec![1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(drop_(&Array::scalar(-2.0), &y).unwrap().data(), &[1.0, 2.0]);
+    }
+
+    #[test]
+    fn drop_more_than_length_empties_without_erroring() {
+        let y = Array::from_vec(vec![1.0, 2.0]);
+        assert!(drop_(&Array::scalar(10.0), &y).unwrap().is_empty());
+        assert!(drop_(&Array::scalar(-10.0), &y).unwrap().is_empty());
+    }
+
+    // --- & where -------------------------------------------------------------
+
+    #[test]
+    fn where_indices_of_nonzero_elements() {
+        let v = Array::from_vec(vec![0.0, 1.0, 1.0, 0.0, 1.0]);
+        assert_eq!(where_indices(&v).unwrap().data(), &[1.0, 2.0, 4.0]);
+    }
+
+    #[test]
+    fn where_indices_rejects_rank_2() {
+        let m = Array::from_rows(vec![vec![1.0, 0.0]]).unwrap();
+        assert!(where_indices(&m).is_err());
+    }
+
+    // --- | reverse -----------------------------------------------------------
+
+    #[test]
+    fn reverse_of_vector() {
+        let v = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        assert_eq!(reverse(&v).unwrap().data(), &[3.0, 2.0, 1.0]);
+    }
+
+    #[test]
+    fn reverse_of_scalar_is_itself() {
+        assert_eq!(reverse(&Array::scalar(9.0)).unwrap().data(), &[9.0]);
+    }
+
+    #[test]
+    fn reverse_of_matrix_reverses_row_order() {
+        let m = Array::from_rows(vec![vec![1.0, 2.0], vec![3.0, 4.0], vec![5.0, 6.0]]).unwrap();
+        let r = reverse(&m).unwrap();
+        assert_eq!(r.get(0, 0), Some(5.0));
+        assert_eq!(r.get(0, 1), Some(6.0));
+        assert_eq!(r.get(2, 0), Some(1.0));
+    }
+
+    // --- ~ match -------------------------------------------------------------
+
+    #[test]
+    fn match_true_for_deeply_equal_arrays() {
+        let a = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        let b = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        assert_eq!(match_(&a, &b).data(), &[1.0]);
+    }
+
+    #[test]
+    fn match_false_for_different_values_or_shapes() {
+        let a = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        let b = Array::from_vec(vec![1.0, 2.0, 4.0]);
+        assert_eq!(match_(&a, &b).data(), &[0.0]);
+
+        let c = Array::from_vec(vec![1.0, 2.0]);
+        assert_eq!(match_(&a, &c).data(), &[0.0]);
+    }
+
+    // --- Prim / to_binop / glyph --------------------------------------------
+
+    #[test]
+    fn exactly_twelve_primitives_map_onto_a_binop() {
+        let all = [
+            Prim::Plus, Prim::Minus, Prim::Star, Prim::Percent, Prim::Bang, Prim::Comma,
+            Prim::Hash, Prim::Underscore, Prim::Amp, Prim::Pipe, Prim::Tilde, Prim::Eq,
+            Prim::Ne, Prim::Lt, Prim::Le, Prim::Ge, Prim::Gt,
+        ];
+        let count = all.iter().filter(|p| p.to_binop().is_some()).count();
+        assert_eq!(count, 12);
+    }
+
+    #[test]
+    fn not_equal_glyph_is_angle_brackets_not_tilde_equals() {
+        // The single easiest glyph to get wrong in this whole crate
+        // (MA11 §4's own callout): Q's not-equal is `<>`, never `~=`
+        // (MATLAB/Scilab's spelling) and never `#` (which is count/take).
+        assert_eq!(Prim::Ne.glyph(), "<>");
+    }
+}

--- a/code/packages/rust/q-runtime/src/eval.rs
+++ b/code/packages/rust/q-runtime/src/eval.rs
@@ -77,10 +77,53 @@ use std::rc::Rc;
 /// individually shallow) and then invoke the last one, which recurses
 /// through [`Interpreter::call_lambda`] once per link in that chain at
 /// *runtime* — a recursion shape no single parse tree's own depth reflects
-/// at all. `MAX_DEPTH` is this evaluator's own independent backstop against
-/// that (and, as defense in depth, against every ordinary tree-walk
-/// recursion `j-runtime`'s identical guard already covers).
-const MAX_DEPTH: usize = 512;
+/// at all, and the reason this constant cannot just be copied from
+/// `j-runtime`'s own (unreachable-in-practice) `MAX_DEPTH` without its own,
+/// independent empirical measurement.
+///
+/// # Measured, not guessed: the real native-stack crash floor
+///
+/// Every recursive `call_lambda` (one per chained function call) leaves
+/// exactly **4** [`Interpreter::enter`] guards on the stack for the
+/// duration of the recursion — one each in
+/// [`Interpreter::eval_assignment`], [`Interpreter::eval_noun_expr`],
+/// [`Interpreter::apply_monadic`], and `call_lambda` itself (every other
+/// call on the path — `eval_statement_value`, `eval_term`, the bounded
+/// evaluation of a call's own argument expression — either doesn't guard
+/// at all or fully unwinds before the next `call_lambda`, so it doesn't
+/// contribute to the *peak* depth). This 4:1 ratio was independently
+/// confirmed empirically (see below), not just derived by inspection.
+///
+/// Measured via the same binary-search methodology `apl-parser`/
+/// `j-parser`/`q-parser` use for their own depth caps, adapted to this
+/// evaluator's genuinely different recursion shape (a real Rust call
+/// chain through `call_lambda`, not a parser's tree descent): a throwaway
+/// **subprocess per data point** (`cargo test --exact` re-invoked per
+/// candidate chain length — a real native-stack overflow calls
+/// `abort()`, which kills the whole process, not just the offending
+/// thread, so each data point must be independently disposable), each
+/// running the chained-call source above on a
+/// [`std::thread::Builder::stack_size`]-controlled worker thread with an
+/// **explicit 2 MiB stack** (2,097,152 bytes — chosen as a known,
+/// reproducible reference point, deliberately *not* relying on the
+/// ambient default, which `RUST_MIN_STACK` can silently enlarge and
+/// invalidate the whole measurement) and `MAX_DEPTH` itself temporarily
+/// raised to 10,000,000 so the *guard* never interfered with finding the
+/// real crash point. Result: **safe up to 268 chained calls, crashes
+/// (`fatal runtime error: stack overflow`, `SIGABRT`) at 271** on a 2 MiB
+/// stack.
+///
+/// `MAX_DEPTH` is set to **760** — `760 / 4 = 190` chained calls before
+/// the guard fires, i.e. **189** succeed — about **29.5%** below the
+/// measured 268-call safe ceiling (and 29.9% below the 271-call crash
+/// point itself), comparable to `apl-parser`'s/`j-parser`'s/`q-parser`'s
+/// own ~26.5–30% margins. This was cross-checked directly (not just
+/// computed on paper): with `MAX_DEPTH` set to 760, a real capped run of
+/// exactly 189 chained calls succeeds and 190 returns a clean `Err` (see
+/// `tests::real_recursion_up_to_max_depth_succeeds_one_past_it_errors_cleanly_on_a_known_stack`),
+/// confirming the 4:1 ratio holds exactly in practice, not just in
+/// theory.
+const MAX_DEPTH: usize = 760;
 
 /// A persistent Q session: a stack of variable-binding frames (index 0 is
 /// the always-present global frame; index 1+ are call-local frames pushed
@@ -831,12 +874,7 @@ mod tests {
     #[test]
     fn a_reasonably_long_call_chain_of_already_defined_functions_works() {
         let depth = 100;
-        let mut src = String::from("f0:{x+1}\n");
-        for i in 1..depth {
-            let prev = i - 1;
-            src.push_str(&format!("f{i}:{{f{prev}(x+1)}}\n"));
-        }
-        src.push_str(&format!("f{}(0)\n", depth - 1));
+        let src = chained_call_source(depth);
         let interp = Interpreter::new();
         let tree = coding_adventures_q_parser::try_parse_q(&src).expect("should parse");
         let out = interp.run(&tree).expect("a 100-deep call chain should not trip MAX_DEPTH");
@@ -892,6 +930,67 @@ mod tests {
         assert!(
             interp.eval_list_literal(&node).is_err(),
             "a list literal of {n} elements must be rejected before evaluating any of them"
+        );
+    }
+
+    /// Build a chained-function-call Q source of `n` links: `f0:{x+1}`,
+    /// `f1:{f0(x+1)}`, ..., `f{n-1}:{f{n-2}(x+1)}`, followed by a call to
+    /// the last one -- the exact recursion shape `MAX_DEPTH` was measured
+    /// against (see that constant's own doc comment for the full
+    /// methodology and results).
+    fn chained_call_source(n: usize) -> String {
+        let mut src = String::from("f0:{x+1}\n");
+        for i in 1..n {
+            let prev = i - 1;
+            src.push_str(&format!("f{i}:{{f{prev}(x+1)}}\n"));
+        }
+        src.push_str(&format!("f{}(0)\n", n - 1));
+        src
+    }
+
+    /// Real (not white-box/synthetic) `call_lambda`-driven recursion,
+    /// exercised right up to `MAX_DEPTH`'s own measured boundary and one
+    /// step past it, run on an **explicit, known 2 MiB stack** -- the same
+    /// stack size `MAX_DEPTH`'s own calibration measurement used (see that
+    /// constant's doc comment) -- rather than relying on the ambient
+    /// default (which `RUST_MIN_STACK` could silently enlarge, invalidating
+    /// the comparison; see this repo's own
+    /// `feedback_rust_min_stack_pollutes_default_stack_probes` lesson).
+    ///
+    /// 189 chained calls succeed outright; 190 hits `MAX_DEPTH` and returns
+    /// a clean `Err` (a `join()` that returns `Ok` from the worker thread,
+    /// not a panicked/aborted thread) -- proving the *guard*, not the
+    /// *native stack*, is what stops it, with the real crash floor (271
+    /// chained calls on this same 2 MiB stack, measured empirically) still
+    /// 81 calls further out.
+    #[test]
+    fn real_recursion_up_to_max_depth_succeeds_one_past_it_errors_cleanly_on_a_known_stack() {
+        const STACK_BYTES: usize = 2 * 1024 * 1024;
+
+        let run_chain = |n: usize| -> Result<String, String> {
+            std::thread::Builder::new()
+                .stack_size(STACK_BYTES)
+                .spawn(move || {
+                    let src = chained_call_source(n);
+                    let interp = Interpreter::new();
+                    let tree = coding_adventures_q_parser::try_parse_q(&src)
+                        .expect("should parse");
+                    interp.run(&tree)
+                })
+                .expect("failed to spawn worker thread")
+                .join()
+                .expect("worker thread panicked/aborted -- this must never happen at these depths")
+        };
+
+        assert!(
+            run_chain(189).is_ok(),
+            "189 chained calls must succeed comfortably under MAX_DEPTH on a 2 MiB stack"
+        );
+        let err = run_chain(190)
+            .expect_err("190 chained calls must trip MAX_DEPTH's guard, not silently succeed");
+        assert!(
+            err.contains("too deep"),
+            "expected the depth-guard's own error message, got: {err}"
         );
     }
 }

--- a/code/packages/rust/q-runtime/src/eval.rs
+++ b/code/packages/rust/q-runtime/src/eval.rs
@@ -1,0 +1,897 @@
+//! The tree-walking evaluator.
+//!
+//! [`Interpreter`] walks the [`GrammarASTNode`] tree from `q-parser` and
+//! computes values over `array_runtime::Array`. Q reuses APL/J's two-
+//! nonterminal split (MA11 §3): `noun_expr` (arrays/scalars/functions) and
+//! `verb_expr` (a callable — a primitive glyph, optionally with one adverb,
+//! or a user-defined function value). Unlike APL/J, a Q value is not
+//! *always* a bare array: a function literal (`{[x;y] ...}`) is itself an
+//! ordinary noun value (MA11 §2/§3 bullet 1), so this evaluator's value
+//! type — [`QValue`] — is `Arr(Array)` **or** `Fn(Rc<Lambda>)`, not just
+//! `Array` the way `j-runtime`'s evaluator gets away with.
+//!
+//! ## `QFn` — generalizing `j-runtime::eval::JFn`, minus trains
+//!
+//! `QFn` is this crate's own representation of "which verb, and with which
+//! adverb (if any) applied" — the direct analogue of `JFn`
+//! (`j-runtime/src/eval.rs`), MA11 §2's own named reference point. Q has
+//! **no trains and no `@` compose** (MA11 §3/§4: deferred, and not even a
+//! genuine K/Q concept to begin with), so `QFn` has no `Compose`/`Hook`/
+//! `Fork` counterpart at all — every variant here is a leaf dispatch with
+//! no self-referential recursion, unlike `JFn` (which needed a hand-rolled
+//! iterative `Drop` specifically because `Compose`/`Hook`/`Fork` box their
+//! own operands). `QFn` needs no such thing:
+//!
+//! - **`Prim(Prim)`** — a bare primitive glyph, applied directly.
+//! - **`Each(Prim)`** — a primitive with `'` (each) applied.
+//! - **`Reduce(BinOp)`** — a `BinOp`-mappable primitive with `/` applied.
+//! - **`Scan(BinOp)`** — a `BinOp`-mappable primitive with `\` applied.
+//! - **`Lambda(Rc<Lambda>)`** — MA11's headline novelty: a user-defined
+//!   function value, with named parameters, a multi-statement body, and
+//!   (implicitly) whatever global bindings are visible at call time (see
+//!   [`Lambda`]'s own doc comment for exactly what "capture" means here).
+//!
+//! `q.grammar` only ever attaches an adverb to a bare `verb_primitive`
+//! (never to a `NAME` or `function_literal` — confirmed directly against
+//! `code/grammars/q/q.grammar`'s own `verb_expr` production), so `Each`/
+//! `Reduce`/`Scan` are only ever built from a `Prim`, never a `Lambda` —
+//! this evaluator does not need to (and does not) handle "each/reduce/scan
+//! of a user-defined function" at all.
+//!
+//! ## Calling a function value: one dispatch site, not two
+//!
+//! MA11 §3 bullet 1 is explicit: a function literal is "applied with the
+//! same juxtaposition/`@` mechanism as a primitive verb — no new
+//! *application* production, only a new way to *produce* a callable
+//! value." This evaluator honors that literally: [`Interpreter::apply_monadic`]/
+//! [`Interpreter::apply_dyadic`] are the **one** dispatch site for every
+//! `QFn` variant, `Lambda` included — there is no separate "call a lambda"
+//! code path bolted on elsewhere. The one place this evaluator *does* need
+//! new logic beyond `j-runtime`'s shape is deciding *what is callable* at
+//! all: `q.grammar`'s `noun_expr` widens its optional continuation to admit
+//! a bare `term` (not just `verb_expr`) in the "apply" position (see
+//! `q.grammar`'s own header comment and `q-parser`'s README for the full
+//! grammar-level rationale) — [`Interpreter::eval_noun_expr`]'s 2-child
+//! case disambiguates by inspecting which alternative actually matched
+//! (`kids[0].rule_name`), and [`as_callable`] is the one place that decides
+//! whether a [`QValue`] just evaluated is actually usable as a `QFn`.
+
+use crate::builtins::{self, Prim};
+use crate::value;
+use array_runtime::{ops, ops::BinOp, Array};
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::rc::Rc;
+
+/// Maximum recursion depth for this evaluator's own tree-walk *and* call
+/// chain. `q-parser`'s own `MAX_RULE_DEPTH` (32) already bounds how deep a
+/// single parsed *statement*'s tree can be before it ever reaches this
+/// crate — but unlike `j-runtime::eval::MAX_DEPTH` (which, per that
+/// module's own doc comment, is "never actually reachable through genuine
+/// parsed input" because J has no user-defined functions to chain calls
+/// through), this guard **is** genuinely reachable by a legitimate (if
+/// unusual) Q program here: a source file can define an arbitrarily long
+/// chain of already-defined functions across many separate top-level
+/// lines (`f1:{x+1}`, `f2:{f1 x+1}`, ..., `f10000:{f9999 x+1}`, each
+/// individually shallow) and then invoke the last one, which recurses
+/// through [`Interpreter::call_lambda`] once per link in that chain at
+/// *runtime* — a recursion shape no single parse tree's own depth reflects
+/// at all. `MAX_DEPTH` is this evaluator's own independent backstop against
+/// that (and, as defense in depth, against every ordinary tree-walk
+/// recursion `j-runtime`'s identical guard already covers).
+const MAX_DEPTH: usize = 512;
+
+/// A persistent Q session: a stack of variable-binding frames (index 0 is
+/// the always-present global frame; index 1+ are call-local frames pushed
+/// around a [`Lambda`] call, MA11 §4's "local to that call only" scoping)
+/// and the current evaluation depth.
+///
+/// Every field uses interior mutability (`RefCell`/`Cell`) so every
+/// evaluation method can take `&self` uniformly — including
+/// [`apply_monadic`](Interpreter::apply_monadic)/
+/// [`apply_dyadic`](Interpreter::apply_dyadic), which must be able to push
+/// and pop a call-local frame (calling a [`Lambda`]) from deep inside an
+/// otherwise-read-only tree walk, mirroring why `j-runtime::eval::Interpreter`
+/// keeps its own depth counter in a `Rc<Cell<usize>>` rather than threading
+/// `&mut self` through every recursive call.
+pub struct Interpreter {
+    env: RefCell<Vec<HashMap<String, QValue>>>,
+    depth: Rc<Cell<usize>>,
+}
+
+/// RAII guard that decrements the depth counter on every exit path
+/// (including a `?` early return) -- mirrors
+/// `j-runtime::eval::DepthGuard` exactly.
+struct DepthGuard(Rc<Cell<usize>>);
+
+impl Drop for DepthGuard {
+    fn drop(&mut self) {
+        self.0.set(self.0.get().saturating_sub(1));
+    }
+}
+
+/// RAII guard that pops the call-local frame pushed by
+/// [`Interpreter::call_lambda`], on every exit path (including an early
+/// `?` return partway through evaluating the body) -- the same "guard owns
+/// the undo" pattern as [`DepthGuard`], applied to the environment stack
+/// instead of the depth counter.
+struct FrameGuard<'a> {
+    env: &'a RefCell<Vec<HashMap<String, QValue>>>,
+}
+
+impl Drop for FrameGuard<'_> {
+    fn drop(&mut self) {
+        self.env.borrow_mut().pop();
+    }
+}
+
+impl Default for Interpreter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A Q value: either a plain numeric array (MA11 §4's in-scope value
+/// model) or a user-defined function (MA11 §2/§3 bullet 1's headline
+/// novelty) -- "a function literal is itself an ordinary noun value...
+/// assignable, passable."
+#[derive(Debug, Clone)]
+pub enum QValue {
+    Arr(Array),
+    Fn(Rc<Lambda>),
+}
+
+/// A user-defined function literal: `{[x;y] stmt; stmt; ...}`, or the
+/// bracket-omitted implicit-`x`/`y`/`z` form. This is the one genuinely new
+/// evaluator concept MA11 §2 flags: neither `apl-runtime::eval::AplFn` nor
+/// `j-runtime::eval::JFn` has ever needed to represent a named-parameter,
+/// multi-statement, user-defined callable, since APL's/J's in-scope
+/// grammars are expression-only (trains *recombine* existing primitives;
+/// they never introduce a new parameter name a body can reference).
+///
+/// ## What "capture" means here (and why no snapshot is needed)
+///
+/// MA11 §5 describes this as capturing "the enclosing call's local-binding
+/// environment at the point of definition" -- in this cut, that reduces to
+/// something simple: since nested function *definitions* are explicitly out
+/// of scope (MA11 §4; see [`Interpreter::build_lambda`]'s own guard against
+/// them), every `Lambda` is always defined at the **top level**, and its
+/// body only ever references top-level (global) variables plus its own
+/// parameters. This evaluator therefore stores **no** captured environment
+/// at all -- `params`/`body` are the complete representation -- and simply
+/// resolves any non-parameter name against the *global* frame at call time
+/// (via [`Interpreter`]'s ordinary two-tier lookup: call-local frame first,
+/// global frame beneath it). Since no nested function literal can exist to
+/// make "at the point of definition" and "at the point of call" diverge,
+/// this is not an approximation for this cut's in-scope programs -- it is
+/// the exact, correct behavior.
+#[derive(Debug)]
+pub struct Lambda {
+    pub params: Vec<String>,
+    /// Each element is a `statement` node (one child of the
+    /// `function_literal`'s `stmt_seq`) -- owned clones out of the original
+    /// parse tree (`GrammarASTNode: Clone`), since a [`Lambda`] must outlive
+    /// the single `feed()` call that parsed it (variables, and therefore
+    /// function values, persist across a REPL session's many `feed` calls).
+    pub body: Vec<GrammarASTNode>,
+}
+
+/// This evaluator's own representation of a `verb_expr`: "which verb, and
+/// with which adverb (if any) applied" -- generalizing `j-runtime::eval::JFn`
+/// per MA11 §2's own explicit instruction, minus the train-shaped variants
+/// Q has no equivalent of (see this module's own top doc comment).
+enum QFn {
+    /// A bare primitive glyph, applied directly.
+    Prim(Prim),
+    /// A primitive with `'` (each) applied. See
+    /// [`Prim::each_monadic_supported`]/[`Prim::each_dyadic_supported`] for
+    /// exactly which primitives this has a well-defined meaning for in this
+    /// cut's flat, dense-array-only value model.
+    Each(Prim),
+    /// A `BinOp`-mappable primitive with `/` (reduce/over) applied --
+    /// inherently monadic (`+/x` reduces the one array `x`).
+    Reduce(BinOp),
+    /// A `BinOp`-mappable primitive with `\` (scan) applied -- also
+    /// monadic.
+    Scan(BinOp),
+    /// A user-defined function value (MA11 §2's headline novelty).
+    Lambda(Rc<Lambda>),
+}
+
+impl Interpreter {
+    pub fn new() -> Self {
+        Interpreter {
+            env: RefCell::new(vec![HashMap::new()]),
+            depth: Rc::new(Cell::new(0)),
+        }
+    }
+
+    /// Enter one level of recursion, erroring if [`MAX_DEPTH`] is exceeded.
+    /// The returned guard decrements the counter when it drops.
+    fn enter(&self) -> Result<DepthGuard, String> {
+        self.depth.set(self.depth.get() + 1);
+        let guard = DepthGuard(Rc::clone(&self.depth));
+        if self.depth.get() > MAX_DEPTH {
+            return Err("q-runtime: expression nesting too deep".to_string());
+        }
+        Ok(guard)
+    }
+
+    /// Look up `name`, searching call-local frames innermost-first and
+    /// falling back to the global frame (index 0) last -- a local binding
+    /// *shadows* a global one of the same name for the duration of that
+    /// call, MA11 §4's "local to that call only" scoping.
+    fn lookup(&self, name: &str) -> Option<QValue> {
+        let env = self.env.borrow();
+        env.iter().rev().find_map(|frame| frame.get(name).cloned())
+    }
+
+    /// Bind `name` in the *current* frame -- the top of the stack, which is
+    /// the global frame at the top level and a call-local frame inside a
+    /// [`Lambda`] call. This single rule ("always write to the top frame")
+    /// is what makes top-level assignment and in-body local assignment the
+    /// same code path with no special-casing.
+    fn assign(&self, name: &str, value: QValue) {
+        let mut env = self.env.borrow_mut();
+        let top = env.last_mut().expect("env always has at least the global frame");
+        top.insert(name.to_string(), value);
+    }
+
+    /// Whether evaluation is currently nested inside at least one active
+    /// [`Lambda`] call -- i.e. whether the environment stack holds more
+    /// than just the global frame. Used by [`Interpreter::build_lambda`] to
+    /// reject a *nested* function literal (MA11 §4: out of scope).
+    fn inside_a_call(&self) -> bool {
+        self.env.borrow().len() > 1
+    }
+
+    /// Evaluate a whole `program` node, returning the auto-print output for
+    /// every statement that is *not* an assignment (MA11's own REPL/runtime
+    /// convention, mirroring `j-runtime`'s/`apl-runtime`'s identical
+    /// "assignment silent, bare expression auto-prints" behavior -- Q's own
+    /// real console works the same way).
+    pub fn run(&self, program: &GrammarASTNode) -> Result<String, String> {
+        let mut out = String::new();
+        for line in node_children(program) {
+            if line.rule_name != "line" {
+                continue;
+            }
+            let stmt = line.children.iter().find_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "statement" => Some(n),
+                _ => None,
+            });
+            let Some(stmt) = stmt else { continue };
+            let assignment = only_node(stmt)?;
+            let is_assignment = assignment.children.len() == 3;
+            let val = self.eval_assignment(assignment)?;
+            if !is_assignment {
+                out.push_str(&value::display(&val));
+                out.push('\n');
+            }
+        }
+        Ok(out)
+    }
+
+    /// `statement = assignment` -- a bare passthrough, always exactly one
+    /// child. Evaluate it for its value, regardless of whether it happened
+    /// to be an actual assignment (used by [`Interpreter::call_lambda`] to
+    /// evaluate a `Lambda` body's statements in order without needing to
+    /// separately decide "should this print", which only matters at the
+    /// top level).
+    fn eval_statement_value(&self, stmt: &GrammarASTNode) -> Result<QValue, String> {
+        let assignment = only_node(stmt)?;
+        self.eval_assignment(assignment)
+    }
+
+    /// `assignment = NAME COLON assignment | noun_expr`. A 3-child node
+    /// (`[Token(NAME), Token(COLON), Node(assignment)]`) is a real
+    /// assignment -- right-associative, so `x:y:3` binds `3` to *both* `y`
+    /// and `x` (mirrors `j-runtime::eval::eval_assignment`'s identical
+    /// chained-assignment shape). A 1-child node is a plain passthrough to
+    /// `noun_expr`.
+    fn eval_assignment(&self, node: &GrammarASTNode) -> Result<QValue, String> {
+        let _guard = self.enter()?;
+        if node.children.len() == 3 {
+            let name = assignment_target_name(node)?;
+            let inner = only_node(node)?;
+            let value = self.eval_assignment(inner)?;
+            self.assign(&name, value.clone());
+            Ok(value)
+        } else {
+            let noun_expr = only_node(node)?;
+            self.eval_noun_expr(noun_expr)
+        }
+    }
+
+    /// `noun_expr = term [ verb_expr noun_expr | noun_expr ] | verb_expr noun_expr`.
+    ///
+    /// - 1 child `[Node(term)]` -- a bare term.
+    /// - 3 children `[Node(term), Node(verb_expr), Node(noun_expr)]` --
+    ///   ordinary dyadic application (`2+3`, or `x f y` for a NAME/lambda
+    ///   `f`), right-recursive.
+    /// - 2 children -- **ambiguous by count alone** (the one genuinely new
+    ///   wrinkle `q.grammar` has that `j.grammar`/`apl.grammar` never
+    ///   needed, see this module's own top doc comment and
+    ///   `q-parser`'s README): `[Node(verb_expr), Node(noun_expr)]` is
+    ///   ordinary monadic primitive application (`-5`); `[Node(term),
+    ///   Node(noun_expr)]` is the genuinely new "apply a callable term"
+    ///   fallback (`f 5`, or `{x*2} 5`). Disambiguated by inspecting
+    ///   `kids[0].rule_name` -- exactly the check `q-parser`'s own grammar
+    ///   file says a later pass (this one) needs to make.
+    fn eval_noun_expr(&self, node: &GrammarASTNode) -> Result<QValue, String> {
+        let _guard = self.enter()?;
+        let kids = node_children(node);
+        match kids.len() {
+            1 => self.eval_term(kids[0]),
+            2 => match kids[0].rule_name.as_str() {
+                "verb_expr" => {
+                    let f = self.parse_verb_expr(kids[0])?;
+                    let arg = self.eval_noun_expr(kids[1])?;
+                    self.apply_monadic(&f, &arg)
+                }
+                "term" => {
+                    let callee = self.eval_term(kids[0])?;
+                    let f = as_callable(callee)?;
+                    let arg = self.eval_noun_expr(kids[1])?;
+                    self.apply_monadic(&f, &arg)
+                }
+                other => Err(format!(
+                    "q-runtime: malformed noun_expr (unexpected first child '{other}')"
+                )),
+            },
+            3 => {
+                let lhs = self.eval_term(kids[0])?;
+                let f = self.parse_verb_expr(kids[1])?;
+                let rhs = self.eval_noun_expr(kids[2])?;
+                self.apply_dyadic(&f, &lhs, &rhs)
+            }
+            n => Err(format!("q-runtime: malformed noun_expr with {n} children")),
+        }
+    }
+
+    /// `term = NUMBER { NUMBER } | NAME | function_literal | LPAREN noun_expr RPAREN | list_literal`.
+    fn eval_term(&self, node: &GrammarASTNode) -> Result<QValue, String> {
+        let _guard = self.enter()?;
+        match node.children.first() {
+            Some(ASTNodeOrToken::Token(t)) if t.effective_type_name() == "NUMBER" => {
+                // Stranding: one or more juxtaposed NUMBER tokens form a
+                // single term -- `1 2 3` is one 3-element vector, a lone `5`
+                // is a rank-0 scalar (MA11 §4, inherited unchanged from
+                // APL/J). No grammar-level depth bound on the *count* of
+                // stranded numbers (`term`'s repetition is flat, not
+                // recursive), so it is capped here directly, mirroring
+                // `j-runtime::eval::eval_term`'s own identical guard.
+                if node.children.len() > builtins::MAX_ARRAY_LENGTH {
+                    return Err(format!(
+                        "q-runtime: stranded literal of {} numbers exceeds the cap of {} elements",
+                        node.children.len(),
+                        builtins::MAX_ARRAY_LENGTH
+                    ));
+                }
+                let mut nums = Vec::new();
+                for c in &node.children {
+                    if let ASTNodeOrToken::Token(tok) = c {
+                        nums.push(parse_q_number(&tok.value)?);
+                    }
+                }
+                let arr = if nums.len() == 1 {
+                    Array::scalar(nums[0])
+                } else {
+                    Array::from_vec(nums)
+                };
+                Ok(QValue::Arr(arr))
+            }
+            Some(ASTNodeOrToken::Token(t)) if t.effective_type_name() == "NAME" => self
+                .lookup(&t.value)
+                .ok_or_else(|| format!("q-runtime: undefined variable '{}'", t.value)),
+            Some(ASTNodeOrToken::Node(n)) if n.rule_name == "function_literal" => {
+                Ok(QValue::Fn(self.build_lambda(n)?))
+            }
+            Some(ASTNodeOrToken::Token(t)) if t.effective_type_name() == "LPAREN" => {
+                let inner = only_node(node)?; // the Node(noun_expr) child
+                self.eval_noun_expr(inner)
+            }
+            Some(ASTNodeOrToken::Node(n)) if n.rule_name == "list_literal" => {
+                self.eval_list_literal(n)
+            }
+            _ => Err("q-runtime: malformed term".to_string()),
+        }
+    }
+
+    /// `list_literal = LPAREN noun_expr SEMICOLON noun_expr { SEMICOLON noun_expr } RPAREN`
+    /// (MA11 §3 bullet 3 / §4).
+    ///
+    /// Both list-literal syntaxes must "lower to the same list value" (MA11
+    /// §3 bullet 3): for the case this actually reduces to -- every element
+    /// a plain numeric scalar -- `(1;2;3)` produces the *identical* 3-element
+    /// vector as stranding `1 2 3`, implemented here by simply collecting
+    /// each element's scalar value.
+    ///
+    /// **Disclosed scope limit**: this cut's value model is "arrays only,
+    /// dense and numeric" (MA11 §4) with *no* nested/boxed/heterogeneous
+    /// list representation at all -- so a list literal containing a
+    /// non-scalar element (itself a vector/matrix) or a function-valued
+    /// element (`(2;{x+1};3)`, which `q-parser`'s own test suite confirms
+    /// *parses* -- the grammar was built slightly ahead of this runtime's
+    /// semantic scope, exactly as this task's own brief anticipates) has no
+    /// representation this crate's dense-numeric `Array` can hold. Rather
+    /// than silently flattening or truncating such a value, this is a
+    /// clean, specific "not yet supported" error naming exactly why.
+    fn eval_list_literal(&self, node: &GrammarASTNode) -> Result<QValue, String> {
+        let _guard = self.enter()?;
+        let elems = node_children(node);
+        if elems.len() > builtins::MAX_ARRAY_LENGTH {
+            return Err(format!(
+                "q-runtime: a list literal of {} elements exceeds the cap of {} elements",
+                elems.len(),
+                builtins::MAX_ARRAY_LENGTH
+            ));
+        }
+        let mut nums = Vec::with_capacity(elems.len());
+        for e in elems {
+            match self.eval_noun_expr(e)? {
+                QValue::Arr(a) if a.is_scalar() => nums.push(a.data()[0]),
+                QValue::Arr(_) => {
+                    return Err(
+                        "q-runtime: a list literal with a non-scalar element has no \
+                         representation in this cut's dense-numeric-only value model (MA11 §4)"
+                            .to_string(),
+                    )
+                }
+                QValue::Fn(_) => {
+                    return Err(
+                        "q-runtime: a list literal containing a function-valued element has \
+                         no representation in this cut's dense-numeric-only value model (MA11 §4)"
+                            .to_string(),
+                    )
+                }
+            }
+        }
+        Ok(QValue::Arr(Array::from_vec(nums)))
+    }
+
+    /// Build a [`Lambda`] from a `function_literal` node -- MA11 §2/§3
+    /// bullet 1's headline novelty.
+    ///
+    /// **Rejects nested function literals** (MA11 §4: "no nested function
+    /// literals to begin with", and the deferred list's "nested function
+    /// definitions and their global/local scoping subtlety"): if this
+    /// method is reached while already [`inside_a_call`](Self::inside_a_call)
+    /// (evaluating a *previous* `Lambda`'s body), this is a function literal
+    /// appearing textually inside another one's body -- exactly the shape
+    /// `q.grammar` happens to parse (`term`'s own alternatives include
+    /// `function_literal`, reachable from inside a `stmt_seq` too) but MA11
+    /// §4 explicitly puts out of scope. This is rejected *unconditionally*,
+    /// not just when the inner literal is actually called: even a nested
+    /// literal that is merely constructed-and-returned (never invoked
+    /// within the same call) would, if later invoked as an independent
+    /// value, need real lexical closure capture to see the *outer* call's
+    /// locals correctly -- and this crate deliberately captures none (see
+    /// [`Lambda`]'s own doc comment) -- so allowing it to build at all
+    /// would silently misrepresent Q's real (deferred) closure semantics
+    /// rather than erroring cleanly, exactly the failure mode this task's
+    /// brief warns against.
+    fn build_lambda(&self, node: &GrammarASTNode) -> Result<Rc<Lambda>, String> {
+        if self.inside_a_call() {
+            return Err(
+                "q-runtime: nested function literals are not supported in this cut (MA11 §4 -- \
+                 every function body in scope calls only primitives and already-defined \
+                 functions, with no nested function-literal definitions of its own)"
+                    .to_string(),
+            );
+        }
+        let param_list_node = node.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Node(n) if n.rule_name == "param_list" => Some(n),
+            _ => None,
+        });
+        let params: Vec<String> = match param_list_node {
+            Some(pl) => {
+                let names: Vec<String> = pl
+                    .children
+                    .iter()
+                    .filter_map(|c| match c {
+                        ASTNodeOrToken::Token(t) if t.effective_type_name() == "NAME" => {
+                            Some(t.value.clone())
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                if names.is_empty() {
+                    return Err(
+                        "q-runtime: malformed function_literal (empty param_list)".to_string()
+                    );
+                }
+                names
+            }
+            // The bracket-omitted implicit-parameter convenience (MA11 §3
+            // bullet 1 / §4): no `[x;y]` at all defaults to the well-
+            // documented `x`/`y`/`z` names. `q.grammar` never emits a
+            // `param_list` node in this case (its own doc comment: "the
+            // parse tree simply has no `param_list` child"), so an absent
+            // node -- not an empty one -- is exactly the signal for this.
+            None => vec!["x".to_string(), "y".to_string(), "z".to_string()],
+        };
+        let stmt_seq_node = node
+            .children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "stmt_seq" => Some(n),
+                _ => None,
+            })
+            .ok_or_else(|| {
+                "q-runtime: malformed function_literal (missing stmt_seq)".to_string()
+            })?;
+        let body: Vec<GrammarASTNode> = node_children(stmt_seq_node)
+            .into_iter()
+            .filter(|n| n.rule_name == "statement")
+            .cloned()
+            .collect();
+        if body.is_empty() {
+            return Err("q-runtime: malformed function_literal (empty body)".to_string());
+        }
+        Ok(Rc::new(Lambda { params, body }))
+    }
+
+    /// Call `lambda` with `args` (1 argument for a monadic application, 2
+    /// for dyadic -- this grammar's call sites, `term noun_expr` and
+    /// `term verb_expr noun_expr`, never produce more than two operands, so
+    /// the well-documented implicit `z` third parameter is never actually
+    /// reachable in practice; it is still honored by name for the
+    /// 1-/2-argument cases MA11 §3 bullet 1 does describe).
+    ///
+    /// Binds `args` to `lambda.params` **positionally** (`args[0]` to
+    /// `params[0]`, etc.) in a fresh call-local frame, pushed on top of the
+    /// environment stack for the duration of the call (MA11 §4: "local to
+    /// that call only") and popped again via [`FrameGuard`] on every exit
+    /// path. Evaluates every body statement in order (the same
+    /// [`eval_statement_value`](Self::eval_statement_value) top-level
+    /// `run` uses, so an in-body assignment behaves identically to a
+    /// top-level one except for *where* it writes -- the top of the
+    /// stack, which is now this call's own frame, not the global one),
+    /// returning the **last** statement's value as the call's result.
+    fn call_lambda(&self, lambda: &Rc<Lambda>, args: Vec<QValue>) -> Result<QValue, String> {
+        let _guard = self.enter()?;
+        if args.len() > lambda.params.len() {
+            return Err(format!(
+                "q-runtime: function takes at most {} parameter(s), called with {}",
+                lambda.params.len(),
+                args.len()
+            ));
+        }
+        let mut frame = HashMap::with_capacity(args.len());
+        for (name, val) in lambda.params.iter().zip(args) {
+            frame.insert(name.clone(), val);
+        }
+        self.env.borrow_mut().push(frame);
+        let _frame_guard = FrameGuard { env: &self.env };
+
+        let mut result = None;
+        let last_index = lambda.body.len() - 1;
+        for (i, stmt) in lambda.body.iter().enumerate() {
+            let value = self.eval_statement_value(stmt)?;
+            if i == last_index {
+                result = Some(value);
+            }
+        }
+        Ok(result.expect("build_lambda guarantees a non-empty body"))
+    }
+
+    /// `verb_expr = verb_primitive [ EACH | REDUCE | SCAN ] | NAME | function_literal`.
+    /// Needs `&self` (unlike a hypothetical free function) because the
+    /// `NAME` alternative requires a variable lookup, and `function_literal`
+    /// requires [`Interpreter::build_lambda`]'s own nested-literal check.
+    fn parse_verb_expr(&self, node: &GrammarASTNode) -> Result<QFn, String> {
+        let _guard = self.enter()?;
+        match node.children.as_slice() {
+            [ASTNodeOrToken::Node(prim)] if prim.rule_name == "verb_primitive" => {
+                Ok(QFn::Prim(parse_verb_primitive(prim)?))
+            }
+            [ASTNodeOrToken::Node(prim), ASTNodeOrToken::Token(adverb)]
+                if prim.rule_name == "verb_primitive" =>
+            {
+                let p = parse_verb_primitive(prim)?;
+                match adverb.effective_type_name() {
+                    "EACH" => Ok(QFn::Each(p)),
+                    "REDUCE" => Ok(QFn::Reduce(require_scalar_binop(p, "/ (reduce)")?)),
+                    "SCAN" => Ok(QFn::Scan(require_scalar_binop(p, "\\ (scan)")?)),
+                    other => Err(format!("q-runtime: unexpected adverb token '{other}'")),
+                }
+            }
+            [ASTNodeOrToken::Token(t)] if t.effective_type_name() == "NAME" => {
+                let val = self
+                    .lookup(&t.value)
+                    .ok_or_else(|| format!("q-runtime: undefined variable '{}'", t.value))?;
+                as_callable(val)
+            }
+            [ASTNodeOrToken::Node(fl)] if fl.rule_name == "function_literal" => {
+                Ok(QFn::Lambda(self.build_lambda(fl)?))
+            }
+            _ => Err("q-runtime: malformed verb_expr".to_string()),
+        }
+    }
+
+    /// Apply a monadic (one-argument) callable -- the single dispatch site
+    /// for every `QFn` variant, `Lambda` included (see this module's own
+    /// top doc comment).
+    fn apply_monadic(&self, f: &QFn, y: &QValue) -> Result<QValue, String> {
+        let _guard = self.enter()?;
+        match f {
+            QFn::Prim(p) => Ok(QValue::Arr(builtins::apply_monadic_prim(
+                *p,
+                as_array(y)?,
+            )?)),
+            QFn::Each(p) => {
+                if !p.each_monadic_supported() {
+                    return Err(format!(
+                        "q-runtime: ' (each) has no well-defined per-element meaning for '{}' \
+                         monadically in this cut's flat, dense-array-only value model (MA11 §4)",
+                        p.glyph()
+                    ));
+                }
+                Ok(QValue::Arr(builtins::apply_monadic_prim(*p, as_array(y)?)?))
+            }
+            QFn::Reduce(op) => Ok(QValue::Arr(ops::reduce(*op, as_array(y)?)?)),
+            QFn::Scan(op) => Ok(QValue::Arr(ops::scan(*op, as_array(y)?)?)),
+            QFn::Lambda(l) => self.call_lambda(l, vec![y.clone()]),
+        }
+    }
+
+    /// Apply a dyadic (two-argument) callable.
+    fn apply_dyadic(&self, f: &QFn, x: &QValue, y: &QValue) -> Result<QValue, String> {
+        let _guard = self.enter()?;
+        match f {
+            QFn::Prim(p) => Ok(QValue::Arr(builtins::apply_dyadic_prim(
+                *p,
+                as_array(x)?,
+                as_array(y)?,
+            )?)),
+            QFn::Each(p) => {
+                if !p.each_dyadic_supported() {
+                    return Err(format!(
+                        "q-runtime: ' (each) has no well-defined per-element meaning for '{}' \
+                         dyadically in this cut's flat, dense-array-only value model (MA11 §4)",
+                        p.glyph()
+                    ));
+                }
+                Ok(QValue::Arr(builtins::apply_dyadic_prim(
+                    *p,
+                    as_array(x)?,
+                    as_array(y)?,
+                )?))
+            }
+            QFn::Reduce(_) => Err(
+                "q-runtime: / (reduce) takes exactly one operand, but was applied dyadically"
+                    .to_string(),
+            ),
+            QFn::Scan(_) => Err(
+                "q-runtime: \\ (scan) takes exactly one operand, but was applied dyadically"
+                    .to_string(),
+            ),
+            QFn::Lambda(l) => self.call_lambda(l, vec![x.clone(), y.clone()]),
+        }
+    }
+}
+
+/// Require `v` to be a plain array, erroring cleanly (naming the fact that
+/// it was a function value instead) rather than ever silently coercing one.
+fn as_array(v: &QValue) -> Result<&Array, String> {
+    match v {
+        QValue::Arr(a) => Ok(a),
+        QValue::Fn(_) => {
+            Err("q-runtime: expected a plain array value, got a function value".to_string())
+        }
+    }
+}
+
+/// Require `v` to be callable, erroring cleanly (this is the one place that
+/// decides whether a [`QValue`] just evaluated can play `verb_expr`'s role
+/// -- see this module's own top doc comment's "Calling a function value"
+/// section).
+fn as_callable(v: QValue) -> Result<QFn, String> {
+    match v {
+        QValue::Fn(l) => Ok(QFn::Lambda(l)),
+        QValue::Arr(_) => Err(
+            "q-runtime: cannot apply a plain array value as a function (only a function \
+             literal, or a name bound to one, can be applied via juxtaposition)"
+                .to_string(),
+        ),
+    }
+}
+
+/// Parse one `NUMBER` token's source text into an `f64`. Unlike J (whose
+/// `NUMBER` folds a leading underscore into ASCII `-` before parsing), a
+/// Q `NUMBER` token's own value is already plain, standard `f64` syntax --
+/// `q-lexer`'s `fold_negative_number_literals` post-tokenize hook already
+/// prepends an ordinary ASCII `-` directly onto the token's `value` string
+/// when a negative literal is recognized (MA11 §3 bullet 2), so no
+/// translation is needed here at all; Rust's own `f64::from_str` parses the
+/// result unchanged.
+fn parse_q_number(s: &str) -> Result<f64, String> {
+    s.parse::<f64>()
+        .map_err(|_| format!("q-runtime: invalid number literal '{s}'"))
+}
+
+/// `verb_primitive`: always exactly one child, a single token naming the
+/// primitive glyph.
+fn parse_verb_primitive(node: &GrammarASTNode) -> Result<Prim, String> {
+    let tok = match node.children.first() {
+        Some(ASTNodeOrToken::Token(t)) => t,
+        _ => return Err("q-runtime: malformed verb_primitive".to_string()),
+    };
+    Ok(match tok.effective_type_name() {
+        "PLUS" => Prim::Plus,
+        "MINUS" => Prim::Minus,
+        "STAR" => Prim::Star,
+        "PERCENT" => Prim::Percent,
+        "BANG" => Prim::Bang,
+        "COMMA" => Prim::Comma,
+        "HASH" => Prim::Hash,
+        "UNDERSCORE" => Prim::Underscore,
+        "AMP" => Prim::Amp,
+        "PIPE" => Prim::Pipe,
+        "TILDE" => Prim::Tilde,
+        "EQ" => Prim::Eq,
+        "LT" => Prim::Lt,
+        "GT" => Prim::Gt,
+        "LE" => Prim::Le,
+        "GE" => Prim::Ge,
+        "NE" => Prim::Ne,
+        other => return Err(format!("q-runtime: unknown verb primitive token '{other}'")),
+    })
+}
+
+/// Reduce/scan apply only to the 12 primitives that map onto a `BinOp` --
+/// `!`/`,`/`#`/`_`/`~` are not "a scalar dyadic function" at all, so
+/// stacking an adverb onto one of them is a clean, explicit scope error
+/// (mirrors `j-runtime::eval::require_scalar_binop` exactly, generalized to
+/// Q's own primitive set).
+fn require_scalar_binop(p: Prim, context: &str) -> Result<BinOp, String> {
+    p.to_binop()
+        .ok_or_else(|| format!("q-runtime: {context}: {} is not a scalar dyadic verb", p.glyph()))
+}
+
+/// The `NAME` token of an actual assignment's target -- the first child of
+/// a 3-child `assignment` node (`[Token(NAME), Token(COLON), Node(assignment)]`).
+fn assignment_target_name(node: &GrammarASTNode) -> Result<String, String> {
+    match node.children.first() {
+        Some(ASTNodeOrToken::Token(t)) if t.effective_type_name() == "NAME" => Ok(t.value.clone()),
+        _ => Err("q-runtime: malformed assignment (missing target name)".to_string()),
+    }
+}
+
+// ── AST helpers ──────────────────────────────────────────────────────────────
+
+fn node_children(node: &GrammarASTNode) -> Vec<&GrammarASTNode> {
+    node.children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Node(n) => Some(n),
+            ASTNodeOrToken::Token(_) => None,
+        })
+        .collect()
+}
+
+fn first_node(node: &GrammarASTNode) -> Option<&GrammarASTNode> {
+    node.children.iter().find_map(|c| match c {
+        ASTNodeOrToken::Node(n) => Some(n),
+        ASTNodeOrToken::Token(_) => None,
+    })
+}
+
+fn only_node(node: &GrammarASTNode) -> Result<&GrammarASTNode, String> {
+    first_node(node).ok_or_else(|| format!("q-runtime: malformed '{}' node", node.rule_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A direct, white-box unit test of the depth guard mechanism itself
+    /// (`enter`/`DepthGuard`) -- mirrors
+    /// `j-runtime::eval::tests::depth_guard_trips_after_max_depth_and_recovers`
+    /// exactly. Unlike J's guard (never reachable through genuine parsed
+    /// input, per that module's own doc comment), this crate's `MAX_DEPTH`
+    /// *is* reachable via a long enough legitimate call chain (see
+    /// `MAX_DEPTH`'s own doc comment) -- this test still exercises the
+    /// guard mechanism directly, since driving it via 512+ distinct
+    /// top-level function definitions in one test would be needlessly
+    /// slow and indirect for what is fundamentally a unit test of `enter()`
+    /// itself.
+    #[test]
+    fn depth_guard_trips_after_max_depth_and_recovers() {
+        let interp = Interpreter::new();
+        let mut guards = Vec::new();
+        for _ in 0..MAX_DEPTH {
+            guards.push(interp.enter().expect("should stay under the cap"));
+        }
+        assert!(interp.enter().is_err(), "one more enter() must trip the cap");
+        drop(guards);
+        assert!(
+            interp.enter().is_ok(),
+            "dropping every guard must let a fresh enter() succeed again"
+        );
+    }
+
+    /// A long (but legitimate) chain of already-defined-function calls must
+    /// still work -- confirms `MAX_DEPTH` (512) leaves comfortable headroom
+    /// for realistic, non-adversarial call chains, not just single
+    /// expressions.
+    ///
+    /// Each link calls the previous function with an explicitly
+    /// parenthesised argument (`f98(x+1)`, not `f98 x+1`) -- without the
+    /// parens, `q.grammar`'s own "which bare NAME plays the verb role"
+    /// resolution (see this module's own top doc comment and
+    /// `q-parser`'s README) would read a bare trailing NAME/expression
+    /// pair like `f98 x+1` as `x` itself being the (dyadic) callable
+    /// applied to `(f98, 1)`, not as "call f98 with argument x+1" -- a
+    /// real, disclosed grammar-level ambiguity this test sidesteps the
+    /// documented way (parenthesise the argument), not a bug in this
+    /// evaluator.
+    #[test]
+    fn a_reasonably_long_call_chain_of_already_defined_functions_works() {
+        let depth = 100;
+        let mut src = String::from("f0:{x+1}\n");
+        for i in 1..depth {
+            let prev = i - 1;
+            src.push_str(&format!("f{i}:{{f{prev}(x+1)}}\n"));
+        }
+        src.push_str(&format!("f{}(0)\n", depth - 1));
+        let interp = Interpreter::new();
+        let tree = coding_adventures_q_parser::try_parse_q(&src).expect("should parse");
+        let out = interp.run(&tree).expect("a 100-deep call chain should not trip MAX_DEPTH");
+        // f0(0)=1, f1(0)=f0(0+1)=f0(1)=2, ..., f_k(0) = k+1.
+        assert_eq!(out.trim(), depth.to_string());
+    }
+
+    /// A minimal placeholder `GrammarASTNode` -- its own content is
+    /// irrelevant to the test below, since [`Interpreter::eval_list_literal`]'s
+    /// element-count cap check happens on `node_children(node).len()`
+    /// *before* evaluating a single element (see that method's own
+    /// implementation), so a `list_literal` node's children never need to
+    /// be *semantically* valid `noun_expr`s to exercise this guard.
+    fn placeholder_node(rule_name: &str) -> GrammarASTNode {
+        GrammarASTNode {
+            rule_name: rule_name.to_string(),
+            children: Vec::new(),
+            start_line: None,
+            start_column: None,
+            end_line: None,
+            end_column: None,
+        }
+    }
+
+    /// Direct, white-box regression test for `list_literal`'s own element-
+    /// count cap, constructing the tree by hand rather than through real
+    /// source text.
+    ///
+    /// A genuine `try_parse_q` call over 1,000,001 semicolon-separated
+    /// elements is *drastically* slower than every other DoS-guard test in
+    /// this crate (tens of seconds) -- `q.grammar`'s `list_literal`
+    /// production has no cap on its own flat repetition *width* (only
+    /// `q-parser`'s `MAX_RULE_DEPTH` bounds nesting *depth*, MA11 §6), so
+    /// parsing that many elements pays real packrat-parser overhead this
+    /// evaluator has no control over. Building the
+    /// [`GrammarASTNode`] tree directly sidesteps that entirely -- this is
+    /// a test of `eval_list_literal`'s own cap check, not of `q-parser`'s
+    /// scalability, so there is no need to route it through a real parse
+    /// at all.
+    #[test]
+    fn list_literal_rejects_an_oversized_element_count_before_evaluating_any_element() {
+        let interp = Interpreter::new();
+        let n = builtins::MAX_ARRAY_LENGTH + 1;
+        let dummy = ASTNodeOrToken::Node(placeholder_node("noun_expr"));
+        let node = GrammarASTNode {
+            rule_name: "list_literal".to_string(),
+            children: vec![dummy; n],
+            start_line: None,
+            start_column: None,
+            end_line: None,
+            end_column: None,
+        };
+        assert!(
+            interp.eval_list_literal(&node).is_err(),
+            "a list literal of {n} elements must be rejected before evaluating any of them"
+        );
+    }
+}

--- a/code/packages/rust/q-runtime/src/lib.rs
+++ b/code/packages/rust/q-runtime/src/lib.rs
@@ -1,0 +1,607 @@
+//! # Q Runtime — a tree-walking evaluator over `array-runtime`.
+//!
+//! This is item **MA-11d** of the Q frontend (spec
+//! `code/specs/MA11-q-language.md`): the runtime that makes the Q
+//! lexer/parser (`q-lexer`/`q-parser`, MA-11b/MA-11c) executable. It parses
+//! with [`coding_adventures_q_parser::try_parse_q`] and walks the resulting
+//! tree with a recursive [`Interpreter`], computing values over
+//! [`array_runtime::Array`] — Q's in-scope core (MA11 §4) is "arrays only,
+//! dense and numeric", the same value model APL/J/Scilab's array-family
+//! cuts already share (MA11 §2's own "zero new substrate" finding).
+//!
+//! ## The one genuinely new evaluator concept: `QFn::Lambda`
+//!
+//! Every array-family runtime in this repo so far (`apl-runtime`'s `AplFn`,
+//! `j-runtime`'s `JFn`) represents a "function value" as a closed set of
+//! variants built *only* from existing primitives — none of them has ever
+//! needed to represent a genuine **user-defined function literal**, since
+//! APL's/J's in-scope grammars are expression-only. Q's `{[x;y] ...}`
+//! function literal (MA11 §2/§3 bullet 1) is exactly that new thing, and a
+//! function literal is itself an ordinary noun value — assignable to a
+//! name, passable as an argument, applied with the *same*
+//! juxtaposition mechanism as a primitive verb. See `eval.rs`'s own module
+//! doc comment for the full design (the `QValue`/`QFn`/`Lambda` shapes, and
+//! exactly how "apply a callable term" is disambiguated from ordinary
+//! monadic primitive application in `noun_expr`'s 2-child case).
+//!
+//! ## Auto-print semantics
+//!
+//! Assignment is silent; a bare (non-assignment) statement auto-prints its
+//! result — mirrors `apl-runtime`'s/`j-runtime`'s own real-session
+//! convention, and real Q's own console behavior. See [`Interpreter::run`].
+//!
+//! ```
+//! use coding_adventures_q_runtime::eval;
+//!
+//! // `!` (til) is 0-based, matching J's `i.` -- never APL's 1-based `⍳`.
+//! assert_eq!(eval("!5\n").unwrap().trim(), "0 1 2 3 4");
+//!
+//! // `%` is always true/float division.
+//! assert_eq!(eval("6%4\n").unwrap().trim(), "1.5");
+//!
+//! // A function literal: bracket-omitted implicit x/y, applied by
+//! // juxtaposition exactly like a primitive.
+//! assert_eq!(eval("f:{x+y}\n2 f 3\n").unwrap().trim(), "5");
+//!
+//! // Assignment is silent; a bare expression auto-prints.
+//! assert_eq!(eval("a:5\n").unwrap(), "");
+//! assert_eq!(eval("a:5\na\n").unwrap().trim(), "5");
+//! ```
+//!
+//! For a persistent session (the REPL), construct an [`Interpreter`] and
+//! call [`Interpreter::feed`] repeatedly — variables (and function
+//! definitions) persist between calls.
+
+mod builtins;
+mod eval;
+mod value;
+
+pub use eval::Interpreter;
+
+use coding_adventures_q_parser::try_parse_q;
+
+impl Interpreter {
+    /// Parse and evaluate a chunk of Q source, returning the concatenated
+    /// auto-print output of every non-assignment statement (one line per
+    /// printed statement). Variables and function definitions persist
+    /// across calls. `q-parser`'s own `MAX_RULE_DEPTH` already rejects
+    /// pathologically deep *input* before a tree is even built, so
+    /// (mirroring `j-runtime::Interpreter::feed`'s identical rationale)
+    /// this method needs no separate pre-parse nesting scan — only this
+    /// evaluator's own `eval.rs::MAX_DEPTH` guard, which (unlike J's) is
+    /// also genuinely reachable through a legitimate, sufficiently long
+    /// call chain, not just defense in depth against an already-bounded
+    /// tree (see `eval.rs::MAX_DEPTH`'s own doc comment).
+    pub fn feed(&mut self, source: &str) -> Result<String, String> {
+        let tree = try_parse_q(source)?;
+        self.run(&tree)
+    }
+}
+
+/// Evaluate Q source in a fresh session and return its auto-print output.
+pub fn eval(source: &str) -> Result<String, String> {
+    Interpreter::new().feed(source)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Evaluate and return the raw output (may contain a trailing `\n` per
+    /// printed line, or be empty for an all-assignment program).
+    fn run(src: &str) -> String {
+        eval(src).unwrap_or_else(|e| panic!("eval failed for {src:?}: {e}"))
+    }
+
+    /// Evaluate and read back a single printed scalar as an `f64`. Q spells
+    /// a negative number with a plain ASCII `-` (MA11 §3 bullet 2), so
+    /// unlike `j-runtime`'s equivalent helper, no underscore translation is
+    /// needed here.
+    fn scalar(src: &str) -> f64 {
+        let out = run(src);
+        out.trim()
+            .parse::<f64>()
+            .unwrap_or_else(|_| panic!("not a scalar echo: {out:?}"))
+    }
+
+    /// Evaluate and read back a single printed vector (one space-separated
+    /// line), as a `Vec<f64>`.
+    fn vector(src: &str) -> Vec<f64> {
+        let out = run(src);
+        out.split_whitespace()
+            .map(|s| s.parse::<f64>().unwrap_or_else(|_| panic!("not a numeric token: {s:?} in {out:?}")))
+            .collect()
+    }
+
+    // ── Value model: scalars, vectors, stranding ───────────────────────────
+
+    #[test]
+    fn scalar_and_stranded_vector_literals() {
+        assert_eq!(scalar("5\n"), 5.0);
+        assert_eq!(vector("1 2 3\n"), vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn whitespace_sensitive_negative_literal_vs_subtraction() {
+        // MA11 §3 bullet 2's headline lexer wrinkle, confirmed end-to-end
+        // through real evaluation, not just tokenization: `2 -1` strands to
+        // a 2-element vector; `2 - 1` and `2-1` both subtract.
+        assert_eq!(vector("2 -1\n"), vec![2.0, -1.0]);
+        assert_eq!(scalar("2 - 1\n"), 1.0);
+        assert_eq!(scalar("2-1\n"), 1.0);
+    }
+
+    // ── Primitive verbs: monadic ────────────────────────────────────────────
+
+    #[test]
+    fn monadic_plus_is_flip_identity_for_scalar_and_vector() {
+        // This cut's grammar has no reshape primitive (no `$`, unlike
+        // APL/J) and `list_literal` is restricted to scalar elements (see
+        // `list_literal_with_a_non_scalar_element_is_a_clean_error` below),
+        // so no in-scope Q program can ever construct a rank-2 array at
+        // all -- `flip`'s matrix-transpose branch is exercised directly
+        // against `array_runtime::Array` in `builtins.rs`'s own
+        // `flip_transposes_a_matrix` unit test instead.
+        assert_eq!(scalar("+5\n"), 5.0);
+        assert_eq!(vector("+1 2 3\n"), vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn negative_number_literal_folds_at_the_lexer_not_via_monadic_minus() {
+        // `-5` (no gap before the digit, at a position a new stranding
+        // element may start) folds into a single negative `NUMBER` token
+        // at the lexer (MA11 §3 bullet 2) -- there is no `MINUS` token
+        // left in the stream at all once `q-lexer`'s post-tokenize hook
+        // runs, so this evaluates via ordinary literal construction, never
+        // by applying `Prim::Minus` monadically. The numeric result is
+        // indistinguishable from monadic negate's own result for a scalar,
+        // but the *code path* is genuinely different -- see
+        // `monadic_minus_negates_a_non_glued_operand` below for a test that
+        // actually exercises the verb.
+        assert_eq!(scalar("-5\n"), -5.0);
+    }
+
+    #[test]
+    fn monadic_minus_negates_a_non_glued_operand() {
+        // Genuinely exercises `Prim::Minus` applied monadically: the
+        // operand here is a parenthesised group, not a bare digit glued
+        // directly to `-`, so `q-lexer`'s negative-literal fold hook never
+        // fires (it only folds `MINUS` immediately followed by a `NUMBER`
+        // token) -- `MINUS` survives as a real verb token, applied to the
+        // whole grouped vector.
+        assert_eq!(vector("-(1 2 3)\n"), vec![-1.0, -2.0, -3.0]);
+    }
+
+    #[test]
+    fn monadic_star_is_first_not_sign() {
+        // Q's own "first / multiply" pairing (MA11 §4) -- completely
+        // different from J's "sign / multiply".
+        assert_eq!(scalar("*5\n"), 5.0);
+        assert_eq!(scalar("*1 2 3\n"), 1.0);
+    }
+
+    #[test]
+    fn monadic_percent_is_reciprocal() {
+        assert_eq!(scalar("%4\n"), 0.25);
+        assert_eq!(vector("%1 2 4\n"), vec![1.0, 0.5, 0.25]);
+    }
+
+    #[test]
+    fn monadic_bang_is_zero_based_til() {
+        // THE single most safety-critical regression test in this crate
+        // (MA11 §4): `!5` is `0 1 2 3 4`, NEVER APL's 1-based `1 2 3 4 5`.
+        assert_eq!(vector("!5\n"), vec![0.0, 1.0, 2.0, 3.0, 4.0]);
+        assert!(vector("!0\n").is_empty());
+    }
+
+    #[test]
+    fn monadic_comma_is_enlist() {
+        assert_eq!(vector(",5\n"), vec![5.0]);
+        assert_eq!(vector(",1 2 3\n"), vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn monadic_hash_is_count() {
+        assert_eq!(scalar("#5\n"), 1.0);
+        assert_eq!(scalar("#1 2 3\n"), 3.0);
+    }
+
+    #[test]
+    fn monadic_underscore_is_floor() {
+        assert_eq!(scalar("_3.8\n"), 3.0);
+        assert_eq!(scalar("_ -3.2\n"), -4.0);
+    }
+
+    #[test]
+    fn monadic_amp_is_where() {
+        assert_eq!(vector("&0 1 1 0 1\n"), vec![1.0, 2.0, 4.0]);
+    }
+
+    #[test]
+    fn monadic_pipe_is_reverse() {
+        assert_eq!(vector("|1 2 3\n"), vec![3.0, 2.0, 1.0]);
+    }
+
+    #[test]
+    fn monadic_tilde_is_not() {
+        assert_eq!(vector("~0 1 5\n"), vec![1.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn comparisons_have_no_monadic_form() {
+        for op in ["=", "<", ">", "<=", ">=", "<>"] {
+            let src = format!("{op}5\n");
+            assert!(eval(&src).is_err(), "monadic {op} should be an error");
+        }
+    }
+
+    // ── Primitive verbs: dyadic ─────────────────────────────────────────────
+
+    #[test]
+    fn dyadic_arithmetic() {
+        assert_eq!(scalar("3+4\n"), 7.0);
+        assert_eq!(scalar("3-4\n"), -1.0);
+        assert_eq!(scalar("3*4\n"), 12.0);
+    }
+
+    #[test]
+    fn dyadic_percent_is_always_true_division_no_integer_special_case() {
+        assert_eq!(scalar("6%4\n"), 1.5);
+        assert_eq!(scalar("6%3\n"), 2.0);
+    }
+
+    #[test]
+    fn dyadic_bang_dict_creation_is_deferred_cleanly() {
+        // MA11 §4: "dyadic `!` (dict creation, and its other real
+        // overloads) is deferred" -- must be a clean, specific error, never
+        // silently misinterpreted as something else.
+        let err = eval("1 2!3 4\n").unwrap_err();
+        assert!(err.contains("not yet implemented"), "got: {err}");
+    }
+
+    #[test]
+    fn dyadic_comma_joins() {
+        assert_eq!(vector("1,2\n"), vec![1.0, 2.0]);
+        assert_eq!(vector("1 2,3 4 5\n"), vec![1.0, 2.0, 3.0, 4.0, 5.0]);
+    }
+
+    #[test]
+    fn dyadic_hash_takes_with_cycling_and_negative_from_end() {
+        assert_eq!(vector("5#1 2 3\n"), vec![1.0, 2.0, 3.0, 1.0, 2.0]);
+        assert_eq!(vector("-2#1 2 3\n"), vec![2.0, 3.0]);
+    }
+
+    #[test]
+    fn dyadic_underscore_drops_from_front_or_end() {
+        assert_eq!(vector("2_1 2 3 4\n"), vec![3.0, 4.0]);
+        assert_eq!(vector("-2_1 2 3 4\n"), vec![1.0, 2.0]);
+    }
+
+    #[test]
+    fn dyadic_amp_is_min_pipe_is_max() {
+        assert_eq!(scalar("3&7\n"), 3.0);
+        assert_eq!(scalar("3|7\n"), 7.0);
+    }
+
+    #[test]
+    fn dyadic_tilde_is_deep_match_not_elementwise() {
+        assert_eq!(scalar("(1 2 3)~1 2 3\n"), 1.0);
+        assert_eq!(scalar("(1 2 3)~1 2 4\n"), 0.0);
+    }
+
+    #[test]
+    fn dyadic_comparisons_all_six_including_q_spelling_of_not_equal() {
+        assert_eq!(scalar("3=3\n"), 1.0);
+        assert_eq!(scalar("3<>4\n"), 1.0); // Q's own not-equal spelling
+        assert_eq!(scalar("3<>3\n"), 0.0);
+        assert_eq!(scalar("3<4\n"), 1.0);
+        assert_eq!(scalar("3<=3\n"), 1.0);
+        assert_eq!(scalar("3>=4\n"), 0.0);
+        assert_eq!(scalar("4>3\n"), 1.0);
+    }
+
+    // ── Adverbs: each, reduce, scan ─────────────────────────────────────────
+
+    #[test]
+    fn reduce_sums_a_vector() {
+        assert_eq!(scalar("+/1 2 3 4\n"), 10.0);
+    }
+
+    #[test]
+    fn scan_keeps_every_running_fold() {
+        assert_eq!(vector("+\\1 2 3 4\n"), vec![1.0, 3.0, 6.0, 10.0]);
+    }
+
+    #[test]
+    fn each_on_an_elementwise_primitive_matches_direct_application() {
+        // In this cut's flat, dense-array-only value model, `each` on an
+        // already-elementwise primitive is well-defined but redundant with
+        // plain application (see `builtins.rs`'s own `each_monadic_supported`
+        // doc comment for the full rationale).
+        assert_eq!(vector("-'1 2 3\n"), vec![-1.0, -2.0, -3.0]);
+        assert_eq!(vector("(1 2 3)+'4 5 6\n"), vec![5.0, 7.0, 9.0]);
+    }
+
+    #[test]
+    fn each_on_a_non_elementwise_primitive_is_a_clean_error() {
+        // `#` (count) monadically is not an elementwise scalar map (it
+        // reduces to a single count) -- `each` has no well-defined meaning
+        // for it in this cut's value model, and must say so cleanly.
+        let err = eval("#'1 2 3\n").unwrap_err();
+        assert!(err.contains("each") || err.contains("'"), "got: {err}");
+    }
+
+    #[test]
+    fn reduce_or_scan_of_a_non_scalar_dyadic_verb_is_a_clean_error() {
+        assert!(eval(",/1 2 3\n").is_err());
+        assert!(eval("#\\1 2 3\n").is_err());
+    }
+
+    // ── Right-to-left evaluation, grouping ──────────────────────────────────
+
+    #[test]
+    fn right_to_left_evaluation_has_no_precedence() {
+        assert_eq!(scalar("2*3+4\n"), 14.0);
+    }
+
+    #[test]
+    fn parenthesised_grouping_overrides_right_to_left_order() {
+        assert_eq!(scalar("(2*3)+4\n"), 10.0);
+    }
+
+    // ── Assignment ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn chained_assignment_sets_both_names() {
+        assert_eq!(scalar("a:b:3\na\n"), 3.0);
+        assert_eq!(scalar("a:b:3\nb\n"), 3.0);
+    }
+
+    #[test]
+    fn assignment_is_silent_bare_expression_prints() {
+        assert_eq!(run("a:5\n"), "");
+        assert!(run("a:5\na\n").contains('5'));
+    }
+
+    #[test]
+    fn variables_persist_across_feed_calls() {
+        let mut m = Interpreter::new();
+        m.feed("a:10\n").unwrap();
+        m.feed("b:20\n").unwrap();
+        let out = m.feed("a+b\n").unwrap();
+        assert!(out.contains("30"));
+    }
+
+    // ── Comments (lexer-level; confirm end-to-end evaluation) ───────────────
+
+    #[test]
+    fn a_comment_containing_program_evaluates_correctly() {
+        // MA11 §4: comments are a lexer-level concern already handled by
+        // `q-lexer` -- this test confirms nothing in this crate needs to
+        // (or accidentally does) special-case them.
+        assert_eq!(run("/ a leading comment\na:1 / trailing comment\na\n").trim(), "1");
+    }
+
+    #[test]
+    fn blank_lines_are_no_ops() {
+        assert_eq!(run("a:1\n\n\na\n").trim(), "1");
+    }
+
+    // ── Function literals: definition, implicit params, calling ────────────
+
+    #[test]
+    fn function_literal_with_implicit_params_x_y() {
+        assert_eq!(scalar("f:{x+y}\n2 f 3\n"), 5.0);
+    }
+
+    #[test]
+    fn function_literal_with_explicit_param_list() {
+        assert_eq!(scalar("f:{[a;b] a*b}\n3 f 4\n"), 12.0);
+    }
+
+    #[test]
+    fn function_literal_called_monadically_binds_only_x() {
+        assert_eq!(scalar("f:{x+1}\nf 5\n"), 6.0);
+    }
+
+    #[test]
+    fn function_literal_is_assignable_without_being_called() {
+        // A function literal is itself an ordinary noun value (MA11 §3
+        // bullet 1) -- assigning it must not require applying it.
+        assert_eq!(run("f:{x+y}\n"), "");
+    }
+
+    #[test]
+    fn multi_statement_function_body_returns_the_last_statements_value() {
+        assert_eq!(scalar("f:{[x] a:x+1; a*2}\nf 5\n"), 12.0); // (5+1)*2
+    }
+
+    #[test]
+    fn local_assignment_inside_a_function_body_does_not_leak_to_global_scope() {
+        // MA11 §4: assignment inside a function body is "local to that call
+        // only" -- `a` set inside `f`'s body must not be visible (or
+        // clobber an outer `a`) once the call returns.
+        let mut m = Interpreter::new();
+        m.feed("a:100\n").unwrap();
+        m.feed("f:{[x] a:x+1; a}\n").unwrap();
+        let out = m.feed("f 5\n").unwrap();
+        assert!(out.contains('6'), "expected f(5)=6, got {out}");
+        let after = m.feed("a\n").unwrap();
+        assert!(
+            after.trim() == "100",
+            "the outer `a` must be unaffected by f's local `a`, got {after}"
+        );
+    }
+
+    #[test]
+    fn calling_an_inline_function_literal_monadically_and_dyadically() {
+        assert_eq!(scalar("{x*2} 5\n"), 10.0);
+        assert_eq!(scalar("2 {x+y} 3\n"), 5.0);
+    }
+
+    #[test]
+    fn a_function_body_calling_another_already_defined_function() {
+        assert_eq!(scalar("double:{x*2}\nadd1:{x+1}\ndouble(add1 5)\n"), 12.0);
+    }
+
+    #[test]
+    fn passing_a_function_value_as_an_argument_to_another_function() {
+        // First-class functions: a param bound to a Fn value can itself be
+        // applied inside the callee's body. Not explicitly required by
+        // MA11 §4, but a natural, disclosed generalization of "a function
+        // literal is an ordinary noun value... assignable, passable" (§3
+        // bullet 1) -- distinct from the explicitly-deferred "nested
+        // function *definitions*" (see `eval.rs::Interpreter::build_lambda`'s
+        // own doc comment for exactly what remains out of scope).
+        assert_eq!(scalar("apply:{[g] g 5}\ninc:{x+1}\napply inc\n"), 6.0);
+    }
+
+    #[test]
+    fn calling_an_undefined_name_is_an_error() {
+        assert!(eval("f 5\n").is_err());
+    }
+
+    #[test]
+    fn applying_a_plain_array_value_as_a_function_is_a_clean_error() {
+        let err = eval("a:5\n(a)3\n").unwrap_err();
+        assert!(err.contains("cannot apply"), "got: {err}");
+    }
+
+    #[test]
+    fn nested_function_literal_definitions_are_a_clean_error() {
+        // MA11 §4: no nested function literals -- this errors the moment
+        // the inner literal is actually evaluated during the outer call
+        // (see `eval.rs::Interpreter::build_lambda`'s own doc comment).
+        let err = eval("f:{g:{y+1}; g x}\nf 5\n").unwrap_err();
+        assert!(
+            err.contains("nested function literals"),
+            "got: {err}"
+        );
+    }
+
+    // ── List literals: dual syntax, same value ──────────────────────────────
+
+    #[test]
+    fn explicit_list_literal_lowers_to_the_same_value_as_stranding() {
+        assert_eq!(vector("(1;2;3)\n"), vector("1 2 3\n"));
+    }
+
+    #[test]
+    fn list_literal_with_a_non_scalar_element_is_a_clean_error() {
+        // `array_runtime::Array` has no nested/heterogeneous representation
+        // (MA11 §4: "arrays only, dense and numeric") -- a list literal
+        // element that is itself a vector cannot be represented, and must
+        // say so cleanly rather than silently flattening or truncating.
+        let err = eval("(1 2;3)\n").unwrap_err();
+        assert!(err.contains("non-scalar"), "got: {err}");
+    }
+
+    #[test]
+    fn list_literal_with_a_function_valued_element_is_a_clean_error() {
+        let err = eval("(2;{x+1};3)\n").unwrap_err();
+        assert!(err.contains("function-valued"), "got: {err}");
+    }
+
+    // ── Explicitly deferred constructs: clean errors, never misinterpreted ──
+
+    #[test]
+    fn symbols_are_not_lexable_and_fail_cleanly() {
+        assert!(eval("`abc\n").is_err());
+    }
+
+    #[test]
+    fn strings_are_not_lexable_and_fail_cleanly() {
+        assert!(eval("\"abc\"\n").is_err());
+    }
+
+    #[test]
+    fn each_prior_each_right_each_left_are_not_valid_syntax_here() {
+        // MA11 §4: each-prior (`':`)/each-right (`/:`)/each-left (`\:`) are
+        // explicitly deferred, and `q.tokens` has no compound token for any
+        // of them -- confirmed here to fail cleanly (a parse error), not to
+        // silently misparse as plain EACH/REDUCE/SCAN followed by a stray
+        // COLON.
+        assert!(eval("+':1 2 3\n").is_err());
+        assert!(eval("+/:1 2 3\n").is_err());
+        assert!(eval("+\\:1 2 3\n").is_err());
+    }
+
+    #[test]
+    fn at_sign_question_mark_and_dot_are_not_lexable() {
+        // MA11 §4: `@`/`?`/`.` are all deferred whole; none of them are
+        // even in `q.tokens`' alphabet, so they fail at the lexer, before
+        // ever reaching this crate.
+        assert!(eval("a@b\n").is_err());
+        assert!(eval("a?b\n").is_err());
+        assert!(eval("a.b\n").is_err());
+    }
+
+    // ── Errors ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn undefined_variable_is_an_error() {
+        assert!(eval("undefined_thing\n").is_err());
+    }
+
+    #[test]
+    fn nonconformable_shapes_in_dyadic_arithmetic_is_an_error() {
+        assert!(eval("(1 2)+(1 2 3)\n").is_err());
+    }
+
+    #[test]
+    fn reduce_of_an_empty_vector_is_an_error() {
+        assert!(eval("+/!0\n").is_err());
+    }
+
+    #[test]
+    fn til_rejects_out_of_range_or_negative_argument() {
+        assert!(eval("!-1\n").is_err());
+        assert!(eval("!2.5\n").is_err());
+    }
+
+    #[test]
+    fn malformed_input_that_fails_to_parse_is_a_clean_error_not_a_panic() {
+        assert!(eval("'a\n").is_err());
+    }
+
+    // ── DoS-guard size caps ───────────────────────────────────────────────────
+
+    #[test]
+    fn til_rejects_an_oversized_argument_instead_of_allocating() {
+        assert!(eval("!2000000\n").is_err());
+    }
+
+    #[test]
+    fn take_rejects_an_oversized_count_instead_of_allocating() {
+        assert!(eval("2000000#1\n").is_err());
+    }
+
+    #[test]
+    fn join_rejects_an_oversized_combined_result_instead_of_allocating() {
+        assert!(eval("(600000#1),(600000#1)\n").is_err());
+    }
+
+    #[test]
+    fn stranded_literal_rejects_an_oversized_count_instead_of_allocating() {
+        // Unlike every builtin, stranding (`1 1 1 ...`) has no grammar-level
+        // depth bound on the count of numbers -- `term`'s repetition is
+        // flat, not recursive -- so this must be capped at the literal-
+        // construction site itself (`eval_term`), mirroring
+        // `j-runtime::eval::tests::stranded_literal_rejects_an_oversized_count_instead_of_allocating`.
+        let n = builtins::MAX_ARRAY_LENGTH + 1;
+        let src: String = "1 ".repeat(n) + "\n";
+        assert!(eval(&src).is_err());
+    }
+
+    // Note: the "list_literal rejects an oversized element count" cap check
+    // is verified in `eval.rs`'s own test module via a synthetically
+    // constructed tree, not through real source text here -- `q-parser`'s
+    // grammar has no cap on `list_literal`'s own flat repetition *width*
+    // (only on nesting *depth*, MA11 §6), so parsing a genuine
+    // 1,000,001-element list literal through `try_parse_q` is drastically
+    // slower than every other DoS-guard test in this file (tens of
+    // seconds, dominated by packrat-parser overhead, not by anything this
+    // crate's own evaluator does) -- see
+    // `eval.rs::tests::list_literal_rejects_an_oversized_element_count_before_evaluating_any_element`
+    // for the fast, direct-tree-construction version of this same check.
+}

--- a/code/packages/rust/q-runtime/src/value.rs
+++ b/code/packages/rust/q-runtime/src/value.rs
@@ -1,0 +1,210 @@
+//! Q-style display formatting.
+//!
+//! `array_runtime::value::Array` already implements [`std::fmt::Display`],
+//! but (exactly like `apl-runtime::value::display`/`j-runtime::value::display`,
+//! whose rationale this module mirrors) that impl is tuned for MATLAB, not
+//! for a Q console session. Q's own conventions differ from `Array`'s
+//! default `Display` in the same places APL's/J's did:
+//!
+//! | Rule                | MATLAB (`Array::fmt`)         | Q (this module)              |
+//! |----------------------|--------------------------------|--------------------------------|
+//! | Negative sign         | ASCII `-3`                    | ASCII `-3` (same!)            |
+//! | Name prefix           | caller adds `x = `            | none — bare value              |
+//! | Whole-valued float     | `3` (no `.0`)                 | `3` (no `.0`)                  |
+//! | Vector layout          | n/a (row vector = 1×n matrix) | one line, space-separated      |
+//! | Matrix layout           | 2-space gutter, right-aligned | 1-space gutter, right-aligned |
+//!
+//! ## Why a plain ASCII `-`, not J's leading underscore
+//!
+//! J needed a leading underscore (`_3`) for its negative-literal spelling
+//! because J's own lexer reserves ASCII `-` exclusively for the `MINUS` verb
+//! token (MA06 §4) — printing `-3` in J would be genuinely ambiguous if
+//! pasted back into a session. Q is different (MA11 §3 bullet 2): Q spells
+//! a negative *literal* with an ordinary leading `-`, disambiguated from
+//! subtraction purely by *whitespace* (`2 -1` strands to `[2, -1]`; `2 - 1`
+//! and `2-1` both subtract). This module's plain-`-` output round-trips
+//! correctly through that exact rule: printing a vector as space-separated
+//! elements (`"2 -1"`) re-tokenizes via `q-lexer`'s
+//! `fold_negative_number_literals` hook back into the same two-element
+//! strand, since there is a space before the `-` and none after. Using J's
+//! underscore convention here would be actively *wrong* for Q — it is not a
+//! free stylistic choice, it follows directly from Q's own real negative-
+//! number spelling (MA11 §3 bullet 2's own callout that this is "not a free
+//! choice ... MA11 §3 bullet 2 documents it as Q's own actual, real
+//! disambiguation rule").
+use crate::eval::QValue;
+use array_runtime::Array;
+
+/// Render a [`QValue`] the way a Q session echoes an unsuppressed result:
+/// no name prefix, just the bare value.
+///
+/// A function value (`QValue::Fn`) has no literal source text kept around
+/// to reproduce verbatim (this crate stores a parsed parameter list + body
+/// AST, not the original source span) — printing one at the REPL is a rare,
+/// cosmetic edge case with no behavioral significance (MA11 §4 never tests
+/// or requires reconstructing a lambda's source), so this prints a small,
+/// honestly-labelled placeholder (`{[x;y] ...}`) rather than attempting a
+/// full, unparsing-based source reconstruction that the spec never asked
+/// for.
+pub fn display(v: &QValue) -> String {
+    match v {
+        QValue::Arr(a) => display_array(a),
+        QValue::Fn(lambda) => format!("{{[{}] ...}}", lambda.params.join(";")),
+    }
+}
+
+/// Render `a` the way a Q session echoes an unsuppressed array result.
+///
+/// - A scalar (`shape == []`) prints as its one number.
+/// - A vector (`shape == [n]`) prints as its elements, space-separated, on
+///   one line (the empty vector prints as the empty string).
+/// - A matrix (`shape == [r, c]`) prints one row per line, elements
+///   space-separated and right-aligned to the widest cell's width *in this
+///   display*.
+pub fn display_array(a: &Array) -> String {
+    match *a.shape() {
+        [] => fmt_num(a.data()[0]),
+        [n] => {
+            if n == 0 {
+                return String::new();
+            }
+            a.data()
+                .iter()
+                .map(|&x| fmt_num(x))
+                .collect::<Vec<_>>()
+                .join(" ")
+        }
+        [r, c] => {
+            let cells: Vec<String> = a.data().iter().map(|&x| fmt_num(x)).collect();
+            let width = cells.iter().map(|s| s.chars().count()).max().unwrap_or(1);
+            let mut lines = Vec::with_capacity(r);
+            for row in 0..r {
+                let row_cells: Vec<String> = (0..c)
+                    .map(|col| {
+                        // `Array` stores data column-major, but `display_array`
+                        // walks row-major -- one printed line per logical row
+                        // (mirrors `j-runtime::value::display` exactly).
+                        let x = a.get(row, col).expect("row/col in bounds");
+                        format!("{:>width$}", fmt_num(x), width = width)
+                    })
+                    .collect();
+                lines.push(row_cells.join(" "));
+            }
+            lines.join("\n")
+        }
+        // This crate (like `array-runtime` itself) is scoped to rank <= 2 --
+        // every value this evaluator ever produces stops there, so this arm
+        // is unreachable in practice. It exists only so `display_array` is
+        // total over `Array`'s public shape space rather than panicking if
+        // that ever changes.
+        _ => format!("{a}"),
+    }
+}
+
+/// Format one number the Q way: an ordinary ASCII `-` for negatives (see
+/// this module's own doc comment for why this differs from J's leading
+/// underscore), and a whole-valued float prints without a trailing `.0`
+/// (`5`, not `5.0`).
+///
+/// Non-finite values (`inf`/`NaN`, reachable via monadic `%` on `0`, or a
+/// `0%0`-shaped computation) still get a readable rendering, mirroring
+/// `apl-runtime`'s/`j-runtime`'s own choice not to special-case these away.
+fn fmt_num(x: f64) -> String {
+    if x.is_nan() {
+        return "NaN".to_string();
+    }
+    if x.is_infinite() {
+        return if x.is_sign_negative() {
+            "-inf".to_string()
+        } else {
+            "inf".to_string()
+        };
+    }
+    let mag = x.abs();
+    let body = if mag.fract() == 0.0 && mag < 1e15 {
+        format!("{}", mag as i64)
+    } else {
+        format!("{mag}")
+    };
+    // `-0.0` is sign-negative but has zero magnitude -- there is no notion
+    // of a "negative zero" literal in this cut, so treat it as plain `0`.
+    if x.is_sign_negative() && mag != 0.0 {
+        format!("-{body}")
+    } else {
+        body
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scalar_displays_bare() {
+        assert_eq!(display_array(&Array::scalar(3.0)), "3");
+        assert_eq!(display_array(&Array::scalar(3.5)), "3.5");
+    }
+
+    #[test]
+    fn negative_numbers_use_plain_ascii_minus() {
+        // Unlike J's leading underscore, Q spells a negative literal with
+        // an ordinary `-` (MA11 §3 bullet 2) -- this is the single most
+        // important assertion in this module.
+        assert_eq!(display_array(&Array::scalar(-3.0)), "-3");
+        assert_eq!(display_array(&Array::scalar(-3.5)), "-3.5");
+    }
+
+    #[test]
+    fn negative_zero_prints_as_plain_zero() {
+        assert_eq!(display_array(&Array::scalar(-0.0)), "0");
+    }
+
+    #[test]
+    fn whole_valued_floats_have_no_trailing_dot_zero() {
+        assert_eq!(display_array(&Array::scalar(5.0)), "5");
+        assert_eq!(display_array(&Array::scalar(5.25)), "5.25");
+    }
+
+    #[test]
+    fn vector_is_space_separated_one_line_and_round_trips_negatives() {
+        let v = Array::from_vec(vec![1.0, -2.0, 3.0]);
+        let printed = display_array(&v);
+        assert_eq!(printed, "1 -2 3");
+        // Round-trip check: re-tokenizing the printed form must fold the
+        // "-2" back into a single negative NUMBER token (space before `-`,
+        // none after), not MINUS -- exactly the property this module's doc
+        // comment claims.
+        let tokens = coding_adventures_q_lexer::tokenize_q(&printed);
+        let numbers: Vec<&str> = tokens
+            .iter()
+            .filter(|t| t.effective_type_name() == "NUMBER")
+            .map(|t| t.value.as_str())
+            .collect();
+        assert_eq!(numbers, vec!["1", "-2", "3"]);
+    }
+
+    #[test]
+    fn empty_vector_displays_as_empty_string() {
+        assert_eq!(display_array(&Array::from_vec(vec![])), "");
+    }
+
+    #[test]
+    fn matrix_is_row_per_line_right_aligned() {
+        let m = Array::from_rows(vec![vec![1.0, 20.0], vec![300.0, 4.0]]).unwrap();
+        assert_eq!(display_array(&m), "  1  20\n300   4");
+    }
+
+    #[test]
+    fn matrix_with_negatives_uses_ascii_minus_in_alignment() {
+        let m = Array::from_rows(vec![vec![1.0, -20.0], vec![-3.0, 4.0]]).unwrap();
+        // Widest cell is "-20" (3 characters).
+        assert_eq!(display_array(&m), "  1 -20\n -3   4");
+    }
+
+    #[test]
+    fn infinities_and_nan_render_readably() {
+        assert_eq!(display_array(&Array::scalar(f64::INFINITY)), "inf");
+        assert_eq!(display_array(&Array::scalar(f64::NEG_INFINITY)), "-inf");
+        assert_eq!(display_array(&Array::scalar(f64::NAN)), "NaN");
+    }
+}


### PR DESCRIPTION
## Summary

Item MA-11d of the Q language rollout (`code/specs/MA11-q-language.md`): `q-runtime` (a tree-walking evaluator over `array-runtime::Array`) and `q-repl` (interactive REPL + the `q` binary), completing the frontend started by `q-lexer`/`q-parser` (MA-11b/c, merged).

- **`QValue::{Arr, Fn}`** — unlike `apl-runtime`/`j-runtime` (which only ever produce a bare `Array`), Q's function literal is itself an ordinary noun value (MA11 §2/§3), so this evaluator's value type has to carry that.
- **`QFn::Lambda`** — the one genuinely new evaluator concept the spec flags: named params (explicit `[x;y]` or the bracket-omitted implicit `x`/`y`/`z` convenience), a multi-statement body, called through the *same* juxtaposition dispatch every primitive uses (no separate "call a lambda" path). Local-only assignment inside a call via a pushed/popped environment frame. Nested function-literal definitions are a clean, explicit error, not a silent misinterpretation.
- 16 primitive verbs, the three in-scope adverbs (`'` each, `/` reduce, `\` scan), dual list-literal syntax (stranding and explicit `(a;b;c)`).
- `q-repl`'s continuation scanner tracks paren/brace/bracket balance independently (a genuinely new concern beyond `j-repl`'s plain paren-balance, since Q has a real user-defined block construct that can span physical lines) by tokenizing with the real `q-lexer`.

## Found and fixed during review (not part of the original build)

- **`MAX_DEPTH` recursion cap**: originally copied from `j-runtime`'s constant (512) with no independent justification. Unlike J's guard (never reachable through genuine parsed input), Q's *is* genuinely reachable via a legitimate long chain of already-defined-function calls. Empirically re-measured via binary search on a controlled 2 MiB worker-thread stack (mirroring this repo's `*-parser` depth-cap methodology): safe to 268 chained calls, crashes at 271. Set to 760 (189 chained calls before firing), ~29.5% margin, with a permanent regression test driving real recursion to the boundary.
- **Security review (2 rounds) found and fixed two real issues in `q-repl`'s continuation scanner**: (1) HIGH — a `/`-comment opened inside a multi-line continuation would silently swallow every subsequent line forever, since the REPL's space-join (not a real newline) gave the comment nothing to stop at; (2) MEDIUM — the completeness check re-tokenized the whole accumulated buffer on every fed line (O(n²) cumulative cost). Both fixed with one redesign: blank each physical line's own comment before it's ever joined, and track running bracket counts incrementally per line rather than re-scanning the whole buffer. A second review round then caught a correctness regression in the first fix's incremental-counting approach (per-line net-delta clamping diverges from the correct per-token clamping in a specific reachable case) — fixed by clamping each counter per token against the persisted running state instead.

## Test plan

- [x] `cargo test -p coding-adventures-q-runtime -p coding-adventures-q-repl --all-targets` — 139 passing (115 q-runtime + 24 q-repl), independently re-run multiple times through the review process
- [x] `cargo test -p coding-adventures-q-runtime --doc` — passing
- [x] `cargo clippy -p coding-adventures-q-runtime -p coding-adventures-q-repl --all-targets -- -D warnings` — clean
- [x] `/security-review` — 2 rounds, both findings fixed and re-verified; converged

🤖 Generated with [Claude Code](https://claude.com/claude-code)