### PR TITLE
feat(spice): add BJT flicker exponent

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add BJT model-card `AF` flicker-noise exponent support, defaulting to `1`
+  and applying `KF * abs(Ib)^AF / frequency` across noise analysis.
 - Add BJT model-card `KF` flicker-noise support with a distinct `flicker`
   contribution and Berkeley-default inverse-frequency scaling.
 - Add BJT model-card `TNOM` / `T_NOM` nominal-temperature support, with

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -241,8 +241,8 @@ omitted.
 It overrides the circuit-level nominal temperature for BJT temperature scaling;
 omitting it preserves the inherited default.
 `KF` (default `0`, disabled) adds a distinct BJT base-current flicker-noise
-source to `.NOISE`, using Berkeley's default `AF=1` exponent so source PSD is
-`KF * abs(Ib) / frequency`.
+source to `.NOISE`. `AF` (default `1`) controls the base-current exponent, so
+source PSD is `KF * abs(Ib)^AF / frequency`.
 `model_card_unsupported_parameter_issues()`,
 `format_model_card_unsupported_parameter_issue_table()`,
 `model_card_unsupported_parameter_issue_records()`,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -610,6 +610,8 @@ class BJT:
         analysis uses its circuit-level nominal temperature.
     Kf:
         Flicker-noise coefficient (default 0.0, disabled).
