### PR TITLE
feat(app): language chain + teaching sweep — HL03 phase 2 (sequencing layer)

### DIFF
--- a/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.8.0 — the language chain and the teaching sweep (HL03 phase 2)
+
+- First implementation piece of the unified language-learning app
+  ([HL03](../../../specs/HL03-unified-language-learning-app.md)): a pure
+  `sequence.ts` module encoding the fixed **language chain**
+  (Spanish → Latin → French → German → Arabic → Hindi → Tamil → Kannada →
+  Telugu → Malayalam) and the **teaching sweep** — for one concept, the active
+  languages that teach it, walked in chain order.
+- `teachingSweep(concept, lessons, active)` filters to the concept, restricts to
+  the active chain prefix, skips languages that do not teach it, and orders the
+  result by the chain (never by input order). `sweepableConcepts` lists concepts
+  in book order (earliest chapter first). No UI — sequencing logic only.
+- Verified against the real curriculum: `GREETING-HELLO` sweeps all ten
+  languages in exact chain order. Every honesty check is paired with a control
+  that fails on broken input — and writing this caught a redundant active-filter
+  that would have made the "only active languages" test vacuous; removed so the
+  test can actually fail.
+
 ## 0.7.1 — each script's at-a-glance identification signature
 
 - Every script now carries a **`signature`** — the one visual feature that gives

--- a/code/programs/typescript/script-writing-visualizer/package.json
+++ b/code/programs/typescript/script-writing-visualizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "script-writing-visualizer",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "private": true,
   "description": "Companion study app (HL02): break a non-Latin script apart and learn to write it — and drill the whole written curriculum with a spaced-repetition schedule that remembers you",
   "type": "module",

