### PR TITLE
feat(sql): explicit COLLATE tail on DISTINCT select-items and GROUP BY keys

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.5.64 — explicit `COLLATE` on DISTINCT select-items and GROUP BY keys
+
+`SELECT DISTINCT b COLLATE NOCASE FROM t` and `SELECT b, COUNT(*) FROM t GROUP BY
+b COLLATE NOCASE` now parse AND fold: an explicit collation suffix on a DISTINCT
+select-item or a GROUP BY key groups/dedupes case-insensitively (or by whatever
+collation is named), even when the underlying column is declared BINARY. Explicit
+`COLLATE BINARY` overrides a column's declared NOCASE. The output column is named
+after its source text (`b COLLATE NOCASE`), and the emitted value stays the
+original text (collation folds keys, not values). Retires the
+`distinct_explicit_collate` and `group_by_explicit_collate` ledger entries.
+
+Spans sql-parser 0.1.22 (grammar tail), sql-planner 0.2.31 (`__collate` wrapping +
+DISTINCT vector), and sql-codegen 0.6.12 (name + value peel).
+
+One orthogonal divergence is newly ledgered as
+`distinct_collate_order_by_representative`: with `ORDER BY` present the VM applies
+the sort BEFORE the DISTINCT dedup, so a case-fold keeps the sort-first original
+text rather than SQLite's scan-first. The folding itself is correct; fixing WHICH
+representative survives requires applying DISTINCT before ORDER BY (SQL semantics),
+a VM post-op reordering left to its own increment. Verified against bundled real
+SQLite.
+
 ## 0.5.63 — `SELECT *` (and `SELECT DISTINCT *`) expand to real columns
 
 `SELECT * FROM t` now returns the table's actual columns instead of a single

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.63"
+version = "0.5.64"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1853,14 +1853,49 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT DISTINCT b FROM t ORDER BY b",
     },
-    // An EXPLICIT `COLLATE` in the DISTINCT operand folds a binary column.
+    // An EXPLICIT `COLLATE` in the DISTINCT operand folds a binary column: `b` is
+    // declared BINARY, so without the suffix 'a'/'A'/'b'/'B' stay four distinct
+    // rows; `COLLATE NOCASE` collapses them to two, keeping each fold's FIRST
+    // (scan-order) original text — 'a','b'. The output column is named after its
+    // source text `b COLLATE NOCASE` (SQLite includes the COLLATE in the name).
+    //
+    // No ORDER BY on purpose: the surviving representative of a fold is only
+    // well-defined once DISTINCT runs, and mini's VM currently applies ORDER BY
+    // BEFORE DISTINCT (post-op order sort→distinct), which would pick the
+    // sort-first row instead — an orthogonal ordering bug tracked separately as
+    // `distinct_collate_order_by_representative`. Compared unordered as a multiset.
     Case {
         id: "distinct_explicit_collate",
         setup: &[
             "CREATE TABLE t (id INTEGER, c TEXT COLLATE NOCASE, b TEXT)",
             "INSERT INTO t VALUES (1,'a','a'),(2,'A','A'),(3,'b','b'),(4,'B','B')",
         ],
+        query: "SELECT DISTINCT b COLLATE NOCASE FROM t",
+    },
+    // Tracks the orthogonal bug the case above sidesteps: with `ORDER BY b` the
+    // VM sorts (post_sort) BEFORE deduping (post_distinct), so the NOCASE fold of
+    // 'a'/'A' keeps the byte-sort-first 'A' rather than SQLite's scan-first 'a'.
+    // The COLLATE *folding* is correct (two rows out); only WHICH original text
+    // survives diverges. Fix is to apply DISTINCT before ORDER BY (SQL semantics),
+    // a VM post-op reordering left to its own increment.
+    Case {
+        id: "distinct_collate_order_by_representative",
+        setup: &[
+            "CREATE TABLE t (b TEXT)",
+            "INSERT INTO t VALUES ('a'),('A'),('b'),('B')",
+        ],
         query: "SELECT DISTINCT b COLLATE NOCASE FROM t ORDER BY b",
+    },
+    // The mirror direction: an explicit `COLLATE BINARY` on a DISTINCT operand
+    // OVERRIDES the column's declared NOCASE, so 'a' and 'A' stay distinct. Guards
+    // that explicit collation outranks declared (not just "any collation folds").
+    Case {
+        id: "distinct_explicit_binary_overrides_declared",
+        setup: &[
+            "CREATE TABLE t (c TEXT COLLATE NOCASE)",
+            "INSERT INTO t VALUES ('a'),('A'),('b')",
+        ],
+        query: "SELECT DISTINCT c COLLATE BINARY FROM t ORDER BY c",
     },
     // GROUP BY likewise groups on the collated key: a declared-NOCASE column
     // yields two groups of two, keyed by the first occurrence's original casing.
