### PR TITLE
feat(constant-fold): fold Math.clz32 / Math.imul on numeric literals (0.109.0)

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.109.0] - 2026-07-22
+
+### Added - fold `Math.clz32(n)` and `Math.imul(a, b)` on numeric literals
+
+Two more static `Math` folds, verified byte-identical to the reference Closure
+Compiler (`closure-compiler-v20260712.jar`, SIMPLE) across a 95-case
+differential probe:
+
+- `Math.clz32(n)` -> leading zero bits of `ToUint32(n)` (`0..=32`): `clz32(0)`
+  -> 32, `clz32(1)` -> 31, `clz32(256)` -> 23, `clz32(-1)` -> 0.
+- `Math.imul(a, b)` -> 32-bit signed product of `ToUint32(a)·ToUint32(b)`:
+  `imul(3, 4)` -> 12, `imul(-1, 5)` -> -5, `imul(65536, 65536)` -> 0.
+
+Both compute their result by pure modular arithmetic via the existing
+`to_uint32` helper (`ToUint32`/`ToInt32` semantics) - NO libm - so they are
+bit-exact independent of the platform math library. Each folds only on the bare
+global `Math` with exactly its argument count (clz32/1, imul/2), all numeric
+literals; other arities and non-literal args decline (leaving the call intact is
+always safe). Results are always finite 32-bit integers, never `-0`, so no
+negative-zero gate is needed. clz32 is handled outside the shared single-argument
+`-0` gate because a negative input mapping to a `0` result (`clz32(-1)`) is a
+legitimate `+0` that must still fold.
+
+Not modelled: `Math.pow` - a differential probe showed Rust's `f64::powf`
+diverges from the reference's `Math.pow` in the last ULP for fractional/negative
+exponents (e.g. `pow(2, 1.5)`, `pow(7, -2)`), so folding it via `powf` would emit
+different bytes; a safe pow fold would need integer-exponent-only exact
+arithmetic (tracked separately). The wrong-arity `Math.imul` cases the reference
+folds (`imul(2)` -> 0, `imul(2, 3, 4)` -> 6) are declined here (rare; tracked).
+
 ## [0.108.0] - 2026-07-22
 
 ### Added - fold `Math.trunc(n)` and `Math.sign(n)` on a numeric literal

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.108.0"
+version = "0.109.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -2697,6 +2697,54 @@ fn fold_call(c: &CallExpression, st: &mut FoldState) -> Expression {
                     }
                 }
 
+                // ---- Math.clz32(n) → numeric literal (0..32) ----
+                //
+                // `Math.clz32` (ECMAScript §21.3.2.11) counts the leading zero
+                // bits of `ToUint32(n)`. The result is always a small
+                // non-negative integer (`0..=32`) with an exact numeric-literal
+                // spelling, computed by pure modular arithmetic (`to_uint32`) —
+                // no libm — so it is bit-identical to the reference compiler:
+                // `clz32(0)` → 32, `clz32(1)` → 31, `clz32(-1)` → 0
+                // (`ToUint32(-1)` = 2³²-1). Only the bare global `Math` with one
+                // numeric-literal argument folds. (Unlike the single-argument
+                // block below, clz32 never yields `-0`, so a negative input that
+                // maps to a `0` result — `clz32(-1)` — must still fold, which is
+                // why it is handled here rather than under the shared `-0` gate.)
+                if obj.name == "Math" && prop.name == "clz32" && arguments.len() == 1 {
+                    if let Expression::NumericLiteral(n) = &arguments[0] {
+                        let result = to_uint32(n.value).leading_zeros() as f64;
+                        let parent = c.cv.clone();
+                        let before = format!("Math.clz32({})", n.value);
+                        let after = format_js_number(result);
+                        let new_cv = st.fork_cv(&parent, &before, &after);
+                        return stamp_literal_cv(FoldedLiteral::Number(result), new_cv);
+                    }
+                }
+
+                // ---- Math.imul(a, b) → numeric literal (32-bit signed product) ----
+                //
+                // `Math.imul` (ECMAScript §21.3.2.19) multiplies
+                // `ToUint32(a) · ToUint32(b)` and keeps the low 32 bits
+                // reinterpreted as a signed int. Pure modular arithmetic — no
+                // libm — so bit-identical: `imul(3, 4)` → 12, `imul(-1, 5)` → -5
+                // (`ToUint32(-1)·5` low-32 = 2³²-5 → -5). Only the bare global
+                // `Math` with exactly two numeric-literal arguments folds. The
+                // result is always a finite 32-bit integer (never `-0`), so no
+                // extra gate is needed.
+                if obj.name == "Math" && prop.name == "imul" && arguments.len() == 2 {
+                    if let (Expression::NumericLiteral(a), Expression::NumericLiteral(b)) =
+                        (&arguments[0], &arguments[1])
+                    {
+                        let result =
+                            (to_uint32(a.value).wrapping_mul(to_uint32(b.value)) as i32) as f64;
+                        let parent = c.cv.clone();
+                        let before = format!("Math.imul({}, {})", a.value, b.value);
+                        let after = format_js_number(result);
+                        let new_cv = st.fork_cv(&parent, &before, &after);
+                        return stamp_literal_cv(FoldedLiteral::Number(result), new_cv);
+                    }
+                }
+
                 // ---- Math.abs/floor/ceil/round(n) → numeric literal ----
                 //
                 // The single-argument numeric `Math` methods (ECMAScript
