### PR TITLE
feat(semantic-ir-to-javascript): SIR23 Derive-specific display convention (item 4 of 4, front1)

### DIFF
--- a/code/packages/rust/derive-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/derive-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## [0.1.3] - 2026-07-22
+
+### Fixed (upstream — `semantic-ir-to-javascript` 0.50.0, not this crate's own lowering)
+
+`semantic-ir-to-javascript`'s SIR23 addendum item 4 (Derive's own SIR23
+display convention — `SIR_DISPLAY_DERIVE`, that crate's own `CHANGELOG.md`
+`[0.50.0]` entry) gives `Symbolic.toDisplayString` a Derive-specific,
+precedence-aware infix/prefix/bracket/case-bridging renderer, ported
+directly from `derive-runtime::printer::print_derive`. This crate's own
+`src/lower.rs` is completely unchanged — every fix here is entirely
+upstream in the shared backend, confirmed by `tests/test_lower.rs`'s ~40
+pre-existing shape assertions still passing unmodified — but 7 more of
+`tests/oracle.rs`'s 38 `known_bug` cases now genuinely agree end-to-end
+(run and confirmed via `cargo test -p derive-to-semantic-ir --test oracle
+-- --nocapture`, not guessed), so their markers flip to `known_bug: None`
+here:
+
+- `negation_of_a_free_symbol` (`-x`) — prefix `Neg` rendering. Corrected a
+  mistaken assumption baked into its label ("Evaluation/display gap"):
+  there was never anything to evaluate (`x` is free), so this was always
+  a display-convention-only case.
+- `equation_with_a_free_variable_stays_symbolic` (`x = 4`) — infix
+  `Equal` rendering.
+- `flat_vector_literal` (`[1, 2, 3]`), `singleton_vector_literal`
+  (`[5]`), `vector_of_expressions_evaluates_elementwise` (`[1+1, 2*3,
+  2^3]`, whose elements item 1 already folds to `2, 6, 8`) — Derive's flat
+  `[a, b, c]` bracket convention.
+- `two_by_two_matrix_literal` (`[1, 2; 3, 4]`), `three_row_one_column_
+  matrix_literal` (`[1; 2; 3]`) — Derive's `;`-row-separated matrix
+  bracket convention.
+
+The remaining 13 `known_bug` cases stay `known_bug` — all blocked purely
+by the held-form/calculus evaluation gap (items 2/3, not part of this
+PR). Four of them (`vector_assignment_persists_across_statements`,
+`dif_differentiates_a_power`, `dif_of_sin_gives_cos`,
+`int_integrates_a_symbol`) have their reason strings **corrected in
+place** (stay `Some`, since they still disagree, but now note that only
+the evaluation half remains — the display half these reasons used to
+also blame is fixed by this PR and will render correctly the moment
+items 2/3 land).
+
 ## [0.1.2] - 2026-07-21
 
 ### Fixed (upstream — `semantic-ir-to-javascript` 0.47.0, not this crate's own lowering)

--- a/code/packages/rust/derive-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/derive-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive-to-semantic-ir"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Derive CST → narrow-waist Semantic IR (SIR23 symbolic/pattern domain, Stream B). Third frontend to target SIR23, sibling to wolfram-to-semantic-ir and macsyma-to-semantic-ir."
 

--- a/code/packages/rust/derive-to-semantic-ir/README.md
+++ b/code/packages/rust/derive-to-semantic-ir/README.md
@@ -173,16 +173,21 @@ regress.
 - `tests/oracle.rs` (HML01 §7) — the same source run through **two**
   independent implementations (`derive-runtime`, the native ground truth,
   vs. this crate → `semantic-ir-to-javascript` → `node`) and diffed,
-  38-case corpus. Building it found that comparing *evaluated* values is
-  currently blocked by two gaps in the SHARED `semantic-ir-to-javascript`
+  38-case corpus. Building it found that comparing *evaluated* values was
+  originally blocked by two gaps in the SHARED `semantic-ir-to-javascript`
   crate, not in this frontend's own lowering: (1) SIR23's `Expr::SymApply`
-  compiles to a pure, inert `__Sir.Symbolic.apply(...)` term constructor
+  compiled to a pure, inert `__Sir.Symbolic.apply(...)` term constructor
   with no arithmetic/comparison/calculus evaluation and no execution of
   the held `Assign`/`Define`/`If` forms at all, and (2) the SIR23
