### PR TITLE
feat(semantic-ir-to-ruby): maps — native Hash (SIR16)

### DIFF
--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.5.0 — maps (SIR16)
+
+Accepts `Feature::Maps`. Ruby has a native Hash, so the three map nodes render
+directly — no runtime value-boxing like the Go/Rust backends' `_sir_map_*`:
+
+- `Expr::MapLit` (`{k => v, …}`) → a native Hash literal.
+- `Expr::MapGet` (`h[k]`) → `(h)[k]`: a missing key yields nil (no raise),
+  matching `_sir_map_get`.
+- `Stmt::MapSet` (`h[k] = v`) → `(h)[k] = v`: insert-or-update, mutating the
+  shared Hash (a write through one binding is visible through every alias). A
+  map has no bounds, so — unlike `SeqSet` — no guard helper is needed.
+
+Ruby's Hash preserves insertion order and compares keys with `eql?`/`hash`,
+which is STRUCTURAL for composite keys — so `{[1, 2] => x}[[1, 2]]` finds the
+entry, matching the reference's `_sir_value_eq` key comparison. (One documented
+divergence: `eql?` is type-strict for numbers, so a Ruby `{1 => x}[1.0]` is nil
+where the reference's cross-representation `_sir_value_eq` would match; a
+mixed int/float map key is rare and not exercised by any conformance case.)
+
+`ForEach` over a Hash needs no new arm — the existing `(iter).each { |x| … }`
+works on a Hash (yielding `[k, v]`) as well as an Array — so accepting Maps
+keeps the emitter total. Every node verified by hand-built modules (bypassing
+the frontend, which does not yet produce these), run against a real `ruby`.
+
 ## 0.4.0 — sequences (SIR16)
 
 Accepts `Feature::Sequences`. Ruby has native arrays, so the SIR16 sequence

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/README.md
+++ b/code/packages/rust/semantic-ir-to-ruby/README.md
@@ -50,11 +50,13 @@ SIR16 control flow and mutation (`Loops` — `While`, `ForRange` (numeric
 `Sequences` — native arrays for all five sequence nodes: `SeqLit` (`[1, 2, 3]`,
 structural `Array#==`), `SeqIndex` (`a[i]`, nil on OOB), `SeqLen` (`a.length`),
 `SeqSet` (`a[i] = v`, bounds-checked via `sir_seq_set`), and `ForEach`
-(`for x in a`).
+(`for x in a`); and SIR16 `Maps` — a native Hash for `MapLit` (`{k => v}`),
+`MapGet` (`h[k]`, nil on miss), and `MapSet` (`h[k] = v`), with structural
+composite keys.
 Rejects `TailCalls`, `Intrinsics`, and every not-yet-wired feature (array
 indexing / slicing via `IndexGet` — `NDArrays`; array-pattern destructuring —
-`ShortCircuit`; maps, collection methods, exceptions, OOP) until its cascade
-batch lands — each a clean, source-positioned `UnsupportedFeature`.
+`ShortCircuit`; collection methods, exceptions, OOP) until its cascade batch
+lands — each a clean, source-positioned `UnsupportedFeature`.
 
 ## Verification
 

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -138,6 +138,11 @@ fn scan_stmt(s: &Stmt) -> Option<(String, semantic_ir::Span)> {
         } => scan_expr(seq)
             .or_else(|| scan_expr(index))
             .or_else(|| scan_expr(value)),
+        Stmt::MapSet {
+            map, key, value, ..
+        } => scan_expr(map)
+            .or_else(|| scan_expr(key))
+            .or_else(|| scan_expr(value)),
         // Compound-statement bodies must be scanned too, or an unsupported
         // builtin hidden in a loop body survives the pre-check and reaches the
         // emitter's `unreachable!`. (`While` was a pre-existing scan hole.)
@@ -187,6 +192,10 @@ fn scan_expr(e: &Expr) -> Option<(String, semantic_ir::Span)> {
         Expr::SeqLit { items, .. } => items.iter().find_map(scan_expr),
         Expr::SeqIndex { seq, index, .. } => scan_expr(seq).or_else(|| scan_expr(index)),
         Expr::SeqLen { seq, .. } => scan_expr(seq),
+        Expr::MapLit { entries, .. } => entries
+            .iter()
+            .find_map(|e| scan_expr(&e.key).or_else(|| scan_expr(&e.value))),
+        Expr::MapGet { map, key, .. } => scan_expr(map).or_else(|| scan_expr(key)),
         _ => None,
     }
 }
@@ -269,6 +278,18 @@ fn emit_stmt(s: &Stmt) -> String {
             "sir_seq_set({}, {}, {})",
             emit_expr(seq),
             emit_expr(index),
+            emit_expr(value)
+        ),
+        // `h[k] = v` — native `Hash#[]=`, which inserts or updates and mutates
+        // the shared Hash (matching `_sir_map_set`). Unlike a sequence, a map
+        // has no bounds, so no guard helper is needed; the assignment evaluates
+        // to `v`, but here it stands in statement position.
+        Stmt::MapSet {
+            map, key, value, ..
+        } => format!(
+            "({})[{}] = {}",
+            emit_expr(map),
+            emit_expr(key),
             emit_expr(value)
         ),
         // `iter.each { |var| … }` — a BLOCK, so `var` and any body-local are