@@ -1900,7 +1935,9 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT a, b, COUNT(*) AS n FROM t GROUP BY a, b ORDER BY a, b",
     },
-    // An explicit `GROUP BY <col> COLLATE NOCASE` folds a binary column.
+    // An explicit `GROUP BY <col> COLLATE NOCASE` folds a binary column: `b` is
+    // BINARY, so it groups case-insensitively only because of the suffix, keying
+    // each group by the first occurrence's original casing.
     Case {
         id: "group_by_explicit_collate",
         setup: &[
@@ -1908,6 +1945,18 @@ const CASES: &[Case] = &[
             "INSERT INTO t VALUES (1,'a','a'),(2,'A','A'),(3,'b','b'),(4,'B','B')",
         ],
         query: "SELECT b, COUNT(*) AS n FROM t GROUP BY b COLLATE NOCASE ORDER BY b",
+    },
+    // Per-key collation on a multi-column GROUP BY: only the second key carries
+    // `COLLATE NOCASE`, so `g` groups by exact bytes while `b` folds case. Guards
+    // that the planner pairs each COLLATE with the column_ref it follows (not the
+    // first, not all of them).
+    Case {
+        id: "group_by_explicit_collate_second_key",
+        setup: &[
+            "CREATE TABLE t (g TEXT, b TEXT)",
+            "INSERT INTO t VALUES ('x','a'),('x','A'),('x','b'),('y','a')",
+        ],
+        query: "SELECT g, b, COUNT(*) AS n FROM t GROUP BY g, b COLLATE NOCASE ORDER BY g, b",
     },
     // ---- Lane 2: division / modulo by zero → NULL ------------------------
     // SQLite yields NULL (not an error) for any division or modulo by zero,
@@ -2265,25 +2314,16 @@ const LEDGER: &[(&str, &str)] = &[
         "order_by_ordinal_over_aggregate",
         "positional ORDER BY over an aggregate output column not yet re-bound to the materialized column",
     ),
-    // An EXPLICIT `COLLATE` suffix in a DISTINCT select-item or a GROUP BY term
-    // does not parse yet: the grammar only accepts a `COLLATE` tail inside a
-    // comparison (`x COLLATE C = y`), not on a bare select-list expression or a
-    // group-by key. The *semantics* half — a column's DECLARED collation folding
-    // the DISTINCT/GROUP BY key — is implemented (see the `distinct_column_*` /
-    // `group_by_column_*` cases); closing these two needs hand-edits to the
-    // sql-parser grammar (`select_item` and `group_by` gaining an optional
-    // `COLLATE NAME` tail), which is the next increment in this lane.
     (
         "select_star_in_place",
         "`*` mixed with other select items (`SELECT a, *`) does not parse (grammar: select_list lacks a bare `*` alternative in a comma list)",
     ),
+    // Explicit COLLATE now parses AND folds (DISTINCT / GROUP BY); the only
+    // remaining divergence is which original row a fold keeps when ORDER BY is
+    // present, because the VM runs sort before distinct. Folding is correct.
     (
-        "distinct_explicit_collate",
-        "explicit COLLATE suffix on a DISTINCT select-item does not parse yet (grammar: select_item lacks a COLLATE tail)",
-    ),
-    (
-        "group_by_explicit_collate",
-        "explicit COLLATE suffix on a GROUP BY term does not parse yet (grammar: group_by lacks a COLLATE tail)",
+        "distinct_collate_order_by_representative",
+        "`SELECT DISTINCT x COLLATE NOCASE ... ORDER BY x` keeps the sort-first original text, not SQLite's scan-first, because the VM applies ORDER BY (post_sort) before DISTINCT (post_distinct); DISTINCT should precede ORDER BY",
     ),
 ];
 

