### PR TITLE
feat(app): give each script an at-a-glance identification signature

### DIFF
--- a/code/learning/human-languages/data/scripts/arabic.json
+++ b/code/learning/human-languages/data/scripts/arabic.json
@@ -4,6 +4,7 @@
   "font": "_fonts/NotoNaskhArabic-Static.ttf",
   "direction": "rtl",
   "system": "abjad",
+  "signature": "Right-to-left, joined into one flowing cursive ribbon, with dots placed above and below the line.",
   "complete": false,
   "combination": "Written right-to-left and cursive: most letters JOIN their neighbours and change shape by position — isolated, initial, medial, final. Six letters (ا د ذ ر ز و) never connect to the letter that follows them, so they force a break. Short vowels are usually unwritten; when shown they are harakat (small marks) above or below. Many letters share one skeleton and differ only by the number and position of DOTS — so the dots are a real 'piece' to practise.",
   "notes": "Used by the Arabic track. The initial inventory below covers the greeting/self-introduction vocabulary; it grows toward the full 28-letter set. Stroke orders are the common handwriting convention (right-to-left), not a standard.",

--- a/code/learning/human-languages/data/scripts/chinese.json
+++ b/code/learning/human-languages/data/scripts/chinese.json
@@ -4,6 +4,7 @@
   "font": "_fonts/NotoSansSC-Subset.ttf",
   "direction": "ltr",
   "system": "logographic",
+  "signature": "Each character is a dense, evenly-sized square block of strokes — not an alphabet of letters at all.",
   "complete": false,
   "combination": "Not an alphabet: each CHARACTER (hànzì) writes a whole syllable/morpheme, and words are one or more characters (你好 = 'you' + 'good' = hello). Characters are built from recurring COMPONENTS called radicals — often one hinting at meaning and one at sound (a phono-semantic compound: 请 qǐng = 讠 'speech' + 青 qīng 'sound'). Stroke order is a real, taught system (top→bottom, left→right, horizontal before vertical, outside before inside), so — unlike the Indic scripts here — the strokeOrder below is authoritative, not merely conventional.",
   "notes": "Simplified characters. An initial inventory of greeting/self-introduction characters plus the radicals they decompose into — it grows as the Mandarin track adds vocabulary. `sound` is tone-marked pinyin; `tone` holds the number (1–4 or neutral). The font is a fonttools subset of NotoSansSC covering exactly these characters (see _fonts/README.md); re-subset when characters are added.",

--- a/code/learning/human-languages/data/scripts/cyrillic.json
+++ b/code/learning/human-languages/data/scripts/cyrillic.json
@@ -4,6 +4,7 @@
   "font": "_fonts/NotoSansCyrillic-Static.ttf",
   "direction": "ltr",
   "system": "alphabet",
+  "signature": "Latin-like at a glance, but studded with give-aways: Я, Ж, Д, Б, и.",
   "complete": false,
   "combination": "A true alphabet: letters are written left-to-right in a row and each spells a sound. No inherent vowels, no diacritics in normal text (stress is unmarked). Two letters — ъ (hard sign) and ь (soft sign) — spell no sound of their own; they modify the consonant before them.",
   "notes": "The 33 lowercase Russian letters. complete:false because the UPPERCASE forms are not yet in the inventory (lessons use the lowercase citation form); the lowercase set itself is whole. Several letters are 'false friends' that look like Latin letters but sound different — those are flagged. Descended from Greek (via Old Church Slavonic), so many letters are Greek cousins: С↔sigma, Р↔rho, П↔pi, Ф↔phi.",

--- a/code/learning/human-languages/data/scripts/devanagari.json
+++ b/code/learning/human-languages/data/scripts/devanagari.json
@@ -4,6 +4,7 @@
   "font": "_fonts/NotoSansDevanagari-Static.ttf",
   "direction": "ltr",
   "system": "abugida",
