### PR TITLE
feat(twig-aot): x86_64 GC entry wrapper + no-op init (AOT00-T1 x86_64 PR-x2)

### DIFF
--- a/code/packages/rust/twig-aot/CHANGELOG.md
+++ b/code/packages/rust/twig-aot/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog — `twig-aot`
 
+## 0.42.0 - 2026-07-22 — x86_64 GC entry wrapper + no-op init (AOT00-T1 x86_64 PR-x2)
+
+Ports increment A to the native x86-64 object path (`compile_module_x86_64_to_text`):
+inject the GC entry wrapper `__gc_aot_entry` and a no-op `__gc_init_stackmaps`, and
+redirect the image entry to the wrapper. Because the ELF/PE packager exports the global
+`main` symbol at whatever `entry_off` it is given (libc's `_start` calls `main`), this is
+a pure offset redirect — the same mechanism as the aarch64 Mach-O entry, no rename:
+
+```
+__gc_aot_entry (exported as `main`):
+    push rbp ; mov rbp, rsp
+    call __gc_init_stackmaps        ; no-op today; PR-x3 fills in registration
+    call <user entry>              ; rax = program result
+    mov rsp, rbp ; pop rbp ; ret   ; return rax → crt0 → exit(rax)
+```
+
+Both calls are intra-module `CALL rel32`s patched in place by the existing pass 2; `rsp`
+stays 16-aligned at each call. Under MsX64 (Windows) the wrapper reserves the 32-byte
+shadow/home space every caller must provide, matching the rest of the backend; SysV
+needs none. Reserved-symbol guard rejects a user function or entry
+named `__gc_aot_entry`/`__gc_init_stackmaps` (mirrors the aarch64 path). aarch64 and the
+x86-64 object bytes are otherwise unchanged.
+
+The wrapper mechanism is landed and proven transparent first; PR-x3 fills
+`__gc_init_stackmaps` in to register each function's stack map (per spec
+`AOT00-T1-x86_64-precise-roots.md`). Verified: 55 lib tests incl. the wrapper structure,
+entry redirect, and guard; the transparency proof (existing x86-64 programs still produce
+their exact exit code with the wrapper interposed) runs on the native x86-64
+`ubuntu-latest` CI runner (`linux_x86_64_smoke`), the authoritative validator for this
+arc (the dev host is aarch64 macOS). twig-aot 0.41.1 → 0.42.0.
+
+
 ## 0.41.1 - 2026-07-22 — test: precise roots keep a real reference AND reclaim a look-alike
 
 Completes the precise-roots correctness statement with an end-to-end test

--- a/code/packages/rust/twig-aot/Cargo.toml
+++ b/code/packages/rust/twig-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-aot"
-version = "0.41.1"
+version = "0.42.0"
 edition = "2021"
 description = "Twig AOT compiler — produces native Mach-O / ELF executables from Twig source. v0.28.0 (E4d-4 fix): strip_dead_aot_string_allocs now keeps EVERY buffer bound to a live string alias — a branch-selected (multi-block) str var aliases several buffers, and the old alias-keyed map dropped all but the last, so a not-last branch read a freed/empty buffer at run time. v0.27.0 (E4-dyn E4d-4): runtime (branch-selected) strings on the native aarch64 + x86_64 columns — a str var assigned by str_const in >1 basic block is kept out of the compile-time literal map so print_str/str_len read the length from the [i64 len][bytes] buffer header at run time (field_load) instead of folding one branch's static length; the var's stack slot already carries the buffer address. v0.26.0 (E4-dyn E4d-1): runtime string helpers __twig_str_concat/_slice/_index/_len/_cmp in twig_runtime.c on the E5 length-prefixed heap block; bounds-trap on slice/index; C-driver unit tests."
 