--- a/code/programs/typescript/script-writing-visualizer/src/sequence.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/sequence.ts
@@ -1,0 +1,161 @@
+// ---------------------------------------------------------------------------
+// sequence.ts — the language CHAIN and the per-concept TEACHING SWEEP (HL03)
+// ---------------------------------------------------------------------------
+//
+// The unified app (HL03) teaches along a fixed CHAIN of languages, each hop
+// chosen because a bridge already exists to a language learned earlier:
+//
+//   Spanish → Latin (the roots beneath Spanish) → French → German (the English
+//   twins) → Arabic → Hindi (where Arabic, Persian and Sanskrit meet) → Tamil
+//   (first Dravidian) → Kannada (Tamil's cousin, + Sanskrit) → Telugu → Malayalam
+//
+// Learning moves CONCEPT BY CONCEPT. To learn a concept is to walk it across
+// every language the learner has added so far — the "active" prefix of the
+// chain — IN CHAIN ORDER, so the cognates, shared roots and false friends line
+// up. That walk is the TEACHING SWEEP, and it is the one operation this module
+// exists to compute.
+//
+// This module is the *sequencing* layer only: pure, deterministic, no UI, no
+// review. Review (the randomised cumulative quiz) and the connections a sweep
+// surfaces are later layers that build on this one. Everything here is a pure
+// function of its inputs so it can be tested exactly, against fixtures and
+// against the real curriculum.
+// ---------------------------------------------------------------------------
+
+import type { Lesson } from "./lessons";
+
+/**
+ * The chain, in the order languages are added. These are track directory names
+ * under `code/learning/human-languages/`. The order is not arbitrary — it is a
+ * connected path where each language reaches back to one already known.
+ */
+export const LANGUAGE_CHAIN = [
+  "spanish",
+  "latin",
+  "french",
+  "german",
+  "arabic",
+  "hindi",
+  "tamil",
+  "kannada",
+  "telugu",
+  "malayalam",
+] as const;
+
+export type ChainLanguage = (typeof LANGUAGE_CHAIN)[number];
+
+/** Position of a language in the chain, or -1 if it is not on the chain. */
+export function chainIndex(language: string): number {
+  return (LANGUAGE_CHAIN as readonly string[]).indexOf(language);
+}
+
+export function isChainLanguage(language: string): language is ChainLanguage {
+  return chainIndex(language) !== -1;
+}
+
+/**
+ * The ACTIVE prefix: the first `count` languages of the chain — the ones the
+ * learner has added so far. `count` is clamped to `[0, chain length]`, so
+ * `activeChain(0)` is empty and any over-count is the whole chain. Adding a
+ * language is `activeChain(count + 1)`.
+ */
+export function activeChain(count: number): ChainLanguage[] {
+  const n = Math.max(0, Math.min(Math.floor(count), LANGUAGE_CHAIN.length));
+  return LANGUAGE_CHAIN.slice(0, n);
+}
+
+/** One stop on a sweep: a language, and the lesson(s) there that teach the concept. */
+export interface SweepStop {
+  language: ChainLanguage;
+  lessons: Lesson[];
+}
+
+/**
+ * The teaching sweep for one concept: every ACTIVE language that teaches the
+ * concept, IN CHAIN ORDER, each with its lesson(s).
+ *
+ * Three filters, in this order of intent:
+ *   1. the concept — only lessons whose `concept` tag matches;
+ *   2. active — only languages in the given active prefix;
+ *   3. teaches-it — a language with no matching lesson simply does not appear
+ *      (the sweep is the languages that *can* show the concept, not the whole
+ *      active set).
+ *
+ * The result order is the CHAIN order, never the input order — the walk is
+ * Spanish-first regardless of how the lessons were listed. Within a language,
+ * lessons are ordered by chapter then id, so the sweep is fully deterministic.
+ *
+ * `active` is expected to be a CHAIN PREFIX (as `activeChain` returns) — ordered,
+ * unique, and all on the chain. Chain order and active-filtering both come from
+ * iterating it, so a hand-built non-prefix (out of order, or with duplicates)
+ * would be reflected verbatim in the output; build `active` via `activeChain`.
+ */
+export function teachingSweep(
+  concept: string,
+  lessons: Lesson[],
+  active: readonly ChainLanguage[],
+): SweepStop[] {
+  if (concept === "") return []; // "" means "no concept" (e.g. writing lessons)
+
+  // Bucket every matching lesson by language. Active-filtering is NOT done here
+  // on purpose: the output loop below walks `active` (a chain prefix), which
+  // enforces both the active set AND chain order in one place — a single source
+  // of truth, so the test that a language outside the active set is excluded can
+  // actually fail if that loop is broken.
+  const byLanguage = new Map<ChainLanguage, Lesson[]>();
+  for (const lesson of lessons) {
+    if (lesson.concept !== concept) continue;
+    if (!isChainLanguage(lesson.language)) continue;
+    const bucket = byLanguage.get(lesson.language) ?? [];
+    bucket.push(lesson);
+    byLanguage.set(lesson.language, bucket);
+  }
+
+  const stops: SweepStop[] = [];
+  for (const language of active) {
+    const found = byLanguage.get(language);
+    if (!found || found.length === 0) continue;
+    found.sort((a, b) => a.chapter - b.chapter || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+    stops.push({ language, lessons: found });
+  }
+  return stops;
+}
+
+/**
+ * The concepts that can be swept given an active prefix — every concept taught
+ * by at least one active language — in BOOK ORDER.
+ *
+ * "Book order" here is the order concepts first come up as you read forward: a
+ * concept's key is the *earliest chapter* at which any active language teaches
+ * it, tie-broken by the earliest chain position that teaches it, then the tag
+ * itself for stability. Writing lessons (concept "") contribute nothing.
+ */
+export function sweepableConcepts(
+  lessons: Lesson[],
+  active: readonly ChainLanguage[],
+): string[] {
+  const activeSet = new Set<string>(active);
+  const minChapter = new Map<string, number>();
+  const minChainPos = new Map<string, number>();
+
+  for (const lesson of lessons) {
+    if (lesson.concept === "") continue;
+    if (!activeSet.has(lesson.language)) continue;
+    const c = lesson.concept;
+    const prevCh = minChapter.get(c);
+    if (prevCh === undefined || lesson.chapter < prevCh) minChapter.set(c, lesson.chapter);
+    const pos = chainIndex(lesson.language);
+    const prevPos = minChainPos.get(c);
+    if (prevPos === undefined || pos < prevPos) minChainPos.set(c, pos);
+  }
+
+  return [...minChapter.keys()].sort((a, b) => {
+    const ca = minChapter.get(a)!;
+    const cb = minChapter.get(b)!;
+    if (ca !== cb) return ca - cb;
+    const pa = minChainPos.get(a)!;
+    const pb = minChainPos.get(b)!;
+    if (pa !== pb) return pa - pb;
+    return a < b ? -1 : a > b ? 1 : 0;
+  });
+}

--- a/code/programs/typescript/script-writing-visualizer/tests/sequence.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/sequence.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import type { Lesson } from "../src/lessons";
+import { loadLessons } from "../src/lessons";
+import {
+  LANGUAGE_CHAIN,
+  chainIndex,
+  isChainLanguage,
+  activeChain,
+  teachingSweep,
+  sweepableConcepts,
+  type ChainLanguage,
+} from "../src/sequence";
+
+// A minimal Lesson factory — only the fields the sequencing layer reads matter;
+// the rest are filled with harmless defaults.
+function L(language: string, concept: string, chapter: number, id?: string): Lesson {
+  return {
+    id: id ?? `${language}-${concept}-${chapter}`,
+    language,
+    headword: "x",
+    gloss: "x",
+    type: "word",
+    chapter,
+    concept,
+    prerequisites: [],
+    reviewsOf: [],
+    romanization: "x",
+    script: language,
+    etymologyHook: "",
+  };
+}
+
+const langsOf = (stops: { language: ChainLanguage }[]) => stops.map((s) => s.language);
+
+describe("the language chain", () => {
+  it("is ten distinct languages in the fixed order", () => {
+    expect(LANGUAGE_CHAIN).toEqual([
+      "spanish", "latin", "french", "german", "arabic",
+      "hindi", "tamil", "kannada", "telugu", "malayalam",
+    ]);
+    expect(new Set(LANGUAGE_CHAIN).size).toBe(10);
+  });
+
+  it("chainIndex and isChainLanguage locate a language, or reject a non-chain one", () => {
+    expect(chainIndex("spanish")).toBe(0);
+    expect(chainIndex("malayalam")).toBe(9);
+    expect(chainIndex("klingon")).toBe(-1);
+    expect(isChainLanguage("hindi")).toBe(true);
+    expect(isChainLanguage("klingon")).toBe(false);
+  });
+
+  it("activeChain takes the first N and clamps out-of-range counts", () => {
+    expect(activeChain(0)).toEqual([]);
+    expect(activeChain(3)).toEqual(["spanish", "latin", "french"]);
+    expect(activeChain(99)).toEqual([...LANGUAGE_CHAIN]);
+    expect(activeChain(-5)).toEqual([]);
+  });
+});
+
+describe("teachingSweep", () => {
+  // A concept taught (out of chain order in the input) by french, spanish, german.
+  const scrambled: Lesson[] = [
+    L("french", "GREETING", 1),
+    L("german", "GREETING", 1),
+    L("spanish", "GREETING", 1),
+  ];
+
+  it("walks the concept in CHAIN order, not input order", () => {
+    const sweep = teachingSweep("GREETING", scrambled, activeChain(10));
+    expect(langsOf(sweep)).toEqual(["spanish", "french", "german"]);
+    // CONTROL: input order was french, german, spanish — prove we reordered.
+    expect(langsOf(sweep)).not.toEqual(["french", "german", "spanish"]);
+  });
+
+  it("includes only ACTIVE languages — adding/removing a language changes the sweep", () => {
+    const full = teachingSweep("GREETING", scrambled, activeChain(10));
+    const narrow = teachingSweep("GREETING", scrambled, activeChain(3)); // spanish, latin, french
+    expect(langsOf(full)).toEqual(["spanish", "french", "german"]);
+    expect(langsOf(narrow)).toEqual(["spanish", "french"]); // german not yet active; latin doesn't teach it
+    expect(narrow.length).toBeLessThan(full.length); // CONTROL: dropping german shortened it
+  });
+
+  it("skips active languages that do not teach the concept", () => {
+    // Concept taught only by spanish and arabic; active includes all ten.
+    const partial = [L("spanish", "NUM-5", 4), L("arabic", "NUM-5", 4)];
+    const sweep = teachingSweep("NUM-5", partial, activeChain(10));
+    expect(langsOf(sweep)).toEqual(["spanish", "arabic"]);
+  });
+
+  it("orders lessons within a language by chapter then id", () => {
+    const many = [
+      L("spanish", "C", 5, "s-b"),
+      L("spanish", "C", 2, "s-a"),
+      L("spanish", "C", 5, "s-a2"),
+    ];
+    const sweep = teachingSweep("C", many, activeChain(1));
+    expect(sweep[0].lessons.map((l) => l.chapter)).toEqual([2, 5, 5]);
+    expect(sweep[0].lessons.map((l) => l.id)).toEqual(["s-a", "s-a2", "s-b"]);
+  });
+
+  it("returns nothing for the empty concept (writing lessons carry none)", () => {
+    expect(teachingSweep("", [L("spanish", "", 1)], activeChain(10))).toEqual([]);
+  });
+});
+
+describe("teachingSweep against the real curriculum", () => {
+  const lessons = loadLessons();
+
+  it("GREETING-HELLO sweeps all ten languages in exact chain order when all are active", () => {
+    const sweep = teachingSweep("GREETING-HELLO", lessons, activeChain(10));
+    expect(langsOf(sweep)).toEqual([...LANGUAGE_CHAIN]); // all ten, chain-ordered
+    for (const stop of sweep) expect(stop.lessons.length).toBeGreaterThan(0);
+  });
+
+  it("a shorter active prefix yields a shorter sweep, still chain-ordered", () => {
+    const four = teachingSweep("GREETING-HELLO", lessons, activeChain(4));
+    expect(langsOf(four)).toEqual(["spanish", "latin", "french", "german"]);
+    // CONTROL: chain order is a property of the SWEEP, not of the (id-sorted)
+    // input — reversing the language filter must not reorder the output.
+    const scrambledInput = [...lessons].reverse();
+    const same = teachingSweep("GREETING-HELLO", scrambledInput, activeChain(4));
+    expect(langsOf(same)).toEqual(["spanish", "latin", "french", "german"]);
+  });
+});
+
+describe("sweepableConcepts", () => {
+  it("lists concepts in book order — earliest chapter first", () => {
+    const fixtures = [
+      L("spanish", "LATER", 4),
+      L("spanish", "EARLY", 1),
+      L("french", "MIDDLE", 2),
+      L("spanish", "", 1), // writing lesson — contributes nothing
+    ];
+    expect(sweepableConcepts(fixtures, activeChain(10))).toEqual(["EARLY", "MIDDLE", "LATER"]);
+    // CONTROL: this is NOT alphabetical (which would be EARLY, LATER, MIDDLE)
+    // and NOT insertion order (LATER, EARLY, MIDDLE).
+    expect(sweepableConcepts(fixtures, activeChain(10))).not.toEqual(["EARLY", "LATER", "MIDDLE"]);
+  });
+
+  it("only counts concepts from ACTIVE languages", () => {
+    const fixtures = [L("spanish", "A", 1), L("german", "B", 1)];
+    expect(sweepableConcepts(fixtures, activeChain(1))).toEqual(["A"]); // german inactive
+  });
+
+  it("the real curriculum offers the whole-chain greetings, ordered early", () => {
+    const lessons = loadLessons();
+    const concepts = sweepableConcepts(lessons, activeChain(10));
+    expect(concepts).toContain("GREETING-HELLO");
+    expect(concepts).toContain("COURTESY-THANKS");
+    // a foundational greeting appears before a late-chapter concept
+    const hello = concepts.indexOf("GREETING-HELLO");
+    expect(hello).toBeGreaterThanOrEqual(0);
+    expect(hello).toBeLessThan(concepts.length - 1);
+  });
+});


### PR DESCRIPTION
First **implementation** piece of the unified language-learning app ([HL03](../blob/main/code/specs/HL03-unified-language-learning-app.md)). A pure, deterministic sequencing module — no UI, no review, no I/O.

## What it adds — `src/sequence.ts`

- **`LANGUAGE_CHAIN`** — the fixed order languages are added, each hop bridging to one already known: Spanish → Latin → French → German → Arabic → Hindi → Tamil → Kannada → Telugu → Malayalam.
- **`activeChain(count)`** — the active prefix the learner has reached (clamped).
- **`teachingSweep(concept, lessons, active)`** — the core operation: for one concept, the active languages that teach it, walked **in chain order**, each with its lessons (chapter then id). Filters to the concept, restricts to the active prefix, skips languages that don't teach it, orders by the chain not the input.
- **`sweepableConcepts(lessons, active)`** — concepts in book order (earliest chapter first).

## Verified against the real curriculum

Not just fixtures: `GREETING-HELLO` sweeps **all ten languages in exact chain order**, and a shorter active prefix yields a correspondingly shorter sweep. (Recon last tick found 3 concepts span the whole chain and 40 span ≥2 — the join is real.)

Every honesty check is paired with a **control that fails on broken input**, confirmed by fault injection: an input-order implementation fails the chain-order test; a broken output loop fails the active test.

Writing this **caught a redundant active-filter** (enforced twice) that made the "only active languages" control vacuous — no single-line injection could break it. Removed, so active is enforced in one place and the test can actually fail.

## Review

Independently reviewed: correctness clean across all edge cases (empty active/lessons, multi-chapter concepts, non-chain input, `concept=""`), no security surface (pure functions over trusted in-repo data). Documented the `active`-is-a-chain-prefix contract per the review's one note.

**144 tests.** Next phase: the session orchestrator that assembles a sweep and surfaces the connections (`roots` / `etymology_hook` / false-friends).

🤖 Generated with [Claude Code](https://claude.com/claude-code)