### PR TITLE
feat(sql-planner): expand SELECT * into base-table columns at plan time

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.5.63 — `SELECT *` (and `SELECT DISTINCT *`) expand to real columns
+
+`SELECT * FROM t` now returns the table's actual columns instead of a single
+NULL column named `*`. Previously `*` survived planning as a placeholder that no
+downstream stage could resolve (`LoadColumn("*")` → NULL). The planner now
+expands `*` into the base table's columns in declaration order — matching SQLite
+— before DISTINCT-collation and ORDER-BY-ordinal resolution, so:
+
+- `SELECT DISTINCT *` folds each column under its own declared collation (a
+  `COLLATE NOCASE` column dedupes case-insensitively) — retires the
+  `distinct_star_collate` ledger entry.
+- `SELECT * FROM t ORDER BY 1` binds the ordinal to the first expanded column,
+  as SQLite does (new `select_star_order_by_ordinal` oracle case).
+
+Scoped to a single base table with no JOIN; joined `*` keeps the placeholder
+(separate gap). `*` mixed with other items (`SELECT a, *`) is newly ledgered as
+`select_star_in_place` — it does not yet PARSE (the grammar's select_list has no
+bare-`*` alternative in a comma list); the planner already handles that shape
+once the parser produces it. Verified against bundled real SQLite. Spans
+sql-planner 0.2.30.
+
 ## 0.5.62 — GROUP BY aggregate columns follow the SELECT list
 
 `SELECT max(x) AS mx, c FROM t GROUP BY c` now returns columns `[mx, c]` — the

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.62"
+version = "0.5.63"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1620,8 +1620,43 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT DISTINCT c FROM t ORDER BY c",
     },
-    // `SELECT DISTINCT *` folds too, because `*` expands to bare column
-    // references — each contributing its own declared collation.
+    // `SELECT *` expands to the table's columns in declaration order (was a
+    // single NULL column named `*`). Multi-column table.
+    Case {
+        id: "select_star_expands",
+        setup: &[
+            "CREATE TABLE t (a INTEGER, b TEXT)",
+            "INSERT INTO t VALUES (1,'x'),(2,'y')",
+        ],
+        query: "SELECT * FROM t ORDER BY a",
+    },
+    // Because `*` expands before ORDER BY ordinals resolve, `ORDER BY 1` binds
+    // to the first expanded column — matching SQLite (orders by `a` descending).
+    Case {
+        id: "select_star_order_by_ordinal",
+        setup: &[
+            "CREATE TABLE t (a INTEGER, b TEXT)",
+            "INSERT INTO t VALUES (2,'y'),(1,'x'),(3,'z')",
+        ],
+        query: "SELECT * FROM t ORDER BY 1 DESC",
+    },
+    // Still ledgered: `*` mixed with another select item (`SELECT a, *`) does
+    // not PARSE — the grammar's select_list has no bare-`*` alternative in a
+    // comma-separated list. The planner's star expansion handles this shape once
+    // the parser produces it (a grammar follow-up).
+    Case {
+        id: "select_star_in_place",
+        setup: &[
+            "CREATE TABLE t (a INTEGER, b TEXT)",
+            "INSERT INTO t VALUES (1,'x'),(2,'y')",
+        ],
+        query: "SELECT a, * FROM t ORDER BY a",
+    },
+    // `SELECT DISTINCT *` now expands AND folds: `*` becomes the bare column
+    // references, each contributing its own declared collation, so a NOCASE
+    // column dedupes case-insensitively. (Previously `*` stayed a single NULL
+    // column and the DISTINCT collation vector was shifted — the reason this was
+    // ledgered.)
     Case {
         id: "distinct_star_collate",
         setup: &[
@@ -2238,16 +2273,9 @@ const LEDGER: &[(&str, &str)] = &[
     // `group_by_column_*` cases); closing these two needs hand-edits to the
     // sql-parser grammar (`select_item` and `group_by` gaining an optional
     // `COLLATE NAME` tail), which is the next increment in this lane.
-    // `SELECT DISTINCT *` does not expand `*` — mini returns a single column
-    // literally named "*" holding NULL, where SQLite returns the table's columns.
-    // Plain `SELECT * FROM t` expands correctly, so this is specific to the
-    // DISTINCT projection path and is UNRELATED to collation: the collation
-    // vector this lane added already expands `*` via the schema's ordered
-    // `column_names`, so it will line up once the projection does. Pre-existing
-    // (this is the first case to exercise `DISTINCT *` at all).
     (
-        "distinct_star_collate",
-        "SELECT DISTINCT * does not expand the star into the table's columns (projection gap, not a collation gap)",
+        "select_star_in_place",
+        "`*` mixed with other select items (`SELECT a, *`) does not parse (grammar: select_list lacks a bare `*` alternative in a comma list)",
     ),
     (
         "distinct_explicit_collate",

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.30] - Unreleased
+
+### Changed
+
+- **`SELECT *` is expanded into the base table's columns at plan time.** A `*`
+  in the select list was previously carried through as a placeholder output
+  column `SqlExpr::Column { name: "*" }`. Nothing downstream could resolve it —
+  `LoadColumn("*")` reads no such column and yields NULL — so `SELECT *` (plain
+  or `DISTINCT`) returned a single NULL column literally named `*`. The new
+  `expand_star_columns` (called after the output list is built, before the
+  DISTINCT collation vector) replaces the `*` with the table's concrete columns
+  in schema-declaration order, matching SQLite. Because expansion precedes
+  DISTINCT-collation and ORDER-BY-ordinal resolution, `SELECT DISTINCT *` now
+  folds per-column collations correctly and `SELECT * ... ORDER BY 1` binds to
+  the first real column.
+- Scoped to a single base table with no JOIN: a joined or comma-joined `*` would
+  need every table's columns in join order, which is a separate gap and keeps
+  the `*` placeholder. Unknown tables / tables with no reported columns also
+  pass through unchanged (the query errors elsewhere). `*` mixed with other
+  select items (`SELECT a, *`) is expanded in place once the grammar produces
+  it — a separate parser follow-up tracks the mixed-list parse.
+
 ## [0.2.29] - Unreleased
 
 ### Changed

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.29"
+version = "0.2.30"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -825,6 +825,13 @@ fn plan_select(
         }]
     };
 
+    // Expand a `*` output column into the base table's columns, in definition
+    // order. `*` is only a placeholder — the rest of the pipeline cannot resolve
+    // it (`LoadColumn("*")` finds no such column and yields NULL), so without
+    // this a `SELECT *` returns a single NULL column literally named `*`. SQLite
+    // expands it to every column of the FROM clause.
+    let output_columns = expand_star_columns(output_columns, schema, &base_table_ref, stmt);
+
     // Now that the output list is known, build the DISTINCT node with one
     // collation per output column. SQLite folds a DISTINCT column only when the
     // output expression is a BARE COLUMN REFERENCE whose column declares a
@@ -1366,6 +1373,62 @@ fn collate_comparisons(expr: SqlExpr, ctx: &OrderCollateCtx) -> SqlExpr {
         }
         other => other,
     }