--- a/code/packages/rust/sql-codegen/CHANGELOG.md
+++ b/code/packages/rust/sql-codegen/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.6.12] - Unreleased
+
+### Changed
+
+- **Explicit-COLLATE output columns: name after source text, emit the underlying
+  value.** For a select-item carried as `__collate(inner, 'NAME')`,
+  `output_column_name` now renders `inner COLLATE NAME` (SQLite includes the
+  `COLLATE` in the column name, e.g. `b COLLATE NOCASE`), and every output-column
+  value-emit site peels the wrapper with `strip_collate` before compiling — a
+  collation folds comparison/dedup/group keys, never the emitted value, so the
+  projection reports the original text. Complements the planner's explicit-COLLATE
+  DISTINCT/GROUP BY support.
+
 ## [0.6.11] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-codegen/Cargo.toml
+++ b/code/packages/rust/sql-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-codegen"
-version = "0.6.11"
+version = "0.6.12"
 edition = "2021"
 description = "Bytecode code generator for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-codegen/src/lib.rs
+++ b/code/packages/rust/sql-codegen/src/lib.rs
@@ -880,7 +880,12 @@ impl Compiler {
                             compiler.emit(Instruction::JumpIfFalse(skip_lbl.clone()));
                             compiler.emit(Instruction::BeginRow);
                             for col in &cols {
-                                compiler.compile_expr(&col.expr);
+                                // Peel any explicit-COLLATE wrapper: a collation
+                                // never changes the emitted value (only how keys
+                                // compare), so the projection emits the underlying
+                                // expression. `output_column_name` still renders the
+                                // `COLLATE` suffix from the unpeeled column.
+                                compiler.compile_expr(strip_collate(&col.expr));
                                 let name = output_column_name(col);
                                 compiler.emit(Instruction::EmitColumn(name));
                             }
@@ -914,7 +919,12 @@ impl Compiler {
                         self.compile_scan_loop(input, move |compiler, _alias| {
                             compiler.emit(Instruction::BeginRow);
                             for col in &cols {
-                                compiler.compile_expr(&col.expr);
+                                // Peel any explicit-COLLATE wrapper: a collation
+                                // never changes the emitted value (only how keys
+                                // compare), so the projection emits the underlying
+                                // expression. `output_column_name` still renders the
+                                // `COLLATE` suffix from the unpeeled column.
+                                compiler.compile_expr(strip_collate(&col.expr));
                                 let name = output_column_name(col);
                                 compiler.emit(Instruction::EmitColumn(name));
                             }
@@ -1151,7 +1161,10 @@ impl Compiler {
                     compiler.emit(Instruction::JumpIfFalse(skip_lbl.clone()));
                     compiler.emit(Instruction::BeginRow);
                     for col in &cols {
-                        compiler.compile_expr(&col.expr);
+                        // Peel an explicit-COLLATE wrapper: the value is the
+                        // underlying expression (collation only folds keys); the
+                        // name still renders the `COLLATE` suffix.
+                        compiler.compile_expr(strip_collate(&col.expr));
                         let name = output_column_name(col);
                         compiler.emit(Instruction::EmitColumn(name));
                     }
@@ -1204,7 +1217,10 @@ impl Compiler {
                 self.compile_scan_loop(input, |compiler, _alias| {
                     compiler.emit(Instruction::BeginRow);
                     for col in &cols {
-                        compiler.compile_expr(&col.expr);
+                        // Peel an explicit-COLLATE wrapper: the value is the
+                        // underlying expression (collation only folds keys); the
+                        // name still renders the `COLLATE` suffix.
+                        compiler.compile_expr(strip_collate(&col.expr));
                         let name = output_column_name(col);
                         compiler.emit(Instruction::EmitColumn(name));
                     }
@@ -1310,7 +1326,10 @@ impl Compiler {
                 // group's fake row instead.
                 self.agg_slots = aggregates.iter().cloned().enumerate().collect();
                 for col in cols {
-                    self.compile_expr(&col.expr);
+                    // Peel an explicit-COLLATE wrapper before emitting the value
+                    // (collation folds keys, not emitted values); the name still
+                    // renders the `COLLATE` suffix from the unpeeled column.
+                    self.compile_expr(strip_collate(&col.expr));
                     self.emit(Instruction::EmitColumn(output_column_name(col)));
                 }
                 self.agg_slots.clear();
@@ -1877,7 +1896,9 @@ impl Compiler {
     fn emit_row_projection(&mut self, columns: &[OutputColumn]) {
         self.emit(Instruction::BeginRow);
         for col in columns {
-            self.compile_expr(&col.expr);
+            // Peel any explicit-COLLATE wrapper: collation folds keys, not the
+            // emitted value; the name still renders the `COLLATE` suffix.
+            self.compile_expr(strip_collate(&col.expr));
             let name = output_column_name(col);
             self.emit(Instruction::EmitColumn(name));
         }
@@ -2326,6 +2347,20 @@ fn peel_post_ops(plan: &OptimizedPlan) -> (&OptimizedPlan, Vec<Instruction>) {
 fn output_column_name(col: &OutputColumn) -> String {
     if let Some(alias) = &col.alias {
         return alias.clone();
+    }
+    // An explicit `COLLATE` on the select-item is carried as `__collate(inner,
+    // 'NAME')`. SQLite names such a column after its SOURCE TEXT — `b COLLATE
+    // NOCASE`, not just `b` and not the internal builtin — so render the suffix
+    // form. The VALUE is still the underlying `inner` (every projection site
+    // peels the wrapper before emitting), and DISTINCT reads the collation from
+    // the wrapper separately.
+    if let SqlExpr::FunctionCall { name, args, .. } = &col.expr {
+        if name == "__collate" && args.len() == 2 {
+            if let SqlExpr::Literal(SqlValue::Text(coll)) = &args[1] {
+                let inner = render_expr_label(&args[0]).unwrap_or_else(|| "?".to_string());
+                return format!("{inner} COLLATE {coll}");
+            }
+        }
     }
     match &col.expr {
         SqlExpr::Column { name, .. } => name.clone(),

--- a/code/packages/rust/sql-parser/CHANGELOG.md
+++ b/code/packages/rust/sql-parser/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.22] - Unreleased
+
+### Added
+
+- **Optional trailing `COLLATE name` on select-items and GROUP BY keys.** The
+  `select_item` rule now parses `expr COLLATE name [ alias ]` (so `SELECT DISTINCT
+  b COLLATE NOCASE` is accepted) and `group_clause` parses a per-key `COLLATE
+  name` tail (so `GROUP BY b COLLATE NOCASE`, and per-key `GROUP BY g, b COLLATE
+  NOCASE`). Both mirror ORDER BY's existing `COLLATE` tail: `COLLATE` is matched
+  as literal text (it is not a lexer keyword, so it and the collation name arrive
+  as `NAME` tokens) and the collation name is validated in the planner. Previously
+  a `COLLATE` suffix parsed only inside a comparison operand.
+
 ## [0.1.21] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-parser/Cargo.toml
+++ b/code/packages/rust/sql-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-parser"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2021"
 description = "SQL parser — parses SQL source text into an AST using the grammar-driven parser and the sql.grammar file"
 

--- a/code/packages/rust/sql-parser/src/_grammar.rs
+++ b/code/packages/rust/sql-parser/src/_grammar.rs
@@ -74,11 +74,25 @@ pub fn parser_grammar() -> ParserGrammar {
             name: r#"select_item"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
-                // `select_item = expr [ [ "AS" ] NAME ]` — the AS keyword is
-                // OPTIONAL, so `SELECT a col1` (bare alias) parses the same as
-                // `SELECT a AS col1`. The alias NAME can never eat a following
-                // keyword (FROM/WHERE/…) because NAME only matches Name-type
-                // tokens, and it can't eat a comma, so `SELECT a, b` is safe.
+                // Optional `COLLATE name` suffix on a select-list expression, e.g.
+                // `SELECT DISTINCT b COLLATE NOCASE`. Same shape as ORDER BY's
+                // COLLATE tail (see `order_item`): `COLLATE` is matched by literal
+                // text (it is NOT a lexer keyword, so it — and the collation name
+                // after it — both arrive as NAME tokens), and the planner both
+                // validates the name and wraps the expression in the internal
+                // `__collate` builtin so DISTINCT folds on the collated key.
+                // Placed BEFORE the alias so `SELECT b COLLATE NOCASE AS x` parses.
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"COLLATE"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    ] }) },
+                // `select_item = expr [ COLLATE name ] [ [ "AS" ] NAME ]` — the AS
+                // keyword is OPTIONAL, so `SELECT a col1` (bare alias) parses the
+                // same as `SELECT a AS col1`. The alias NAME can never eat a
+                // following keyword (FROM/WHERE/…) because NAME only matches
+                // Name-type tokens, and it can't eat a comma, so `SELECT a, b` is
+                // safe. `extract_as_alias` skips the COLLATE tail (both tokens are
+                // Name-type) so the collation name is never mistaken for an alias.
                 GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
                         GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"AS"#.to_string() }) },
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
@@ -167,9 +181,24 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"GROUP"#.to_string() },
                 GrammarElement::Literal { value: r#"BY"#.to_string() },
                 GrammarElement::RuleReference { name: r#"column_ref"#.to_string() },
+                // Optional per-key `COLLATE name`, e.g. `GROUP BY b COLLATE NOCASE`.
+                // Same tail as ORDER BY (`order_item`); the planner
+                // (`plan_group_by_exprs`) pairs each COLLATE with the `column_ref`
+                // it directly follows and wraps that key in `__collate`, so
+                // grouping folds on the collated value while the emitted key row
+                // keeps its original text. `column_ref` itself stays COLLATE-free
+                // because it is also a general expression atom (used in `primary`).
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"COLLATE"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    ] }) },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
                         GrammarElement::Literal { value: r#","#.to_string() },
                         GrammarElement::RuleReference { name: r#"column_ref"#.to_string() },
+                        GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                                GrammarElement::Literal { value: r#"COLLATE"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                            ] }) },
                     ] }) },
             ] },
             line_number: 33,

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.31] - Unreleased
+
+### Added
+
+- **Explicit `COLLATE` on DISTINCT select-items and GROUP BY keys folds the key.**
+  A trailing `COLLATE name` (newly parsed by sql-parser) is lowered to the
+  internal `__collate(inner, 'NAME')` wrapper — the same representation explicit
+  COLLATE already uses in WHERE comparisons:
+  - `plan_select_item` wraps the select-item expression; `distinct_output_collations`
+    reads the collation from the wrapper (via `effective_output_collation` /
+    `collate_wrapper_name`) into the DISTINCT vector, so `SELECT DISTINCT b COLLATE
+    NOCASE` dedupes case-insensitively. An explicit `COLLATE BINARY` overrides a
+    column's declared NOCASE (explicit outranks declared).
+  - `plan_group_by_exprs` now walks `group_clause` children in order, pairing each
+    `column_ref` with the `COLLATE name` tokens that follow it, and wraps that key
+    — so `GROUP BY b COLLATE NOCASE` (and per-key `GROUP BY g, b COLLATE NOCASE`)
+    groups on the collated value while codegen emits the original.
+  - `extract_as_alias` skips the `COLLATE` tail (both tokens are `NAME`-type) so a
+    collation name is never mistaken for an implicit alias. New helpers:
+    `tail_collation`, `direct_token_uppers`.
+
 ## [0.2.30] - Unreleased
 
 ### Changed

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.30"
+version = "0.2.31"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -1037,12 +1037,45 @@ fn extract_join_condition(join_clause: &GrammarASTNode) -> Result<Option<SqlExpr
 
 /// Plan the `group_clause` into a list of GROUP BY key expressions.
 ///
-/// Grammar: `group_clause = GROUP BY column_ref { "," column_ref }`
+/// Grammar: `group_clause = GROUP BY column_ref [ COLLATE name ]
+///                          { "," column_ref [ COLLATE name ] }`
+///
+/// Because the grammar's optionals/repetitions FLATTEN into `group_clause`'s
+/// direct children, a `COLLATE name` clause appears as two loose tokens sitting
+/// immediately after the `column_ref` node it qualifies (and before the next
+/// key's comma). We therefore walk the children in order — planning each
+/// `column_ref` node, then reading any `COLLATE` tokens that follow it up to the
+/// next node — rather than harvesting `column_ref` nodes in isolation (which
+/// would drop the per-key collation). An explicit collation wraps the key in
+/// `__collate`; codegen groups on the collated value but emits the original.
 fn plan_group_by_exprs(group_clause: &GrammarASTNode) -> Result<Vec<SqlExpr>, PlanError> {
-    find_nodes(group_clause, "column_ref")
-        .iter()
-        .map(|cr| plan_column_ref(cr))
-        .collect()
+    let children = &group_clause.children;
+    let mut keys = Vec::new();
+    for (i, child) in children.iter().enumerate() {
+        let ASTNodeOrToken::Node(node) = child else {
+            continue;
+        };
+        if node.rule_name != "column_ref" {
+            continue;
+        }
+        let mut key = plan_column_ref(node)?;
+        // Collect the loose tokens between this column_ref and the next node —
+        // that window holds this key's optional `COLLATE name` (plus a trailing
+        // comma, which `tail_collation` ignores).
+        let tail: Vec<String> = children[i + 1..]
+            .iter()
+            .take_while(|c| matches!(c, ASTNodeOrToken::Token(_)))
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Token(t) => Some(t.value.to_ascii_uppercase()),
+                ASTNodeOrToken::Node(_) => None,
+            })
+            .collect();
+        if let Some(name) = tail_collation(&tail)? {
+            key = wrap_collate(key, &name);
+        }
+        keys.push(key);
+    }
+    Ok(keys)
 }
 
 /// Plan the `order_clause` into sort keys.
@@ -1488,15 +1521,48 @@ fn distinct_output_collations(
                     out.push(ctx.collations.get(&cname.to_ascii_lowercase()).cloned());
                 }
             }
-            // A bare column reference inherits its declared collation. An ALIAS
-            // is irrelevant — the collation comes from the expression, so
-            // `c AS y` still folds. (`resolve_column_collation` yields `None` for
-            // any non-column expression, which is exactly the "expressions drop
-            // the collation" rule.)
-            expr => out.push(resolve_column_collation(expr, &ctx)),
+            // An explicit `COLLATE` on the select-item (wrapped as
+            // `__collate(inner, 'NAME')`) OUTRANKS any declared collation, and a
+            // bare column reference inherits its declared collation. An ALIAS is
+            // irrelevant — the collation comes from the expression, so `c AS y`
+            // still folds. (`effective_output_collation` yields `None` for any
+            // other expression, which is exactly the "expressions drop the
+            // collation" rule.)
+            expr => out.push(effective_output_collation(expr, &ctx)),
         }
     }
     out
