### PR TITLE
feat(spice): add BJT reverse beta rolloff

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- **BJT reverse high-current beta roll-off** — BJT model cards now accept
+  `IKR` and apply reverse base-charge modulation in DC, transient, AC,
+  transfer-function, temperature, and noise paths, matching Rust and
+  TypeScript. The supported-parameter catalog now contains 110 canonical rows.
+
 - **BJT reverse current gain** — BJT model cards now accept `BR`/`BETA_R` and
   apply the reverse base-current branch in DC, transient, AC,
   transfer-function, temperature, and noise paths, matching Rust and

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -232,6 +232,8 @@ base-collector conductance, and shot noise.
 `BR`/`BETA_R` (default `1` on model cards) controls reverse current gain and
 adds the base-collector reverse base-current branch. Direct `BJT` constructors
 default to infinite reverse beta to preserve their legacy behavior.
+`IKR` (default `0`, disabled) applies Berkeley reverse high-current base-charge
+modulation to that branch, increasing base current as reverse beta rolls off.
 `XTB` (default `0`) scales both forward and reverse beta with the
 analysis-to-nominal absolute temperature ratio, preserving nominal beta when
 omitted.
@@ -260,7 +262,7 @@ catalog by model kind for compact release dashboards and Mosaic UI inventories.
 `model_card_supported_parameter_coverage_gate_issue_records()`,
 `format_model_card_supported_parameter_coverage_gate_issue_csv()`, and
 `format_model_card_supported_parameter_coverage_gate_issue_json()` validate the
-expected seven-kind, 108-row supported-parameter catalog and expose stable issue
+expected seven-kind, 110-row supported-parameter catalog and expose stable issue
 rows for release automation.
 `model_card_supported_parameter_coverage_dashboard()`,
 `format_model_card_supported_parameter_coverage_dashboard_table()`,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -637,6 +637,7 @@ class BJT:
     Nc: float = 2.0         # base-collector leakage emission coefficient
     Xtb: float = 0.0        # forward-beta temperature exponent
     beta_r: float = float("inf")  # reverse current gain; infinity disables
+    Ikr: float = 0.0        # reverse-beta roll-off current (A); 0 disables
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -604,7 +604,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -9074,9 +9074,17 @@ def _bjt_reverse_base_current(el: BJT, junction_voltage: float) -> tuple[float, 
     thermal_voltage = el.Vt * el.Nr
     exponent = max(-40.0, min(40.0, junction_voltage / thermal_voltage))
     exp_value = math.exp(exponent)
+    diffusion_current = el.Is * (exp_value - 1.0)
+    diffusion_conductance = el.Is / thermal_voltage * exp_value
+    if el.Ikr == 0.0 or diffusion_current <= 0.0:
+        return diffusion_current / el.beta_r, diffusion_conductance / el.beta_r
+    root = math.sqrt(1.0 + 4.0 * diffusion_current / el.Ikr)
+    charge_factor = 0.5 * (1.0 + root)
+    charge_derivative = diffusion_conductance / (el.Ikr * root)
     return (
-        el.Is * (exp_value - 1.0) / el.beta_r,
-        el.Is / thermal_voltage * exp_value / el.beta_r,
+        diffusion_current * charge_factor / el.beta_r,
+        (diffusion_conductance * charge_factor + diffusion_current * charge_derivative)
+        / el.beta_r,
     )
 
 
@@ -9289,6 +9297,10 @@ def _validate_bjt(el: BJT) -> None:
     if not math.isfinite(el.Ikf) or el.Ikf < 0.0:
         raise ValueError(
             f"{el.name}: BJT forward beta roll-off current must be finite and non-negative"
+        )
+    if not math.isfinite(el.Ikr) or el.Ikr < 0.0:
+        raise ValueError(
+            f"{el.name}: BJT reverse beta roll-off current must be finite and non-negative"
         )
     if not math.isfinite(el.Ise) or el.Ise < 0.0:
         raise ValueError(
@@ -14090,6 +14102,7 @@ def sens_dc(
                     Fc=el.Fc,
                     Xtb=el.Xtb,
                     beta_r=el.beta_r,
+                    Ikr=el.Ikr,
                 ),
             )
             delta_beta = max(abs(el.beta_f) * perturbation, abs_floor)
@@ -14124,6 +14137,7 @@ def sens_dc(
                     Fc=el.Fc,
                     Xtb=el.Xtb,
                     beta_r=el.beta_r,
+                    Ikr=el.Ikr,
                 ),
             )
 