+}
+
+/// Expand a `*` output column into the base table's columns, in the table's
+/// declaration order (what SQLite uses). `*` is a placeholder that nothing
+/// downstream can resolve — `LoadColumn("*")` reads no column and yields NULL —
+/// so a `SELECT *` (plain OR `DISTINCT`) would otherwise return a single NULL
+/// column named `*`. Replacing it here with the concrete columns fixes both.
+///
+/// Scoped to a single base table with no JOIN: a joined `*` would need every
+/// table's columns in join order (and a qualified `t.*` there would need
+/// per-table resolution), which is a separate gap — a JOIN keeps the `*`
+/// placeholder. On a single base table the qualifier is irrelevant, so `t.*`
+/// expands the same as `*`. An unknown table or a table with no reported
+/// columns also passes through unchanged (the query errors elsewhere). A `*`
+/// mixed with other items (`SELECT a, *`) is expanded in place, preserving
+/// position.
+fn expand_star_columns(
+    cols: Vec<OutputColumn>,
+    schema: &dyn SchemaProvider,
+    base_table_ref: &Option<(String, Option<String>)>,
+    stmt: &GrammarASTNode,
+) -> Vec<OutputColumn> {
+    let has_star = cols
+        .iter()
+        .any(|c| matches!(&c.expr, SqlExpr::Column { name, .. } if name == "*"));
+    if !has_star {
+        return cols;
+    }
+    let Some((table, _alias)) = base_table_ref.as_ref() else {
+        return cols;
+    };
+    if !find_nodes(stmt, "join_clause").is_empty() {
+        return cols;
+    }
+    let names = match schema.column_names(table) {
+        Ok(n) if !n.is_empty() => n,
+        _ => return cols,
+    };
+    let mut out = Vec::with_capacity(cols.len() + names.len());
+    for c in cols {
+        match &c.expr {
+            SqlExpr::Column { name, .. } if name == "*" => {
+                for cn in &names {
+                    out.push(OutputColumn {
+                        expr: SqlExpr::Column {
+                            table: None,
+                            name: cn.clone(),
+                        },
+                        alias: None,
+                    });
+                }
+            }
+            _ => out.push(c),
+        }
+    }
+    out
 }
 
 /// One collation per DISTINCT **output** column, positionally parallel to the