+}
+
+/// The collating sequence a DISTINCT output column dedupes under: an explicit
+/// `COLLATE` (carried as a `__collate` wrapper) if present — with `BINARY`
+/// meaning "compare bytes as-is", represented as `None` — otherwise the column's
+/// declared collation, otherwise `None`.
+fn effective_output_collation(expr: &SqlExpr, ctx: &OrderCollateCtx) -> Option<String> {
+    if let Some(name) = collate_wrapper_name(expr) {
+        return if name.eq_ignore_ascii_case("BINARY") {
+            None
+        } else {
+            Some(name)
+        };
+    }
+    resolve_column_collation(expr, ctx)
+}
+
+/// The collation name from a `__collate(inner, 'NAME')` wrapper, or `None` for
+/// any other expression. The production counterpart to the WHERE-comparison
+/// pass's `is_collate_call` boolean — here we need the name itself, to feed the
+/// DISTINCT collation vector.
+fn collate_wrapper_name(expr: &SqlExpr) -> Option<String> {
+    match expr {
+        SqlExpr::FunctionCall { name, args, .. } if name == "__collate" && args.len() == 2 => {
+            match &args[1] {
+                SqlExpr::Literal(SqlValue::Text(coll)) => Some(coll.clone()),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
 }
 
 fn resolve_column_collation(expr: &SqlExpr, ctx: &OrderCollateCtx) -> Option<String> {
@@ -1790,10 +1856,50 @@ fn plan_select_item(item: &GrammarASTNode) -> Result<OutputColumn, PlanError> {
 
     let expr = plan_expression(expr_node)?;
 
+    // An explicit trailing `COLLATE name` (grammar: `select_item = expr
+    // [ COLLATE name ] [ alias ]`) wraps the expression in the internal
+    // `__collate` builtin — the same representation explicit COLLATE uses in a
+    // WHERE comparison. `distinct_output_collations` reads that wrapper to fold a
+    // `SELECT DISTINCT b COLLATE NOCASE` key, after which `plan_select` peels the
+    // wrapper back off (collation never changes the emitted value or column name).
+    let expr = match tail_collation(&direct_token_uppers(item)) {
+        Ok(Some(name)) => wrap_collate(expr, &name),
+        Ok(None) => expr,
+        Err(e) => return Err(e),
+    };
+
     // Look for an AS alias.
     let alias = extract_as_alias(item);
 
     Ok(OutputColumn { expr, alias })
+}
+
+/// Uppercased text of every DIRECT token child of `node` (nested nodes skipped),
+/// in order — the raw material for reading a trailing `COLLATE name` clause off a
+/// `select_item` or a `group_clause` key.
+fn direct_token_uppers(node: &GrammarASTNode) -> Vec<String> {
+    node.children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Token(t) => Some(t.value.to_ascii_uppercase()),
+            ASTNodeOrToken::Node(_) => None,
+        })
+        .collect()
+}
+
+/// Read an optional trailing `COLLATE name` clause from a token list.
+///
+/// Returns `Ok(Some(NAME))` for a valid `COLLATE NOCASE|RTRIM|BINARY`, an error
+/// for an unknown collation (matching SQLite's "no such collating sequence"), and
+/// `Ok(None)` when there is no `COLLATE` — OR when a bare trailing `collate`
+/// token has nothing after it. That last case is not a collation clause but an
+/// (unusual) identifier named `collate` the grammar left as a select-item alias
+/// or the parser would already have rejected; either way it is not ours to fold.
+fn tail_collation(direct_tok_uppers: &[String]) -> Result<Option<String>, PlanError> {
+    match direct_tok_uppers.iter().position(|t| t == "COLLATE") {
+        Some(p) if p + 1 < direct_tok_uppers.len() => collate_name_after(direct_tok_uppers),
+        _ => Ok(None),
+    }
 }
 
 /// Extract a `select_item` alias.
@@ -1824,9 +1930,24 @@ fn extract_as_alias(node: &GrammarASTNode) -> Option<String> {
     // Implicit `name` (no AS): the first bare identifier token directly under
     // the item. Restricting to Name-type tokens keeps us from mistaking any
     // stray keyword/punctuation for an alias.
+    //
+    // A trailing `COLLATE name` clause (grammar: `expr [ COLLATE name ] [ alias ]`)
+    // arrives as TWO Name-type tokens — `COLLATE` is not a lexer keyword, and the
+    // collation name is a generic NAME — so both must be skipped or the collation
+    // name would be read as an implicit alias (`SELECT b COLLATE NOCASE` would be
+    // named `NOCASE`). Skip the `COLLATE` token and the one immediately after it.
+    let mut skip_next = false;
     for child in children {
+        if skip_next {
+            skip_next = false; // the collation name — never an alias
+            continue;
+        }
         if let ASTNodeOrToken::Token(tok) = child {
             if tok.type_ == lexer::token::TokenType::Name {
+                if tok.value.eq_ignore_ascii_case("COLLATE") {
+                    skip_next = true;
+                    continue;
+                }
                 return Some(tok.value.clone());
             }
         }


### PR DESCRIPTION
## What

Explicit `COLLATE name` on **DISTINCT select-items** and **GROUP BY keys** now parses and folds, matching SQLite:

```sql
SELECT DISTINCT b COLLATE NOCASE FROM t;                   -- dedupes case-insensitively
SELECT b, COUNT(*) FROM t GROUP BY b COLLATE NOCASE;        -- groups case-insensitively
SELECT g, b, COUNT(*) FROM t GROUP BY g, b COLLATE NOCASE;  -- per-key collation
```

Previously a `COLLATE` suffix parsed only inside a comparison operand (`x COLLATE C = y`); on a select-list expression or a group-by key it was a parse error. Retires the `distinct_explicit_collate` and `group_by_explicit_collate` oracle ledger entries.

## How

Reuses the existing `__collate(inner, 'NAME')` wrapper representation (the same one COLLATE already uses in WHERE), so this is mostly plumbing an explicit collation from two new grammar tails into the DISTINCT/GROUP-BY key-folding that was already implemented for *declared* collations.

- **Grammar** (`sql-parser` 0.1.22, hand-edited `_grammar.rs`): `select_item = expr [ COLLATE name ] [ [AS] alias ]`, and `group_clause` gains a per-key `COLLATE name` tail — both mirror ORDER BY's existing tail.
- **Planner** (`sql-planner` 0.2.31): `plan_select_item` wraps the expr; `plan_group_by_exprs` walks `group_clause` children in order and pairs each `column_ref` with the COLLATE tokens that follow it; `distinct_output_collations` reads the collation off the wrapper (explicit outranks declared; explicit `COLLATE BINARY` overrides a declared NOCASE); `extract_as_alias` skips the COLLATE tokens (both are NAME-type) so the collation name isn't mistaken for an implicit alias.
- **Codegen** (`sql-codegen` 0.6.12): `output_column_name` renders `b COLLATE NOCASE` (SQLite names such a column after its source text); every output-column value-emit site peels the wrapper with `strip_collate`, so a collation folds keys but never the emitted value (the original text is reported).

## Orthogonal bug, ledgered not hidden

While building this I found the VM applies **ORDER BY before DISTINCT** (post-op order sort→distinct). With `ORDER BY` present, a case-fold keeps the sort-first original text rather than SQLite's scan-first — the *folding* is correct, only *which* representative survives diverges. This is independent of COLLATE (it affects declared-collation DISTINCT too; existing cases only avoided it by insert order). Rather than mask it, it's newly ledgered as `distinct_collate_order_by_representative` with a repro, and the DISTINCT oracle case here compares **unordered** to isolate the feature under test. Fixing it (apply DISTINCT before ORDER BY) is a VM post-op reordering for its own increment. Net ledger change: **−1**.

## Verification
- Differential oracle green vs **bundled real SQLite** — retires 2 entries, adds guard cases for explicit-BINARY-overrides-declared and per-key multi-column GROUP BY collation.
- Full `sql-parser` / `sql-planner` / `sql-optimizer` / `sql-codegen` / `sql-vm` / `mini-sqlite` suites pass; clippy clean.
- Inline security review **CLEAN**: parser flattens optionals/repetitions into the parent so the group-by token windows are disjoint (no cross-key mis-attribution), no panics/DoS, all six value-emit sites peeled.

Versions: `sql-parser` 0.1.22, `sql-planner` 0.2.31, `sql-codegen` 0.6.12, `mini-sqlite` 0.5.64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
