### PR TITLE
feat(semantic-ir-to-c): sequences — composite equality now on all 6 backends (SIR16)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 0.6.0 — sequences (SIR16)
+
+Accepts `Feature::Sequences`. `SirValue` gains a `SIR_SEQ` tag — a heap-boxed
+dynamic array (`struct SirSeq { SirValue *items; int64_t len; }`, arena
+allocated like every other heap value) — so a sequence is a shared, mutable
+handle: a `SeqSet` through one binding is visible through every alias, matching
+the Go/Rust `*Seq`. Every construct the feature can surface is lowered:
+
+- `SeqLit` (`[1, 2, 3]`) → `_sir_seq_lit(n, …)`.
+- `SeqIndex` (`a[i]`) → `_sir_seq_index`: a negative index counts from the end,
+  an out-of-range index yields nil (it does NOT raise — matching the reference
+  and every other backend).
+- `SeqLen` (`a.length`) → `_sir_seq_len`.
+- `SeqSet` (`a[i] = v`) → `_sir_seq_set`, which TRAPS (`stderr` + `exit(1)`) on
+  a negative or out-of-range index, matching the Go/Rust `panic`.
+- `ForEach` (`for x in a`) → a `for` loop over `_sir_seq_iter(a)`, which
+  snapshots the iterable (a real sequence is copied so a mutating body does not
+  disturb iteration; a cons-list is flattened). `x` is declared inside the loop
+  body block, so it is block-scoped — matching the validator's rewind and Go's
+  `:=` counter. This is why `ForEach` is no longer rejected by the `first_foreach`
+  pre-pass added in 0.5.0 (that pre-pass and its clean-rejection are removed).
+
+`_sir_value_eq` gains a structural `SIR_SEQ` arm — equal length, element-wise
+equal, with an identical-handle fast path (which also short-circuits the common
+self-referential `a == a`). `_sir_fmt` renders a sequence as `[1, 2, 3]`
+(bracket, comma-space), matching the Go/Rust backends. With this, the
+cross-backend composite-equality conformance (`[1,2] == [1,2]`) now asserts on
+**all six** backends — C was the last that skipped it.
+
+Because `SeqSet` is the first MUTABLE heap aggregate (cons pairs are immutable
+and so cannot form a cycle), a self-referential sequence (`a[0] = a`) is now
+constructible; both `_sir_value_eq` and `_sir_fmt` carry a recursion-depth cap
+so a cyclic structure terminates rather than overflowing the C stack — a guard
+the immutable pair path never needed. (Found by security review, which also
+caught that the earlier "matches the pair arm" claim was wrong.)
+
+Every node is verified by hand-built modules (producer-agnostic), compiled with
+a real `cc` under `-Werror=unused-variable` and run: display, structural
+equality (positive/negative/nested), index (in-range/negative/OOB), length,
+in-bounds set, and block-scoped ForEach.
+
 ## 0.5.0 — `ForRange` (numeric for-loop) + a scan hole (SIR16)
 
 Fixes a **pre-existing panic**: `Stmt::ForRange` (`for i in 0...3`) is gated by

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -77,13 +77,18 @@ The emitter is **thin**; the semantics live in an inlined C runtime
 
 ## Capability declaration (v0)
 
-**Accepts** the SIR-v0 feature set: `Closures`, `Pairs`, `Symbols`, `Strings`,
-`DynamicTyping`, `OptionalTypeAnnotations`, `MutualRecursion`, `Globals`.
+**Accepts** `Closures`, `Pairs`, `Symbols`, `Strings`, `DynamicTyping`,
+`OptionalTypeAnnotations`, `MutualRecursion`, `Globals`; the SIR26 integer
+conversions (`Conversions`, `SizedIntegers`, `Unsigned`, `WrappingArithmetic`);
+SIR16 control flow and mutation (`Loops` — `While`, `ForRange`, `ForEach`; and
+`MutableBindings`); and SIR16 `Sequences` — a `SIR_SEQ` heap array with
+`SeqLit`/`SeqIndex`/`SeqLen`/`SeqSet` and structural equality.
 
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
-`Intrinsics`, and every later feature until its batch lands.  `Bignum` stays
-rejected until a bignum runtime ships — a module needing arbitrary precision is
-refused, never silently truncated.
+`Intrinsics`, `Maps`, `NDArrays`, `ShortCircuit`, exceptions/OOP, and every
+other not-yet-wired feature until its batch lands.  `Bignum` stays rejected
+until a bignum runtime ships — a module needing arbitrary precision is refused,
+never silently truncated.
 
 ## Roadmap to parity
 

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -391,6 +391,54 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         // emit. `ForEach` is the exception — it observes only `Feature::Loops`
         // (accepted), so `compile`'s `first_foreach` pre-pass rejects it
         // cleanly rather than letting it reach this `unreachable!`.
