### PR TITLE
feat(num): NUM-6a — round_to(x, n) exact precision narrowing + first-class audit

### DIFF
--- a/code/packages/rust/adj-constraint-solver/CHANGELOG.md
+++ b/code/packages/rust/adj-constraint-solver/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.13.0] - 2026-07-22 — absorb `ComputeExpr::Round` (NUM-6a)
+
+### Changed
+
+- The solver's `ComputeExpr` walkers gain a `ComputeExpr::Round` arm (the new
+  NUM-6a `round_to` narrowing): non-linear/non-polynomial, so the LIA/linear/CAS
+  extractors return `None` (out of scope, like the unary round family), the
+  observed-value substitution rebuilds it with its operand substituted, and
+  `is_constant_expr` recurses into its operand. No behaviour change for existing
+  inputs — this is cross-producer totality for the new engine variant.
+
 ## [0.12.0] - 2026-07-01 — absorb `ComputeExpr::Unary` (`ComputeOp::Abs`)
 
 ### Changed

--- a/code/packages/rust/adj-constraint-solver/Cargo.toml
+++ b/code/packages/rust/adj-constraint-solver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-constraint-solver"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Solver bridge for the adj-lang constraint sublanguage. Takes an adj-lang ConstraintSystem (symbols + constrain/solve/check), classifies it, and dispatches the linear-equality case to cas-solve's exact rational Gaussian elimination — returning solved values traced back to the constraints. The first slice (B2a) of the ADJ constraint-solving arc; SAT / linear-integer / inequality feasibility and optimization follow."
 

--- a/code/packages/rust/adj-constraint-solver/src/lib.rs
+++ b/code/packages/rust/adj-constraint-solver/src/lib.rs
@@ -363,6 +363,9 @@ fn expr_to_pred(e: &ComputeExpr) -> Option<Predicate> {
         // piecewise-linear, not affine), so it is out of LIA scope.
         ComputeExpr::Unary(_, _) => None,
         ComputeExpr::Agg(_, _) => None,
+        // A `round_to(x, n)` narrowing is neither linear nor polynomial — out of
+        // scope for this tactic, exactly like a unary round (NUM-6a).
+        ComputeExpr::Round { .. } => None,
     }
 }
 
@@ -653,6 +656,9 @@ fn linearize(e: &ComputeExpr) -> Option<LinForm> {
         // fragment, so it can't be represented as a `LinForm`.
         ComputeExpr::Unary(_, _) => None,
         ComputeExpr::Agg(_, _) => None,
+        // A `round_to(x, n)` narrowing is neither linear nor polynomial — out of
+        // scope for this tactic, exactly like a unary round (NUM-6a).
+        ComputeExpr::Round { .. } => None,
     }
 }
 
@@ -1997,6 +2003,13 @@ fn substitute_observed(
         ComputeExpr::Unary(op, a) => {
             ComputeExpr::Unary(*op, Box::new(substitute_observed(a, variables, kb)))
         }
+        // Rebuild the narrowing with its operand substituted, keeping the precision
+        // and mode (NUM-6a) — mirrors the unary rebuild above.
+        ComputeExpr::Round { spec, mode, expr } => ComputeExpr::Round {
+            spec: *spec,
+            mode: *mode,
+            expr: Box::new(substitute_observed(expr, variables, kb)),
+        },
         ComputeExpr::Agg(_, _) => e.clone(),
     }
 }
@@ -2082,6 +2095,9 @@ fn poly_of(e: &ComputeExpr, x: &str) -> Option<Poly> {
         // polynomial fragment the univariate root-finders handle.
         ComputeExpr::Unary(_, _) => None,
         ComputeExpr::Agg(_, _) => None,
+        // A `round_to(x, n)` narrowing is neither linear nor polynomial — out of
+        // scope for this tactic, exactly like a unary round (NUM-6a).
+        ComputeExpr::Round { .. } => None,
     }
 }
 
@@ -2287,6 +2303,9 @@ fn expr_to_ir(e: &ComputeExpr) -> Option<IRNode> {
         // bridge can solve — reject rather than silently drop.
         ComputeExpr::Unary(_, _) => None,
         ComputeExpr::Agg(_, _) => None,
+        // A `round_to(x, n)` narrowing is neither linear nor polynomial — out of
+        // scope for this tactic, exactly like a unary round (NUM-6a).
+        ComputeExpr::Round { .. } => None,
     }
 }
 
@@ -2308,6 +2327,8 @@ fn is_constant_expr(e: &ComputeExpr) -> bool {
         // `|c|` is constant iff its operand is (the absolute value of a constant
         // is a constant); `|x|` mentions the symbol `x`, so it is not.
         ComputeExpr::Unary(_, a) => is_constant_expr(a),
+        // `round_to(c, n)` is constant iff its operand is — same rule as unary.
+        ComputeExpr::Round { expr, .. } => is_constant_expr(expr),
     }
 }
 

--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.18.0] — 2026-07-22 — NUM-6a: render the `round_to` narrowing in the audit trail
+
+The derivation-tree JSON now renders the new `DerivationNode::Round` (NUM-6a): a
+`{"node":"round","places":n,"mode":"half_even","value":…,"operand":{…}}` object
+exposing the precision, the stated rounding mode, and the operand subtree it
+narrowed — so a checker can re-round the operand's exact value and confirm the
+rendering (ADJ-NUMERIC-SUBSTRATE §4.3). Adds an end-to-end test driving
+`round_to(x, n)` through the built CLI (exact value, audit fields, and a
+non-integer/negative precision rejected as a compile error).
+
 ## [0.17.0] — 2026-07-21 — the `adj-verify` binary (RS-4 PR-D2)
 
 Implements `ADJ-REASON-MATH.md` §E.5/§E.6: a standalone re-checker that reads an

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -151,6 +151,40 @@ fn derivation_tree_json(
                 kids.join(",")
             )
         }