@@ -12741,6 +12789,56 @@ mod tests {
         for c in cases {
             let (out, _, changed, _) = run_pass(program_with_expr(c, true));
             assert!(!changed, "a -0 result must not fold (no -0 literal spelling)");
+            assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+        }
+    }
+
+    #[test]
+    fn fold_math_clz32_basic() {
+        // clz32 counts leading zero bits of ToUint32(n): 0..32.
+        assert_eq!(folded_number(math_call("clz32", vec![num(0.0, None)])), 32.0);
+        assert_eq!(folded_number(math_call("clz32", vec![num(1.0, None)])), 31.0);
+        assert_eq!(folded_number(math_call("clz32", vec![num(256.0, None)])), 23.0);
+        // ToUint32(-1) == 2^32-1 (top bit set) → 0 leading zeros; must still fold
+        // (a negative input with a 0 result is +0 here, NOT the -0 the unary
+        // fold's gate would decline).
+        assert_eq!(folded_number(math_call("clz32", vec![num(-1.0, None)])), 0.0);
+        // ToUint32 truncates toward zero: clz32(3.9) == clz32(3) == 30.
+        assert_eq!(folded_number(math_call("clz32", vec![num(3.9, None)])), 30.0);
+    }
+
+    #[test]
+    fn fold_math_imul_basic() {
+        // 32-bit signed multiply of ToUint32 operands.
+        assert_eq!(
+            folded_number(math_call("imul", vec![num(3.0, None), num(4.0, None)])),
+            12.0
+        );
+        assert_eq!(
+            folded_number(math_call("imul", vec![num(-1.0, None), num(5.0, None)])),
+            -5.0
+        );
+        // 65536 * 65536 == 2^32, low 32 bits are 0.
+        assert_eq!(
+            folded_number(math_call("imul", vec![num(65536.0, None), num(65536.0, None)])),
+            0.0
+        );
+    }
+
+    #[test]
+    fn math_clz32_imul_non_literal_or_wrong_arity_declines() {
+        // Non-literal arg, and any arity other than clz32/1 and imul/2, decline.
+        let cases = [
+            math_call("clz32", vec![ident("x")]),
+            math_call("clz32", vec![]),
+            math_call("clz32", vec![num(1.0, None), num(2.0, None)]),
+            math_call("imul", vec![num(2.0, None)]),
+            math_call("imul", vec![num(2.0, None), ident("y")]),
+            math_call("imul", vec![num(2.0, None), num(3.0, None), num(4.0, None)]),
+        ];
+        for c in cases {
+            let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+            assert!(!changed, "clz32/imul must decline non-literal / wrong arity");
             assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
         }
     }

--- a/code/programs/rust/closurec/tests/diff/simple-fold-math-clz32-imul/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-math-clz32-imul/README.md
@@ -1,0 +1,15 @@
+# simple-fold-math-clz32-imul
+
+Locks the byte output of SIMPLE-level static `Math.clz32(n)` / `Math.imul(a,b)`
+folding (`closure-pass-constant-fold`). `clz32` counts leading zero bits of
+`ToUint32(n)` (0..32); `imul` is the 32-bit signed product of `ToUint32(a)` and
+`ToUint32(b)`. Both are pure modular integer operations (no libm), so the fold is
+bit-exact and verified byte-identical to the reference Closure Compiler
+(`closure-compiler-v20260712.jar`, SIMPLE, `--language_out NO_TRANSPILE`):
+
+- `Math.clz32(1)` -> `31`, `Math.clz32(0)` -> `32`, `Math.clz32(-1)` -> `0`
+- `Math.imul(3,4)` -> `12`, `Math.imul(-1,5)` -> `-5`, `Math.imul(65536,65536)` -> `0`
+
+Declined (left intact), matching the reference: a non-literal argument
+(`Math.clz32(x)`) and a non-global receiver (`m.imul(2,3)`). See `input/a.js` and
+`expected.stdout`.

