### PR TITLE
feat(spice): add BJT flicker noise

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add BJT model-card `KF` flicker-noise support with a distinct `flicker`
+  contribution and Berkeley-default inverse-frequency scaling.
 - Add BJT model-card `TNOM` / `T_NOM` nominal-temperature support, with
   Berkeley Celsius card values converted to Kelvin for model-owned temperature
   scaling and inherited circuit defaults when absent.

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -240,6 +240,9 @@ omitted.
 `TNOM`/`T_NOM` sets the BJT model's nominal temperature in degrees Celsius.
 It overrides the circuit-level nominal temperature for BJT temperature scaling;
 omitting it preserves the inherited default.
+`KF` (default `0`, disabled) adds a distinct BJT base-current flicker-noise
+source to `.NOISE`, using Berkeley's default `AF=1` exponent so source PSD is
+`KF * abs(Ib) / frequency`.
 `model_card_unsupported_parameter_issues()`,
 `format_model_card_unsupported_parameter_issue_table()`,
 `model_card_unsupported_parameter_issue_records()`,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -608,6 +608,8 @@ class BJT:
     Tnom:
         Optional model nominal temperature in Kelvin. When omitted, temperature
         analysis uses its circuit-level nominal temperature.
+    Kf:
+        Flicker-noise coefficient (default 0.0, disabled).
     """
 
     name: str
@@ -642,6 +644,7 @@ class BJT:
     beta_r: float = float("inf")  # reverse current gain; infinity disables
     Ikr: float = 0.0        # reverse-beta roll-off current (A); 0 disables
     Tnom: float | None = None  # model nominal temperature (K); None inherits
+    Kf: float = 0.0            # flicker-noise coefficient; 0 disables
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -605,7 +605,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr, element.Tnom)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr, element.Tnom, element.Kf)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -9305,6 +9305,8 @@ def _validate_bjt(el: BJT) -> None:
         )
     if el.Tnom is not None and (not math.isfinite(el.Tnom) or el.Tnom <= 0.0):
         raise ValueError(f"{el.name}: BJT nominal temperature must be finite and positive")
+    if not math.isfinite(el.Kf) or el.Kf < 0.0:
+        raise ValueError(f"{el.name}: BJT flicker noise coefficient must be finite and non-negative")
     if not math.isfinite(el.Ise) or el.Ise < 0.0:
         raise ValueError(
             f"{el.name}: BJT base-emitter leakage saturation current must be finite and non-negative"
@@ -14681,7 +14683,8 @@ class NoiseEntry:
     noise_type : str
         ``"thermal"`` (Johnson-Nyquist noise, for resistors and MOSFET
         channel noise) or
-        ``"shot"`` (Poisson/shot noise, for diodes and BJTs).
+        ``"shot"`` (Poisson/shot noise, for diodes and BJTs), or
+        ``"flicker"`` (BJT base-current flicker noise).
     source_psd : float
         Noise current power spectral density at the source itself, in A²/Hz.
         For resistors: ``4kT/R``.  For MOSFETs: ``4kTγgm``.  For
@@ -14763,7 +14766,7 @@ def _collect_noise_sources(
     node_to_idx: dict[str, int],
     dc_x: list[float],
     temperature: float,
-) -> list[tuple[str, str, int | None, int | None, float]]:
+) -> list[tuple[str, str, int | None, int | None, float, float]]:
     """Enumerate noise current sources for all noisy circuit elements.
 
     Each element that contributes noise is modelled as an ideal Norton
