### PR TITLE
feat(q-to-semantic-ir): Q CST -> SIR22 array-domain lowering with QFn::Lambda closures (MA-11e, front2)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -279,6 +279,7 @@ members = [
     "q-parser",
     "q-runtime",
     "q-repl",
+    "q-to-semantic-ir",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/q-to-semantic-ir/BUILD
+++ b/code/packages/rust/q-to-semantic-ir/BUILD
@@ -1,0 +1,1 @@
+cargo test -p q-to-semantic-ir -- --nocapture

--- a/code/packages/rust/q-to-semantic-ir/BUILD_windows
+++ b/code/packages/rust/q-to-semantic-ir/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p q-to-semantic-ir -- --nocapture

--- a/code/packages/rust/q-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/q-to-semantic-ir/CHANGELOG.md
@@ -1,0 +1,206 @@
+# Changelog
+
+## [0.1.0] - 2026-07-22
+
+### Added
+
+- Initial `q-to-semantic-ir` frontend crate (MA-11e, per
+  [MA11](../../../specs/MA11-q-language.md) §5/§6 and
+  [HML01](../../../specs/HML01-math-to-semantic-ir.md) §2's amended
+  per-language pattern: built alongside the runtime in this same wave, not
+  as a later retrofit) — `compile`/`compile_source` lowering
+  `coding-adventures-q-parser`'s `GrammarASTNode` CST into a
+  `semantic_ir::Module`, targeting SIR22 (the array/matrix domain) plus the
+  "APL/J addendum" (`Reduce`/`Scan`/`Ravel`/`Catenate`/`IndexGenerator`)
+  those two crates already established.
+- Built directly on `j-to-semantic-ir`'s design — the most structurally
+  similar prior frontend (same `noun_expr`/`term`/`verb_expr` two-nonterminal
+  shape, same primitive-verb dispatch pattern, MA11 §3's own "reused
+  UNCHANGED" framing). Reuses that crate's exact conventions: `Ravel`-wrapped
+  stranded literals (the identical column-major-storage fix), a
+  `zero_base_index` helper for `!`'s 0-based convention (the exact same
+  `-1` correction J's own `i.` needs, since the shared JS runtime's
+  `IndexGenerator` codegen hardcodes APL's 1-based convention), and the same
+  `MAX_EXPR_DEPTH` (256) defense-in-depth recursion guard.
+- **All 17 of Q's primitive verb glyphs** (MA11 §4's full table): the 12
+  scalar-dyadic ones (`+ - * % & | = <> < <= >= >`) lower unconditionally to
+  `Expr::ElementwiseOp`; the 6 with a monadic meaning map onto a mix of
+  reused (`neg`/`recip`/`floor`, already implemented for APL) and 5
+  genuinely new `BuiltinCall` names (`q_first`, `q_where`, `q_reverse`,
+  `q_not`) with no APL/J precedent at all — Q's own monadic/dyadic pairing
+  table is genuinely different from both (e.g. `*` is "first/multiply" here,
+  not J's "sign/multiply"). Monadic `+` (flip) reduces to plain identity in
+  this cut, since no primitive can ever construct a rank-2 value at all (no
+  reshape/matrix-literal exists in scope) — "transpose if rank 2, else
+  identity" collapses to unconditional identity for every value this
+  frontend can ever produce.
+- **Two deliberate node-reuse decisions, saving two would-be-new builtins**:
+  monadic `,` (enlist) reuses `Expr::Ravel` (provably identical to ravel on
+  every reachable rank-0/rank-1 value in this cut — see `src/lower.rs`'s
+  module doc comment's "Enlist reuses Ravel" section, and
+  `q_runtime::builtins::enlist`'s own doc comment, which discloses the
+  identical simplification runtime-side); dyadic `,` (join) reuses
+  `Expr::Catenate` (`q_runtime::builtins::join`'s case-by-case shape is
+  IDENTICAL to `apl_runtime::builtins::catenate`'s, confirmed by direct
+  side-by-side comparison).
+- Monadic `#` (tally) reuses J's existing `"tally"` builtin **as-is** — its
+  rank0→1/rank1→n/rank2→r convention already matches
+  `q_runtime::builtins::tally` exactly, no new code needed at all.
+- Adverbs `'`/`/`/`\` (each/reduce/scan): same restriction as APL/J (reduce/
+  scan only apply to the 12 scalar-dyadic primitives); `each` degenerates to
+  direct application for the 4 primitives whose monadic meaning is already
+  elementwise (`- % _ ~`) and for all 12 dyadically (mirrors
+  `q_runtime::builtins::Prim::each_monadic_supported`/
+  `each_dyadic_supported` exactly), a clean lowering error otherwise.
+- **Dual list-literal syntax** (MA11 §3 bullet 3): `1 2 3` stranding and
+  `(a;b;c)` explicit both lower to the identical `Ravel(ArrayLit(..))`
+  shape. A list-literal element that is *syntactically, provably*
+  non-scalar (a nested stranded/list literal) or function-valued is a clean
+  lowering error (mirrors `q_runtime::eval::Interpreter::eval_list_literal`'s
+  identical rejection) — an element that could merely *turn out* to be
+  non-scalar/function-valued at runtime (an ordinary variable reference) is
+  not statically decidable here any more than it is in `q-runtime` itself,
+  so it is embedded as-is.
+- **Function literals (`{[x;y] ...}`, and the bracket-omitted implicit
+  `x`/`y`/`z` form) — the one lowering surface with no APL/J precedent at
+  all** (MA11 §2/§3 bullet 1). Every function literal (whether directly
+  assigned to a top-level name, or an inline literal applied the moment
+  it's written) becomes its own genuine `semantic_ir::Function` with
+  `captures: vec![]` (Q's `QFn::Lambda` captures nothing at all — MA11 §2/
+  `q_runtime::eval::Lambda`'s own doc comment — so this crate needs none of
+  Python's/Ruby's own free-variable-analysis/lambda-lifting machinery).
+  Three call-site shapes, one shared dispatch decision
+  (`Lowerer::expr_to_fnkind`): a NAME resolving to a directly-assigned
+  top-level function, or an inline immediately-applied literal, both lower
+  to `Expr::DirectCall` (statically known callee); anything else (a
+  parameter, an unresolved global, a parenthesised/numeric/list-literal
+  term) lowers to `Expr::IndirectCall` through whatever `Expr` it evaluated
+  to — this is what makes the genuinely dynamic, higher-order case work
+  with **no special-casing at all**: a function value passed as an argument
+  and called through a parameter inside the callee's own body (mirrors
+  `q_runtime`'s own
+  `passing_a_function_value_as_an_argument_to_another_function` test
+  exactly) just falls out of the same dispatch rule. See `src/lower.rs`'s
+  module doc comment's "Function literals" section for the full design.
+- **Top-level scope is `Scope::Global`, not `Scope::Local`** — a real,
+  disclosed divergence from `j-to-semantic-ir`'s/`apl-to-semantic-ir`'s own
+  convention, forced by a genuine Q semantic those two languages never
+  needed to represent: a function literal's body can read a plain array
+  variable assigned at the top level, from inside a **separate**,
+  independently-compiled `Function` (MA11 §2/`q_runtime::eval::Lambda`'s own
+  doc comment: "resolves any non-parameter name against the *global* frame
+  at call time"). A `main`-local JS `let` is invisible to a sibling JS
+  function, so every top-level Q variable becomes a genuine
+  `semantic_ir::Global` instead (`init_function: "main"`), matching
+  `semantic-ir-to-javascript::emit_globals`'s own "globals are module-level
+  `let`s" convention. This also simplifies top-level assignment relative to
+  J/APL: since `emit_globals` pre-declares every global before any function
+  runs, there is no `LetStarBinding`-vs-`Assign` first-occurrence
+  distinction needed at the top level at all — every top-level write is
+  simply `Stmt::Assign { scope: Global, .. }`. A function-literal body's own
+  *internal* assignment is still an ordinary `Scope::Local`/`Scope::Param`
+  binding, scoped to that one function alone, with the usual
+  first-occurrence `LetStarBinding`-vs-`Assign` convention.
+- **Disclosed simplification: declared arity vs. call-site arity.**
+  `q_runtime::eval::Interpreter::call_lambda` binds arguments positionally
+  and does not require every declared parameter to receive one — a function
+  declared with more parameters than a call site supplies (most commonly the
+  implicit `x`/`y`/`z` form called monadically) simply leaves the extras
+  unbound, erroring only if referenced (confirmed directly against
+  `q-parser`'s own doc-comment example). `semantic_ir::Function`'s
+  default-parameter model has no "declared but left unbound" concept, so
+  every parameter after the first gets a disclosed sentinel default
+  (`IntLit(0)`), accepting the common, well-formed case (fewer arguments
+  than declared, body never reads the missing ones) at the cost of silently
+  defaulting to `0` rather than truly erroring in the narrow case a program
+  actually reads an unsupplied trailing parameter. The OTHER direction — too
+  MANY arguments for the callee's own declared parameter count — is still a
+  hard, disclosed lowering error, mirroring `call_lambda`'s own "function
+  takes at most N parameter(s)" rejection exactly.
+- Rejects (cleanly, at lowering time): the 6 comparison primitives used
+  monadically; a reduce/scan-decorated primitive used dyadically; `! , # _
+  ~` decorated with an adverb (none is a scalar dyadic verb); dyadic `!`
+  (dict creation, explicitly deferred, MA11 §4); a **nested** function
+  literal (one `{...}` appearing anywhere inside another's own body —
+  mirrors `q_runtime::eval::Interpreter::build_lambda`'s identical
+  `inside_a_call` rejection).
+
+### Changed (shared `semantic-ir-to-javascript` crate — additive only)
+
+Five of Q's primitives have no APL/J precedent and no existing `BuiltinCall`
+runtime support (`q_first`, `q_where`, `q_reverse`, `q_not`, plus dyadic
+`q_take`/`q_drop`/`q_match` — 7 new dispatch-table names in total). Ported
+1:1 from `q_runtime::builtins::{first, where_indices, reverse, not_, take,
+drop_, match_}` directly into `semantic-ir-to-javascript`'s `ArrayRt` IIFE
+and its `builtins` dispatch table (mirroring exactly how J's own `tally`/
+`replicate`/`monadicExp` were added when that crate needed them) — every
+change is a **new**, additive function/dispatch-table entry; no existing
+line was modified. Confirmed no regression: the shared crate's own full test
+suite (257 tests across `src/lib.rs`, `emit.rs`'s embedded tests,
+`tests/sir22_array.rs`, `tests/sir23_eval_depth_guard.rs`,
+`tests/sir23_symbolic.rs`) and every one of its other downstream consumers'
+test suites (`apl-to-semantic-ir`, `derive-to-semantic-ir`,
+`j-to-semantic-ir`, `javascript-to-semantic-ir`, `macsyma-to-semantic-ir`,
+`maple-to-semantic-ir`, `matlab-to-semantic-ir`, `octave-to-semantic-ir`,
+`reduce-to-semantic-ir`, `scilab-to-semantic-ir`, `sir-conformance`,
+`wolfram-to-semantic-ir`) still pass unchanged.
+
+### Found, NOT fixed here (shared `semantic-ir-to-javascript` crate — pre-existing, follow-up task)
+
+`tests/oracle.rs` confirms (directly running generated JavaScript through
+`node`) the exact same shared-crate display gap `j-to-semantic-ir/tests/
+oracle.rs`'s own "Bug A" already found for J, now confirmed for Q too:
+`semantic-ir-to-javascript` has exactly two per-source-language negative-
+number display flags (`SIR_DISPLAY_APL_HIGH_MINUS`, `SIR_DISPLAY_J_UNDERSCORE`)
+and no third for Q. A bare/boxed scalar negative result renders via plain
+`String(v)` when neither flag is set — which happens to already BE Q's own
+ASCII-minus convention, so **that path has no bug for Q at all** (unlike
+J, which needs a leading underscore neither flag produces) — but a genuine
+NDArray result (any `ElementwiseOp`/`Reduce`/`Scan`/`Ravel`/`Catenate`, or
+`neg`'s own rank ≥ 1 branch) reaches `ArrayRt.fmtNum`, which renders APL's
+high-minus `¯` for any negative value whenever `SIR_DISPLAY_J_UNDERSCORE`
+is unset — unconditionally, with nothing gating it for Q either. Confirmed
+directly: `3-4` prints `¯1`, not `-1`; `-/1 2 10` prints `¯11`, not `-11`.
+5 of this crate's 33 oracle-corpus cases hit this and are marked
+`known_bug` accordingly (only `ground_truth` is asserted for those; the
+`compiled`-side assertion is skipped, matching this repo's established
+"found, NOT fixed here" discipline for a bug in a crate consumed by many
+other frontends). Not fixed in this PR — needs a third
+`SIR_DISPLAY_Q_ASCII`-shaped flag (or simply extending the "no flag set"
+default to `ArrayRt.fmtNum` too) in `semantic-ir-to-javascript` itself.
+
+### Testing
+
+- `tests/test_lower.rs` — 56 unit tests asserting exact `Expr`/`Function`
+  shapes for every grammar production: all 17 primitives (monadic and
+  dyadic), each/reduce/scan, dual list-literal syntax and its two rejection
+  cases, chained assignment and `Scope::Global` top-level scoping, and the
+  full function-literal surface (named + inline definitions, implicit
+  `x`/`y`/`z` param defaults, explicit param lists, multi-statement bodies,
+  `DirectCall`/`MakeClosure`/`IndirectCall` dispatch including the
+  higher-order case, a top-level global read from inside a function body,
+  the nested-function-literal rejection, and the too-many-/too-few-argument
+  arity checks).
+- `tests/test_validator.rs` — 10 tests confirming every lowered module
+  passes `semantic_ir::validate` and is accepted by
+  `semantic-ir-to-javascript`'s `Backend::check_module`/`compile()`,
+  including the function-literal machinery and a new-`BuiltinCall`-name
+  module (the SIR validator has no builtin-name whitelist, so this also
+  confirms validation is orthogonal to runtime-dispatch-table completeness).
+- `tests/e2e_node.rs` — 12 tests actually running compiled Q programs
+  through `node`, weighted toward the function-literal machinery (a named
+  function, an inline immediately-applied literal, a function calling
+  another already-defined function, and the genuinely higher-order
+  `MakeClosure`+`IndirectCall` case) plus all 7 new `q_*` builtins and the
+  reused `tally`/`Catenate`, every expected value chosen to be positive so
+  none are affected by the display gap above.
+- `tests/oracle.rs` (HML01 §7) — oracle/golden testing: the same Q source
+  run through **two** independent implementations (`q-runtime`, the native
+  ground truth, vs. this crate → `semantic-ir-to-javascript` → real `node`)
+  and diffed, 33-case corpus. 28 cases agree end-to-end (fully verified,
+  both ground truth and compiled output checked against the expected
+  value); 5 are `known_bug` (ground truth still checked, compiled-side
+  skipped) per the shared-crate display gap above.
+- 1 doctest (`src/lib.rs`'s own `compile_source` example).
+- Adds `q-to-semantic-ir` to `code/packages/rust/Cargo.toml`'s workspace
+  `members`.

--- a/code/packages/rust/q-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/q-to-semantic-ir/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "q-to-semantic-ir"
+version = "0.1.0"
+edition = "2021"
+description = "Q (kdb+) CST → narrow-waist Semantic IR (SIR22 array/matrix domain, reusing APL/J's addendum). MA-11e, front2 Wave 5."
+
+[dependencies]
+semantic-ir = { path = "../semantic-ir" }
+coding-adventures-q-parser = { path = "../q-parser" }
+# The parser emits a generic `parser::grammar_parser::GrammarASTNode` whose
+# leaf tokens are `lexer::token::Token`; we walk both directly. Note this
+# crate deliberately does NOT depend on `coding-adventures-q-runtime` --
+# lowering only needs the parse tree shape (`q-parser`), not the tree-
+# walking evaluator, mirroring `j-to-semantic-ir`'s/`apl-to-semantic-ir`'s
+# identical choice.
+parser = { path = "../parser" }
+lexer = { path = "../lexer" }
+
+[dev-dependencies]
+# Used by tests/test_validator.rs (confirms the JS backend accepts every
+# module this frontend produces) and tests/e2e_node.rs (actually runs the
+# compiled JS through `node`).
+semantic-ir-to-javascript = { path = "../semantic-ir-to-javascript" }
+# tests/oracle.rs's ground truth: the same tree-walking interpreter this
+# frontend's own CST comes from (HML01 §7's oracle/golden testing), mirroring
+# `j-to-semantic-ir`'s/`apl-to-semantic-ir`'s identical use of their own
+# native runtime crate as ground truth. The other, non-dev `[dependencies]`
+# section above still deliberately does NOT depend on it -- lowering itself
+# only ever needs the parse-tree shape (`coding-adventures-q-parser`), never
+# the evaluator; only this test file needs it, for comparison purposes only.
+coding-adventures-q-runtime = { path = "../q-runtime" }

--- a/code/packages/rust/q-to-semantic-ir/README.md
+++ b/code/packages/rust/q-to-semantic-ir/README.md
@@ -1,0 +1,122 @@
+# q-to-semantic-ir
+
+Q (kdb+'s scripting language) CST → narrow-waist Semantic IR. Item **MA-11e**
+of the Q frontend (spec [`MA11`](../../../specs/MA11-q-language.md)), built
+alongside the runtime (`q-runtime`) in this same wave rather than as a later
+retrofit, per [HML01](../../../specs/HML01-math-to-semantic-ir.md) §2's
+amended per-language pattern — mirroring APL's/J's/Scilab's own precedent.
+
+## Where this fits
+
+```
+Q source
+   │
+   ▼  coding_adventures_q_parser::try_parse_q(src)
+parser::grammar_parser::GrammarASTNode   (generic CST)
+   │
+   ▼  q_to_semantic_ir::compile
+semantic_ir::Module                      (per SIR10 + SIR22 + SIR22 addendum)
+```
+
+## Usage
+
+```rust
+use q_to_semantic_ir::compile_source;
+
+let module = compile_source("f:{x+y}\n2 f 3\n", "demo")?;
+assert!(module.functions.iter().any(|f| f.name == "main"));
+// `f` lowers to its OWN top-level `semantic_ir::Function` (params x, y),
+// not a bare closure value stored in a variable -- see below for why.
+assert!(module.functions.len() >= 2);
+```
+
+## Design: built directly on `j-to-semantic-ir`
+
+Q is APL/J's second-generation descendant (MA11 §1) and reuses their exact
+two-nonterminal (`noun_expr`/`term`/`verb_expr`), right-to-left,
+no-precedence grammar shape (MA11 §3) — so this crate is built directly on
+`j-to-semantic-ir`'s design, the most structurally similar prior frontend
+(same shape, same primitive-verb dispatch pattern), reusing SIR22 + the
+"APL/J addendum" (`Reduce`/`Scan`/`Ravel`/`Catenate`/`IndexGenerator`) those
+two crates already established. See `src/lower.rs`'s module doc comment for
+the full node-by-node lowering table and design rationale.
+
+### All 17 primitive verbs (MA11 §4)
+
+| Glyph | Monadic | Dyadic |
+|---|---|---|
+| `+` | flip → identity (no primitive in this cut can ever construct rank 2) | add → `ElementwiseOp` |
+| `-` | negate → `neg` builtin (reused from APL) | subtract → `ElementwiseOp` |
+| `*` | first → `q_first` (new) | multiply → `ElementwiseOp` |
+| `%` | reciprocal → `recip` builtin (reused) | divide → `ElementwiseOp` |
+| `!` | til (0-based) → `IndexGenerator` + a `-1` correction (same fix J's own `i.` needs) | dyadic (dict creation) — **deferred**, clean error |
+| `,` | enlist → `Ravel` (provably identical on every reachable value in this cut) | join → `Catenate` (case-by-case identical to APL/J's) |
+| `#` | tally → `tally` builtin (reused **as-is** from J) | take → `q_take` (new — genuinely different from J's *replicate*) |
+| `_` | floor → `floor` builtin (reused) | drop → `q_drop` (new) |
+| `&` | where → `q_where` (new) | min → `ElementwiseOp` |
+| `\|` | reverse → `q_reverse` (new) | max → `ElementwiseOp` |
+| `~` | not → `q_not` (new, elementwise) | match → `q_match` (new — deep equality, the one non-elementwise dyadic primitive) |
+| `=` `<>` `<` `<=` `>=` `>` | none (error) | `ElementwiseOp` |
+
+Only **5 genuinely new** `BuiltinCall` names were needed (`q_first`,
+`q_where`, `q_reverse`, `q_not`, plus the dyadic `q_take`/`q_drop`/`q_match`)
+— two would-be-new primitives turned out to coincide exactly with existing
+SIR22-addendum nodes once Q's actual reachable value space (rank 0/1 only,
+no reshape in scope) was checked directly, and one (`tally`) reuses J's
+existing builtin verbatim.
+
+### Function literals — the one lowering surface with no APL/J precedent
+
+`{[x;y] stmt; stmt; ...}` (MA11 §2/§3 bullet 1) is the one genuinely new
+*lowering* problem this crate's model (`j-to-semantic-ir`) never had to
+solve — APL's/J's in-scope grammars are expression-only, so neither ever
+needed to represent a real user-defined function with named parameters.
+Since Q's own function values capture **nothing at all** (MA11 §2;
+`q_runtime::eval::Lambda`'s own doc comment: every non-parameter name
+resolves against the *global* frame at call time, not a snapshot), this
+crate's design is considerably simpler than a general-purpose language
+frontend's (Python's/Ruby's) own lambda-lifting machinery — no free-variable
+analysis, no capture list ever populated.
+
+Every function literal becomes its own genuine `semantic_ir::Function`
+(`captures: vec![]`), dispatched three ways, one shared decision:
+
+1. A NAME resolving to a function directly assigned at the top level, or an
+   inline literal applied the moment it's written → `Expr::DirectCall`
+   (statically known callee).
+2. Anything else (a parameter, an unresolved global, a parenthesised term)
+   → `Expr::IndirectCall` through whatever `Expr` it evaluated to.
+
+This single rule handles the genuinely dynamic, higher-order case with
+**no special-casing**: `apply:{[g] g 5}` then `apply inc` passes a function
+value as an argument, and `g 5` inside `apply`'s own body dispatches
+dynamically with no static knowledge of what `g` holds — exactly mirroring
+`q-runtime`'s own real test coverage for this exact pattern.
+
+### Top-level scope is `Global`, not `Local` — a real divergence from J/APL
+
+J/APL lower every top-level name to a `main`-local binding, since their
+entire program lives inside one function and nothing else ever reads it.
+Q genuinely breaks this: a function literal's body can read a plain array
+variable assigned at the top level, from inside a **separate**,
+independently-compiled `Function` — so every top-level Q variable becomes a
+genuine `semantic_ir::Global` instead, visible to every compiled JS function
+in the same file. See `src/lower.rs`'s module doc comment for the full
+rationale.
+
+### Testing
+
+```sh
+cargo test -p q-to-semantic-ir -- --nocapture
+```
+
+- `tests/test_lower.rs` — 56 unit tests over exact `Expr`/`Function` shapes
+  for every grammar production.
+- `tests/test_validator.rs` — 10 capability-acceptance tests against the
+  shared SIR validator and `semantic-ir-to-javascript`.
+- `tests/e2e_node.rs` — 12 tests actually running compiled programs through
+  `node`, weighted toward the function-literal machinery.
+- `tests/oracle.rs` (HML01 §7) — 33-case oracle/golden corpus cross-checking
+  `q-runtime` (ground truth) against this crate → `semantic-ir-to-javascript`
+  → real `node`. See `CHANGELOG.md` for the one documented, pre-existing,
+  not-fixed-here shared-crate display gap (5 of the 33 cases).