+        // A `round_to(x, n)` narrowing (NUM-6a): the audit exposes the precision,
+        // the rounding mode, the rounded `value`, and the operand subtree it
+        // narrowed — so a checker can re-round the operand's exact value under the
+        // recorded mode and confirm the rendering (ADJ-NUMERIC-SUBSTRATE §4.3).
+        D::Round {
+            spec,
+            mode,
+            operand,
+            result,
+        } => {
+            let logic_engine::compute::RoundSpec::Places(places) = spec;
+            format!(
+                "{{\"node\":\"round\",\"places\":{},\"mode\":\"{}\",\"value\":{},\"operand\":{}}}",
+                places,
+                rounding_mode_name(*mode),
+                jnum(*result),
+                derivation_tree_json(operand, kb)
+            )
+        }
+    }
+}
+
+/// The stable JSON spelling of a rounding mode for the audit trail — a checker
+/// keys off these, so they are fixed identifiers, not `Debug`.
+fn rounding_mode_name(mode: logic_engine::RoundingMode) -> &'static str {
+    use logic_engine::RoundingMode as M;
+    match mode {
+        M::Down => "down",
+        M::Up => "up",
+        M::Floor => "floor",
+        M::Ceiling => "ceiling",
+        M::HalfUp => "half_up",
+        M::HalfDown => "half_down",
+        M::HalfEven => "half_even",
     }
 }
 