-  domain's only stringifier has no per-source-language display convention
+  domain's only stringifier had no per-source-language display convention
   (generic `head(args)` only — no infix, no bracket-list, no case-bridging
-  back to Derive's own UPPERCASE surface spelling). Both are documented via
-  each affected case's `known_bug` field (not patched here — see `tests/
-  oracle.rs`'s own module doc and this crate's `CHANGELOG.md` for the full
-  write-up); only 4 of 38 cases (bare integer/float/symbol literals) are
-  `known_bug: None`.
+  back to Derive's own UPPERCASE surface spelling). Gap (1) is now
+  partially closed (arithmetic/comparison/logic folding, SIR23 addendum
+  item 1) and gap (2) is now fully closed for Derive (item 4,
+  `SIR_DISPLAY_DERIVE`) — held-form execution and calculus (items 2/3)
+  remain open, not part of this frontend's own lowering either way. Each
+  gap is documented via the affected case's own `known_bug` field (not
+  patched in *this* crate — see `tests/oracle.rs`'s own module doc and
+  this crate's `CHANGELOG.md` for the full write-up); 25 of 38 cases are
+  now `known_bug: None`, and the remaining 13 are blocked purely by the
+  still-open held-form/calculus evaluation gap.

--- a/code/packages/rust/derive-to-semantic-ir/tests/oracle.rs
+++ b/code/packages/rust/derive-to-semantic-ir/tests/oracle.rs
@@ -114,26 +114,40 @@
 //! any symbolic-domain frontend, not just Derive.
 //!
 //! ## A second, narrower finding layered on top: no per-language SIR23
-//! display convention either (also found, NOT fixed here)
+//! display convention either — FIXED for Derive by this PR (SIR23
+//! addendum, item 4 of 4)
 //!
 //! Independent of the evaluation gap above: even a term that WAS already
 //! fully reduced would still print wrong for Derive. `semantic-ir-to-
 //! javascript`'s only SIR23 stringifier, `Symbolic.toDisplayString`
-//! (`runtime.rs`), renders **every** compound term generically as
-//! `head(args, ...)` — e.g. an unevaluated `Add(x, 1)` prints `"Add(x,
-//! 1)"`, a `List(1, 2, 3)` prints `"List(1, 2, 3)"`, a `Neg(x)` prints
-//! `"Neg(x)"` — with no infix `+`/`*`/`^` convention, no `[...]`/`[...;...]`
-//! bracket convention for `List`, no prefix `-`/`NOT` convention, and no
-//! case-bridging back to Derive's own UPPERCASE builtin surface spelling
-//! (`derive-runtime::printer::print_derive` reverses ALL of these:
-//! `Add(x,1)` → `"x + 1"`, `List(1,2,3)` → `"[1, 2, 3]"`, `Neg(x)` →
-//! `"-x"`, an unresolved `Cos(x)` → `"COS(x)"`). Unlike the SIR22 array
-//! domain's `ArrayRt.fmtNum`/`display` (which already has per-language
-//! flags — `SIR_DISPLAY_APL_HIGH_MINUS`, `SIR_DISPLAY_J_UNDERSCORE`), the
-//! SIR23 domain has no such mechanism for ANY source language yet. Also a
-//! shared-crate gap, also `known_bug`, cited alongside the evaluation gap
-//! above wherever a `CORPUS` entry's compiled output would still disagree
-//! even under a hypothetical fix to the first gap.
+//! (`runtime.rs`), used to render **every** compound term generically as
+//! `head(args, ...)` regardless of source language — e.g. an unevaluated
+//! `Add(x, 1)` printed `"Add(x, 1)"`, a `List(1, 2, 3)` printed `"List(1,
+//! 2, 3)"`, a `Neg(x)` printed `"Neg(x)"` — with no infix `+`/`*`/`^`
+//! convention, no `[...]`/`[...;...]` bracket convention for `List`, no
+//! prefix `-`/`NOT` convention, and no case-bridging back to Derive's own
+//! UPPERCASE builtin surface spelling (`derive-runtime::printer::
+//! print_derive` reverses ALL of these: `Add(x,1)` → `"x + 1"`,
+//! `List(1,2,3)` → `"[1, 2, 3]"`, `Neg(x)` → `"-x"`, an unresolved
+//! `Cos(x)` → `"COS(x)"`). Unlike the SIR22 array domain's `ArrayRt.
+//! fmtNum`/`display` (which already had per-language flags —
+//! `SIR_DISPLAY_APL_HIGH_MINUS`, `SIR_DISPLAY_J_UNDERSCORE`), the SIR23
+//! domain had no such mechanism for ANY source language.
+//!
+//! This PR adds `SIR_DISPLAY_DERIVE` — the fourth instance of that exact
+//! `emit.rs`/`runtime.rs` mechanism — which gates a byte-for-byte JS port
+//! of `derive-runtime::printer::print_derive`'s own precedence-based
+//! renderer (infix `Add`/`Sub`/`Mul`/`Div`/`Equal`/`Less`/`Greater`/
+//! `LessEqual`/`GreaterEqual`, n-ary `And`/`Or`, prefix `Neg`/`Not`,
+//! Derive's own `;`-row-separated `List` bracket convention, and the
+//! `Sin` → `"SIN"`-style UPPERCASE case-bridge). Below, every `CORPUS`
+//! entry whose *only* remaining disagreement was this display gap (not
+//! the evaluation gap above) has been flipped to `known_bug: None` and
+//! re-verified by actually running this file's own oracle test. Every
+//! entry that ALSO needs the evaluation gap (items 2/3, not part of this
+//! PR) to close first stays `known_bug`, with its reason text updated to
+//! call out that the display half is now resolved and only the
+//! evaluation half remains.
 //!
 //! ## Corpus
 //!
@@ -149,9 +163,17 @@
 //! including a 3-term `AND` chain exercising the n-ary logical-chain
 //! fold); vectors and matrices as D-5 structural `List` data (flat,
 //! singleton, elementwise-evaluated, 2×2, and 3-row/1-column shapes); a
-//! free-symbol additive-identity simplification; and bare integer/float/
-//! symbol atoms (this subset's only `known_bug: None` cases, per the
-//! evaluation-gap finding above).
+//! free-symbol additive-identity simplification; free-symbol negation and
+//! equation display; and bare integer/float/symbol atoms. As of item 4
+//! (this PR), 25 of the 38 cases are `known_bug: None` — the bare atoms
+//! (never needed evaluation), every case item 1's arithmetic/comparison/
+//! logic folding alone already flipped, and the 7 cases this PR's own
+//! `SIR_DISPLAY_DERIVE` flips (`negation_of_a_free_symbol`,
+//! `equation_with_a_free_variable_stays_symbolic`, the three flat/
+//! elementwise `List` cases, and the two matrix cases). The remaining 13
+//! stay `known_bug`, all blocked purely by the held-form/calculus
+//! evaluation gap (items 2/3, not part of this PR) — see each entry's own
+//! `known_bug` reason.
 
 use std::fs::OpenOptions;
 use std::io::Write as _;
@@ -189,9 +211,12 @@ struct Case {
 }
 
 const CORPUS: &[Case] = &[
-    // --- Bare atoms: the ONLY `known_bug: None` cases (see module doc's
+    // --- Bare atoms: `known_bug: None` from the start (see module doc's
     // "dominant finding" -- these need no evaluation at all, since the
-    // source already denotes exactly one value). ---
+    // source already denotes exactly one value). No longer the ONLY such
+    // cases as of item 1 (arithmetic/comparison/logic folding) and item 4
+    // (this PR's own Derive display convention) -- see the module doc's
+    // "Corpus" section for the current, complete accounting. ---
     Case {
         name: "bare_integer_literal",
         source: "42\n",
@@ -301,11 +326,13 @@ const CORPUS: &[Case] = &[
         name: "negation_of_a_free_symbol",
         source: "-x\n",
         expected: "-x",
-        known_bug: Some(
-            "Evaluation/display gap (module doc): compiles to a bare Neg(x) term; there is nothing \
-             to fold (x is free), but the display-convention gap alone means this prints \"Neg(x)\", \
-             never the prefix surface \"-x\".",
-        ),
+        // Flipped by item 4 (SIR_DISPLAY_DERIVE): compiles to a bare
+        // Neg(x) term -- there is nothing to fold (x is free), so this
+        // was ALWAYS a display-convention-only case (the original
+        // known_bug reason's "Evaluation/display gap" label was broader
+        // than the actual root cause); Symbolic.toDisplayString's new
+        // Derive-specific prefix-Neg rendering now prints "-x" directly.
+        known_bug: None,
     },
 
     // --- Assignment: read back by a LATER statement (mirrors
@@ -328,10 +355,11 @@ const CORPUS: &[Case] = &[
         source: "v := [1, 2, 3]\nv\n",
         expected: "[1, 2, 3]\n[1, 2, 3]",
         known_bug: Some(
-            "Evaluation gap (module doc): the compiled side's Assign never binds v, so the second \
-             statement compiles to the bare, still-unbound symbol v, not the list; and even a bound \
-             List(1,2,3) would print via the display-convention gap as \"List(1, 2, 3)\", not \
-             \"[1, 2, 3]\".",
+            "Evaluation gap ONLY now (module doc; display half fixed by item 4): the compiled side's \
+             Assign still never binds v (item 2, not part of this PR), so the second statement still \
+             compiles to the bare, still-unbound symbol v, not the list -- once item 2 lands and binds \
+             v to an actual List(1,2,3), it will already print correctly as \"[1, 2, 3]\" via this PR's \
+             own SIR_DISPLAY_DERIVE List bracket convention.",
         ),
     },
 
@@ -365,10 +393,11 @@ const CORPUS: &[Case] = &[
         source: "DIF(x^2, x)\n",
         expected: "2*x",
         known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare D(Pow(x, 2), x) term -- confirmed by \
-             direct inspection of the emitted JS -- differentiation never runs, so it never reduces \
-             to 2*x; even if it did, the display-convention gap would print \"Mul(2, x)\", not \
-             \"2*x\".",
+            "Evaluation gap ONLY now (module doc; display half fixed by item 4): compiles to a bare \
+             D(Pow(x, 2), x) term -- confirmed by direct inspection of the emitted JS -- \
+             differentiation still never runs (item 3, not part of this PR), so it never reduces to \
+             2*x; once item 3 lands and folds this to Mul(2, x), this PR's own SIR_DISPLAY_DERIVE \
+             infix convention will already render it as \"2*x\".",
         ),
     },
     Case {
@@ -376,9 +405,10 @@ const CORPUS: &[Case] = &[
         source: "DIF(SIN(x), x)\n",
         expected: "COS(x)",
         known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare D(Sin(x), x) term, never differentiates \
-             to Cos(x); even folded, the display-convention gap has no case-bridge back to Derive's \
-             UPPERCASE surface convention, so it would print \"Cos(x)\", not \"COS(x)\".",
+            "Evaluation gap ONLY now (module doc; display half fixed by item 4): compiles to a bare \
+             D(Sin(x), x) term, still never differentiates to Cos(x) (item 3, not part of this PR); \
+             once item 3 lands and folds this to Cos(x), this PR's own SIR_DISPLAY_DERIVE \
+             case-bridge will already render it as \"COS(x)\".",
         ),
     },
     // Mirrors derive-runtime's own `a_small_derive_program_evaluates_end_
@@ -400,8 +430,10 @@ const CORPUS: &[Case] = &[
         source: "INT(x, x)\n",
         expected: "1/2*x^2",
         known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare Integrate(x, x) term, never integrates \
-             to 1/2*x^2.",
+            "Evaluation gap ONLY now (module doc; display half fixed by item 4): compiles to a bare \
+             Integrate(x, x) term, still never integrates to 1/2*x^2 (item 3, not part of this PR); \
+             once item 3 lands and folds this to Mul(Rational(1,2), Pow(x,2))-shaped output, this \
+             PR's own SIR_DISPLAY_DERIVE infix/Pow convention will already render it as \"1/2*x^2\".",
         ),
     },
 
@@ -454,12 +486,11 @@ const CORPUS: &[Case] = &[
         name: "equation_with_a_free_variable_stays_symbolic",
         source: "x = 4\n",
         expected: "x = 4",
-        known_bug: Some(
-            "Display-convention gap only (module doc) -- this one needs no evaluation at all (x is \
-             free, so Equal(x, 4) is already the fully-reduced ground-truth value); the compiled \
-             side's generic, non-infix Symbolic.toDisplayString prints \"Equal(x, 4)\", never \
-             Derive's own infix \"x = 4\".",
-        ),
+        // Flipped by item 4 (SIR_DISPLAY_DERIVE): this one needs no
+        // evaluation at all (x is free, so Equal(x, 4) is already the
+        // fully-reduced ground-truth value); Symbolic.toDisplayString's
+        // new Derive-specific infix rendering now prints "x = 4" directly.
+        known_bug: None,
     },
 
     // --- Logic keywords: AND / OR / NOT, including a 3-term AND chain
@@ -517,21 +548,19 @@ const CORPUS: &[Case] = &[
         name: "flat_vector_literal",
         source: "[1, 2, 3]\n",
         expected: "[1, 2, 3]",
-        known_bug: Some(
-            "Display-convention gap (module doc): a flat List(1, 2, 3) needs no evaluation at all \
-             (every element is already a literal), but the compiled side's generic \
-             Symbolic.toDisplayString prints \"List(1, 2, 3)\", never Derive's own bracket surface \
-             \"[1, 2, 3]\".",
-        ),
+        // Flipped by item 4 (SIR_DISPLAY_DERIVE): a flat List(1, 2, 3)
+        // needs no evaluation at all (every element is already a
+        // literal); Symbolic.toDisplayString's new Derive-specific flat
+        // bracket convention now prints "[1, 2, 3]" directly.
+        known_bug: None,
     },
     Case {
         name: "singleton_vector_literal",
         source: "[5]\n",
         expected: "[5]",
-        known_bug: Some(
-            "Display-convention gap only (module doc): List(5) needs no evaluation; prints \
-             \"List(5)\", not \"[5]\".",
-        ),
+        // Flipped by item 4: List(5) needs no evaluation; now prints
+        // "[5]" via the same flat bracket convention.
+        known_bug: None,
     },
     Case {
         name: "vector_of_expressions_evaluates_elementwise",
@@ -544,37 +573,36 @@ const CORPUS: &[Case] = &[
         // folds each element for free: this now compiles to and
         // evaluates as `List(2, 6, 8)`, confirmed by direct inspection
         // of the emitted JS -- the elements are NOT unfolded anymore.
-        // Only Derive's own `[...]` bracket display convention (item 4)
-        // is still missing, so this stays `known_bug`, now for a purely
-        // display-convention reason.
-        known_bug: Some(
-            "Display-convention gap ONLY (module doc; corrected after item 1 landed) -- NOT an \
-             evaluation gap anymore: evalTerm's applicative-order argument evaluation folds each \
-             List element for free even though List itself has no handler, so this now compiles to \
-             and evaluates as List(2, 6, 8) (confirmed by direct inspection of the emitted JS) -- \
-             only the generic Symbolic.toDisplayString printing \"List(2, 6, 8)\" instead of Derive's \
-             own bracket surface \"[2, 6, 8]\" remains, which is item 4's job (Derive's own SIR23 \
-             display convention).",
-        ),
+        // Item 4 (Derive's own `[...]` bracket display convention) is what
+        // flips this one, below.
+        //
+        // Flipped by item 4 (SIR_DISPLAY_DERIVE): NOT an evaluation gap
+        // (fixed by item 1) -- evalTerm's applicative-order argument
+        // evaluation folds each List element for free even though List
+        // itself has no handler, so this compiles to and evaluates as
+        // List(2, 6, 8) (confirmed by direct inspection of the emitted
+        // JS); Symbolic.toDisplayString's new Derive-specific flat
+        // bracket convention now prints "[2, 6, 8]" directly.
+        known_bug: None,
     },
     Case {
         name: "two_by_two_matrix_literal",
         source: "[1, 2; 3, 4]\n",
         expected: "[1, 2; 3, 4]",
-        known_bug: Some(
-            "Display-convention gap only (module doc): List(List(1,2), List(3,4)) needs no \
-             evaluation (a matrix of literals), but prints \"List(List(1, 2), List(3, 4))\", never \
-             the \";\"-separated row surface \"[1, 2; 3, 4]\".",
-        ),
+        // Flipped by item 4: List(List(1,2), List(3,4)) needs no
+        // evaluation (a matrix of literals); Symbolic.toDisplayString's
+        // new Derive-specific matrix convention (every element itself a
+        // List -> ";"-separated rows) now prints "[1, 2; 3, 4]" directly.
+        known_bug: None,
     },
     Case {
         name: "three_row_one_column_matrix_literal",
         source: "[1; 2; 3]\n",
         expected: "[1; 2; 3]",
-        known_bug: Some(
-            "Display-convention gap only (module doc): a three-row matrix of literals needs no \
-             evaluation, but prints generically, not with Derive's own \";\"-separated row surface.",
-        ),
+        // Flipped by item 4: a three-row matrix of literals needs no
+        // evaluation; now prints with Derive's own ";"-separated row
+        // surface via the same matrix convention.
+        known_bug: None,
     },
 ];
 

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,90 @@
 # Changelog
 
+## 0.50.0 — Derive's own SIR23 display convention (SIR23 addendum, item 4 of 4)
+
+Item 4 of the 4-item rollout described by `SIR23-symbolic-pattern-
+semantic-ir.md`'s own "Addendum — SIR23 symbolic evaluator + per-language
+display convention" section, and the last of the four (items 2 and 3 —
+held-form execution and calculus/elementary-function handlers — remain
+separate, not-yet-landed work; this item has no code dependency on either,
+since it touches only `toDisplayString`, a different function than
+`evalTerm`/`evalApply`). Found by `derive-to-semantic-ir/tests/oracle.rs`:
+even a fully-reduced SIR23 term printed wrong for Derive, because
+`Symbolic.toDisplayString` had no per-source-language display convention
+at all — every compound term rendered generically as `head(args, …)`
+regardless of `source_language`, unlike the SIR22 array domain's
+`ArrayRt.fmtNum`/`display` (already gated by `SIR_DISPLAY_APL_HIGH_MINUS`/
+`SIR_DISPLAY_J_UNDERSCORE`).
+
+### Added
+
+- **`emit.rs`/`runtime.rs`: a fourth `SIR_DISPLAY_*` flag,
+  `SIR_DISPLAY_DERIVE`** — extends the existing, already-proven
+  `SIR_DISPLAY_RUBY`/`SIR_DISPLAY_APL_HIGH_MINUS`/`SIR_DISPLAY_J_UNDERSCORE`
+  mechanism exactly (a mutually-exclusive boolean computed from
+  `m.metadata.source_language`, substituted into the inlined `RUNTIME`
+  blob as a hardcoded literal — never source-derived text, preserving the
+  existing SECURITY invariant), rather than inventing a new one. Unlike
+  the first three flags (which all gate `formatSeen`'s bare-number/
+  `SirFloat` branches), this one gates `Symbolic.toDisplayString` — the
+  SIR23 domain's own stringifier, a different function entirely.
+- **`runtime.rs`: `Symbolic`'s `deriveRender`/`derivePrintAt`/
+  `deriveRenderApply`/`deriveRenderList`/`deriveIsListNode`** — a direct,
+  byte-for-byte JS port of `derive-runtime::printer::print_derive`'s own
+  precedence-based renderer (`render`/`print_at`/`render_apply`/
+  `render_list`/`infix_binary`/`nary_logic`/`ir_head_to_surface`), kept as
+  its own separate function family rather than folded into the generic
+  `toDisplayString` (the two conventions disagree on almost every compound
+  shape). Reproduces, gated behind `SIR_DISPLAY_DERIVE`:
+  - Infix `Add`/`Sub`/`Mul`/`Div` and comparisons `Equal`/`Less`/`Greater`/
+    `LessEqual`/`GreaterEqual`, plus n-ary `And`/`Or`, each with the exact
+    9-level precedence ladder `printer.rs` documents (`Or` < `And` <
+    `Not`/comparisons < `Add`/`Sub` < `Mul`/`Div` < unary `Neg` < `Pow` <
+    atoms), so a looser child gets parenthesised exactly when re-parsing
+    would otherwise disagree with the built tree.
+  - Prefix `Neg` (`-x`) and `Not` (`NOT a`).
+  - Right-associative `Pow` (`a^b^c`, never `(a^b)^c`).
+  - Derive's own `List` bracket convention (D-5): a flat vector prints
+    `[a, b, c]`; a "list of lists" (every element itself a `List`) prints
+    as a `;`-row-separated matrix, `[a, b; c, d]` — the exact reverse of
+    `derive-runtime::lower::lower_vector`.
+  - Case-bridging a fixed table of builtin heads back to Derive's own
+    UPPERCASE surface spelling (`D` → `"DIF"`, `Sin` → `"SIN"`, …, the
+    exact same table as `printer.rs::ir_head_to_surface`); any other head
+    (a user-defined function, or one this subset's printer never bridges
+    either, e.g. `Abs`/`Inv`/`NotEqual`) renders as-typed.
+  - `True`/`False` need **no** special-casing at all: both the generic and
+    Derive-specific conventions already render a bare `Symbol` term as its
+    verbatim name, and `symbolic-ir`'s canonical boolean symbols are
+    already spelled `"True"`/`"False"` — Derive's own printer never
+    intercepts them either (confirmed by reading `printer.rs`: it falls
+    through to the generic `IRNode::Symbol(s) => s.clone()` arm), so there
+    was nothing to fix here.
+  - `Assign`/`Define` need no special-casing either (a finding that
+    shrinks this item's real scope, per the spec's own addendum): once
+    items 2/3 land, those heads' handlers return the bound *value* (or
+    `Symbol(name)`), never an `Assign(...)`/`Define(...)` term, so
+    `toDisplayString` never has to render either head at all — matching
+    every native `<lang>-runtime` printer's own documented invariant.
+  - Depth-capped with the same `MAX_TERM_DEPTH` guard the generic path
+    already uses (CWE-674) — this walk's per-frame cost is no heavier.
+
+### Changed
+
+- **`derive-to-semantic-ir/tests/oracle.rs`**: flips 7 `known_bug` cases
+  to `known_bug: None` — every case whose *only* remaining disagreement
+  was this display-convention gap (verified by actually running the
+  oracle test, not just inferred from source reading):
+  `negation_of_a_free_symbol` (prefix `Neg`), `equation_with_a_free_
+  variable_stays_symbolic` (infix `Equal`), `flat_vector_literal`/
+  `singleton_vector_literal`/`vector_of_expressions_evaluates_
+  elementwise` (flat `List` brackets), `two_by_two_matrix_literal`/
+  `three_row_one_column_matrix_literal` (`;`-row-separated matrix
+  brackets). Every other still-`known_bug` case (the ones also blocked by
+  the held-form/calculus evaluation gaps, items 2/3) has its reason text
+  updated to note the display half is now resolved and only the
+  evaluation half remains.
+
 ## 0.49.0 — `Symbolic.evalTerm`: arithmetic/comparison/logic folding (SIR23 addendum, item 1 of 4)
 
 ### Security fix (found by this item's own `/security-review` pass)

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.49.0"
+version = "0.50.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/README.md
+++ b/code/packages/rust/semantic-ir-to-javascript/README.md
@@ -402,8 +402,10 @@ forward the fix the TypeScript sibling package's own `/security-review`
 found.
 
 `print`/`puts` render a Symbolic term via `Symbolic.toDisplayString`
