### PR TITLE
feat(spice): add BJT nominal temperature

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- Add BJT model-card `TNOM` / `T_NOM` nominal-temperature support, with
+  Berkeley Celsius card values converted to Kelvin for model-owned temperature
+  scaling and inherited circuit defaults when absent.
+
 ## Unreleased
 
 ### Added

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -237,6 +237,9 @@ modulation to that branch, increasing base current as reverse beta rolls off.
 `XTB` (default `0`) scales both forward and reverse beta with the
 analysis-to-nominal absolute temperature ratio, preserving nominal beta when
 omitted.
+`TNOM`/`T_NOM` sets the BJT model's nominal temperature in degrees Celsius.
+It overrides the circuit-level nominal temperature for BJT temperature scaling;
+omitting it preserves the inherited default.
 `model_card_unsupported_parameter_issues()`,
 `format_model_card_unsupported_parameter_issue_table()`,
 `model_card_unsupported_parameter_issue_records()`,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -605,6 +605,9 @@ class BJT:
         Reverse emission coefficient (default 1.0).
     Xtb:
         Forward- and reverse-beta temperature exponent (default 0.0).
+    Tnom:
+        Optional model nominal temperature in Kelvin. When omitted, temperature
+        analysis uses its circuit-level nominal temperature.
     """
 
     name: str
@@ -638,6 +641,7 @@ class BJT:
     Xtb: float = 0.0        # forward-beta temperature exponent
     beta_r: float = float("inf")  # reverse current gain; infinity disables
     Ikr: float = 0.0        # reverse-beta roll-off current (A); 0 disables
+    Tnom: float | None = None  # model nominal temperature (K); None inherits
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -338,6 +338,7 @@ def bjt_at_temperature(
 
     if not math.isfinite(temperature_kelvin) or temperature_kelvin <= 0.0:
         raise ValueError("temperature_kelvin must be finite and positive")
+    nominal_temperature_kelvin = bjt.Tnom if bjt.Tnom is not None else nominal_temperature_kelvin
     if not math.isfinite(nominal_temperature_kelvin) or nominal_temperature_kelvin <= 0.0:
         raise ValueError("nominal_temperature_kelvin must be finite and positive")
     if not math.isfinite(energy_gap_ev) or energy_gap_ev <= 0.0:
@@ -604,7 +605,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr, element.Tnom)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -9302,6 +9303,8 @@ def _validate_bjt(el: BJT) -> None:
         raise ValueError(
             f"{el.name}: BJT reverse beta roll-off current must be finite and non-negative"
         )
+    if el.Tnom is not None and (not math.isfinite(el.Tnom) or el.Tnom <= 0.0):
+        raise ValueError(f"{el.name}: BJT nominal temperature must be finite and positive")
     if not math.isfinite(el.Ise) or el.Ise < 0.0:
         raise ValueError(
             f"{el.name}: BJT base-emitter leakage saturation current must be finite and non-negative"

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (26, 42, 12, 4),
-    "PNP": (26, 42, 12, 4),
+    "NPN": (27, 44, 13, 4),
+    "PNP": (27, 44, 13, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -379,6 +379,8 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "IKF": "IKF",
     "IK": "IKF",
     "IKR": "IKR",
+    "TNOM": "TNOM",
+    "T_NOM": "TNOM",
     "ISE": "ISE",
     "NE": "NE",
     "ISC": "ISC",
@@ -940,6 +942,7 @@ def bjt_from_model_card(
         Xtb=p.get("XTB", 0.0),
         beta_r=p.get("BR", 1.0),
         Ikr=p.get("IKR", 0.0),
+        Tnom=(p["TNOM"] + 273.15) if "TNOM" in p else None,
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 110
+    assert len(coverage) == 112
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 110
+    assert len(records) == 112
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,17 +501,17 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 110
-    assert report.expected_canonical_parameter_count == 110
-    assert report.accepted_name_count == 174
-    assert report.aliased_parameter_count == 51
+    assert report.canonical_parameter_count == 112
+    assert report.expected_canonical_parameter_count == 112
+    assert report.accepted_name_count == 178
+    assert report.aliased_parameter_count == 53
     assert report.max_alias_count == 4
     assert report.issues == ()
     assert format_model_card_supported_parameter_coverage_gate_report(report) == (
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t110\t110\t174\t51\t4\t0"
+        "true\t7\t7\t112\t112\t178\t53\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,9 +539,9 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 109
-    assert report.accepted_name_count == 171
-    assert report.aliased_parameter_count == 50
+    assert report.canonical_parameter_count == 111
+    assert report.accepted_name_count == 175
+    assert report.aliased_parameter_count == 52
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t109\t110\t171\t50\t4\t4\n"
+        "false\t7\t7\t111\t112\t175\t52\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,10 +647,10 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
+        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
+    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "TNOM": 50.0, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.beta_r == pytest.approx(0.25)
@@ -662,6 +662,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert bjt_model.Var == pytest.approx(120.0)
     assert bjt_model.Ikf == pytest.approx(2.0e-3)
     assert bjt_model.Ikr == pytest.approx(3.0e-3)
+    assert bjt_model.Tnom == pytest.approx(323.15)
     assert bjt_model.Ise == pytest.approx(3.0e-13)
     assert bjt_model.Ne == pytest.approx(1.7)
     assert bjt_model.Isc == pytest.approx(4.0e-13)
@@ -2303,7 +2304,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3, Tnom=323.15),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2329,6 +2330,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.Xtb == pytest.approx(1.5)
     assert expanded.beta_r == pytest.approx(0.25)
     assert expanded.Ikr == pytest.approx(3.0e-3)
+    assert expanded.Tnom == pytest.approx(323.15)
 
 
 def test_branch_current_in_voltage_source():
@@ -2553,6 +2555,20 @@ def test_bjt_temperature_scaling_uses_beta_temperature_exponent():
     hot = bjt_at_temperature(transistor, 350.0)
     assert hot.beta_f > transistor.beta_f
     assert hot.beta_r > transistor.beta_r
+
+
+def test_bjt_temperature_scaling_uses_model_nominal_temperature():
+    transistor = BJT("Q1", "c", "b", "e", Tnom=325.0)
+    at_model_nominal = bjt_at_temperature(transistor, 325.0)
+    assert at_model_nominal.Is == pytest.approx(transistor.Is)
+    assert at_model_nominal.Vt == pytest.approx(transistor.Vt)
+
+
+def test_dc_rejects_invalid_bjt_nominal_temperature():
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", Tnom=0.0))
+    with pytest.raises(ValueError, match="nominal temperature must be finite and positive"):
+        dc_op(circuit)
 
 
 def test_dc_rejects_invalid_bjt_beta_temperature_exponent():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- Add BJT model-card `TNOM` / `T_NOM` nominal-temperature support, with
+  Berkeley Celsius card values converted to Kelvin for model-owned temperature
+  scaling and inherited circuit defaults when absent.
+
 ## Unreleased
 
 - Add BJT model-card `IKR` reverse high-current beta roll-off support in DC,

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -154,6 +154,9 @@ modulation to that branch, increasing base current as reverse beta rolls off.
 `XTB` (default `0`) scales both forward and reverse beta with the
 analysis-to-nominal absolute temperature ratio, preserving nominal beta when
 omitted.
+`TNOM`/`T_NOM` sets the BJT model's nominal temperature in degrees Celsius.
+It overrides the circuit-level nominal temperature for BJT temperature scaling;
+omitting it preserves the inherited default.
 `model_card_unsupported_parameter_issues`,
 `format_model_card_unsupported_parameter_issue_table`,
 `model_card_unsupported_parameter_issue_records`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -168,6 +168,7 @@ impl SubcircuitDefinition {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[allow(clippy::large_enum_variant)]
 pub enum SubcircuitElement {
     Element(Element),
     XInstance(XInstance),
@@ -452,6 +453,7 @@ fn clone_subckt_element(
                 element.reverse_beta,
             );
             expanded.reverse_beta_rolloff_current = element.reverse_beta_rolloff_current;
+            expanded.nominal_temperature_kelvin = element.nominal_temperature_kelvin;
             Element::Bjt(expanded)
         }
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
@@ -2655,6 +2657,9 @@ pub fn bjt_at_temperature(
             reason: "temperature must be finite and positive".to_string(),
         });
     }
+    let nominal_temperature_kelvin = bjt
+        .nominal_temperature_kelvin
+        .unwrap_or(nominal_temperature_kelvin);
     if !nominal_temperature_kelvin.is_finite() || nominal_temperature_kelvin <= 0.0 {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
@@ -2890,6 +2895,7 @@ pub struct Bjt {
     pub forward_beta_temperature_exponent: f64,
     pub reverse_beta: f64,
     pub reverse_beta_rolloff_current: f64,
+    pub nominal_temperature_kelvin: Option<f64>,
 }
 
 impl Bjt {
@@ -3352,6 +3358,7 @@ impl Bjt {
             forward_beta_temperature_exponent,
             reverse_beta,
             reverse_beta_rolloff_current: 0.0,
+            nominal_temperature_kelvin: None,
         }
     }
 }
@@ -3742,8 +3749,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 26, 42, 12, 4),
-    (ModelCardKind::Pnp, 26, 42, 12, 4),
+    (ModelCardKind::Npn, 27, 44, 13, 4),
+    (ModelCardKind::Pnp, 27, 44, 13, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3794,6 +3801,8 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IKF", "IKF"),
     ("IK", "IKF"),
     ("IKR", "IKR"),
+    ("TNOM", "TNOM"),
+    ("T_NOM", "TNOM"),
     ("ISE", "ISE"),
     ("NE", "NE"),
     ("ISC", "ISC"),
@@ -4484,6 +4493,10 @@ pub fn bjt_from_model_card(
             model_card_value(model, "BR", 1.0),
         );
     bjt.reverse_beta_rolloff_current = model_card_value(model, "IKR", 0.0);
+    bjt.nominal_temperature_kelvin = model
+        .parameters
+        .get("TNOM")
+        .map(|temperature_celsius| temperature_celsius + 273.15);
     Ok(bjt)
 }
 
@@ -23986,6 +23999,14 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
             name: bjt.name.clone(),
             reason: "reverse beta roll-off current must be finite and non-negative".to_string(),
         });
+    }
+    if let Some(nominal_temperature_kelvin) = bjt.nominal_temperature_kelvin {
+        if !nominal_temperature_kelvin.is_finite() || nominal_temperature_kelvin <= 0.0 {
+            return Err(SpiceError::InvalidElement {
+                name: bjt.name.clone(),
+                reason: "nominal temperature must be finite and positive".to_string(),
+            });
+        }
     }
     if !bjt.base_emitter_leakage_saturation_current.is_finite()
         || bjt.base_emitter_leakage_saturation_current < 0.0

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 110);
+    assert_eq!(coverage.len(), 112);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 110);
+    assert_eq!(records.len(), 112);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 110);
-    assert_eq!(report.expected_canonical_parameter_count, 110);
-    assert_eq!(report.accepted_name_count, 174);
-    assert_eq!(report.aliased_parameter_count, 51);
+    assert_eq!(report.canonical_parameter_count, 112);
+    assert_eq!(report.expected_canonical_parameter_count, 112);
+    assert_eq!(report.accepted_name_count, 178);
+    assert_eq!(report.aliased_parameter_count, 53);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t110\t110\t174\t51\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t112\t112\t178\t53\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,9 +235,9 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 109);
-    assert_eq!(report.accepted_name_count, 171);
-    assert_eq!(report.aliased_parameter_count, 50);
+    assert_eq!(report.canonical_parameter_count, 111);
+    assert_eq!(report.accepted_name_count, 175);
+    assert_eq!(report.aliased_parameter_count, 52);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
     assert_eq!(report.issues[0].kind, "NMOS");
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t109\t110\t171\t50\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t111\t112\t175\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -436,6 +436,7 @@ fn model_card_aliases_build_device_instances() {
             ("VB", 120.0),
             ("IK", 2.0e-3),
             ("IKR", 3.0e-3),
+            ("T_NOM", 50.0),
             ("ISE", 3.0e-13),
             ("NE", 1.7),
             ("ISC", 4.0e-13),
@@ -461,6 +462,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("VAR").unwrap(), 120.0);
     assert_close(*bjt_card.parameters.get("IKF").unwrap(), 2.0e-3);
     assert_close(*bjt_card.parameters.get("IKR").unwrap(), 3.0e-3);
+    assert_close(*bjt_card.parameters.get("TNOM").unwrap(), 50.0);
     assert_close(*bjt_card.parameters.get("ISE").unwrap(), 3.0e-13);
     assert_close(*bjt_card.parameters.get("NE").unwrap(), 1.7);
     assert_close(*bjt_card.parameters.get("ISC").unwrap(), 4.0e-13);
@@ -483,6 +485,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(bjt_model.reverse_early_voltage, 120.0);
     assert_close(bjt_model.forward_beta_rolloff_current, 2.0e-3);
     assert_close(bjt_model.reverse_beta_rolloff_current, 3.0e-3);
+    assert_close(bjt_model.nominal_temperature_kelvin.unwrap(), 323.15);
     assert_close(bjt_model.base_emitter_leakage_saturation_current, 3.0e-13);
     assert_close(bjt_model.base_emitter_leakage_emission_coefficient, 1.7);
     assert_close(bjt_model.base_collector_leakage_saturation_current, 4.0e-13);
@@ -1423,6 +1426,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
         0.25,
     );
     bjt.reverse_beta_rolloff_current = 3.0e-3;
+    bjt.nominal_temperature_kelvin = Some(323.15);
     let mut circuit = Circuit::new();
     circuit
         .define_subcircuit(SubcircuitDefinition::new(
@@ -1466,6 +1470,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.forward_beta_temperature_exponent, 1.5);
     assert_close(expanded.reverse_beta, 0.25);
     assert_close(expanded.reverse_beta_rolloff_current, 3.0e-3);
+    assert_close(expanded.nominal_temperature_kelvin.unwrap(), 323.15);
 }
 
 #[test]
@@ -1961,6 +1966,30 @@ fn bjt_temperature_scaling_uses_beta_temperature_exponent() {
     let hot = bjt_at_temperature(&transistor, 350.0, 300.15, 1.11).unwrap();
     assert!(hot.forward_beta > transistor.forward_beta);
     assert!(hot.reverse_beta > transistor.reverse_beta);
+}
+
+#[test]
+fn bjt_temperature_scaling_uses_model_nominal_temperature() {
+    let mut transistor = Bjt::new("Q1", "c", "b", "e");
+    transistor.nominal_temperature_kelvin = Some(325.0);
+    let at_model_nominal = bjt_at_temperature(&transistor, 325.0, 300.15, 1.11).unwrap();
+    assert_close(
+        at_model_nominal.saturation_current,
+        transistor.saturation_current,
+    );
+    assert_close(at_model_nominal.thermal_voltage, transistor.thermal_voltage);
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_nominal_temperature() {
+    let mut transistor = Bjt::new("Qbad", "c", "b", "0");
+    transistor.nominal_temperature_kelvin = Some(0.0);
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Bjt(transistor));
+    let error = dc_op(&circuit).unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("nominal temperature must be finite and positive"));
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- Add BJT model-card `TNOM` / `T_NOM` nominal-temperature support, with
+  Berkeley Celsius card values converted to Kelvin for model-owned temperature
+  scaling and inherited circuit defaults when absent.
+
 ## Unreleased
 
 - Add BJT model-card `IKR` reverse high-current beta roll-off support in DC,

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -224,6 +224,9 @@ modulation to that branch, increasing base current as reverse beta rolls off.
 `XTB` (default `0`) scales both forward and reverse beta with the
 analysis-to-nominal absolute temperature ratio, preserving nominal beta when
 omitted.
+`TNOM`/`T_NOM` sets the BJT model's nominal temperature in degrees Celsius.
+It overrides the circuit-level nominal temperature for BJT temperature scaling;
+omitting it preserves the inherited default.
 `modelCardUnsupportedParameterIssues`,
 `formatModelCardUnsupportedParameterIssueTable`,
 `modelCardUnsupportedParameterIssueRecords`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1729,6 +1729,7 @@ export interface Bjt {
   readonly forwardBetaTemperatureExponent: number;
   readonly reverseBeta: number;
   readonly reverseBetaRolloffCurrent: number;
+  readonly nominalTemperatureKelvin: number | undefined;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -2006,8 +2007,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [26, 42, 12, 4],
-  PNP: [26, 42, 12, 4],
+  NPN: [27, 44, 13, 4],
+  PNP: [27, 44, 13, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3597,7 +3598,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7624,6 +7625,7 @@ export function bjtAtTemperature(
   if (!Number.isFinite(temperatureKelvin) || temperatureKelvin <= 0.0) {
     throw invalidElement(element.name, "temperature must be finite and positive");
   }
+  nominalTemperatureKelvin = element.nominalTemperatureKelvin ?? nominalTemperatureKelvin;
   if (!Number.isFinite(nominalTemperatureKelvin) || nominalTemperatureKelvin <= 0.0) {
     throw invalidElement(element.name, "nominal temperature must be finite and positive");
   }
@@ -7781,6 +7783,7 @@ export function bjt(
   forwardBetaTemperatureExponent = 0.0,
   reverseBeta = Number.POSITIVE_INFINITY,
   reverseBetaRolloffCurrent = 0.0,
+  nominalTemperatureKelvin: number | undefined = undefined,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7815,6 +7818,7 @@ export function bjt(
     forwardBetaTemperatureExponent,
     reverseBeta,
     reverseBetaRolloffCurrent,
+    nominalTemperatureKelvin,
   };
 }
 
@@ -7925,6 +7929,8 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   IKF: "IKF",
   IK: "IKF",
   IKR: "IKR",
+  TNOM: "TNOM",
+  T_NOM: "TNOM",
   ISE: "ISE",
   NE: "NE",
   ISC: "ISC",
@@ -8458,6 +8464,7 @@ export function bjtFromModelCard(
     p.XTB ?? 0.0,
     p.BR ?? 1.0,
     p.IKR ?? 0.0,
+    p.TNOM !== undefined ? p.TNOM + 273.15 : undefined,
   );
 }
 
@@ -19894,6 +19901,10 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.reverseBetaRolloffCurrent) || element.reverseBetaRolloffCurrent < 0.0) {
     throw invalidElement(element.name, "reverse beta roll-off current must be finite and non-negative");
+  }
+  if (element.nominalTemperatureKelvin !== undefined &&
+      (!Number.isFinite(element.nominalTemperatureKelvin) || element.nominalTemperatureKelvin <= 0.0)) {
+    throw invalidElement(element.name, "nominal temperature must be finite and positive");
   }
   if (!Number.isFinite(element.baseEmitterLeakageSaturationCurrent) || element.baseEmitterLeakageSaturationCurrent < 0.0) {
     throw invalidElement(element.name, "base-emitter leakage saturation current must be finite and non-negative");

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(110);
+    expect(coverage).toHaveLength(112);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(110);
+    expect(records).toHaveLength(112);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 110,
-      expectedCanonicalParameterCount: 110,
-      acceptedNameCount: 174,
-      aliasedParameterCount: 51,
+      canonicalParameterCount: 112,
+      expectedCanonicalParameterCount: 112,
+      acceptedNameCount: 178,
+      aliasedParameterCount: 53,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t110\t110\t174\t51\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t112\t112\t178\t53\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,9 +241,9 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(109);
-    expect(report.acceptedNameCount).toBe(171);
-    expect(report.aliasedParameterCount).toBe(50);
+    expect(report.canonicalParameterCount).toBe(111);
+    expect(report.acceptedNameCount).toBe(175);
+    expect(report.aliasedParameterCount).toBe(52);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t109\t110\t171\t50\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t111\t112\t175\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -342,6 +342,7 @@ describe("dcOp", () => {
       VB: 120.0,
       IK: 2.0e-3,
       IKR: 3.0e-3,
+      T_NOM: 50.0,
       ISE: 3.0e-13,
       NE: 1.7,
       ISC: 4.0e-13,
@@ -355,7 +356,7 @@ describe("dcOp", () => {
       FC: 0.4,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, TNOM: 50.0, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.reverseBeta, 0.25);
@@ -367,6 +368,7 @@ describe("dcOp", () => {
     expectClose(bjtModel.reverseEarlyVoltage, 120.0);
     expectClose(bjtModel.forwardBetaRolloffCurrent, 2.0e-3);
     expectClose(bjtModel.reverseBetaRolloffCurrent, 3.0e-3);
+    expectClose(bjtModel.nominalTemperatureKelvin, 323.15);
     expectClose(bjtModel.baseEmitterLeakageSaturationCurrent, 3.0e-13);
     expectClose(bjtModel.baseEmitterLeakageEmissionCoefficient, 1.7);
     expectClose(bjtModel.baseCollectorLeakageSaturationCurrent, 4.0e-13);
@@ -1010,7 +1012,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3, 323.15),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -1037,6 +1039,7 @@ describe("dcOp", () => {
       expectClose(expanded.forwardBetaTemperatureExponent, 1.5);
       expectClose(expanded.reverseBeta, 0.25);
       expectClose(expanded.reverseBetaRolloffCurrent, 3.0e-3);
+      expectClose(expanded.nominalTemperatureKelvin, 323.15);
     }
   });
 
@@ -1368,6 +1371,22 @@ describe("dcOp", () => {
     const hot = bjtAtTemperature(transistor, 350);
     expect(hot.forwardBeta).toBeGreaterThan(transistor.forwardBeta);
     expect(hot.reverseBeta).toBeGreaterThan(transistor.reverseBeta);
+  });
+
+  it("uses the BJT model nominal temperature", () => {
+    const transistor = {
+      ...bjt("Q1", "c", "b", "e"),
+      nominalTemperatureKelvin: 325.0,
+    };
+    const atModelNominal = bjtAtTemperature(transistor, 325.0);
+    expectClose(atModelNominal.saturationCurrent, transistor.saturationCurrent);
+    expectClose(atModelNominal.thermalVoltage, transistor.thermalVoltage);
+  });
+
+  it("rejects invalid BJT nominal temperatures", () => {
+    const circuit = new Circuit();
+    circuit.add({ ...bjt("Qbad", "c", "b", "0"), nominalTemperatureKelvin: 0.0 });
+    expect(() => dcOp(circuit)).toThrowError("nominal temperature must be finite and positive");
   });
 
   it("rejects non-finite BJT beta temperature exponents", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,17 +33,17 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT reverse high-current beta roll-off.
+1. Cross-language BJT nominal model temperature.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `IKR` model-card support in Rust, Python, and TypeScript
-     with a behavior-preserving default of `0`.
-   - Apply reverse high-current base-charge modulation to the base-collector
-     reverse-current branch in DC, transient, AC, transfer-function,
-     temperature, and noise paths while preserving the complete BJT model
-     through subcircuits.
-   - Extend the supported-parameter coverage gate from 108 to 110 canonical
-     rows and lock model-card behavior, validation, and hierarchy in all
-     engines.
+   - Add Berkeley BJT `TNOM` / `T_NOM` model-card support in Rust, Python, and
+     TypeScript, interpreting card values in degrees Celsius and storing the
+     absolute model temperature internally.
+   - Let a model-owned nominal temperature override the circuit-level default
+     in temperature scaling while preserving inherited behavior when `TNOM`
+     is absent and preserving the complete BJT model through subcircuits.
+   - Extend the supported-parameter coverage gate from 110 to 112 canonical
+     rows and lock model-card behavior, validation, hierarchy, and temperature
+     scaling in all engines.
 
 ## Completed Slices
 
@@ -3103,6 +3103,14 @@ the Rust, Python, and TypeScript surfaces together.
    - `XTB` scales both forward and reverse beta, hierarchical subcircuit
      expansion preserves the complete BJT model, and the supported-parameter
      release gate now covers 108 canonical rows.
+
+232. Cross-language BJT reverse high-current beta roll-off.
+   - Status: completed in PR 8801.
+   - Rust, Python, and TypeScript BJT model cards now accept `IKR` and apply
+     reverse high-current base-charge modulation in DC, transient, AC,
+     transfer-function, temperature, and noise paths.
+   - Hierarchical subcircuit expansion preserves the complete BJT model, and
+     the supported-parameter release gate now covers 110 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley BJT TNOM / T_NOM model-card support in Rust, Python, and TypeScript
- convert card temperatures from Celsius to Kelvin and let model-owned nominal temperatures override the circuit default
- preserve nominal temperature through subcircuits, validate it, expand the coverage gate to 112 canonical parameters, and reconcile the implementation plan

## Verification
- Rust: cargo fmt -p spice-engine -- --check
- Rust: cargo clippy -p spice-engine --all-targets -- -D warnings
- Rust: 362 package tests across unit, AC, compatibility, DC, Monte Carlo, noise, sensitivity, transfer-function, and transient binaries
- Python: Ruff check; 554 tests passed; 88.79% coverage
- TypeScript: 312 tests passed; npm run build