@@ -14368,6 +14382,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             Fc=el.Fc,
             Xtb=el.Xtb,
             beta_r=el.beta_r,
+            Ikr=el.Ikr,
         )
 
     # Capacitor, Inductor, Mosfet — no tunable DC parameter; return unchanged.

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (25, 41, 12, 4),
-    "PNP": (25, 41, 12, 4),
+    "NPN": (26, 42, 12, 4),
+    "PNP": (26, 42, 12, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -378,6 +378,7 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "VB": "VAR",
     "IKF": "IKF",
     "IK": "IKF",
+    "IKR": "IKR",
     "ISE": "ISE",
     "NE": "NE",
     "ISC": "ISC",
@@ -938,6 +939,7 @@ def bjt_from_model_card(
         Nc=p.get("NC", 2.0),
         Xtb=p.get("XTB", 0.0),
         beta_r=p.get("BR", 1.0),
+        Ikr=p.get("IKR", 0.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 108
+    assert len(coverage) == 110
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 108
+    assert len(records) == 110
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,9 +501,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 108
-    assert report.expected_canonical_parameter_count == 108
-    assert report.accepted_name_count == 172
+    assert report.canonical_parameter_count == 110
+    assert report.expected_canonical_parameter_count == 110
+    assert report.accepted_name_count == 174
     assert report.aliased_parameter_count == 51
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -511,7 +511,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t108\t108\t172\t51\t4\t0"
+        "true\t7\t7\t110\t110\t174\t51\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,8 +539,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 107
-    assert report.accepted_name_count == 169
+    assert report.canonical_parameter_count == 109
+    assert report.accepted_name_count == 171
     assert report.aliased_parameter_count == 50
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t107\t108\t169\t50\t4\t4\n"
+        "false\t7\t7\t109\t110\t171\t50\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,10 +647,10 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
+        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
+    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.beta_r == pytest.approx(0.25)
@@ -661,6 +661,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert bjt_model.Vaf == pytest.approx(80.0)
     assert bjt_model.Var == pytest.approx(120.0)
     assert bjt_model.Ikf == pytest.approx(2.0e-3)
+    assert bjt_model.Ikr == pytest.approx(3.0e-3)
     assert bjt_model.Ise == pytest.approx(3.0e-13)
     assert bjt_model.Ne == pytest.approx(1.7)
     assert bjt_model.Isc == pytest.approx(4.0e-13)
@@ -2302,7 +2303,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2327,6 +2328,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.Nc == pytest.approx(1.8)
     assert expanded.Xtb == pytest.approx(1.5)
     assert expanded.beta_r == pytest.approx(0.25)
+    assert expanded.Ikr == pytest.approx(3.0e-3)
 
 
 def test_branch_current_in_voltage_source():
@@ -2658,6 +2660,26 @@ def test_dc_rejects_invalid_bjt_reverse_beta():
     circuit = Circuit()
     circuit.add(BJT("Qbad", "c", "b", "0", beta_r=0.0))
     with pytest.raises(ValueError, match="BJT reverse beta must be positive"):
+        dc_op(circuit)
+
+
+def test_bjt_reverse_beta_rolloff_increases_high_current_base_current():
+    def base_current(ikr: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vbase", "base", "0", 0.65))
+        circuit.add(VoltageSource("Vemitter", "emitter", "0", 0.65))
+        circuit.add(BJT("Q1", "0", "base", "emitter", beta_r=1.0, Ikr=ikr))
+        return abs(dc_op(circuit).branch_currents["I(Vbase)"])
+
+    assert base_current(1.0e-4) > base_current(0.0)
+
+
+def test_dc_rejects_invalid_bjt_reverse_beta_rolloff_current():
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", Ikr=-1.0))
+    with pytest.raises(
+        ValueError, match="BJT reverse beta roll-off current must be finite and non-negative"
+    ):
         dc_op(circuit)
 
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add BJT model-card `IKR` reverse high-current beta roll-off support in DC,
+  transient, AC, transfer-function, temperature, and noise paths, matching
+  Python and TypeScript. The supported-parameter catalog now contains 110
+  canonical rows.
 - Add BJT model-card `BR`/`BETA_R` reverse-current-gain support in DC,
   transient, AC, transfer-function, temperature, and noise paths, matching
   Python and TypeScript. `XTB` now scales both forward and reverse beta. The

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -149,6 +149,8 @@ base-collector conductance, and shot noise.
 `BR`/`BETA_R` (default `1` on model cards) controls reverse current gain and
 adds the base-collector reverse base-current branch. Direct `Bjt` constructors
 default to infinite reverse beta to preserve their legacy behavior.
+`IKR` (default `0`, disabled) applies Berkeley reverse high-current base-charge
+modulation to that branch, increasing base current as reverse beta rolls off.
 `XTB` (default `0`) scales both forward and reverse beta with the
 analysis-to-nominal absolute temperature ratio, preserving nominal beta when
 omitted.
@@ -177,7 +179,7 @@ catalog by model kind for compact release dashboards and Mosaic UI inventories.
 `model_card_supported_parameter_coverage_gate_issue_records`,
 `format_model_card_supported_parameter_coverage_gate_issue_csv`, and
 `format_model_card_supported_parameter_coverage_gate_issue_json` validate the
-expected seven-kind, 108-row supported-parameter catalog and expose stable issue
+expected seven-kind, 110-row supported-parameter catalog and expose stable issue
 rows for release automation.
 `model_card_supported_parameter_coverage_dashboard`,
 `format_model_card_supported_parameter_coverage_dashboard_table`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -418,8 +418,8 @@ fn clone_subckt_element(
             element.gate_source_capacitance,
             element.gate_drain_capacitance,
         )),
-        Element::Bjt(element) => Element::Bjt(
-            Bjt::with_model_temperature_depletion_early_rolloff_junction_leakage_and_reverse_beta_parameters(
+        Element::Bjt(element) => {
+            let mut expanded = Bjt::with_model_temperature_depletion_early_rolloff_junction_leakage_and_reverse_beta_parameters(
                 format!("{instance_name}.{}", element.name),
                 map_subckt_node(&element.collector, instance_name, node_map),
                 map_subckt_node(&element.base, instance_name, node_map),
@@ -450,8 +450,10 @@ fn clone_subckt_element(
                 element.base_collector_leakage_emission_coefficient,
                 element.forward_beta_temperature_exponent,
                 element.reverse_beta,
-            ),
-        ),
+            );
+            expanded.reverse_beta_rolloff_current = element.reverse_beta_rolloff_current;
+            Element::Bjt(expanded)
+        }
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
             format!("{instance_name}.{}", element.name),
             map_subckt_node(&element.drain, instance_name, node_map),
@@ -2887,6 +2889,7 @@ pub struct Bjt {
     pub base_collector_leakage_emission_coefficient: f64,
     pub forward_beta_temperature_exponent: f64,
     pub reverse_beta: f64,
+    pub reverse_beta_rolloff_current: f64,
 }
 
 impl Bjt {
@@ -3348,6 +3351,7 @@ impl Bjt {
             base_collector_leakage_emission_coefficient,
             forward_beta_temperature_exponent,
             reverse_beta,
+            reverse_beta_rolloff_current: 0.0,
         }
     }
 }
@@ -3738,8 +3742,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 25, 41, 12, 4),
-    (ModelCardKind::Pnp, 25, 41, 12, 4),
+    (ModelCardKind::Npn, 26, 42, 12, 4),
+    (ModelCardKind::Pnp, 26, 42, 12, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3789,6 +3793,7 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("VB", "VAR"),
     ("IKF", "IKF"),
     ("IK", "IKF"),
+    ("IKR", "IKR"),
     ("ISE", "ISE"),
     ("NE", "NE"),
     ("ISC", "ISC"),
@@ -4446,8 +4451,7 @@ pub fn bjt_from_model_card(
         ModelCardKind::Pnp => BjtPolarity::Pnp,
         _ => return Err(model_card_kind_error(&name, "BJT", model.kind)),
     };
-    Ok(
-        Bjt::with_model_temperature_depletion_early_rolloff_junction_leakage_and_reverse_beta_parameters(
+    let mut bjt = Bjt::with_model_temperature_depletion_early_rolloff_junction_leakage_and_reverse_beta_parameters(
             name,
             collector,
             base,
@@ -4478,8 +4482,9 @@ pub fn bjt_from_model_card(
             model_card_value(model, "NC", 2.0),
             model_card_value(model, "XTB", 0.0),
             model_card_value(model, "BR", 1.0),
-        ),
-    )
+        );
+    bjt.reverse_beta_rolloff_current = model_card_value(model, "IKR", 0.0);
+    Ok(bjt)
 }
 
 pub fn jfet_from_model_card(
@@ -22675,9 +22680,21 @@ fn bjt_reverse_base_current(bjt: &Bjt, junction_voltage: f64) -> (f64, f64) {
     let thermal_voltage = bjt.thermal_voltage * bjt.reverse_emission_coefficient;
     let exponent = (junction_voltage / thermal_voltage).clamp(-40.0, 40.0);
     let exp_value = exponent.exp();
+    let diffusion_current = bjt.saturation_current * (exp_value - 1.0);
+    let diffusion_conductance = bjt.saturation_current / thermal_voltage * exp_value;
+    if bjt.reverse_beta_rolloff_current == 0.0 || diffusion_current <= 0.0 {
+        return (
+            diffusion_current / bjt.reverse_beta,
+            diffusion_conductance / bjt.reverse_beta,
+        );
+    }
+    let root = (1.0 + 4.0 * diffusion_current / bjt.reverse_beta_rolloff_current).sqrt();
+    let charge_factor = 0.5 * (1.0 + root);
+    let charge_derivative = diffusion_conductance / (bjt.reverse_beta_rolloff_current * root);
     (
-        bjt.saturation_current * (exp_value - 1.0) / bjt.reverse_beta,
-        bjt.saturation_current / thermal_voltage * exp_value / bjt.reverse_beta,
+        diffusion_current * charge_factor / bjt.reverse_beta,
+        (diffusion_conductance * charge_factor + diffusion_current * charge_derivative)
+            / bjt.reverse_beta,
     )
 }
 
@@ -23962,6 +23979,12 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "forward beta roll-off current must be finite and non-negative".to_string(),
+        });
+    }
+    if !bjt.reverse_beta_rolloff_current.is_finite() || bjt.reverse_beta_rolloff_current < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "reverse beta roll-off current must be finite and non-negative".to_string(),
         });
     }
     if !bjt.base_emitter_leakage_saturation_current.is_finite()

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 108);
+    assert_eq!(coverage.len(), 110);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 108);
+    assert_eq!(records.len(), 110);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 108);
-    assert_eq!(report.expected_canonical_parameter_count, 108);
-    assert_eq!(report.accepted_name_count, 172);
+    assert_eq!(report.canonical_parameter_count, 110);
+    assert_eq!(report.expected_canonical_parameter_count, 110);
+    assert_eq!(report.accepted_name_count, 174);
     assert_eq!(report.aliased_parameter_count, 51);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t108\t108\t172\t51\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t110\t110\t174\t51\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,8 +235,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 107);
