### PR TITLE
feat(semantic-ir-to-c): ForRange (numeric for-loop) + total-emitter fixes (SIR16)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 0.5.0 — `ForRange` (numeric for-loop) + a scan hole (SIR16)
+
+Fixes a **pre-existing panic**: `Stmt::ForRange` (`for i in 0...3`) is gated by
+`Feature::Loops` alone (accepted since 0.4.0), so a producer emitting a numeric
+for-loop reached the emitter — which sent it to `unreachable!`. It now lowers to
+a native `int64_t` counter loop mirroring the Go/Rust backends byte-for-byte:
+
+- `start`/`stop`/`step` are evaluated ONCE (they may have side effects) into
+  `SirValue` temporaries, then reduced to `int64_t` via the new `_sir_as_int`
+  runtime helper (a truncating integer view — a float bound truncates toward
+  zero).
+- the stop is EXCLUSIVE and the direction follows the step's sign
+  (`step >= 0 ? i < stop : i > stop`), so a descending loop with a negative step
+  works — matching Go's `_sir_range_cont`.
+- the loop `var` is declared INSIDE the loop body block, so it (and any
+  body-local) is block-scoped — matching the validator (which rewinds the loop
+  body) and Go's `:=` counter, never clobbering an enclosing same-named local.
+  The outer `{…}` scopes the counter temporaries (nesting-safe via `fresh_id`).
+
+Also closes a **pre-existing scan hole** (same class): the unsupported-builtin
+pre-check (`scan_block_for_builtin`) did not recurse into `While` or `ForRange`
+bodies, so an unknown builtin hidden in a loop body escaped the clean rejection
+and hit the emitter's `unreachable!`. It now scans both; such input rejects
+cleanly with a `BackendError` instead of panicking.
+
+Makes the emitter TOTAL for its accepted feature set. `ForEach` also observes
+only `Feature::Loops` (not gated out), so it was likewise a latent
+`unreachable!` — `compile` now rejects it CLEANLY via a `first_foreach`
+pre-pass (a clear `UnsupportedFeature` error) until the sequences batch gives it
+an iterator, rather than panicking. The sequence nodes stay rejected at the
+feature gate — a follow-up adds `Feature::Sequences` (a real `SIR_SEQ`
+runtime).
+
 ## 0.4.0 — control flow, mutation & the rest of the comparisons (SIR16)
 
 Accepts `Feature::Loops` and `Feature::MutableBindings`, and:

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -337,8 +337,60 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             }
             let _ = writeln!(out, "{pad}}}");
         }
-        // Other SIR16+ statements (ForRange/ForEach/index-set/class/try) are not
-        // accepted; the capability check rejects such modules before emit.
+        // `for var in start...stop step step`. Gated by `Feature::Loops` alone,
+        // so it is reachable whenever loops are accepted. Counts in native
+        // `int64_t` mirroring the Go/Rust backends: `start`/`stop`/`step` are
+        // evaluated ONCE into `SirValue` temporaries (they may have side
+        // effects), then reduced to `int64_t`. Direction-aware EXCLUSIVE stop
+        // (`step >= 0 ? i < stop : i > stop`, so a descending loop works). The
+        // outer `{…}` scopes the counter temporaries; `var` is declared INSIDE
+        // the loop body, so it (and any body-local) is block-scoped — matching
+        // the validator (which rewinds the loop body) and Go's `:=` counter,
+        // never clobbering an enclosing same-named local.
+        Stmt::ForRange {
+            var,
+            start,
+            stop,
+            step,
+            body,
+            ..
+        } => {
+            let id = fresh_id();
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let sv = |kind: &str| format!("_sir_fr{kind}v{id}");
+            let _ = writeln!(out, "{pad}{{");
+            for (kind, e) in [("start", start), ("stop", stop), ("step", step)] {
+                let _ = writeln!(out, "{ipad}SirValue {};", sv(kind));
+                emit_assign(out, &sv(kind), e, inner);
+            }
+            let _ = writeln!(out, "{ipad}int64_t _sir_fri{id} = _sir_as_int({});", sv("start"));
+            let _ = writeln!(out, "{ipad}int64_t _sir_frstop{id} = _sir_as_int({});", sv("stop"));
+            let _ = writeln!(out, "{ipad}int64_t _sir_frstep{id} = _sir_as_int({});", sv("step"));
+            let _ = writeln!(
+                out,
+                "{ipad}while (_sir_frstep{id} >= 0 ? _sir_fri{id} < _sir_frstop{id} : \
+                 _sir_fri{id} > _sir_frstop{id}) {{",
+            );
+            let body_i = inner + 1;
+            let bpad = indent_str(body_i);
+            let _ = writeln!(out, "{bpad}SirValue {} = _sir_int(_sir_fri{id});", sanitize_ident(var));
+            // A loop that never reads its counter (an empty body, or `for _ in
+            // 0..n { … }`) would leave `var` unused — `(void)` silences
+            // `-Wunused-variable` so a `-Werror` consumer still compiles.
+            let _ = writeln!(out, "{bpad}(void){};", sanitize_ident(var));
+            for st in &body.stmts {
+                emit_stmt(out, st, body_i);
+            }
+            let _ = writeln!(out, "{bpad}_sir_fri{id} += _sir_frstep{id};");
+            let _ = writeln!(out, "{ipad}}}");
+            let _ = writeln!(out, "{pad}}}");
+        }
+        // Other SIR16+ statements (index-set/class/try) require features this
+        // backend does not accept, so the capability check rejects them before
+        // emit. `ForEach` is the exception — it observes only `Feature::Loops`
+        // (accepted), so `compile`'s `first_foreach` pre-pass rejects it
+        // cleanly rather than letting it reach this `unreachable!`.
         other => unreachable!("C backend reached unsupported statement: {other:?}"),
     }
 }