+        // `a[i] = v` — mutate the shared sequence box (via `_sir_seq_set`,
+        // which traps on an out-of-range index). Operands are hoisted so
+        // left-to-right evaluation order holds; the returned value is discarded
+        // in statement position.
+        Stmt::SeqSet {
+            seq, index, value, ..
+        } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let names = hoist_operands(out, &[seq, index, value], inner);
+            let _ = writeln!(
+                out,
+                "{ipad}(void)_sir_seq_set({}, {}, {});",
+                names[0], names[1], names[2]
+            );
+            let _ = writeln!(out, "{pad}}}");
+        }
+        // `for var in iter … end`. `_sir_seq_iter` normalises the iterable to a
+        // snapshot sequence (a real sequence is copied, a cons-list flattened),
+        // so the body renders ONCE over one array. `var` is declared inside the
+        // loop body block → block-scoped (matching the validator's rewind and
+        // the Go reference), never clobbering an enclosing same-named local.
+        Stmt::ForEach {
+            var, iter, body, ..
+        } => {
+            let id = fresh_id();
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let it = hoist_operands(out, &[iter], inner);
+            let _ = writeln!(out, "{ipad}SirValue _sir_feq{id} = _sir_seq_iter({});", it[0]);
+            let _ = writeln!(out, "{ipad}int64_t _sir_fen{id} = _sir_feq{id}.as.seq->len;");
+            let _ = writeln!(
+                out,
+                "{ipad}for (int64_t _sir_fei{id} = 0; _sir_fei{id} < _sir_fen{id}; _sir_fei{id}++) {{"
+            );
+            let body_i = inner + 1;
+            let bpad = indent_str(body_i);
+            let v = sanitize_ident(var);
+            let _ = writeln!(out, "{bpad}SirValue {v} = _sir_feq{id}.as.seq->items[_sir_fei{id}];");
+            let _ = writeln!(out, "{bpad}(void){v};");
+            for st in &body.stmts {
+                emit_stmt(out, st, body_i);
+            }
+            let _ = writeln!(out, "{ipad}}}");
+            let _ = writeln!(out, "{pad}}}");
+        }
         other => unreachable!("C backend reached unsupported statement: {other:?}"),
     }
 }
@@ -489,6 +537,37 @@ fn emit_assign(out: &mut String, dst: &str, e: &Expr, indent: usize) {
                 let _ = writeln!(out, "{pad}{dst} = _sir_convert({dst}, {bits}, {signed});");
             }
         }
+        // SIR16 sequences with a compound operand: hoist operands into temps
+        // (preserving left-to-right order), then build/read the sequence.
+        Expr::SeqLit { items, .. } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let ops: Vec<&Expr> = items.iter().collect();
+            let names = hoist_operands(out, &ops, inner);
+            let _ = write!(out, "{ipad}{dst} = _sir_seq_lit({}", items.len());
+            for n in &names {
+                let _ = write!(out, ", {n}");
+            }
+            out.push_str(");\n");
+            let _ = writeln!(out, "{pad}}}");
+        }
+        Expr::SeqIndex { seq, index, .. } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let names = hoist_operands(out, &[seq.as_ref(), index.as_ref()], inner);
+            let _ = writeln!(out, "{ipad}{dst} = _sir_seq_index({}, {});", names[0], names[1]);
+            let _ = writeln!(out, "{pad}}}");
+        }
+        Expr::SeqLen { seq, .. } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let names = hoist_operands(out, &[seq.as_ref()], inner);
+            let _ = writeln!(out, "{ipad}{dst} = _sir_seq_len({});", names[0]);
+            let _ = writeln!(out, "{pad}}}");
+        }
         // A call whose arguments contain control flow: hoist every argument
         // into a temp (left-to-right), then make the call.
         _ => emit_compound_call(out, dst, e, indent),
@@ -522,6 +601,28 @@ fn emit_cond(out: &mut String, cond: &Expr, indent: usize) -> String {
 /// Hoist a call's compound arguments into temps, then assign the call to
 /// `dst`.  Every argument becomes a temp so left-to-right evaluation order is
 /// preserved.
+/// Hoist each operand into a fresh `SirValue` temporary (left-to-right, so
+/// evaluation order is preserved even with side effects), returning the temp
+/// names. A simple operand is assigned directly; a compound one goes through
+/// `emit_assign`. Shared by the `Seq*` compound arms below.
+fn hoist_operands(out: &mut String, ops: &[&Expr], indent: usize) -> Vec<String> {
+    let ipad = indent_str(indent);
+    let mut names = Vec::with_capacity(ops.len());
+    for a in ops {
+        let t = format!("_sir_a{}", fresh_id());
+        if is_simple(a) {
+            let _ = write!(out, "{ipad}SirValue {t} = ");
+            emit_expr(out, a, indent);
+            out.push_str(";\n");
+        } else {
+            let _ = writeln!(out, "{ipad}SirValue {t};");
+            emit_assign(out, &t, a, indent);
+        }
+        names.push(t);
+    }
+    names
+}
+
 fn emit_compound_call(out: &mut String, dst: &str, e: &Expr, indent: usize) {
     let pad = indent_str(indent);
     let args = call_args(e).expect("emit_compound_call on a non-call expr");
@@ -618,6 +719,12 @@ fn is_simple(e: &Expr) -> bool {
         Expr::MakeClosure { captures, .. } => captures.iter().all(|c| is_simple(&c.value)),
         // SIR26: a conversion is as simple as its value.
         Expr::Convert { value, .. } => is_simple(value),
+        // SIR16 sequences: a `_sir_seq_*` call is simple iff its operands are
+        // (they render inline as function arguments); otherwise the operands
+        // are hoisted by `emit_assign`.
+        Expr::SeqLit { items, .. } => items.iter().all(is_simple),
+        Expr::SeqIndex { seq, index, .. } => is_simple(seq) && is_simple(index),
+        Expr::SeqLen { seq, .. } => is_simple(seq),
         // SIR16+ nodes / Intrinsic are not accepted in v0 → unreachable after
         // the capability check.  Treat as non-simple defensively.
         _ => false,
@@ -676,6 +783,29 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             emit_expr(out, &b.value, indent);
         }
         Expr::Convert { value, to, .. } => emit_convert(out, value, to, indent),
+        // SIR16 sequences (simple-operand forms; compound operands are hoisted
+        // by `emit_assign`). `_sir_seq_lit(N, e0, e1, …)` boxes a fresh array;
+        // `_sir_seq_index`/`_sir_seq_len` read it.
+        Expr::SeqLit { items, .. } => {
+            let _ = write!(out, "_sir_seq_lit({}", items.len());
+            for it in items {
+                out.push_str(", ");
+                emit_expr(out, it, indent);
+            }
+            out.push(')');
+        }
+        Expr::SeqIndex { seq, index, .. } => {
+            out.push_str("_sir_seq_index(");
+            emit_expr(out, seq, indent);
+            out.push_str(", ");
+            emit_expr(out, index, indent);
+            out.push(')');
+        }
+        Expr::SeqLen { seq, .. } => {
+            out.push_str("_sir_seq_len(");
+            emit_expr(out, seq, indent);
+            out.push(')');
+        }
         other => unreachable!("emit_expr on compound/unsupported node: {other:?}"),
     }
 }