-(`f(x, 1/3)`-style), reached from `formatSeen` by checking for a plain
-object carrying a `.kind` tag.
+(`f(x, 1/3)`-style — Derive-sourced modules get a different, own-language
+convention instead; see "Derive's own SIR23 display convention" below),
+reached from `formatSeen` by checking for a plain object carrying a
+`.kind` tag.
 
 **`Symbolic.evalTerm` (SIR23 addendum, item 1 of 4 — arithmetic/
 comparison/logic folding only).** Every top-level SIR23 statement
@@ -429,10 +431,10 @@ This item's scope is intentionally narrow:
   today's codegen already produces — no environment, no user-function
   dispatch, no branching. That is item 2's job.
 - **Not wired up at all:** calculus/elementary functions (`Sin`, `D`,
-  `Integrate`, … — item 3) and any per-language display convention
-  (infix `+`/`*`/`^`, `[...]`/`{...}` brackets, case-bridging — item 4).
-  `List` needs no handler ever: applicative-order argument evaluation
-  alone folds `List(Add(1,1), Mul(2,3))` into `List(2, 6)` for free.
+  `Integrate`, … — item 3; held-form execution — `Assign`/`Define`/`If`
+  dispatch — is item 2, above). `List` needs no handler ever:
+  applicative-order argument evaluation alone folds `List(Add(1,1),
+  Mul(2,3))` into `List(2, 6)` for free.
 - `MAX_EVAL_DEPTH = 2000` is `evalTerm`'s own empirically-measured
   recursion-depth cap (CWE-674) — deliberately not a reuse of
   `MAX_TERM_DEPTH` above, which guards a different function