-    assert_eq!(report.accepted_name_count, 169);
+    assert_eq!(report.canonical_parameter_count, 109);
+    assert_eq!(report.accepted_name_count, 171);
     assert_eq!(report.aliased_parameter_count, 50);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t107\t108\t169\t50\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t109\t110\t171\t50\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -435,6 +435,7 @@ fn model_card_aliases_build_device_instances() {
             ("VA", 80.0),
             ("VB", 120.0),
             ("IK", 2.0e-3),
+            ("IKR", 3.0e-3),
             ("ISE", 3.0e-13),
             ("NE", 1.7),
             ("ISC", 4.0e-13),
@@ -459,6 +460,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("VAF").unwrap(), 80.0);
     assert_close(*bjt_card.parameters.get("VAR").unwrap(), 120.0);
     assert_close(*bjt_card.parameters.get("IKF").unwrap(), 2.0e-3);
+    assert_close(*bjt_card.parameters.get("IKR").unwrap(), 3.0e-3);
     assert_close(*bjt_card.parameters.get("ISE").unwrap(), 3.0e-13);
     assert_close(*bjt_card.parameters.get("NE").unwrap(), 1.7);
     assert_close(*bjt_card.parameters.get("ISC").unwrap(), 4.0e-13);
@@ -480,6 +482,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(bjt_model.forward_early_voltage, 80.0);
     assert_close(bjt_model.reverse_early_voltage, 120.0);
     assert_close(bjt_model.forward_beta_rolloff_current, 2.0e-3);