--- a/code/programs/rust/closurec/tests/diff/simple-fold-math-clz32-imul/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-math-clz32-imul/expected.stdout
@@ -1,0 +1,1 @@
+var a=31,b=32,c=0,d=12,e=-5,f=0,g=Math.clz32(x),h=m.imul(2,3);report(a,b,c,d,e,f,g,h);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-math-clz32-imul/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-math-clz32-imul/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-fold-math-clz32-imul/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-fold-math-clz32-imul/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-math-clz32-imul/input/a.js
@@ -1,0 +1,23 @@
+// SIMPLE-level static Math.clz32(n) / Math.imul(a,b) fold -> numeric literal.
+//
+// clz32 counts the leading zero bits of ToUint32(n) (0..32); imul is the 32-bit
+// signed product of ToUint32(a) and ToUint32(b). Both are pure modular integer
+// operations, so the fold is bit-exact and byte-identical to the reference:
+//   * Math.clz32(1)      -> 31     Math.clz32(0)     -> 32
+//   * Math.clz32(-1)     -> 0      (ToUint32(-1) = 2**32-1, top bit set)
+//   * Math.imul(3, 4)    -> 12     Math.imul(-1, 5)  -> -5
+//   * Math.imul(65536, 65536) -> 0 (product 2**32, low 32 bits are 0)
+//   * Math.clz32(x)      -> declined (x is a non-literal, runtime-unknown)
+//   * m.imul(2, 3)       -> declined (only the bare global Math)
+//
+// Under WHITESPACE_ONLY every call survives; under SIMPLE the bare-global
+// numeric-literal calls collapse. Each value flows into report(...).
+var a = Math.clz32(1);
+var b = Math.clz32(0);
+var c = Math.clz32(-1);
+var d = Math.imul(3, 4);
+var e = Math.imul(-1, 5);
+var f = Math.imul(65536, 65536);
+var g = Math.clz32(x);
+var h = m.imul(2, 3);
+report(a, b, c, d, e, f, g, h);

--- a/code/programs/rust/closurec/tests/diff_simple_fold_math_clz32_imul.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_math_clz32_imul.rs
@@ -1,0 +1,40 @@
+//! Integration test for the `tests/diff/simple-fold-math-clz32-imul/` fixture.
+//!
+//! End-to-end oracle for static `Math.clz32(...)` / `Math.imul(...)` folding in
+//! `closure-pass-constant-fold`: `clz32` -> leading zero bits of ToUint32 (0..32),
+//! `imul` -> 32-bit signed product of the ToUint32 operands. Both are exact
+//! modular integer operations. A non-literal argument and a non-global receiver
+//! are declined.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    std::fs::read_to_string("tests/diff/simple-fold-math-clz32-imul/flags.txt")
+        .expect("read flags.txt")
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_fold_math_clz32_imul_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY).args(&flags).output().expect("run closurec");
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-fold-math-clz32-imul/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}


### PR DESCRIPTION
## What

Fold `Math.clz32(n)` and `Math.imul(a, b)` on numeric literals at SIMPLE/ADVANCED,
extending the existing static `Math` folds.

## Why

Oracle probing against the reference Closure Compiler
(`closure-compiler-v20260712.jar`, SIMPLE) showed closurec left these un-folded:

- `Math.clz32(n)` → leading zero bits of `ToUint32(n)` (`0..=32`): `clz32(0)` → 32,
  `clz32(1)` → 31, `clz32(256)` → 23, `clz32(-1)` → 0
- `Math.imul(a, b)` → 32-bit signed product of `ToUint32(a)·ToUint32(b)`:
  `imul(3, 4)` → 12, `imul(-1, 5)` → -5, `imul(65536, 65536)` → 0

Both compute their result by **pure modular arithmetic** via the existing
`to_uint32` helper (ES `ToUint32`/`ToInt32`) — **no libm** — so they are
bit-exact independent of the platform math library. A **95-case differential
probe** confirmed byte-identity.

## Why NOT Math.pow

`Math.pow` is deliberately **not** folded: a differential probe found Rust's
`f64::powf` diverges from the reference's `Math.pow` in the **last ULP** for
fractional/negative exponents (e.g. `pow(2, 1.5)`: oracle `2.82842712474619` vs
`powf` `2.8284271247461903`; `pow(7, -2)`, `pow(7, 1.5)` likewise). Folding via
`powf` would emit different bytes — a byte-identity soundness failure. A safe
pow fold needs integer-exponent-only exact arithmetic (tracked as #221).

## Changes

- **closure-pass-constant-fold 0.108.0 → 0.109.0**: add `Math.clz32` and
  `Math.imul` handlers (reuse `to_uint32`). Each folds only on the bare global
  `Math` with exactly its arity (clz32/1, imul/2) and numeric-literal args; other
  arities / non-literal args decline (always safe). Results are always finite
  32-bit integers (never `-0`), so no negative-zero gate; clz32 is handled
  outside the shared single-arg `-0` gate because `clz32(-1)` → `+0` must fold.
  3 unit tests (folds + non-literal/wrong-arity declines).
- **closurec**: new `tests/diff/simple-fold-math-clz32-imul` e2e fixture
  (byte-verified against the oracle) + its diff test harness.

## Verification

- `closure-pass-constant-fold` unit tests (407) pass, incl. 3 new.
- consumer crates (dce, fold-control-flow, inline, inline-variables) and the full
  closurec suite (158 test targets) pass — **zero fixture drift**.
- `cargo clippy -- -D warnings` clean.
- 95-case clz32/imul differential probe byte-identical to the reference compiler.
- Security review passed (no panic, correct ToInt32, exact arity gating).

## Scope / follow-up

The wrong-arity `Math.imul` cases the reference folds (`imul(2)` → 0,
`imul(2, 3, 4)` → 6) are declined here (rare; tracked). `Math.pow` (integer-exp
subset) and the conditional `Math.fround` remain in #221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