@@ -440,6 +442,43 @@ This item's scope is intentionally narrow:
   per-frame cost. See `runtime.rs`'s own doc comment on the constant for
   the full measurement writeup, and `tests/sir23_eval_depth_guard.rs`
   for the executable proof.
+
+**Derive's own SIR23 display convention (SIR23 addendum, item 4 of 4 —
+display only, scoped to Derive).** `Symbolic.toDisplayString` branches,
+at its own top, on a fourth `SIR_DISPLAY_*` flag — `SIR_DISPLAY_DERIVE`,
+computed from `m.metadata.source_language == "derive"` exactly like the
+existing `SIR_DISPLAY_RUBY`/`SIR_DISPLAY_APL_HIGH_MINUS`/
+`SIR_DISPLAY_J_UNDERSCORE` flags (see the "Array/matrix domain" section
+below for those) — to a separate function family (`deriveRender`/
+`derivePrintAt`/`deriveRenderApply`/`deriveRenderList`) that is a direct,
+byte-for-byte JS port of `derive-runtime::printer::print_derive`'s own
+precedence-based renderer, rather than the generic `head(args, …)` form
+every other source language still gets:
+
+- Infix `Add`/`Sub`/`Mul`/`Div` and comparisons `Equal`/`Less`/`Greater`/
+  `LessEqual`/`GreaterEqual`, n-ary `And`/`Or`, prefix `Neg`/`Not`, and
+  right-associative `Pow` (`a^b^c`), each parenthesised exactly where
+  `printer.rs`'s own 9-level precedence ladder says a looser child needs
+  it.
+- Derive's own `List` bracket convention (D-5): a flat vector prints
+  `[a, b, c]`; a "list of lists" prints as a `;`-row-separated matrix,
+  `[a, b; c, d]`.
+- Case-bridging a fixed table of builtin heads back to Derive's own
+  UPPERCASE surface spelling (`D` → `"DIF"`, `Sin` → `"SIN"`, …); any
+  other head (a user-defined function) renders as-typed.
+- `True`/`False` and `Assign`/`Define` need **no** special-casing: the
+  former already renders identically under both conventions (a bare
+  `Symbol` term's verbatim name); the latter never reach the display path
+  at all once items 2/3 land (their handlers return the bound value, not
+  an `Assign(...)`/`Define(...)` term) — see `runtime.rs`'s own
+  `SIR_DISPLAY_DERIVE` doc comment for the full writeup.
+
+This item has no code dependency on items 2/3 (it touches only
+`toDisplayString`, a different function than `evalTerm`/`evalApply`) and
+is scoped to Derive only — `derive-to-semantic-ir` is the only Stream B
+frontend with an oracle corpus proving it today; Wolfram/Macsyma/Reduce/
+Maple's own conventions are separate future work following the identical
+recipe (one more `SIR_DISPLAY_*` flag + printer port).
 
 ### Array/matrix domain (SIR22 base cut)
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -136,13 +136,26 @@ pub fn emit_module(m: &Module) -> String {
     // the same single `source_language` field), so `runtime.rs`'s
     // `fmtNum` never needs to arbitrate between them.
     //
-    // SECURITY: all three replacement values MUST remain a hardcoded literal
+    // A FOURTH, independent placeholder (SIR23 addendum item 4 of 4 — see
+    // `code/specs/SIR23-symbolic-pattern-semantic-ir.md`'s "Per-language
+    // display convention" section): a Derive-sourced module renders a
+    // compound SIR23 symbolic term through Derive's OWN precedence-aware
+    // infix/prefix/bracket/case-bridged convention (`runtime.rs`'s
+    // `SIR_DISPLAY_DERIVE`, gating `Symbolic.toDisplayString` rather than
+    // `formatSeen`/`fmtNum` — a DIFFERENT stringifier than the first three
+    // flags gate, since this one is about the SIR23 symbolic-expression
+    // domain, not SIR16 booleans or SIR22 arrays), rather than the
+    // generic, source-language-agnostic `head(args, …)` form every other
+    // language (and Derive, before this item) still gets.
+    //
+    // SECURITY: all four replacement values MUST remain a hardcoded literal
     // selected by a boolean — never text derived from `source_language` or
     // any other source-controlled field — so this substitution can never
     // inject into the emitted JavaScript.
     let display_ruby = m.metadata.source_language.as_deref() == Some("ruby");
     let display_apl_high_minus = m.metadata.source_language.as_deref() == Some("apl");
     let display_j_underscore = m.metadata.source_language.as_deref() == Some("j");
+    let display_derive = m.metadata.source_language.as_deref() == Some("derive");
     out.push_str(
         &RUNTIME
             .replace(
@@ -156,6 +169,10 @@ pub fn emit_module(m: &Module) -> String {
             .replace(
                 "__SIR_DISPLAY_J_UNDERSCORE__",
                 if display_j_underscore { "true" } else { "false" },
+            )
+            .replace(
+                "__SIR_DISPLAY_DERIVE__",
+                if display_derive { "true" } else { "false" },
             ),
     );
     emit_ancestry_registration(&mut out, m);

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -3120,11 +3120,29 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     // produces a mixed shape (some elements `List`, some not), so this
     // all-or-nothing check is unambiguous for anything this frontend's own
     // lowering can produce.
+    //
+    // SECURITY (CWE-674, /security-review finding): each `row` is itself
+    // ONE tree level below the `List(...)` node this call is rendering
+    // (the same distance every OTHER child in this function family covers
+    // via a single `derivePrintAt(child, ..., depth + 1)` call) — so
+    // entering it must consume exactly one unit of the shared depth
+    // budget, with its own `depth + 1 > MAX_TERM_DEPTH` check, before its
+    // OWN children (two levels below the current node) get `depth + 2`.
+    // Reaching into `row.args` directly with no check and `depth + 1` for
+    // the grandchildren (the original bug) skipped charging for the `row`
+    // level entirely, letting a nested-list-of-lists chain reach roughly
+    // DOUBLE `MAX_TERM_DEPTH` real tree-nesting levels before the "..."
+    // sentinel fires — still short of this walk's proven-safe crash
+    // margin today, but a real, measured erosion of it; see `tests/
+    // sir23_symbolic.rs::derive_display_on_a_deeply_nested_list_of_lists_
+    // truncates_at_the_same_depth_as_any_other_shape` for the executable
+    // proof (reverting this fix makes that test fail).
     function deriveRenderList(args, depth) {
       if (args.length > 0 && args.every(deriveIsListNode)) {
-        const rows = args.map((row) =>
-          row.args.map((a) => derivePrintAt(a, DERIVE_PREC_LOWEST, depth + 1)).join(", ")
-        );
+        const rows = args.map((row) => {
+          if (depth + 1 > MAX_TERM_DEPTH) { return "..."; }
+          return row.args.map((a) => derivePrintAt(a, DERIVE_PREC_LOWEST, depth + 2)).join(", ");
+        });
         return "[" + rows.join("; ") + "]";
       }
       const parts = args.map((a) => derivePrintAt(a, DERIVE_PREC_LOWEST, depth + 1));

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -112,6 +112,29 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
   // `fmtNum`/`formatSeen` below never need to arbitrate between them —
   // only one can ever be `true` for a given module.
   const SIR_DISPLAY_J_UNDERSCORE = __SIR_DISPLAY_J_UNDERSCORE__;
+  // A FOURTH, independent display-convention flag (SIR23 addendum, item 4
+  // of 4 — see `code/specs/SIR23-symbolic-pattern-semantic-ir.md`'s own
+  // "Per-language display convention" section): `true` when the module's
+  // `source_language` is Derive, else `false`. Unlike the three flags
+  // above (which all gate `formatSeen`'s bare-number/`SirFloat` branches),
+  // this one gates `Symbolic.toDisplayString` (further below, in the
+  // "Symbolic expressions" section) — the SIR23 domain's own stringifier,
+  // which until this item had no per-language convention at ALL (every
+  // source language rendered every compound term identically, generically,
+  // as `head(args, …)`). Derive's OWN convention — infix
+  // `+`/`-`/`*`/`/`/`^`, prefix `-`/`NOT`, a `;`-row-separated
+  // `[a, b; c, d]` bracket convention for `List`, and case-bridging a
+  // handful of builtin heads back to Derive's own UPPERCASE surface
+  // spelling (`Sin` → `"SIN"`, …) — is a direct, byte-for-byte port of
+  // `derive-runtime::printer::print_derive`'s existing, already-written
+  // precedence ladder; see `Symbolic`'s own `toDisplayString` for the full
+  // port and its own doc comment for the precedence-level mapping.
+  // Mutually exclusive with the three flags above by construction (all
+  // four are computed from the same single `source_language` field in
+  // `emit.rs`), and orthogonal in EFFECT too, since no `<lang>-to-
+  // semantic-ir` frontend that sets one of the first three (Ruby/APL/J)
+  // emits any SIR23 `SymApply`/`SymSymbol` node at all today.
+  const SIR_DISPLAY_DERIVE = __SIR_DISPLAY_DERIVE__;
   // ── value model ────────────────────────────────────────────────
   // A symbol is an interned name; `===` on two interned symbols with
   // the same name is therefore identity-equal.
@@ -2988,6 +3011,218 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
 
     function headName(node) { return node.kind === "symbol" ? node.name : ""; }
 
+    // ── Derive's own SIR23 display convention (SIR_DISPLAY_DERIVE) ────
+    //
+    // A direct, byte-for-byte JS port of `derive-runtime::printer`'s
+    // precedence-based renderer (`print_derive`/`print_at`/`render`/
+    // `render_apply`/`render_list`/`infix_binary`/`nary_logic`/
+    // `ir_head_to_surface`) — SIR23 addendum item 4 (see `code/specs/
+    // SIR23-symbolic-pattern-semantic-ir.md`'s "Per-language display
+    // convention" section). Kept as its OWN set of functions rather than
+    // folded into the generic `toDisplayString` below, because the two
+    // conventions disagree on almost every compound shape (infix vs.
+    // generic `head(args)`, `;`-row-separated brackets vs. none,
+    // case-bridged builtin names vs. verbatim) — keeping them apart means
+    // neither reader has to mentally subtract the other's special cases.
+    // `toDisplayString` picks between the two wholesale, once, at its own
+    // top (see that function, below).
+    //
+    // Precedence ladder (loosest -> tightest), copied verbatim from
+    // `derive-runtime/src/printer.rs`'s own module-doc table:
+    //
+    //   0 lowest  (top-level / a generic call's argument position)
+    //   1 Or
+    //   2 And
+    //   3 Not (prefix) / comparisons  =  <=  <  >  >=
+    //   4 Add Sub
+    //   5 Mul Div  (and a bare Rational leaf, e.g. `1/3`)
+    //   6 unary Neg
+    //   7 Pow
+    //   8 atoms, F(…)
+    const DERIVE_PREC_LOWEST = 0;
+    const DERIVE_PREC_OR = 1;
+    const DERIVE_PREC_AND = 2;
+    const DERIVE_PREC_NOT_CMP = 3;
+    const DERIVE_PREC_ADD = 4;
+    const DERIVE_PREC_MUL = 5;
+    const DERIVE_PREC_NEG = 6;
+    const DERIVE_PREC_POW = 7;
+    const DERIVE_PREC_ATOM = 8;
+
+    // Binary infix arithmetic/comparison operators — `[surface, prec]`,
+    // mirroring `printer.rs::infix_binary` exactly (a `NotEqual` head has
+    // no entry here, matching that table exactly: Derive's own grammar has
+    // no "<>"/"!=" operator, so a `NotEqual` term — if one is ever built —
+    // falls through to the generic, case-bridged call form below, exactly
+    // as `printer.rs` itself does).
+    const DERIVE_INFIX_BINARY = new Map([
+      ["Add", [" + ", DERIVE_PREC_ADD]],
+      ["Sub", [" - ", DERIVE_PREC_ADD]],
+      ["Mul", ["*", DERIVE_PREC_MUL]],
+      ["Div", ["/", DERIVE_PREC_MUL]],
+      ["Equal", [" = ", DERIVE_PREC_NOT_CMP]],
+      ["Less", [" < ", DERIVE_PREC_NOT_CMP]],
+      ["Greater", [" > ", DERIVE_PREC_NOT_CMP]],
+      ["LessEqual", [" <= ", DERIVE_PREC_NOT_CMP]],
+      ["GreaterEqual", [" >= ", DERIVE_PREC_NOT_CMP]],
+    ]);
+
+    // n-ary associative logic — `[join-text, prec]`, mirroring
+    // `printer.rs::nary_logic`. A flat `And(a, b, c, …)`/`Or(a, b, c, …)`
+    // chain (matching how this frontend's own lowering already flattens a
+    // homogeneous run rather than nesting pairwise) joins with
+    // `" AND "`/`" OR "`.
+    const DERIVE_NARY_LOGIC = new Map([
+      ["And", [" AND ", DERIVE_PREC_AND]],
+      ["Or", [" OR ", DERIVE_PREC_OR]],
+    ]);
+
+    // The IR -> surface head dictionary — the exact same table as
+    // `printer.rs::ir_head_to_surface`. An unrecognised head (a
+    // user-defined function, or a head like `Abs`/`Inv`/`NotEqual` this
+    // subset's own printer never bridges either) renders AS-TYPED, exactly
+    // matching the Rust reference's `unwrap_or(name)` fallback.
+    const DERIVE_HEAD_TO_SURFACE = new Map([
+      ["D", "DIF"],
+      ["Integrate", "INT"],
+      ["If", "IF"],
+      ["Sin", "SIN"],
+      ["Cos", "COS"],
+      ["Tan", "TAN"],
+      ["Sqrt", "SQRT"],
+      ["Exp", "EXP"],
+      ["Log", "LOG"],
+      ["Atan", "ATAN"],
+      ["Asin", "ASIN"],
+      ["Acos", "ACOS"],
+      ["Sinh", "SINH"],
+      ["Cosh", "COSH"],
+      ["Tanh", "TANH"],
+      ["Asinh", "ASINH"],
+      ["Acosh", "ACOSH"],
+      ["Atanh", "ATANH"],
+      ["Coth", "COTH"],
+      ["Sech", "SECH"],
+      ["Csch", "CSCH"],
+    ]);
+
+    // True if `node` is itself a `List(...)` apply — `printer.rs::
+    // is_list_node`'s exact mirror.
+    function deriveIsListNode(node) {
+      return node.kind === "apply" && node.head.kind === "symbol" && node.head.name === "List";
+    }
+
+    // Render a `List(...)` node in Derive's own bracket surface (D-5) —
+    // the exact reverse of `derive-runtime::lower::lower_vector`,
+    // mirroring `printer.rs::render_list`. A matrix (every element ITSELF
+    // a `List`) prints `;`-separated rows; a flat vector (or the empty
+    // list) prints `,`-separated (or empty) — `lower_vector` never
+    // produces a mixed shape (some elements `List`, some not), so this
+    // all-or-nothing check is unambiguous for anything this frontend's own
+    // lowering can produce.
+    function deriveRenderList(args, depth) {
+      if (args.length > 0 && args.every(deriveIsListNode)) {
+        const rows = args.map((row) =>
+          row.args.map((a) => derivePrintAt(a, DERIVE_PREC_LOWEST, depth + 1)).join(", ")
+        );
+        return "[" + rows.join("; ") + "]";
+      }
+      const parts = args.map((a) => derivePrintAt(a, DERIVE_PREC_LOWEST, depth + 1));
+      return "[" + parts.join(", ") + "]";
+    }
+
+    // Render `node`, returning `[text, ownPrecedence]` — `printer.rs::
+    // render`'s exact mirror.
+    //
+    // SECURITY (CWE-674): capped with the SAME `MAX_TERM_DEPTH` guard
+    // `toDisplayString` uses below (reused deliberately — this walk's
+    // per-frame cost, a `kind` switch plus at most one more recursive call
+    // per level, is no heavier than `toDisplayString`'s own
+    // already-proven-safe-at-that-cap frame).
+    function deriveRender(node, depth) {
+      if (depth > MAX_TERM_DEPTH) { return ["...", DERIVE_PREC_ATOM]; }
+      switch (node.kind) {
+        case "integer": return [String(node.value), DERIVE_PREC_ATOM];
+        case "float": return [String(node.value), DERIVE_PREC_ATOM];
+        case "rational": return [node.numer + "/" + node.denom, DERIVE_PREC_MUL];
+        case "string": return [JSON.stringify(node.value), DERIVE_PREC_ATOM];
+        case "symbol": return [node.name, DERIVE_PREC_ATOM];
+        case "apply": return deriveRenderApply(node, depth);
+        default: return [String(node), DERIVE_PREC_ATOM];
+      }
+    }
+
+    // Render `node`, wrapping it in parentheses if its own precedence is
+    // looser than `parentPrec` — `printer.rs::print_at`'s exact mirror,
+    // the one place parenthesisation is actually decided (so the surface
+    // string re-parses to the same tree).
+    function derivePrintAt(node, parentPrec, depth) {
+      const [text, prec] = deriveRender(node, depth);
+      return prec < parentPrec ? "(" + text + ")" : text;
+    }
+
+    // Render a compound `head(args)` node in Derive's own convention —
+    // `printer.rs::render_apply`'s exact mirror (infix binary, n-ary
+    // logic, then the `Pow`/`Neg`/`Not`/`List` special cases, then the
+    // generic, case-bridged call form).
+    function deriveRenderApply(node, depth) {
+      const head = node.head;
+      const args = node.args;
+      if (head.kind === "symbol") {
+        const name = head.name;
+        const infix = DERIVE_INFIX_BINARY.get(name);
+        if (infix && args.length === 2) {
+          const [op, prec] = infix;
+          const l = derivePrintAt(args[0], prec, depth + 1);
+          const r = derivePrintAt(args[1], prec, depth + 1);
+          return [l + op + r, prec];
+        }
+        const logic = DERIVE_NARY_LOGIC.get(name);
+        if (logic) {
+          const [op, prec] = logic;
+          if (args.length >= 2) {
+            const parts = args.map((a) => derivePrintAt(a, prec, depth + 1));
+            return [parts.join(op), prec];
+          }
+          if (args.length === 1) { return deriveRender(args[0], depth + 1); }
+        }
+        if (name === "Pow" && args.length === 2) {
+          // Right-associative and tighter than unary minus, matching
+          // `printer.rs`'s own `POW` arm exactly (`PREC_POW + 1` for the
+          // base so a LEFT-nested `Pow` parenthesises while a
+          // RIGHT-nested one doesn't; `PREC_NEG` for the exponent so a
+          // bare `Neg` there needs no parens but anything looser does).
+          const base = derivePrintAt(args[0], DERIVE_PREC_POW + 1, depth + 1);
+          const exp = derivePrintAt(args[1], DERIVE_PREC_NEG, depth + 1);
+          return [base + "^" + exp, DERIVE_PREC_POW];
+        }
+        if (name === "Neg" && args.length === 1) {
+          const inner = derivePrintAt(args[0], DERIVE_PREC_NEG, depth + 1);
+          return ["-" + inner, DERIVE_PREC_NEG];
+        }
+        if (name === "Not" && args.length === 1) {
+          const inner = derivePrintAt(args[0], DERIVE_PREC_NOT_CMP, depth + 1);
+          return ["NOT " + inner, DERIVE_PREC_NOT_CMP];
+        }
+        if (name === "List") {
+          return [deriveRenderList(args, depth), DERIVE_PREC_ATOM];
+        }
+        // Ordinary function application: `head(args…)`, bridging the
+        // canonical IR head back to Derive's uppercase surface spelling;
+        // an unrecognised head (a user-defined function) renders as-typed.
+        // Each argument renders at `DERIVE_PREC_LOWEST` (a fresh,
+        // comma-separated slot never needs parens of its own), matching
+        // `printer.rs`'s own `args.iter().map(print_derive)`.
+        const surface = DERIVE_HEAD_TO_SURFACE.get(name) || name;
+        const parts = args.map((a) => derivePrintAt(a, DERIVE_PREC_LOWEST, depth + 1));
+        return [surface + "(" + parts.join(", ") + ")", DERIVE_PREC_ATOM];
+      }
+      // A computed (non-symbol) head — render generically as `(head)(args…)`.
+      const headText = derivePrintAt(head, DERIVE_PREC_ATOM, depth + 1);
+      const parts = args.map((a) => derivePrintAt(a, DERIVE_PREC_LOWEST, depth + 1));
+      return [headText + "(" + parts.join(", ") + ")", DERIVE_PREC_ATOM];
+    }
+
     // A display helper `print`/`puts`/`formatSeen` (above) reach for,
     // mirroring `symbolic-ir`'s own `toDisplayString`. Not part of the
     // SIR23 spec's own contract.
@@ -3007,6 +3242,15 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     function toDisplayString(node, depth) {
       if (depth === undefined) { depth = 0; }
       if (depth > MAX_TERM_DEPTH) { return "..."; }
+      // SIR_DISPLAY_DERIVE (SIR23 addendum item 4): Derive's own
+      // precedence-aware, infix/prefix/bracket/case-bridged convention —
+      // see `deriveRender`'s own doc comment (just above) for the full
+      // port. Entirely separate from the generic `head(args, …)` form
+      // below, which every OTHER source language (and Derive before this
+      // item) still gets.
+      if (SIR_DISPLAY_DERIVE) {
+        return derivePrintAt(node, DERIVE_PREC_LOWEST, depth);
+      }
       switch (node.kind) {
         case "symbol": return node.name;
         case "integer": return String(node.value);

--- a/code/packages/rust/semantic-ir-to-javascript/tests/sir23_symbolic.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/sir23_symbolic.rs
@@ -330,3 +330,108 @@ fn print_on_deeply_nested_term_truncates_instead_of_crashing_node() {
         assert!(stdout.contains("..."), "got: {stdout}");
     }
 }
+
+#[test]
+fn derive_display_on_a_deeply_nested_list_of_lists_truncates_at_the_same_depth_as_any_other_shape()
+{
+    // Regression test (/security-review finding on SIR_DISPLAY_DERIVE):
+    // `deriveRenderList`'s matrix branch (every element of a `List(...)`
+    // itself a `List`) used to reach into a `row`'s own `.args` directly,
+    // skipping the `depth + 1 > MAX_TERM_DEPTH` check every OTHER shape
+    // in this function family pays for descending one tree level, and
+    // handing the row's OWN children `depth + 1` instead of `depth + 2` —
+    // so two real tree-nesting levels consumed only one unit of the
+    // shared depth budget. A chain of `N` nested single-element
+    // `List(...)` wrappers (built via a real, compiled `for`-loop — an
+    // ordinary runtime VALUE, not a giant hand-built static AST, exactly
+    // like `print_on_deeply_nested_term_truncates_instead_of_crashing_
+    // node` above) is exactly the shape that bug doubled: pre-fix, this
+    // walk's effective depth budget was roughly `2 * MAX_TERM_DEPTH`
+    // (~1024) real nesting levels before the "..." sentinel fired, vs.
+    // every other shape's `MAX_TERM_DEPTH` (512). `N = 700` sits strictly
+    // between those two numbers, so this is a genuine discriminating
+    // test: reverting the `deriveRenderList` fix makes this test FAIL
+    // (the pre-fix build renders the full 700-level nest with no "..." at
+    // all, since 700 real levels only charged ~350 units of the buggy
+    // halved budget), not just a weaker "doesn't crash" check.
+    //
+    // for i in range(0, 700, 1) { acc = List(acc) }
+    // print(acc)   -- source_language "derive", so SIR_DISPLAY_DERIVE
+    //                 is on and this walk actually goes through
+    //                 deriveRenderList, not the generic toDisplayString.
+    let stmts = vec![
+        Stmt::LetBinding {
+            name: "acc".into(),
+            sir_type: None,
+            value: sym_apply(sym("List"), vec![sym("leaf")]),
+            span: sp(),
+        },
+        Stmt::ForRange {
+            var: "i".into(),
+            start: Expr::IntLit {
+                value: 0,
+                span: sp(),
+            },
+            stop: Expr::IntLit {
+                value: 700,
+                span: sp(),
+            },
+            step: Expr::IntLit {
+                value: 1,
+                span: sp(),
+            },
+            body: Block {
+                stmts: vec![Stmt::Assign {
+                    name: "acc".into(),
+                    scope: Scope::Local,
+                    value: sym_apply(sym("List"), vec![local("acc")]),
+                    span: sp(),
+                }],
+                value: Expr::NilLit { span: sp() },
+                span: sp(),
+            },
+            span: sp(),
+        },
+        print(local("acc")),
+    ];
+    let module = Module {
+        name: "sir23".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::SymbolicExpr,
+            Feature::Loops,
+            Feature::MutableBindings,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts,
+                value: Expr::IntLit {
+                    value: 0,
+                    span: sp(),
+                },
+                span: sp(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: sp(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("derive")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    };
+    if let Some(stdout) = run_module(&module, "sym_deep_derive_display") {
+        assert!(
+            stdout.contains("..."),
+            "expected truncation well before 700 real nesting levels under the intended \
+             MAX_TERM_DEPTH=512 cap, got the full render instead (the deriveRenderList depth-\
+             charging regression this test guards against): {stdout}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a fourth `SIR_DISPLAY_*` per-language flag, `SIR_DISPLAY_DERIVE`, to `semantic-ir-to-javascript`'s inlined JS runtime — mirroring the existing `SIR_DISPLAY_RUBY`/`SIR_DISPLAY_APL_HIGH_MINUS`/`SIR_DISPLAY_J_UNDERSCORE` mechanism, but gating `Symbolic.toDisplayString` (the SIR23 symbolic-domain stringifier) rather than `formatSeen`/`fmtNum`.
- This is SIR23 addendum item 4 of 4 (item 1 — arithmetic/comparison/logic folding — landed as 0.49.0; items 2/3 — held-form execution and calculus — remain separate, not-yet-started work).
- Ports `derive-runtime::printer::print_derive`'s precedence-based renderer byte-for-byte to JS: infix `+`/`-`/`*`/`/` and comparisons, n-ary `AND`/`OR`, prefix `-`/`NOT`, right-associative `^`, Derive's own `;`-row-separated `[a, b; c, d]` matrix bracket convention, and case-bridging back to Derive's UPPERCASE surface spelling (`Sin`→`SIN`, etc.). Verified against the actual `printer.rs` source line-by-line — every table and precedence level matches exactly.
- Flips 7 display-convention-only `known_bug` oracle cases in `derive-to-semantic-ir/tests/oracle.rs` to `known_bug: None` (25 of 38 total now pass end-to-end); the remaining 13 stay `known_bug`, blocked purely by the still-open held-form/calculus evaluation gap (items 2/3).
- Bumps `semantic-ir-to-javascript` 0.49.0→0.50.0, `derive-to-semantic-ir` 0.1.2→0.1.3, with CHANGELOG/README updates on both.

## Security fix included
`/security-review` found a real MEDIUM issue in the initial build: the new `deriveRenderList`'s matrix (list-of-lists) branch reached into each row's `.args` directly instead of routing the row through the same depth-checked path every other shape in the function family uses — so descending one real tree level cost zero depth-budget, roughly doubling the effective `MAX_TERM_DEPTH` (512) cap for nested-list input before truncation. Fixed by charging exactly one depth unit per row level. Added a permanent regression test (`derive_display_on_a_deeply_nested_list_of_lists_truncates_at_the_same_depth_as_any_other_shape`) that builds the shape via a real compiled `for`-loop and — verified by reverting the fix — genuinely fails without it. A second security-review round on the fix itself passed clean.

## Verification
- Independently re-ran `cargo test -p semantic-ir-to-javascript -p derive-to-semantic-ir` (full suite, both crates) — all green, including the oracle test (confirmed via `--nocapture` showing exactly 13 `KNOWN BUG` skip messages, meaning the 25 `known_bug: None` cases were actually asserted).
- Spot-verified the fix is genuinely load-bearing: temporarily forced `display_derive = false`, confirmed the oracle test then fails (`"Neg(x)"` instead of `"-x"`), then reverted.
- Cross-checked every constant/table/function in the new `deriveRender*` family against the actual `derive-runtime::printer::print_derive` Rust source — confirmed byte-for-byte faithful port.
- `cargo clippy --all-targets` clean.
- Two rounds of `/security-review`-equivalent agent review: round 1 found the MEDIUM depth-guard issue (fixed + regression-tested), round 2 (on the fix) passed clean.

## Test plan
- [x] `cargo test -p semantic-ir-to-javascript -p derive-to-semantic-ir` — all green
- [x] New depth-guard regression test genuinely discriminates (reverted → fails, restored → passes)
- [x] `cargo clippy --all-targets` clean
- [x] Two security-review rounds, both resolved/clean