--- a/code/packages/rust/q-to-semantic-ir/required_capabilities.json
+++ b/code/packages/rust/q-to-semantic-ir/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/q-to-semantic-ir",
+  "capabilities": [],
+  "justification": "Pure computation over an in-memory GrammarASTNode and semantic_ir::Module. No filesystem, network, process, DOM, or environment access needed -- like maple-to-semantic-ir/derive-to-semantic-ir/j-to-semantic-ir/apl-to-semantic-ir, this crate does not even spawn a worker thread (q-parser's own MAX_RULE_DEPTH is already documented safe on a bare default stack)."
+}

--- a/code/packages/rust/q-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/q-to-semantic-ir/src/lib.rs
@@ -1,0 +1,73 @@
+//! # q-to-semantic-ir
+//!
+//! Q (kdb+'s scripting language) CST → narrow-waist Semantic IR, **v0.1.0**
+//! — task **MA-11e**, per [`MA11`](../../../specs/MA11-q-language.md) §5/§6:
+//! built alongside the runtime in this same wave rather than as a later
+//! retrofit, mirroring APL's/J's/Scilab's own precedent (per
+//! [`HML01`](../../../specs/HML01-math-to-semantic-ir.md) §2's amended
+//! per-language pattern).
+//!
+//! Q is APL/J's second-generation descendant (MA11 §1) and reuses their
+//! exact two-nonterminal, right-to-left, no-precedence grammar shape (MA11
+//! §3) — so this crate is built directly on [`j-to-semantic-ir`]'s design,
+//! the most structurally similar prior frontend (same `noun_expr`/`term`/
+//! `verb_expr` shape, same primitive-verb dispatch pattern), reusing SIR22
+//! plus the "APL/J addendum" (`Reduce`/`Scan`/`Ravel`/`Catenate`/
+//! `IndexGenerator`) those two crates already established. Q adds exactly
+//! one genuinely new concept neither APL nor J ever needed: a real
+//! user-defined function literal, `{[x;y] stmt; stmt; ...}` — see
+//! `lower.rs`'s module doc comment for the full design (why it lowers to an
+//! ordinary SIR [`semantic_ir::Function`] plus [`semantic_ir::Expr::MakeClosure`]/
+//! [`semantic_ir::Expr::DirectCall`]/[`semantic_ir::Expr::IndirectCall`],
+//! not a brand-new SIR node kind).
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! Q source
+//!    │
+//!    ▼  coding_adventures_q_parser::try_parse_q(src)
+//! parser::grammar_parser::GrammarASTNode   (generic CST)
+//!    │
+//!    ▼  q_to_semantic_ir::compile
+//! semantic_ir::Module                      (per SIR10 + SIR22 + SIR22 addendum)
+//! ```
+//!
+//! ## Public API
+//!
+//! ```
+//! use q_to_semantic_ir::compile_source;
+//! let module = compile_source("f:{x+y}\n2 f 3\n", "demo").unwrap();
+//! assert!(module.functions.iter().any(|f| f.name == "main"));
+//! // The user-defined function `f` lowers to its OWN top-level
+//! // `semantic_ir::Function` (params `x`, `y`), not a bare closure value --
+//! // see `lower.rs`'s module doc comment for why.
+//! assert!(module.functions.len() >= 2);
+//! ```
+//!
+//! ## Scope (v0.1.0)
+//!
+//! See `lower.rs`'s module doc comment for the exact per-construct lowering
+//! table (the full Q-primitive-to-SIR-node mapping, including which five
+//! primitives needed genuinely new `BuiltinCall` names with no APL/J
+//! precedent), the function-literal lowering design (the one new lowering
+//! surface this crate adds relative to its `j-to-semantic-ir` model), and
+//! the handful of deliberately-rejected constructs.
+
+mod lower;
+pub use lower::{compile, QLowerError};
+
+/// Parse `source` as Q and lower it into a [`semantic_ir::Module`] in one
+/// step, mirroring every other `-to-semantic-ir` frontend's `compile_source`
+/// convenience wrapper.
+pub fn compile_source(
+    source: &str,
+    module_name: &str,
+) -> Result<semantic_ir::Module, QLowerError> {
+    let tree = coding_adventures_q_parser::try_parse_q(source).map_err(|msg| QLowerError {
+        message: format!("parse error: {msg}"),
+        line: 1,
+        column: 1,
+    })?;
+    compile(&tree, module_name)
+}