@@ -430,6 +451,24 @@ fn emit_expr(e: &Expr) -> String {
         }
         // `a.length` — native `Array#length`, matching `_sir_seq_len`.
         Expr::SeqLen { seq, .. } => format!("({}).length", emit_expr(seq)),
+        // SIR16 map literal (`{k => v, …}`) → a native Ruby Hash — no runtime
+        // helper (unlike the Go/Rust backends, whose tagged-value runtimes box
+        // a `*Map`/assoc-list). Each key and value is an expression, emitted
+        // recursively. Ruby's Hash preserves insertion order and compares keys
+        // structurally (`eql?`/`hash`), so a composite key like `[1, 2]` works.
+        Expr::MapLit { entries, .. } => {
+            let pairs: Vec<String> = entries
+                .iter()
+                .map(|e| format!("{} => {}", emit_expr(&e.key), emit_expr(&e.value)))
+                .collect();
+            format!("{{{}}}", pairs.join(", "))
+        }
+        // `h[k]` (read). Native `Hash#[]`: a missing key yields nil (no raise),
+        // matching `_sir_map_get`. The receiver is parenthesised so a compound
+        // `map` expression indexes correctly.
+        Expr::MapGet { map, key, .. } => {
+            format!("({})[{}]", emit_expr(map), emit_expr(key))
+        }
         // SIR26: integer conversion → a mask helper chosen by target width +
         // signedness.  A target width of `Arbitrary` is the identity (a widen
         // into Ruby's already-unbounded Integer), so no helper wraps it.

--- a/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
@@ -87,6 +87,16 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // not accepted); array-*pattern* destructuring needs `ShortCircuit` (not
     // accepted) — so those stay rejected at the feature gate.
     Feature::Sequences,