+    assert_close(bjt_model.reverse_beta_rolloff_current, 3.0e-3);
     assert_close(bjt_model.base_emitter_leakage_saturation_current, 3.0e-13);
     assert_close(bjt_model.base_emitter_leakage_emission_coefficient, 1.7);
     assert_close(bjt_model.base_collector_leakage_saturation_current, 4.0e-13);
@@ -1387,7 +1390,7 @@ fn subcircuit_expansion_preserves_complete_diode_model() {
 
 #[test]
 fn subcircuit_expansion_preserves_complete_bjt_model() {
-    let bjt = Bjt::with_model_temperature_depletion_early_rolloff_junction_leakage_and_reverse_beta_parameters(
+    let mut bjt = Bjt::with_model_temperature_depletion_early_rolloff_junction_leakage_and_reverse_beta_parameters(
         "Qcell",
         "c",
         "b",
@@ -1419,6 +1422,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
         1.5,
         0.25,
     );
+    bjt.reverse_beta_rolloff_current = 3.0e-3;
     let mut circuit = Circuit::new();
     circuit
         .define_subcircuit(SubcircuitDefinition::new(
@@ -1461,6 +1465,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.base_collector_leakage_emission_coefficient, 1.8);
     assert_close(expanded.forward_beta_temperature_exponent, 1.5);
     assert_close(expanded.reverse_beta, 0.25);
+    assert_close(expanded.reverse_beta_rolloff_current, 3.0e-3);
 }
 
 #[test]
@@ -2212,6 +2217,42 @@ fn dc_rejects_invalid_bjt_reverse_beta() {
     circuit.add(Element::Bjt(transistor));
     let error = dc_op(&circuit).unwrap_err();
     assert!(error.to_string().contains("reverse beta must be positive"));
+}
+
+#[test]
+fn bjt_reverse_beta_rolloff_increases_high_current_base_current() {
+    let base_current = |rolloff_current: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vbase", "base", "0", 0.65,
+        )));
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vemitter", "emitter", "0", 0.65,
+        )));
+        let mut transistor = Bjt::new("Q1", "0", "base", "emitter");
+        transistor.reverse_beta = 1.0;
+        transistor.reverse_beta_rolloff_current = rolloff_current;
+        circuit.add(Element::Bjt(transistor));
+        dc_op(&circuit)
+            .unwrap()
+            .branch_current("Vbase")
+            .unwrap()
+            .abs()
+    };
+
+    assert!(base_current(1.0e-4) > base_current(0.0));
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_reverse_beta_rolloff_current() {
+    let mut circuit = Circuit::new();
+    let mut transistor = Bjt::new("Qbad", "c", "b", "0");
+    transistor.reverse_beta_rolloff_current = -1.0;
+    circuit.add(Element::Bjt(transistor));
+    let error = dc_op(&circuit).unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("reverse beta roll-off current must be finite and non-negative"));
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add BJT model-card `IKR` reverse high-current beta roll-off support in DC,
+  transient, AC, transfer-function, temperature, and noise paths, matching
+  Rust and Python. The supported-parameter catalog now contains 110 canonical
+  rows.
 - Add BJT model-card `BR`/`BETA_R` reverse-current-gain support in DC,
   transient, AC, transfer-function, temperature, and noise paths, matching
   Rust and Python. `XTB` now scales both forward and reverse beta. The

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -219,6 +219,8 @@ base-collector conductance, and shot noise.
 `BR`/`BETA_R` (default `1` on model cards) controls reverse current gain and
 adds the base-collector reverse base-current branch. Direct `bjt` constructors
 default to infinite reverse beta to preserve their legacy behavior.