--- a/code/packages/rust/twig-aot/src/lib.rs
+++ b/code/packages/rust/twig-aot/src/lib.rs
@@ -969,6 +969,70 @@ use x86_64_backend::{compile_function_with_globals as x86_64_compile_with_global
 // Return tuple bundles the emitted text bytes, the symbol→offset map, the text
 // size, and the relocation list — a cohesive "compiled module" result; a named
 // struct would add indirection without clarifying this internal helper.
+/// Build the **x86-64 GC entry wrapper** [`GC_AOT_ENTRY`] — the image's real `main`.
+///
+/// The ELF/PE packager exports a global `main` symbol at whatever `entry_off` the
+/// caller supplies (libc's `_start` calls `main`), so — exactly like the aarch64 Mach-O
+/// entry redirect — making the wrapper the entry is a pure offset redirect; no rename.
+///
+/// ```text
+///   __gc_aot_entry (exported as `main`):
+///       push rbp ; mov rbp, rsp
+///       call __gc_init_stackmaps        ; register every function's stack map
+///       call <user entry>              ; rax = program result
+///       mov rsp, rbp ; pop rbp ; ret   ; return rax verbatim → crt0 → exit(rax)
+/// ```
+///
+/// Both `call`s are intra-module `CALL rel32`s the two-pass linker patches in place.
+/// `rsp` is 16-aligned at each call (crt0 enters `main` 16-aligned-minus-8; `push rbp`
+/// restores alignment; a 32-byte reservation keeps it aligned). The user entry's `rax`
+/// survives the epilogue. `call __gc_init_stackmaps` runs before the user entry and a
+/// twig `main` takes no arguments, so clobbering caller-saved registers is harmless.
+///
+/// Under **MsX64** (Windows) the wrapper reserves the 32-byte **shadow space** every
+/// caller must give a callee, matching the rest of the backend (`shadow_space()`); SysV
+/// needs none. The reservation is a 16-byte multiple, so alignment holds either way.
+fn build_gc_wrapper_x86_64(
+    user_entry: &str,
+    abi: X86_64Abi,
+) -> Result<(Vec<u8>, Vec<x86_64_encoder::ExternalReloc>), AotError> {
+    use x86_64_encoder::{Assembler, ExternalRelocKind, Reg};
+    // Win64 mandates a 32-byte caller-provided shadow (home) space; SysV needs none.
+    let shadow: i32 = match abi {
+        X86_64Abi::MsX64 => 32,
+        X86_64Abi::SysV => 0,
+    };
+    let mut a = Assembler::new();
+    a.push(Reg::Rbp);
+    a.mov_r64_r64(Reg::Rbp, Reg::Rsp);
+    if shadow != 0 {
+        a.sub_imm32(Reg::Rsp, shadow); // Win64 shadow / home space for the two calls
+    }
+    a.call_rel32(GC_INIT_STACKMAPS, ExternalRelocKind::PltRel32);
+    a.call_rel32(user_entry, ExternalRelocKind::PltRel32);
+    a.mov_r64_r64(Reg::Rsp, Reg::Rbp); // deallocates the shadow reservation
+    a.pop(Reg::Rbp);
+    a.ret();
+    let relocs = std::mem::take(&mut a.external_relocs);
+    let bytes = a.finish().map_err(|e| AotError::Linker {
+        status: None,
+        stderr: format!("twig-aot: x86_64 GC wrapper codegen: {e:?}"),
+    })?;
+    Ok((bytes, relocs))
+}
+
+/// Build the **no-op** `__gc_init_stackmaps` for x86-64 (a bare `ret`). A later PR
+/// (AOT00-T1 x86_64 PR-x3) fills it in to register each function's stack map; this
+/// increment lands the wrapper mechanism and proves it transparent first.
+fn build_gc_noop_init_x86_64() -> Result<Vec<u8>, AotError> {
+    let mut a = x86_64_encoder::Assembler::new();
+    a.ret();
+    a.finish().map_err(|e| AotError::Linker {
+        status: None,
+        stderr: format!("twig-aot: x86_64 GC init codegen: {e:?}"),
+    })
+}
+
 #[allow(clippy::type_complexity)]
 fn compile_module_x86_64_to_text(
     module: &IIRModule,
@@ -993,14 +1057,46 @@ fn compile_module_x86_64_to_text(
         fn_results.push((fn_.name.clone(), bytes, relocs));
     }
 
+    // ── Inject the GC entry wrapper + (no-op) stack-map registration (AOT00-T1
+    //    x86_64 PR-x2) ──────────────────────────────────────────────────────────
+    //
+    // Mirrors the aarch64 path: the wrapper `__gc_aot_entry` becomes the image entry
+    // (the packager exports the global `main` symbol at `entry_off`, so redirecting
+    // `entry_off` to the wrapper's offset makes it `main` — no rename). It calls the
+    // (currently no-op) `__gc_init_stackmaps`, then the user entry, returning its rax.
+    // Both calls are intra-module and patched in place by pass 2 below.
+    let entry = module.entry_point.as_deref().ok_or(AotError::NoEntryPoint)?;
+    // Reserved-symbol guard: `link()` is last-write-wins and the wrapper emits
+    // `call <entry>`, so a user function OR entry named `__gc_aot_entry` /
+    // `__gc_init_stackmaps` would shadow the synthetic symbol or make the wrapper call
+    // itself/the no-op init. Reject rather than miscompile (same as the aarch64 path).
+    for reserved in [GC_AOT_ENTRY, GC_INIT_STACKMAPS] {
+        if entry == reserved || fn_results.iter().any(|(name, _, _)| name == reserved) {
+            return Err(AotError::Linker {
+                status: None,
+                stderr: format!(
+                    "twig-aot: symbol '{reserved}' is reserved for the GC entry wrapper \
+                     and cannot be a module function or entry point",
+                ),
+            });
+        }
+    }
+    fn_results.push((GC_INIT_STACKMAPS.to_string(), build_gc_noop_init_x86_64()?, Vec::new()));
+    let (wrapper_bytes, wrapper_relocs) = build_gc_wrapper_x86_64(entry, abi)?;
+    fn_results.push((GC_AOT_ENTRY.to_string(), wrapper_bytes, wrapper_relocs));
+
     // Concatenate function bytes and record per-function offsets.
     let plain: Vec<(String, Vec<u8>)> = fn_results.iter()
         .map(|(name, bytes, _)| (name.clone(), bytes.clone()))
         .collect();
     let (mut linked, offsets) = link(&plain);
 
-    let entry = module.entry_point.as_deref().ok_or(AotError::NoEntryPoint)?;
-    let entry_off = entry_point_offset(&offsets, Some(entry));
+    // The image's `main` is the GC entry wrapper; fall back to the user entry only if
+    // the wrapper is somehow absent, so the pipeline degrades gracefully.
+    let entry_off = offsets
+        .get(GC_AOT_ENTRY)
+        .copied()
+        .unwrap_or_else(|| entry_point_offset(&offsets, Some(entry)));
 
     // Pass 2: lift per-function reloc offsets into linked-text offsets, and
     // patch cross-function calls in place.  Keep only truly-external relocs
@@ -2978,6 +3074,88 @@ mod dynval_runtime_golden;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── AOT00-T1 x86_64 PR-x2: GC entry wrapper + no-op init ──────────────────
+
+    /// The x86_64 wrapper is well-formed: `push rbp` … `ret`, with two intra-module
+    /// `CALL rel32` relocations (→ init, → user entry) for the linker to patch.
+    #[test]
+    fn gc_wrapper_x86_64_is_well_formed() {
+        for abi in [X86_64Abi::SysV, X86_64Abi::MsX64] {
+            let (bytes, relocs) = build_gc_wrapper_x86_64("main", abi).expect("codegen");
+            assert_eq!(bytes.first(), Some(&0x55), "starts with push rbp");
+            assert_eq!(bytes.last(), Some(&0xC3), "ends with ret");
+            let targets: Vec<&str> = relocs
+                .iter()
+                .filter(|r| matches!(r.kind, x86_64_encoder::ExternalRelocKind::PltRel32))
+                .map(|r| r.symbol.as_str())
+                .collect();
+            assert!(targets.contains(&GC_INIT_STACKMAPS), "calls the init ({abi:?})");
+            assert!(targets.contains(&"main"), "calls the user entry ({abi:?})");
+        }
+        // MsX64 reserves the 32-byte shadow space (a `sub rsp, imm32` after the
+        // prologue); SysV does not → the MsX64 wrapper is strictly longer.
+        let sysv = build_gc_wrapper_x86_64("main", X86_64Abi::SysV).unwrap().0;
+        let ms = build_gc_wrapper_x86_64("main", X86_64Abi::MsX64).unwrap().0;
+        assert!(ms.len() > sysv.len(), "MsX64 reserves shadow space");
+    }
+
+    /// The no-op x86_64 init is a bare `ret`.
+    #[test]
+    fn gc_noop_init_x86_64_is_ret() {
+        assert_eq!(build_gc_noop_init_x86_64().expect("codegen"), vec![0xC3]);
+    }
+
+    /// After injection, the x86_64 image entry is the wrapper: `entry_off` equals the
+    /// wrapper's link offset, and the byte there is `push rbp` (0x55). So the packager
+    /// exports `main` at the wrapper, and libc's `_start` runs the GC entry.
+    #[test]
+    fn x86_64_entry_is_the_gc_wrapper() {
+        let main = IIRFunction::new(
+            "main", vec![], "u64",
+            vec![
+                IIRInstr::new("const", Some("v".into()), vec![Operand::Int(7)], "u64"),
+                IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "u64"),
+            ],
+        );
+        let mut m = IIRModule::new("m", "twig");
+        m.add_or_replace(main);
+        m.entry_point = Some("main".into());
+
+        let (linked, offsets, entry_off, _relocs) =
+            compile_module_x86_64_to_text(&m, X86_64Abi::SysV).expect("compiles");
+        assert_eq!(
+            entry_off,
+            *offsets.get(GC_AOT_ENTRY).expect("wrapper present"),
+            "entry redirected to the wrapper",
+        );
+        assert_eq!(linked[entry_off], 0x55, "wrapper begins with push rbp");
+        assert!(offsets.contains_key("__gc_init_stackmaps"), "init injected");
+        // The user's `main` is still present (called by the wrapper), at a different
+        // offset than the entry wrapper.
+        assert_ne!(offsets["main"], entry_off);
+    }
+
+    /// A module whose entry is a reserved GC symbol is rejected on the x86_64 path too.
+    #[test]
+    fn x86_64_reserved_entry_is_rejected() {
+        let f = IIRFunction::new(
+            GC_AOT_ENTRY, vec![], "u64",
+            vec![
+                IIRInstr::new("const", Some("v".into()), vec![Operand::Int(0)], "u64"),
+                IIRInstr::new("ret", None, vec![Operand::Var("v".into())], "u64"),
+            ],
+        );
+        let mut m = IIRModule::new("m", "twig");
+        m.add_or_replace(f);
+        m.entry_point = Some(GC_AOT_ENTRY.into());
+        let err = compile_module_x86_64_to_text(&m, X86_64Abi::SysV);
+        assert!(
+            matches!(&err, Err(AotError::Linker { stderr, .. }) if stderr.contains("reserved")),
+            "expected reserved-name error, got {err:?}",
+        );
+    }
+
 
 
     /// The GC entry wrapper is well-formed: the two `BL`s (→ init, → user entry)


### PR DESCRIPTION
## x86_64 precise roots — step 2: the entry wrapper

Per the [x86_64 precise-roots spec](code/specs/AOT00-T1-x86_64-precise-roots.md) (§5, merged). Ports increment A ([#8782](https://github.com/adhithyan15/coding-adventures/pull/8782)) to the native x86_64 object path: inject the GC entry wrapper `__gc_aot_entry` + a no-op `__gc_init_stackmaps`, and redirect the image entry to the wrapper.

**Entry interposition turned out simpler than the spec feared.** I verified (by generating a real ELF locally) that `pack_elf64_object_x86_64` exports the global `main` symbol at whatever `entry_off` it's given — so making the wrapper the entry is a **pure offset redirect** (the same as aarch64's Mach-O entry), *not* a rename. The spec's Delta 1 over-thought it.

```
__gc_aot_entry (exported as `main`):
    push rbp ; mov rbp, rsp
    [ sub rsp, 32 ]                 ; MsX64 shadow space only
    call __gc_init_stackmaps        ; no-op today; PR-x3 fills in registration
    call <user entry>              ; rax = program result
    mov rsp, rbp ; pop rbp ; ret   ; return rax → crt0 → exit(rax)
```

- Both calls are intra-module `CALL rel32`s patched in place by the existing pass 2; `rsp` stays 16-aligned at each call.
- **MsX64** reserves the 32-byte shadow/home space (matching the rest of the backend); SysV needs none. (Added after security review flagged the gap.)
- Reserved-symbol guard mirrors aarch64. Existing x86_64 user-function bytes are unchanged — the two synthetic functions are appended; only the entry path changes.

### Verification
- 55 lib tests incl. the wrapper structure (both ABIs), the entry redirect (`entry_off == offsets[__gc_aot_entry]`, byte there is `push rbp`), and the guard. Clippy clean.
- Adversarial `/security-review`: **no exploitable defect** (verified against the aarch64 reference — ABI/alignment, entry redirect, both intra-calls patched, guard, transparency all sound); its one note (MsX64 shadow space) is addressed here.
- **Transparency proof** (existing x86_64 programs still exit with their exact code, wrapper interposed) runs on the native x86_64 `ubuntu-latest` runner (`linux_x86_64_smoke`) — the authoritative validator, since the dev host is aarch64 macOS.

### Next
- **PR-x3** — fill `__gc_init_stackmaps` with real registration (RIP-relative `lea` func_start; SysV/MsX64 8-arg marshalling; register the wrapper too).

twig-aot 0.41.1 → 0.42.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)