### PR TITLE
fix(fold-control-flow): stop dropping a hoisted var from a dead if/for (miscompile) (0.34.0)

### DIFF
--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.34.0] - 2026-07-22
+
+### Fixed — a dead `if` branch / `for` loop no longer DROPS a hoisted `var` (miscompile)
+
+A statically-dead `if` branch used to be discarded whole, taking any hoisted
+`var` inside it with it — a **miscompile**, since the `var` still hoists to the
+enclosing function scope and a later read would flip from a declared-`undefined`
+binding to a `ReferenceError` (or a different outer binding):
+
+```js
+if (false) { var z = g(); } sink(z);   // was: sink(z)          → now: var z; sink(z);
+if (false) { var z = 1; } else h();    // was: h()              → now: var z; h();
+if (true)  h(); else { var z = 1; }    // was: h()              → now: var z; h();
+```
+
+The dead branch's hoisted `var`s are now EXTRACTED (initializers stripped, since
+the branch never runs) as a bare `var …;` placed BEFORE the taken branch —
+byte-identical to the reference Closure Compiler at SIMPLE (the same bug class as
+the `while (false)` drop fixed in 0.30.0). This is the `if` counterpart of the
+dead-loop var extraction.
+
+The dead-`for`-loop collapse also no longer DECLINES the last shape it couldn't
+represent — an **expression** init combined with a hoisted body `var`, which is
+two statements:
+
+```js
+for (f(); false; ) { var x = 1; } sink(x);   // was: loop kept   → now: var x; f(); sink(x);
+```
+
+Mechanism: a new `collapse_extracting_dead_vars` helper returns the two
+statements (`var …;` + survivor) wrapped in a `BlockStatement`, which
+`fold_program` / `fold_block_statement` then splice into the enclosing statement
+list (`block_is_scope_safe_to_hoist` admits a `var`-only block; adjacent `var`s
+then coalesce). The `if` literal-branch arms and the `for` collapse both route
+through it; the reversed extraction order matches `extract_dead_loop_vars`.
+
 ## [0.33.0] - 2026-07-21
 
 ### Removed — the `gap-015` function-body `var` hoist/split (net-wrong for byte-identity)

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -980,7 +980,9 @@ fn fold_if_statement(s: &IfStatement, st: &mut FoldState) -> Statement {
     match literal_truthy(&test) {
         Some(true) => {
             // The `alternate` branch is statically unreachable and is
-            // discarded — tombstone it so its span stays auditable.
+            // discarded — tombstone it so its span stays auditable. Any
+            // hoisted `var` inside it must SURVIVE the removal (dropping it is
+            // a miscompile), so extract it before the taken `consequent`.
             let discarded = [alternate.as_ref().and_then(statement_cv)];
             st.record_fold_deleting(
                 &s.cv,
@@ -989,11 +991,18 @@ fn fold_if_statement(s: &IfStatement, st: &mut FoldState) -> Statement {
                 "if (<truthy literal>) { … } else { … }",
                 "{ consequent }",
             );
-            consequent
+            match alternate {
+                Some(alt) => collapse_extracting_dead_vars(&alt, Some(consequent), &s.cv),
+                None => consequent,
+            }
         }
         Some(false) => {
             // The `consequent` branch is statically unreachable and is
-            // discarded — tombstone it so its span stays auditable.
+            // discarded — tombstone it so its span stays auditable. Any
+            // hoisted `var` inside it must SURVIVE the removal (dropping it is
+            // a miscompile), so extract it before the taken `alternate` (or as
+            // the sole survivor when there is no `else`). A no-var branch pick
+            // yields the `alternate` / `;` unchanged, exactly as before.
             let discarded = [statement_cv(&consequent)];
             st.record_fold_deleting(
                 &s.cv,
@@ -1002,13 +1011,7 @@ fn fold_if_statement(s: &IfStatement, st: &mut FoldState) -> Statement {
                 "if (<falsy literal>) { … } else { … }",
                 "{ alternate }",
             );
-            alternate.unwrap_or_else(|| {
-                // No alternate to take — replace with `;`. The
-                // EmptyStatement inherits the IfStatement's cv so
-                // source maps still point at the original
-                // position when tracing is on.
-                Statement::empty_statement(EmptyStatement { cv: s.cv.clone() })
-            })
+            collapse_extracting_dead_vars(&consequent, alternate, &s.cv)
         }
         None => {
             // Non-literal test. Try the if-else→ternary fold first
@@ -1619,6 +1622,68 @@ fn extract_dead_loop_vars(
     }
 }
 
+/// Collapse a dead control-flow construct: `surviving` is the part that is kept
+/// and still runs (`None` when nothing survives — a dead `if` with no `else`),
+/// and `dead` is the statically-unreachable part whose hoisted `var`s must be
+/// rescued. Used for a dead `if` branch (survivor = the taken branch) and for a
+/// dead `for` loop with an expression init (survivor = the once-run init `e;`,
+/// dead = the never-run body).
+///
+/// A hoisted `var` inside the dead branch still hoists to the enclosing function
+/// scope, so — exactly like a dead loop's body `var` (see
+/// [`extract_dead_loop_vars`]) — it must SURVIVE the branch's removal rather than
+/// be dropped. Dropping it is a miscompile: a later `z` / `typeof z` read flips
+/// from reading a declared-`undefined` binding to a `ReferenceError` (or a
+/// different outer `z`). We EXTRACT those bindings — initializers STRIPPED, since
+/// the dead branch never runs — as a bare `var …;` placed BEFORE the surviving
+/// branch, matching the reference Closure Compiler at SIMPLE byte-for-byte:
+///
+/// ```text
+///   if (false) { var z = 1; }              →  var z;
+///   if (false) { var a=1; var b=2; }       →  var b, a;      (reversed, as loops)
+///   if (false) { var z = g(); } else h();  →  var z; h();    (init stripped)
+///   if (true)  h(); else { var z = 1; }     →  var z; h();    (var before survivor)
+/// ```
+///
+/// When the dead branch has no hoistable `var`, this is a plain branch pick and
+/// the surviving branch (or `;`) is returned unchanged. When there IS a `var` and
+/// a surviving branch, the two are wrapped in a `BlockStatement`, which
+/// [`fold_program`] / [`fold_block_statement`] then splice into the enclosing
+/// statement list ([`block_is_scope_safe_to_hoist`] admits a `var`-only block, so
+/// the wrapper is redundant and flattens; adjacent `var`s then coalesce).
+fn collapse_extracting_dead_vars(
+    dead: &Statement,
+    surviving: Option<Statement>,
+    cv: &Option<String>,
+) -> Statement {
+    let mut names: Vec<Identifier> = Vec::new();
+    collect_hoistable_vars(dead, &mut names);
+    names.reverse();
+    if names.is_empty() {
+        return surviving
+            .unwrap_or_else(|| Statement::empty_statement(EmptyStatement { cv: cv.clone() }));
+    }
+    let var_decl = Statement::Declaration(Declaration::VariableDeclaration(VariableDeclaration {
+        cv: cv.clone(),
+        kind: VarKind::Var,
+        declarations: names
+            .into_iter()
+            .map(|id| VariableDeclarator {
+                cv: None,
+                id: BindingTarget::Identifier(id),
+                init: None,
+            })
+            .collect(),
+    }));
+    match surviving {
+        None => var_decl,
+        Some(surv) => Statement::block_statement(BlockStatement {
+            cv: None,
+            body: vec![var_decl, surv],
+        }),
+    }
+}
+
 /// Is a `let`/`const` `for`-header safe to *drop* when its loop is dead? Only
 /// when every declarator's initializer is absent or a side-effect-free literal.
 ///
@@ -1650,20 +1715,25 @@ fn lexical_header_is_droppable(v: &VariableDeclaration) -> bool {
 ///                                                      the binding unobservably)
 /// ```
 ///
-/// The collapse is **declined** (loop kept, test folded) in the two cases where
-/// removing more than the loop would delete an observable effect — both flagged
-/// by the security review, and both places Closure keeps the loop or lifts a
-/// binding rather than dropping it:
+/// A hoisted body `var` still hoists to the enclosing function scope, so it is
+/// EXTRACTED (initializer stripped, since the body never runs) rather than
+/// dropped — including when an *expression* init means the result is two
+/// statements, which are wrapped in a block that the enclosing list then
+/// flattens (see [`collapse_extracting_dead_vars`]):
+///
+/// ```text
+///   for (; false; ) { var y = 1; }    →  var y;
+///   for (f(); false; ) { var x = 1; } →  var x; f();     (two statements)
+/// ```
+///
+/// The collapse is **declined** (loop kept, test folded) only when a `let`/
+/// `const` header runs a side-effecting initializer, which is loop-scoped and
+/// cannot be lifted out (§14.7.4) — flagged by the security review:
 ///
 /// ```text
 ///   for (let i = f(); false; ) body   →  loop kept   (lexical init runs once at
 ///                                                      entry; side effect can't
 ///                                                      be lifted out — §14.7.4)
-///   for (; false; ) { var y = 1; }     →  loop kept   (a body `var` hoists to the
-///                                                      function scope and stays
-///                                                      observable; Closure
-///                                                      extracts it, which this
-///                                                      pass does not yet do)
 /// ```
 ///
 /// A **truthy** literal test is instead redundant — the loop runs forever, and
@@ -1713,42 +1783,54 @@ fn fold_for_statement(s: &ForStatement, st: &mut FoldState) -> Statement {
             // `extract_dead_loop_vars` for the exact reversed-body-then-init
             // order).
             //
-            // The one shape we still DECLINE: an *expression* init combined with
-            // a hoisted body `var` — that is two statements (`var x; e;`), which
-            // a single fold return can't represent, so we keep the loop (valid,
-            // no binding dropped). An expression init with no body `var`
-            // collapses to the init expression (`for(a();false;) …` → `a();`),
-            // which runs once at entry.
+            // An *expression* init combined with a hoisted body `var` is two
+            // statements (`var x; e;`); we emit them wrapped in a block that the
+            // enclosing list then flattens (`collapse_extracting_dead_vars`).
+            // An expression init with no body `var` collapses to the init
+            // expression (`for(a();false;) …` → `a();`), which runs once at
+            // entry.
             let mut body_names = Vec::new();
             collect_hoistable_vars(&body, &mut body_names);
-            let expr_init_with_body_vars = matches!(&init, Some(ForInit::Expression(_)))
-                && !body_names.is_empty();
-            if !expr_init_with_body_vars {
-                let discarded = [statement_cv(&body)];
-                st.record_fold_deleting(
-                    &s.cv,
-                    &discarded,
-                    "folded-branch",
-                    "for (…; <falsy literal>; …) { … }",
-                    "<hoisted var(s)> / <init>;",
-                );
-                return match &init {
-                    // Expression init (no body vars): the init runs once, kept.
-                    Some(ForInit::Expression(e)) => {
-                        Statement::expression_statement(ExpressionStatement {
+            let discarded = [statement_cv(&body)];
+            st.record_fold_deleting(
+                &s.cv,
+                &discarded,
+                "folded-branch",
+                "for (…; <falsy literal>; …) { … }",
+                "<hoisted var(s)> / <init>;",
+            );
+            return match &init {
+                // Expression init WITH hoisted body `var`(s): two statements
+                // (`var x; e;`). Extract the body `var`s BEFORE the once-run
+                // init expression, wrapped in a block that `fold_program` /
+                // `fold_block_statement` then splice into the enclosing list
+                // (`for(f();false;){var x=1}` → `var x; f();`).
+                Some(ForInit::Expression(e)) if !body_names.is_empty() => {
+                    collapse_extracting_dead_vars(
+                        &body,
+                        Some(Statement::expression_statement(ExpressionStatement {
                             cv: s.cv.clone(),
                             expression: e.clone(),
-                        })
-                    }
-                    // `None` or `var`/`let`/`const` init: hoist the body `var`s
-                    // out and, for a `var` header, append its declarators (kept
-                    // with initializers). A `let`/`const` header is loop-scoped
-                    // and contributes nothing.
-                    _ => extract_dead_loop_vars(&body, init.as_ref(), &s.cv),
-                };
-            }
+                        })),
+                        &s.cv,
+                    )
+                }
+                // Expression init, no body vars: the init runs once, kept.
+                Some(ForInit::Expression(e)) => {
+                    Statement::expression_statement(ExpressionStatement {
+                        cv: s.cv.clone(),
+                        expression: e.clone(),
+                    })
+                }
+                // `None` or `var`/`let`/`const` init: hoist the body `var`s
+                // out and, for a `var` header, append its declarators (kept
+                // with initializers). A `let`/`const` header is loop-scoped
+                // and contributes nothing.
+                _ => extract_dead_loop_vars(&body, init.as_ref(), &s.cv),
+            };
         }
-        // Declined — fall through to rebuild the loop with the folded test.
+        // A side-effecting lexical header declined above — fall through to
+        // rebuild the loop with the folded test.
     }
 
     // Always-TRUE test → the loop runs forever; the test is redundant, so drop
@@ -3118,6 +3200,98 @@ mod tests {
             Statement::Tagged(TaggedStatement::EmptyStatement(_)) => {}
             other => panic!("expected EmptyStatement; got {:?}", other),
         }
+    }
+
+    /// Build a block `{ var <name> = 1; }` for the dead-branch extraction tests.
+    fn block_with_var(name: &str) -> Statement {
+        use coding_adventures_javascript_ast::{
+            BindingTarget, VariableDeclaration, VariableDeclarator,
+        };
+        Statement::Tagged(TaggedStatement::BlockStatement(BlockStatement {
+            cv: None,
+            body: vec![Statement::Declaration(Declaration::VariableDeclaration(
+                VariableDeclaration {
+                    cv: None,
+                    kind: VarKind::Var,
+                    declarations: vec![VariableDeclarator {
+                        cv: None,
+                        id: BindingTarget::Identifier(Identifier {
+                            cv: None,
+                            name: name.to_string(),
+                        }),
+                        init: Some(num(1.0, None)),
+                    }],
+                },
+            ))],
+        }))
+    }
+
+    /// `if (false) { var z = 1; }` (no `else`) must EXTRACT the dead branch's
+    /// hoisted `var` as `var z;` — dropping it is a miscompile (a later `z` read
+    /// flips from a declared `undefined` binding to a `ReferenceError`).
+    #[test]
+    fn if_false_no_else_extracts_dead_var() {
+        let if_stmt = Statement::if_statement(IfStatement {
+            cv: Some("if.1".to_string()),
+            test: boolean(false, None),
+            consequent: Box::new(block_with_var("z")),
+            alternate: None,
+        });
+        let prog = program().with_body(vec![ProgramItem::Statement(if_stmt)]);
+        let (out, _, changed, _) = run_pass(prog);
+        assert!(changed);
+        assert_hoisted_var_names(first_stmt(&out), &["z"]);
+    }
+
+    /// `if (false) { var z = 1; } else h;` — extract `var z;` BEFORE the taken
+    /// `else` body; the wrapper block flattens into the list: `var z; h;`.
+    #[test]
+    fn if_false_with_else_extracts_dead_var_first() {
+        let if_stmt = Statement::if_statement(IfStatement {
+            cv: Some("if.1".to_string()),
+            test: boolean(false, None),
+            consequent: Box::new(block_with_var("z")),
+            alternate: Some(Box::new(expr_stmt(ident("h"), None))),
+        });
+        let prog = program().with_body(vec![ProgramItem::Statement(if_stmt)]);
+        let (out, _, changed, _) = run_pass(prog);
+        assert!(changed);
+        assert_eq!(out.body.len(), 2, "expected [var z; h;]; got {:?}", out.body);
+        assert_hoisted_var_names(first_stmt(&out), &["z"]);
+    }
+
+    /// `if (true) h; else { var z = 1; }` — the DEAD alternate's `var z` is
+    /// extracted before the taken consequent: `var z; h;`.
+    #[test]
+    fn if_true_extracts_dead_alternate_var() {
+        let if_stmt = Statement::if_statement(IfStatement {
+            cv: Some("if.1".to_string()),
+            test: boolean(true, None),
+            consequent: Box::new(expr_stmt(ident("h"), None)),
+            alternate: Some(Box::new(block_with_var("z"))),
+        });
+        let prog = program().with_body(vec![ProgramItem::Statement(if_stmt)]);
+        let (out, _, changed, _) = run_pass(prog);
+        assert!(changed);
+        assert_eq!(out.body.len(), 2, "expected [var z; h;]; got {:?}", out.body);
+        assert_hoisted_var_names(first_stmt(&out), &["z"]);
+    }
+
+    /// `for (h; false; ) { var x = 1; }` — an expression init combined with a
+    /// hoisted body `var` is two statements; extract `var x;` before the once-run
+    /// init: `var x; h;`.
+    #[test]
+    fn for_false_expr_init_plus_body_var_extracted() {
+        let f = for_stmt(
+            Some(ForInit::Expression(ident("h"))),
+            Some(boolean(false, None)),
+            block_with_var("x"),
+        );
+        let prog = program().with_body(vec![ProgramItem::Statement(f)]);
+        let (out, _, changed, _) = run_pass(prog);
+        assert!(changed);
+        assert_eq!(out.body.len(), 2, "expected [var x; h;]; got {:?}", out.body);
+        assert_hoisted_var_names(first_stmt(&out), &["x"]);
     }
 
     #[test]

--- a/code/programs/rust/closurec/tests/diff/simple-dead-branch-var/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-dead-branch-var/README.md
@@ -1,0 +1,16 @@
+# simple-dead-branch-var
+
+Locks the byte output of SIMPLE-level dead-branch hoisted-`var` extraction
+(`closure-pass-fold-control-flow`), a **miscompile** fix. A statically-dead `if`
+branch is removed, but a `var` inside it still hoists to the enclosing function
+scope; dropping it would flip a later read from a declared-`undefined` binding to
+a `ReferenceError`. The binding is extracted (initializer stripped, since the
+branch never runs) before the taken code:
+
+```js
+if (false) { var z = compute(); } else use();  ->  var z; use();
+```
+
+Verified byte-identical to the reference Closure Compiler
+(`closure-compiler-v20260712.jar`, SIMPLE, `--language_out NO_TRANSPILE`). See
+`input/a.js` and `expected.stdout`.

--- a/code/programs/rust/closurec/tests/diff/simple-dead-branch-var/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-dead-branch-var/expected.stdout
@@ -1,0 +1,1 @@
+var z;use();sink(z);

--- a/code/programs/rust/closurec/tests/diff/simple-dead-branch-var/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-dead-branch-var/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-dead-branch-var/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-dead-branch-var/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-dead-branch-var/input/a.js
@@ -1,0 +1,16 @@
+// SIMPLE-level dead-branch hoisted-`var` extraction (miscompile fix).
+//
+// A statically-dead `if` branch is removed, but a `var` declared inside it still
+// HOISTS to the enclosing function scope. Dropping it would be a miscompile: a
+// later read of the name flips from a declared-`undefined` binding to a
+// `ReferenceError`. So the binding is EXTRACTED (its initializer stripped, since
+// the branch never runs) as a bare `var z;` placed before the taken `else` body:
+//
+//   if (false) { var z = compute(); } else use();  ->  var z; use();
+//
+// `z` is still read afterwards, so the binding must survive. Byte-identical to
+// the reference Closure Compiler at SIMPLE. (When several such extractions occur
+// in one scope the reference additionally coalesces the bare `var`s to the scope
+// top — a separate normalization tracked elsewhere.)
+if (false) { var z = compute(); } else use();
+sink(z);

--- a/code/programs/rust/closurec/tests/diff_simple_dead_branch_var.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_dead_branch_var.rs
@@ -1,0 +1,40 @@
+//! Integration test for the `tests/diff/simple-dead-branch-var/` fixture.
+//!
+//! End-to-end oracle for dead-branch hoisted-`var` extraction in
+//! `closure-pass-fold-control-flow` (a miscompile fix): a dead `if` branch is
+//! removed but its hoisted `var` is EXTRACTED (initializer stripped) before the
+//! taken branch, so the binding survives — `if(false){var z=compute()}else use()`
+//! optimizes to `var z;use();`.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    std::fs::read_to_string("tests/diff/simple-dead-branch-var/flags.txt")
+        .expect("read flags.txt")
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_dead_branch_var_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY).args(&flags).output().expect("run closurec");
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-dead-branch-var/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}


### PR DESCRIPTION
## What

A statically-dead `if` branch (or dead `for` loop body) no longer DROPS a hoisted
`var` declared inside it — a **miscompile** — and the dead-`for`-loop collapse
now also handles its last unhandled shape (an expression init combined with a
body `var`).

## Why (miscompile)

`fold_if_statement` discarded a dead branch whole, taking any hoisted `var` with
it. But a `var` hoists to the enclosing function scope, so a later read flips
from a declared-`undefined` binding to a `ReferenceError` (or a different outer
binding):

```js
if (false) { var z = g(); } sink(z);   // was: sink(z)   → now: var z; sink(z);
if (false) { var z = 1; } else h();    // was: h()       → now: var z; h();
if (true)  h(); else { var z = 1; }    // was: h()       → now: var z; h();
```

The dead branch's hoisted `var`s are now EXTRACTED (initializers stripped, since
the branch never runs) as a bare `var …;` before the taken branch —
byte-identical to the reference Closure Compiler at SIMPLE, the same bug class as
the `while (false)` drop fixed in 0.30.0.

