### PR TITLE
feat(num): NUM-6b — round_sig(x, n) exact significant-figures rounding

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.19.0] — 2026-07-22 — NUM-6b: render `round_sig` in the audit trail
+
+The derivation-tree renderer now names the KIND of precision narrowing: `"places"`
+for `round_to` (NUM-6a) and `"sig_figures"` for `round_sig` (NUM-6b), e.g.
+`{"node":"round","sig_figures":3,"mode":"half_even","value":31500,"operand":{…}}`.
+Adds an end-to-end test driving `round_sig(x, n)` through the built CLI across
+scales (large integer → power of ten, fraction, sub-1 value) with `n = 0` rejected.
+
 ## [0.18.0] — 2026-07-22 — NUM-6a: render the `round_to` narrowing in the audit trail
 
 The derivation-tree JSON now renders the new `DerivationNode::Round` (NUM-6a): a

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -161,10 +161,17 @@ fn derivation_tree_json(
             operand,
             result,
         } => {
-            let logic_engine::compute::RoundSpec::Places(places) = spec;
+            // The precision field names the KIND of narrowing: `places` for
+            // `round_to` (decimal places), `sig_figures` for `round_sig`.
+            let precision = match spec {
+                logic_engine::compute::RoundSpec::Places(p) => format!("\"places\":{p}"),
+                logic_engine::compute::RoundSpec::SigFigures(n) => {
+                    format!("\"sig_figures\":{n}")
+                }
+            };
             format!(
-                "{{\"node\":\"round\",\"places\":{},\"mode\":\"{}\",\"value\":{},\"operand\":{}}}",
-                places,
+                "{{\"node\":\"round\",{},\"mode\":\"{}\",\"value\":{},\"operand\":{}}}",
+                precision,
                 rounding_mode_name(*mode),
                 jnum(*result),
                 derivation_tree_json(operand, kb)

--- a/code/packages/rust/adj-lang-cli/tests/num6b_round_sig_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/num6b_round_sig_e2e.rs
@@ -1,0 +1,77 @@
+//! End-to-end tests for the NUM-6b `round_sig(x, n)` significant-figures
+//! narrowing, driven through the built `adj-lang-cli`. They prove the whole path
+//! — native application surface → the engine's magnitude-aware exact rounding →
+//! the audit JSON — works together across scales: a large integer rounds to the
+//! right power of ten, a fraction rounds to `n` significant digits (leading zeros
+//! not counted), the value stays **exact**, the audit exposes `sig_figures`, and
+//! `n = 0` (meaningless) is a clean compile error (ADJ-NUMERIC-SUBSTRATE §4.1–§4.4).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_num6b_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(src: &str, tag: &str) -> (bool, String) {
+    let dir = scratch(tag);
+    let p = dir.join("case.adj");
+    std::fs::write(&p, src).unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(&p)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn round_sig_rounds_a_large_integer_to_a_power_of_ten_and_audits_it() {
+    // 31459 to 3 significant figures = 31500 — rounding to the hundreds, held
+    // exactly as 31500/1, with the audit naming the significant-figures spec.
+    let (ok, s) = run("let r = round_sig(31459, 3)\n? r\n", "bigint");
+    assert!(ok, "cli should succeed: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    assert!(s.contains("\"value\":31500"), "rounds to 31500: {s}");
+    assert!(
+        s.contains("\"num\":\"31500\"") && s.contains("\"den\":\"1\""),
+        "exact 31500/1: {s}"
+    );
+    assert!(
+        s.contains("\"node\":\"round\"")
+            && s.contains("\"sig_figures\":3")
+            && s.contains("\"mode\":\"half_even\""),
+        "audit records the significant-figures narrowing: {s}"
+    );
+}
+
+#[test]
+fn round_sig_rounds_fractional_values_exactly_across_scales() {
+    // 3.14159 to 3 sig-figs = 3.14 = 157/50.
+    let (ok, s) = run("let r = round_sig(314159 / 100000, 3)\n? r\n", "frac");
+    assert!(ok, "cli should succeed: {s}");
+    assert!(
+        s.contains("\"value\":3.14") && s.contains("\"num\":\"157\"") && s.contains("\"den\":\"50\""),
+        "3.14159 → 3.14 = 157/50: {s}"
+    );
+    // 0.00314159 to 2 sig-figs = 0.0031 = 31/10000 (leading zeros don't count).
+    let (ok2, s2) = run("let r = round_sig(314159 / 100000000, 2)\n? r\n", "small");
+    assert!(ok2, "cli should succeed: {s2}");
+    assert!(
+        s2.contains("\"num\":\"31\"") && s2.contains("\"den\":\"10000\""),
+        "0.00314159 → 0.0031 = 31/10000: {s2}"
+    );
+}
+
+#[test]
+fn zero_significant_figures_is_a_compile_error() {
+    // Zero significant figures is meaningless; it must be rejected, not silently
+    // rounded to something.
+    let (ok, s) = run("let r = round_sig(5, 0)\n? r\n", "zero");
+    assert!(
+        !ok || s.contains("\"error\""),
+        "round_sig(x, 0) must be rejected: {s}"
+    );
+}

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.58.0] — 2026-07-22
+
+### Added — NUM-6b: the `round_sig(x, n)` significant-figures narrowing (ADJ-NUMERIC-SUBSTRATE §4.1–§4.4)
+
+```
+let reported = round_sig(measured / trials, 3)   % 3 significant figures
+```
+
+- `round_sig` joins `round_to` as a built-in recognised during `Apply` lowering
+  (same native comma-list application surface, no new grammar). Both now build a
+  `logic_engine::RoundSpec` — `Places` for `round_to`, `SigFigures` for `round_sig`
+  — carried by the shared `ExprAst::RoundTo` node and lowered to the engine's exact
+  `Round` eval.
+- `n` must be an integer literal within the DoS cap; **≥ 1** for `round_sig` (zero
+  significant figures is meaningless), ≥ 0 for `round_to`. Anything else is a clean
+  `FormulaBadArgument` compile error.
+
 ## [0.57.0] — 2026-07-22
 
 ### Added — NUM-6a: the `round_to(x, n)` precision narrowing (ADJ-NUMERIC-SUBSTRATE §4.1–§4.4)

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -254,17 +254,19 @@ pub enum ExprAst {
     /// `latex "…"` adapter from a `MathExpr::Call` whose argument is a
     /// two-element `Sequence`.
     Call2(BinFn, Box<ExprAst>, Box<ExprAst>),
-    /// A **precision narrowing** — `round_to(x, n)` (NUM-6a): round the operand to
-    /// `n` decimal places. Unlike [`ExprAst::Round`] (round to the nearest
-    /// *integer*), this carries a precision, so it lowers to the distinct
-    /// `logic_engine::ComputeExpr::Round` node (not a unary `ComputeOp`), rounding
-    /// on the exact path under the default half-even mode (ADJ-NUMERIC-SUBSTRATE
-    /// §4.1–§4.4). The `u32` is `n`, already validated a non-negative integer
-    /// within the precision cap. Produced by the **native application** surface
-    /// `round_to(x, n)` — recognised as a built-in in [`ExprAst::Apply`] lowering,
-    /// which reuses the same comma-list argument grammar as user formula
-    /// applications (`quotient(a, b)`), so no new grammar or LaTeX change is needed.
-    RoundTo(Box<ExprAst>, u32),
+    /// A **precision narrowing** — `round_to(x, n)` (NUM-6a, decimal places) or
+    /// `round_sig(x, n)` (NUM-6b, significant figures). Unlike [`ExprAst::Round`]
+    /// (round to the nearest *integer*), this carries a precision spec, so it lowers
+    /// to the distinct `logic_engine::ComputeExpr::Round` node (not a unary
+    /// `ComputeOp`), rounding on the exact path under the default half-even mode
+    /// (ADJ-NUMERIC-SUBSTRATE §4.1–§4.4). The [`logic_engine::RoundSpec`] is already
+    /// validated (a non-negative integer within the precision cap; ≥ 1 for
+    /// significant figures). Produced by the **native application** surface
+    /// `round_to(x, n)` / `round_sig(x, n)` — recognised as built-ins in
+    /// [`ExprAst::Apply`] lowering, which reuses the same comma-list argument grammar
+    /// as user formula applications (`quotient(a, b)`), so no new grammar or LaTeX
+    /// change is needed.
+    RoundTo(Box<ExprAst>, logic_engine::RoundSpec),
     /// An aggregation over every observation of a slot.
     Agg(AggOp, String),
     /// A **formula application** used as a sub-expression: `name(arg₁, …, argₙ)`

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -1216,8 +1216,8 @@ fn lower_expr(expr: &ExprAst) -> ComputeExpr {
         // and the default half-even mode ride along and the exact-path audit records
         // them (ADJ-NUMERIC-SUBSTRATE §4.1–§4.4). `n` was validated a non-negative
         // integer by the adapter.
-        ExprAst::RoundTo(a, places) => ComputeExpr::Round {
-            spec: logic_engine::RoundSpec::Places(*places),
+        ExprAst::RoundTo(a, spec) => ComputeExpr::Round {
+            spec: *spec,
             mode: bignum_core::RoundingMode::HalfEven,
             expr: Box::new(lower_expr(a)),
         },
@@ -1800,16 +1800,18 @@ fn expand_rec(
     let d = descend(node_depth)?;
     match expr {
         ExprAst::Apply(name, args) => {
-            // NUM-6a built-in: `round_to(x, n)` — the precision narrowing. Recognised
-            // by NAME here, BEFORE the user-formula lookup, so it needs no formula
-            // definition; it reuses the same comma-list application grammar as user
-            // formulas (`quotient(a, b)`), which is why no new grammar or LaTeX
+            // NUM-6a/6b built-ins: `round_to(x, n)` (n decimal PLACES) and
+            // `round_sig(x, n)` (n significant FIGURES) — the precision narrowings.
+            // Recognised by NAME here, BEFORE the user-formula lookup, so they need no
+            // formula definition; they reuse the same comma-list application grammar as
+            // user formulas (`quotient(a, b)`), which is why no new grammar or LaTeX
             // surface is required (ADJ-NUMERIC-SUBSTRATE §4.1). The value arg `x` is
-            // expanded (it may itself be an application); the precision `n` must be a
-            // non-negative INTEGER literal within the DoS cap [`MAX_ROUND_PLACES`] —
-            // a variable, fraction, negative, or oversized `n` is a clean compile
-            // error, never a silent mis-rounding.
-            if name == "round_to" {
+            // expanded (it may itself be an application); the precision `n` must be an
+            // INTEGER literal within the DoS cap [`MAX_ROUND_PLACES`] — non-negative for
+            // `round_to`, and ≥ 1 for `round_sig` (zero significant figures is
+            // meaningless). A variable, fraction, out-of-range, or oversized `n` is a
+            // clean compile error, never a silent mis-rounding.
+            if name == "round_to" || name == "round_sig" {
                 if args.len() != 2 {
                     return Err(LowerError::FormulaArity {
                         formula: name.clone(),
@@ -1817,16 +1819,22 @@ fn expand_rec(
                         got: args.len(),
                     });
                 }
-                let places = match &args[1] {
+                let min = if name == "round_sig" { 1.0 } else { 0.0 };
+                let n = match &args[1] {
                     ExprAst::Lit(v)
-                        if v.fract() == 0.0 && *v >= 0.0 && *v <= MAX_ROUND_PLACES as f64 =>
+                        if v.fract() == 0.0 && *v >= min && *v <= MAX_ROUND_PLACES as f64 =>
                     {
                         *v as u32
                     }
                     _ => return Err(LowerError::FormulaBadArgument { formula: name.clone() }),
                 };
+                let spec = if name == "round_sig" {
+                    logic_engine::RoundSpec::SigFigures(n)
+                } else {
+                    logic_engine::RoundSpec::Places(n)
+                };
                 let value = expand_rec(&args[0], formulas, depth, chain, active, budget, d)?;
-                return Ok(ExprAst::RoundTo(Box::new(value), places));
+                return Ok(ExprAst::RoundTo(Box::new(value), spec));
             }
             // Resolve the callee against the SAME registry the top-level query path
             // uses. An unknown name is a clean, specific error — distinct from an

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.46.0] — 2026-07-22 — NUM-6b: `round_sig` — significant-figures rounding (exact)
+
+Adds the significant-figures half of the precision narrowing (NUM-6b,
+`ADJ-NUMERIC-SUBSTRATE.md` §4.1–§4.4), reusing the NUM-6a `Round` node and exact
+eval path.
+
+### Added
+
+- `RoundSpec::SigFigures(u32)` — round to `n` **significant figures**. Rounding to
+  `n` sig-figs is rounding to `n − 1 − e` decimal *places*, where `e = ⌊log₁₀|x|⌋`
+  is the base-10 exponent of the operand's most-significant digit; the place count
+  (which may be **negative** — `round_sig(31_459, 3) = 31_500`) is derived exactly
+  and fed to the same `BigDecimal::div_round` path as `Places`.
+- `msd_exponent` — computes `⌊log₁₀(num/den)⌋` exactly for positive integers from
+  their decimal digit counts plus one big-integer comparison (no `f64` log, no
+  unbounded loop). `round_sig(0, n) = 0` (zero has no significant figures).
+
 ## [0.45.0] — 2026-07-22 — NUM-6a: the `round_to` precision narrowing (exact + audited)
 
 Implements the compute-engine half of NUM-6a (`ADJ-NUMERIC-SUBSTRATE.md` §4.1–§4.4):

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -435,6 +435,13 @@ pub enum RoundSpec {
     /// Round to exactly `n` digits after the decimal point. `round_to(x, 0)` is
     /// the precision-parameterized generalization of the integer `Round`.
     Places(u32),
+    /// Round to `n` **significant figures** — `round_sig(x, n)` (NUM-6b). Rounding
+    /// to `n` sig-figs is rounding to `n − 1 − e` decimal *places*, where `e` is the
+    /// base-10 exponent of `x`'s most-significant digit (`e = ⌊log₁₀|x|⌋`); that
+    /// place count is derived exactly from the operand's magnitude and handed to the
+    /// same exact rounding path as [`RoundSpec::Places`] (the place count may be
+    /// negative — `round_sig(31_459, 3) = 31_500`, rounding to the hundreds). `n ≥ 1`.
+    SigFigures(u32),
 }
 
 /// A node in the derivation tree — the provenance-through-math record.
@@ -1153,26 +1160,74 @@ fn eval_round(
 }
 
 /// Round an exact rational to `spec`'s precision under `mode`, staying exact.
+///
+/// Both forms reduce to "round `n / d` to `places` decimal places" via
+/// [`BigDecimal::div_round`] — `Places` uses the stated count directly;
+/// `SigFigures` derives it from the operand's magnitude ([`msd_exponent`]). `d` is
+/// a rational denominator, always > 0, so the division is total (never the
+/// divide-by-zero `div_round` guards against). `places` may be **negative** for a
+/// significant-figures rounding of a large number (`round_sig(31_459, 3) → 31_500`,
+/// `places = 3 − 1 − 4 = −2`), which `div_round` and `BigDecimal::to_rational`
+/// both handle.
 fn round_rational(r: &ExactRational, spec: RoundSpec, mode: RoundingMode) -> ExactRational {
-    let RoundSpec::Places(places) = spec;
-    // `n / d` as two integer `BigDecimal`s, then divide-with-rounding to `places`
-    // decimal places. `d` is a rational denominator, always > 0, so the division
-    // is total (never the divide-by-zero `div_round` guards against).
+    let places: i64 = match spec {
+        RoundSpec::Places(p) => p as i64,
+        RoundSpec::SigFigures(sig) => {
+            // Zero has no significant figures — `round_sig(0, n)` is exactly 0
+            // (any other place count would still round 0/d to 0, but short-circuit
+            // to avoid a meaningless `msd_exponent(0)`).
+            if r.numerator().is_zero() {
+                return ExactRational::from_i128(0);
+            }
+            // n sig-figs = round to (n − 1 − e) decimal places, e = ⌊log₁₀|x|⌋.
+            (sig as i64) - 1 - msd_exponent(&r.numerator().abs(), r.denominator())
+        }
+    };
     let num = BigDecimal::from_integer(r.numerator().clone());
     let den = BigDecimal::from_integer(r.denominator().clone());
-    let rounded = num.div_round(&den, places as i64, mode);
+    let rounded = num.div_round(&den, places, mode);
     ExactRational::from_ratio(rounded.to_rational())
 }
 
-/// Round an `f64` to `spec`'s decimal places — the fallback for an operand that
-/// carried no exact value (already inexact, e.g. a transcendental result). It
-/// scales, rounds to the nearest integer, and unscales; on this already-lossy
-/// path the tie rule is `f64::round`'s ties-away rather than `mode`, which is
-/// acceptable because the value is approximate to begin with (the exact path,
-/// which every rational formula takes, honors `mode` precisely).
+/// `⌊log₁₀(num / den)⌋` for positive integers `num, den` — the base-10 exponent of
+/// the most-significant digit of the value. Exact and allocation-cheap: from the
+/// decimal digit counts `dn, dd` we have `num/den ∈ (10^(dn−dd−1), 10^(dn−dd+1))`,
+/// so the exponent is either `dn − dd` or one less; a single big-integer comparison
+/// against `10^e` (moved to the numerator side when `e < 0` to stay in integers)
+/// picks the right one. Assumes `num > 0` (the caller short-circuits zero).
+fn msd_exponent(num: &BigInteger, den: &BigInteger) -> i64 {
+    let e0 = num.to_string().len() as i64 - den.to_string().len() as i64;
+    let ten = BigInteger::from_i64(10);
+    // Is `num/den ≥ 10^e0`?  ⟺  `num ≥ den·10^e0` (e0 ≥ 0)  or  `num·10^(−e0) ≥ den` (e0 < 0).
+    let at_least_e0 = if e0 >= 0 {
+        *num >= &den.clone() * &ten.pow(e0 as u32)
+    } else {
+        &num.clone() * &ten.pow((-e0) as u32) >= *den
+    };
+    if at_least_e0 {
+        e0
+    } else {
+        e0 - 1
+    }
+}
+
+/// Round an `f64` to `spec`'s precision — the fallback for an operand that carried
+/// no exact value (already inexact, e.g. a transcendental result). It scales,
+/// rounds to the nearest integer, and unscales; on this already-lossy path the tie
+/// rule is `f64::round`'s ties-away rather than `mode`, which is acceptable because
+/// the value is approximate to begin with (the exact path, which every rational
+/// formula takes, honors `mode` precisely).
 fn round_f64(value: f64, spec: RoundSpec, _mode: RoundingMode) -> f64 {
-    let RoundSpec::Places(places) = spec;
-    let factor = 10f64.powi(places as i32);
+    let places: i32 = match spec {
+        RoundSpec::Places(p) => p as i32,
+        RoundSpec::SigFigures(sig) => {
+            if value == 0.0 || !value.is_finite() {
+                return value;
+            }
+            (sig as i32) - 1 - value.abs().log10().floor() as i32
+        }
+    };
+    let factor = 10f64.powi(places);
     (value * factor).round() / factor
 }
 
@@ -2511,6 +2566,65 @@ mod tests {
             Box::new(ComputeExpr::Lit(a as f64)),
             Box::new(ComputeExpr::Lit(b as f64)),
         )
+    }
+    fn round_sig(n: u32, inner: ComputeExpr) -> ComputeExpr {
+        ComputeExpr::Round {
+            spec: RoundSpec::SigFigures(n),
+            mode: RoundingMode::HalfEven,
+            expr: Box::new(inner),
+        }
+    }
+
+    // ---- NUM-6b: round_sig — the significant-figures narrowing ----
+
+    #[test]
+    fn msd_exponent_is_exact_across_magnitudes() {
+        // ⌊log₁₀(num/den)⌋ for a spread of values, incl. the boundary cases (exact
+        // powers of ten, values just under a power, sub-1 values).
+        let e = |num: i64, den: i64| {
+            super::msd_exponent(
+                &BigInteger::from_i64(num),
+                &BigInteger::from_i64(den),
+            )
+        };
+        assert_eq!(e(314159, 1000), 2); // 314.159 → MSD at 10^2
+        assert_eq!(e(314, 100), 0); // 3.14 → 10^0
+        assert_eq!(e(1, 1), 0); // 1 → 10^0
+        assert_eq!(e(999, 100), 0); // 9.99 → 10^0 (just under 10^1)
+        assert_eq!(e(1000, 1), 3); // 1000 → 10^3 (exact power)
+        assert_eq!(e(1, 2), -1); // 0.5 → 10^-1
+        assert_eq!(e(1, 1000), -3); // 0.001 → 10^-3 (exact power)
+        assert_eq!(e(9, 10000), -4); // 0.0009 → 10^-4
+        assert_eq!(e(314, 100000), -3); // 0.00314 → 10^-3
+    }
+
+    #[test]
+    fn round_sig_rounds_a_large_integer_to_the_hundreds_exactly() {
+        let kb = KnowledgeBase::new();
+        // 31459 to 3 significant figures = 31500 (place count −2 — rounding to the
+        // hundreds — which the exact path handles). Held exactly as 31500/1.
+        let d = compute("r", &round_sig(3, ComputeExpr::Lit(31459.0)), &kb).unwrap();
+        assert_eq!(d.value, 31500.0);
+        assert_eq!(d.exact, ExactRational::new(31500, 1));
+    }
+
+    #[test]
+    fn round_sig_rounds_fractional_values_exactly_across_scales() {
+        let kb = KnowledgeBase::new();
+        // 3.14159 (314159/100000) to 3 sig-figs = 3.14 = 157/50.
+        let a = compute("r", &round_sig(3, frac(314159, 100000)), &kb).unwrap();
+        assert_eq!(a.exact, ExactRational::new(157, 50));
+        // 0.00314159 to 2 sig-figs = 0.0031 = 31/10000 (leading zeros don't count).
+        let b = compute("r", &round_sig(2, frac(314159, 100_000_000)), &kb).unwrap();
+        assert_eq!(b.exact, ExactRational::new(31, 10000));
+    }
+
+    #[test]
+    fn round_sig_of_zero_is_zero() {
+        let kb = KnowledgeBase::new();
+        let d = compute("r", &round_sig(3, ComputeExpr::Lit(0.0)), &kb).unwrap();
+        assert_eq!(d.exact, ExactRational::new(0, 1));
+        assert_eq!(d.value, 0.0);
     }
 
     #[test]

--- a/code/specs/ADJ-NUMERIC-SUBSTRATE.md
+++ b/code/specs/ADJ-NUMERIC-SUBSTRATE.md
@@ -156,11 +156,13 @@ to the target scale — both already in `bignum-core` — then back to an exact 
 the recorded exact-source sidecar for the audit. NUM-6 lands in focused PRs, each spec-sync →
 tests → impl → security-review → babysit:
 
-- **NUM-6a** — `round_to` (decimal places): the `Round`/`RoundSpec::Places` engine node, the
-  `\operatorname{round}(x, n)` LaTeX surface + adapter arm, exact eval, the §4.3 audit record,
-  and an end-to-end formula test. (First increment.)
-- **NUM-6b** — `round_sig` (`RoundSpec::SigFigures`): derive the target scale from the value's
-  most-significant-digit exponent, reusing 6a's eval.
+- **NUM-6a** — `round_to` (decimal places) ✅ **shipped** (#8806): the
+  `Round`/`RoundSpec::Places` engine node, the native `round_to(x, n)` application surface (see
+  §4.1's surface note), exact eval, the §4.3 audit record, and an end-to-end formula test.
+- **NUM-6b** — `round_sig` (`RoundSpec::SigFigures`) ✅ **shipped**: derives the target place
+  count `n − 1 − ⌊log₁₀|x|⌋` from the value's most-significant-digit exponent (computed exactly
+  from big-integer digit counts) and reuses 6a's exact eval. Native `round_sig(x, n)` surface,
+  `n ≥ 1`.
 - **NUM-6c** — the formatters `to_scientific` / `to_percent` / `to_currency` (rendering, on the
   6a/6b core) and per-`KnowledgeBase` `BigDouble` precision (the configurable default §3 defers
   here).


### PR DESCRIPTION
## What & why

Second increment of **NUM-6** (`ADJ-NUMERIC-SUBSTRATE.md` §4.1–§4.4), on top of the just-merged NUM-6a (#8806): `round_sig(x, n)` rounds a value to `n` **significant figures**, exactly. Like `round_to`, it's an explicit, auditable narrowing — `round_sig(31459, 3) = 31500`, `round_sig(3.14159, 3) = 3.14` (held exactly as `157/50`), `round_sig(0.00314159, 2) = 0.0031` (`31/10000`).

## How it reuses NUM-6a

Rounding to `n` sig-figs is rounding to `n − 1 − e` decimal **places**, where `e = ⌊log₁₀|x|⌋` is the base-10 exponent of the operand's most-significant digit. So `round_sig` adds one `RoundSpec::SigFigures` variant and derives the place count — the rest is NUM-6a's exact `div_round` path unchanged. The place count may be **negative** (rounding `31459` to 3 sig-figs = the hundreds), which the exact path already handles.

- **logic-engine 0.46.0** — `RoundSpec::SigFigures(u32)` + `msd_exponent`, which computes `⌊log₁₀(num/den)⌋` **exactly** from the operands' decimal digit counts plus one big-integer comparison (no `f64` log, no unbounded loop). `round_sig(0, n) = 0`.
- **adj-lang 0.58.0** — `round_sig` joins `round_to` as an `Apply`-lowering built-in (same native comma-list surface, no new grammar). The shared node became `ExprAst::RoundTo(Box<ExprAst>, RoundSpec)` so both ops ride one node. `n ≥ 1` for `round_sig` (0 sig-figs is meaningless) — else a clean `FormulaBadArgument`.
- **adj-lang-cli 0.19.0** — the audit renders `"sig_figures":n` for `round_sig`, `"places":n` for `round_to`.
- **adj-constraint-solver** — no change needed: its `Round { .. }` arms are transparent to a new `RoundSpec` variant.

## Verification

- 4 engine unit tests (exact `msd_exponent` across magnitudes incl. exact powers and sub-1 values; large-int → power of ten; fractional across scales; zero) + a 3-case adj-lang-cli e2e (`31459→31500`, `3.14159→3.14=157/50`, `0.00314159→0.0031=31/10000`, `n=0` rejected).
- Full `cargo test` across the four crates **green** (40 suites, 0 failures). Clippy clean. Security review passed (exact-and-bounded `msd_exponent`, no panics/overflow on malformed input, denominator provably non-zero, zero short-circuits before `msd_exponent`).

## Deferred

NUM-6c — the formatters `to_scientific` / `to_percent` / `to_currency` + per-`KnowledgeBase` `BigDouble` precision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)