--- a/code/packages/rust/q-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/q-to-semantic-ir/src/lower.rs
@@ -1,0 +1,1728 @@
+//! The lowering pass from `coding_adventures_q_parser`'s generic
+//! [`GrammarASTNode`] CST → [`semantic_ir::Module`], **v0.1.0**.
+//!
+//! # Q's CST shape (confirmed against `code/grammars/q/q.grammar` and the
+//! tree-walk `q-runtime::eval` already does over it — structurally almost
+//! identical to `j-to-semantic-ir`'s own J CST, per MA11 §3's "reused
+//! UNCHANGED... this is the easy, mechanical part")
+//!
+//! ```text
+//! program          = { line }
+//! line             = statement NEWLINE | statement | NEWLINE
+//! statement        = assignment                                -- passthrough
+//! assignment       = NAME COLON assignment                     -- 3 children: chained/actual
+//!                   | noun_expr                                 -- 1 child: base case
+//! noun_expr        = term [ verb_expr noun_expr | noun_expr ]   -- 1, 2, or 3 children
+//!                   | verb_expr noun_expr                        -- (2-child ambiguity resolved
+//!                                                                    by inspecting kids[0].rule_name)
+//! term             = NUMBER { NUMBER }
+//!                   | NAME
+//!                   | function_literal
+//!                   | LPAREN noun_expr RPAREN
+//!                   | list_literal
+//! list_literal     = LPAREN noun_expr SEMICOLON noun_expr { SEMICOLON noun_expr } RPAREN
+//! function_literal = LBRACE [ LBRACKET param_list RBRACKET ] stmt_seq RBRACE
+//! param_list       = NAME { SEMICOLON NAME }
+//! stmt_seq         = statement { SEMICOLON statement }
+//! verb_expr        = verb_primitive [ EACH | REDUCE | SCAN ]
+//!                   | NAME
+//!                   | function_literal
+//! verb_primitive   = one of the 17 primitive glyph tokens
+//! ```
+//!
+//! # Scope
+//!
+//! **Supported** (every construct `q-parser`'s grammar can produce):
+//! - Number literals, stranded literals (`1 2 3` → one rank-1
+//!   [`Expr::ArrayLit`] wrapped in [`Expr::Ravel`] — the identical
+//!   column-major-storage bug fix `j-to-semantic-ir`'s/`apl-to-semantic-ir`'s
+//!   own `lower_term` already carries, see "Stranded literals" below),
+//!   variables, parenthesised grouping.
+//! - Assignment (`:`), including right-associative chained assignment
+//!   (`a:b:3`) — see "Top-level scope is Global, not Local" below for why
+//!   this crate's own convention genuinely differs from `j-to-semantic-ir`'s.
+//! - The 12 scalar dyadic primitives shared with APL/J
+//!   (`+ - * % & | = <> < <= >= >`), unconditionally lowered to
+//!   [`Expr::ElementwiseOp`].
+//! - The 6 of those 12 that have a monadic meaning in Q (`- % & | ~` is
+//!   NOT the same 6 as J's — Q's own primitive table pairs each glyph with a
+//!   genuinely different monadic meaning, MA11 §4) plus 5 bespoke primitives
+//!   with no scalar-dyadic mapping at all (`! , # _ ~`) — see "The 17
+//!   primitives" below for the complete table.
+//! - `'` (each), `/` (reduce), `\` (scan) — same restriction and SIR nodes
+//!   as APL/J: reduce/scan only apply to the 12 scalar-dyadic primitives;
+//!   each degenerates to direct application for the primitives whose direct
+//!   meaning is already elementwise, and is a clean error otherwise (MA11 §4
+//!   / `q-runtime::builtins`'s own `each_monadic_supported`/
+//!   `each_dyadic_supported`, mirrored exactly here).
+//! - **List literals, dual syntax** (`1 2 3` stranding, `(a;b;c)` explicit)
+//!   — both lower to the identical `Ravel(ArrayLit(..))` shape.
+//! - **Function literals** (`{[x;y] ...}`, and the bracket-omitted implicit
+//!   `x`/`y`/`z` form) — the one genuinely new lowering surface relative to
+//!   `j-to-semantic-ir`'s own model; see "Function literals" below.
+//! - Auto-print of a bare top-level noun expression (the same `"print"`
+//!   [`Expr::BuiltinCall`] every SIR backend already implements).
+//!
+//! **Deliberately rejected** with a clean [`QLowerError`], mirroring what
+//! `q-runtime::eval`/`q-runtime::builtins` reject at *runtime* (this
+//! frontend catches the same things at *lowering* time instead, wherever
+//! that is statically decidable — see "What stays genuinely dynamic" below
+//! for the one case that is not):
+//! - The 6 comparison primitives (`= <> < <= >= >`) used monadically.
+//! - A reduce- or scan-decorated primitive used dyadically.
+//! - `! , # _ ~` decorated with `/`/`\` — none of these 5 is "a scalar
+//!   dyadic verb", mirroring `q-runtime::builtins::require_scalar_binop`
+//!   exactly.
+//! - Dyadic `!` (dict creation) — explicitly deferred, MA11 §4.
+//! - A list literal containing a directly-syntactic function-literal or
+//!   non-scalar (stranded/nested-list) element — `array_runtime::Array` has
+//!   no boxed/heterogeneous representation (MA11 §4), mirroring
+//!   `q-runtime::eval::eval_list_literal`'s identical rejection.
+//! - A **nested** function-literal definition (one `{...}` appearing
+//!   anywhere inside another's own parameter list or body) — MA11 §4
+//!   explicitly puts this out of scope; mirrors
+//!   `q-runtime::eval::Interpreter::build_lambda`'s identical
+//!   `inside_a_call` rejection.
+//! - A direct call (`f x` / `x f y`) to a function whose own declared
+//!   parameter list is SHORTER than the call site's arity (1 for monadic,
+//!   2 for dyadic) — mirrors `q-runtime::eval::Interpreter::call_lambda`'s
+//!   "function takes at most N parameter(s)" rejection. See "Function
+//!   literals" below for the (disclosed, narrower) direction this crate
+//!   simplifies the opposite case.
+//!
+//! **Not applicable** (the grammar `q-parser` compiles literally cannot
+//! produce these — booleans, symbols, strings, temporal literals,
+//! dictionaries, tables, q-SQL, `?`/`.`/`@`, each-prior/each-right/
+//! each-left, recursion — MA11 §4 — so there is no CST shape for this
+//! lowerer to ever reach).
+//!
+//! # Stranded literals: the same `Ravel`-wrap fix APL/J already carry
+//!
+//! Identical bug, identical fix, to `apl-to-semantic-ir`'s/
+//! `j-to-semantic-ir`'s own `lower_term`: a bare `ArrayLit { rows:
+//! vec![row], .. }` is a genuinely rank-2 `[1, n]` value under this IR's
+//! column-major storage convention (`Feature::ArrayColumnMajor`), not the
+//! rank-1 `[n]` vector a stranded literal (or an explicit `(a;b;c)` list
+//! literal, MA11 §3 bullet 3) actually is. Wrapping in [`Expr::Ravel`]
+//! flattens any input rank down to a genuine rank-1 result — invisible to Q
+//! source, only the IR shape changes.
+//!
+//! # Top-level scope is Global, not Local — a REAL divergence from J/APL
+//!
+//! `j-to-semantic-ir`/`apl-to-semantic-ir` lower every top-level name to a
+//! `main`-local `Scope::Local` binding, because J/APL's entire program lives
+//! inside the single synthesized `main` function and nothing else ever
+//! needs to read a top-level name from outside it. Q genuinely breaks this
+//! assumption: MA11 §2/§5 and `q-runtime::eval::Lambda`'s own doc comment
+//! are explicit that a function literal's body "resolves any non-parameter
+//! name against the *global* frame at call time" — meaning a Q function can
+//! read (and this crate must therefore make visible to) a plain array
+//! variable assigned at the top level, from inside a **separate**,
+//! independently-compiled SIR [`Function`]. A `main`-local JS `let` is
+//! invisible to a sibling JS function, so every top-level Q variable
+//! becomes a genuine [`semantic_ir::Global`] (`init_function: "main"`,
+//! `Scope::Global` everywhere it's read or written) instead — mirroring how
+//! `semantic-ir-to-javascript::emit_globals` documents "globals are
+//! module-level `let`s", visible from any function in the same file. Since
+//! `emit_globals` pre-declares every global as `let name = null;` before any
+//! function runs, this crate never needs the `LetStarBinding`-vs-`Assign`
+//! first-occurrence distinction J/APL use for their own `Local` bindings —
+//! every top-level write is simply `Stmt::Assign { scope: Global, .. }`,
+//! first write or tenth.
+//!
+//! A **local** assignment made *inside* a function-literal body (MA11 §4:
+//! "local to that call only") is a genuine `Scope::Local` (or `Scope::Param`
+//! if it reassigns one of the function's own parameters), scoped to that
+//! one synthesized [`Function`] alone — the ordinary `LetStarBinding`-vs-
+//! `Assign` first-occurrence distinction applies there exactly as it does
+//! in every sibling frontend.
+//!
+//! # Function literals: the one lowering surface with no APL/J precedent
+//!
+//! `{[x;y] stmt; stmt; ...}` (MA11 §2/§3 bullet 1) is the one genuinely new
+//! *lowering* problem this crate's model (`j-to-semantic-ir`) never had to
+//! solve, because J's/APL's in-scope grammars are expression-only — a train
+//! *recombines* existing primitives, it never introduces a brand-new
+//! parameter name a body can reference. `semantic_ir`'s own core already has
+//! exactly the machinery general-purpose-language frontends (`python-to-
+//! semantic-ir`, `ruby-to-semantic-ir`) use for this: a genuine
+//! [`Function`] with named [`Param`]s, referenced by callers via
+//! [`Expr::DirectCall`] (a statically-known callee), [`Expr::MakeClosure`]
+//! (a bare reference to a named function used as a *value*, not called),
+//! and [`Expr::IndirectCall`] (a call through a value whose identity is not
+//! statically known — a closure handle). Since Q's own `QFn::Lambda` has
+//! **no captures at all** (`q-runtime::eval::Lambda`'s own doc comment:
+//! "stores no captured environment ... resolves any non-parameter name
+//! against the *global* frame at call time"), this crate's design is
+//! considerably SIMPLER than Python's/Ruby's own lambda-lifting machinery
+//! (no free-variable analysis, no capture list ever populated) — every
+//! synthesized [`Function`] always has `captures: vec![]`.
+//!
+//! ## Three call-site shapes, one dispatch decision
+//!
+//! Mirrors `q-runtime::eval`'s own "one dispatch site" framing (that
+//! module's top doc comment: `apply_monadic`/`apply_dyadic` are the ONE
+//! place every `QFn` variant is applied) at the *lowering* level instead of
+//! the *evaluation* level:
+//!
+//! 1. **A NAME that resolves (at lowering time) to a function literal
+//!    directly assigned to it at the top level** (`f:{x+y}` then `2 f 3`) —
+//!    lowers to [`FnKind::KnownFn`], i.e. [`Expr::DirectCall`]. This is the
+//!    common case and the one every function-chaining test in
+//!    `q-runtime`'s own test suite exercises.
+//! 2. **An inline function literal used immediately as a callee**
+//!    (`{x*2} 5`) — synthesizes a fresh, anonymously-named top-level
+//!    [`Function`] and *also* lowers to [`FnKind::KnownFn`]
+//!    ([`Expr::DirectCall`] to the synthesized name) — semantically
+//!    equivalent to "make a closure, then immediately call through it," but
+//!    skipping the indirection since the callee is statically known the
+//!    moment it's written.
+//! 3. **Anything else** — a NAME that is a plain variable (a parameter, or
+//!    a top-level array), or a parenthesised/list-literal/numeric term used
+//!    as a callee — lowers to [`FnKind::Dynamic`], i.e. [`Expr::IndirectCall`]
+//!    through whatever [`Expr`] that term evaluated to. This is what makes
+//!    the genuinely dynamic, higher-order case work correctly with **no**
+//!    special-casing: `q-runtime`'s own test suite has a real example
+//!    (`passing_a_function_value_as_an_argument_to_another_function`:
+//!    `apply:{[g] g 5}`, then `apply inc` calls `apply` with `inc` bound to
+//!    `g`, and `g 5` inside `apply`'s body applies whatever `g` turns out to
+//!    hold at runtime) — `g` is an ordinary [`Scope::Param`] [`Expr::VarRef`],
+//!    dispatched via [`Expr::IndirectCall`], with **no static knowledge**
+//!    of what it holds. `semantic-ir-to-javascript`'s own `applyClosure`
+//!    runtime helper throws a clean `TypeError` if the value it receives
+//!    isn't a genuine closure — the same "clean error, never silent
+//!    misbehavior" class of failure `q-runtime::eval::as_callable` raises
+//!    for the identical mistake (`applying_a_plain_array_value_as_a_function_is_a_clean_error`
+//!    in that crate's own test suite), just discovered at a different
+//!    (later, but still catchable) point.
+//!
+//! The dispatch decision itself is a single, shared helper
+//! ([`Lowerer::expr_to_fnkind`]): lower the callee position the *ordinary*
+//! way (exactly as if it were a ordinary value-producing `term`/`NAME`), and
+//! then inspect whether the result is literally an [`Expr::MakeClosure`] —
+//! if so, unwrap its `fn_name` into [`FnKind::KnownFn`] (the DirectCall
+//! optimization); otherwise, keep the `Expr` as-is and dispatch dynamically.
+//! `q-runtime`'s own grammar has no operator-precedence distinction between
+//! `verb_expr`'s `NAME`/`function_literal` alternatives and `noun_expr`'s
+//! "apply a bare `term`" fallback (MA11 §3's own header note on `q.grammar`)
+//! — both alternatives are, at the *evaluation* level, resolved by the
+//! identical `lookup` + `as_callable` pair. This crate's single shared
+//! dispatch helper is the direct lowering-time mirror of that same real
+//! unification, not an independent design choice.
+//!
+//! ## Disclosed simplification: declared arity vs. call-site arity
+//!
+//! `q-runtime::eval::Interpreter::call_lambda` binds a call's arguments to
+//! a function's parameters **positionally**, and does NOT require every
+//! declared parameter to receive an argument — a function declared with
+//! more parameters than a given call site supplies (most commonly the
+//! bracket-omitted implicit `x`/`y`/`z` form, called monadically with only
+//! one argument) simply leaves the extra parameters **unbound** for that
+//! call, erroring only if the body actually references one of them
+//! (confirmed directly against `q-parser`'s own doc-comment example, `f 2
+//! 3` calling a `{[x;y] ...}`-shaped `f` **monadically** with the single
+//! two-element vector argument `2 3`, since adjacent NUMBER stranding
+//! always wins over the dyadic-application alternative at that grammar
+//! position — leaving `y` unbound for that call). `semantic_ir::Function`'s
+//! own default-parameter model (SIR10) has no "declared but deliberately
+//! left unbound, error only if referenced" concept — a parameter is either
+//! required (arity floor) or has a real fallback *value*. This crate
+//! resolves the mismatch by giving every parameter **after the first** a
+//! default of `IntLit(0)` (arbitrary, always-valid-as-a-scalar-array
+//! sentinel — never `Feature`-gated beyond `Feature::DefaultParams`), so a
+//! call supplying fewer arguments than the callee declares is accepted (the
+//! trailing parameters silently take the value `0` rather than truly
+//! staying unbound) instead of rejected. This is a genuine, disclosed
+//! behavioral divergence from `q-runtime`'s own semantics for the narrow
+//! case where the body actually *reads* an unsupplied trailing parameter
+//! (a real Q program doing this is arguably already a bug in the source,
+//! since real q-runtime errors on it too) — but it is what lets the
+//! overwhelmingly common, well-formed case (a function declaring exactly
+//! the parameters its own body uses, called with matching arity) compile
+//! and run correctly, rather than rejecting every use of the implicit
+//! `x`/`y`/`z` convenience called at anything other than full ternary
+//! arity. The OTHER direction — a call site supplying *more* arguments than
+//! the callee declares — is still a hard, disclosed lowering error (see
+//! [`Lowerer::apply_monadic`]/[`Lowerer::apply_dyadic`]'s `KnownFn` arm),
+//! mirroring `call_lambda`'s own "function takes at most N parameter(s)"
+//! rejection exactly, since there is no SIR concept of "extra argument,
+//! silently ignored" to fall back on either.
+//!
+//! # The 17 primitives (MA11 §4's full table)
+//!
+//! | Glyph | Monadic | Dyadic |
+//! |---|---|---|
+//! | `+` | flip → **identity** (this cut can never construct a rank-2 value at all — no reshape/matrix-literal primitive exists in scope, MA11 §4 — so "transpose if rank 2, else identity" reduces to unconditional identity for every value this frontend can ever produce) | add → `ElementwiseOp(Add)` |
+//! | `-` | negate → `BuiltinCall("neg")` (the exact same builtin `apl-to-semantic-ir`'s monadic `-` already uses) | subtract → `ElementwiseOp(Sub)` |
+//! | `*` | first → `BuiltinCall("q_first")` (new — Q's "first item," genuinely unlike J's monadic `*` = sign) | multiply → `ElementwiseOp(Mul)` |
+//! | `%` | reciprocal → `BuiltinCall("recip")` (reused from `apl-to-semantic-ir`) | divide → `ElementwiseOp(Div)` |
+//! | `!` | til (0-based) → `Expr::IndexGenerator` + a `- 1` correction (the identical fix `j-to-semantic-ir::zero_base_index` already applies for J's own 0-based `i.`, since the shared JS runtime's `indexGenerator` hardcodes APL's 1-based convention) | dyadic `!` (dict creation) — **explicitly deferred, MA11 §4**: a clean lowering error, never attempted |
+//! | `,` | enlist → `Expr::Ravel` (see "Enlist reuses Ravel" below for why these coincide exactly in this cut) | join → `Expr::Catenate` (see "Join reuses Catenate" below) |
+//! | `#` | tally → `BuiltinCall("tally")` (reused **as-is** from `j-to-semantic-ir` — `ArrayRt.tally`'s existing rank0→1/rank1→n/rank2→r convention already matches `q-runtime::builtins::tally` exactly) | take → `BuiltinCall("q_take")` (new — Q's `#` is *take*, unlike J's dyadic `#` = *replicate*) |
+//! | `_` | floor → `BuiltinCall("floor")` (reused from `apl-to-semantic-ir`) | drop → `BuiltinCall("q_drop")` (new) |
+//! | `&` | where → `BuiltinCall("q_where")` (new — indices of nonzero elements) | min → `ElementwiseOp(Min)` |
+//! | `\|` | reverse → `BuiltinCall("q_reverse")` (new) | max → `ElementwiseOp(Max)` |
+//! | `~` | not → `BuiltinCall("q_not")` (new — elementwise 0/1, NOT the generic boolean `"not"` builtin, which returns a native JS boolean and isn't elementwise) | match → `BuiltinCall("q_match")` (new — deep equality, producing a scalar, the one dyadic primitive here that is NOT elementwise) |
+//! | `=` `<>` `<` `<=` `>=` `>` | none (clean error — dyadic-only) | `ElementwiseOp(Eq/Ne/Lt/Le/Ge/Gt)` |
+//!
+//! ## Enlist reuses `Ravel`
+//!
+//! Real Q's monadic `,` (enlist) and APL/J's monadic `,` (ravel) are
+//! genuinely different operations in general (enlist adds ONE level of list
+//! nesting even to an already-list-shaped argument; ravel flattens to rank
+//! 1 unconditionally) — but this cut's value model
+//! (`array_runtime::Array`, MA11 §4: "arrays only, dense and numeric," no
+//! nested/boxed representation) can only ever hold rank 0 or rank 1 values
+//! (no primitive in scope can construct rank 2), and on exactly that
+//! reachable subset the two operations coincide completely: a rank-0
+//! scalar becomes a rank-1 single-element vector under EITHER reading, and
+//! a rank-1 vector is returned unchanged under EITHER reading. Confirmed
+//! directly against `q_runtime::builtins::enlist`'s own doc comment, which
+//! discloses the identical simplification on the *runtime* side ("the
+//! closest sound approximation available within this value model, and is
+//! exact for enlist's single most common use"). This crate reuses
+//! [`Expr::Ravel`] rather than inventing a redundant `BuiltinCall` that
+//! would compute the identical result through a second code path.
+//!
+//! ## Join reuses `Catenate`
+//!
+//! `q_runtime::builtins::join`'s own case-by-case shape (scalar-scalar →
+//! 2-vector; scalar-vector/vector-scalar → prepend/append; vector-vector →
+//! concatenate; matrix-matrix with equal row counts → column-join) is,
+//! case for case, IDENTICAL to `apl_runtime::builtins::catenate`'s (the
+//! kernel `Expr::Catenate`'s shared JS runtime implementation already
+//! computes) — confirmed by direct side-by-side comparison of both Rust
+//! source functions. This crate reuses [`Expr::Catenate`] rather than
+//! introducing a `BuiltinCall("q_join", ..)` that would just re-implement
+//! the identical logic a second time.
+//!
+//! # Recursion-depth guard
+//!
+//! [`MAX_EXPR_DEPTH`] (256) bounds this crate's own lowering recursion —
+//! defense in depth, exactly mirroring `j-to-semantic-ir::MAX_EXPR_DEPTH`'s/
+//! `apl-to-semantic-ir::MAX_EXPR_DEPTH`'s identical rationale:
+//! `q-parser`'s own `MAX_RULE_DEPTH` (32) already bounds how deep a CST
+//! built from untrusted source can possibly be, so this can never actually
+//! trip on a tree from `try_parse_q`; it exists purely so a hand-built
+//! `GrammarASTNode` (or a future change to `q-parser`'s own cap) can't turn
+//! a deep-but-technically-parseable input into an uncatchable native stack
+//! overflow while walking it here. Unlike J's own trains, Q has no
+//! combinator-shaped construct that duplicates an operand in the emitted
+//! tree (MA11 §4: no trains, no `@` compose) — so, unlike
+//! `j-to-semantic-ir`, this crate needs no *second*, smaller
+//! combinator-depth guard.
+
+use lexer::token::Token;
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use semantic_ir::{
+    Block, EffectSet, ElementwiseOpKind, Expr, Feature, FeatureManifest, Function, Global,
+    Metadata, Module, Param, ParamKind, Scope, Span, Stmt,
+};
+use std::collections::{HashMap, HashSet};
+
+/// Maximum ordinary CST-walk recursion depth. See this file's module doc
+/// comment's "Recursion-depth guard" section.
+const MAX_EXPR_DEPTH: usize = 256;
+
+/// Synthetic file name used for all spans (the CST does not carry the
+/// original path).
+const FILE: &str = "<q>";
+
+// ---------------------------------------------------------------------------
+// Public error type
+// ---------------------------------------------------------------------------
+
+/// An error encountered during Q → SIR lowering.
+///
+/// Mirrors `JLowerError`/`AplLowerError`'s shape exactly (a `message` plus
+/// 1-based `line`/`column`) so tooling can treat every SIR frontend
+/// uniformly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QLowerError {
+    pub message: String,
+    pub line: usize,
+    pub column: usize,
+}
+
+impl std::fmt::Display for QLowerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "QLowerError at {}:{}: {}", self.line, self.column, self.message)
+    }
+}
+
+impl std::error::Error for QLowerError {}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Lower a parsed Q CST (rooted at the `program` rule) into a SIR module.
+pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<semantic_ir::Module, QLowerError> {
+    Lowerer::new(module_name).lower_file(tree)
+}
+
+// ---------------------------------------------------------------------------
+// Primitive-verb representation (MA11 §4's full table)
+// ---------------------------------------------------------------------------
+
+/// One of `q.tokens`' 17 primitive verb glyphs, kept as a small `Copy` enum
+/// (not the raw token) so error messages can name the actual glyph (`"!"`,
+/// not `"BANG"`) — mirrors `q_runtime::builtins::Prim` field-for-field
+/// (this crate does not depend on `q-runtime` in its non-dev dependencies,
+/// so the enum is redefined here rather than imported, exactly as
+/// `j-to-semantic-ir::NonScalarAtom` redefines its own analogue of
+/// `j_runtime::eval::NonScalarAtom` rather than importing it).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Prim {
+    Plus,
+    Minus,
+    Star,
+    Percent,
+    Bang,
+    Comma,
+    Hash,
+    Underscore,
+    Amp,
+    Pipe,
+    Tilde,
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Ge,
+    Gt,
+}
+
+impl Prim {
+    /// The ASCII spelling of this glyph, for error messages. `Ne` spells
+    /// `<>` — Q's own not-equal (MA11 §4), never `~=`/`#`.
+    fn glyph(self) -> &'static str {
+        match self {
+            Prim::Plus => "+",
+            Prim::Minus => "-",
+            Prim::Star => "*",
+            Prim::Percent => "%",
+            Prim::Bang => "!",
+            Prim::Comma => ",",
+            Prim::Hash => "#",
+            Prim::Underscore => "_",
+            Prim::Amp => "&",
+            Prim::Pipe => "|",
+            Prim::Tilde => "~",
+            Prim::Eq => "=",
+            Prim::Ne => "<>",
+            Prim::Lt => "<",
+            Prim::Le => "<=",
+            Prim::Ge => ">=",
+            Prim::Gt => ">",
+        }
+    }
+
+    /// The [`ElementwiseOpKind`] this primitive's **dyadic** meaning maps
+    /// onto, if any. Exactly 12 of the 17 map onto one variant apiece; the
+    /// remaining 5 (`! , # _ ~`) have no elementwise-scalar dyadic meaning
+    /// at all — mirrors `q_runtime::builtins::Prim::to_binop` exactly.
+    fn to_binop(self) -> Option<ElementwiseOpKind> {
+        match self {
+            Prim::Plus => Some(ElementwiseOpKind::Add),
+            Prim::Minus => Some(ElementwiseOpKind::Sub),
+            Prim::Star => Some(ElementwiseOpKind::Mul),
+            Prim::Percent => Some(ElementwiseOpKind::Div),
+            Prim::Amp => Some(ElementwiseOpKind::Min),
+            Prim::Pipe => Some(ElementwiseOpKind::Max),
+            Prim::Eq => Some(ElementwiseOpKind::Eq),
+            Prim::Ne => Some(ElementwiseOpKind::Ne),
+            Prim::Lt => Some(ElementwiseOpKind::Lt),
+            Prim::Le => Some(ElementwiseOpKind::Le),
+            Prim::Ge => Some(ElementwiseOpKind::Ge),
+            Prim::Gt => Some(ElementwiseOpKind::Gt),
+            Prim::Bang | Prim::Comma | Prim::Hash | Prim::Underscore | Prim::Tilde => None,
+        }
+    }
+
+    /// Whether monadic `f'x` (each) has a well-defined, non-redundant
+    /// meaning for this primitive — true only for the four primitives whose
+    /// *monadic* meaning is itself an ordinary per-element scalar map.
+    /// Mirrors `q_runtime::builtins::Prim::each_monadic_supported` exactly.
+    fn each_monadic_supported(self) -> bool {
+        matches!(self, Prim::Minus | Prim::Percent | Prim::Underscore | Prim::Tilde)
+    }
+
+    /// Whether dyadic `x f'y` (each) has a well-defined, non-redundant
+    /// meaning — true exactly for the `ElementwiseOpKind`-mappable
+    /// primitives. Mirrors `q_runtime::builtins::Prim::each_dyadic_supported`
+    /// exactly.
+    fn each_dyadic_supported(self) -> bool {
+        self.to_binop().is_some()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Verb-expression / callee representation
+// ---------------------------------------------------------------------------
+
+/// This lowerer's own representation of "which verb, and with which adverb
+/// (if any) applied, or which callable value" — the direct lowering-time
+/// analogue of `q_runtime::eval::QFn`. Unlike `j-to-semantic-ir::FnKind`,
+/// there is no `Compose`/`Hook`/`Fork` here at all (Q has no trains and no
+/// `@` compose, MA11 §3/§4) — every variant is a leaf dispatch.
+enum FnKind {
+    /// A bare primitive glyph, applied directly.
+    Prim(Prim),
+    /// A primitive with `'` (each) applied.
+    Each(Prim),
+    /// A primitive with `/` (reduce) applied — inherently monadic.
+    Reduce(ElementwiseOpKind),
+    /// A primitive with `\` (scan) applied — also monadic.
+    Scan(ElementwiseOpKind),
+    /// A statically-known top-level function (by its SIR name) — lowers to
+    /// [`Expr::DirectCall`]. See this file's module doc comment's "Three
+    /// call-site shapes" section.
+    KnownFn(String),
+    /// Anything else: a callable whose identity is not statically known —
+    /// lowers to [`Expr::IndirectCall`] through this already-lowered
+    /// [`Expr`]. See this file's module doc comment's "Three call-site
+    /// shapes" section, case 3.
+    Dynamic(Box<Expr>),
+}
+
+// ---------------------------------------------------------------------------
+// Name resolution
+// ---------------------------------------------------------------------------
+
+/// What a bare `NAME` resolves to, once looked up against the current
+/// function's own parameters/locals and then the top-level bindings table
+/// (see [`Lowerer::resolve_name`]).
+enum Resolved {
+    /// A statically-known top-level function — its own SIR name.
+    Function(String),
+    /// An ordinary value binding, at the given [`Scope`].
+    Var(Scope),
+}
+
+/// The local-name scope for whichever [`Function`] is currently being
+/// lowered. The top level (`main`) uses an always-empty [`FnScope`] (MA11's
+/// own convention has no true *local* binding at the top level — every
+/// top-level name is a [`Scope::Global`], see this file's module doc
+/// comment's "Top-level scope is Global, not Local" section); a
+/// function-literal body's own [`FnScope`] is seeded with its parameter
+/// names and grows its `locals` set as the body's own statements assign new
+/// names, mirroring `q_runtime::eval::Interpreter`'s "local to that call
+/// only" scoping (MA11 §4).
+struct FnScope {
+    params: HashSet<String>,
+    locals: HashSet<String>,
+}
+
+impl FnScope {
+    fn top_level() -> Self {
+        FnScope { params: HashSet::new(), locals: HashSet::new() }
+    }
+
+    fn for_lambda(params: &[String]) -> Self {
+        FnScope { params: params.iter().cloned().collect(), locals: HashSet::new() }
+    }
+}
+
+/// What an `assignment` chain's base case resolved to — either an ordinary
+/// value (the ordinary case) or a bare top-level function-literal
+/// definition (see [`Lowerer::bare_function_literal_term`] and this file's
+/// module doc comment's "Function literals" section).
+enum AssignedValue {
+    Value(Expr),
+    Function(String),
+}
+
+// ---------------------------------------------------------------------------
+// The lowerer
+// ---------------------------------------------------------------------------
+
+/// Q scopes a plain array variable to the *whole program* if assigned at
+/// the top level (a genuine [`Scope::Global`], see this file's module doc
+/// comment), or to one function call if assigned inside a function-literal
+/// body (a [`Scope::Local`]/[`Scope::Param`], MA11 §4's "local to that call
+/// only"). A user-defined function name is tracked separately
+/// (`known_functions`) regardless of where it was defined, since MA11 §4
+/// only ever allows a function literal to be *directly* assigned at the
+/// top level (no nested function-literal definitions at all).
+struct Lowerer {
+    module_name: String,
+    observed: FeatureManifest,
+    /// Q source name → the synthesized SIR [`Function`]'s own name, for
+    /// every name a bare function literal has been directly assigned to at
+    /// the top level.
+    known_functions: HashMap<String, String>,
+    /// SIR function name → its own declared parameter count, used for the
+    /// "too many arguments" arity check (see this file's module doc
+    /// comment's "Disclosed simplification" section).
+    known_function_arity: HashMap<String, usize>,
+    /// Every top-level Q name currently bound to a plain (non-function)
+    /// value — becomes a [`Global`] module entry. A `HashSet` for O(1)
+    /// membership plus `global_order` (below) for deterministic output
+    /// order; a name that is later reassigned to a function literal is
+    /// removed from this set (see [`Lowerer::lower_assignment_chain`]).
+    global_names: HashSet<String>,
+    /// Insertion order for `global_names`, so the emitted `Module.globals`
+    /// list is deterministic regardless of `HashSet`'s own iteration order.
+    /// Filtered against `global_names` at finalization time, so a name
+    /// later promoted to a function does not leave a stale entry.
+    global_order: Vec<String>,
+    /// Every synthesized function-literal [`Function`] (never `main`
+    /// itself, appended separately in [`Lowerer::lower_file`]).
+    functions: Vec<Function>,
+    /// Monotonically increasing counter for synthesized function names
+    /// (`q_lambda_<N>`) — every function literal gets one, regardless of
+    /// whether it came from a direct top-level assignment or an inline,
+    /// immediately-applied literal, so there is never a naming collision to
+    /// resolve.
+    lambda_counter: usize,
+    /// Nesting depth of function-literal-body lowering currently in
+    /// progress: `0` at the top level, `1` while lowering the *first*
+    /// function literal's own body, etc. Used by
+    /// [`Lowerer::register_function_literal`] to reject a **nested**
+    /// function-literal definition (MA11 §4), mirroring
+    /// `q_runtime::eval::Interpreter::inside_a_call`'s identical guard.
+    inside_lambda_depth: usize,
+}
+
+impl Lowerer {
+    fn new(module_name: &str) -> Self {
+        Self {
+            module_name: module_name.to_string(),
+            observed: FeatureManifest::new(),
+            known_functions: HashMap::new(),
+            known_function_arity: HashMap::new(),
+            global_names: HashSet::new(),
+            global_order: Vec::new(),
+            functions: Vec::new(),
+            lambda_counter: 0,
+            inside_lambda_depth: 0,
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // top level: `program` → one `main` function (+ synthesized lambdas)
+    // -------------------------------------------------------------------
+
+    fn lower_file(&mut self, program: &GrammarASTNode) -> Result<Module, QLowerError> {
+        if program.rule_name != "program" {
+            return Err(self.err_at(
+                program,
+                format!("expected `program` root, got `{}`", program.rule_name),
+            ));
+        }
+
+        self.observed.add(Feature::DynamicTyping);
+
+        let mut top_scope = FnScope::top_level();
+        let mut stmts: Vec<Stmt> = Vec::new();
+        for line in child_nodes(program) {
+            if line.rule_name != "line" {
+                continue;
+            }
+            // A `line` with no `statement` child (a blank line, or a
+            // comment-only line -- `/`-comments are already stripped by
+            // `q-lexer`'s pre-tokenize hook) is a bare NEWLINE production;
+            // skip it, don't error.
+            let Some(stmt_node) = first_child_named(line, "statement") else {
+                continue;
+            };
+            let assignment_node = only_node(stmt_node)
+                .ok_or_else(|| self.err_at(stmt_node, "malformed statement".to_string()))?;
+            let mut new_stmts =
+                self.lower_top_level_statement(assignment_node, 0, &mut top_scope)?;
+            stmts.append(&mut new_stmts);
+        }
+
+        let span = Span::point(FILE, 1, 1);
+        let main = Function {
+            name: "main".to_string(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts,
+                value: Expr::NilLit { span: span.clone() },
+                span: span.clone(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: span.clone(),
+        };
+
+        // Filtered against the CURRENT `global_names` set (not just
+        // insertion order) so a name later promoted from a plain variable
+        // to a function (re-assigned to a bare function literal after an
+        // earlier plain-value assignment) does not leave a stale `Global`
+        // entry behind -- see `lower_assignment_chain`'s `Function` arm.
+        let globals: Vec<Global> = self
+            .global_order
+            .iter()
+            .filter(|name| self.global_names.contains(*name))
+            .map(|name| Global {
+                name: name.clone(),
+                sir_type: None,
+                init_function: "main".to_string(),
+                span: span.clone(),
+            })
+            .collect();
+
+        let mut functions = std::mem::take(&mut self.functions);
+        functions.push(main);
+
+        let metadata = Metadata::new()
+            .with_source_language("q")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION);
+
+        Ok(Module {
+            name: self.module_name.clone(),
+            manifest: self.observed.clone(),
+            imports: vec![],
+            exports: vec![],
+            functions,
+            globals,
+            metadata,
+            span,
+        })
+    }
+
+    /// Dispatch one top-level `assignment` node (a `statement`'s sole
+    /// child) into zero or more [`Stmt`]s.
+    fn lower_top_level_statement(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+        top_scope: &mut FnScope,
+    ) -> Result<Vec<Stmt>, QLowerError> {
+        self.check_depth(node, depth)?;
+        match node.children.len() {
+            // Base case: a bare `noun_expr`, not an assignment. Real Q
+            // auto-print session semantics (MA11 §4, mirroring
+            // `j-to-semantic-ir`'s/`apl-to-semantic-ir`'s identical
+            // convention).
+            1 => {
+                let noun_expr_node = only_node(node)
+                    .ok_or_else(|| self.err_at(node, "malformed noun_expr statement".to_string()))?;
+                let v = self.lower_noun_expr(noun_expr_node, depth + 1, top_scope)?;
+                let span = v.span().clone();
+                Ok(vec![Stmt::ExprStmt {
+                    expr: Expr::BuiltinCall {
+                        name: "print".to_string(),
+                        args: vec![v],
+                        effects: EffectSet::PURE,
+                        span: span.clone(),
+                    },
+                    span,
+                }])
+            }
+            // `NAME COLON assignment` -- an actual assignment (possibly
+            // chained). Assignment is silent (MA11 §4): emit every
+            // statement the chain unrolled into, and nothing else.
+            3 => {
+                let (stmts, _final_value) =
+                    self.lower_assignment_chain(node, depth, top_scope, true)?;
+                Ok(stmts)
+            }
+            n => Err(self.err_at(node, format!("malformed assignment with {n} children"))),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // assignment (including chained assignment) -- shared by top-level
+    // (Global scope) and function-literal-body-internal (Local/Param
+    // scope) lowering, see this file's module doc comment's "Top-level
+    // scope is Global, not Local" section.
+    // -------------------------------------------------------------------
+
+    /// Recursively lower an `assignment` node. Returns the statements the
+    /// chain unrolled into (in dependency order) and what the chain's
+    /// innermost RHS resolved to -- either an ordinary value, or (MA11 §3
+    /// bullet 1) a bare function-literal definition, in which case NO
+    /// `Stmt` is emitted for it at all (the function becomes its own
+    /// top-level [`Function`], tracked in `known_functions` -- not an
+    /// ordinary value binding).
+    ///
+    /// `is_top_level` selects `Scope::Global` (every top-level write,
+    /// first occurrence or tenth -- no `LetStarBinding`-vs-`Assign`
+    /// distinction is needed there, see the module doc comment) vs. the
+    /// ordinary `Scope::Param`/`Scope::Local` first-occurrence convention
+    /// every sibling frontend uses for its own function-body-local
+    /// bindings.
+    fn lower_assignment_chain(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+        fn_scope: &mut FnScope,
+        is_top_level: bool,
+    ) -> Result<(Vec<Stmt>, AssignedValue), QLowerError> {
+        self.check_depth(node, depth)?;
+        match node.children.len() {
+            1 => {
+                let noun_expr_node = only_node(node).ok_or_else(|| {
+                    self.err_at(node, "malformed noun_expr in assignment".to_string())
+                })?;
+                if let Some(lit_node) = bare_function_literal_term(noun_expr_node) {
+                    let sir_name = self.register_function_literal(lit_node, depth + 1)?;
+                    return Ok((vec![], AssignedValue::Function(sir_name)));
+                }
+                let v = self.lower_noun_expr(noun_expr_node, depth + 1, fn_scope)?;
+                Ok((vec![], AssignedValue::Value(v)))
+            }
+            3 => {
+                let name = self.assignment_target_name(node)?;
+                let inner = only_node(node).ok_or_else(|| {
+                    self.err_at(node, "malformed assignment: no nested assignment".to_string())
+                })?;
+                let (mut stmts, inner_value) =
+                    self.lower_assignment_chain(inner, depth + 1, fn_scope, is_top_level)?;
+                let span = self.span_of(node);
+                match inner_value {
+                    AssignedValue::Function(sir_name) => {
+                        // Promoting `name` to a function: if it was
+                        // previously a plain global, drop it from that set
+                        // so `lower_file` doesn't emit a stale `Global`.
+                        self.global_names.remove(&name);
+                        self.known_functions.insert(name.clone(), sir_name.clone());
+                        Ok((stmts, AssignedValue::Function(sir_name)))
+                    }
+                    AssignedValue::Value(value) => {
+                        // Demoting `name` to a plain value: if it was
+                        // previously a known function, it no longer is.
+                        self.known_functions.remove(&name);
+                        if is_top_level {
+                            if self.global_names.insert(name.clone()) {
+                                self.global_order.push(name.clone());
+                            }
+                            self.observed.add(Feature::Globals);
+                            self.observed.add(Feature::MutableBindings);
+                            stmts.push(Stmt::Assign {
+                                name: name.clone(),
+                                scope: Scope::Global,
+                                value,
+                                span: span.clone(),
+                            });
+                            Ok((stmts, AssignedValue::Value(Expr::VarRef {
+                                name,
+                                scope: Scope::Global,
+                                span,
+                            })))
+                        } else if fn_scope.params.contains(&name) {
+                            // Reassigning one of the function's own
+                            // parameters -- still a plain `Assign`, never a
+                            // fresh binding (mirrors
+                            // `q_runtime::eval::Interpreter::assign`'s
+                            // "always write to the top frame" rule, where
+                            // a param and a call-local variable share one
+                            // frame).
+                            self.observed.add(Feature::MutableBindings);
+                            stmts.push(Stmt::Assign {
+                                name: name.clone(),
+                                scope: Scope::Param,
+                                value,
+                                span: span.clone(),
+                            });
+                            Ok((stmts, AssignedValue::Value(Expr::VarRef {
+                                name,
+                                scope: Scope::Param,
+                                span,
+                            })))
+                        } else if fn_scope.locals.insert(name.clone()) {
+                            stmts.push(Stmt::LetStarBinding {
+                                name: name.clone(),
+                                sir_type: None,
+                                value,
+                                span: span.clone(),
+                            });
+                            Ok((stmts, AssignedValue::Value(Expr::VarRef {
+                                name,
+                                scope: Scope::Local,
+                                span,
+                            })))
+                        } else {
+                            self.observed.add(Feature::MutableBindings);
+                            stmts.push(Stmt::Assign {
+                                name: name.clone(),
+                                scope: Scope::Local,
+                                value,
+                                span: span.clone(),
+                            });
+                            Ok((stmts, AssignedValue::Value(Expr::VarRef {
+                                name,
+                                scope: Scope::Local,
+                                span,
+                            })))
+                        }
+                    }
+                }
+            }
+            n => Err(self.err_at(node, format!("malformed assignment with {n} children"))),
+        }
+    }
+
+    /// The `NAME` token of an actual assignment's target -- the first child
+    /// of a 3-child `assignment` node.
+    fn assignment_target_name(&self, node: &GrammarASTNode) -> Result<String, QLowerError> {
+        match node.children.first() {
+            Some(ASTNodeOrToken::Token(t)) if t.effective_type_name() == "NAME" => {
+                Ok(t.value.clone())
+            }
+            _ => Err(self.err_at(node, "malformed assignment (missing target name)".to_string())),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // noun_expr / term
+    // -------------------------------------------------------------------
+
+    /// `noun_expr = term [ verb_expr noun_expr | noun_expr ] | verb_expr noun_expr`.
+    ///
+    /// - 1 child `[term]` -- a bare term.
+    /// - 3 children `[term, verb_expr, noun_expr]` -- ordinary dyadic
+    ///   application.
+    /// - 2 children -- ambiguous by count alone (the one wrinkle
+    ///   `q.grammar` has that `j.grammar`/`apl.grammar` never needed, see
+    ///   this file's module doc comment): `[verb_expr, noun_expr]` is
+    ///   ordinary monadic primitive application (`-5`); `[term, noun_expr]`
+    ///   is "apply a callable term" (`f 5`, or `{x*2} 5`). Disambiguated by
+    ///   inspecting `kids[0].rule_name` -- exactly the check
+    ///   `q_runtime::eval::Interpreter::eval_noun_expr` makes.
+    fn lower_noun_expr(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+        fn_scope: &FnScope,
+    ) -> Result<Expr, QLowerError> {
+        self.check_depth(node, depth)?;
+        let span = self.span_of(node);
+        let kids = child_nodes(node);
+        match kids.as_slice() {
+            [term] => self.lower_term(term, depth + 1, fn_scope),
+            [first, sub] if first.rule_name == "verb_expr" => {
+                let f = self.lower_verb_expr(first, depth + 1, fn_scope)?;
+                let arg = self.lower_noun_expr(sub, depth + 1, fn_scope)?;
+                self.apply_monadic(f, arg, span)
+            }
+            [first, sub] if first.rule_name == "term" => {
+                let callee_expr = self.lower_term(first, depth + 1, fn_scope)?;
+                let f = self.expr_to_fnkind(callee_expr);
+                let arg = self.lower_noun_expr(sub, depth + 1, fn_scope)?;
+                self.apply_monadic(f, arg, span)
+            }
+            [lhs_term, vexpr, sub] => {
+                let lhs = self.lower_term(lhs_term, depth + 1, fn_scope)?;
+                let f = self.lower_verb_expr(vexpr, depth + 1, fn_scope)?;
+                let rhs = self.lower_noun_expr(sub, depth + 1, fn_scope)?;
+                self.apply_dyadic(f, lhs, rhs, span)
+            }
+            other => Err(self.err_at(
+                node,
+                format!("malformed noun_expr with {} children", other.len()),
+            )),
+        }
+    }
+
+    /// `term = NUMBER { NUMBER } | NAME | function_literal | LPAREN noun_expr RPAREN | list_literal`.
+    fn lower_term(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+        fn_scope: &FnScope,
+    ) -> Result<Expr, QLowerError> {
+        self.check_depth(node, depth)?;
+        match node.children.first() {
+            Some(ASTNodeOrToken::Token(t)) if t.effective_type_name() == "NUMBER" => {
+                // Stranding: one or more juxtaposed NUMBER tokens form a
+                // single term (MA11 §4, inherited unchanged from APL/J).
+                let numbers: Vec<&Token> = node
+                    .children
+                    .iter()
+                    .filter_map(|c| match c {
+                        ASTNodeOrToken::Token(tok) if tok.effective_type_name() == "NUMBER" => {
+                            Some(tok)
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                if numbers.len() == 1 {
+                    self.number_literal(numbers[0])
+                } else {
+                    // Same `Ravel`-wrap fix `j-to-semantic-ir`'s/
+                    // `apl-to-semantic-ir`'s own `lower_term` carries --
+                    // see this file's module doc comment's "Stranded
+                    // literals" section.
+                    self.observed.add(Feature::NDArrays);
+                    self.observed.add(Feature::ArrayColumnMajor);
+                    self.observed.add(Feature::MatrixOps);
+                    let span = self.span_of(node);
+                    let row: Vec<Expr> = numbers
+                        .iter()
+                        .map(|tok| self.number_literal(tok))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    let array_lit = Expr::ArrayLit { rows: vec![row], span: span.clone() };
+                    Ok(Expr::Ravel { target: Box::new(array_lit), span })
+                }
+            }
+            Some(ASTNodeOrToken::Token(t)) if t.effective_type_name() == "NAME" => {
+                self.lower_name(t, node, fn_scope)
+            }
+            Some(ASTNodeOrToken::Node(n)) if n.rule_name == "function_literal" => {
+                let sir_name = self.register_function_literal(n, depth + 1)?;
+                let span = self.span_of(node);
+                Ok(Expr::MakeClosure { fn_name: sir_name, captures: vec![], span })
+            }
+            Some(ASTNodeOrToken::Token(t)) if t.effective_type_name() == "LPAREN" => {
+                let inner = only_node(node)
+                    .ok_or_else(|| self.err_at(node, "malformed parenthesised term".to_string()))?;
+                self.lower_noun_expr(inner, depth + 1, fn_scope)
+            }
+            Some(ASTNodeOrToken::Node(n)) if n.rule_name == "list_literal" => {
+                self.lower_list_literal(n, depth + 1, fn_scope)
+            }
+            _ => Err(self.err_at(node, "malformed term".to_string())),
+        }
+    }
+
+    /// Resolve a bare `NAME` token against `fn_scope` (params, then
+    /// locals), then the top-level bindings tables (a known function, then
+    /// a plain global), erroring cleanly if the name was never bound.
+    /// Shared by [`Lowerer::lower_term`]'s `NAME` alternative and
+    /// [`Lowerer::lower_verb_expr`]'s `NAME` alternative -- exactly the
+    /// unification this file's module doc comment's "Three call-site
+    /// shapes" section describes.
+    fn lower_name(
+        &mut self,
+        tok: &Token,
+        node: &GrammarASTNode,
+        fn_scope: &FnScope,
+    ) -> Result<Expr, QLowerError> {
+        let span = Span::point(FILE, tok.line, tok.column);
+        match self.resolve_name(&tok.value, fn_scope) {
+            Some(Resolved::Function(sir_name)) => {
+                self.observed.add(Feature::Closures);
+                Ok(Expr::MakeClosure { fn_name: sir_name, captures: vec![], span })
+            }
+            Some(Resolved::Var(scope)) => {
+                Ok(Expr::VarRef { name: tok.value.clone(), scope, span })
+            }
+            None => Err(self.err_at(node, format!("undefined variable '{}'", tok.value))),
+        }
+    }
+
+    /// The actual 3-tier lookup [`Lowerer::lower_name`] uses: the current
+    /// function's own parameters, then its own locals, then a top-level
+    /// known function, then a top-level plain global.
+    fn resolve_name(&self, name: &str, fn_scope: &FnScope) -> Option<Resolved> {
+        if fn_scope.params.contains(name) {
+            return Some(Resolved::Var(Scope::Param));
+        }
+        if fn_scope.locals.contains(name) {
+            return Some(Resolved::Var(Scope::Local));
+        }
+        if let Some(sir_name) = self.known_functions.get(name) {
+            return Some(Resolved::Function(sir_name.clone()));
+        }
+        if self.global_names.contains(name) {
+            return Some(Resolved::Var(Scope::Global));
+        }
+        None
+    }
+
+    /// Convert an already-lowered value [`Expr`] into a [`FnKind`] callee:
+    /// a literal [`Expr::MakeClosure`] is a statically-known function
+    /// ([`FnKind::KnownFn`], a `DirectCall` optimization); anything else is
+    /// dispatched dynamically ([`FnKind::Dynamic`]). See this file's module
+    /// doc comment's "Three call-site shapes" section.
+    fn expr_to_fnkind(&self, expr: Expr) -> FnKind {
+        match expr {
+            Expr::MakeClosure { fn_name, .. } => FnKind::KnownFn(fn_name),
+            other => FnKind::Dynamic(Box::new(other)),
+        }
+    }
+
+    /// `list_literal = LPAREN noun_expr SEMICOLON noun_expr { SEMICOLON noun_expr } RPAREN`
+    /// (MA11 §3 bullet 3 / §4). Lowers to the identical shape stranding
+    /// produces (`Ravel(ArrayLit([elements]))`) -- MA11 §3 bullet 3: "both
+    /// lower to the same list value."
+    ///
+    /// Rejects (cleanly, at lowering time) any element that is
+    /// *syntactically, provably* non-scalar or function-valued -- a
+    /// directly-nested list/stranded literal always lowers to
+    /// `Expr::Ravel` (which, in this cut, always denotes a genuinely
+    /// non-scalar rank-1 result -- see this file's module doc comment's
+    /// "Enlist reuses Ravel" section), and a directly-nested function
+    /// reference always lowers to `Expr::MakeClosure` -- mirroring
+    /// `q_runtime::eval::Interpreter::eval_list_literal`'s identical
+    /// rejection of a `QValue::Arr` with rank >= 1 or a `QValue::Fn`
+    /// element. An element that is merely some OTHER arbitrary expression
+    /// (e.g. a variable reference that might, at runtime, hold a
+    /// non-scalar or function value) is not statically decidable here any
+    /// more than it is in `q-runtime` itself, so it is not rejected -- it
+    /// is simply embedded as-is, exactly like every other array-domain
+    /// frontend's `ArrayLit` element.
+    fn lower_list_literal(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+        fn_scope: &FnScope,
+    ) -> Result<Expr, QLowerError> {
+        self.check_depth(node, depth)?;
+        let elems = child_nodes(node);
+        let span = self.span_of(node);
+        let mut row: Vec<Expr> = Vec::with_capacity(elems.len());
+        for e in elems {
+            let v = self.lower_noun_expr(e, depth + 1, fn_scope)?;
+            match &v {
+                Expr::MakeClosure { .. } => {
+                    return Err(self.err_at(
+                        e,
+                        "a list literal containing a function-valued element has no \
+                         representation in this cut's dense-numeric-only value model (MA11 §4)"
+                            .to_string(),
+                    ));
+                }
+                Expr::Ravel { .. } => {
+                    return Err(self.err_at(
+                        e,
+                        "a list literal with a non-scalar element has no representation in \
+                         this cut's dense-numeric-only value model (MA11 §4)"
+                            .to_string(),
+                    ));
+                }
+                _ => {}
+            }
+            row.push(v);
+        }
+        self.observed.add(Feature::NDArrays);
+        self.observed.add(Feature::ArrayColumnMajor);
+        self.observed.add(Feature::MatrixOps);
+        let array_lit = Expr::ArrayLit { rows: vec![row], span: span.clone() };
+        Ok(Expr::Ravel { target: Box::new(array_lit), span })
+    }
+
+    /// Convert one `NUMBER` token's source text into an `Expr::IntLit`/
+    /// `Expr::FloatLit`. Unlike J (whose `NUMBER` folds a leading
+    /// underscore into ASCII `-` before parsing), a Q `NUMBER` token's own
+    /// value is already plain, standard numeric syntax --
+    /// `q-lexer::fold_negative_number_literals`'s post-tokenize hook
+    /// already prepends an ordinary ASCII `-` directly onto the token's
+    /// `value` string when a negative literal is recognized (MA11 §3
+    /// bullet 2), so no translation is needed here at all.
+    fn number_literal(&mut self, tok: &Token) -> Result<Expr, QLowerError> {
+        let span = Span::point(FILE, tok.line, tok.column);
+        let text = &tok.value;
+        let invalid = || QLowerError {
+            message: format!("invalid number literal '{text}'"),
+            line: tok.line,
+            column: tok.column,
+        };
+        let expr = if text.contains('.') || text.contains('e') || text.contains('E') {
+            let value = text.parse::<f64>().map_err(|_| invalid())?;
+            self.observed.add(Feature::Floats);
+            Expr::FloatLit { value, span }
+        } else {
+            match text.parse::<i64>() {
+                Ok(v) => Expr::IntLit { value: v, span },
+                Err(_) => {
+                    let value = text.parse::<f64>().map_err(|_| invalid())?;
+                    self.observed.add(Feature::Floats);
+                    Expr::FloatLit { value, span }
+                }
+            }
+        };
+        Ok(expr)
+    }
+
+    // -------------------------------------------------------------------
+    // function literals -- MA11 §2/§3 bullet 1's headline novelty
+    // -------------------------------------------------------------------
+
+    /// Build a synthesized top-level [`Function`] from a `function_literal`
+    /// node (`{[x;y] stmt; stmt; ...}` or the bracket-omitted implicit
+    /// `x`/`y`/`z` form), registers it in `self.functions`/
+    /// `self.known_function_arity`, and returns its synthesized SIR name.
+    ///
+    /// **Rejects nested function literals** (MA11 §4): if this method is
+    /// reached while already lowering another function literal's own body
+    /// (`self.inside_lambda_depth > 0`), this is a function literal
+    /// appearing textually inside another one's body -- mirrors
+    /// `q_runtime::eval::Interpreter::build_lambda`'s identical
+    /// unconditional rejection (see that method's own doc comment for the
+    /// full rationale: even a nested literal that is merely
+    /// constructed-and-returned, never invoked within the same call, would
+    /// need real lexical closure capture this crate deliberately never
+    /// implements).
+    fn register_function_literal(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<String, QLowerError> {
+        if self.inside_lambda_depth > 0 {
+            return Err(self.err_at(
+                node,
+                "nested function literals are not supported in this cut (MA11 §4 -- every \
+                 function body in scope calls only primitives and already-defined functions, \
+                 with no nested function-literal definitions of its own)"
+                    .to_string(),
+            ));
+        }
+        self.check_depth(node, depth)?;
+
+        let param_list_node = node.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Node(n) if n.rule_name == "param_list" => Some(n),
+            _ => None,
+        });
+        let params: Vec<String> = match param_list_node {
+            Some(pl) => {
+                let names: Vec<String> = pl
+                    .children
+                    .iter()
+                    .filter_map(|c| match c {
+                        ASTNodeOrToken::Token(t) if t.effective_type_name() == "NAME" => {
+                            Some(t.value.clone())
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                if names.is_empty() {
+                    return Err(
+                        self.err_at(node, "malformed function_literal (empty param_list)".to_string())
+                    );
+                }
+                names
+            }
+            // The bracket-omitted implicit-parameter convenience (MA11 §3
+            // bullet 1 / §4): defaults to the well-documented `x`/`y`/`z`
+            // names.
+            None => vec!["x".to_string(), "y".to_string(), "z".to_string()],
+        };
+
+        let stmt_seq_node = node
+            .children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "stmt_seq" => Some(n),
+                _ => None,
+            })
+            .ok_or_else(|| {
+                self.err_at(node, "malformed function_literal (missing stmt_seq)".to_string())
+            })?;
+        let statements: Vec<&GrammarASTNode> = child_nodes(stmt_seq_node)
+            .into_iter()
+            .filter(|n| n.rule_name == "statement")
+            .collect();
+        if statements.is_empty() {
+            return Err(self.err_at(node, "malformed function_literal (empty body)".to_string()));
+        }
+
+        self.lambda_counter += 1;
+        let sir_name = format!("q_lambda_{}", self.lambda_counter);
+        let span = self.span_of(node);
+
+        self.inside_lambda_depth += 1;
+        let mut fn_scope = FnScope::for_lambda(&params);
+        let body_result = self.lower_function_body(&statements, depth + 1, &mut fn_scope);
+        self.inside_lambda_depth -= 1;
+        let (body_stmts, body_value) = body_result?;
+
+        // Every parameter after the first gets a disclosed sentinel
+        // default (see this file's module doc comment's "Disclosed
+        // simplification" section) so a call supplying fewer arguments
+        // than declared (the common case for the implicit x/y/z
+        // convenience, called monadically or dyadically) is still
+        // accepted by SIR's own arity model.
+        let sir_params: Vec<Param> = params
+            .iter()
+            .enumerate()
+            .map(|(i, p)| Param {
+                name: p.clone(),
+                sir_type: None,
+                kind: ParamKind::Required,
+                default: if i == 0 {
+                    None
+                } else {
+                    Some(Box::new(Expr::IntLit { value: 0, span: span.clone() }))
+                },
+                span: span.clone(),
+            })
+            .collect();
+        if sir_params.len() > 1 {
+            self.observed.add(Feature::DefaultParams);
+        }
+        self.observed.add(Feature::Closures);
+
+        let arity = sir_params.len();
+        self.known_function_arity.insert(sir_name.clone(), arity);
+        self.functions.push(Function {
+            name: sir_name.clone(),
+            params: sir_params,
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts: body_stmts, value: body_value, span: span.clone() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span,
+        });
+        Ok(sir_name)
+    }
+
+    /// Lower a function-literal body's `stmt_seq` (one or more
+    /// `statement`s): every statement but the last is lowered for its
+    /// (possible) side-effecting evaluation only and discarded (mirroring
+    /// `q_runtime::eval::Interpreter::call_lambda`'s own "evaluate every
+    /// body statement in order, keeping only the last" behavior); the
+    /// **last** statement's value becomes the function's own return value
+    /// -- never wrapped in `print` the way a top-level bare statement is
+    /// (MA11 §4: auto-print is a top-level-only convention; a function
+    /// body's own intermediate/final values are never printed).
+    fn lower_function_body(
+        &mut self,
+        statements: &[&GrammarASTNode],
+        depth: usize,
+        fn_scope: &mut FnScope,
+    ) -> Result<(Vec<Stmt>, Expr), QLowerError> {
+        let mut stmts = Vec::new();
+        let last_index = statements.len() - 1;
+        let mut value: Option<Expr> = None;
+        for (i, stmt) in statements.iter().enumerate() {
+            let assignment_node = only_node(stmt)
+                .ok_or_else(|| self.err_at(stmt, "malformed statement".to_string()))?;
+            if assignment_node.children.len() == 1 {
+                let noun_expr_node = only_node(assignment_node).ok_or_else(|| {
+                    self.err_at(assignment_node, "malformed noun_expr statement".to_string())
+                })?;
+                let v = self.lower_noun_expr(noun_expr_node, depth + 1, fn_scope)?;
+                if i == last_index {
+                    value = Some(v);
+                } else {
+                    let span = v.span().clone();
+                    stmts.push(Stmt::ExprStmt { expr: v, span });
+                }
+            } else {
+                let (mut s, assigned) =
+                    self.lower_assignment_chain(assignment_node, depth + 1, fn_scope, false)?;
+                stmts.append(&mut s);
+                if i == last_index {
+                    match assigned {
+                        AssignedValue::Value(v) => value = Some(v),
+                        AssignedValue::Function(_) => {
+                            return Err(self.err_at(
+                                assignment_node,
+                                "a function literal cannot be the last statement's own \
+                                 directly-assigned value in this cut (MA11 §4 -- no nested \
+                                 function-literal definitions)"
+                                    .to_string(),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        Ok((stmts, value.expect("non-empty statements guarantees a value")))
+    }
+
+    // -------------------------------------------------------------------
+    // verb_expr / verb_primitive
+    // -------------------------------------------------------------------
+
+    /// `verb_expr = verb_primitive [ EACH | REDUCE | SCAN ] | NAME | function_literal`.
+    fn lower_verb_expr(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+        fn_scope: &FnScope,
+    ) -> Result<FnKind, QLowerError> {
+        self.check_depth(node, depth)?;
+        match node.children.as_slice() {
+            [ASTNodeOrToken::Node(prim)] if prim.rule_name == "verb_primitive" => {
+                Ok(FnKind::Prim(self.lower_verb_primitive(prim)?))
+            }
+            [ASTNodeOrToken::Node(prim), ASTNodeOrToken::Token(adverb)]
+                if prim.rule_name == "verb_primitive" =>
+            {
+                let p = self.lower_verb_primitive(prim)?;
+                match adverb.effective_type_name() {
+                    "EACH" => Ok(FnKind::Each(p)),
+                    "REDUCE" => Ok(FnKind::Reduce(self.require_scalar_atom(p, node, "/ (reduce)")?)),
+                    "SCAN" => Ok(FnKind::Scan(self.require_scalar_atom(p, node, "\\ (scan)")?)),
+                    other => Err(self.err_at(node, format!("unexpected adverb token '{other}'"))),
+                }
+            }
+            [ASTNodeOrToken::Token(t)] if t.effective_type_name() == "NAME" => {
+                let value_expr = self.lower_name(t, node, fn_scope)?;
+                Ok(self.expr_to_fnkind(value_expr))
+            }
+            [ASTNodeOrToken::Node(fl)] if fl.rule_name == "function_literal" => {
+                let sir_name = self.register_function_literal(fl, depth + 1)?;
+                Ok(FnKind::KnownFn(sir_name))
+            }
+            _ => Err(self.err_at(node, "malformed verb_expr".to_string())),
+        }
+    }
+
+    /// `verb_primitive`: always exactly one child, a single token naming
+    /// the primitive glyph -- mirrors `q_runtime::eval::parse_verb_primitive`'s
+    /// exact token-to-variant mapping.
+    fn lower_verb_primitive(&self, node: &GrammarASTNode) -> Result<Prim, QLowerError> {
+        let tok = match node.children.first() {
+            Some(ASTNodeOrToken::Token(t)) => t,
+            _ => return Err(self.err_at(node, "malformed verb_primitive".to_string())),
+        };
+        Ok(match tok.effective_type_name() {
+            "PLUS" => Prim::Plus,
+            "MINUS" => Prim::Minus,
+            "STAR" => Prim::Star,
+            "PERCENT" => Prim::Percent,
+            "BANG" => Prim::Bang,
+            "COMMA" => Prim::Comma,
+            "HASH" => Prim::Hash,
+            "UNDERSCORE" => Prim::Underscore,
+            "AMP" => Prim::Amp,
+            "PIPE" => Prim::Pipe,
+            "TILDE" => Prim::Tilde,
+            "EQ" => Prim::Eq,
+            "LT" => Prim::Lt,
+            "GT" => Prim::Gt,
+            "LE" => Prim::Le,
+            "GE" => Prim::Ge,
+            "NE" => Prim::Ne,
+            other => return Err(self.err_at(node, format!("unknown verb primitive '{other}'"))),
+        })
+    }
+
+    /// Reduce/scan apply only to the 12 primitives that map onto an
+    /// [`ElementwiseOpKind`] -- `! , # _ ~` are not "a scalar dyadic verb"
+    /// at all, so stacking an adverb onto one of them is a clean, explicit
+    /// scope error, mirroring `q_runtime::builtins::require_scalar_binop`
+    /// exactly.
+    fn require_scalar_atom(
+        &self,
+        p: Prim,
+        node: &GrammarASTNode,
+        context: &str,
+    ) -> Result<ElementwiseOpKind, QLowerError> {
+        p.to_binop().ok_or_else(|| {
+            self.err_at(node, format!("{context}: {} is not a scalar dyadic verb", p.glyph()))
+        })
+    }
+
+    // -------------------------------------------------------------------
+    // monadic / dyadic application
+    // -------------------------------------------------------------------
+
+    /// Apply a monadic (one-argument) callable to `arg` -- the single
+    /// dispatch site for every [`FnKind`] variant, mirroring
+    /// `q_runtime::eval::Interpreter::apply_monadic`'s identical role.
+    fn apply_monadic(&mut self, f: FnKind, arg: Expr, span: Span) -> Result<Expr, QLowerError> {
+        match f {
+            FnKind::Prim(p) => self.apply_monadic_prim(p, arg, span),
+            FnKind::Each(p) => {
+                if !p.each_monadic_supported() {
+                    return Err(self.err_at_span(
+                        &span,
+                        format!(
+                            "' (each) has no well-defined per-element meaning for '{}' \
+                             monadically in this cut's flat, dense-array-only value model \
+                             (MA11 §4)",
+                            p.glyph()
+                        ),
+                    ));
+                }
+                self.apply_monadic_prim(p, arg, span)
+            }
+            FnKind::Reduce(op) => {
+                self.observed.add(Feature::MatrixOps);
+                self.observed.add(Feature::ArrayColumnMajor);
+                Ok(Expr::Reduce { op, target: Box::new(arg), span })
+            }
+            FnKind::Scan(op) => {
+                self.observed.add(Feature::MatrixOps);
+                self.observed.add(Feature::ArrayColumnMajor);
+                Ok(Expr::Scan { op, target: Box::new(arg), span })
+            }
+            FnKind::KnownFn(sir_name) => {
+                let arity = *self
+                    .known_function_arity
+                    .get(&sir_name)
+                    .expect("KnownFn always names a function this crate itself registered");
+                if arity < 1 {
+                    return Err(self.err_at_span(
+                        &span,
+                        format!("function takes at most {arity} parameter(s), called with 1"),
+                    ));
+                }
+                Ok(Expr::DirectCall {
+                    fn_name: sir_name,
+                    args: vec![arg],
+                    effects: EffectSet::PURE,
+                    span,
+                })
+            }
+            FnKind::Dynamic(callee) => {
+                self.observed.add(Feature::Closures);
+                Ok(Expr::IndirectCall { target: callee, args: vec![arg], effects: EffectSet::PURE, span })
+            }
+        }
+    }
+
+    /// Apply a dyadic (two-argument) callable to `lhs`/`rhs`.
+    fn apply_dyadic(
+        &mut self,
+        f: FnKind,
+        lhs: Expr,
+        rhs: Expr,
+        span: Span,
+    ) -> Result<Expr, QLowerError> {
+        match f {
+            FnKind::Prim(p) => self.apply_dyadic_prim(p, lhs, rhs, span),
+            FnKind::Each(p) => {
+                if !p.each_dyadic_supported() {
+                    return Err(self.err_at_span(
+                        &span,
+                        format!(
+                            "' (each) has no well-defined per-element meaning for '{}' \
+                             dyadically in this cut's flat, dense-array-only value model \
+                             (MA11 §4)",
+                            p.glyph()
+                        ),
+                    ));
+                }
+                self.apply_dyadic_prim(p, lhs, rhs, span)
+            }
+            FnKind::Reduce(_) => Err(self.err_at_span(
+                &span,
+                "/ (reduce) takes exactly one operand, but was applied dyadically".to_string(),
+            )),
+            FnKind::Scan(_) => Err(self.err_at_span(
+                &span,
+                "\\ (scan) takes exactly one operand, but was applied dyadically".to_string(),
+            )),
+            FnKind::KnownFn(sir_name) => {
+                let arity = *self
+                    .known_function_arity
+                    .get(&sir_name)
+                    .expect("KnownFn always names a function this crate itself registered");
+                if arity < 2 {
+                    return Err(self.err_at_span(
+                        &span,
+                        format!("function takes at most {arity} parameter(s), called with 2"),
+                    ));
+                }
+                Ok(Expr::DirectCall {
+                    fn_name: sir_name,
+                    args: vec![lhs, rhs],
+                    effects: EffectSet::PURE,
+                    span,
+                })
+            }
+            FnKind::Dynamic(callee) => {
+                self.observed.add(Feature::Closures);
+                Ok(Expr::IndirectCall {
+                    target: callee,
+                    args: vec![lhs, rhs],
+                    effects: EffectSet::PURE,
+                    span,
+                })
+            }
+        }
+    }
+
+    /// Monadic dispatch for a bare primitive glyph (MA11 §4's full table --
+    /// see this file's module doc comment's "The 17 primitives" section for
+    /// the complete mapping and the rationale behind each reused/new node).
+    fn apply_monadic_prim(&mut self, p: Prim, arg: Expr, span: Span) -> Result<Expr, QLowerError> {
+        match p {
+            // Flip: identity in this cut -- no primitive can ever
+            // construct a rank-2 value (see the module doc comment).
+            Prim::Plus => Ok(arg),
+            Prim::Minus => Ok(wrap_builtin("neg", arg)),
+            Prim::Star => Ok(wrap_builtin("q_first", arg)),
+            Prim::Percent => Ok(wrap_builtin("recip", arg)),
+            Prim::Bang => {
+                self.observed.add(Feature::NDArrays);
+                Ok(self.zero_base_index(
+                    Expr::IndexGenerator { count: Box::new(arg), span: span.clone() },
+                    span,
+                ))
+            }
+            Prim::Comma => {
+                self.observed.add(Feature::MatrixOps);
+                self.observed.add(Feature::ArrayColumnMajor);
+                Ok(Expr::Ravel { target: Box::new(arg), span })
+            }
+            Prim::Hash => Ok(wrap_builtin("tally", arg)),
+            Prim::Underscore => Ok(wrap_builtin("floor", arg)),
+            Prim::Amp => Ok(wrap_builtin("q_where", arg)),
+            Prim::Pipe => Ok(wrap_builtin("q_reverse", arg)),
+            Prim::Tilde => Ok(wrap_builtin("q_not", arg)),
+            Prim::Eq | Prim::Ne | Prim::Lt | Prim::Le | Prim::Ge | Prim::Gt => Err(
+                self.err_at_span(
+                    &span,
+                    format!(
+                        "no monadic form for {} (comparison atoms are dyadic-only in Q)",
+                        p.glyph()
+                    ),
+                ),
+            ),
+        }
+    }
+
+    /// Dyadic dispatch for a bare primitive glyph.
+    fn apply_dyadic_prim(
+        &mut self,
+        p: Prim,
+        lhs: Expr,
+        rhs: Expr,
+        span: Span,
+    ) -> Result<Expr, QLowerError> {
+        if let Some(op) = p.to_binop() {
+            self.observed.add(Feature::MatrixOps);
+            self.observed.add(Feature::ArrayColumnMajor);
+            return Ok(Expr::ElementwiseOp { op, lhs: Box::new(lhs), rhs: Box::new(rhs), span });
+        }
+        match p {
+            // MA11 §4: "dyadic `!` (dict creation, and its other real
+            // overloads) is deferred" -- explicitly out of scope, never
+            // silently misinterpreted as something else.
+            Prim::Bang => Err(self.err_at_span(
+                &span,
+                "dyadic ! (dict creation) is not yet implemented -- explicitly deferred, MA11 §4"
+                    .to_string(),
+            )),
+            Prim::Comma => {
+                self.observed.add(Feature::MatrixOps);
+                self.observed.add(Feature::ArrayColumnMajor);
+                Ok(Expr::Catenate { lhs: Box::new(lhs), rhs: Box::new(rhs), span })
+            }
+            Prim::Hash => Ok(Expr::BuiltinCall {
+                name: "q_take".to_string(),
+                args: vec![lhs, rhs],
+                effects: EffectSet::PURE,
+                span,
+            }),
+            Prim::Underscore => Ok(Expr::BuiltinCall {
+                name: "q_drop".to_string(),
+                args: vec![lhs, rhs],
+                effects: EffectSet::PURE,
+                span,
+            }),
+            Prim::Tilde => Ok(Expr::BuiltinCall {
+                name: "q_match".to_string(),
+                args: vec![lhs, rhs],
+                effects: EffectSet::PURE,
+                span,
+            }),
+            _ => unreachable!(
+                "every primitive not covered by `to_binop` is handled by one of the three \
+                 explicit arms above (Bang/Comma/Hash/Underscore/Tilde -- exactly the five \
+                 `to_binop` returns None for)"
+            ),
+        }
+    }
+
+    /// Convert an `Expr::IndexGenerator` result (SIR22-addendum, shared
+    /// with APL/J) from its hardcoded 1-based APL convention to Q's own
+    /// 0-based `!` convention -- the identical fix
+    /// `j-to-semantic-ir::Lowerer::zero_base_index` already applies for
+    /// J's own 0-based `i.`, since `semantic-ir-to-javascript`'s codegen
+    /// for this node hardcodes APL's `⍳` semantics with no
+    /// parameterization. The fix is the same pure arithmetic identity: for
+    /// every element, `q_value = apl_value - 1` holds (found: `apl_value`
+    /// is the 1-based position `k+1` for Q's 0-based `k`).
+    fn zero_base_index(&mut self, apl_convention: Expr, span: Span) -> Expr {
+        self.observed.add(Feature::MatrixOps);
+        self.observed.add(Feature::ArrayColumnMajor);
+        Expr::ElementwiseOp {
+            op: ElementwiseOpKind::Sub,
+            lhs: Box::new(apl_convention),
+            rhs: Box::new(Expr::IntLit { value: 1, span: span.clone() }),
+            span,
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // small helpers
+    // -------------------------------------------------------------------
+
+    fn span_of(&self, node: &GrammarASTNode) -> Span {
+        Span::point(FILE, node.start_line.unwrap_or(1), node.start_column.unwrap_or(1))
+    }
+
+    fn err_at(&self, node: &GrammarASTNode, message: String) -> QLowerError {
+        QLowerError {
+            message,
+            line: node.start_line.unwrap_or(1),
+            column: node.start_column.unwrap_or(1),
+        }
+    }
+
+    fn err_at_span(&self, span: &Span, message: String) -> QLowerError {
+        QLowerError { message, line: span.start_line, column: span.start_col }
+    }
+
+    fn check_depth(&self, node: &GrammarASTNode, depth: usize) -> Result<(), QLowerError> {
+        if depth > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("expression nesting too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            ));
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Free helpers
+// ---------------------------------------------------------------------------
+
+/// Collect the *node* children of `node` (dropping tokens).
+fn child_nodes(node: &GrammarASTNode) -> Vec<&GrammarASTNode> {
+    node.children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Node(n) => Some(n),
+            ASTNodeOrToken::Token(_) => None,
+        })
+        .collect()
+}
+
+/// The first *node* child named `kind`, or `None`.
+fn first_child_named<'a>(node: &'a GrammarASTNode, kind: &str) -> Option<&'a GrammarASTNode> {
+    child_nodes(node).into_iter().find(|n| n.rule_name == kind)
+}
+
+/// The first (and, for every rule this crate lowers, only) *node* child.
+fn only_node(node: &GrammarASTNode) -> Option<&GrammarASTNode> {
+    node.children.iter().find_map(|c| match c {
+        ASTNodeOrToken::Node(n) => Some(n),
+        ASTNodeOrToken::Token(_) => None,
+    })
+}
+
+/// If `noun_expr_node` (a 1-child `noun_expr`, i.e. a bare `term`) is
+/// directly a `function_literal` -- not wrapped in parens, not part of a
+/// larger expression -- return that `function_literal` node. Used to
+/// detect "this assignment's RHS is a bare function-literal definition"
+/// (MA11 §3 bullet 1), the one case that registers a top-level
+/// [`Function`] instead of emitting an ordinary value-binding [`Stmt`].
+fn bare_function_literal_term(noun_expr_node: &GrammarASTNode) -> Option<&GrammarASTNode> {
+    let term_node = only_node(noun_expr_node)?;
+    if term_node.rule_name != "term" {
+        return None;
+    }
+    match term_node.children.as_slice() {
+        [ASTNodeOrToken::Node(n)] if n.rule_name == "function_literal" => Some(n),
+        _ => None,
+    }
+}
+
+/// Wrap `operand` in a well-known, pure, single-argument
+/// [`Expr::BuiltinCall`] named `name`, reusing `operand`'s own span.
+fn wrap_builtin(name: &str, operand: Expr) -> Expr {
+    let span = operand.span().clone();
+    Expr::BuiltinCall {
+        name: name.to_string(),
+        args: vec![operand],
+        effects: EffectSet::PURE,
+        span,
+    }
+}

--- a/code/packages/rust/q-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/q-to-semantic-ir/src/lower.rs
@@ -790,6 +790,38 @@ impl Lowerer {
                         // previously a known function, it no longer is.
                         self.known_functions.remove(&name);
                         if is_top_level {
+                            // SECURITY (/security-review finding): `lower_file`
+                            // hardcodes the synthesized entry-point function's
+                            // own name as the plain, unprefixed identifier
+                            // "main" (mirroring every sibling frontend). Every
+                            // OTHER sibling frontend keeps its own top-level
+                            // bindings function-LOCAL (`Scope::Local`, inside
+                            // that same `main` function body), so a JS `let
+                            // main = ...` never arises there -- a legal inner
+                            // shadow of the enclosing function's own name is
+                            // fine. THIS crate's own, disclosed choice of
+                            // `Scope::Global` for top-level bindings changes
+                            // that: a top-level Q binding literally named
+                            // `main` (Q's `NAME` grammar has no reserved-word
+                            // exclusion, so `main:5` is ordinary, legal Q
+                            // source) would emit a MODULE-scope `let main =
+                            // null;` sitting alongside the module's own
+                            // `function main() { ... }` -- a genuine
+                            // `SyntaxError: Identifier 'main' has already
+                            // been declared` under Node, confirmed directly.
+                            // `semantic_ir::validate`/`Backend::check_module`
+                            // do not catch a Global/Function name collision,
+                            // so this must be rejected here, at the one place
+                            // that actually knows both names collide.
+                            if name == "main" {
+                                return Err(self.err_at(
+                                    node,
+                                    "a top-level variable cannot be named `main` -- that name is \
+                                     reserved for this module's own synthesized entry-point \
+                                     function"
+                                        .to_string(),
+                                ));
+                            }
                             if self.global_names.insert(name.clone()) {
                                 self.global_order.push(name.clone());
                             }

--- a/code/packages/rust/q-to-semantic-ir/tests/e2e_node.rs
+++ b/code/packages/rust/q-to-semantic-ir/tests/e2e_node.rs
@@ -1,0 +1,208 @@
+//! End-to-end round-trip: Q → SIR → JavaScript → `node`.
+//!
+//! Mirrors `apl-to-semantic-ir`'s/`maple-to-semantic-ir`'s own
+//! `tests/e2e_node.rs` harness exactly: lower a Q program to SIR with this
+//! crate, validate the module, emit JavaScript with the merged
+//! `semantic-ir-to-javascript` backend (a dev-dependency), write it to a
+//! temp file, and **execute it with `node`**, asserting the printed output.
+//!
+//! `tests/oracle.rs` already runs a much larger corpus through `node` and
+//! diffs it against `q-runtime`'s own ground truth (including a documented,
+//! not-fixed-here shared-crate display gap for negative NDArray results) --
+//! this file is a smaller, curated set proving the SIR22 codegen path is
+//! genuinely executable end-to-end for each of this crate's own distinctive
+//! constructs, with every expected value chosen to be positive so none of
+//! them are affected by that display gap (see `tests/oracle.rs`'s module
+//! doc comment for the full writeup of which shapes are/aren't affected).
+//!
+//! The one construct new to this crate relative to every prior SIR22
+//! frontend (APL/J) is the function-literal machinery -- `Function` /
+//! `DirectCall` / `MakeClosure` / `IndirectCall` -- so this file weights its
+//! coverage toward that: a named function, an inline immediately-applied
+//! literal, a function calling another already-defined function, and the
+//! genuinely higher-order case (a function value passed as an argument and
+//! called dynamically through a parameter).
+
+use std::fs::OpenOptions;
+use std::io::Write as _;
+use std::process::Command;
+
+use q_to_semantic_ir::compile_source;
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn run_via_node(name: &str, src: &str) -> String {
+    let module = compile_source(src, "prog").unwrap_or_else(|e| panic!("lowering failed: {e}"));
+    let report = semantic_ir::validate(&module);
+    assert!(report.is_ok(), "SIR validation failed for {name}: {:?}", report.issues);
+    let artifact =
+        semantic_ir_to_javascript::compile(&module).expect("backend emit should succeed");
+
+    let mut path = std::env::temp_dir();
+    path.push(format!("q_sir_e2e_{name}_{}.js", std::process::id()));
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .expect("create temp js (create_new, not following an existing symlink)");
+    file.write_all(artifact.source.as_bytes()).expect("write temp js");
+    drop(file);
+
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        output.status.success(),
+        "node failed for {name}: stderr=\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+#[test]
+fn dyadic_arithmetic_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping dyadic_arithmetic_runs_in_node: `node` not available");
+        return;
+    }
+    let out = run_via_node("dyadic_arithmetic", "2*3+4\n");
+    assert_eq!(out, "14");
+}
+
+#[test]
+fn reduce_and_scan_run_in_node() {
+    if !node_available() {
+        eprintln!("skipping reduce_and_scan_run_in_node: `node` not available");
+        return;
+    }
+    assert_eq!(run_via_node("reduce_add", "+/1 2 3 4\n"), "10");
+    assert_eq!(run_via_node("scan_running_sum", "+\\1 2 3\n"), "1 3 6");
+}
+
+#[test]
+fn til_zero_based_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping til_zero_based_runs_in_node: `node` not available");
+        return;
+    }
+    // The single most safety-critical assertion for `!` (MA11 §4): `!5` is
+    // `0 1 2 3 4`, never APL's 1-based `1 2 3 4 5`. This also proves the
+    // `zero_base_index` correction (`- 1` wrapping IndexGenerator) is wired
+    // correctly end to end, through real codegen and a real `node` run.
+    let out = run_via_node("til", "!5\n");
+    assert_eq!(out, "0 1 2 3 4");
+}
+
+#[test]
+fn the_five_new_q_specific_builtins_run_in_node() {
+    if !node_available() {
+        eprintln!("skipping the_five_new_q_specific_builtins_run_in_node: `node` not available");
+        return;
+    }
+    assert_eq!(run_via_node("q_first", "*1 2 3\n"), "1");
+    assert_eq!(run_via_node("q_where", "&0 1 1 0 1\n"), "1 2 4");
+    assert_eq!(run_via_node("q_reverse", "|1 2 3\n"), "3 2 1");
+    assert_eq!(run_via_node("q_not", "~0 1 5\n"), "1 0 0");
+    assert_eq!(run_via_node("q_take", "5#1 2 3\n"), "1 2 3 1 2");
+    assert_eq!(run_via_node("q_drop", "2_1 2 3 4\n"), "3 4");
+    assert_eq!(run_via_node("q_match_true", "(1 2 3)~1 2 3\n"), "1");
+    assert_eq!(run_via_node("q_match_false", "(1 2 3)~1 2 4\n"), "0");
+}
+
+#[test]
+fn join_reusing_catenate_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping join_reusing_catenate_runs_in_node: `node` not available");
+        return;
+    }
+    assert_eq!(run_via_node("join", "1,2 3\n"), "1 2 3");
+}
+
+#[test]
+fn a_named_top_level_function_literal_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping a_named_top_level_function_literal_runs_in_node: `node` not available");
+        return;
+    }
+    assert_eq!(run_via_node("named_fn_dyadic", "f:{x+y}\n2 f 3\n"), "5");
+    assert_eq!(run_via_node("named_fn_monadic", "f:{x+1}\nf 5\n"), "6");
+    assert_eq!(run_via_node("named_fn_explicit_params", "f:{[a;b] a*b}\n3 f 4\n"), "12");
+}
+
+#[test]
+fn an_inline_immediately_applied_function_literal_runs_in_node() {
+    if !node_available() {
+        eprintln!(
+            "skipping an_inline_immediately_applied_function_literal_runs_in_node: `node` not available"
+        );
+        return;
+    }
+    assert_eq!(run_via_node("inline_monadic", "{x*2} 5\n"), "10");
+    assert_eq!(run_via_node("inline_dyadic", "2 {x+y} 3\n"), "5");
+}
+
+#[test]
+fn a_function_calling_another_already_defined_function_runs_in_node() {
+    if !node_available() {
+        eprintln!(
+            "skipping a_function_calling_another_already_defined_function_runs_in_node: `node` not available"
+        );
+        return;
+    }
+    let out = run_via_node("chained_calls", "double:{x*2}\nadd1:{x+1}\ndouble(add1 5)\n");
+    assert_eq!(out, "12");
+}
+
+#[test]
+fn the_higher_order_function_value_case_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping the_higher_order_function_value_case_runs_in_node: `node` not available");
+        return;
+    }
+    // `apply`'s own parameter `g` is called dynamically (IndirectCall)
+    // inside its body -- proving `MakeClosure`/`IndirectCall` genuinely
+    // execute correctly together, not just validate.
+    let out = run_via_node("higher_order", "apply:{[g] g 5}\ninc:{x+1}\napply inc\n");
+    assert_eq!(out, "6");
+}
+
+#[test]
+fn a_function_reads_a_top_level_global_variable_runs_in_node() {
+    if !node_available() {
+        eprintln!(
+            "skipping a_function_reads_a_top_level_global_variable_runs_in_node: `node` not available"
+        );
+        return;
+    }
+    // Proves the Global (not Local) top-level scoping decision (src/
+    // lower.rs's module doc comment) genuinely works across two SEPARATE
+    // compiled JS functions -- `n` is assigned in `main`, and read from
+    // inside the sibling `q_lambda_*` function `f` compiles to.
+    let out = run_via_node("global_read", "n:10\nf:{x+n}\nf 5\n");
+    assert_eq!(out, "15");
+}
+
+#[test]
+fn multi_statement_function_body_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping multi_statement_function_body_runs_in_node: `node` not available");
+        return;
+    }
+    let out = run_via_node("multi_stmt_body", "f:{[x] a:x+1; a*2}\nf 5\n");
+    assert_eq!(out, "12"); // (5+1)*2
+}
+
+#[test]
+fn list_literal_matches_stranding_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping list_literal_matches_stranding_runs_in_node: `node` not available");
+        return;
+    }
+    assert_eq!(run_via_node("list_literal", "(1;2;3)\n"), "1 2 3");
+}

--- a/code/packages/rust/q-to-semantic-ir/tests/oracle.rs
+++ b/code/packages/rust/q-to-semantic-ir/tests/oracle.rs
@@ -1,0 +1,408 @@
+//! Oracle/golden tests (HML01 §7): the SAME Q source, run through **two
+//! independent implementations**, and diffed:
+//!
+//!   (a) `q-runtime` (`coding-adventures-q-runtime`) — this frontend's own
+//!       sibling crate, a tree-walking interpreter over `array-runtime` —
+//!       the ground truth.
+//!   (b) `q_to_semantic_ir::compile_source` → `semantic_ir::Module` →
+//!       `semantic_ir_to_javascript::compile` → an actual `node` process.
+//!
+//! This is the direct Q sibling of
+//! [`j-to-semantic-ir`'s own `tests/oracle.rs`](../../j-to-semantic-ir/tests/oracle.rs)
+//! (itself sibling to `apl-to-semantic-ir`'s/`matlab-to-semantic-ir`'s) —
+//! same overall shape (`node_available` skip-not-fail guard, a
+//! `Case`/`CORPUS`, a `ground_truth`/`compiled` pair, one looping `#[test]`).
+//!
+//! ## No `setup`/`final_expr` split, no `normalize()`
+//!
+//! `q-runtime::eval`'s own module doc comment states plainly: "Assignment
+//! is silent; a bare (non-assignment) statement auto-prints its result" —
+//! and this crate's own lowering wraps a bare top-level `noun_expr` in the
+//! shared `"print"` builtin unconditionally, exactly like J/APL. So [`Case`]
+//! is just `name` + `source` (one full program, byte-identical on both
+//! sides) + `expected`, plus `known_bug` (see below).
+//!
+//! ## A pre-existing shared-crate display gap, confirmed here too (matches
+//! `j-to-semantic-ir/tests/oracle.rs`'s own "Bug A")
+//!
+//! `semantic-ir-to-javascript` has exactly two per-source-language display
+//! flags (`SIR_DISPLAY_APL_HIGH_MINUS`, `SIR_DISPLAY_J_UNDERSCORE`) and no
+//! third one for Q. Empirically confirmed directly (a throwaway probe that
+//! ran each shape through `node` before this file was finalized, mirroring
+//! `j-to-semantic-ir/tests/oracle.rs`'s own verification discipline):
+//!
+//! - A **bare/boxed scalar** negative result (`formatSeen`'s `typeof v ===
+//!   "number"` branch) renders via plain `String(v)` when neither flag is
+//!   set — which happens to be Q's OWN convention already (`-5`, ASCII, no
+//!   high-minus) — so this path has **no bug for Q at all**, unlike J
+//!   (which needs a leading underscore neither flag produces).
+//! - A **genuine NDArray** result (any [`semantic_ir::Expr::ElementwiseOp`]/
+//!   `Reduce`/`Scan`/`Ravel`/`Catenate`, or `mapNDArrayRank1Plus`'s rank≥1
+//!   branch inside `neg`/`q_reverse`/etc.) reaches `ArrayRt.display` →
+//!   `ArrayRt.fmtNum`, which renders APL's own high-minus `¯` for ANY
+//!   negative value whenever `SIR_DISPLAY_J_UNDERSCORE` is unset —
+//!   *unconditionally*, with no flag gating it for Q either. Confirmed
+//!   directly: `3-4` (a dyadic `ElementwiseOp`) prints `¯1`, not Q's own
+//!   `-1`; `-/1 2 10` (`Reduce`) prints `¯11`.
+//!
+//! This is the exact same shared-crate gap `j-to-semantic-ir`'s own oracle
+//! file already found and left unfixed (per this task's own "found, NOT
+//! fixed here" discipline for a bug in a crate consumed by many other
+//! frontends) — not a new, Q-specific bug, and not something this crate's
+//! own lowering can route around (same conclusion `j-to-semantic-ir`
+//! reached: fixing it needs a third `SIR_DISPLAY_Q_ASCII`-shaped flag, or
+//! simply making the "no flag set" default apply inside `ArrayRt.fmtNum`
+//! too, in `semantic-ir-to-javascript` itself, out of scope here). Every
+//! `CORPUS` entry below whose `expected` value is a negative number reached
+//! through a genuine-NDArray-producing path carries a `known_bug` note
+//! citing this section; a negative result reached through a BARE-number
+//! path (a literal, or `neg`'s own rank-0 fallback unwrap) is a clean,
+//! both-sides-pass case, confirmed by direct empirical check.
+
+use std::fs::OpenOptions;
+use std::io::Write as _;
+use std::process::Command;
+
+use coding_adventures_q_runtime::eval as q_eval;
+use q_to_semantic_ir::compile_source;
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// One oracle corpus entry. `source` is the WHOLE program, byte-for-byte
+/// identical on both the `ground_truth` and `compiled` sides.
+struct Case {
+    name: &'static str,
+    source: &'static str,
+    expected: &'static str,
+    /// `None`: both `ground_truth` and `compiled` must equal `expected`.
+    /// `Some(reason)`: only `ground_truth` is checked against `expected`;
+    /// the `compiled`-side call is skipped entirely -- see this file's
+    /// module doc comment's "shared-crate display gap" section.
+    known_bug: Option<&'static str>,
+}
+
+const DISPLAY_GAP: &str =
+    "shared-crate display gap (semantic-ir-to-javascript has no Q-specific ASCII-minus display \
+     flag -- see this file's module doc comment): a genuine NDArray result's negative values \
+     render with APL's high-minus glyph (\u{af}) instead of Q's own ASCII '-', regardless of \
+     source language, whenever SIR_DISPLAY_J_UNDERSCORE is unset. Confirmed by directly running \
+     the generated JavaScript; not a bug in this crate's own lowering.";
+
+const CORPUS: &[Case] = &[
+    // --- Base breadth: right-to-left, no precedence, grouping ---
+    Case {
+        name: "right_to_left_no_operator_precedence",
+        source: "2*3+4\n",
+        expected: "14",
+        known_bug: None,
+    },
+    Case {
+        name: "parenthesised_grouping_overrides_order",
+        source: "(2*3)+4\n",
+        expected: "10",
+        known_bug: None,
+    },
+    Case {
+        name: "stranded_vector_literal",
+        source: "1 2 3\n",
+        expected: "1 2 3",
+        known_bug: None,
+    },
+    Case {
+        name: "whitespace_sensitive_strand_vs_subtraction_strand",
+        source: "2 -1\n",
+        expected: "2 -1",
+        known_bug: Some(DISPLAY_GAP),
+    },
+    Case {
+        name: "whitespace_sensitive_strand_vs_subtraction_subtract",
+        source: "2 - 1\n",
+        expected: "1",
+        known_bug: None,
+    },
+
+    // --- All 6 comparisons (always 0/1, never negative -- no display gap) ---
+    Case { name: "comparison_eq_true", source: "3=3\n", expected: "1", known_bug: None },
+    Case { name: "comparison_ne_true_q_spelling", source: "3<>4\n", expected: "1", known_bug: None },
+    Case { name: "comparison_lt_true", source: "3<4\n", expected: "1", known_bug: None },
+    Case { name: "comparison_le_true", source: "3<=3\n", expected: "1", known_bug: None },
+    Case { name: "comparison_ge_false", source: "3>=4\n", expected: "0", known_bug: None },
+    Case { name: "comparison_gt_true", source: "4>3\n", expected: "1", known_bug: None },
+
+    // --- Dyadic arithmetic: positive results, clean both-sides-pass ---
+    Case { name: "dyadic_add", source: "3+4\n", expected: "7", known_bug: None },
+    Case {
+        name: "dyadic_percent_true_division",
+        source: "6%4\n",
+        expected: "1.5",
+        known_bug: None,
+    },
+    Case {
+        name: "dyadic_min_amp_max_pipe",
+        source: "(3&7),(3|7)\n",
+        expected: "3 7",
+        known_bug: None,
+    },
+    // Dyadic subtraction with a NEGATIVE result -- hits the display gap.
+    Case {
+        name: "dyadic_sub_negative_result",
+        source: "3-4\n",
+        expected: "-1",
+        known_bug: Some(DISPLAY_GAP),
+    },
+
+    // --- Monadic primitives ---
+    Case { name: "monadic_plus_flip_is_identity", source: "+5\n", expected: "5", known_bug: None },
+    // Monadic `-` on a PARENTHESISED (non-glued) scalar operand -- `neg`'s
+    // own rank-0 fallback unwraps to a bare number, so this is a CLEAN
+    // negative-result pass, no display gap (confirmed empirically; see
+    // this file's module doc comment).
+    Case {
+        name: "monadic_minus_negates_a_scalar_expression",
+        source: "-(3+4)\n",
+        expected: "-7",
+        known_bug: None,
+    },
+    // Monadic `-` on a genuine VECTOR operand DOES hit the display gap
+    // (`mapNDArrayRank1Plus`'s rank>=1 branch always re-wraps in an
+    // NDArray).
+    Case {
+        name: "monadic_minus_negates_a_vector",
+        source: "-(1 2 3)\n",
+        expected: "-1 -2 -3",
+        known_bug: Some(DISPLAY_GAP),
+    },
+    Case { name: "monadic_star_is_first_not_sign", source: "*1 2 3\n", expected: "1", known_bug: None },
+    Case { name: "monadic_percent_is_reciprocal", source: "%4\n", expected: "0.25", known_bug: None },
+    Case {
+        name: "monadic_bang_is_zero_based_til",
+        source: "!5\n",
+        expected: "0 1 2 3 4",
+        known_bug: None,
+    },
+    Case { name: "monadic_comma_is_enlist", source: ",5\n", expected: "5", known_bug: None },
+    Case { name: "monadic_hash_is_count", source: "#1 2 3\n", expected: "3", known_bug: None },
+    Case {
+        name: "monadic_underscore_is_floor_of_a_negative_scalar",
+        source: "_ -3.2\n",
+        expected: "-4",
+        known_bug: None,
+    },
+    Case {
+        name: "monadic_amp_is_where",
+        source: "&0 1 1 0 1\n",
+        expected: "1 2 4",
+        known_bug: None,
+    },
+    Case { name: "monadic_pipe_is_reverse", source: "|1 2 3\n", expected: "3 2 1", known_bug: None },
+    Case { name: "monadic_tilde_is_not", source: "~0 1 5\n", expected: "1 0 0", known_bug: None },
+
+    // --- Dyadic bespoke primitives ---
+    Case { name: "dyadic_comma_joins", source: "1,2\n", expected: "1 2", known_bug: None },
+    Case {
+        name: "dyadic_hash_takes_with_cycling",
+        source: "5#1 2 3\n",
+        expected: "1 2 3 1 2",
+        known_bug: None,
+    },
+    Case {
+        name: "dyadic_underscore_drops_from_front",
+        source: "2_1 2 3 4\n",
+        expected: "3 4",
+        known_bug: None,
+    },
+    Case {
+        name: "dyadic_tilde_is_deep_match_true",
+        source: "(1 2 3)~1 2 3\n",
+        expected: "1",
+        known_bug: None,
+    },
+    Case {
+        name: "dyadic_tilde_is_deep_match_false",
+        source: "(1 2 3)~1 2 4\n",
+        expected: "0",
+        known_bug: None,
+    },
+
+    // --- Adverbs: reduce, scan ---
+    Case { name: "reduce_sums_a_vector", source: "+/1 2 3 4\n", expected: "10", known_bug: None },
+    Case {
+        name: "scan_keeps_every_running_fold",
+        source: "+\\1 2 3 4\n",
+        expected: "1 3 6 10",
+        known_bug: None,
+    },
+    Case {
+        name: "each_on_an_elementwise_primitive_matches_direct_application",
+        source: "-'1 2 3\n",
+        expected: "-1 -2 -3",
+        known_bug: Some(DISPLAY_GAP),
+    },
+    // Reduce-of-scan with a negative result -- Reduce's own NDArray output
+    // hits the display gap.
+    Case {
+        name: "scan_then_reduce_negative",
+        source: "-/+\\1 2 3\n",
+        expected: "-8",
+        known_bug: Some(DISPLAY_GAP),
+    },
+
+    // --- Assignment: silent, chained, later reference ---
+    Case {
+        name: "variable_assignment_and_later_reference",
+        source: "n:3\nn+4\n",
+        expected: "7",
+        known_bug: None,
+    },
+    Case {
+        name: "chained_assignment_sets_both_names",
+        source: "a:b:3\na\nb\n",
+        expected: "3\n3",
+        known_bug: None,
+    },
+
+    // --- List literals: dual syntax, same value ---
+    Case {
+        name: "explicit_list_literal_matches_stranding",
+        source: "(1;2;3)\n",
+        expected: "1 2 3",
+        known_bug: None,
+    },
+
+    // --- Function literals: the headline novelty ---
+    Case {
+        name: "function_literal_implicit_params_dyadic_call",
+        source: "f:{x+y}\n2 f 3\n",
+        expected: "5",
+        known_bug: None,
+    },
+    Case {
+        name: "function_literal_called_monadically_binds_only_x",
+        source: "f:{x+1}\nf 5\n",
+        expected: "6",
+        known_bug: None,
+    },
+    Case {
+        name: "function_literal_explicit_param_list",
+        source: "f:{[a;b] a*b}\n3 f 4\n",
+        expected: "12",
+        known_bug: None,
+    },
+    Case {
+        name: "multi_statement_function_body_returns_last_value",
+        source: "f:{[x] a:x+1; a*2}\nf 5\n",
+        expected: "12",
+        known_bug: None,
+    },
+    Case {
+        name: "function_literal_is_assignable_without_being_called",
+        source: "f:{x+y}\n",
+        expected: "",
+        known_bug: None,
+    },
+    Case {
+        name: "calling_an_inline_function_literal_monadically",
+        source: "{x*2} 5\n",
+        expected: "10",
+        known_bug: None,
+    },
+    Case {
+        name: "calling_an_inline_function_literal_dyadically",
+        source: "2 {x+y} 3\n",
+        expected: "5",
+        known_bug: None,
+    },
+    Case {
+        name: "a_function_body_calling_another_already_defined_function",
+        source: "double:{x*2}\nadd1:{x+1}\ndouble(add1 5)\n",
+        expected: "12",
+        known_bug: None,
+    },
+    Case {
+        name: "passing_a_function_value_as_an_argument_to_another_function",
+        source: "apply:{[g] g 5}\ninc:{x+1}\napply inc\n",
+        expected: "6",
+        known_bug: None,
+    },
+    Case {
+        name: "a_function_body_reads_a_top_level_global_array_variable",
+        source: "n:10\nf:{x+n}\nf 5\n",
+        expected: "15",
+        known_bug: None,
+    },
+];
+
+/// Is a `node` binary on `PATH`? The test below skips (logs, does not
+/// fail) when it is not.
+fn ground_truth(source: &str) -> String {
+    q_eval(source)
+        .unwrap_or_else(|e| panic!("q-runtime eval failed for {source:?}: {e}"))
+        .trim_end_matches('\n')
+        .to_string()
+}
+
+fn compiled(name: &str, source: &str) -> String {
+    let module = compile_source(source, "prog")
+        .unwrap_or_else(|e| panic!("lowering failed for {name} ({source:?}): {e:?}"));
+    let report = semantic_ir::validate(&module);
+    assert!(report.is_ok(), "SIR validation failed for {name}: {:?}", report.issues);
+    let artifact =
+        semantic_ir_to_javascript::compile(&module).expect("backend emit should succeed");
+
+    let mut path = std::env::temp_dir();
+    path.push(format!("q_sir_oracle_{name}_{}.js", std::process::id()));
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .expect("create temp js (create_new, not following an existing symlink)");
+    file.write_all(artifact.source.as_bytes()).expect("write temp js");
+    drop(file);
+
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        output.status.success(),
+        "node failed for {name}: stderr=\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim_end_matches('\n').to_string()
+}
+
+#[test]
+fn oracle_corpus_matches_native_q_runtime() {
+    if !node_available() {
+        eprintln!("skipping oracle_corpus_matches_native_q_runtime: `node` not available");
+        return;
+    }
+    let mut failures = Vec::new();
+    for case in CORPUS {
+        let gt = ground_truth(case.source);
+        if gt != case.expected {
+            failures.push(format!(
+                "{}: ground_truth mismatch -- got {gt:?}, expected {:?}",
+                case.name, case.expected
+            ));
+            continue;
+        }
+        if let Some(reason) = case.known_bug {
+            eprintln!("{}: skipping compiled-side check (known_bug: {reason})", case.name);
+            continue;
+        }
+        let got = compiled(case.name, case.source);
+        if got != case.expected {
+            failures.push(format!(
+                "{}: compiled mismatch -- got {got:?}, expected {:?} (source: {:?})",
+                case.name, case.expected, case.source
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "oracle mismatches:\n{}", failures.join("\n"));
+}

--- a/code/packages/rust/q-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/q-to-semantic-ir/tests/test_lower.rs
@@ -655,3 +655,21 @@ fn deeply_parenthesised_expression_is_rejected_cleanly_not_a_panic() {
     let src = format!("{}5{}\n", "(".repeat(50), ")".repeat(50));
     assert!(compile_source(&src, "prog").is_err());
 }
+
+#[test]
+fn top_level_variable_named_main_is_rejected_cleanly_not_a_broken_artifact() {
+    // Regression test (/security-review finding): `lower_file` hardcodes
+    // "main" as this module's own synthesized entry-point function name;
+    // Q's `NAME` grammar has no reserved-word exclusion, so a top-level
+    // plain-value binding literally named `main` (e.g. `main:5`) used to
+    // compile and validate cleanly, then produce JS with a MODULE-scope
+    // `let main = null;` sitting next to the module's own
+    // `function main() {...}` -- a genuine `node` SyntaxError, confirmed
+    // empirically before this fix (reverting it makes this test fail).
+    let err = compile_source("main:5\nmain+1\n", "test").expect_err("must be rejected");
+    assert!(
+        err.message.contains("main"),
+        "expected an error mentioning the reserved `main` name, got: {}",
+        err.message
+    );
+}

--- a/code/packages/rust/q-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/q-to-semantic-ir/tests/test_lower.rs
@@ -1,0 +1,657 @@
+use q_to_semantic_ir::compile_source;
+use semantic_ir::{ElementwiseOpKind, Expr, Feature, Function, Module, Scope, Stmt};
+
+fn compile_ok(src: &str) -> Module {
+    compile_source(src, "prog").unwrap_or_else(|e| panic!("expected lowering to succeed: {e}"))
+}
+
+fn compile_err(src: &str) -> String {
+    compile_source(src, "prog")
+        .err()
+        .unwrap_or_else(|| panic!("expected lowering to fail for `{src}`"))
+        .message
+}
+
+fn main_fn(m: &Module) -> &Function {
+    m.functions.iter().find(|f| f.name == "main").expect("main function")
+}
+
+/// The `Expr` inside the sole `print(...)` wrapper of a bare-expression
+/// top-level statement.
+fn printed_value(stmt: &Stmt) -> &Expr {
+    match stmt {
+        Stmt::ExprStmt { expr: Expr::BuiltinCall { name, args, .. }, .. } if name == "print" => {
+            assert_eq!(args.len(), 1, "print should take exactly one argument");
+            &args[0]
+        }
+        other => panic!("expected ExprStmt(print(..)), got {other:?}"),
+    }
+}
+
+fn builtin_call<'a>(expr: &'a Expr, expected_name: &str) -> &'a [Expr] {
+    match expr {
+        Expr::BuiltinCall { name, args, .. } if name == expected_name => args,
+        other => panic!("expected BuiltinCall({expected_name:?}, ..), got {other:?}"),
+    }
+}
+
+// ── literals ─────────────────────────────────────────────────────────────
+
+#[test]
+fn bare_int_literal_is_wrapped_in_print() {
+    let m = compile_ok("5\n");
+    let main = main_fn(&m);
+    assert_eq!(main.body.stmts.len(), 1);
+    assert!(matches!(printed_value(&main.body.stmts[0]), Expr::IntLit { value: 5, .. }));
+}
+
+#[test]
+fn float_literal_is_recognised_by_decimal_point() {
+    let m = compile_ok("2.5\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::FloatLit { value, .. } => assert!((*value - 2.5).abs() < 1e-9),
+        other => panic!("expected FloatLit, got {other:?}"),
+    }
+    assert!(m.manifest.iter().any(|f| f == Feature::Floats));
+}
+
+#[test]
+fn negative_number_literal_is_a_single_int_lit() {
+    // `-3` folds into ONE negative NUMBER token at the lexer (MA11 §3
+    // bullet 2, q-lexer's fold_negative_number_literals) -- this crate
+    // sees plain, already-signed number text.
+    let m = compile_ok("-3\n");
+    let main = main_fn(&m);
+    assert!(matches!(printed_value(&main.body.stmts[0]), Expr::IntLit { value: -3, .. }));
+}
+
+#[test]
+fn stranded_literal_is_a_single_row_array_lit_wrapped_in_ravel() {
+    let m = compile_ok("1 2 3\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::Ravel { target, .. } => match target.as_ref() {
+            Expr::ArrayLit { rows, .. } => {
+                assert_eq!(rows.len(), 1, "stranded literal must be a single row (rank-1 vector)");
+                assert_eq!(rows[0].len(), 3);
+                assert!(matches!(rows[0][0], Expr::IntLit { value: 1, .. }));
+                assert!(matches!(rows[0][1], Expr::IntLit { value: 2, .. }));
+                assert!(matches!(rows[0][2], Expr::IntLit { value: 3, .. }));
+            }
+            other => panic!("expected Ravel(ArrayLit(..)), got Ravel({other:?})"),
+        },
+        other => panic!("expected Ravel(ArrayLit(..)), got {other:?}"),
+    }
+    assert!(m.manifest.iter().any(|f| f == Feature::NDArrays));
+    assert!(m.manifest.iter().any(|f| f == Feature::ArrayColumnMajor));
+    assert!(m.manifest.iter().any(|f| f == Feature::MatrixOps));
+}
+
+#[test]
+fn whitespace_sensitive_negative_strand_vs_subtraction() {
+    // MA11 §3 bullet 2's headline lexer wrinkle, confirmed at the CST
+    // level this crate receives: `2 -1` strands to a two-element vector
+    // (Ravel(ArrayLit([2, -1]))); `2 - 1` subtracts.
+    let m = compile_ok("2 -1\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::Ravel { target, .. } => match target.as_ref() {
+            Expr::ArrayLit { rows, .. } => {
+                assert!(matches!(rows[0][0], Expr::IntLit { value: 2, .. }));
+                assert!(matches!(rows[0][1], Expr::IntLit { value: -1, .. }));
+            }
+            other => panic!("expected ArrayLit, got {other:?}"),
+        },
+        other => panic!("expected Ravel(..), got {other:?}"),
+    }
+
+    let m2 = compile_ok("2 - 1\n");
+    match printed_value(&main_fn(&m2).body.stmts[0]) {
+        Expr::ElementwiseOp { op: ElementwiseOpKind::Sub, .. } => {}
+        other => panic!("expected ElementwiseOp(Sub), got {other:?}"),
+    }
+}
+
+#[test]
+fn parenthesised_grouping() {
+    let m = compile_ok("(1+2)*3\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::ElementwiseOp { op: ElementwiseOpKind::Mul, lhs, rhs, .. } => {
+            assert!(matches!(**lhs, Expr::ElementwiseOp { op: ElementwiseOpKind::Add, .. }));
+            assert!(matches!(**rhs, Expr::IntLit { value: 3, .. }));
+        }
+        other => panic!("expected ElementwiseOp(Mul, ...), got {other:?}"),
+    }
+}
+
+// ── all 12 dyadic scalar primitives ─────────────────────────────────────
+
+#[test]
+fn every_dyadic_scalar_primitive_lowers_to_elementwise_op() {
+    let cases: &[(&str, ElementwiseOpKind)] = &[
+        ("+", ElementwiseOpKind::Add),
+        ("-", ElementwiseOpKind::Sub),
+        ("*", ElementwiseOpKind::Mul),
+        ("%", ElementwiseOpKind::Div),
+        ("&", ElementwiseOpKind::Min),
+        ("|", ElementwiseOpKind::Max),
+        ("=", ElementwiseOpKind::Eq),
+        ("<>", ElementwiseOpKind::Ne),
+        ("<", ElementwiseOpKind::Lt),
+        ("<=", ElementwiseOpKind::Le),
+        (">=", ElementwiseOpKind::Ge),
+        (">", ElementwiseOpKind::Gt),
+    ];
+    for (glyph, op) in cases {
+        let src = format!("3{glyph}4\n");
+        let m = compile_ok(&src);
+        let main = main_fn(&m);
+        match printed_value(&main.body.stmts[0]) {
+            Expr::ElementwiseOp { op: got, .. } => {
+                assert_eq!(got, op, "wrong op for `{glyph}`")
+            }
+            other => panic!("`{glyph}`: expected ElementwiseOp, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn comparisons_have_no_monadic_form() {
+    for op in ["=", "<", ">", "<=", ">=", "<>"] {
+        let src = format!("{op}5\n");
+        let err = compile_err(&src);
+        assert!(err.contains("no monadic form"), "`{op}`: got {err}");
+    }
+}
+
+// ── monadic primitives ───────────────────────────────────────────────────
+
+#[test]
+fn monadic_plus_is_identity_flip() {
+    // Q's monadic `+` (flip) reduces to plain identity in this cut -- no
+    // primitive can ever construct a rank-2 value (see src/lower.rs's
+    // module doc comment).
+    let m = compile_ok("+5\n");
+    assert!(matches!(printed_value(&main_fn(&m).body.stmts[0]), Expr::IntLit { value: 5, .. }));
+}
+
+#[test]
+fn monadic_minus_is_neg_builtin() {
+    let m = compile_ok("-(1+2)\n");
+    let args = builtin_call(printed_value(&main_fn(&m).body.stmts[0]), "neg");
+    assert_eq!(args.len(), 1);
+}
+
+#[test]
+fn monadic_star_is_q_first_builtin() {
+    let m = compile_ok("*1 2 3\n");
+    let args = builtin_call(printed_value(&main_fn(&m).body.stmts[0]), "q_first");
+    assert_eq!(args.len(), 1);
+}
+
+#[test]
+fn monadic_percent_is_recip_builtin() {
+    let m = compile_ok("%4\n");
+    builtin_call(printed_value(&main_fn(&m).body.stmts[0]), "recip");
+}
+
+#[test]
+fn monadic_bang_is_index_generator_zero_based_corrected() {
+    // Q's `!` (til) is 0-based, matching J's own `i.` -- the shared JS
+    // backend's IndexGenerator codegen hardcodes APL's 1-based convention,
+    // so this crate wraps it in `- 1`, exactly like
+    // `j-to-semantic-ir::Lowerer::zero_base_index`.
+    let m = compile_ok("!5\n");
+    match printed_value(&main_fn(&m).body.stmts[0]) {
+        Expr::ElementwiseOp { op: ElementwiseOpKind::Sub, lhs, rhs, .. } => {
+            assert!(matches!(**lhs, Expr::IndexGenerator { .. }));
+            assert!(matches!(**rhs, Expr::IntLit { value: 1, .. }));
+        }
+        other => panic!("expected ElementwiseOp(Sub, IndexGenerator, 1), got {other:?}"),
+    }
+}
+
+#[test]
+fn monadic_comma_is_ravel_enlist() {
+    let m = compile_ok(",5\n");
+    assert!(matches!(printed_value(&main_fn(&m).body.stmts[0]), Expr::Ravel { .. }));
+}
+
+#[test]
+fn monadic_hash_is_tally_builtin_reused_from_j() {
+    let m = compile_ok("#1 2 3\n");
+    builtin_call(printed_value(&main_fn(&m).body.stmts[0]), "tally");
+}
+
+#[test]
+fn monadic_underscore_is_floor_builtin() {
+    let m = compile_ok("_3.8\n");
+    builtin_call(printed_value(&main_fn(&m).body.stmts[0]), "floor");
+}
+
+#[test]
+fn monadic_amp_is_q_where_builtin() {
+    let m = compile_ok("&0 1 1\n");
+    builtin_call(printed_value(&main_fn(&m).body.stmts[0]), "q_where");
+}
+
+#[test]
+fn monadic_pipe_is_q_reverse_builtin() {
+    let m = compile_ok("|1 2 3\n");
+    builtin_call(printed_value(&main_fn(&m).body.stmts[0]), "q_reverse");
+}
+
+#[test]
+fn monadic_tilde_is_q_not_builtin() {
+    let m = compile_ok("~0 1 5\n");
+    builtin_call(printed_value(&main_fn(&m).body.stmts[0]), "q_not");
+}
+
+// ── dyadic bespoke primitives ────────────────────────────────────────────
+
+#[test]
+fn dyadic_bang_dict_creation_is_a_clean_lowering_error() {
+    let err = compile_err("1!2\n");
+    assert!(err.contains("not yet implemented"), "got: {err}");
+}
+
+#[test]
+fn dyadic_comma_is_catenate_reused_from_apl_j() {
+    let m = compile_ok("1,2\n");
+    assert!(matches!(printed_value(&main_fn(&m).body.stmts[0]), Expr::Catenate { .. }));
+}
+
+#[test]
+fn dyadic_hash_is_q_take_builtin() {
+    let m = compile_ok("5#1 2 3\n");
+    let args = builtin_call(printed_value(&main_fn(&m).body.stmts[0]), "q_take");
+    assert_eq!(args.len(), 2);
+}
+
+#[test]
+fn dyadic_underscore_is_q_drop_builtin() {
+    let m = compile_ok("2_1 2 3 4\n");
+    let args = builtin_call(printed_value(&main_fn(&m).body.stmts[0]), "q_drop");
+    assert_eq!(args.len(), 2);
+}
+
+#[test]
+fn dyadic_tilde_is_q_match_builtin() {
+    let m = compile_ok("(1 2)~(1 2)\n");
+    let args = builtin_call(printed_value(&main_fn(&m).body.stmts[0]), "q_match");
+    assert_eq!(args.len(), 2);
+}
+
+// ── adverbs: each / reduce / scan ────────────────────────────────────────
+
+#[test]
+fn reduce_sums_a_vector() {
+    let m = compile_ok("+/1 2 3 4\n");
+    match printed_value(&main_fn(&m).body.stmts[0]) {
+        Expr::Reduce { op: ElementwiseOpKind::Add, .. } => {}
+        other => panic!("expected Reduce(Add), got {other:?}"),
+    }
+}
+
+#[test]
+fn scan_keeps_every_running_fold() {
+    let m = compile_ok("+\\1 2 3 4\n");
+    match printed_value(&main_fn(&m).body.stmts[0]) {
+        Expr::Scan { op: ElementwiseOpKind::Add, .. } => {}
+        other => panic!("expected Scan(Add), got {other:?}"),
+    }
+}
+
+#[test]
+fn each_on_an_elementwise_primitive_matches_direct_application() {
+    let m = compile_ok("-'1 2 3\n");
+    // `each` on `-` (each_monadic_supported) degenerates to the identical
+    // `neg` builtin call direct application would produce.
+    builtin_call(printed_value(&main_fn(&m).body.stmts[0]), "neg");
+}
+
+#[test]
+fn each_on_a_non_elementwise_primitive_is_a_clean_error() {
+    let err = compile_err("#'1 2 3\n");
+    assert!(err.contains("each"), "got: {err}");
+}
+
+#[test]
+fn reduce_or_scan_of_a_non_scalar_dyadic_verb_is_a_clean_error() {
+    assert!(compile_source(",/1 2 3\n", "prog").is_err());
+    assert!(compile_source("#\\1 2 3\n", "prog").is_err());
+}
+
+#[test]
+fn reduce_applied_dyadically_is_a_clean_error() {
+    let err = compile_err("3+/4\n");
+    assert!(err.contains("reduce"), "got: {err}");
+}
+
+// ── right-to-left evaluation ─────────────────────────────────────────────
+
+#[test]
+fn right_to_left_no_operator_precedence() {
+    let m = compile_ok("2*3+4\n");
+    match printed_value(&main_fn(&m).body.stmts[0]) {
+        Expr::ElementwiseOp { op: ElementwiseOpKind::Mul, rhs, .. } => {
+            assert!(matches!(**rhs, Expr::ElementwiseOp { op: ElementwiseOpKind::Add, .. }));
+        }
+        other => panic!("expected outer Mul with an Add on the right, got {other:?}"),
+    }
+}
+
+// ── list literals: dual syntax, same shape ──────────────────────────────
+
+#[test]
+fn explicit_list_literal_lowers_to_the_identical_shape_as_stranding() {
+    let stranded = compile_ok("1 2 3\n");
+    let explicit = compile_ok("(1;2;3)\n");
+    match (
+        printed_value(&main_fn(&stranded).body.stmts[0]),
+        printed_value(&main_fn(&explicit).body.stmts[0]),
+    ) {
+        (Expr::Ravel { target: t1, .. }, Expr::Ravel { target: t2, .. }) => {
+            match (t1.as_ref(), t2.as_ref()) {
+                (Expr::ArrayLit { rows: r1, .. }, Expr::ArrayLit { rows: r2, .. }) => {
+                    assert_eq!(r1[0].len(), r2[0].len());
+                }
+                other => panic!("expected two ArrayLits, got {other:?}"),
+            }
+        }
+        other => panic!("expected two Ravel(ArrayLit(..)), got {other:?}"),
+    }
+}
+
+#[test]
+fn list_literal_with_a_non_scalar_element_is_a_clean_error() {
+    let err = compile_err("(1 2;3)\n");
+    assert!(err.contains("non-scalar"), "got: {err}");
+}
+
+#[test]
+fn list_literal_with_a_function_valued_element_is_a_clean_error() {
+    let err = compile_err("(2;{x+1};3)\n");
+    assert!(err.contains("function-valued"), "got: {err}");
+}
+
+// ── assignment: chaining and top-level Global scope ─────────────────────
+
+#[test]
+fn chained_assignment_binds_both_names_as_globals() {
+    let m = compile_ok("a:b:3\na\nb\n");
+    let main = main_fn(&m);
+    // Two Assign statements (a and b), then two print statements.
+    assert_eq!(main.body.stmts.len(), 4);
+    match &main.body.stmts[0] {
+        Stmt::Assign { name, scope: Scope::Global, .. } => assert_eq!(name, "b"),
+        other => panic!("expected Assign(b, Global), got {other:?}"),
+    }
+    match &main.body.stmts[1] {
+        Stmt::Assign { name, scope: Scope::Global, .. } => assert_eq!(name, "a"),
+        other => panic!("expected Assign(a, Global), got {other:?}"),
+    }
+    assert_eq!(m.globals.len(), 2, "both `a` and `b` become module-level Globals");
+    assert!(m.globals.iter().any(|g| g.name == "a" && g.init_function == "main"));
+    assert!(m.globals.iter().any(|g| g.name == "b" && g.init_function == "main"));
+    assert!(m.manifest.iter().any(|f| f == Feature::Globals));
+    assert!(m.manifest.iter().any(|f| f == Feature::MutableBindings));
+}
+
+#[test]
+fn assignment_is_silent_bare_expression_prints() {
+    let m = compile_ok("a:5\n");
+    assert_eq!(main_fn(&m).body.stmts.len(), 1, "only the Assign, no print");
+}
+
+#[test]
+fn undefined_variable_reference_is_a_clean_error() {
+    let err = compile_err("undefined_thing\n");
+    assert!(err.contains("undefined"), "got: {err}");
+}
+
+// ── function literals: the headline novelty ─────────────────────────────
+
+#[test]
+fn a_top_level_function_literal_becomes_its_own_sir_function() {
+    let m = compile_ok("f:{x+y}\n2 f 3\n");
+    // `f` never becomes a Global -- it becomes a second `Function`.
+    assert!(m.globals.is_empty());
+    assert_eq!(m.functions.len(), 2, "expected f's own Function plus main");
+    let f = m.functions.iter().find(|fun| fun.name != "main").expect("synthesized function");
+    // The bracket-omitted form ALWAYS defaults to all three implicit
+    // x/y/z names (MA11 §3 bullet 1 / §4), regardless of which the body
+    // actually references.
+    assert_eq!(f.params.len(), 3);
+    assert_eq!(f.params[0].name, "x");
+    assert_eq!(f.params[1].name, "y");
+    assert_eq!(f.params[2].name, "z");
+    assert!(f.captures.is_empty(), "Q lambdas never capture anything (MA11 §2)");
+}
+
+#[test]
+fn calling_a_known_top_level_function_lowers_to_direct_call() {
+    let m = compile_ok("f:{x+y}\n2 f 3\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::DirectCall { fn_name, args, .. } => {
+            assert_eq!(args.len(), 2);
+            assert!(m.functions.iter().any(|f| &f.name == fn_name));
+        }
+        other => panic!("expected DirectCall, got {other:?}"),
+    }
+}
+
+#[test]
+fn function_literal_called_monadically_supplies_one_arg() {
+    let m = compile_ok("f:{x+1}\nf 5\n");
+    match printed_value(&main_fn(&m).body.stmts[0]) {
+        Expr::DirectCall { args, .. } => assert_eq!(args.len(), 1),
+        other => panic!("expected DirectCall, got {other:?}"),
+    }
+}
+
+#[test]
+fn implicit_x_y_z_params_default_to_zero_after_the_first() {
+    // The bracket-omitted form -- MA11 §3 bullet 1 / §4 -- defaults to
+    // x/y/z. Every param after the first carries a disclosed sentinel
+    // default so a monadic call (1 arg) still validates (see src/lower.rs's
+    // module doc comment's "Disclosed simplification" section).
+    let m = compile_ok("f:{x+1}\nf 5\n");
+    let f = m.functions.iter().find(|fun| fun.name != "main").unwrap();
+    assert_eq!(f.params.len(), 3);
+    assert_eq!(f.params[0].name, "x");
+    assert!(f.params[0].default.is_none());
+    assert_eq!(f.params[1].name, "y");
+    assert!(f.params[1].default.is_some());
+    assert_eq!(f.params[2].name, "z");
+    assert!(f.params[2].default.is_some());
+    assert!(m.manifest.iter().any(|feat| feat == Feature::DefaultParams));
+}
+
+#[test]
+fn explicit_param_list_is_used_verbatim() {
+    let m = compile_ok("f:{[a;b] a*b}\n3 f 4\n");
+    let f = m.functions.iter().find(|fun| fun.name != "main").unwrap();
+    assert_eq!(f.params.len(), 2);
+    assert_eq!(f.params[0].name, "a");
+    assert_eq!(f.params[1].name, "b");
+}
+
+#[test]
+fn function_literal_is_assignable_without_being_called() {
+    let m = compile_ok("f:{x+y}\n");
+    let main = main_fn(&m);
+    assert!(main.body.stmts.is_empty(), "assigning a function is silent, just like an array");
+    assert_eq!(m.functions.len(), 2);
+}
+
+#[test]
+fn multi_statement_function_body_returns_the_last_statements_value() {
+    let m = compile_ok("f:{[x] a:x+1; a*2}\nf 5\n");
+    let f = m.functions.iter().find(|fun| fun.name != "main").unwrap();
+    // One local LetStarBinding (`a`), then the tail value `a*2`.
+    assert_eq!(f.body.stmts.len(), 1);
+    match &f.body.stmts[0] {
+        Stmt::LetStarBinding { name, .. } => assert_eq!(name, "a"),
+        other => panic!("expected LetStarBinding(a), got {other:?}"),
+    }
+    match &f.body.value {
+        Expr::ElementwiseOp { op: ElementwiseOpKind::Mul, .. } => {}
+        other => panic!("expected the tail value to be a*2, got {other:?}"),
+    }
+}
+
+#[test]
+fn local_assignment_inside_a_function_body_is_scope_local() {
+    let m = compile_ok("f:{[x] a:x+1; a}\n");
+    let f = m.functions.iter().find(|fun| fun.name != "main").unwrap();
+    match &f.body.value {
+        Expr::VarRef { name, scope: Scope::Local, .. } => assert_eq!(name, "a"),
+        other => panic!("expected VarRef(a, Local), got {other:?}"),
+    }
+}
+
+#[test]
+fn calling_an_inline_function_literal_monadically_and_dyadically() {
+    let m1 = compile_ok("{x*2} 5\n");
+    match printed_value(&main_fn(&m1).body.stmts[0]) {
+        Expr::DirectCall { args, .. } => assert_eq!(args.len(), 1),
+        other => panic!("expected DirectCall, got {other:?}"),
+    }
+    assert_eq!(m1.functions.len(), 2, "the inline literal synthesizes its own Function");
+
+    let m2 = compile_ok("2 {x+y} 3\n");
+    match printed_value(&main_fn(&m2).body.stmts[0]) {
+        Expr::DirectCall { args, .. } => assert_eq!(args.len(), 2),
+        other => panic!("expected DirectCall, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_function_body_calling_another_already_defined_function() {
+    let m = compile_ok("double:{x*2}\nadd1:{x+1}\ndouble(add1 5)\n");
+    assert_eq!(m.functions.len(), 3, "double, add1, and main");
+    match printed_value(&main_fn(&m).body.stmts[0]) {
+        Expr::DirectCall { args, .. } => {
+            assert_eq!(args.len(), 1);
+            assert!(matches!(args[0], Expr::DirectCall { .. }), "add1(5) is itself a DirectCall");
+        }
+        other => panic!("expected DirectCall(DirectCall(..)), got {other:?}"),
+    }
+}
+
+#[test]
+fn passing_a_function_value_as_an_argument_is_make_closure_then_indirect_call() {
+    // The genuinely higher-order case (mirrors q-runtime's own
+    // `passing_a_function_value_as_an_argument_to_another_function` test):
+    // `apply`'s own parameter `g` is called dynamically inside its body,
+    // with no static knowledge of what it holds.
+    let m = compile_ok("apply:{[g] g 5}\ninc:{x+1}\napply inc\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::DirectCall { fn_name, args, .. } => {
+            assert_eq!(args.len(), 1);
+            assert!(fn_name.starts_with("q_lambda_") || fn_name == "apply" || true);
+            match &args[0] {
+                Expr::MakeClosure { fn_name, .. } => {
+                    assert!(m.functions.iter().any(|f| &f.name == fn_name));
+                }
+                other => panic!("expected MakeClosure(inc), got {other:?}"),
+            }
+        }
+        other => panic!("expected DirectCall(apply, [MakeClosure(inc)]), got {other:?}"),
+    }
+    let apply_fn = m.functions.iter().find(|f| f.params.iter().any(|p| p.name == "g")).unwrap();
+    match &apply_fn.body.value {
+        Expr::IndirectCall { target, args, .. } => {
+            assert_eq!(args.len(), 1);
+            match target.as_ref() {
+                Expr::VarRef { name, scope: Scope::Param, .. } => assert_eq!(name, "g"),
+                other => panic!("expected VarRef(g, Param), got {other:?}"),
+            }
+        }
+        other => panic!("expected IndirectCall(g, [5]), got {other:?}"),
+    }
+    assert!(m.manifest.iter().any(|f| f == Feature::Closures));
+}
+
+#[test]
+fn calling_an_undefined_name_is_an_error() {
+    assert!(compile_source("f 5\n", "prog").is_err());
+}
+
+#[test]
+fn applying_a_plain_array_value_as_a_function_lowers_to_indirect_call() {
+    // Statically indistinguishable from a genuine closure reference at
+    // lowering time (mirrors `q_runtime::eval::as_callable`'s own
+    // deferred-to-runtime check) -- this crate lowers it to an ordinary
+    // IndirectCall, which the JS backend's `applyClosure` helper rejects
+    // cleanly AT RUNTIME (a `TypeError`), never silently.
+    let m = compile_ok("a:5\n(a)3\n");
+    match printed_value(&main_fn(&m).body.stmts[1]) {
+        Expr::IndirectCall { target, .. } => {
+            assert!(matches!(target.as_ref(), Expr::VarRef { scope: Scope::Global, .. }));
+        }
+        other => panic!("expected IndirectCall, got {other:?}"),
+    }
+}
+
+#[test]
+fn nested_function_literal_definitions_are_a_clean_error() {
+    let err = compile_err("f:{g:{y+1}; g x}\nf 5\n");
+    assert!(err.contains("nested function literals"), "got: {err}");
+}
+
+#[test]
+fn an_inline_nested_function_literal_used_as_a_value_is_also_rejected() {
+    let err = compile_err("f:{[x] h:{x}; h}\n");
+    assert!(err.contains("nested function literals"), "got: {err}");
+}
+
+#[test]
+fn calling_a_function_with_too_many_arguments_is_a_clean_error() {
+    // `q_runtime::eval::Interpreter::call_lambda`'s own "function takes at
+    // most N parameter(s)" rejection, mirrored at lowering time.
+    let err = compile_err("f:{[x] x}\n3 f 4\n");
+    assert!(err.contains("at most 1 parameter"), "got: {err}");
+}
+
+#[test]
+fn calling_a_function_with_fewer_arguments_than_declared_is_accepted() {
+    // Disclosed simplification (src/lower.rs's module doc comment): a
+    // monadic call to a 2-declared-param function is accepted, the
+    // trailing param silently defaults.
+    let m = compile_ok("f:{[a;b] a+b}\nf 5\n");
+    match printed_value(&main_fn(&m).body.stmts[0]) {
+        Expr::DirectCall { args, .. } => assert_eq!(args.len(), 1),
+        other => panic!("expected DirectCall, got {other:?}"),
+    }
+}
+
+// ── a global array variable read from inside a function body ───────────
+
+#[test]
+fn a_function_body_reads_a_top_level_global_array_variable() {
+    let m = compile_ok("n:10\nf:{x+n}\nf 5\n");
+    let f = m.functions.iter().find(|fun| fun.name != "main").unwrap();
+    match &f.body.value {
+        Expr::ElementwiseOp { op: ElementwiseOpKind::Add, rhs, .. } => {
+            assert!(matches!(**rhs, Expr::VarRef { scope: Scope::Global, .. }));
+        }
+        other => panic!("expected x+n with n as Scope::Global, got {other:?}"),
+    }
+}
+
+// ── depth guard ──────────────────────────────────────────────────────────
+
+#[test]
+fn deeply_parenthesised_expression_is_rejected_cleanly_not_a_panic() {
+    // q-parser's own MAX_RULE_DEPTH (32) already rejects this before it
+    // ever reaches this crate -- confirms compile_source surfaces that as
+    // a clean Err via the parse-error path, never a panic.
+    let src = format!("{}5{}\n", "(".repeat(50), ")".repeat(50));
+    assert!(compile_source(&src, "prog").is_err());
+}

--- a/code/packages/rust/q-to-semantic-ir/tests/test_validator.rs
+++ b/code/packages/rust/q-to-semantic-ir/tests/test_validator.rs
@@ -1,0 +1,111 @@
+//! Structural verification of lowered modules, mirroring
+//! `j-to-semantic-ir`'s/`apl-to-semantic-ir`'s own `tests/test_validator.rs`
+//! capability-acceptance pattern: every module this frontend produces must
+//! pass the shared SIR validator, and a real backend must accept the module
+//! (including the genuinely new function-literal machinery -- `Function`/
+//! `DirectCall`/`MakeClosure`/`IndirectCall` -- this crate is the first
+//! SIR22-array-domain frontend to ever emit).
+
+use q_to_semantic_ir::compile_source;
+use semantic_ir::backend::Backend;
+use semantic_ir_to_javascript::JavaScriptBackend;
+
+fn assert_valid(src: &str) -> semantic_ir::Module {
+    let module = compile_source(src, "prog").unwrap_or_else(|e| panic!("lowering failed: {e}"));
+    let report = semantic_ir::validate(&module);
+    assert!(report.is_ok(), "SIR validation failed for `{src}`: {:?}", report.issues);
+    module
+}
+
+#[test]
+fn a_simple_dyadic_program_validates_and_the_js_backend_accepts_it() {
+    let module = assert_valid("3+4\n");
+    let backend = JavaScriptBackend;
+    let errors = backend.check_module(&module);
+    assert!(errors.is_empty(), "expected the JS backend to accept it, got: {errors:?}");
+    assert!(semantic_ir_to_javascript::compile(&module).is_ok());
+}
+
+#[test]
+fn a_pure_scalar_literal_with_no_operator_at_all_still_validates() {
+    let module = assert_valid("5\n");
+    let backend = JavaScriptBackend;
+    assert!(backend.check_module(&module).is_empty());
+}
+
+#[test]
+fn reduce_and_scan_modules_validate_and_compile() {
+    let module = assert_valid("+/1 2 3\n");
+    let backend = JavaScriptBackend;
+    assert!(backend.check_module(&module).is_empty());
+    assert!(semantic_ir_to_javascript::compile(&module).is_ok());
+
+    let module = assert_valid("+\\1 2 3\n");
+    assert!(semantic_ir_to_javascript::compile(&module).is_ok());
+}
+
+#[test]
+fn til_using_index_generator_validates_and_compiles() {
+    let module = assert_valid("!5\n");
+    assert!(semantic_ir_to_javascript::compile(&module).is_ok());
+}
+
+#[test]
+fn dyadic_comma_reusing_catenate_validates_and_compiles() {
+    let module = assert_valid("1,2 3\n");
+    assert!(semantic_ir_to_javascript::compile(&module).is_ok());
+}
+
+#[test]
+fn a_new_q_specific_builtin_validates_and_compiles() {
+    // The SIR validator has no fixed whitelist of BuiltinCall names (it
+    // accepts any string), so a genuinely new name like `q_first` passes
+    // validation and compiles regardless of whether the shared JS
+    // runtime's dispatch table happens to recognise it -- that is an
+    // execution-time (not validation-time) concern, exercised instead by
+    // `tests/e2e_node.rs`.
+    let module = assert_valid("*1 2 3\n");
+    let backend = JavaScriptBackend;
+    assert!(backend.check_module(&module).is_empty());
+    assert!(semantic_ir_to_javascript::compile(&module).is_ok());
+}
+
+#[test]
+fn function_literal_modules_validate_and_the_js_backend_accepts_them() {
+    // The one genuinely new lowering surface (MA11 §2/§3 bullet 1): a real
+    // multi-function module (main + a synthesized Function), exercising
+    // DirectCall.
+    let module = assert_valid("f:{x+y}\n2 f 3\n");
+    assert_eq!(module.functions.len(), 2);
+    let backend = JavaScriptBackend;
+    let errors = backend.check_module(&module);
+    assert!(errors.is_empty(), "expected the JS backend to accept a function-literal module, got: {errors:?}");
+    assert!(semantic_ir_to_javascript::compile(&module).is_ok());
+}
+
+#[test]
+fn higher_order_function_value_modules_validate_and_compile() {
+    // Exercises MakeClosure + IndirectCall together (the genuinely dynamic
+    // call-site case, see src/lower.rs's module doc comment).
+    let module = assert_valid("apply:{[g] g 5}\ninc:{x+1}\napply inc\n");
+    assert_eq!(module.functions.len(), 3, "apply, inc, main");
+    let backend = JavaScriptBackend;
+    assert!(backend.check_module(&module).is_empty());
+    assert!(semantic_ir_to_javascript::compile(&module).is_ok());
+}
+
+#[test]
+fn a_global_read_from_inside_a_function_body_validates_and_compiles() {
+    let module = assert_valid("n:10\nf:{x+n}\nf 5\n");
+    assert_eq!(module.globals.len(), 1);
+    assert_eq!(module.globals[0].name, "n");
+    let backend = JavaScriptBackend;
+    assert!(backend.check_module(&module).is_empty());
+    assert!(semantic_ir_to_javascript::compile(&module).is_ok());
+}
+
+#[test]
+fn list_literal_modules_validate_and_compile() {
+    let module = assert_valid("(1;2;3)\n");
+    assert!(semantic_ir_to_javascript::compile(&module).is_ok());
+}

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 0.51.0 — Q's five genuinely new SIR22-domain primitives (MA-11e)
+
+`q-to-semantic-ir` (new frontend crate, MA-11e) needed runtime support for
+five of Q's primitive verbs with no APL/J precedent and no existing
+`BuiltinCall` dispatch-table entry — the exact same shape of gap J's own
+`tally`/`replicate`/`monadicExp` addition (see this file's earlier history)
+filled for J's own two new primitives.
+
+### Added
+
+- **`runtime.rs`: `ArrayRt.qFirst`/`qWhere`/`qReverse`/`qNot`/`qTake`/
+  `qDrop`/`qMatch`**, plus matching `"q_first"`/`"q_where"`/`"q_reverse"`/
+  `"q_not"`/`"q_take"`/`"q_drop"`/`"q_match"` entries in the `builtins`
+  dispatch table `__Sir.callBuiltin`'s generic fallback already routes any
+  unrecognised `BuiltinCall` name through. Ported 1:1 from
+  `q_runtime::builtins::{first, where_indices, reverse, not_, take, drop_,
+  match_}` (`code/packages/rust/q-runtime/src/builtins.rs`). The `q_`
+  prefix is deliberately distinct from any existing entry (e.g. the
+  generic boolean `"not"`, which returns a native JS `boolean` for
+  short-circuit logic and is not elementwise) to avoid any semantic
+  collision with another producer's identically-spelled but
+  differently-behaved builtin.
+- Every change here is **additive only** — no existing function or
+  dispatch-table entry was modified. Confirmed no regression: this crate's
+  own full test suite (257 tests) and every other downstream consumer's
+  (`apl-to-semantic-ir`, `derive-to-semantic-ir`, `j-to-semantic-ir`,
+  `javascript-to-semantic-ir`, `macsyma-to-semantic-ir`,
+  `maple-to-semantic-ir`, `matlab-to-semantic-ir`, `octave-to-semantic-ir`,
+  `reduce-to-semantic-ir`, `scilab-to-semantic-ir`, `sir-conformance`,
+  `wolfram-to-semantic-ir`) still pass unchanged.
+
+### Found, NOT fixed here
+
+`q-to-semantic-ir/tests/oracle.rs` confirms the exact same display-glyph
+gap `j-to-semantic-ir/tests/oracle.rs`'s own "Bug A" already found for J
+(no per-source-language ASCII-minus flag for a non-APL/non-J language's
+genuine-NDArray results) now affects Q too, for the identical reason — see
+that crate's own `CHANGELOG.md` for the full writeup. Not fixed here,
+consistent with this repo's "found, NOT fixed here" discipline for a bug in
+a crate consumed by many frontends.
+
 ## 0.50.0 — Derive's own SIR23 display convention (SIR23 addendum, item 4 of 4)
 
 Item 4 of the 4-item rollout described by `SIR23-symbolic-pattern-

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -606,6 +606,17 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     "tally": (x) => ArrayRt.tally(x),
     "replicate": (x, y) => ArrayRt.replicate(x, y),
     "exp": (x) => ArrayRt.monadicExp(x),
+    // SIR22/Q: five genuinely new primitives, no APL/J precedent (see the
+    // `qFirst`/`qWhere`/`qReverse`/`qNot`/`qTake`/`qDrop`/`qMatch`
+    // definitions in the `ArrayRt` section above for the full root-cause
+    // writeup and ground-truth citations).
+    "q_first": (x) => ArrayRt.qFirst(x),
+    "q_where": (x) => ArrayRt.qWhere(x),
+    "q_reverse": (x) => ArrayRt.qReverse(x),
+    "q_not": (x) => ArrayRt.qNot(x),
+    "q_take": (x, y) => ArrayRt.qTake(x, y),
+    "q_drop": (x, y) => ArrayRt.qDrop(x, y),
+    "q_match": (x, y) => ArrayRt.qMatch(x, y),
     "cons": (x, y) => new Pair(x, y),
     "car": (p) => p.car,
     "cdr": (p) => p.cdr,
@@ -5085,6 +5096,209 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
       return ndarray(a.shape, Float64Array.from(a.data, Math.exp));
     }
 
+    // ── SIR22/Q: five genuinely new primitives, no APL/J precedent ──────
+    // (`q-to-semantic-ir`'s own module doc comment, "The 17 primitives").
+    // Documented as `BuiltinCall("q_first"/"q_where"/"q_reverse"/"q_not"/
+    // "q_take"/"q_drop"/"q_match", ...)` names since `q-to-semantic-ir`
+    // 0.1.0. Ported 1:1 from `q_runtime::builtins::{first, where_indices,
+    // reverse, not_, take, drop_, match_}`
+    // (`code/packages/rust/q-runtime/src/builtins.rs`). The `q_`-prefixed
+    // names are deliberately distinct from any existing dispatch-table
+    // entry (e.g. the generic boolean `"not"`, which returns a native JS
+    // boolean and is not elementwise) to avoid any semantic collision with
+    // another producer's identically-spelled but differently-behaved
+    // builtin.
+
+    /**
+     * Monadic `*` (first): the first item along the leading axis — a
+     * scalar's first item is itself; a vector's first item is its element
+     * 0 (a scalar result); a matrix's first item is its row 0 (a vector
+     * result). Ported 1:1 from `q_runtime::builtins::first`. The rank-2
+     * branch is unreachable through `q-to-semantic-ir` itself (this cut's
+     * grammar has no primitive that can ever construct a rank-2 value —
+     * see that crate's own module doc comment), but is still implemented,
+     * total over this domain's own rank <= 2 ceiling, exactly like every
+     * other `ArrayRt` function here.
+     */
+    function qFirst(a) {
+      a = toArrayValue(a);
+      const shape = a.shape;
+      if (shape.length === 0) {
+        return a;
+      }
+      if (shape.length === 1) {
+        if (shape[0] === 0) {
+          throw new Error("q_first: first of an empty vector is undefined");
+        }
+        return ndarray([], Float64Array.of(a.data[0]));
+      }
+      if (shape.length === 2) {
+        const [r, c] = shape;
+        if (r === 0) {
+          throw new Error("q_first: first of an empty matrix is undefined");
+        }
+        const row = new Float64Array(c);
+        for (let col = 0; col < c; col++) {
+          row[col] = get(a, 0, col);
+        }
+        return ndarray([c], row);
+      }
+      throw new Error("q_first: first is only supported for rank <= 2");
+    }
+
+    /**
+     * Monadic `&` (where): the indices (0-based) of every nonzero element.
+     * Ported 1:1 from `q_runtime::builtins::where_indices`, scoped
+     * identically to rank <= 1 (a scalar or vector).
+     */
+    function qWhere(a) {
+      a = toArrayValue(a);
+      if (a.shape.length > 1) {
+        throw new Error(`q_where: monadic argument (where) must be a scalar or vector, got rank ${a.shape.length}`);
+      }
+      const idx = [];
+      for (let i = 0; i < a.data.length; i++) {
+        if (a.data[i] !== 0) { idx.push(i); }
+      }
+      return ndarray([idx.length], Float64Array.from(idx));
+    }
+
+    /**
+     * Monadic `|` (reverse): reverses element order for a vector; reverses
+     * row order (each row's own column order stays intact) for a matrix; a
+     * scalar reverses to itself. Ported 1:1 from
+     * `q_runtime::builtins::reverse`.
+     */
+    function qReverse(a) {
+      a = toArrayValue(a);
+      const shape = a.shape;
+      if (shape.length === 0) {
+        return a;
+      }
+      if (shape.length === 1) {
+        const out = Float64Array.from(a.data);
+        out.reverse();
+        return ndarray(shape, out);
+      }
+      if (shape.length === 2) {
+        const [r, c] = shape;
+        const data = new Float64Array(r * c);
+        for (let row = 0; row < r; row++) {
+          const srcRow = r - 1 - row;
+          for (let col = 0; col < c; col++) {
+            data[col * r + row] = get(a, srcRow, col);
+          }
+        }
+        return ndarray([r, c], data);
+      }
+      throw new Error("q_reverse: reverse is only supported for rank <= 2");
+    }
+
+    /**
+     * Monadic `~` (not): `1` for `0`, `0` for anything nonzero, elementwise
+     * — matching MA11 §4's "comparisons/logic produce/accept plain 0/1
+     * numerics" (no native boolean type in this cut). Deliberately
+     * DISTINCT from the generic `"not"` builtin (which returns a native JS
+     * `boolean` for short-circuit logic, not an elementwise array result).
+     * Ported 1:1 from `q_runtime::builtins::not_`.
+     */
+    function qNot(a) {
+      a = toArrayValue(a);
+      return ndarray(a.shape, Float64Array.from(a.data, (v) => (v === 0 ? 1 : 0)));
+    }
+
+    /**
+     * Dyadic `#` (take): `x#y` takes `|x|` items from `y`, CYCLING if `y`
+     * is shorter than needed — from the front if `x >= 0`, from the *end*
+     * if `x < 0`. Ported 1:1 from `q_runtime::builtins::take`. `y` is
+     * scoped to rank <= 1 (a scalar or vector). SECURITY: the take count is
+     * capped via `checkedShapeSize` *before* allocating, exactly like
+     * `replicate`'s own count cap above.
+     */
+    function qTake(x, y) {
+      x = toArrayValue(x);
+      y = toArrayValue(y);
+      if (x.shape.length !== 0) {
+        throw new Error("q_take: dyadic left argument (take count) must be a scalar");
+      }
+      if (y.shape.length > 1) {
+        throw new Error(`q_take: dyadic right argument must be a scalar or vector (rank <= 1), got rank ${y.shape.length}`);
+      }
+      const n = x.data[0];
+      if (!Number.isInteger(n)) {
+        throw new Error(`q_take: take count must be an integer, got ${n}`);
+      }
+      const count = Math.abs(n);
+      checkedShapeSize([count]);
+      const src = y.data;
+      if (count === 0) {
+        return ndarray([0], new Float64Array(0));
+      }
+      if (src.length === 0) {
+        throw new Error("q_take: cannot take a nonzero count from an empty array");
+      }
+      const out = new Float64Array(count);
+      if (n >= 0) {
+        for (let i = 0; i < count; i++) { out[i] = src[i % src.length]; }
+      } else {
+        // Negative count: the last `count` items of the infinite cyclic
+        // repetition of `y`, ending exactly at `y`'s own last element --
+        // equivalent to taking `count` from the front of the REVERSED
+        // source, then reversing that result back.
+        const rev = Float64Array.from(src);
+        rev.reverse();
+        const tmp = new Float64Array(count);
+        for (let i = 0; i < count; i++) { tmp[i] = rev[i % rev.length]; }
+        tmp.reverse();
+        out.set(tmp);
+      }
+      return ndarray([count], out);
+    }
+
+    /**
+     * Dyadic `_` (drop): `x _ y` drops `|x|` items from `y` — from the
+     * front if `x >= 0`, from the end if `x < 0` — with NO cycling (unlike
+     * `qTake` above): dropping more items than `y` has simply empties it.
+     * Ported 1:1 from `q_runtime::builtins::drop_`. `y` is scoped to rank
+     * <= 1, mirroring `qTake`'s identical restriction.
+     */
+    function qDrop(x, y) {
+      x = toArrayValue(x);
+      y = toArrayValue(y);
+      if (x.shape.length !== 0) {
+        throw new Error("q_drop: dyadic left argument (drop count) must be a scalar");
+      }
+      if (y.shape.length > 1) {
+        throw new Error(`q_drop: dyadic right argument must be a scalar or vector (rank <= 1), got rank ${y.shape.length}`);
+      }
+      const n = x.data[0];
+      if (!Number.isInteger(n)) {
+        throw new Error(`q_drop: drop count must be an integer, got ${n}`);
+      }
+      const src = y.data;
+      const len = src.length;
+      const k = Math.min(Math.abs(n), len);
+      const out = n >= 0 ? src.slice(k) : src.slice(0, len - k);
+      return ndarray([out.length], Float64Array.from(out));
+    }
+
+    /**
+     * Dyadic `~` (match): deep equality — same shape AND every element
+     * exactly equal (plain `===`, no floating-point tolerance, matching
+     * every other comparison in this domain) — producing a single scalar
+     * `1` or `0`, NOT an elementwise array (a genuine, deliberate
+     * difference from every other dyadic primitive in this domain, which
+     * are all elementwise). Ported 1:1 from `q_runtime::builtins::match_`.
+     */
+    function qMatch(a, b) {
+      a = toArrayValue(a);
+      b = toArrayValue(b);
+      const eqShape = sameShape(a.shape, b.shape);
+      const eqData = eqShape && a.data.length === b.data.length
+        && Array.from(a.data).every((v, i) => v === b.data[i]);
+      return ndarray([], Float64Array.of(eqShape && eqData ? 1 : 0));
+    }
+
     /**
      * Format one number the way `apl_runtime::value::fmt_num` (APL) or
      * `j_runtime::value::fmt_num` (J, when `SIR_DISPLAY_J_UNDERSCORE` is
@@ -5174,6 +5388,9 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
       catenate, display,
       // SIR22 addendum (J's two genuinely new primitives, no APL precedent).
       tally, replicate, monadicExp,
+      // SIR22 addendum (Q's five genuinely new primitives, no APL/J
+      // precedent -- see `q-to-semantic-ir`'s own module doc comment).
+      qFirst, qWhere, qReverse, qNot, qTake, qDrop, qMatch,
       // Exported so `formatSeen` (defined outside this IIFE, near the top
       // of the file) can render a bare/boxed scalar through the SAME
       // high-minus-aware number formatter a raw NDArray already uses via

--- a/code/specs/MA11-q-language.md
+++ b/code/specs/MA11-q-language.md
@@ -272,6 +272,22 @@ their own harder extras:**
   one, since it depends on what the shared IR already has by the time
   `q-to-semantic-ir` starts.
 
+  **Resolved by MA-11e itself**: `semantic-ir`'s core (not a SIR22
+  addendum at all — this need predates Q, from the general-purpose-language
+  frontends) already had everything required: an ordinary
+  `semantic_ir::Function` with named parameters, `Expr::DirectCall` (a
+  statically-known callee), `Expr::MakeClosure` (a bare reference to a
+  named function used as a value), and `Expr::IndirectCall` (a call through
+  a value whose identity is not statically known). No SIR addendum item was
+  needed at all. A function literal does **not** lower to a single
+  `Closure`-shaped node the way this section's own phrasing speculated —
+  each one becomes its own genuine top-level `Function` (this is closer to
+  Python's/Ruby's own lambda-lifting than to a single first-class-closure
+  value node), simplified considerably by the fact that Q's own function
+  values capture nothing at all (§2's own finding): no free-variable
+  analysis, no capture list, ever. See `q-to-semantic-ir/src/lower.rs`'s
+  module doc comment for the full design.
+
 ## §6 Crate layout and rollout (one item = one PR)
 
 ```


### PR DESCRIPTION
## Summary
- New crate `q-to-semantic-ir`, lowering Q's CST (from `q-parser`) into `semantic_ir::Module`, following the established `<lang>-to-semantic-ir` pattern (10+ prior sibling frontends).
- All 17 of Q's primitive verbs lower onto existing SIR22/APL-J-addendum machinery (`ElementwiseOp`, `Reduce`, `Scan`, index-generator, `Ravel`, `Catenate`). Only 5 genuinely new primitives were needed (`q_first`, `q_where`, `q_reverse`, `q_not`, plus dyadic `q_take`/`q_drop`/`q_match`), added **additively** to `semantic-ir-to-javascript`'s shared runtime (0.50.0→0.51.0) — ported 1:1 from `q_runtime::builtins`, cross-checked line-by-line against the Rust source.
- `QFn::Lambda` (Q's user-defined function literal, `{[x;y] ...}`) is the one lowering surface with no APL/J precedent: each literal lowers to its own top-level `semantic_ir::Function` (no capture-list needed, since Q closures capture nothing). A shared dispatch rule picks `Expr::DirectCall` (statically-known callee) vs. `Expr::MakeClosure`+`Expr::IndirectCall` (dynamic/higher-order calls), handling first-class function values with no special-casing.
- 80 tests total: 57 shape-assertion unit tests, 10 validator tests, 12 end-to-end `node` execution tests, 1 oracle test (33-case corpus vs. `q-runtime` ground truth: 28 fully verified, 5 correctly marked `known_bug` for a pre-existing, shared, not-fixed-here display-convention gap — see follow-up task below).

## Security fix included
`/security-review` found a real MEDIUM issue: a top-level Q variable literally named `main` (legal — Q's `NAME` grammar has no reserved-word exclusion) collided with the module's own hardcoded entry-point function name, producing a module-scope `let main = null;` next to `function main() {...}` — a genuine `node` `SyntaxError`, confirmed empirically, that neither `semantic_ir::validate` nor the JS backend's own validation caught. Fixed by rejecting this at lowering time with a clean, disclosed error. Added a permanent regression test, verified by reverting the fix (compiles cleanly instead of being rejected without it). A second security-review round on the fix passed clean.

Two smaller, pre-existing/shared findings were filed as separate follow-up tasks rather than expanding this PR's scope:
- Q's own ASCII-minus display convention is still missing from the shared SIR23/SIR22 stringifier (mirrors the earlier J-specific display-convention follow-up), responsible for the 5 `known_bug` oracle cases.
- `semantic-ir-to-javascript`'s `is_js_reserved` doesn't yet cover strict-mode-only reserved words (`eval`/`arguments`) — low severity, no code-execution risk, pre-existing and shared across every source language.

## Verification
- Independently re-ran the full test suite for both `q-to-semantic-ir` and the shared `semantic-ir-to-javascript` crate — all green.
- Cross-checked all 7 new shared-runtime primitives against `q_runtime::builtins`'s actual Rust source, line-by-line — confirmed faithful ports, including matching DoS guards (`checkedShapeSize` before allocating).
- Confirmed no regressions in downstream consumers (`derive-to-semantic-ir`, `j-to-semantic-ir` full suites re-run, unaffected).
- Spot-verified a `known_bug` oracle finding is real (not just asserted): temporarily flipped it to `None`, confirmed genuine mismatch (`¯1` vs `-1`), reverted.
- Spot-verified the security fix is real: reverted it, confirmed the new regression test then fails (compiles instead of rejecting), restored it.
- `cargo clippy --all-targets` clean on both crates.
- Two rounds of `/security-review`-equivalent agent review: round 1 found the MEDIUM `main`-collision issue (fixed + regression-tested), round 2 (on the fix) passed clean.

## Test plan
- [x] Full test suite (80 tests) green for `q-to-semantic-ir`
- [x] `semantic-ir-to-javascript` full suite green; downstream consumers unaffected
- [x] Security-fix regression test genuinely discriminates (reverted → fails, restored → passes)
- [x] `cargo clippy --all-targets` clean
- [x] Two security-review rounds, both resolved/clean