@@ -3776,8 +3839,12 @@ mod tests {
 
     /// The simplest possible plan: project all columns from a single scan.
     ///
+    /// `SELECT *` is expanded at plan time into the base table's columns, in
+    /// schema-definition order (`users` = id, name, age, city, status), so the
+    /// downstream stages see concrete column references — never a `*` placeholder.
+    ///
     /// ```text
-    /// Project { * }
+    /// Project { id, name, age, city, status }
     ///   Scan { users }
     /// ```
     #[test]
@@ -3788,9 +3855,17 @@ mod tests {
             "Root must be Project, got: {plan:?}"
         );
         if let LogicalPlan::Project { input, columns } = &plan {
-            assert!(
-                matches!(columns[0].expr, SqlExpr::Column { name: ref n, .. } if n == "*"),
-                "Expected * projection"
+            let names: Vec<&str> = columns
+                .iter()
+                .map(|c| match &c.expr {
+                    SqlExpr::Column { name, .. } => name.as_str(),
+                    other => panic!("Expected expanded Column, got {other:?}"),
+                })
+                .collect();
+            assert_eq!(
+                names,
+                ["id", "name", "age", "city", "status"],
+                "`*` must expand to the table's columns in definition order"
             );
             assert!(matches!(**input, LogicalPlan::Scan { .. }));
         }
@@ -5058,11 +5133,16 @@ mod tests {
     }
 
     #[test]
-    fn test_order_by_ordinal_over_star_is_unchanged() {
-        // With `SELECT *` the output column count/identity isn't known at plan
-        // time, so a positional key is left as the literal (no guess, no error).
+    fn test_order_by_ordinal_over_expanded_star() {
+        // `SELECT *` is expanded into the base table's columns before ORDER BY
+        // ordinals are resolved, so `ORDER BY 1` now binds to the first expanded
+        // column (`t` = id, x, y, …) exactly as SQLite does, rather than being
+        // left as an unresolved literal.
         let keys = sort_keys_of("SELECT * FROM t ORDER BY 1");
         assert_eq!(keys.len(), 1);
-        assert_eq!(keys[0].expr, SqlExpr::Literal(SqlValue::Int(1)));
+        assert_eq!(
+            keys[0].expr,
+            SqlExpr::Column { table: None, name: "id".to_string() }
+        );
     }
 }


### PR DESCRIPTION
## What

Expand `SELECT *` (and `SELECT DISTINCT *`) into the base table's concrete columns at plan time, matching SQLite.

Previously `*` survived planning as a placeholder output column `SqlExpr::Column { name: "*" }`. Nothing downstream could resolve it — `LoadColumn("*")` reads no such column and yields NULL — so **`SELECT *` returned a single NULL column literally named `*`**. This is a fairly fundamental correctness gap surfaced while reconciling the DISTINCT-collation work.

## How

New `expand_star_columns` in `sql-planner`, called in `plan_select` **after** the output list is built and **before** the DISTINCT collation vector and ORDER-BY-ordinal resolution. It replaces a `*` output column with the table's columns in schema-declaration order (via `schema.column_names`). Because it runs before the later stages:

- **`SELECT DISTINCT *`** now folds each column under its own declared collation — a `COLLATE NOCASE` column dedupes case-insensitively. Retires the `distinct_star_collate` oracle ledger entry.
- **`SELECT * FROM t ORDER BY 1`** binds the ordinal to the first expanded column, exactly as SQLite does (new `select_star_order_by_ordinal` oracle case).

### Scope / guards
- Single base table, no JOIN. A joined/comma-joined `*` needs every table's columns in join order (separate gap) → keeps the placeholder.
- Unknown table or a table reporting no columns → passes through unchanged (query errors elsewhere).
- `*` mixed with other items (`SELECT a, *`) is expanded in place **once the parser produces that shape** — it does not yet PARSE (the grammar's `select_list` has no bare-`*` alternative in a comma list). Newly ledgered as `select_star_in_place` for a parser follow-up.

## Verification
- Differential oracle green vs **bundled real SQLite**, including new `select_star_expands`, `select_star_order_by_ordinal`, and the retired-from-ledger `distinct_star_collate`.
- Two planner unit tests that encoded the *old* non-expanded behavior rewritten to assert the SQLite-matching expansion.
- Full `sql-planner` / `sql-optimizer` / `sql-codegen` / `sql-vm` / `mini-sqlite` suites pass; clippy clean.
- Inline security review: expand path has no DoS/panic/injection surface; DISTINCT collation vector is correctly one-per-expanded-column.

Versions: `sql-planner` 0.2.30, `mini-sqlite` 0.5.63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