@@ -14782,15 +14785,17 @@ def _collect_noise_sources(
 
     Returns
     -------
-    list of 5-tuples (element_name, noise_type, n_plus_idx, n_minus_idx, psd)
+    list of 6-tuples
+        (element_name, noise_type, n_plus_idx, n_minus_idx, coefficient,
+        frequency_exponent).
         ``n_plus_idx`` and ``n_minus_idx`` are integer matrix indices, or
         ``None`` when the terminal connects to ground.
-        ``psd`` is the current noise PSD in A²/Hz.
+        The current noise PSD is coefficient / frequency**frequency_exponent.
     """
     kT4 = 4.0 * _BOLTZMANN * temperature  # 4kT factor
     q2 = 2.0 * _ELECTRON_CHARGE           # 2q factor
 
-    sources: list[tuple[str, str, int | None, int | None, float]] = []
+    sources: list[tuple[str, str, int | None, int | None, float, float]] = []
 
     for el in circuit.elements:
         if isinstance(el, Resistor):
@@ -14798,7 +14803,7 @@ def _collect_noise_sources(
             psd = kT4 / el.resistance
             n_p = node_to_idx.get(el.n_plus)   # None for ground
             n_m = node_to_idx.get(el.n_minus)  # None for ground
-            sources.append((el.name, "thermal", n_p, n_m, psd))
+            sources.append((el.name, "thermal", n_p, n_m, psd, 0.0))
 
         elif isinstance(el, Diode):
             # Shot noise: S_i = 2q |I_D|
@@ -14813,7 +14818,7 @@ def _collect_noise_sources(
             psd = q2 * abs(I_D)
             n_a = None if _is_ground(el.anode) else node_to_idx[el.anode]
             n_k = None if _is_ground(el.cathode) else node_to_idx[el.cathode]
-            sources.append((el.name, "shot", n_a, n_k, psd))
+            sources.append((el.name, "shot", n_a, n_k, psd, 0.0))
 
         elif isinstance(el, BJT):
             # Shot noise on the base-emitter junction: S_i = 2q |I_C|
@@ -14846,7 +14851,10 @@ def _collect_noise_sources(
             )
             n_b = None if _is_ground(el.base) else node_to_idx[el.base]
             n_e = None if _is_ground(el.emitter) else node_to_idx[el.emitter]
-            sources.append((el.name, "shot", n_b, n_e, psd))
+            sources.append((el.name, "shot", n_b, n_e, psd, 0.0))
+            if el.Kf > 0.0:
+                base_current = base_collector_current / el.beta_f + leakage_current
+                sources.append((el.name, "flicker", n_b, n_e, el.Kf * abs(base_current), 1.0))
 
         elif isinstance(el, Mosfet):
             # Long-channel MOSFET channel thermal noise: S_i = 4kTγgm.
@@ -14860,7 +14868,7 @@ def _collect_noise_sources(
                 psd = kT4 * _MOSFET_CHANNEL_NOISE_GAMMA * gm
                 n_d = None if _is_ground(el.drain) else node_to_idx[el.drain]
                 n_s = None if _is_ground(el.source) else node_to_idx[el.source]
-                sources.append((el.name, "thermal", n_d, n_s, psd))
+                sources.append((el.name, "thermal", n_d, n_s, psd, 0.0))
 
         elif isinstance(el, JFET):
             Vd = 0.0 if _is_ground(el.drain) else dc_x[node_to_idx[el.drain]]
@@ -14872,7 +14880,7 @@ def _collect_noise_sources(
                 psd = kT4 * _MOSFET_CHANNEL_NOISE_GAMMA * gm
                 n_d = None if _is_ground(el.drain) else node_to_idx[el.drain]
                 n_s = None if _is_ground(el.source) else node_to_idx[el.source]
-                sources.append((el.name, "thermal", n_d, n_s, psd))
+                sources.append((el.name, "thermal", n_d, n_s, psd, 0.0))
 
         # Capacitors, Inductors, VoltageSources, CurrentSources: noiseless in
         # this first-order model.
@@ -14894,7 +14902,7 @@ def noise_ac(
 
     Computes the voltage noise power spectral density (PSD) at ``output_node``
     due to thermal noise (Johnson-Nyquist) in resistors, MOSFET channel
-    thermal noise, and shot noise in diodes and BJTs, at each frequency in
+    thermal noise, and shot plus flicker noise in diodes and BJTs, at each frequency in
     ``freqs``.  Also reports the noise referred back to ``input_source`` so
     you can compare it directly to your signal level.
 
@@ -15079,7 +15087,8 @@ def noise_ac(
                     source_psd=psd,
                     output_psd=0.0,
                 )
-                for (name, ntype, _, _, psd) in noise_sources
+                for (name, ntype, _, _, coefficient, frequency_exponent) in noise_sources
+                for psd in (coefficient / freq**frequency_exponent,)
             )
             points.append(NoisePoint(
                 freq=freq,
@@ -15096,7 +15105,8 @@ def noise_ac(
         entries_list: list[NoiseEntry] = []
         total_psd = 0.0
 
-        for (elem_name, noise_type, n_p, n_m, src_psd) in noise_sources:
+        for (elem_name, noise_type, n_p, n_m, coefficient, frequency_exponent) in noise_sources:
+            src_psd = coefficient / freq**frequency_exponent
             h_p: complex = v_adj[n_p] if n_p is not None else 0j
             h_m: complex = v_adj[n_m] if n_m is not None else 0j
             H_k = h_p - h_m

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (27, 44, 13, 4),
-    "PNP": (27, 44, 13, 4),
+    "NPN": (28, 45, 13, 4),
+    "PNP": (28, 45, 13, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -381,6 +381,7 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "IKR": "IKR",
     "TNOM": "TNOM",
     "T_NOM": "TNOM",
+    "KF": "KF",
     "ISE": "ISE",
     "NE": "NE",
     "ISC": "ISC",
@@ -943,6 +944,7 @@ def bjt_from_model_card(
         beta_r=p.get("BR", 1.0),
         Ikr=p.get("IKR", 0.0),
         Tnom=(p["TNOM"] + 273.15) if "TNOM" in p else None,
+        Kf=p.get("KF", 0.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 112
+    assert len(coverage) == 114
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 112
+    assert len(records) == 114
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,9 +501,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 112
-    assert report.expected_canonical_parameter_count == 112
-    assert report.accepted_name_count == 178
+    assert report.canonical_parameter_count == 114
+    assert report.expected_canonical_parameter_count == 114
+    assert report.accepted_name_count == 180
     assert report.aliased_parameter_count == 53
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -511,7 +511,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t112\t112\t178\t53\t4\t0"
+        "true\t7\t7\t114\t114\t180\t53\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,8 +539,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 111
-    assert report.accepted_name_count == 175
+    assert report.canonical_parameter_count == 113
+    assert report.accepted_name_count == 177
     assert report.aliased_parameter_count == 52
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t111\t112\t175\t52\t4\t4\n"
+        "false\t7\t7\t113\t114\t177\t52\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,10 +647,10 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
+        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "KF": 1.0e-12, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "TNOM": 50.0, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
+    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "TNOM": 50.0, "KF": 1.0e-12, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.beta_r == pytest.approx(0.25)
@@ -663,6 +663,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert bjt_model.Ikf == pytest.approx(2.0e-3)
     assert bjt_model.Ikr == pytest.approx(3.0e-3)
     assert bjt_model.Tnom == pytest.approx(323.15)
+    assert bjt_model.Kf == pytest.approx(1.0e-12)
     assert bjt_model.Ise == pytest.approx(3.0e-13)
     assert bjt_model.Ne == pytest.approx(1.7)
     assert bjt_model.Isc == pytest.approx(4.0e-13)
@@ -2304,7 +2305,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3, Tnom=323.15),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3, Tnom=323.15, Kf=1.0e-12),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2331,6 +2332,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.beta_r == pytest.approx(0.25)
     assert expanded.Ikr == pytest.approx(3.0e-3)
     assert expanded.Tnom == pytest.approx(323.15)
+    assert expanded.Kf == pytest.approx(1.0e-12)
 
 
 def test_branch_current_in_voltage_source():
@@ -2568,6 +2570,13 @@ def test_dc_rejects_invalid_bjt_nominal_temperature():
     circuit = Circuit()
     circuit.add(BJT("Qbad", "c", "b", "0", Tnom=0.0))
     with pytest.raises(ValueError, match="nominal temperature must be finite and positive"):
+        dc_op(circuit)
+
+
+def test_dc_rejects_invalid_bjt_flicker_noise_coefficient():
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", Kf=-1.0))
+    with pytest.raises(ValueError, match="flicker noise coefficient must be finite and non-negative"):
         dc_op(circuit)
 
 
@@ -6922,6 +6931,27 @@ def test_noise_bjt_shot_noise_type_string() -> None:
     )
     assert bjt_entry is not None, "No entry for Q1"
     assert bjt_entry.noise_type == "shot"
+
+
+def test_noise_bjt_kf_adds_inverse_frequency_flicker_noise() -> None:
+    circuit = Circuit()
+    circuit.add(VoltageSource("Vcc", "vcc", "0", 5.0))
+    circuit.add(VoltageSource("Vbase", "base", "0", 0.7))
+    circuit.add(Resistor("Rc", "vcc", "col", 1_000.0))
+    circuit.add(BJT("Q1", "col", "base", "0", Kf=1.0e-12))
+
+    result = noise_ac(circuit, "col", "Vbase", freqs=[10.0, 1_000.0])
+    flicker_psds = [
+        next(
+            entry.source_psd
+            for entry in point.entries
+            if entry.element_name == "Q1" and entry.noise_type == "flicker"
+        )
+        for point in result.points
+    ]
+
+    assert flicker_psds[0] > 0.0
+    assert flicker_psds[0] / flicker_psds[1] == pytest.approx(100.0)
 
 
 def test_noise_bjt_forward_beta_rolloff_reduces_shot_noise() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add BJT model-card `KF` flicker-noise support with a distinct `flicker`
+  contribution and Berkeley-default inverse-frequency scaling.
 - Add BJT model-card `TNOM` / `T_NOM` nominal-temperature support, with
   Berkeley Celsius card values converted to Kelvin for model-owned temperature
   scaling and inherited circuit defaults when absent.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -157,6 +157,9 @@ omitted.
 `TNOM`/`T_NOM` sets the BJT model's nominal temperature in degrees Celsius.
 It overrides the circuit-level nominal temperature for BJT temperature scaling;
 omitting it preserves the inherited default.
+`KF` (default `0`, disabled) adds a distinct BJT base-current flicker-noise
+source to `.NOISE`, using Berkeley's default `AF=1` exponent so source PSD is
+`KF * abs(Ib) / frequency`.
 `model_card_unsupported_parameter_issues`,
 `format_model_card_unsupported_parameter_issue_table`,
 `model_card_unsupported_parameter_issue_records`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -454,6 +454,7 @@ fn clone_subckt_element(
             );
             expanded.reverse_beta_rolloff_current = element.reverse_beta_rolloff_current;
             expanded.nominal_temperature_kelvin = element.nominal_temperature_kelvin;
+            expanded.flicker_noise_coefficient = element.flicker_noise_coefficient;
             Element::Bjt(expanded)
         }
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
@@ -2896,6 +2897,7 @@ pub struct Bjt {
     pub reverse_beta: f64,
     pub reverse_beta_rolloff_current: f64,
     pub nominal_temperature_kelvin: Option<f64>,
+    pub flicker_noise_coefficient: f64,
 }
 
 impl Bjt {
@@ -3359,6 +3361,7 @@ impl Bjt {
             reverse_beta,
             reverse_beta_rolloff_current: 0.0,
             nominal_temperature_kelvin: None,
+            flicker_noise_coefficient: 0.0,
         }
     }
 }
@@ -3749,8 +3752,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 27, 44, 13, 4),
-    (ModelCardKind::Pnp, 27, 44, 13, 4),
+    (ModelCardKind::Npn, 28, 45, 13, 4),
+    (ModelCardKind::Pnp, 28, 45, 13, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3803,6 +3806,7 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IKR", "IKR"),
     ("TNOM", "TNOM"),
     ("T_NOM", "TNOM"),
+    ("KF", "KF"),
     ("ISE", "ISE"),
     ("NE", "NE"),
     ("ISC", "ISC"),
@@ -4497,6 +4501,7 @@ pub fn bjt_from_model_card(
         .parameters
         .get("TNOM")
         .map(|temperature_celsius| temperature_celsius + 273.15);
+    bjt.flicker_noise_coefficient = model_card_value(model, "KF", 0.0);
     Ok(bjt)
 }
 
@@ -11596,6 +11601,7 @@ pub struct CornerSParameterResult {
 pub enum NoiseType {
     Thermal,
     Shot,
+    Flicker,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -17134,6 +17140,7 @@ fn format_noise_type(noise_type: NoiseType) -> &'static str {
     match noise_type {
         NoiseType::Thermal => "thermal",
         NoiseType::Shot => "shot",
+        NoiseType::Flicker => "flicker",
     }
 }
 
@@ -19577,7 +19584,7 @@ pub fn noise_ac(
                 frequency_hz,
                 output_psd: 0.0,
                 input_referred_psd: 0.0,
-                entries: zero_noise_entries(&noise_sources),
+                entries: zero_noise_entries(&noise_sources, frequency_hz),
             });
             continue;
         }
@@ -19599,7 +19606,7 @@ pub fn noise_ac(
                     frequency_hz,
                     output_psd: 0.0,
                     input_referred_psd: 0.0,
-                    entries: zero_noise_entries(&noise_sources),
+                    entries: zero_noise_entries(&noise_sources, frequency_hz),
                 });
                 continue;
             }
@@ -19616,11 +19623,12 @@ pub fn noise_ac(
                     .negative
                     .map_or(Complex::zero(), |index| adjoint[index]);
                 let transfer = h_positive - h_negative;
+                let source_psd = noise_source_psd(source, frequency_hz);
                 NoiseEntry {
                     element_name: source.element_name.clone(),
                     noise_type: source.noise_type,
-                    source_psd: source.source_psd,
-                    output_psd: transfer.abs().powi(2) * source.source_psd,
+                    source_psd,
+                    output_psd: transfer.abs().powi(2) * source_psd,
                 }
             })
             .collect();
@@ -21033,6 +21041,7 @@ struct NoiseSource {
     positive: Option<usize>,
     negative: Option<usize>,
     source_psd: f64,
+    frequency_exponent: f64,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -22115,6 +22124,7 @@ fn collect_noise_sources(
                     positive: node_index(node_indices, &resistor.n1),
                     negative: node_index(node_indices, &resistor.n2),
                     source_psd: 4.0 * BOLTZMANN * temperature_kelvin / resistor.resistance_ohms,
+                    frequency_exponent: 0.0,
                 });
             }
             Element::Diode(diode) => {
@@ -22131,6 +22141,7 @@ fn collect_noise_sources(
                     positive: anode,
                     negative: cathode,
                     source_psd: 2.0 * ELECTRON_CHARGE * current.abs(),
+                    frequency_exponent: 0.0,
                 });
             }
             Element::Bjt(bjt) => {
@@ -22182,7 +22193,19 @@ fn collect_noise_sources(
                             + leakage_current.abs()
                             + collector_leakage_current.abs()
                             + reverse_base_current.abs()),
+                    frequency_exponent: 0.0,
                 });
+                if bjt.flicker_noise_coefficient > 0.0 {
+                    let base_current = base_collector_current / bjt.forward_beta + leakage_current;
+                    sources.push(NoiseSource {
+                        element_name: bjt.name.clone(),
+                        noise_type: NoiseType::Flicker,
+                        positive,
+                        negative,
+                        source_psd: bjt.flicker_noise_coefficient * base_current.abs(),
+                        frequency_exponent: 1.0,
+                    });
+                }
             }
             Element::Jfet(jfet) => {
                 validate_jfet(jfet)?;
@@ -22209,6 +22232,7 @@ fn collect_noise_sources(
                             * temperature_kelvin
                             * MOSFET_CHANNEL_NOISE_GAMMA
                             * gm,
+                        frequency_exponent: 0.0,
                     });
                 }
             }
@@ -22240,6 +22264,7 @@ fn collect_noise_sources(
                             * temperature_kelvin
                             * MOSFET_CHANNEL_NOISE_GAMMA
                             * gm,
+                        frequency_exponent: 0.0,
                     });
                 }
             }
@@ -22249,13 +22274,17 @@ fn collect_noise_sources(
     Ok(sources)
 }
 
-fn zero_noise_entries(sources: &[NoiseSource]) -> Vec<NoiseEntry> {
+fn noise_source_psd(source: &NoiseSource, frequency_hz: f64) -> f64 {
+    source.source_psd / frequency_hz.powf(source.frequency_exponent)
+}
+
+fn zero_noise_entries(sources: &[NoiseSource], frequency_hz: f64) -> Vec<NoiseEntry> {
     sources
         .iter()
         .map(|source| NoiseEntry {
             element_name: source.element_name.clone(),
             noise_type: source.noise_type,
-            source_psd: source.source_psd,
+            source_psd: noise_source_psd(source, frequency_hz),
             output_psd: 0.0,
         })
         .collect()
@@ -24007,6 +24036,12 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
                 reason: "nominal temperature must be finite and positive".to_string(),
             });
         }
+    }
+    if !bjt.flicker_noise_coefficient.is_finite() || bjt.flicker_noise_coefficient < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "flicker noise coefficient must be finite and non-negative".to_string(),
+        });
     }
     if !bjt.base_emitter_leakage_saturation_current.is_finite()
         || bjt.base_emitter_leakage_saturation_current < 0.0

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 112);
+    assert_eq!(coverage.len(), 114);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 112);
+    assert_eq!(records.len(), 114);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 112);
-    assert_eq!(report.expected_canonical_parameter_count, 112);
-    assert_eq!(report.accepted_name_count, 178);
+    assert_eq!(report.canonical_parameter_count, 114);
+    assert_eq!(report.expected_canonical_parameter_count, 114);
+    assert_eq!(report.accepted_name_count, 180);
     assert_eq!(report.aliased_parameter_count, 53);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t112\t112\t178\t53\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t114\t114\t180\t53\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,8 +235,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 111);
-    assert_eq!(report.accepted_name_count, 175);
+    assert_eq!(report.canonical_parameter_count, 113);
+    assert_eq!(report.accepted_name_count, 177);
     assert_eq!(report.aliased_parameter_count, 52);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t111\t112\t175\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t113\t114\t177\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -437,6 +437,7 @@ fn model_card_aliases_build_device_instances() {
             ("IK", 2.0e-3),
             ("IKR", 3.0e-3),
             ("T_NOM", 50.0),
+            ("KF", 1.0e-12),
             ("ISE", 3.0e-13),
             ("NE", 1.7),
             ("ISC", 4.0e-13),
@@ -463,6 +464,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("IKF").unwrap(), 2.0e-3);
     assert_close(*bjt_card.parameters.get("IKR").unwrap(), 3.0e-3);
     assert_close(*bjt_card.parameters.get("TNOM").unwrap(), 50.0);
+    assert_close(*bjt_card.parameters.get("KF").unwrap(), 1.0e-12);
     assert_close(*bjt_card.parameters.get("ISE").unwrap(), 3.0e-13);
     assert_close(*bjt_card.parameters.get("NE").unwrap(), 1.7);
     assert_close(*bjt_card.parameters.get("ISC").unwrap(), 4.0e-13);
@@ -486,6 +488,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(bjt_model.forward_beta_rolloff_current, 2.0e-3);
     assert_close(bjt_model.reverse_beta_rolloff_current, 3.0e-3);
     assert_close(bjt_model.nominal_temperature_kelvin.unwrap(), 323.15);
+    assert_close(bjt_model.flicker_noise_coefficient, 1.0e-12);
     assert_close(bjt_model.base_emitter_leakage_saturation_current, 3.0e-13);
     assert_close(bjt_model.base_emitter_leakage_emission_coefficient, 1.7);
     assert_close(bjt_model.base_collector_leakage_saturation_current, 4.0e-13);
@@ -1427,6 +1430,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     );
     bjt.reverse_beta_rolloff_current = 3.0e-3;
     bjt.nominal_temperature_kelvin = Some(323.15);
+    bjt.flicker_noise_coefficient = 1.0e-12;
     let mut circuit = Circuit::new();
     circuit
         .define_subcircuit(SubcircuitDefinition::new(
@@ -1471,6 +1475,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.reverse_beta, 0.25);
     assert_close(expanded.reverse_beta_rolloff_current, 3.0e-3);
     assert_close(expanded.nominal_temperature_kelvin.unwrap(), 323.15);
+    assert_close(expanded.flicker_noise_coefficient, 1.0e-12);
 }
 
 #[test]
@@ -1990,6 +1995,18 @@ fn dc_rejects_invalid_bjt_nominal_temperature() {
     assert!(error
         .to_string()
         .contains("nominal temperature must be finite and positive"));
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_flicker_noise_coefficient() {
+    let mut transistor = Bjt::new("Qbad", "c", "b", "0");
+    transistor.flicker_noise_coefficient = -1.0;
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Bjt(transistor));
+    let error = dc_op(&circuit).unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("flicker noise coefficient must be finite and non-negative"));
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -88,6 +88,36 @@ fn bjt_base_collector_leakage_increases_shot_noise() {
     assert!(source_psd(1.0e-10) > source_psd(0.0));
 }
 
+#[test]
+fn bjt_flicker_noise_uses_kf_with_inverse_frequency_scaling() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vcc", "vcc", "0", 5.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vbase", "base", "0", 0.7,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "vcc", "out", 1_000.0,
+    )));
+    let mut transistor = Bjt::new("Q1", "out", "base", "0");
+    transistor.flicker_noise_coefficient = 1.0e-12;
+    circuit.add(Element::Bjt(transistor));
+
+    let result = noise_ac(&circuit, "out", "Vbase", &[10.0, 1_000.0], 300.0).unwrap();
+    let flicker_psd = |point_index: usize| {
+        result.points[point_index]
+            .entries
+            .iter()
+            .find(|entry| entry.element_name == "Q1" && entry.noise_type == NoiseType::Flicker)
+            .unwrap()
+            .source_psd
+    };
+
+    assert!(flicker_psd(0) > 0.0);
+    assert_close(flicker_psd(0) / flicker_psd(1), 100.0, 1.0e-10);
+}
+
 const BOLTZMANN: f64 = 1.380_649e-23;
 const MOSFET_CHANNEL_NOISE_GAMMA: f64 = 2.0 / 3.0;
 

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add BJT model-card `KF` flicker-noise support with a distinct `flicker`
+  contribution and Berkeley-default inverse-frequency scaling.
 - Add BJT model-card `TNOM` / `T_NOM` nominal-temperature support, with
   Berkeley Celsius card values converted to Kelvin for model-owned temperature
   scaling and inherited circuit defaults when absent.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -227,6 +227,9 @@ omitted.
 `TNOM`/`T_NOM` sets the BJT model's nominal temperature in degrees Celsius.
 It overrides the circuit-level nominal temperature for BJT temperature scaling;
 omitting it preserves the inherited default.
+`KF` (default `0`, disabled) adds a distinct BJT base-current flicker-noise
+source to `.NOISE`, using Berkeley's default `AF=1` exponent so source PSD is
+`KF * abs(Ib) / frequency`.
 `modelCardUnsupportedParameterIssues`,
 `formatModelCardUnsupportedParameterIssueTable`,
 `modelCardUnsupportedParameterIssueRecords`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1730,6 +1730,7 @@ export interface Bjt {
   readonly reverseBeta: number;
   readonly reverseBetaRolloffCurrent: number;
   readonly nominalTemperatureKelvin: number | undefined;
+  readonly flickerNoiseCoefficient: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -2007,8 +2008,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [27, 44, 13, 4],
-  PNP: [27, 44, 13, 4],
+  NPN: [28, 45, 13, 4],
+  PNP: [28, 45, 13, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -2288,7 +2289,7 @@ export interface CornerSParameterResult {
   readonly points: readonly CornerSParameterPoint[];
 }
 
-export type NoiseType = "thermal" | "shot";
+export type NoiseType = "thermal" | "shot" | "flicker";
 
 export interface NoiseEntry {
   readonly elementName: string;
@@ -3598,7 +3599,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7784,6 +7785,7 @@ export function bjt(
   reverseBeta = Number.POSITIVE_INFINITY,
   reverseBetaRolloffCurrent = 0.0,
   nominalTemperatureKelvin: number | undefined = undefined,
+  flickerNoiseCoefficient = 0.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7819,6 +7821,7 @@ export function bjt(
     reverseBeta,
     reverseBetaRolloffCurrent,
     nominalTemperatureKelvin,
+    flickerNoiseCoefficient,
   };
 }
 
@@ -7931,6 +7934,7 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   IKR: "IKR",
   TNOM: "TNOM",
   T_NOM: "TNOM",
+  KF: "KF",
   ISE: "ISE",
   NE: "NE",
   ISC: "ISC",
@@ -8465,6 +8469,7 @@ export function bjtFromModelCard(
     p.BR ?? 1.0,
     p.IKR ?? 0.0,
     p.TNOM !== undefined ? p.TNOM + 273.15 : undefined,
+    p.KF ?? 0.0,
   );
 }
 
@@ -14770,7 +14775,12 @@ export function noiseAc(
 
   const points = frequenciesHz.map((frequencyHz) => {
     if (outputIndex === undefined || matrixSize === 0) {
-      return makeNoisePoint(frequencyHz, 0.0, 0.0, zeroNoiseEntries(noiseSources));
+      return makeNoisePoint(
+        frequencyHz,
+        0.0,
+        0.0,
+        zeroNoiseEntries(noiseSources, frequencyHz),
+      );
     }
 
     const matrix = buildAcMatrix(
@@ -14792,7 +14802,7 @@ export function noiseAc(
           frequencyHz,
           0.0,
           0.0,
-          zeroNoiseEntries(noiseSources),
+          zeroNoiseEntries(noiseSources, frequencyHz),
         );
       }
       throw error;
@@ -14804,11 +14814,12 @@ export function noiseAc(
       const hNegative =
         source.negative === undefined ? complex(0.0, 0.0) : adjoint[source.negative];
       const transfer = complexSub(hPositive, hNegative);
+      const sourcePsd = source.sourcePsd / frequencyHz ** source.frequencyExponent;
       return {
         elementName: source.elementName,
         noiseType: source.noiseType,
-        sourcePsd: source.sourcePsd,
-        outputPsd: complexAbs(transfer) ** 2 * source.sourcePsd,
+        sourcePsd,
+        outputPsd: complexAbs(transfer) ** 2 * sourcePsd,
       };
     });
     entries.sort(
@@ -16750,6 +16761,7 @@ interface NoiseSource {
   readonly positive: number | undefined;
   readonly negative: number | undefined;
   readonly sourcePsd: number;
+  readonly frequencyExponent: number;
 }
 
 type InputSource = VoltageSource | CurrentSource;
@@ -18366,6 +18378,7 @@ function collectNoiseSources(
         positive: nodeIndex(nodeIndices, element.n1),
         negative: nodeIndex(nodeIndices, element.n2),
         sourcePsd: 4.0 * BOLTZMANN * temperatureKelvin / element.resistanceOhms,
+        frequencyExponent: 0.0,
       });
     } else if (element.kind === "diode") {
       validateDiode(element);
@@ -18380,6 +18393,7 @@ function collectNoiseSources(
         positive: anode,
         negative: cathode,
         sourcePsd: 2.0 * ELECTRON_CHARGE * Math.abs(current),
+        frequencyExponent: 0.0,
       });
     } else if (element.kind === "bjt") {
       validateBjt(element);
@@ -18426,7 +18440,20 @@ function collectNoiseSources(
           2.0 * ELECTRON_CHARGE *
           (Math.abs(collectorCurrent) + Math.abs(leakageCurrent) +
             Math.abs(collectorLeakageCurrent) + Math.abs(reverseBaseCurrent)),
+        frequencyExponent: 0.0,
       });
+      if (element.flickerNoiseCoefficient > 0.0) {
+        const baseCurrent =
+          baseCollectorCurrent / element.forwardBeta + leakageCurrent;
+        sources.push({
+          elementName: element.name,
+          noiseType: "flicker",
+          positive: element.polarity === "NPN" ? base : emitter,
+          negative: element.polarity === "NPN" ? emitter : base,
+          sourcePsd: element.flickerNoiseCoefficient * Math.abs(baseCurrent),
+          frequencyExponent: 1.0,
+        });
+      }
     } else if (element.kind === "jfet") {
       validateJfet(element);
       const drain = nodeIndex(nodeIndices, element.drain);
@@ -18448,6 +18475,7 @@ function collectNoiseSources(
           positive: drain,
           negative: source,
           sourcePsd: 4.0 * BOLTZMANN * temperatureKelvin * MOSFET_CHANNEL_NOISE_GAMMA * gm,
+          frequencyExponent: 0.0,
         });
       }
     } else if (element.kind === "mosfet") {
@@ -18474,6 +18502,7 @@ function collectNoiseSources(
           positive: drain,
           negative: source,
           sourcePsd: 4.0 * BOLTZMANN * temperatureKelvin * MOSFET_CHANNEL_NOISE_GAMMA * gm,
+          frequencyExponent: 0.0,
         });
       }
     }
@@ -18481,11 +18510,14 @@ function collectNoiseSources(
   return sources;
 }
 
-function zeroNoiseEntries(sources: readonly NoiseSource[]): NoiseEntry[] {
+function zeroNoiseEntries(
+  sources: readonly NoiseSource[],
+  frequencyHz: number,
+): NoiseEntry[] {
   return sources.map((source) => ({
     elementName: source.elementName,
     noiseType: source.noiseType,
-    sourcePsd: source.sourcePsd,
+    sourcePsd: source.sourcePsd / frequencyHz ** source.frequencyExponent,
     outputPsd: 0.0,
   }));
 }
@@ -19905,6 +19937,9 @@ function validateBjt(element: Bjt): void {
   if (element.nominalTemperatureKelvin !== undefined &&
       (!Number.isFinite(element.nominalTemperatureKelvin) || element.nominalTemperatureKelvin <= 0.0)) {
     throw invalidElement(element.name, "nominal temperature must be finite and positive");
+  }
+  if (!Number.isFinite(element.flickerNoiseCoefficient) || element.flickerNoiseCoefficient < 0.0) {
+    throw invalidElement(element.name, "flicker noise coefficient must be finite and non-negative");
   }
   if (!Number.isFinite(element.baseEmitterLeakageSaturationCurrent) || element.baseEmitterLeakageSaturationCurrent < 0.0) {
     throw invalidElement(element.name, "base-emitter leakage saturation current must be finite and non-negative");

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(112);
+    expect(coverage).toHaveLength(114);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(112);
+    expect(records).toHaveLength(114);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 112,
-      expectedCanonicalParameterCount: 112,
-      acceptedNameCount: 178,
+      canonicalParameterCount: 114,
+      expectedCanonicalParameterCount: 114,
+      acceptedNameCount: 180,
       aliasedParameterCount: 53,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t112\t112\t178\t53\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t114\t114\t180\t53\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,8 +241,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(111);
-    expect(report.acceptedNameCount).toBe(175);
+    expect(report.canonicalParameterCount).toBe(113);
+    expect(report.acceptedNameCount).toBe(177);
     expect(report.aliasedParameterCount).toBe(52);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t111\t112\t175\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t113\t114\t177\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -343,6 +343,7 @@ describe("dcOp", () => {
       IK: 2.0e-3,
       IKR: 3.0e-3,
       T_NOM: 50.0,
+      KF: 1.0e-12,
       ISE: 3.0e-13,
       NE: 1.7,
       ISC: 4.0e-13,
@@ -356,7 +357,7 @@ describe("dcOp", () => {
       FC: 0.4,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, TNOM: 50.0, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, TNOM: 50.0, KF: 1.0e-12, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.reverseBeta, 0.25);
@@ -369,6 +370,7 @@ describe("dcOp", () => {
     expectClose(bjtModel.forwardBetaRolloffCurrent, 2.0e-3);
     expectClose(bjtModel.reverseBetaRolloffCurrent, 3.0e-3);
     expectClose(bjtModel.nominalTemperatureKelvin, 323.15);
+    expectClose(bjtModel.flickerNoiseCoefficient, 1.0e-12);
     expectClose(bjtModel.baseEmitterLeakageSaturationCurrent, 3.0e-13);
     expectClose(bjtModel.baseEmitterLeakageEmissionCoefficient, 1.7);
     expectClose(bjtModel.baseCollectorLeakageSaturationCurrent, 4.0e-13);
@@ -1012,7 +1014,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3, 323.15),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3, 323.15, 1.0e-12),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -1040,6 +1042,7 @@ describe("dcOp", () => {
       expectClose(expanded.reverseBeta, 0.25);
       expectClose(expanded.reverseBetaRolloffCurrent, 3.0e-3);
       expectClose(expanded.nominalTemperatureKelvin, 323.15);
+      expectClose(expanded.flickerNoiseCoefficient, 1.0e-12);
     }
   });
 
@@ -1387,6 +1390,14 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.add({ ...bjt("Qbad", "c", "b", "0"), nominalTemperatureKelvin: 0.0 });
     expect(() => dcOp(circuit)).toThrowError("nominal temperature must be finite and positive");
+  });
+
+  it("rejects invalid BJT flicker noise coefficients", () => {
+    const circuit = new Circuit();
+    circuit.add({ ...bjt("Qbad", "c", "b", "0"), flickerNoiseCoefficient: -1.0 });
+    expect(() => dcOp(circuit)).toThrowError(
+      "flicker noise coefficient must be finite and non-negative",
+    );
   });
 
   it("rejects non-finite BJT beta temperature exponents", () => {

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -67,6 +67,26 @@ describe("noiseAc", () => {
 
     expect(sourcePsd(1.0e-10)).toBeGreaterThan(sourcePsd(0.0));
   });
+  it("uses BJT KF for inverse-frequency flicker noise", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vcc", "vcc", "0", 5.0));
+    circuit.add(voltageSource("Vbase", "base", "0", 0.7));
+    circuit.add(resistor("Rload", "vcc", "out", 1_000.0));
+    circuit.add({
+      ...bjt("Q1", "out", "base", "0"),
+      flickerNoiseCoefficient: 1.0e-12,
+    });
+
+    const result = noiseAc(circuit, "out", "Vbase", [10.0, 1_000.0], 300.0);
+    const flickerPsds = result.points.map((point) =>
+      point.entries.find(
+        (entry) => entry.elementName === "Q1" && entry.noiseType === "flicker",
+      )!.sourcePsd,
+    );
+
+    expect(flickerPsds[0]).toBeGreaterThan(0.0);
+    expect(flickerPsds[0] / flickerPsds[1]).toBeCloseTo(100.0, 12);
+  });
   it("computes Johnson noise for a single grounded resistor", () => {
     const circuit = new Circuit();
     circuit.add(currentSource("Iin", "0", "out", 0.0));

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,16 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT nominal model temperature.
+1. Cross-language BJT flicker-noise coefficient.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `TNOM` / `T_NOM` model-card support in Rust, Python, and
-     TypeScript, interpreting card values in degrees Celsius and storing the
-     absolute model temperature internally.
-   - Let a model-owned nominal temperature override the circuit-level default
-     in temperature scaling while preserving inherited behavior when `TNOM`
-     is absent and preserving the complete BJT model through subcircuits.
-   - Extend the supported-parameter coverage gate from 110 to 112 canonical
-     rows and lock model-card behavior, validation, hierarchy, and temperature
+   - Add Berkeley BJT `KF` model-card support in Rust, Python, and TypeScript,
+     defaulting to zero so existing noise results remain unchanged.
+   - Emit a distinct `flicker` contribution from base current and apply the
+     Berkeley-default `AF=1` inverse-frequency exponent through the adjoint
+     noise path while preserving the complete BJT model through subcircuits.
+   - Extend the supported-parameter coverage gate from 112 to 114 canonical
+     rows and lock model-card behavior, validation, hierarchy, and noise
      scaling in all engines.
 
 ## Completed Slices
@@ -3111,6 +3110,14 @@ the Rust, Python, and TypeScript surfaces together.
      transfer-function, temperature, and noise paths.
    - Hierarchical subcircuit expansion preserves the complete BJT model, and
      the supported-parameter release gate now covers 110 canonical rows.
+
+233. Cross-language BJT nominal model temperature.
+   - Status: completed in PR 8807.
+   - Rust, Python, and TypeScript BJT model cards now accept `TNOM` / `T_NOM`,
+     convert Berkeley Celsius card values to an absolute model temperature,
+     and use that model-owned value for temperature scaling when present.
+   - Hierarchical subcircuit expansion preserves the complete BJT model, and
+     the supported-parameter release gate now covers 112 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- add cross-language Berkeley BJT KF model-card support with zero-preserving defaults
- emit a distinct flicker noise contribution using base current and the default AF=1 inverse-frequency slope
- keep hierarchy cloning, validation, supported-parameter coverage, docs, and the SPICE completion plan aligned

## Verification

- cargo test -p spice-engine (364 tests)
- Python pytest (556 tests)
- Python Ruff on touched source and test files
- npm run build
- npm test -- --run (314 tests)
- git diff --check