+    Af:
+        Flicker-noise base-current exponent (default 1.0).
     """
 
     name: str
@@ -645,6 +647,7 @@ class BJT:
     Ikr: float = 0.0        # reverse-beta roll-off current (A); 0 disables
     Tnom: float | None = None  # model nominal temperature (K); None inherits
     Kf: float = 0.0            # flicker-noise coefficient; 0 disables
+    Af: float = 1.0            # flicker-noise base-current exponent
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -605,7 +605,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr, element.Tnom, element.Kf)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr, element.Tnom, element.Kf, element.Af)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -9307,6 +9307,8 @@ def _validate_bjt(el: BJT) -> None:
         raise ValueError(f"{el.name}: BJT nominal temperature must be finite and positive")
     if not math.isfinite(el.Kf) or el.Kf < 0.0:
         raise ValueError(f"{el.name}: BJT flicker noise coefficient must be finite and non-negative")
+    if not math.isfinite(el.Af) or el.Af < 0.0:
+        raise ValueError(f"{el.name}: BJT flicker noise exponent must be finite and non-negative")
     if not math.isfinite(el.Ise) or el.Ise < 0.0:
         raise ValueError(
             f"{el.name}: BJT base-emitter leakage saturation current must be finite and non-negative"
@@ -14854,7 +14856,7 @@ def _collect_noise_sources(
             sources.append((el.name, "shot", n_b, n_e, psd, 0.0))
             if el.Kf > 0.0:
                 base_current = base_collector_current / el.beta_f + leakage_current
-                sources.append((el.name, "flicker", n_b, n_e, el.Kf * abs(base_current), 1.0))
+                sources.append((el.name, "flicker", n_b, n_e, el.Kf * abs(base_current) ** el.Af, 1.0))
 
         elif isinstance(el, Mosfet):
             # Long-channel MOSFET channel thermal noise: S_i = 4kTγgm.

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (28, 45, 13, 4),
-    "PNP": (28, 45, 13, 4),
+    "NPN": (29, 46, 13, 4),
+    "PNP": (29, 46, 13, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -382,6 +382,7 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "TNOM": "TNOM",
     "T_NOM": "TNOM",
     "KF": "KF",
+    "AF": "AF",
     "ISE": "ISE",
     "NE": "NE",
     "ISC": "ISC",
@@ -945,6 +946,7 @@ def bjt_from_model_card(
         Ikr=p.get("IKR", 0.0),
         Tnom=(p["TNOM"] + 273.15) if "TNOM" in p else None,
         Kf=p.get("KF", 0.0),
+        Af=p.get("AF", 1.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 114
+    assert len(coverage) == 116
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 114
+    assert len(records) == 116
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,9 +501,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 114
-    assert report.expected_canonical_parameter_count == 114
-    assert report.accepted_name_count == 180
+    assert report.canonical_parameter_count == 116
+    assert report.expected_canonical_parameter_count == 116
+    assert report.accepted_name_count == 182
     assert report.aliased_parameter_count == 53
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -511,7 +511,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t114\t114\t180\t53\t4\t0"
+        "true\t7\t7\t116\t116\t182\t53\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,8 +539,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 113
-    assert report.accepted_name_count == 177
+    assert report.canonical_parameter_count == 115
+    assert report.accepted_name_count == 179
     assert report.aliased_parameter_count == 52
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t113\t114\t177\t52\t4\t4\n"
+        "false\t7\t7\t115\t116\t179\t52\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,10 +647,10 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "KF": 1.0e-12, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
+        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "TNOM": 50.0, "KF": 1.0e-12, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
+    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "TNOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.beta_r == pytest.approx(0.25)
@@ -664,6 +664,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert bjt_model.Ikr == pytest.approx(3.0e-3)
     assert bjt_model.Tnom == pytest.approx(323.15)
     assert bjt_model.Kf == pytest.approx(1.0e-12)
+    assert bjt_model.Af == pytest.approx(1.3)
     assert bjt_model.Ise == pytest.approx(3.0e-13)
     assert bjt_model.Ne == pytest.approx(1.7)
     assert bjt_model.Isc == pytest.approx(4.0e-13)
@@ -2305,7 +2306,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3, Tnom=323.15, Kf=1.0e-12),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3, Tnom=323.15, Kf=1.0e-12, Af=1.3),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2333,6 +2334,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.Ikr == pytest.approx(3.0e-3)
     assert expanded.Tnom == pytest.approx(323.15)
     assert expanded.Kf == pytest.approx(1.0e-12)
+    assert expanded.Af == pytest.approx(1.3)
 
 
 def test_branch_current_in_voltage_source():
@@ -2577,6 +2579,13 @@ def test_dc_rejects_invalid_bjt_flicker_noise_coefficient():
     circuit = Circuit()
     circuit.add(BJT("Qbad", "c", "b", "0", Kf=-1.0))
     with pytest.raises(ValueError, match="flicker noise coefficient must be finite and non-negative"):
+        dc_op(circuit)
+
+
+def test_dc_rejects_invalid_bjt_flicker_noise_exponent():
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", Af=-1.0))
+    with pytest.raises(ValueError, match="flicker noise exponent must be finite and non-negative"):
         dc_op(circuit)
 
 
@@ -6952,6 +6961,23 @@ def test_noise_bjt_kf_adds_inverse_frequency_flicker_noise() -> None:
 
     assert flicker_psds[0] > 0.0
     assert flicker_psds[0] / flicker_psds[1] == pytest.approx(100.0)
+
+
+def test_noise_bjt_af_controls_base_current_exponent() -> None:
+    def source_psd(exponent: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vcc", "vcc", "0", 5.0))
+        circuit.add(VoltageSource("Vbase", "base", "0", 0.7))
+        circuit.add(Resistor("Rc", "vcc", "col", 1_000.0))
+        circuit.add(BJT("Q1", "col", "base", "0", Kf=1.0e-12, Af=exponent))
+        point = noise_ac(circuit, "col", "Vbase", freqs=[1_000.0]).points[0]
+        return next(
+            entry.source_psd
+            for entry in point.entries
+            if entry.element_name == "Q1" and entry.noise_type == "flicker"
+        )
+
+    assert source_psd(2.0) < source_psd(1.0)
 
 
 def test_noise_bjt_forward_beta_rolloff_reduces_shot_noise() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add BJT model-card `AF` flicker-noise exponent support, defaulting to `1`
+  and applying `KF * abs(Ib)^AF / frequency` across noise analysis.
 - Add BJT model-card `KF` flicker-noise support with a distinct `flicker`
   contribution and Berkeley-default inverse-frequency scaling.
 - Add BJT model-card `TNOM` / `T_NOM` nominal-temperature support, with

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -158,8 +158,8 @@ omitted.
 It overrides the circuit-level nominal temperature for BJT temperature scaling;
 omitting it preserves the inherited default.
 `KF` (default `0`, disabled) adds a distinct BJT base-current flicker-noise
-source to `.NOISE`, using Berkeley's default `AF=1` exponent so source PSD is
-`KF * abs(Ib) / frequency`.
+source to `.NOISE`. `AF` (default `1`) controls the base-current exponent, so
+source PSD is `KF * abs(Ib)^AF / frequency`.
 `model_card_unsupported_parameter_issues`,
 `format_model_card_unsupported_parameter_issue_table`,
 `model_card_unsupported_parameter_issue_records`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -455,6 +455,7 @@ fn clone_subckt_element(
             expanded.reverse_beta_rolloff_current = element.reverse_beta_rolloff_current;
             expanded.nominal_temperature_kelvin = element.nominal_temperature_kelvin;
             expanded.flicker_noise_coefficient = element.flicker_noise_coefficient;
+            expanded.flicker_noise_exponent = element.flicker_noise_exponent;
             Element::Bjt(expanded)
         }
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
@@ -2898,6 +2899,7 @@ pub struct Bjt {
     pub reverse_beta_rolloff_current: f64,
     pub nominal_temperature_kelvin: Option<f64>,
     pub flicker_noise_coefficient: f64,
+    pub flicker_noise_exponent: f64,
 }
 
 impl Bjt {
@@ -3362,6 +3364,7 @@ impl Bjt {
             reverse_beta_rolloff_current: 0.0,
             nominal_temperature_kelvin: None,
             flicker_noise_coefficient: 0.0,
+            flicker_noise_exponent: 1.0,
         }
     }
 }
@@ -3752,8 +3755,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 28, 45, 13, 4),
-    (ModelCardKind::Pnp, 28, 45, 13, 4),
+    (ModelCardKind::Npn, 29, 46, 13, 4),
+    (ModelCardKind::Pnp, 29, 46, 13, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3807,6 +3810,7 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("TNOM", "TNOM"),
     ("T_NOM", "TNOM"),
     ("KF", "KF"),
+    ("AF", "AF"),
     ("ISE", "ISE"),
     ("NE", "NE"),
     ("ISC", "ISC"),
@@ -4502,6 +4506,7 @@ pub fn bjt_from_model_card(
         .get("TNOM")
         .map(|temperature_celsius| temperature_celsius + 273.15);
     bjt.flicker_noise_coefficient = model_card_value(model, "KF", 0.0);
+    bjt.flicker_noise_exponent = model_card_value(model, "AF", 1.0);
     Ok(bjt)
 }
 
@@ -22202,7 +22207,8 @@ fn collect_noise_sources(
                         noise_type: NoiseType::Flicker,
                         positive,
                         negative,
-                        source_psd: bjt.flicker_noise_coefficient * base_current.abs(),
+                        source_psd: bjt.flicker_noise_coefficient
+                            * base_current.abs().powf(bjt.flicker_noise_exponent),
                         frequency_exponent: 1.0,
                     });
                 }
@@ -24041,6 +24047,12 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "flicker noise coefficient must be finite and non-negative".to_string(),
+        });
+    }
+    if !bjt.flicker_noise_exponent.is_finite() || bjt.flicker_noise_exponent < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "flicker noise exponent must be finite and non-negative".to_string(),
         });
     }
     if !bjt.base_emitter_leakage_saturation_current.is_finite()

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 114);
+    assert_eq!(coverage.len(), 116);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 114);
+    assert_eq!(records.len(), 116);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 114);
-    assert_eq!(report.expected_canonical_parameter_count, 114);
-    assert_eq!(report.accepted_name_count, 180);
+    assert_eq!(report.canonical_parameter_count, 116);
+    assert_eq!(report.expected_canonical_parameter_count, 116);
+    assert_eq!(report.accepted_name_count, 182);
     assert_eq!(report.aliased_parameter_count, 53);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t114\t114\t180\t53\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t116\t116\t182\t53\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,8 +235,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 113);
-    assert_eq!(report.accepted_name_count, 177);
+    assert_eq!(report.canonical_parameter_count, 115);
+    assert_eq!(report.accepted_name_count, 179);
     assert_eq!(report.aliased_parameter_count, 52);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t113\t114\t177\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t115\t116\t179\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -438,6 +438,7 @@ fn model_card_aliases_build_device_instances() {
             ("IKR", 3.0e-3),
             ("T_NOM", 50.0),
             ("KF", 1.0e-12),
+            ("AF", 1.3),
             ("ISE", 3.0e-13),
             ("NE", 1.7),
             ("ISC", 4.0e-13),
@@ -465,6 +466,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("IKR").unwrap(), 3.0e-3);
     assert_close(*bjt_card.parameters.get("TNOM").unwrap(), 50.0);
     assert_close(*bjt_card.parameters.get("KF").unwrap(), 1.0e-12);
+    assert_close(*bjt_card.parameters.get("AF").unwrap(), 1.3);
     assert_close(*bjt_card.parameters.get("ISE").unwrap(), 3.0e-13);
     assert_close(*bjt_card.parameters.get("NE").unwrap(), 1.7);
     assert_close(*bjt_card.parameters.get("ISC").unwrap(), 4.0e-13);
@@ -489,6 +491,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(bjt_model.reverse_beta_rolloff_current, 3.0e-3);
     assert_close(bjt_model.nominal_temperature_kelvin.unwrap(), 323.15);
     assert_close(bjt_model.flicker_noise_coefficient, 1.0e-12);
+    assert_close(bjt_model.flicker_noise_exponent, 1.3);
     assert_close(bjt_model.base_emitter_leakage_saturation_current, 3.0e-13);
     assert_close(bjt_model.base_emitter_leakage_emission_coefficient, 1.7);
     assert_close(bjt_model.base_collector_leakage_saturation_current, 4.0e-13);
@@ -1431,6 +1434,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     bjt.reverse_beta_rolloff_current = 3.0e-3;
     bjt.nominal_temperature_kelvin = Some(323.15);
     bjt.flicker_noise_coefficient = 1.0e-12;
+    bjt.flicker_noise_exponent = 1.3;
     let mut circuit = Circuit::new();
     circuit
         .define_subcircuit(SubcircuitDefinition::new(
@@ -1476,6 +1480,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.reverse_beta_rolloff_current, 3.0e-3);
     assert_close(expanded.nominal_temperature_kelvin.unwrap(), 323.15);
     assert_close(expanded.flicker_noise_coefficient, 1.0e-12);
+    assert_close(expanded.flicker_noise_exponent, 1.3);
 }
 
 #[test]
@@ -2007,6 +2012,18 @@ fn dc_rejects_invalid_bjt_flicker_noise_coefficient() {
     assert!(error
         .to_string()
         .contains("flicker noise coefficient must be finite and non-negative"));
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_flicker_noise_exponent() {
+    let mut transistor = Bjt::new("Qbad", "c", "b", "0");
+    transistor.flicker_noise_exponent = -1.0;
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Bjt(transistor));
+    let error = dc_op(&circuit).unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("flicker noise exponent must be finite and non-negative"));
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -118,6 +118,36 @@ fn bjt_flicker_noise_uses_kf_with_inverse_frequency_scaling() {
     assert_close(flicker_psd(0) / flicker_psd(1), 100.0, 1.0e-10);
 }
 
+#[test]
+fn bjt_flicker_noise_uses_af_base_current_exponent() {
+    let source_psd = |exponent: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vcc", "vcc", "0", 5.0,
+        )));
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vbase", "base", "0", 0.7,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rload", "vcc", "out", 1_000.0,
+        )));
+        let mut transistor = Bjt::new("Q1", "out", "base", "0");
+        transistor.flicker_noise_coefficient = 1.0e-12;
+        transistor.flicker_noise_exponent = exponent;
+        circuit.add(Element::Bjt(transistor));
+        noise_ac(&circuit, "out", "Vbase", &[1_000.0], 300.0)
+            .unwrap()
+            .points[0]
+            .entries
+            .iter()
+            .find(|entry| entry.element_name == "Q1" && entry.noise_type == NoiseType::Flicker)
+            .unwrap()
+            .source_psd
+    };
+
+    assert!(source_psd(2.0) < source_psd(1.0));
+}
+
 const BOLTZMANN: f64 = 1.380_649e-23;
 const MOSFET_CHANNEL_NOISE_GAMMA: f64 = 2.0 / 3.0;
 

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add BJT model-card `AF` flicker-noise exponent support, defaulting to `1`
+  and applying `KF * abs(Ib)^AF / frequency` across noise analysis.
 - Add BJT model-card `KF` flicker-noise support with a distinct `flicker`
   contribution and Berkeley-default inverse-frequency scaling.
 - Add BJT model-card `TNOM` / `T_NOM` nominal-temperature support, with

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -228,8 +228,8 @@ omitted.
 It overrides the circuit-level nominal temperature for BJT temperature scaling;
 omitting it preserves the inherited default.
 `KF` (default `0`, disabled) adds a distinct BJT base-current flicker-noise
-source to `.NOISE`, using Berkeley's default `AF=1` exponent so source PSD is
-`KF * abs(Ib) / frequency`.
+source to `.NOISE`. `AF` (default `1`) controls the base-current exponent, so
+source PSD is `KF * abs(Ib)^AF / frequency`.
 `modelCardUnsupportedParameterIssues`,
 `formatModelCardUnsupportedParameterIssueTable`,
 `modelCardUnsupportedParameterIssueRecords`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1731,6 +1731,7 @@ export interface Bjt {
   readonly reverseBetaRolloffCurrent: number;
   readonly nominalTemperatureKelvin: number | undefined;
   readonly flickerNoiseCoefficient: number;
+  readonly flickerNoiseExponent: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -2008,8 +2009,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [28, 45, 13, 4],
-  PNP: [28, 45, 13, 4],
+  NPN: [29, 46, 13, 4],
+  PNP: [29, 46, 13, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3599,7 +3600,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7786,6 +7787,7 @@ export function bjt(
   reverseBetaRolloffCurrent = 0.0,
   nominalTemperatureKelvin: number | undefined = undefined,
   flickerNoiseCoefficient = 0.0,
+  flickerNoiseExponent = 1.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7822,6 +7824,7 @@ export function bjt(
     reverseBetaRolloffCurrent,
     nominalTemperatureKelvin,
     flickerNoiseCoefficient,
+    flickerNoiseExponent,
   };
 }
 
@@ -7935,6 +7938,7 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   TNOM: "TNOM",
   T_NOM: "TNOM",
   KF: "KF",
+  AF: "AF",
   ISE: "ISE",
   NE: "NE",
   ISC: "ISC",
@@ -8470,6 +8474,7 @@ export function bjtFromModelCard(
     p.IKR ?? 0.0,
     p.TNOM !== undefined ? p.TNOM + 273.15 : undefined,
     p.KF ?? 0.0,
+    p.AF ?? 1.0,
   );
 }
 
@@ -18450,7 +18455,8 @@ function collectNoiseSources(
           noiseType: "flicker",
           positive: element.polarity === "NPN" ? base : emitter,
           negative: element.polarity === "NPN" ? emitter : base,
-          sourcePsd: element.flickerNoiseCoefficient * Math.abs(baseCurrent),
+          sourcePsd:
+            element.flickerNoiseCoefficient * Math.abs(baseCurrent) ** element.flickerNoiseExponent,
           frequencyExponent: 1.0,
         });
       }
@@ -19940,6 +19946,9 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.flickerNoiseCoefficient) || element.flickerNoiseCoefficient < 0.0) {
     throw invalidElement(element.name, "flicker noise coefficient must be finite and non-negative");
+  }
+  if (!Number.isFinite(element.flickerNoiseExponent) || element.flickerNoiseExponent < 0.0) {
+    throw invalidElement(element.name, "flicker noise exponent must be finite and non-negative");
   }
   if (!Number.isFinite(element.baseEmitterLeakageSaturationCurrent) || element.baseEmitterLeakageSaturationCurrent < 0.0) {
     throw invalidElement(element.name, "base-emitter leakage saturation current must be finite and non-negative");

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(114);
+    expect(coverage).toHaveLength(116);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(114);
+    expect(records).toHaveLength(116);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 114,
-      expectedCanonicalParameterCount: 114,
-      acceptedNameCount: 180,
+      canonicalParameterCount: 116,
+      expectedCanonicalParameterCount: 116,
+      acceptedNameCount: 182,
       aliasedParameterCount: 53,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t114\t114\t180\t53\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t116\t116\t182\t53\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,8 +241,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(113);
-    expect(report.acceptedNameCount).toBe(177);
+    expect(report.canonicalParameterCount).toBe(115);
+    expect(report.acceptedNameCount).toBe(179);
     expect(report.aliasedParameterCount).toBe(52);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t113\t114\t177\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t115\t116\t179\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -344,6 +344,7 @@ describe("dcOp", () => {
       IKR: 3.0e-3,
       T_NOM: 50.0,
       KF: 1.0e-12,
+      AF: 1.3,
       ISE: 3.0e-13,
       NE: 1.7,
       ISC: 4.0e-13,
@@ -357,7 +358,7 @@ describe("dcOp", () => {
       FC: 0.4,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, TNOM: 50.0, KF: 1.0e-12, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, TNOM: 50.0, KF: 1.0e-12, AF: 1.3, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.reverseBeta, 0.25);
@@ -371,6 +372,7 @@ describe("dcOp", () => {
     expectClose(bjtModel.reverseBetaRolloffCurrent, 3.0e-3);
     expectClose(bjtModel.nominalTemperatureKelvin, 323.15);
     expectClose(bjtModel.flickerNoiseCoefficient, 1.0e-12);
+    expectClose(bjtModel.flickerNoiseExponent, 1.3);
     expectClose(bjtModel.baseEmitterLeakageSaturationCurrent, 3.0e-13);
     expectClose(bjtModel.baseEmitterLeakageEmissionCoefficient, 1.7);
     expectClose(bjtModel.baseCollectorLeakageSaturationCurrent, 4.0e-13);
@@ -1014,7 +1016,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3, 323.15, 1.0e-12),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3, 323.15, 1.0e-12, 1.3),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -1043,6 +1045,7 @@ describe("dcOp", () => {
       expectClose(expanded.reverseBetaRolloffCurrent, 3.0e-3);
       expectClose(expanded.nominalTemperatureKelvin, 323.15);
       expectClose(expanded.flickerNoiseCoefficient, 1.0e-12);
+      expectClose(expanded.flickerNoiseExponent, 1.3);
     }
   });
 
@@ -1397,6 +1400,14 @@ describe("dcOp", () => {
     circuit.add({ ...bjt("Qbad", "c", "b", "0"), flickerNoiseCoefficient: -1.0 });
     expect(() => dcOp(circuit)).toThrowError(
       "flicker noise coefficient must be finite and non-negative",
+    );
+  });
+
+  it("rejects invalid BJT flicker noise exponents", () => {
+    const circuit = new Circuit();
+    circuit.add({ ...bjt("Qbad", "c", "b", "0"), flickerNoiseExponent: -1.0 });
+    expect(() => dcOp(circuit)).toThrowError(
+      "flicker noise exponent must be finite and non-negative",
     );
   });
 

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -87,6 +87,24 @@ describe("noiseAc", () => {
     expect(flickerPsds[0]).toBeGreaterThan(0.0);
     expect(flickerPsds[0] / flickerPsds[1]).toBeCloseTo(100.0, 12);
   });
+  it("uses BJT AF as the base-current exponent", () => {
+    function sourcePsd(exponent: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vcc", "vcc", "0", 5.0));
+      circuit.add(voltageSource("Vbase", "base", "0", 0.7));
+      circuit.add(resistor("Rload", "vcc", "out", 1_000.0));
+      circuit.add({
+        ...bjt("Q1", "out", "base", "0"),
+        flickerNoiseCoefficient: 1.0e-12,
+        flickerNoiseExponent: exponent,
+      });
+      return noiseAc(circuit, "out", "Vbase", [1_000.0], 300.0).points[0]!.entries
+        .find((entry) => entry.elementName === "Q1" && entry.noiseType === "flicker")!
+        .sourcePsd;
+    }
+
+    expect(sourcePsd(2.0)).toBeLessThan(sourcePsd(1.0));
+  });
   it("computes Johnson noise for a single grounded resistor", () => {
     const circuit = new Circuit();
     circuit.add(currentSource("Iin", "0", "out", 0.0));

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,14 +33,14 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT flicker-noise coefficient.
+1. Cross-language BJT flicker-noise exponent.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `KF` model-card support in Rust, Python, and TypeScript,
-     defaulting to zero so existing noise results remain unchanged.
-   - Emit a distinct `flicker` contribution from base current and apply the
-     Berkeley-default `AF=1` inverse-frequency exponent through the adjoint
-     noise path while preserving the complete BJT model through subcircuits.
-   - Extend the supported-parameter coverage gate from 112 to 114 canonical
+   - Add Berkeley BJT `AF` model-card support in Rust, Python, and TypeScript,
+     defaulting to one so existing `KF` noise results remain unchanged.
+   - Apply the exponent to base-current flicker noise as
+     `KF * abs(Ib)^AF / frequency` while preserving the complete BJT model
+     through subcircuits.
+   - Extend the supported-parameter coverage gate from 114 to 116 canonical
      rows and lock model-card behavior, validation, hierarchy, and noise
      scaling in all engines.
 
@@ -3118,6 +3118,14 @@ the Rust, Python, and TypeScript surfaces together.
      and use that model-owned value for temperature scaling when present.
    - Hierarchical subcircuit expansion preserves the complete BJT model, and
      the supported-parameter release gate now covers 112 canonical rows.
+
+234. Cross-language BJT flicker-noise coefficient.
+   - Status: completed in PR 8812.
+   - Rust, Python, and TypeScript BJT model cards now accept `KF`, default it
+     to zero, and emit a distinct base-current `flicker` contribution with the
+     Berkeley-default `AF=1` inverse-frequency slope.
+   - Hierarchical subcircuit expansion preserves the complete BJT model, and
+     the supported-parameter release gate now covers 114 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- add cross-language Berkeley BJT AF model-card support with a backward-compatible default of one
- apply AF to the base-current term in KF flicker noise while retaining inverse-frequency scaling
- keep hierarchy cloning, validation, supported-parameter coverage, docs, tests, and the SPICE completion plan aligned

## Verification

- cargo test -p spice-engine (366 tests)
- Python pytest (558 tests)
- Python Ruff on touched source and test files
- npm run build
- npm test -- --run (316 tests)
- git diff --check