+`IKR` (default `0`, disabled) applies Berkeley reverse high-current base-charge
+modulation to that branch, increasing base current as reverse beta rolls off.
 `XTB` (default `0`) scales both forward and reverse beta with the
 analysis-to-nominal absolute temperature ratio, preserving nominal beta when
 omitted.
@@ -247,7 +249,7 @@ model kind for compact release dashboards and Mosaic UI inventories.
 `modelCardSupportedParameterCoverageGateIssueRecords`,
 `formatModelCardSupportedParameterCoverageGateIssueCsv`, and
 `formatModelCardSupportedParameterCoverageGateIssueJson` validate the expected
-seven-kind, 108-row supported-parameter catalog and expose stable issue rows for
+seven-kind, 110-row supported-parameter catalog and expose stable issue rows for
 release automation.
 `modelCardSupportedParameterCoverageDashboard`,
 `formatModelCardSupportedParameterCoverageDashboardTable`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1728,6 +1728,7 @@ export interface Bjt {
   readonly baseCollectorLeakageEmissionCoefficient: number;
   readonly forwardBetaTemperatureExponent: number;
   readonly reverseBeta: number;
+  readonly reverseBetaRolloffCurrent: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -2005,8 +2006,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [25, 41, 12, 4],
-  PNP: [25, 41, 12, 4],
+  NPN: [26, 42, 12, 4],
+  PNP: [26, 42, 12, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3596,7 +3597,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7779,6 +7780,7 @@ export function bjt(
   baseCollectorLeakageEmissionCoefficient = 2.0,
   forwardBetaTemperatureExponent = 0.0,
   reverseBeta = Number.POSITIVE_INFINITY,
+  reverseBetaRolloffCurrent = 0.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7812,6 +7814,7 @@ export function bjt(
     baseCollectorLeakageEmissionCoefficient,
     forwardBetaTemperatureExponent,
     reverseBeta,
+    reverseBetaRolloffCurrent,
   };
 }
 
@@ -7921,6 +7924,7 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   VB: "VAR",
   IKF: "IKF",
   IK: "IKF",
+  IKR: "IKR",
   ISE: "ISE",
   NE: "NE",
   ISC: "ISC",
@@ -8453,6 +8457,7 @@ export function bjtFromModelCard(
     p.NC ?? 2.0,
     p.XTB ?? 0.0,
     p.BR ?? 1.0,
+    p.IKR ?? 0.0,
   );
 }
 
@@ -18963,10 +18968,25 @@ function bjtReverseBaseCurrent(
   const thermalVoltage = element.thermalVoltage * element.reverseEmissionCoefficient;
   const exponent = Math.max(-40.0, Math.min(40.0, junctionVoltage / thermalVoltage));
   const expValue = Math.exp(exponent);
+  const diffusionCurrent = element.saturationCurrent * (expValue - 1.0);
+  const diffusionConductance = element.saturationCurrent / thermalVoltage * expValue;
+  if (element.reverseBetaRolloffCurrent === 0.0 || diffusionCurrent <= 0.0) {
+    return {
+      current: diffusionCurrent / element.reverseBeta,
+      conductance: diffusionConductance / element.reverseBeta,
+    };
+  }
+  const root = Math.sqrt(
+    1.0 + 4.0 * diffusionCurrent / element.reverseBetaRolloffCurrent,
+  );
+  const chargeFactor = 0.5 * (1.0 + root);
+  const chargeDerivative =
+    diffusionConductance / (element.reverseBetaRolloffCurrent * root);
   return {
-    current: element.saturationCurrent * (expValue - 1.0) / element.reverseBeta,
+    current: diffusionCurrent * chargeFactor / element.reverseBeta,
     conductance:
-      element.saturationCurrent / thermalVoltage * expValue / element.reverseBeta,
+      (diffusionConductance * chargeFactor + diffusionCurrent * chargeDerivative)
+      / element.reverseBeta,
   };
 }
 
@@ -19871,6 +19891,9 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.forwardBetaRolloffCurrent) || element.forwardBetaRolloffCurrent < 0.0) {
     throw invalidElement(element.name, "forward beta roll-off current must be finite and non-negative");
+  }
+  if (!Number.isFinite(element.reverseBetaRolloffCurrent) || element.reverseBetaRolloffCurrent < 0.0) {
+    throw invalidElement(element.name, "reverse beta roll-off current must be finite and non-negative");
   }
   if (!Number.isFinite(element.baseEmitterLeakageSaturationCurrent) || element.baseEmitterLeakageSaturationCurrent < 0.0) {
     throw invalidElement(element.name, "base-emitter leakage saturation current must be finite and non-negative");

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(108);
+    expect(coverage).toHaveLength(110);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(108);
+    expect(records).toHaveLength(110);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 108,
-      expectedCanonicalParameterCount: 108,
-      acceptedNameCount: 172,
+      canonicalParameterCount: 110,
+      expectedCanonicalParameterCount: 110,
+      acceptedNameCount: 174,
       aliasedParameterCount: 51,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t108\t108\t172\t51\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t110\t110\t174\t51\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,8 +241,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(107);
-    expect(report.acceptedNameCount).toBe(169);
+    expect(report.canonicalParameterCount).toBe(109);
+    expect(report.acceptedNameCount).toBe(171);
     expect(report.aliasedParameterCount).toBe(50);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t107\t108\t169\t50\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t109\t110\t171\t50\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -341,6 +341,7 @@ describe("dcOp", () => {
       VA: 80.0,
       VB: 120.0,
       IK: 2.0e-3,
+      IKR: 3.0e-3,
       ISE: 3.0e-13,
       NE: 1.7,
       ISC: 4.0e-13,
@@ -354,7 +355,7 @@ describe("dcOp", () => {
       FC: 0.4,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.reverseBeta, 0.25);
@@ -365,6 +366,7 @@ describe("dcOp", () => {
     expectClose(bjtModel.forwardEarlyVoltage, 80.0);
     expectClose(bjtModel.reverseEarlyVoltage, 120.0);
     expectClose(bjtModel.forwardBetaRolloffCurrent, 2.0e-3);
+    expectClose(bjtModel.reverseBetaRolloffCurrent, 3.0e-3);
     expectClose(bjtModel.baseEmitterLeakageSaturationCurrent, 3.0e-13);
     expectClose(bjtModel.baseEmitterLeakageEmissionCoefficient, 1.7);
     expectClose(bjtModel.baseCollectorLeakageSaturationCurrent, 4.0e-13);
@@ -1008,7 +1010,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -1034,6 +1036,7 @@ describe("dcOp", () => {
       expectClose(expanded.baseCollectorLeakageEmissionCoefficient, 1.8);
       expectClose(expanded.forwardBetaTemperatureExponent, 1.5);
       expectClose(expanded.reverseBeta, 0.25);
+      expectClose(expanded.reverseBetaRolloffCurrent, 3.0e-3);
     }
   });
 
@@ -1489,6 +1492,30 @@ describe("dcOp", () => {
     circuit.add({ ...bjt("Qbad", "c", "b", "0"), reverseBeta: 0.0 });
     expect(() => dcOp(circuit)).toThrowError(
       "reverse beta must be positive",
+    );
+  });
+
+  it("uses BJT reverse beta roll-off to increase high-current base current", () => {
+    const baseCurrent = (reverseBetaRolloffCurrent: number): number => {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vbase", "base", "0", 0.65));
+      circuit.add(voltageSource("Vemitter", "emitter", "0", 0.65));
+      circuit.add({
+        ...bjt("Q1", "0", "base", "emitter"),
+        reverseBeta: 1.0,
+        reverseBetaRolloffCurrent,
+      });
+      return Math.abs(dcOp(circuit).branchCurrent("Vbase")!);
+    };
+
+    expect(baseCurrent(1.0e-4)).toBeGreaterThan(baseCurrent(0.0));
+  });
+
+  it("rejects an invalid BJT reverse beta roll-off current", () => {
+    const circuit = new Circuit();
+    circuit.add({ ...bjt("Qbad", "c", "b", "0"), reverseBetaRolloffCurrent: -1.0 });
+    expect(() => dcOp(circuit)).toThrowError(
+      "reverse beta roll-off current must be finite and non-negative",
     );
   });
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,17 +33,17 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT reverse current gain.
+1. Cross-language BJT reverse high-current beta roll-off.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `BR` / `BETA_R` model-card support in Rust, Python, and
-     TypeScript with a model-card default of `1` and behavior-preserving direct
-     element defaults.
-   - Apply reverse base current in DC, transient, AC, transfer-function,
-     temperature, and noise paths, and scale both forward and reverse beta by
-     `XTB` while preserving the complete BJT model through subcircuits.
-   - Extend the supported-parameter coverage gate from 106 to 108 canonical
-     rows and lock model-card aliases, behavior, validation, and hierarchy in
-     all engines.
+   - Add Berkeley BJT `IKR` model-card support in Rust, Python, and TypeScript
+     with a behavior-preserving default of `0`.
+   - Apply reverse high-current base-charge modulation to the base-collector
+     reverse-current branch in DC, transient, AC, transfer-function,
+     temperature, and noise paths while preserving the complete BJT model
+     through subcircuits.
+   - Extend the supported-parameter coverage gate from 108 to 110 canonical
+     rows and lock model-card behavior, validation, and hierarchy in all
+     engines.
 
 ## Completed Slices
 
@@ -3094,6 +3094,15 @@ the Rust, Python, and TypeScript surfaces together.
      forward beta by the analysis-to-nominal absolute temperature ratio.
    - Hierarchical subcircuit expansion preserves the complete BJT model, and
      the supported-parameter release gate now covers 106 canonical rows.
+
+231. Cross-language BJT reverse current gain.
+   - Status: completed in PR 8797.
+   - Rust, Python, and TypeScript BJT model cards now accept `BR` / `BETA_R`
+     and apply the reverse base-current branch in DC, transient, AC,
+     transfer-function, temperature, and noise paths.
+   - `XTB` scales both forward and reverse beta, hierarchical subcircuit
+     expansion preserves the complete BJT model, and the supported-parameter
+     release gate now covers 108 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add cross-language BJT `IKR` model-card support with behavior-preserving defaults
- apply reverse high-current base-charge modulation and its small-signal derivative across shared analysis paths
- preserve `IKR` through hierarchy and model copies, and advance the supported-parameter gate to 110 rows
- reconcile the SPICE completion plan after PR #8797

## Verification
- Rust: fmt, clippy, and all integration suites (360 tests)
- Python: Ruff and full pytest suite (552 tests, 88.78% coverage)
- TypeScript: build and full Vitest suite (310 tests)
- `git diff --check`