+  "signature": "A horizontal head-line (shirorekha) runs across the top; letters hang beneath it like laundry on a line.",
   "complete": false,
   "combination": "A consonant carries an inherent 'a' (क = ka). A vowel mark (mātrā) replaces that vowel (क + ी → की = kī). The virama ् strips the vowel, and the bare consonant joins the next into a conjunct (न + ् + म → न्म). The horizontal top line (shirorekhā) runs across the whole word.",
   "notes": "Used by Hindi, Marathi, and Sanskrit in this curriculum. The initial inventory below covers the greeting/self-introduction vocabulary; it grows toward a complete set. Stroke orders are the common handwriting convention, not a standard.",

--- a/code/learning/human-languages/data/scripts/gujarati.json
+++ b/code/learning/human-languages/data/scripts/gujarati.json
@@ -4,6 +4,7 @@
   "font": "_fonts/NotoSansGujarati-Static.ttf",
   "direction": "ltr",
   "system": "abugida",
+  "signature": "Looks like Devanagari with the head-line erased — round tops and no bar running across the top.",
   "complete": false,
   "combination": "A consonant carries an inherent 'a' (ક = ka). A vowel mark (mātrā) replaces that vowel (ક + ી → કી = kī). The virama ્ strips the vowel, and the bare consonant joins the next into a conjunct (ન + ્ + મ → ન્મ). Gujarati is Devanagari's sister, but with one visible difference: it has NO horizontal top line (shirorekhā) — the letters float free, which is why it is sometimes called 'the headless script.'",
   "notes": "Used by Gujarati (the language of Gandhi). The initial inventory below covers the greeting/self-introduction/first-verbs vocabulary; it grows toward a complete set. Letterforms mirror Devanagari without the top bar. Stroke orders are the common handwriting convention, not a standard.",

--- a/code/learning/human-languages/data/scripts/hebrew.json
+++ b/code/learning/human-languages/data/scripts/hebrew.json
@@ -4,6 +4,7 @@
   "font": "_fonts/NotoSansHebrew-Static.ttf",
   "direction": "rtl",
   "system": "abjad",
+  "signature": "Right-to-left, but blocky and separate — squarish letters sitting apart, not joined into a cursive.",
   "complete": false,
   "combination": "Written right-to-left. Letters are consonants; vowels are usually left UNwritten (modern Hebrew), or shown as small dots/lines called niqqud above, below, or inside a letter. Letters do NOT join cursively (unlike Arabic), but five letters take a special FINAL form when they end a word: כ→ך, מ→ם, נ→ן, פ→ף, צ→ץ. A dagesh (dot inside) hardens some letters (ב v→b, כ kh→k, פ f→p).",
   "notes": "The 22-letter Hebrew alphabet with final forms and the main niqqud. Marked complete:false only because the niqqud set here is the common core, not exhaustive; the letters themselves are complete. Descended from the same Phoenician source as Greek and Latin, so the letter ORDER and names are cousins: alef↔alpha↔A, bet↔beta↔B, gimel↔gamma↔C/G.",

--- a/code/learning/human-languages/data/scripts/tamil.json
+++ b/code/learning/human-languages/data/scripts/tamil.json
@@ -4,6 +4,7 @@
   "font": "_fonts/NotoSansTamil-Static.ttf",
   "direction": "ltr",
   "system": "abugida",
+  "signature": "Curvy and loopy with flat top-bars on many letters, repeated arches, and no continuous head-line.",
   "complete": false,
   "combination": "A consonant carries an inherent 'a' (க = ka). A vowel sign replaces that vowel (க + ா → கா = kā). The puḷḷi ் — a DOT above the letter — removes the vowel entirely (க் = k). Unlike Devanagari, Tamil does NOT fuse the bare consonant into a conjunct: the dot stays visible and both letters keep their full shape. (A handful of Sanskrit-borrowed ligatures are the exception — க்ஷ kṣa and ஸ்ரீ śrī.)",
   "notes": "Used by Tamil in this curriculum. The inventory below covers the greeting and self-introduction vocabulary of Chapters 1–2 and grows from there; it is deliberately not the full 247-character grid. Stroke orders are the common handwriting convention, not a standard — Tamil is taught with regional and school-to-school variation. Component descriptions name the pieces a learner can see in the vendored Noto Sans Tamil face; several letters share a straight top bar and are best learned as a family (ண/ன, ந, ற).",