The dead-`for`-loop collapse also stops DECLINING an expression init + hoisted
body `var` (two statements):

```js
for (f(); false; ) { var x = 1; } sink(x);   // was: loop kept   → now: var x; f(); sink(x);
```

## How

New `collapse_extracting_dead_vars` helper returns `var …;` + the survivor
wrapped in a `BlockStatement`, which `fold_program` / `fold_block_statement` then
splice into the enclosing list (`block_is_scope_safe_to_hoist` admits a
`var`-only block; adjacent `var`s coalesce). Both `if` literal-branch arms and
the `for` collapse route through it; extraction order (reversed) matches the
existing `extract_dead_loop_vars`.

## Changes

- **closure-pass-fold-control-flow 0.33.0 → 0.34.0**: add
  `collapse_extracting_dead_vars`; wire into `fold_if_statement`
  (Some(true)/Some(false)) and `fold_for_statement` (expr-init + body-var); 4 new
  unit tests; corrected the stale decline-docs.
- **closurec**: new `tests/diff/simple-dead-branch-var` e2e fixture (byte-verified
  against the oracle) + its diff test harness.

## Verification

- `closure-pass-fold-control-flow` unit tests (88 + 13) pass, including 4 new.
- dce consumer and full closurec suite (156 test targets) pass — **zero fixture
  drift**.
- `cargo clippy -- -D warnings` clean in both workspaces.
- 9 oracle probes (if no-else / multi / else / if-true-alt / for-expr-init /
  nested, plus the pre-existing one-statement cases) byte-identical to the
  reference compiler.
- Security review passed (confirmed no panic, sound stripped-init extraction, no
  block-scoped leak, no regression).

## Scope / follow-up

When *several* such extractions occur in one scope, the reference additionally
coalesces the bare `var`s to the scope top (`var x,r,q,z;` at front) — a separate
whole-scope var-hoist normalization (tracked as a follow-up). closurec's output
is correct (all bindings declared) and byte-identical for a single occurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