@@ -772,6 +824,55 @@ pub fn first_unsupported_builtin(m: &Module) -> Option<(String, Span)> {
     None
 }
 
+/// Locate a `Stmt::ForEach` anywhere in the module. `ForEach` observes only
+/// `Feature::Loops` (the validator; same feature as `While`/`ForRange`), which
+/// this backend accepts — so a module using `for x in <iterable>` passes the
+/// capability check and would reach the emitter's `unreachable!`. The emitter
+/// cannot lower it yet (a sequence/`each` iterator is the sequences batch), so
+/// `compile` rejects it CLEANLY via this pre-pass rather than panicking. Walks
+/// the full statement/expression tree so a nested `ForEach` (in a loop or `if`
+/// body) is caught too.
+pub fn first_foreach(m: &Module) -> Option<Span> {
+    fn in_block(b: &Block) -> Option<Span> {
+        b.stmts
+            .iter()
+            .find_map(in_stmt)
+            .or_else(|| in_expr(&b.value))
+    }
+    fn in_stmt(s: &Stmt) -> Option<Span> {
+        match s {
+            Stmt::ForEach { span, .. } => Some(span.clone()),
+            Stmt::While { cond, body, .. } => in_expr(cond).or_else(|| in_block(body)),
+            Stmt::ForRange {
+                start, stop, step, body, ..
+            } => in_expr(start)
+                .or_else(|| in_expr(stop))
+                .or_else(|| in_expr(step))
+                .or_else(|| in_block(body)),
+            Stmt::LetBinding { value, .. }
+            | Stmt::LetStarBinding { value, .. }
+            | Stmt::ExprStmt { expr: value, .. }
+            | Stmt::Assign { value, .. } => in_expr(value),
+            _ => None,
+        }
+    }
+    fn in_expr(e: &Expr) -> Option<Span> {
+        match e {
+            Expr::If {
+                cond,
+                then_branch,
+                else_branch,
+                ..
+            } => in_expr(cond)
+                .or_else(|| in_block(then_branch))
+                .or_else(|| in_block(else_branch)),
+            Expr::Block(b) => in_block(b),
+            _ => None,
+        }
+    }
+    m.functions.iter().find_map(|f| in_block(&f.body))
+}
+
 fn scan_block_for_builtin(b: &Block) -> Option<(String, Span)> {
     for s in &b.stmts {
         let inner = match s {
@@ -779,6 +880,22 @@ fn scan_block_for_builtin(b: &Block) -> Option<(String, Span)> {
             | Stmt::LetStarBinding { value, .. }
             | Stmt::ExprStmt { expr: value, .. }
             | Stmt::Assign { value, .. } => scan_expr_for_builtin(value),
+            // Loop bodies must be scanned too, or an unsupported builtin hidden
+            // in a `while`/`for` body escapes the pre-check and hits the
+            // emitter's `unreachable!`. (`While` was a pre-existing scan hole.)
+            Stmt::While { cond, body, .. } => {
+                scan_expr_for_builtin(cond).or_else(|| scan_block_for_builtin(body))
+            }
+            Stmt::ForRange {
+                start,
+                stop,
+                step,
+                body,
+                ..
+            } => scan_expr_for_builtin(start)
+                .or_else(|| scan_expr_for_builtin(stop))
+                .or_else(|| scan_expr_for_builtin(step))
+                .or_else(|| scan_block_for_builtin(body)),
             _ => None,
         };
         if inner.is_some() {

--- a/code/packages/rust/semantic-ir-to-c/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/lib.rs
@@ -127,6 +127,20 @@ impl Backend for CBackend {
             });
         }
 
+        // 3b. `Stmt::ForEach` observes only `Feature::Loops` (accepted), so it
+        //     is NOT gated out — a module using `for x in <iterable>` would
+        //     otherwise reach the emitter's `unreachable!`. Reject it cleanly
+        //     until the sequences batch gives it an iterator.
+        if let Some(span) = emit::first_foreach(module) {
+            return Err(BackendError {
+                kind: BackendErrorKind::UnsupportedFeature,
+                message: "the v0 C backend does not yet lower `for … in` (ForEach) \
+                          — deferred to the sequences feature batch"
+                    .to_string(),
+                span,
+            });
+        }
+
         // 4. Emit.
         let source = emit::emit_module(module);
         let line_count = source.lines().count();

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -138,6 +138,15 @@ double _sir_as_num(SirValue v) {
     return 0.0;
 }
 
+/* Truncating integer view of a numeric value — the loop-counter form used by
+ * `ForRange` (which counts in int64, matching the Go/Rust backends).  A float
+ * bound truncates toward zero; a non-number yields 0. */
+int64_t _sir_as_int(SirValue v) {
+    if (v.tag == SIR_INT)   return v.as.i;
+    if (v.tag == SIR_FLOAT) return (int64_t)v.as.f;
+    return 0;
+}
+
 const char *_sir_str_of(SirValue v) {
     return (v.tag == SIR_STR || v.tag == SIR_SYM) ? v.as.s : "";
 }

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_forrange.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_forrange.rs
@@ -1,0 +1,247 @@
+//! Execution proof for `Stmt::ForRange` on the C backend — hand-build a module
+//! (bypassing any frontend, since ForRange is producer-agnostic and gated by
+//! `Feature::Loops` alone), emit C, compile with a real gcc/clang-style
+//! compiler, run it, assert stdout. Skips gracefully when no `cc` is present.
+//!
+//! ForRange was a PRE-EXISTING `unreachable!` panic: C accepts `Loops` but the
+//! emitter did not lower ForRange. These prove it now runs and matches the
+//! Go/Rust `_sir_range_cont` semantics (direction-aware exclusive stop).
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Scope, Span,
+    Stmt, CURRENT_SIR_VERSION,
+};
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    for cand in ["cc", "clang", "gcc"] {
+        let ok = Command::new(cand)
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if ok {
+            return Some(cand.to_string());
+        }
+    }
+    None
+}
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn compile_and_run(cc: &str, module: &Module) -> String {
+    let artifact = semantic_ir_to_c::compile(module).expect("C backend compile (no panic)");
+    let dir = std::env::temp_dir();
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let stem = format!("sirc_fr_{}_{}", std::process::id(), n);
+    let cpath: PathBuf = dir.join(format!("{stem}.c"));
+    let exe: PathBuf = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::File::create(&cpath)
+        .and_then(|mut f| f.write_all(artifact.source.as_bytes()))
+        .expect("write .c");
+    let out = Command::new(cc)
+        .args(["-std=c99", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn C compiler");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        artifact.source
+    );
+    let run = Command::new(&exe).output().expect("run emitted program");
+    assert!(run.status.success(), "run failed (exit {:?})", run.status.code());
+    String::from_utf8_lossy(&run.stdout).replace("\r\n", "\n")
+}
+
+fn s() -> Span {
+    Span::synthetic()
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn local(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
+}
+fn puts(arg: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "puts".into(),
+            args: vec![arg],
+            effects: EffectSet::PURE,
+            span: s(),
+        },
+        span: s(),
+    }
+}
+fn forrange(var: &str, start: i64, stop: i64, step: i64, body: Vec<Stmt>) -> Stmt {
+    Stmt::ForRange {
+        var: var.into(),
+        start: ilit(start),
+        stop: ilit(stop),
+        step: ilit(step),
+        body: Block { stmts: body, value: Expr::NilLit { span: s() }, span: s() },
+        span: s(),
+    }
+}
+fn loops_module(stmts: Vec<Stmt>) -> Module {
+    Module {
+        name: "frprog".into(),
+        manifest: FeatureManifest::from_features(&[Feature::Loops]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+#[test]
+fn for_range_counts_up_exclusive() {
+    let Some(cc) = find_cc() else {
+        eprintln!("skip: no C compiler");
+        return;
+    };
+    // `for i in 0, 3, 1: puts i` → 0,1,2 (stop is EXCLUSIVE).
+    let out = compile_and_run(&cc, &loops_module(vec![forrange("i", 0, 3, 1, vec![puts(local("i"))])]));
+    assert_eq!(out, "0\n1\n2\n");
+}
+
+#[test]
+fn for_range_counts_down_with_negative_step() {
+    let Some(cc) = find_cc() else {
+        eprintln!("skip: no C compiler");
+        return;
+    };
+    // `for i in 3, 0, -1: puts i` → 3,2,1 (descending, exclusive of 0).
+    let out = compile_and_run(&cc, &loops_module(vec![forrange("i", 3, 0, -1, vec![puts(local("i"))])]));
+    assert_eq!(out, "3\n2\n1\n");
+}
+
+#[test]
+fn for_range_nested_distinct_counters() {
+    let Some(cc) = find_cc() else {
+        eprintln!("skip: no C compiler");
+        return;
+    };
+    // Nested loops must not clobber each other's counter temporaries.
+    let inner = forrange("j", 0, 2, 1, vec![puts(local("j"))]);
+    let out = compile_and_run(&cc, &loops_module(vec![forrange("i", 0, 2, 1, vec![inner])]));
+    assert_eq!(out, "0\n1\n0\n1\n"); // i=0:{j0,j1}, i=1:{j0,j1}
+}
+
+#[test]
+fn for_range_var_is_block_scoped() {
+    let Some(cc) = find_cc() else {
+        eprintln!("skip: no C compiler");
+        return;
+    };
+    // A loop var declared inside the loop body block does not clobber an
+    // enclosing same-named local — `x = 99; for x in 0..3 {}; puts x` → 99.
+    let out = compile_and_run(
+        &cc,
+        &loops_module(vec![
+            Stmt::LetBinding { name: "x".into(), sir_type: None, value: ilit(99), span: s() },
+            forrange("x", 0, 3, 1, vec![]),
+            puts(local("x")),
+        ]),
+    );
+    assert_eq!(out, "99\n");
+}
+
+#[test]
+fn unsupported_builtin_in_while_body_is_rejected_not_panicked() {
+    // Gap B: a `While` body was not scanned by the unsupported-builtin
+    // pre-check, so an unknown builtin there hit the emitter's `unreachable!`.
+    // It must now reject CLEANLY (a `BackendError`), never panic.
+    let bad = Expr::BuiltinCall {
+        name: "totally_unsupported_xyz".into(),
+        args: vec![],
+        effects: EffectSet::PURE,
+        span: s(),
+    };
+    let while_stmt = Stmt::While {
+        cond: Expr::BoolLit { value: false, span: s() },
+        body: Block {
+            stmts: vec![Stmt::ExprStmt { expr: bad, span: s() }],
+            value: Expr::NilLit { span: s() },
+            span: s(),
+        },
+        span: s(),
+    };
+    let result = semantic_ir_to_c::compile(&loops_module(vec![while_stmt]));
+    assert!(result.is_err(), "unsupported builtin in a while body must reject cleanly, not panic");
+}
+
+#[test]
+fn for_each_is_rejected_cleanly_not_panicked() {
+    // `Stmt::ForEach` observes only `Feature::Loops` (accepted), so it is NOT
+    // gated out — it must be rejected by the `first_foreach` pre-pass with a
+    // clean `BackendError`, never reach the emitter's `unreachable!`.
+    let for_each = Stmt::ForEach {
+        var: "e".into(),
+        iter: local("xs"),
+        body: Block { stmts: vec![puts(local("e"))], value: Expr::NilLit { span: s() }, span: s() },
+        span: s(),
+    };
+    let result = semantic_ir_to_c::compile(&loops_module(vec![
+        Stmt::LetBinding { name: "xs".into(), sir_type: None, value: ilit(0), span: s() },
+        for_each,
+    ]));
+    assert!(result.is_err(), "ForEach must reject cleanly, not panic");
+}
+
+#[test]
+fn for_range_with_unused_counter_compiles_under_werror() {
+    // Regression: an empty-body / unused-counter loop must not emit an unused
+    // variable — a `-Werror` consumer would break. Compile a for-range whose
+    // body never reads the counter, with `-Wall -Werror`.
+    let Some(cc) = find_cc() else {
+        eprintln!("skip: no C compiler");
+        return;
+    };
+    let module = loops_module(vec![forrange("i", 0, 3, 1, vec![puts(ilit(7))])]); // body ignores `i`
+    let artifact = semantic_ir_to_c::compile(&module).expect("compile");
+    let dir = std::env::temp_dir();
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let stem = format!("sirc_frwe_{}_{}", std::process::id(), n);
+    let cpath: PathBuf = dir.join(format!("{stem}.c"));
+    let exe: PathBuf = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::File::create(&cpath)
+        .and_then(|mut f| f.write_all(artifact.source.as_bytes()))
+        .expect("write .c");
+    // `-Werror` only for the unused-variable class, to avoid failing on any
+    // unrelated pre-existing runtime warning under a strict compiler.
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-Werror=unused-variable", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "unused-counter loop must compile under -Werror=unused-variable:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+}


### PR DESCRIPTION
## What

The C backend accepts `Feature::Loops` but the emitter sent `Stmt::ForRange` (`for i in 0...3`) straight to `unreachable!` — a **pre-existing panic**. ForRange is `Loops`-gated and frontend-produced, so any producer (Python→SIR→C, etc.) emitting a numeric for-loop crashed the backend. Same bug class the Ruby backend had.

## How

`ForRange` now lowers to a native `int64_t` counter loop mirroring the Go/Rust backends **byte-for-byte**:

- `start`/`stop`/`step` evaluated **once** into `SirValue` temporaries, then reduced to `int64_t` via a new `_sir_as_int` runtime helper (truncating integer view — a float bound truncates toward zero).
- direction-aware **exclusive** stop (`step >= 0 ? i < stop : i > stop`), matching Go's `_sir_range_cont`, so a descending loop with a negative step works.
- the loop `var` is declared **inside** the loop body block → C block-scoped, matching the validator's rewind and Go's `:=` counter, so it never clobbers an enclosing same-named local. The outer `{…}` scopes the counter temporaries (nesting-safe via `fresh_id`).

Also closes a **pre-existing scan hole** (same class): `scan_block_for_builtin` didn't recurse into `While`/`ForRange` bodies, so an unsupported builtin hidden in a loop body escaped the clean pre-check and hit the emitter's `unreachable!`. It now scans both → clean `BackendError` instead of a panic.

## Tests

Hand-built modules (producer-agnostic — ForRange is masked by some frontends), each compiled with a real `cc` and run: count-up-exclusive (`0,1,2`), count-down-negative-step (`3,2,1`), nested distinct counters, loop-var block-scoping (a shadowed enclosing `x=99` survives), and a `while`-body unsupported builtin rejecting cleanly. Skips gracefully when no C compiler is present.

## Total emitter (from review)

Two review findings made the emitter genuinely total — no `unreachable!` reachable with the accepted feature set:
- **`ForEach`** also observes only `Feature::Loops` (not gated out), so it was a latent panic too. `compile` now rejects it **cleanly** via a `first_foreach` pre-pass (a clear `UnsupportedFeature` error) — full lowering lands with the sequences batch.
- an **unused-counter** loop (`for _ in 0..n` or an empty body) left `var` unused; the arm emits `(void)var;` so a **`-Werror`** consumer still compiles (pinned by a `-Werror=unused-variable` test).

## Scope

The sequence nodes stay rejected at the feature gate. This is **PR 1 of the C-sequences arc** — a follow-up adds `Feature::Sequences` (a real `SIR_SEQ` runtime), after which the cross-backend composite-equality conformance case asserts on C too (C is currently the last backend that skips it).

Version: `semantic-ir-to-c` 0.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