--- a/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.7.1 — each script's at-a-glance identification signature
+
+- Every script now carries a **`signature`** — the one visual feature that gives
+  it away at a glance (Devanagari's head-line; Gujarati being Devanagari with
+  that line erased; Arabic's joined right-to-left ribbon vs Hebrew's blocky
+  separate letters; Cyrillic's Я/Ж/Д tells; Chinese's dense square blocks).
+- Added to all seven script data files (`data/scripts/*.json`) and to the
+  `ScriptData` type; a test asserts every script ships a non-empty signature.
+- Each signature was written **against the rendered font**, not from memory —
+  the same verify-by-looking discipline the stroke data uses. This is the data
+  backbone for a future "spot the script" identification mode.
+
 ## 0.7.0 — read the letter's TRUE shape out of the font
 
 - **`src/truetype.ts`** — a zero-dependency TrueType reader: table directory,

--- a/code/programs/typescript/script-writing-visualizer/package.json
+++ b/code/programs/typescript/script-writing-visualizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "script-writing-visualizer",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "description": "Companion study app (HL02): break a non-Latin script apart and learn to write it — and drill the whole written curriculum with a spaced-repetition schedule that remembers you",
   "type": "module",

--- a/code/programs/typescript/script-writing-visualizer/src/types.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/types.ts
@@ -40,6 +40,9 @@ export interface ScriptData {
   font: string;
   direction: "ltr" | "rtl";
   system: string; // alphabet | abugida | abjad | logographic | …
+  /** The one visual feature that gives this script away at a glance — for a
+   *  "spot the script" identification mode. Verified by rendering the font. */
+  signature?: string;
   letters: Letter[];
   marks?: unknown[];
   combination?: string;

--- a/code/programs/typescript/script-writing-visualizer/tests/core.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/core.test.ts
@@ -131,6 +131,15 @@ describe("real script data", () => {
     }
   });
 
+  it("every script carries an identification signature (its at-a-glance tell)", () => {
+    // Powers a "spot the script" identification mode. Each signature was
+    // written against the rendered font, not from memory.
+    for (const data of SCRIPTS) {
+      expect(data.signature, `${data.script} is missing its identification signature`).toBeTruthy();
+      expect((data.signature ?? "").length, `${data.script} signature is too short to be a real tell`).toBeGreaterThan(20);
+    }
+  });
+
   it("Cyrillic flags its Latin-lookalike false friends (в, р, с, н)", () => {
     const cyr = SCRIPTS.find((s) => s.script === "cyrillic")!;
     const ffGlyphs = falseFriends(cyr).map((v) => v.glyph);


### PR DESCRIPTION
Makes the script-identification knowledge durable in the repo: every script data file now carries a **`signature`** — the one visual feature that gives it away at a glance. This is the data backbone for a future "spot the script" mode in the companion app.

| script | the tell |
|---|---|
| Devanagari | a head-line (shirorekha) across the top; letters hang beneath it |
| Gujarati | Devanagari with that head-line erased — round tops, no bar |
| Arabic | right-to-left, joined into one flowing cursive ribbon, dotted |
| Hebrew | right-to-left too, but blocky and **separate**, not joined |
| Cyrillic | Latin-like at a glance, but studded with Я Ж Д Б и |
| Chinese | dense, evenly-sized square blocks — not an alphabet |
| Tamil | curvy loops, flat top-bars, repeated arches, no continuous head-line |

## Grounding

Each signature was written **against the rendered font** — I rendered every script from its vendored `.ttf` and read the distinguishing feature off the page, not from memory. Independently fact-checked in review (all 7 correct, e.g. Cyrillic и flagged as the reversed-N that reads as Latin but isn't).

## Scope

- `signature` added to all 7 `data/scripts/*.json` (each exactly +1 line).
- Optional `signature` field on the `ScriptData` type (backward-compatible).
- A test asserting every script ships a non-empty signature (>20 chars). It **bites** — blanking a signature fails it — and the empty-`SCRIPTS` vacuous path is closed by the sibling "ships at least five scripts" test.
- App CHANGELOG + version 0.7.0 → 0.7.1.

**131 tests.** No script renders these strings yet, so there's no injection surface; the field is pure reference data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)