@@ -824,55 +954,6 @@ pub fn first_unsupported_builtin(m: &Module) -> Option<(String, Span)> {
     None
 }
 
-/// Locate a `Stmt::ForEach` anywhere in the module. `ForEach` observes only
-/// `Feature::Loops` (the validator; same feature as `While`/`ForRange`), which
-/// this backend accepts — so a module using `for x in <iterable>` passes the
-/// capability check and would reach the emitter's `unreachable!`. The emitter
-/// cannot lower it yet (a sequence/`each` iterator is the sequences batch), so
-/// `compile` rejects it CLEANLY via this pre-pass rather than panicking. Walks
-/// the full statement/expression tree so a nested `ForEach` (in a loop or `if`
-/// body) is caught too.
-pub fn first_foreach(m: &Module) -> Option<Span> {
-    fn in_block(b: &Block) -> Option<Span> {
-        b.stmts
-            .iter()
-            .find_map(in_stmt)
-            .or_else(|| in_expr(&b.value))
-    }
-    fn in_stmt(s: &Stmt) -> Option<Span> {
-        match s {
-            Stmt::ForEach { span, .. } => Some(span.clone()),
-            Stmt::While { cond, body, .. } => in_expr(cond).or_else(|| in_block(body)),
-            Stmt::ForRange {
-                start, stop, step, body, ..
-            } => in_expr(start)
-                .or_else(|| in_expr(stop))
-                .or_else(|| in_expr(step))
-                .or_else(|| in_block(body)),
-            Stmt::LetBinding { value, .. }
-            | Stmt::LetStarBinding { value, .. }
-            | Stmt::ExprStmt { expr: value, .. }
-            | Stmt::Assign { value, .. } => in_expr(value),
-            _ => None,
-        }
-    }
-    fn in_expr(e: &Expr) -> Option<Span> {
-        match e {
-            Expr::If {
-                cond,
-                then_branch,
-                else_branch,
-                ..
-            } => in_expr(cond)
-                .or_else(|| in_block(then_branch))
-                .or_else(|| in_block(else_branch)),
-            Expr::Block(b) => in_block(b),
-            _ => None,
-        }
-    }
-    m.functions.iter().find_map(|f| in_block(&f.body))
-}
-
 fn scan_block_for_builtin(b: &Block) -> Option<(String, Span)> {
     for s in &b.stmts {
         let inner = match s {
@@ -896,6 +977,15 @@ fn scan_block_for_builtin(b: &Block) -> Option<(String, Span)> {
                 .or_else(|| scan_expr_for_builtin(stop))
                 .or_else(|| scan_expr_for_builtin(step))
                 .or_else(|| scan_block_for_builtin(body)),
+            // Sequence write / iteration bodies likewise carry sub-expressions.
+            Stmt::SeqSet {
+                seq, index, value, ..
+            } => scan_expr_for_builtin(seq)
+                .or_else(|| scan_expr_for_builtin(index))
+                .or_else(|| scan_expr_for_builtin(value)),
+            Stmt::ForEach { iter, body, .. } => {
+                scan_expr_for_builtin(iter).or_else(|| scan_block_for_builtin(body))
+            }
             _ => None,
         };
         if inner.is_some() {
@@ -932,6 +1022,11 @@ fn scan_expr_for_builtin(e: &Expr) -> Option<(String, Span)> {
             .iter()
             .find_map(|c| scan_expr_for_builtin(&c.value)),
         Expr::Convert { value, .. } => scan_expr_for_builtin(value),
+        Expr::SeqLit { items, .. } => items.iter().find_map(scan_expr_for_builtin),
+        Expr::SeqIndex { seq, index, .. } => {
+            scan_expr_for_builtin(seq).or_else(|| scan_expr_for_builtin(index))
+        }
+        Expr::SeqLen { seq, .. } => scan_expr_for_builtin(seq),
         _ => None,
     }
 }

--- a/code/packages/rust/semantic-ir-to-c/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/lib.rs
@@ -73,6 +73,15 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // the C frontend's milestone-2 `if`/`while`/`for` lowering.
     Feature::Loops,
     Feature::MutableBindings,
+    // ── SIR16 sequences ──────────────────────────────────────────────
+    // `SirValue` gains a `SIR_SEQ` heap-boxed dynamic array. The emitter
+    // handles every construct the feature can surface: `SeqLit` (`[1, 2, 3]`),
+    // `SeqIndex` (`a[i]`, nil-on-OOB), `SeqLen` (`a.length`), `SeqSet`
+    // (`a[i] = v`, traps out-of-range), and `ForEach` (`for x in a`, over a
+    // `_sir_seq_iter` snapshot — so it is no longer rejected by `first_foreach`
+    // as it was in 0.5.0). Structural `_sir_value_eq` makes `[1, 2] == [1, 2]`
+    // true, matching every backend that carries sequences.
+    Feature::Sequences,
 ];
 
 impl Backend for CBackend {
@@ -127,19 +136,6 @@ impl Backend for CBackend {
             });
         }
 
-        // 3b. `Stmt::ForEach` observes only `Feature::Loops` (accepted), so it
-        //     is NOT gated out — a module using `for x in <iterable>` would
-        //     otherwise reach the emitter's `unreachable!`. Reject it cleanly
-        //     until the sequences batch gives it an iterator.
-        if let Some(span) = emit::first_foreach(module) {
-            return Err(BackendError {
-                kind: BackendErrorKind::UnsupportedFeature,
-                message: "the v0 C backend does not yet lower `for … in` (ForEach) \
-                          — deferred to the sequences feature batch"
-                    .to_string(),
-                span,
-            });
-        }
 
         // 4. Emit.
         let source = emit::emit_module(module);

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -42,12 +42,13 @@ pub const RUNTIME: &str = r####"/* =============================================
 
 typedef enum {
     SIR_NIL, SIR_BOOL, SIR_INT, SIR_FLOAT,
-    SIR_STR, SIR_SYM, SIR_PAIR, SIR_CLOSURE
+    SIR_STR, SIR_SYM, SIR_PAIR, SIR_CLOSURE, SIR_SEQ
 } SirTag;
 
 typedef struct SirValue SirValue;
 typedef struct SirPair SirPair;
 typedef struct SirClosure SirClosure;
+typedef struct SirSeq SirSeq;
 
 struct SirValue {
     SirTag tag;
@@ -58,10 +59,17 @@ struct SirValue {
         const char *s;    /* SIR_STR / SIR_SYM (interned) */
         SirPair *pair;    /* SIR_PAIR */
         SirClosure *clo;  /* SIR_CLOSURE */
+        SirSeq *seq;      /* SIR_SEQ */
     } as;
 };
 
 struct SirPair { SirValue car; SirValue cdr; };
+
+/* A SIR16 sequence (`[1, 2, 3]`) — a heap-boxed dynamic array. `items` points
+ * at `len` `SirValue`s (arena-allocated, never freed like every other heap
+ * value). Boxed so the value is a shared, mutable handle: a `SeqSet` through
+ * one binding is visible through every alias (matching the Go/Rust `*Seq`). */
+struct SirSeq { SirValue *items; int64_t len; };
 
 /* A closure's function takes its captured environment and the call args. */
 typedef SirValue (*SirFn)(SirValue *caps, SirValue *args, int argc);
@@ -304,7 +312,17 @@ SirValue _sir_ge(SirValue a, SirValue b) {
     return _sir_bool(_sir_as_num(a) >= _sir_as_num(b));
 }
 
-int _sir_value_eq(SirValue a, SirValue b) {
+/* Structural equality can recurse through nested sequences/pairs. `SeqSet` is
+ * this backend's FIRST mutable heap aggregate, so — unlike the immutable cons
+ * pairs, which cannot form a cycle (there is no `set-car!`) — a sequence CAN be
+ * made self-referential (`a[0] = a`). A depth cap keeps such a structure from
+ * overflowing the C stack: past the cap two values are ASSUMED equal (the
+ * co-inductive answer, so a cyclic comparison terminates). The cap is far
+ * beyond any real (non-cyclic) nesting and comfortably under the stack limit. */
+#define SIR_MAX_EQ_DEPTH 5000
+
+int _sir_value_eq_d(SirValue a, SirValue b, int depth) {
+    if (depth > SIR_MAX_EQ_DEPTH) return 1;
     if (_sir_is_num(a) && _sir_is_num(b)) {
         if (a.tag == SIR_INT && b.tag == SIR_INT) return a.as.i == b.as.i;
         return _sir_as_num(a) == _sir_as_num(b);
@@ -315,12 +333,26 @@ int _sir_value_eq(SirValue a, SirValue b) {
         case SIR_BOOL:    return a.as.b == b.as.b;
         case SIR_STR:     return strcmp(a.as.s, b.as.s) == 0;
         case SIR_SYM:     return a.as.s == b.as.s;  /* interned: pointer eq */
-        case SIR_PAIR:    return _sir_value_eq(a.as.pair->car, b.as.pair->car)
-                              && _sir_value_eq(a.as.pair->cdr, b.as.pair->cdr);
+        case SIR_PAIR:    return _sir_value_eq_d(a.as.pair->car, b.as.pair->car, depth + 1)
+                              && _sir_value_eq_d(a.as.pair->cdr, b.as.pair->cdr, depth + 1);
+        case SIR_SEQ: {
+            /* STRUCTURAL: equal length and element-wise equal (`[1, 2] ==
+             * [1, 2]` is true). The identical-handle fast path short-circuits
+             * `a == a` (and the common self-referential `a[0] = a`); the depth
+             * cap above bounds a comparison of two DISTINCT cyclic sequences. */
+            SirSeq *sa = a.as.seq, *sb = b.as.seq;
+            if (sa == sb) return 1;
+            if (sa->len != sb->len) return 0;
+            for (int64_t i = 0; i < sa->len; i++)
+                if (!_sir_value_eq_d(sa->items[i], sb->items[i], depth + 1)) return 0;
+            return 1;
+        }
         case SIR_CLOSURE: return a.as.clo == b.as.clo;
         default:          return 0;
     }
 }
+
+int _sir_value_eq(SirValue a, SirValue b) { return _sir_value_eq_d(a, b, 0); }
 SirValue _sir_eq(SirValue a, SirValue b) { return _sir_bool(_sir_value_eq(a, b)); }
 SirValue _sir_ne(SirValue a, SirValue b) { return _sir_bool(!_sir_value_eq(a, b)); }
 
@@ -341,6 +373,89 @@ SirValue _sir_cons(SirValue a, SirValue b) {
 }
 SirValue _sir_car(SirValue v) { return v.tag == SIR_PAIR ? v.as.pair->car : _sir_nil(); }
 SirValue _sir_cdr(SirValue v) { return v.tag == SIR_PAIR ? v.as.pair->cdr : _sir_nil(); }
+
+/* ---- SIR16 sequences ---------------------------------------- */
+
+/* `[e0, e1, …]` — box `n` values into a fresh heap sequence. The variadic
+ * elements are copied into an arena-allocated array. */
+SirValue _sir_seq_lit(int n, ...) {
+    SirSeq *s = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    s->len = (int64_t)n;
+    s->items = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)n) : NULL;
+    va_list ap;
+    va_start(ap, n);
+    for (int i = 0; i < n; i++) s->items[i] = va_arg(ap, SirValue);
+    va_end(ap);
+    SirValue v;
+    v.tag = SIR_SEQ; v.as.seq = s;
+    return v;
+}
+
+/* `a[i]` (read). Ruby's `Array#[]`: a negative index counts from the end, and
+ * an index outside `0 .. len-1` yields nil (it does NOT raise — that is
+ * `fetch`). Matches the Go/Rust `_sir_seq_index`. A non-sequence yields nil. */
+SirValue _sir_seq_index(SirValue seq, SirValue idx) {
+    if (seq.tag != SIR_SEQ) return _sir_nil();
+    int64_t n = seq.as.seq->len;
+    int64_t i = _sir_as_int(idx);
+    if (i < 0) i += n;
+    if (i < 0 || i >= n) return _sir_nil();
+    return seq.as.seq->items[i];
+}
+
+/* `a.length` — the element count. A non-sequence has length 0. */
+SirValue _sir_seq_len(SirValue seq) {
+    return _sir_int(seq.tag == SIR_SEQ ? seq.as.seq->len : 0);
+}
+
+/* `a[i] = v` (write). Unlike the lenient read, the SIR reference treats ONLY
+ * `0 <= i < len` as valid and traps on a negative or out-of-range index
+ * (matching the Go/Rust `_sir_seq_set`, which panic). Mutates the shared box
+ * and returns the value (an indexed assignment evaluates to its RHS). */
+SirValue _sir_seq_set(SirValue seq, SirValue idx, SirValue val) {
+    if (seq.tag != SIR_SEQ) {
+        fprintf(stderr, "sir: []= on a non-sequence\n");
+        exit(1);
+    }
+    int64_t n = seq.as.seq->len;
+    int64_t i = _sir_as_int(idx);
+    if (i < 0 || i >= n) {
+        fprintf(stderr, "sir: sequence index out of range\n");
+        exit(1);
+    }
+    seq.as.seq->items[i] = val;
+    return val;
+}
+
+/* Normalise an iterable to a SNAPSHOT sequence for `ForEach`. A real sequence
+ * is copied (so a body that mutates the original does not disturb the
+ * iteration — matching the Go/Rust snapshot semantics); a cons-list is
+ * flattened into a sequence; anything else yields an empty sequence (zero
+ * iterations — the lenient choice, consistent with `_sir_car` returning nil on
+ * a non-pair). Lets the emitter render a `ForEach` body ONCE, over one array. */
+SirValue _sir_seq_iter(SirValue it) {
+    SirSeq *s = (SirSeq *)_sir_alloc(sizeof(SirSeq));
+    if (it.tag == SIR_SEQ) {
+        int64_t n = it.as.seq->len;
+        s->len = n;
+        s->items = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)n) : NULL;
+        for (int64_t i = 0; i < n; i++) s->items[i] = it.as.seq->items[i];
+    } else if (it.tag == SIR_PAIR) {
+        int64_t n = 0;
+        SirValue cur = it;
+        while (cur.tag == SIR_PAIR) { n++; cur = cur.as.pair->cdr; }
+        s->len = n;
+        s->items = (n > 0) ? (SirValue *)_sir_alloc(sizeof(SirValue) * (size_t)n) : NULL;
+        cur = it;
+        for (int64_t i = 0; cur.tag == SIR_PAIR; i++) { s->items[i] = cur.as.pair->car; cur = cur.as.pair->cdr; }
+    } else {
+        s->len = 0;
+        s->items = NULL;
+    }
+    SirValue v;
+    v.tag = SIR_SEQ; v.as.seq = s;
+    return v;
+}
 
 SirValue _sir_is_null(SirValue v)   { return _sir_bool(v.tag == SIR_NIL); }
 SirValue _sir_is_pair(SirValue v)   { return _sir_bool(v.tag == SIR_PAIR); }