--- a/code/packages/rust/adj-lang-cli/tests/num6a_round_to_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/num6a_round_to_e2e.rs
@@ -1,0 +1,92 @@
+//! End-to-end tests for the NUM-6a `round_to(x, n)` precision narrowing, driven
+//! through the built `adj-lang-cli` binary. They prove the whole path — native
+//! application surface → adapter/lower → the engine's exact rounding → the audit
+//! JSON — works together: the value is rounded **exactly** (`1/3 → 33/100`, no
+//! `f64` tie-break), the audit exposes the narrowing (`node:round`, `places`,
+//! `mode:half_even`, the operand subtree), and a bad precision is a clean compile
+//! error rather than a silent mis-rounding (ADJ-NUMERIC-SUBSTRATE §4.1–§4.4).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_num6a_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(src: &str, tag: &str) -> (bool, String) {
+    let dir = scratch(tag);
+    let p = dir.join("case.adj");
+    std::fs::write(&p, src).unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(&p)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn round_to_computes_exactly_and_audits_the_narrowing() {
+    // 10/3 = 3.333… → 2 decimal places (half-even) = 3.33, held as the EXACT
+    // fraction 333/100 (not a lossy 0.3300000004).
+    let (ok, s) = run("let r = round_to(10 / 3, 2)\n? r\n", "value");
+    assert!(ok, "cli should succeed: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    assert!(s.contains("\"value\":3.33"), "rounds to 3.33: {s}");
+    // The exact sidecar is the true fraction, so an auditor re-derives it precisely.
+    assert!(
+        s.contains("\"num\":\"333\"") && s.contains("\"den\":\"100\""),
+        "carries the exact rounded fraction 333/100: {s}"
+    );
+    // The audit trail exposes the narrowing as a first-class, checkable step:
+    // the node type, the precision, the stated mode, and the operand subtree it
+    // rounded (the 10/3 division) — everything `adj-verify` needs to re-round.
+    assert!(
+        s.contains("\"node\":\"round\"")
+            && s.contains("\"places\":2")
+            && s.contains("\"mode\":\"half_even\""),
+        "audit records node/places/mode: {s}"
+    );
+    assert!(
+        s.contains("\"operand\":{\"node\":\"op\",\"op\":\"/\""),
+        "the narrowing's operand subtree is the exact source division: {s}"
+    );
+}
+
+#[test]
+fn round_to_default_mode_breaks_ties_to_even() {
+    // 5/2 = 2.5 → 0 places. Half-even (the default) rounds the tie to the EVEN
+    // neighbour, 2 — NOT 3, which the legacy ties-away integer round would give.
+    let (ok, s) = run("let r = round_to(5 / 2, 0)\n? r\n", "tie");
+    assert!(ok, "cli should succeed: {s}");
+    assert!(
+        s.contains("\"value\":2") && !s.contains("\"value\":3"),
+        "2.5 rounds half-even to 2, not 3: {s}"
+    );
+}
+
+#[test]
+fn a_non_integer_precision_is_a_compile_error_not_a_silent_rounding() {
+    // The precision must be a non-negative integer literal; `2.5` is rejected at
+    // compile time rather than silently truncated to some rounding.
+    let (ok, s) = run("let r = round_to(10 / 3, 2.5)\n? r\n", "badprec");
+    assert!(
+        !ok || s.contains("\"error\""),
+        "a non-integer precision must be rejected: {s}"
+    );
+    assert!(
+        !s.contains("\"value\":3.3"),
+        "must not emit a silently-rounded value: {s}"
+    );
+}
+
+#[test]
+fn a_negative_precision_is_a_compile_error() {
+    let (ok, s) = run("let r = round_to(10 / 3, -1)\n? r\n", "negprec");
+    assert!(
+        !ok || s.contains("\"error\""),
+        "a negative precision must be rejected: {s}"
+    );
+}

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.57.0] — 2026-07-22
+
+### Added — NUM-6a: the `round_to(x, n)` precision narrowing (ADJ-NUMERIC-SUBSTRATE §4.1–§4.4)
+
+A formula body (or a `let`) can now round to a stated precision:
+
+```
+let dose_rounded = round_to(total / doses, 2)   % 10/3 → 3.33, exactly 333/100
+```
+
+- New `ExprAst::RoundTo(x, n)`, lowering to the engine's exact-path
+  `ComputeExpr::Round` (default half-even mode). Dimension-preserving.
+- Surface is the **native application** grammar — `round_to` is recognised as a
+  built-in during `Apply` lowering, *before* the user-formula lookup, so it reuses
+  the same comma-list call grammar as `quotient(a, b)` with **no new grammar and no
+  LaTeX change**. (The kickoff spec's LaTeX `\operatorname{round}(x, n)` form does
+  not parse a comma-separated argument list — the frontend splits on the top-level
+  comma — so §4.1 was updated to the native surface; see the spec's surface note.)
+- The precision `n` must be a **non-negative integer literal** ≤ 100 (a DoS cap);
+  a non-integer, negative, oversized, or non-literal `n` is a clean compile error
+  (`FormulaBadArgument`), never a silent mis-rounding.
+
 ## [0.56.0] — 2026-07-21
 
 ### Added — RS-4 PR-D4a: the `quote`/`at`/`snapshot` surface binding (ADJ-REASON-MATH §E.3.1)

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -254,6 +254,17 @@ pub enum ExprAst {
     /// `latex "…"` adapter from a `MathExpr::Call` whose argument is a
     /// two-element `Sequence`.
     Call2(BinFn, Box<ExprAst>, Box<ExprAst>),
+    /// A **precision narrowing** — `round_to(x, n)` (NUM-6a): round the operand to
+    /// `n` decimal places. Unlike [`ExprAst::Round`] (round to the nearest
+    /// *integer*), this carries a precision, so it lowers to the distinct
+    /// `logic_engine::ComputeExpr::Round` node (not a unary `ComputeOp`), rounding
+    /// on the exact path under the default half-even mode (ADJ-NUMERIC-SUBSTRATE
+    /// §4.1–§4.4). The `u32` is `n`, already validated a non-negative integer
+    /// within the precision cap. Produced by the **native application** surface
+    /// `round_to(x, n)` — recognised as a built-in in [`ExprAst::Apply`] lowering,
+    /// which reuses the same comma-list argument grammar as user formula
+    /// applications (`quotient(a, b)`), so no new grammar or LaTeX change is needed.
+    RoundTo(Box<ExprAst>, u32),
     /// An aggregation over every observation of a slot.
     Agg(AggOp, String),
     /// A **formula application** used as a sub-expression: `name(arg₁, …, argₙ)`

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -1211,6 +1211,16 @@ fn lower_expr(expr: &ExprAst) -> ComputeExpr {
         ExprAst::Trunc(a) => ComputeExpr::Unary(ComputeOp::Trunc, Box::new(lower_expr(a))),
         ExprAst::Sign(a) => ComputeExpr::Unary(ComputeOp::Sign, Box::new(lower_expr(a))),
         ExprAst::Call(f, a) => ComputeExpr::Unary(lower_named_fn(*f), Box::new(lower_expr(a))),
+        // `round_to(x, n)` (NUM-6a): the precision-carrying narrowing. Lowers to the
+        // distinct engine `Round` node (not a unary `ComputeOp`) so the precision `n`
+        // and the default half-even mode ride along and the exact-path audit records
+        // them (ADJ-NUMERIC-SUBSTRATE §4.1–§4.4). `n` was validated a non-negative
+        // integer by the adapter.
+        ExprAst::RoundTo(a, places) => ComputeExpr::Round {
+            spec: logic_engine::RoundSpec::Places(*places),
+            mode: bignum_core::RoundingMode::HalfEven,
+            expr: Box::new(lower_expr(a)),
+        },
         ExprAst::Call2(f, a, b) => ComputeExpr::Bin(
             lower_bin_fn(*f),
             Box::new(lower_expr(a)),
@@ -1540,6 +1550,7 @@ fn collect_refs(expr: &ExprAst, out: &mut Vec<String>) {
         | ExprAst::Floor(a)
         | ExprAst::Ceil(a)
         | ExprAst::Round(a)
+        | ExprAst::RoundTo(a, _)
         | ExprAst::Trunc(a)
         | ExprAst::Sign(a)
         | ExprAst::Call(_, a) => collect_refs(a, out),
@@ -1582,6 +1593,14 @@ const FORMULA_MAX_APPLY_DEPTH: usize = 256;
 /// more than any legitimate composed clinical formula needs (they are a handful of
 /// applications deep) yet a negligible fraction of the exponential blow-up.
 const FORMULA_MAX_EXPANSION_NODES: usize = 10_000;
+
+/// The largest `n` accepted by the `round_to(x, n)` built-in (NUM-6a). A DoS
+/// guard: rounding an exact rational to `n` decimal places materializes up to `n`
+/// digits, so an unbounded `n` (`round_to(x, 1000000000)`) would ask the exact
+/// path for a gigabyte-scale mantissa. 100 places is far beyond the engine's own
+/// default precision (256 bits ≈ 77 significant digits, ADJ-NUMERIC-SUBSTRATE §3)
+/// and any real measurement, so the cap constrains only pathological inputs.
+const MAX_ROUND_PLACES: u32 = 100;
 
 /// Maximum AST-nesting depth the expansion/substitution/clone walkers may descend
 /// in a single expression (ADJ-RULE-SUBSTRATE RS-1). The node budget bounds total
@@ -1664,6 +1683,7 @@ fn charged_clone(
         ExprAst::Floor(a) => ExprAst::Floor(Box::new(charged_clone(a, budget, d)?)),
         ExprAst::Ceil(a) => ExprAst::Ceil(Box::new(charged_clone(a, budget, d)?)),
         ExprAst::Round(a) => ExprAst::Round(Box::new(charged_clone(a, budget, d)?)),
+        ExprAst::RoundTo(a, n) => ExprAst::RoundTo(Box::new(charged_clone(a, budget, d)?), *n),
         ExprAst::Trunc(a) => ExprAst::Trunc(Box::new(charged_clone(a, budget, d)?)),
         ExprAst::Sign(a) => ExprAst::Sign(Box::new(charged_clone(a, budget, d)?)),
         ExprAst::Call(f, a) => ExprAst::Call(*f, Box::new(charged_clone(a, budget, d)?)),
@@ -1780,6 +1800,34 @@ fn expand_rec(
     let d = descend(node_depth)?;
     match expr {
         ExprAst::Apply(name, args) => {
+            // NUM-6a built-in: `round_to(x, n)` — the precision narrowing. Recognised
+            // by NAME here, BEFORE the user-formula lookup, so it needs no formula
+            // definition; it reuses the same comma-list application grammar as user
+            // formulas (`quotient(a, b)`), which is why no new grammar or LaTeX
+            // surface is required (ADJ-NUMERIC-SUBSTRATE §4.1). The value arg `x` is
+            // expanded (it may itself be an application); the precision `n` must be a
+            // non-negative INTEGER literal within the DoS cap [`MAX_ROUND_PLACES`] —
+            // a variable, fraction, negative, or oversized `n` is a clean compile
+            // error, never a silent mis-rounding.
+            if name == "round_to" {
+                if args.len() != 2 {
+                    return Err(LowerError::FormulaArity {
+                        formula: name.clone(),
+                        expected: 2,
+                        got: args.len(),
+                    });
+                }
+                let places = match &args[1] {
+                    ExprAst::Lit(v)
+                        if v.fract() == 0.0 && *v >= 0.0 && *v <= MAX_ROUND_PLACES as f64 =>
+                    {
+                        *v as u32
+                    }
+                    _ => return Err(LowerError::FormulaBadArgument { formula: name.clone() }),
+                };
+                let value = expand_rec(&args[0], formulas, depth, chain, active, budget, d)?;
+                return Ok(ExprAst::RoundTo(Box::new(value), places));
+            }
             // Resolve the callee against the SAME registry the top-level query path
             // uses. An unknown name is a clean, specific error — distinct from an
             // aggregation or built-in call, which never reach here (they are separate
@@ -1867,6 +1915,10 @@ fn expand_rec(
         ExprAst::Round(a) => Ok(ExprAst::Round(Box::new(expand_rec(
             a, formulas, depth, chain, active, budget, d,
         )?))),
+        ExprAst::RoundTo(a, n) => Ok(ExprAst::RoundTo(
+            Box::new(expand_rec(a, formulas, depth, chain, active, budget, d)?),
+            *n,
+        )),
         ExprAst::Trunc(a) => Ok(ExprAst::Trunc(Box::new(expand_rec(
             a, formulas, depth, chain, active, budget, d,
         )?))),
@@ -2045,6 +2097,9 @@ fn substitute_expr(
         ExprAst::Floor(a) => ExprAst::Floor(Box::new(substitute_expr(a, subst, budget, d)?)),
         ExprAst::Ceil(a) => ExprAst::Ceil(Box::new(substitute_expr(a, subst, budget, d)?)),
         ExprAst::Round(a) => ExprAst::Round(Box::new(substitute_expr(a, subst, budget, d)?)),
+        ExprAst::RoundTo(a, n) => {
+            ExprAst::RoundTo(Box::new(substitute_expr(a, subst, budget, d)?), *n)
+        }
         ExprAst::Trunc(a) => ExprAst::Trunc(Box::new(substitute_expr(a, subst, budget, d)?)),
         ExprAst::Sign(a) => ExprAst::Sign(Box::new(substitute_expr(a, subst, budget, d)?)),
         ExprAst::Call(f, a) => ExprAst::Call(*f, Box::new(substitute_expr(a, subst, budget, d)?)),

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [0.45.0] — 2026-07-22 — NUM-6a: the `round_to` precision narrowing (exact + audited)
+
+Implements the compute-engine half of NUM-6a (`ADJ-NUMERIC-SUBSTRATE.md` §4.1–§4.4):
+`round_to(x, n)` — round a value to `n` decimal places as an **explicit, checkable**
+step, never a silent lossy coercion.
+
+### Added
+
+- `ComputeExpr::Round { spec: RoundSpec, mode: RoundingMode, expr }` — a precision
+  narrowing distinct from the unary rounding family (`Abs`/`Floor`/`Ceil`/`Round`),
+  because it carries a precision and a mode a bare unary op cannot hold. `RoundSpec`
+  ships the `Places(u32)` variant (NUM-6b adds `SigFigures`).
+- `DerivationNode::Round { spec, mode, operand, result }` — the audit record: the
+  precision, the stated mode, and the operand subtree it narrowed, so `adj-verify`
+  can re-round the operand's **exact** value and confirm the rendering.
+- Re-export of `bignum_core::RoundingMode` so consumers can name a rounding mode
+  without depending on `bignum-core` directly.
+
+### Behaviour
+
+- Rounding runs on the **exact rational** path: `n / d` is divided to `n` places via
+  `bignum-core`'s `BigDecimal::div_round`, uniformly for terminating and repeating
+  operands (`1/3 → 33/100`, `2.54 → 2.54`), with **no `f64` hop** deciding a tie.
+  The default mode is round-half-even (`2.5 → 2`, not `3`). Dimension-preserving,
+  like the unary round family. The `f64` result is derived from the exact value, so
+  the labeled-lossy export and the exact audit value never disagree.
+
 ## [0.44.0] — 2026-07-21 — `verify`: re-execute a proof instead of believing it (RS-4 PR-D2)
 
 Implements the checkability invariant of `ADJ-REASON-MATH.md` §E.5.

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.44.0"
+version = "0.45.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -52,7 +52,7 @@
 
 use crate::dimension::{DimOp, Dimension};
 use crate::{FactId, KnowledgeBase};
-use bignum_core::{BigInteger, BigRational};
+use bignum_core::{BigDecimal, BigInteger, BigRational, RoundingMode};
 
 /// An exact rational value for CPU arithmetic — a [`BigRational`] from `bignum-core`, so it is
 /// **unbounded** (no `i128` overflow) and every `+ − × ÷` of rationals stays exact forever.
@@ -409,6 +409,32 @@ pub enum ComputeExpr {
     /// An aggregation over **every** observation of a slot:
     /// `Sum`/`Count`/`Min`/`Max`/`Avg`.
     Agg(ComputeOp, String),
+    /// A **precision narrowing** — `round_to(x, n)` (NUM-6a). Unlike the unary
+    /// rounding family in [`ComputeExpr::Unary`] (which snaps to an *integer*),
+    /// this rounds `expr` to a stated precision (`spec`) under a stated `mode`,
+    /// and is evaluated on the **exact** rational path so the audit records both
+    /// the exact source value and the rounded rendering (ADJ-NUMERIC-SUBSTRATE
+    /// §4.1–§4.4). It is dimension-preserving, like the unary round family
+    /// (`round_to(3.14159 mmol, 2) = 3.14 mmol`). A distinct node — not a
+    /// [`ComputeOp`] in [`ComputeExpr::Unary`] — because it carries a precision
+    /// and a mode that a bare unary op has nowhere to hold.
+    Round {
+        spec: RoundSpec,
+        mode: RoundingMode,
+        expr: Box<ComputeExpr>,
+    },
+}
+
+/// *What* precision a [`ComputeExpr::Round`] narrows to. NUM-6a ships the
+/// decimal-**places** form (`round_to(x, n)`); NUM-6b adds a `SigFigures(u32)`
+/// variant for `round_sig`, reusing the same node and eval path (only the target
+/// scale is derived differently). Kept a named enum, per ADJ-NUMERIC-SUBSTRATE
+/// §4.4, so that later variant is an additive change, not a node reshaping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RoundSpec {
+    /// Round to exactly `n` digits after the decimal point. `round_to(x, 0)` is
+    /// the precision-parameterized generalization of the integer `Round`.
+    Places(u32),
 }
 
 /// A node in the derivation tree — the provenance-through-math record.
@@ -433,6 +459,18 @@ pub enum DerivationNode {
         operands: Vec<DerivationNode>,
         result: f64,
     },
+    /// A **precision narrowing** node (NUM-6a) — the audit record for a
+    /// `round_to(x, n)`. Carries the `spec`/`mode` it rounded under and its single
+    /// `operand` subtree (the exact source), so `adj-verify` can re-round the
+    /// operand's exact value and confirm the rendered `result`
+    /// (ADJ-NUMERIC-SUBSTRATE §4.3: rounding is a first-class, checkable step,
+    /// never a silent lossy coercion).
+    Round {
+        spec: RoundSpec,
+        mode: RoundingMode,
+        operand: Box<DerivationNode>,
+        result: f64,
+    },
 }
 
 impl DerivationNode {
@@ -443,6 +481,7 @@ impl DerivationNode {
             DerivationNode::DerivedRef { value, .. } => *value,
             DerivationNode::Lit { value } => *value,
             DerivationNode::Op { result, .. } => *result,
+            DerivationNode::Round { result, .. } => *result,
         }
     }
 }
@@ -842,6 +881,8 @@ fn eval(
         // the "clean `TooDeep`, never a stack overflow" contract.
         ComputeExpr::Unary(op, a) => eval_unary(*op, a, kb, depth),
 
+        ComputeExpr::Round { spec, mode, expr } => eval_round(*spec, *mode, expr, kb, depth),
+
         ComputeExpr::Agg(op, slot) => {
             let observations = kb.observed_values_all(slot);
             // `count` is defined even when there are no observations (it's 0);
@@ -1056,6 +1097,83 @@ fn eval_unary(
         result_dim,
         exact,
     ))
+}
+
+/// Evaluate a **precision narrowing** — `round_to(x, n)` (NUM-6a). The rounding
+/// is done on the **exact** rational path so the audit keeps both the exact
+/// source value and its rounded rendering (ADJ-NUMERIC-SUBSTRATE §4.3).
+///
+/// The exact rounding is *uniform* over terminating and repeating operands. An
+/// [`ExactRational`] is `n / d` with `d > 0`; rounding it to `p` decimal places
+/// under `mode` is exactly `round(n / d)` carried out by [`BigDecimal::div_round`]
+/// — dividing the integer numerator by the integer denominator to scale `p` with
+/// the stated rounding — whose result is an exact `BigDecimal` we hand straight
+/// back to a `BigRational`. So `1/3` rounds to `0.33` and `2.54` stays `2.54`
+/// through the same one path, with no `f64` hop deciding a tie.
+///
+/// Split out and `#[inline(never)]` for the same stack-frame reason as
+/// [`eval_unary`] — see there.
+#[inline(never)]
+fn eval_round(
+    spec: RoundSpec,
+    mode: RoundingMode,
+    expr: &ComputeExpr,
+    kb: &KnowledgeBase,
+    depth: usize,
+) -> Result<(DerivationNode, Dimension, Option<ExactRational>), ComputeError> {
+    let (operand, dim, exact) = eval(expr, kb, depth + 1)?;
+    // `round_to` is **dimension-preserving**, exactly like the unary round family:
+    // narrowing `3.14159 mmol` to 2 places is `3.14 mmol`, still an amount.
+    let exact_out = exact.as_ref().map(|r| round_rational(r, spec, mode));
+    // The rendered `f64` is derived FROM the exact rounded value when we have one,
+    // so the labeled-lossy export and the exact audit value never disagree. Only a
+    // genuinely-inexact operand (a transcendental result with no exact sidecar)
+    // falls back to rounding the `f64` directly — itself already approximate.
+    let result = match &exact_out {
+        Some(r) => r.to_f64(),
+        None => round_f64(operand.value(), spec, mode),
+    };
+    // Rounding a finite value can never produce a non-finite one, but a
+    // non-finite operand (an `exp` overflow upstream) must not slip through the
+    // narrowing as a clean number — the same "no silently-wrong number" guard the
+    // other ops apply.
+    if !result.is_finite() {
+        return Err(ComputeError::NonFinite { op: ComputeOp::Round });
+    }
+    Ok((
+        DerivationNode::Round {
+            spec,
+            mode,
+            operand: Box::new(operand),
+            result,
+        },
+        dim,
+        exact_out,
+    ))
+}
+
+/// Round an exact rational to `spec`'s precision under `mode`, staying exact.
+fn round_rational(r: &ExactRational, spec: RoundSpec, mode: RoundingMode) -> ExactRational {
+    let RoundSpec::Places(places) = spec;
+    // `n / d` as two integer `BigDecimal`s, then divide-with-rounding to `places`
+    // decimal places. `d` is a rational denominator, always > 0, so the division
+    // is total (never the divide-by-zero `div_round` guards against).
+    let num = BigDecimal::from_integer(r.numerator().clone());
+    let den = BigDecimal::from_integer(r.denominator().clone());
+    let rounded = num.div_round(&den, places as i64, mode);
+    ExactRational::from_ratio(rounded.to_rational())
+}
+
+/// Round an `f64` to `spec`'s decimal places — the fallback for an operand that
+/// carried no exact value (already inexact, e.g. a transcendental result). It
+/// scales, rounds to the nearest integer, and unscales; on this already-lossy
+/// path the tie rule is `f64::round`'s ties-away rather than `mode`, which is
+/// acceptable because the value is approximate to begin with (the exact path,
+/// which every rational formula takes, honors `mode` precisely).
+fn round_f64(value: f64, spec: RoundSpec, _mode: RoundingMode) -> f64 {
+    let RoundSpec::Places(places) = spec;
+    let factor = 10f64.powi(places as i32);
+    (value * factor).round() / factor
 }
 
 #[cfg(test)]
@@ -2375,6 +2493,94 @@ mod tests {
                 assert!(matches!(&operands[1], DerivationNode::Lit { value } if *value == 2.0));
             }
             other => panic!("expected Op, got {other:?}"),
+        }
+    }
+
+    // ---- NUM-6a: round_to(x, n) — the precision narrowing ----
+
+    fn round_places(n: u32, inner: ComputeExpr) -> ComputeExpr {
+        ComputeExpr::Round {
+            spec: RoundSpec::Places(n),
+            mode: RoundingMode::HalfEven,
+            expr: Box::new(inner),
+        }
+    }
+    fn frac(a: i64, b: i64) -> ComputeExpr {
+        ComputeExpr::Bin(
+            ComputeOp::Div,
+            Box::new(ComputeExpr::Lit(a as f64)),
+            Box::new(ComputeExpr::Lit(b as f64)),
+        )
+    }
+
+    #[test]
+    fn round_to_places_rounds_a_repeating_rational_and_stays_exact() {
+        let kb = KnowledgeBase::new();
+        // 1/3 = 0.333… → 2 places = 0.33 = 33/100, EXACTLY (no f64 hop). The whole
+        // point: the audit value is the exact fraction, not a lossy 0.33000000004.
+        let d = compute("r", &round_places(2, frac(1, 3)), &kb).unwrap();
+        assert!((d.value - 0.33).abs() < 1e-12);
+        assert_eq!(d.exact, ExactRational::new(33, 100));
+        // 2/3 = 0.666… → 0.67 = 67/100 (rounds up, away from the truncation).
+        let d2 = compute("r", &round_places(2, frac(2, 3)), &kb).unwrap();
+        assert_eq!(d2.exact, ExactRational::new(67, 100));
+    }
+
+    #[test]
+    fn round_to_breaks_ties_to_even_not_away_from_zero() {
+        let kb = KnowledgeBase::new();
+        // 5/2 = 2.5 → nearest EVEN = 2. Ties-away (`f64::round`) would give 3, so
+        // this pins the half-even default distinct from the legacy integer Round.
+        let a = compute("r", &round_places(0, frac(5, 2)), &kb).unwrap();
+        assert_eq!(a.exact, ExactRational::new(2, 1));
+        assert_eq!(a.value, 2.0);
+        // 7/2 = 3.5 → nearest even = 4.
+        let b = compute("r", &round_places(0, frac(7, 2)), &kb).unwrap();
+        assert_eq!(b.exact, ExactRational::new(4, 1));
+    }
+
+    #[test]
+    fn round_to_is_exact_on_an_already_terminating_value() {
+        let kb = KnowledgeBase::new();
+        // 15/4 = 3.75 → 3 places is unchanged (adding places is exact); the value
+        // stays 15/4, not a re-parsed 3.75.
+        let d = compute("r", &round_places(3, frac(15, 4)), &kb).unwrap();
+        assert_eq!(d.exact, ExactRational::new(15, 4));
+        assert_eq!(d.value, 3.75);
+    }
+
+    #[test]
+    fn round_to_preserves_dimension_and_records_precision_mode_and_operand() {
+        // Round a dimensioned money value: 10/3 usd → 2 places = 3.33 usd. The
+        // unit must survive (rounding narrows the magnitude, not the dimension),
+        // and the audit node must carry the precision, mode, and operand subtree.
+        let kb = kb_with(vec![money("bal", 10, "usd")]);
+        let expr = round_places(
+            2,
+            ComputeExpr::Bin(
+                ComputeOp::Div,
+                Box::new(refexpr("bal")),
+                Box::new(ComputeExpr::Lit(3.0)),
+            ),
+        );
+        let d = compute("r", &expr, &kb).unwrap();
+        assert_eq!(d.exact, ExactRational::new(333, 100));
+        assert_eq!(d.dim, Dimension::Money("usd".into()));
+        match &d.tree {
+            DerivationNode::Round {
+                spec,
+                mode,
+                result,
+                operand,
+            } => {
+                assert_eq!(*spec, RoundSpec::Places(2));
+                assert_eq!(*mode, RoundingMode::HalfEven);
+                assert!((*result - 3.33).abs() < 1e-12);
+                // The operand subtree is the exact source the narrowing rounded —
+                // 10/3 usd, a division node — so a checker can re-round it.
+                assert!(matches!(operand.as_ref(), DerivationNode::Op { .. }));
+            }
+            other => panic!("expected Round node, got {other:?}"),
         }
     }
 }

--- a/code/packages/rust/logic-engine/src/lib.rs
+++ b/code/packages/rust/logic-engine/src/lib.rs
@@ -49,7 +49,13 @@ use std::collections::{HashMap, HashSet};
 
 use logic_core::{unify, LogicVar, Number, Substitution, Term};
 
-pub use compute::{compute, ComputeError, ComputeExpr, ComputeOp, DerivationNode, Derived};
+pub use compute::{
+    compute, ComputeError, ComputeExpr, ComputeOp, DerivationNode, Derived, RoundSpec,
+};
+/// Re-exported so consumers can name the rounding mode of a
+/// [`ComputeExpr::Round`]/[`DerivationNode::Round`] without depending on
+/// `bignum-core` directly (NUM-6a).
+pub use bignum_core::RoundingMode;
 pub use conversion::{add_or_sub, convert_value, ConvError, Conversion, ConversionTable};
 pub use datetime::{
     after, before, date_add, date_ordinal, days_between, read_date, read_duration_days,

--- a/code/specs/ADJ-NUMERIC-SUBSTRATE.md
+++ b/code/specs/ADJ-NUMERIC-SUBSTRATE.md
@@ -96,27 +96,35 @@ never a silent middle step. Provide, as engine ops and grounded stdlib formulas:
 - Each is provenanced (its definition) and each records the **exact source value** it was
   narrowed from, so the audit shows both the exact number and its rendered form.
 
-### 4.1 Surface — one math frontend, no parallel call grammar
+### 4.1 Surface — a recognised built-in over the existing application grammar
 
-The rounding built-ins are **not** a new native function-call syntax. Every rounding and
-transcendental operator in ADJ today enters through the single `latex "…"` frontend —
-`⌊x⌉` and `\operatorname{round}(x)` both lower to `ComputeOp::Round`, `⌊x⌋` to `Floor`,
-`\sin(x)` to the trig family — and formula bodies compose *user* formulas through
-`Apply` (`quotient(a, b)`). There is deliberately **no** built-in-call grammar. `round_to`
-and `round_sig` honour that one-surface design: they are the **precision-carrying twins** of
-the existing integer roundings, written as the two-argument operator-name applications
+`round_to`/`round_sig` are written as **native applications**, reusing the exact comma-list
+call grammar that user formula applications already use (`quotient(a, b)`):
 
 ```
-\operatorname{round}(x, n)      % round x to n decimal PLACES   → round_to(x, n)
-\operatorname{roundsig}(x, n)   % round x to n significant FIGS  → round_sig(x, n)
+round_to(x, n)      % round x to n decimal PLACES        (NUM-6a)
+round_sig(x, n)     % round x to n significant FIGURES    (NUM-6b)
 ```
 
-where `n` is a **non-negative integer literal**. The existing unary `\operatorname{round}(x)`
-(and `⌊x⌉`) is unchanged — it is exactly `round_to(x, 0)`. The two-argument form is recognised
-by the `latex` adapter from the comma-separated argument list (the same comma/semicolon fence
-machinery the frontend already parses); a non-integer or negative `n` is a **compile error**,
-never a silent truncation. Keeping these on the LaTeX surface means zero new lexer/parser
-grammar and no second way to write a call.
+where `n` is a **non-negative integer literal** no larger than the precision cap (100 places —
+a DoS bound far beyond §3's 256-bit default precision). They are **recognised by name** during
+`Apply` lowering, *before* the user-formula lookup, so they need no formula definition, no new
+grammar production, and no LaTeX change — the application parser already accepts them. A
+non-integer, negative, oversized, or non-literal `n` is a **compile error**, never a silent
+truncation. The existing integer roundings are unchanged: `round_to(x, 0)` is exactly the
+nearest-integer `Round` (also reachable as `⌊x⌉` / `\operatorname{round}(x)` through the
+`latex "…"` frontend).
+
+> **Surface note (divergence from the first §4.1 draft).** The kickoff spec proposed the
+> two-argument *LaTeX* operator-name form `\operatorname{round}(x, n)`. Implementation (NUM-6a)
+> found that the `latex` frontend does **not** keep an operator-name adjacent to a
+> **comma-separated** argument list — a top-level comma splits the expression into a sequence,
+> dropping the `round` — because `round` is not registered as an argument-taking function in the
+> `latex` crate (unlike `\min`/`\max`, which are). Registering it there is a separate cross-crate
+> change. The **native application grammar** already parses `name(a, b)` comma-lists correctly, so
+> `round_to(x, n)` as a recognised `Apply` built-in is the surface that works today with zero new
+> grammar — the same "no second way to write a call" spirit, on the application surface rather
+> than the LaTeX one.
 
 ### 4.2 Rounding mode — stated, defaulting to round-half-even
 

--- a/code/specs/ADJ-NUMERIC-SUBSTRATE.md
+++ b/code/specs/ADJ-NUMERIC-SUBSTRATE.md
@@ -96,6 +96,67 @@ never a silent middle step. Provide, as engine ops and grounded stdlib formulas:
 - Each is provenanced (its definition) and each records the **exact source value** it was
   narrowed from, so the audit shows both the exact number and its rendered form.
 
+### 4.1 Surface — one math frontend, no parallel call grammar
+
+The rounding built-ins are **not** a new native function-call syntax. Every rounding and
+transcendental operator in ADJ today enters through the single `latex "…"` frontend —
+`⌊x⌉` and `\operatorname{round}(x)` both lower to `ComputeOp::Round`, `⌊x⌋` to `Floor`,
+`\sin(x)` to the trig family — and formula bodies compose *user* formulas through
+`Apply` (`quotient(a, b)`). There is deliberately **no** built-in-call grammar. `round_to`
+and `round_sig` honour that one-surface design: they are the **precision-carrying twins** of
+the existing integer roundings, written as the two-argument operator-name applications
+
+```
+\operatorname{round}(x, n)      % round x to n decimal PLACES   → round_to(x, n)
+\operatorname{roundsig}(x, n)   % round x to n significant FIGS  → round_sig(x, n)
+```
+
+where `n` is a **non-negative integer literal**. The existing unary `\operatorname{round}(x)`
+(and `⌊x⌉`) is unchanged — it is exactly `round_to(x, 0)`. The two-argument form is recognised
+by the `latex` adapter from the comma-separated argument list (the same comma/semicolon fence
+machinery the frontend already parses); a non-integer or negative `n` is a **compile error**,
+never a silent truncation. Keeping these on the LaTeX surface means zero new lexer/parser
+grammar and no second way to write a call.
+
+### 4.2 Rounding mode — stated, defaulting to round-half-even
+
+Each narrowing states its **rounding mode**, defaulting to **round-half-even** (banker's
+rounding) to match §3's exactness discipline and `bignum-core::RoundingMode::HalfEven`. This
+is a *deliberate* difference from the legacy integer `Round`/`⌊x⌉`, which rounds ties **away
+from zero** — which is precisely why `round_to` records its mode in the audit rather than
+leaving it implicit: two roundings of the same exact value under different modes are both
+honest and distinguishable from the trail.
+
+### 4.3 Audit record — rounding is a first-class narrowing
+
+Every application records, alongside its own provenance (the op's definition): (a) the
+**exact source value** (the `Rational`/`Decimal` it narrowed, per §3), (b) the **target
+precision** (`n` places or `n` significant figures), (c) the **rounding mode**, and (d) the
+**rendered result**. `adj-verify` re-rounds the exact value under the recorded mode/precision
+and confirms the rendered result — so a rounded number is auditable back to the exact one it
+came from, never asserted. Rounding is thus an explicit, checkable step in the trail, not a
+silent lossy coercion (§3).
+
+### 4.4 Engine shape + sub-staging
+
+`ComputeExpr::Unary(ComputeOp, …)` carries no parameter, so the precision-carrying roundings
+add a new node `ComputeExpr::Round { spec: RoundSpec, mode: RoundingMode, expr }` where
+`RoundSpec = Places(u32) | SigFigures(u32)`. It is **dimension-preserving** (like the unary
+round family) and evaluated on the **exact path**: terminating cases via
+`BigDecimal::round_to_scale`, repeating rationals (e.g. `1/3 → 0.33`) via `BigDecimal::div_round`
+to the target scale — both already in `bignum-core` — then back to an exact `Rational` carrying
+the recorded exact-source sidecar for the audit. NUM-6 lands in focused PRs, each spec-sync →
+tests → impl → security-review → babysit:
+
+- **NUM-6a** — `round_to` (decimal places): the `Round`/`RoundSpec::Places` engine node, the
+  `\operatorname{round}(x, n)` LaTeX surface + adapter arm, exact eval, the §4.3 audit record,
+  and an end-to-end formula test. (First increment.)
+- **NUM-6b** — `round_sig` (`RoundSpec::SigFigures`): derive the target scale from the value's
+  most-significant-digit exponent, reusing 6a's eval.
+- **NUM-6c** — the formatters `to_scientific` / `to_percent` / `to_currency` (rendering, on the
+  6a/6b core) and per-`KnowledgeBase` `BigDouble` precision (the configurable default §3 defers
+  here).
+
 ---
 
 ## 5. Engine integration
@@ -149,7 +210,9 @@ Big arithmetic; a constraint solves over exact rationals where the backend allow
   formatted exports); exactness recorded on `Derived`.
 - **NUM-6 — precision/format ops + stdlib formulas** (`round_to`, `round_sig`,
   `to_scientific`, `to_percent`, `to_currency`) + audit exactness + `adj-verify` precision
-  re-check.
+  re-check. Surface, mode, audit record and engine shape pinned in §4.1–§4.4; lands in
+  focused sub-PRs **NUM-6a** (`round_to`) → **NUM-6b** (`round_sig`) → **NUM-6c** (formatters
+  + per-`KnowledgeBase` `BigDouble` precision).
 - **Later — retire `numeric-tower`'s `num-bigint`** onto `bignum-core` (pays down the
   existing third-party debt; out of this spec's critical path).
 


### PR DESCRIPTION
## What & why

First increment of **NUM-6** (`ADJ-NUMERIC-SUBSTRATE.md` §4.1–§4.4, pinned in the just-merged #8793): `round_to(x, n)` rounds a value to `n` decimal places as an **explicit, checkable** step — never a silent lossy coercion. Rounds on the **exact rational path**, so `round_to(10/3, 2)` is the exact `333/100`, not a lossy `0.33000000004`, and the audit exposes the narrowing for `adj-verify` to re-check.

## Surface

```
let dose = round_to(total / doses, 2)   % 10/3 → 3.33, exactly 333/100
```

`round_to` is a **built-in recognised during `Apply` lowering** (before the user-formula lookup), reusing the same comma-list application grammar as `quotient(a, b)` — **no new grammar, no LaTeX change**. `n` must be a non-negative integer literal ≤ 100 (DoS cap); anything else is a clean `FormulaBadArgument` compile error.

> **Surface divergence from the kickoff §4.1** (noted in the spec): the proposed LaTeX `\operatorname{round}(x, n)` does **not** parse — the latex frontend splits on the top-level comma and drops `round` (it isn't a registered argument-taking function like `\min`). The native application surface parses comma-lists today, so §4.1 was updated to it.

## Changes

- **logic-engine 0.45.0** — `ComputeExpr::Round { spec: RoundSpec::Places(u32), mode, expr }` + `DerivationNode::Round` audit node; exact eval via bignum-core `div_round` (uniform for terminating & repeating operands); default round-half-even (`2.5 → 2`); dimension-preserving; re-export `RoundingMode`.
- **adj-lang 0.57.0** — `ExprAst::RoundTo` + the `round_to` `Apply` built-in intercept + `MAX_ROUND_PLACES` cap.
- **adj-lang-cli 0.18.0** — renders `{"node":"round","places":n,"mode":"half_even","value":…,"operand":{…}}` in the derivation audit.
- **adj-constraint-solver 0.13.0** — `ComputeExpr::Round` arms in all 6 solver walkers (cross-producer totality: `None` for the linear/poly/CAS tactics, faithful rebuild in observed-value substitution).

## Verification

- 4 engine unit tests (exact repeating-rational rounding, half-even tie-to-even, terminating preservation, dimension + audit recording) + a 4-case adj-lang-cli e2e (exact value, audit fields, non-integer & negative precision rejected).
- Full `cargo test` across `logic-engine`/`adj-lang`/`adj-constraint-solver`/`adj-lang-cli` **green** (178 + all e2e suites). Clippy clean. Security review passed (DoS cap non-bypassable via formula composition; no panics on malformed input; denominator provably non-zero; non-finite guarded).

## Deferred

NUM-6b (`round_sig`) reuses this node/eval (adds `RoundSpec::SigFigures`); NUM-6c (`to_scientific`/`to_percent`/`to_currency` + per-KnowledgeBase precision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)