+    // ── SIR16 maps ───────────────────────────────────────────────────
+    // Ruby has a native Hash, so the three `maps` nodes render directly (no
+    // runtime value-boxing like the Go/Rust `_sir_map_*`):
+    //   `Expr::MapLit` → `{k => v, …}` (a Hash literal; keys compared by
+    //                     `eql?`/`hash`, which is structural for composite keys)
+    //   `Expr::MapGet` → `(h)[k]`      (missing key → nil, no raise)
+    //   `Stmt::MapSet` → `(h)[k] = v`  (insert/update, mutates the shared Hash)
+    // `ForEach` over a Hash is already covered — `(h).each { |kv| … }` works on
+    // a Hash as well as an Array — so accepting Maps adds no new `unreachable!`.
+    Feature::Maps,
 ];
 
 impl Backend for RubyBackend {

--- a/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
@@ -591,3 +591,114 @@ fn unsupported_builtin_in_while_body_is_rejected_not_panicked() {
     let result = compile(&loops_module(vec![while_stmt]));
     assert!(result.is_err(), "an unsupported builtin in a while body must be rejected cleanly");
 }
+
+// ── SIR16 maps: HAND-BUILT modules (producer-agnostic) ──────────────────────
+//
+// The Ruby frontend does not yet PRODUCE MapLit/MapGet/MapSet, so a source
+// test would mask them. SIR is producer-agnostic — a C→SIR / Twig→SIR module
+// can carry these with a `{Maps}` manifest this backend now accepts. Built
+// directly; each proves the emitter is total and matches native Hash.
+
+use semantic_ir::MapEntry;
+
+fn strlit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s2() }
+}
+fn maplit(entries: Vec<(Expr, Expr)>) -> Expr {
+    Expr::MapLit {
+        entries: entries.into_iter().map(|(k, v)| MapEntry { key: k, value: v }).collect(),
+        span: s2(),
+    }
+}
+fn mapget(map: Expr, key: Expr) -> Expr {
+    Expr::MapGet { map: Box::new(map), key: Box::new(key), span: s2() }
+}
+/// A `main` module declaring Maps + Sequences + Strings + Loops.
+fn map_module(stmts: Vec<Stmt>) -> Module {
+    let mut m = seq_module(stmts);
+    m.manifest = FeatureManifest::from_features(&[
+        Feature::Maps,
+        Feature::Sequences,
+        Feature::Strings,
+        Feature::Loops,
+    ]);
+    m
+}
+fn run_map(stmts: Vec<Stmt>) -> Option<String> {
+    run_ruby(&compile(&map_module(stmts)).expect("map module must compile, not panic").source)
+}
+fn let_(name: &str, value: Expr) -> Stmt {
+    Stmt::LetBinding { name: name.into(), sir_type: None, value, span: s2() }
+}
+
+#[test]
+fn map_get_reads_present_and_missing_keys() {
+    // `h = {1 => 10, 2 => 20}; puts h[2]; puts h[9]` → 20, then nil (a missing
+    // key yields nil, no raise — matching `_sir_map_get`).
+    let out = run_map(vec![
+        let_("h", maplit(vec![(ilit(1), ilit(10)), (ilit(2), ilit(20))])),
+        puts(mapget(local("h"), ilit(2))),
+        puts(mapget(local("h"), ilit(9))),
+    ]);
+    match out {
+        Some(o) => assert_eq!(o, "20\nnil"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn map_set_inserts_and_updates_the_shared_hash() {
+    // `h = {1 => 10}; h[2] = 20; h[1] = 99; puts h[1]; puts h[2]` → 99, 20.
+    let out = run_map(vec![
+        let_("h", maplit(vec![(ilit(1), ilit(10))])),
+        Stmt::MapSet { map: local("h"), key: ilit(2), value: ilit(20), span: s2() },
+        Stmt::MapSet { map: local("h"), key: ilit(1), value: ilit(99), span: s2() },
+        puts(mapget(local("h"), ilit(1))),
+        puts(mapget(local("h"), ilit(2))),
+    ]);
+    match out {
+        Some(o) => assert_eq!(o, "99\n20"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn map_composite_key_is_structural() {
+    // A composite key `[1, 2]` looks up by VALUE (Ruby Array#eql?/#hash are
+    // structural), so a DISTINCT equal array finds the entry.
+    let out = run_map(vec![
+        let_("h", maplit(vec![(seq(vec![ilit(1), ilit(2)]), strlit("found"))])),
+        puts(mapget(local("h"), seq(vec![ilit(1), ilit(2)]))),
+    ]);
+    match out {
+        Some(o) => assert_eq!(o, "found"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn map_literal_emits_a_native_hash() {
+    let rb = compile(&map_module(vec![puts(maplit(vec![(ilit(1), ilit(2))]))]))
+        .expect("compile")
+        .source;
+    assert!(rb.contains("{1 => 2}"), "MapLit should be a native Hash literal:\n{rb}");
+}
+
+#[test]
+fn for_each_over_a_map_does_not_panic() {
+    // Accepting Maps makes `ForEach` over a Hash reachable (Loops + Maps). The
+    // emitted `(h).each { |kv| … }` works on a Hash (yielding [k, v]) as well
+    // as an Array — so the backend must not panic and the program must run.
+    let m = map_module(vec![Stmt::ForEach {
+        var: "kv".into(),
+        iter: maplit(vec![(ilit(1), ilit(10))]),
+        body: Block { stmts: vec![puts(local("kv"))], value: Expr::NilLit { span: s2() }, span: s2() },
+        span: s2(),
+    }]);
+    // Must compile without an `unreachable!` panic.
+    let rb = compile(&m).expect("ForEach over a map must compile, not panic").source;
+    assert!(rb.contains(").each do |kv|"), "map ForEach is a .each block:\n{rb}");
+    if let Some(out) = run_ruby(&rb) {
+        assert!(!out.is_empty(), "the loop ran and printed the entry");
+    }
+}


### PR DESCRIPTION
## What

The Ruby backend rejected hash literals (it didn't accept `Feature::Maps`), so map programs every other backend runs were skipped. Ruby has a native Hash, so the three map nodes render directly — no runtime value-boxing like the Go/Rust `_sir_map_*`:

| node | Ruby |
|---|---|
| `MapLit` (`{k => v}`) | a native Hash literal |
| `MapGet` (`h[k]`) | `(h)[k]` — missing key → nil (no raise), matching `_sir_map_get` |
| `MapSet` (`h[k] = v`) | `(h)[k] = v` — insert/update, mutates the shared Hash |

Ruby's Hash compares keys with `eql?`/`hash` — **structural** for composite keys, so `{[1,2] => x}[[1,2]]` finds the entry, matching the reference's `_sir_value_eq`.

## Totality & scope

Accepting `Feature::Maps` — the gated node set is exactly {`MapLit`, `MapGet`, `MapSet`}, all handled (plus scan arms). `ForEach` over a Hash needs no new arm: the existing `(iter).each { |x| … }` works on a Hash (yielding `[k, v]`) as well as an Array, so the emitter stays **total**.

**Documented divergence** (rare, no conformance case): `eql?` is type-strict for numbers, so `{1 => x}[1.0]` is nil where the reference's cross-representation `_sir_value_eq` would return `x`. Map value-equality order-independence (Ruby `Hash#==`) vs the reference's insertion-order comparison is likewise a latent difference with no conformance case yet.

## Tests

Hand-built modules (producer-agnostic — the Ruby frontend doesn't yet produce these), run against a real `ruby`: get (present/missing), set (insert/update), a structural composite key, native-Hash emission, and a `ForEach` over a map (no panic).

Version: `semantic-ir-to-ruby` 0.5.0. This is the first half of the Maps arc (mirroring the sequences arc); a follow-up gives the C backend a `SIR_MAP` runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