@@ -404,6 +519,19 @@ SirValue _sir_global_get(SirValue name)               { return _sir_global_get_s
 
 void _sir_fmt(FILE *out, SirValue v);
 
+/* A sequence renders as `[e0, e1, …]` (bracket, comma-space separator),
+ * matching the Go/Rust backends. Elements render through `_sir_fmt`, whose
+ * depth counter bounds a self-referential sequence (constructible via the
+ * mutable `SeqSet`). */
+void _sir_fmt_seq(FILE *out, SirValue v) {
+    fputc('[', out);
+    for (int64_t i = 0; i < v.as.seq->len; i++) {
+        if (i) fputs(", ", out);
+        _sir_fmt(out, v.as.seq->items[i]);
+    }
+    fputc(']', out);
+}
+
 void _sir_fmt_float(FILE *out, double f) {
     /* Ruby keeps a trailing .0 on integral floats and prints non-finite
      * values as Infinity / NaN.  A plain "%g" would drop the .0, so format
@@ -441,8 +569,21 @@ void _sir_fmt_pair(FILE *out, SirValue v) {
     fputc(')', out);
 }
 
+/* Rendering recurses through nested sequences/pairs. A self-referential
+ * sequence (`a[0] = a`, now constructible via the mutable `SeqSet`) would
+ * otherwise recurse forever, so a static depth counter bounds it: past the cap
+ * a `[...]` ellipsis is printed instead of descending (the emitted program is
+ * single-threaded, so a plain static counter is sufficient). */
+#define SIR_MAX_FMT_DEPTH 5000
+static int _sir_fmt_depth = 0;
+
 void _sir_fmt(FILE *out, SirValue v) {
     char buf[32];
+    if (_sir_fmt_depth > SIR_MAX_FMT_DEPTH) {
+        fputs("[...]", out);
+        return;
+    }
+    _sir_fmt_depth++;
     switch (v.tag) {
         case SIR_NIL:   fputs(SIR_DISPLAY_RUBY ? "" : "nil", out); break;
         case SIR_BOOL:  fputs(v.as.b ? (SIR_DISPLAY_RUBY ? "true" : "#t")
@@ -452,9 +593,11 @@ void _sir_fmt(FILE *out, SirValue v) {
         case SIR_STR:   fputs(v.as.s, out); break;
         case SIR_SYM:   fputs(v.as.s, out); break;
         case SIR_PAIR:  _sir_fmt_pair(out, v); break;
+        case SIR_SEQ:   _sir_fmt_seq(out, v); break;
         case SIR_CLOSURE: fputs("#<closure>", out); break;
         default: break;
     }
+    _sir_fmt_depth--;
 }
 
 SirValue _sir_print_v(SirValue *xs, int n) {

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_forrange.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_forrange.rs
@@ -195,24 +195,6 @@ fn unsupported_builtin_in_while_body_is_rejected_not_panicked() {
 }
 
 #[test]
-fn for_each_is_rejected_cleanly_not_panicked() {
-    // `Stmt::ForEach` observes only `Feature::Loops` (accepted), so it is NOT
-    // gated out — it must be rejected by the `first_foreach` pre-pass with a
-    // clean `BackendError`, never reach the emitter's `unreachable!`.
-    let for_each = Stmt::ForEach {
-        var: "e".into(),
-        iter: local("xs"),
-        body: Block { stmts: vec![puts(local("e"))], value: Expr::NilLit { span: s() }, span: s() },
-        span: s(),
-    };
-    let result = semantic_ir_to_c::compile(&loops_module(vec![
-        Stmt::LetBinding { name: "xs".into(), sir_type: None, value: ilit(0), span: s() },
-        for_each,
-    ]));
-    assert!(result.is_err(), "ForEach must reject cleanly, not panic");
-}
-
-#[test]
 fn for_range_with_unused_counter_compiles_under_werror() {
     // Regression: an empty-body / unused-counter loop must not emit an unused
     // variable — a `-Werror` consumer would break. Compile a for-range whose

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_sequences.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_sequences.rs
@@ -1,0 +1,247 @@
+//! Execution proof for SIR16 sequences on the C backend — hand-build modules
+//! (producer-agnostic), emit C, compile with a real gcc/clang-style compiler,
+//! run, assert stdout. Skips gracefully when no `cc` is present.
+//!
+//! Covers every `Feature::Sequences`-gated node — `SeqLit`, `SeqIndex`,
+//! `SeqLen`, `SeqSet` — plus `ForEach` (reachable once `Loops` is accepted) and
+//! structural equality (`[1,2] == [1,2]`). Hand-built to bypass any frontend
+//! that masks these nodes (the totality lesson).
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Scope, Span,
+    Stmt, CURRENT_SIR_VERSION,
+};
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    for cand in ["cc", "clang", "gcc"] {
+        if Command::new(cand)
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+        {
+            return Some(cand.to_string());
+        }
+    }
+    None
+}
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn run(module: &Module) -> Option<String> {
+    let cc = find_cc()?;
+    let artifact = semantic_ir_to_c::compile(module).expect("C backend compile (no panic)");
+    let dir = std::env::temp_dir();
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let stem = format!("sirc_seq_{}_{}", std::process::id(), n);
+    let cpath: PathBuf = dir.join(format!("{stem}.c"));
+    let exe: PathBuf = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::File::create(&cpath)
+        .and_then(|mut f| f.write_all(artifact.source.as_bytes()))
+        .expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-Werror=unused-variable", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        artifact.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "run failed (exit {:?})", r.status.code());
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+fn s() -> Span {
+    Span::synthetic()
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn seq(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+fn local(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
+}
+fn bc(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+fn puts(arg: Expr) -> Stmt {
+    Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: s() }
+}
+fn let_(name: &str, value: Expr) -> Stmt {
+    Stmt::LetBinding { name: name.into(), sir_type: None, value, span: s() }
+}
+/// A `main` module declaring Sequences + Loops.
+fn seq_module(stmts: Vec<Stmt>) -> Module {
+    Module {
+        name: "seqprog".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Sequences,
+            Feature::Loops,
+            Feature::Strings,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+#[test]
+fn seq_literal_displays_as_a_bracketed_list() {
+    // `puts([1, 2, 3])` → `[1, 2, 3]`, matching the Go/Rust format.
+    match run(&seq_module(vec![puts(seq(vec![ilit(1), ilit(2), ilit(3)]))])) {
+        Some(out) => assert_eq!(out, "[1, 2, 3]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn seq_structural_equality() {
+    // The point of this batch: `Array#==` is STRUCTURAL, so two DISTINCT arrays
+    // with equal elements compare equal — driven through an `if` so the check
+    // is convention-independent. Positive, negative, and nested.
+    let if_eq = |a: Expr, b: Expr, then: &str, els: &str| Stmt::ExprStmt {
+        expr: Expr::If {
+            cond: Box::new(bc("=", vec![a, b])),
+            then_branch: Box::new(Block {
+                stmts: vec![puts(Expr::StrLit { value: then.into(), span: s() })],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            }),
+            else_branch: Box::new(Block {
+                stmts: vec![puts(Expr::StrLit { value: els.into(), span: s() })],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            }),
+            span: s(),
+        },
+        span: s(),
+    };
+    let m = seq_module(vec![
+        if_eq(seq(vec![ilit(1), ilit(2)]), seq(vec![ilit(1), ilit(2)]), "same", "diff"),
+        if_eq(seq(vec![ilit(1), ilit(2)]), seq(vec![ilit(1), ilit(3)]), "same", "diff"),
+        if_eq(
+            seq(vec![seq(vec![ilit(1)]), ilit(2)]),
+            seq(vec![seq(vec![ilit(1)]), ilit(2)]),
+            "same",
+            "diff",
+        ),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "same\ndiff\nsame\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn seq_index_and_len() {
+    // `a = [10, 20, 30]; puts a[1]; puts a[-1]; puts a[9]; puts a.length`.
+    // `a[9]` is OOB → nil (prints "nil"); a negative index counts from the end.
+    let m = seq_module(vec![
+        let_("a", seq(vec![ilit(10), ilit(20), ilit(30)])),
+        puts(Expr::SeqIndex { seq: Box::new(local("a")), index: Box::new(ilit(1)), span: s() }),
+        puts(Expr::SeqIndex { seq: Box::new(local("a")), index: Box::new(ilit(-1)), span: s() }),
+        puts(Expr::SeqIndex { seq: Box::new(local("a")), index: Box::new(ilit(9)), span: s() }),
+        puts(Expr::SeqLen { seq: Box::new(local("a")), span: s() }),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "20\n30\nnil\n3\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn seq_set_mutates_the_shared_box() {
+    // `a = [1, 2, 3]; a[1] = 99; puts a` → `[1, 99, 3]`. The write is visible
+    // through the same handle (a boxed, shared sequence).
+    let m = seq_module(vec![
+        let_("a", seq(vec![ilit(1), ilit(2), ilit(3)])),
+        Stmt::SeqSet { seq: local("a"), index: ilit(1), value: ilit(99), span: s() },
+        puts(local("a")),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "[1, 99, 3]\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn for_each_iterates_a_sequence_block_scoped() {
+    // `for x in [1, 2, 3]: puts x` → `1\n2\n3`, and `x` is block-scoped: an
+    // enclosing `x = 99` survives the loop.
+    let m = seq_module(vec![
+        let_("x", ilit(99)),
+        Stmt::ForEach {
+            var: "x".into(),
+            iter: seq(vec![ilit(1), ilit(2), ilit(3)]),
+            body: Block { stmts: vec![puts(local("x"))], value: Expr::NilLit { span: s() }, span: s() },
+            span: s(),
+        },
+        puts(local("x")),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "1\n2\n3\n99\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn cyclic_sequence_does_not_stack_overflow() {
+    // `SeqSet` is the first MUTABLE heap aggregate, so a sequence can be made
+    // self-referential (`a[0] = a`) — a newly-reachable cycle. Equality and
+    // display must TERMINATE (via the depth caps), not crash the stack. `run`
+    // asserts the process exits 0; a stack overflow would be a non-zero exit.
+    let nil = || Expr::NilLit { span: s() };
+    let m = seq_module(vec![
+        // a = [nil]; a[0] = a   → a self-referential sequence
+        let_("a", seq(vec![nil()])),
+        Stmt::SeqSet { seq: local("a"), index: ilit(0), value: local("a"), span: s() },
+        // a == a → #t via the identical-handle fast path (no walk)
+        puts(bc("=", vec![local("a"), local("a")])),
+        // print(a) → terminates via the fmt depth cap (prints a bounded string)
+        puts(local("a")),
+        // two DISTINCT mutually-cyclic sequences: a[0]=b, b[0]=a
+        let_("b", seq(vec![nil()])),
+        Stmt::SeqSet { seq: local("b"), index: ilit(0), value: local("a"), span: s() },
+        Stmt::SeqSet { seq: local("a"), index: ilit(0), value: local("b"), span: s() },
+        // a == b → terminates via the eq depth cap (result is cap-defined; the
+        // point is it does not stack-overflow)
+        puts(bc("=", vec![local("a"), local("b")])),
+    ]);
+    match run(&m) {
+        Some(out) => {
+            let lines: Vec<&str> = out.lines().collect();
+            assert_eq!(lines.first().copied(), Some("#t"), "a == a is true (fast path)");
+            assert_eq!(lines.len(), 3, "all three puts ran — no stack overflow");
+        }
+        None => eprintln!("skip: no cc"),
+    }
+}

--- a/code/packages/rust/semantic-ir-to-c/tests/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/emit.rs
@@ -114,11 +114,11 @@ fn self_contained_no_external_headers() {
 
 #[test]
 fn unaccepted_feature_is_rejected_cleanly() {
-    // An array literal declares Feature::Sequences, which this backend does not
-    // accept (loops and mutation are now accepted, so a `while` no longer
-    // exercises the rejection path — an array still does).
-    let m = lower_ruby("puts [1, 2, 3]");
-    let err = compile(&m).expect_err("backend rejects Sequences");
+    // A hash literal declares Feature::Maps, which this backend does not accept
+    // (arrays now declare the accepted Sequences feature, so they no longer
+    // exercise the rejection path — a hash still does).
+    let m = lower_ruby("h = {1 => 2}\nputs h");
+    let err = compile(&m).expect_err("backend rejects Maps");
     assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
 }
 

--- a/code/packages/rust/sir-conformance/tests/comparisons.rs
+++ b/code/packages/rust/sir-conformance/tests/comparisons.rs
@@ -29,9 +29,9 @@
 //! **Composite equality.** `==`/`!=` on arrays are STRUCTURAL, not reference
 //! identity — the end-to-end proof that the JavaScript backend's `eq`→`valEq`
 //! change agrees cross-backend (JS used to answer `[1,2] == [1,2]` false). This
-//! runs on Python, JavaScript, Go and Rust; the C and Ruby v0 backends do not
-//! accept the `sequences` feature, so an array-literal program never lowers and
-//! those two `Skip` (a skipped case is not asserted, like a missing toolchain).
+//! now runs on ALL SIX backends: the Ruby (0.4.0) and C (0.6.0) backends gained
+//! the `sequences` feature, so an array-literal program lowers and asserts on
+//! each — C was the last that skipped it.
 //!
 //! Booleans render in the harness's default (Lisp) convention, so the expected
 //! strings are `#t` / `#f`.
@@ -76,10 +76,8 @@ const CASES: &[(&str, &str)] = &[
     // COMPOSITE equality — `==`/`!=` are STRUCTURAL for arrays, not reference
     // identity. This is the end-to-end proof that the JavaScript `eq`→`valEq`
     // change agrees cross-backend: JS used to answer `[1,2] == [1,2]` false
-    // (reference), the other backends true (structural). Runs on Python,
-    // JavaScript, Go and Rust; C and Ruby SKIP (their v0 backends do not accept
-    // the `sequences` feature, so a program with an array literal never lowers
-    // — a `Skipped` case is not asserted, exactly like a missing toolchain).
+    // (reference), the other backends true (structural). Now asserts on ALL SIX
+    // backends — Ruby and C gained the `sequences` feature (C was last).
     ("[1, 2] == [1, 2]", "#t"),
     ("[1, 2] == [1, 3]", "#f"),
     ("[1, 2] != [1, 3]", "#t"),


### PR DESCRIPTION
## What

The C backend was the **last** that rejected array literals (it didn't accept `Feature::Sequences`), so the cross-backend composite-equality conformance case skipped C. This gives C a real sequence runtime — **completing the arc**: `[1,2] == [1,2]` now asserts on all six backends (Python, JavaScript, Go, Rust, Ruby, C).

## How

`SirValue` gains a `SIR_SEQ` tag — a heap-boxed dynamic array (`struct SirSeq { SirValue *items; int64_t len; }`, arena-allocated) — so a sequence is a shared, mutable handle (a `SeqSet` through one binding is visible through every alias, matching the Go/Rust `*Seq`). Every construct the feature can surface is lowered:

| node | C |
|---|---|
| `SeqLit` | `_sir_seq_lit(n, …)` |
| `SeqIndex` | `_sir_seq_index` — negative-from-end, OOB → nil (no trap) |
| `SeqLen` | `_sir_seq_len` |
| `SeqSet` | `_sir_seq_set` — **traps** (`stderr`+`exit(1)`) on OOB/negative, matching the Go/Rust panic |
| `ForEach` | a `for` loop over `_sir_seq_iter` (snapshots a real sequence, flattens a cons-list); `var` block-scoped |

`_sir_value_eq` gains a structural `SIR_SEQ` arm (len + element-wise, with an identical-handle fast path that also short-circuits `a == a`); `_sir_fmt` renders `[1, 2, 3]` — both matching the Go/Rust backends.

**Cyclic-sequence guard (from review).** `SeqSet` is the first *mutable* heap aggregate — cons pairs are immutable, so cyclic cons-lists were unconstructable, but a self-referential sequence (`a[0] = a`) now is. `value_eq` and `fmt` carry a recursion-depth cap so such a structure terminates instead of overflowing the C stack (pinned by an adversarial cyclic test that must exit 0).

Removes the `first_foreach` pre-pass rejection added in 0.5.0 (`ForEach` is now handled). The emitter stays **total** — `is_simple`, the compound-operand hoisting, and the unsupported-builtin scan all handle the new nodes, so no conforming producer reaches an `unreachable!`.

## Tests

Every node verified by hand-built modules (producer-agnostic), compiled with a real `cc` under `-Werror=unused-variable` and run: display, structural equality (positive/negative/nested), index (in-range/negative/OOB→nil), length, in-bounds set, and block-scoped `ForEach`. The `sir-conformance` composite-equality doc + note updated to reflect all-six assertion.

Version: `semantic-ir-to-c` 0.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
