### PR TITLE
feat(app): carry etymological roots on each Lesson (HL03 phase-3 prerequisite)

### DIFF
--- a/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.8.1 — carry etymological roots on each lesson (HL03 phase 3 prerequisite)
+
+- `Lesson` now carries `roots: string[]` — the etymological roots a lesson cites
+  (e.g. `["bonus", "dies"]`). `toLesson` maps them from the frontmatter the same
+  way it maps `prerequisites`; the human-language-data parser already extracted
+  them, they just were not threaded into the app's `Lesson`.
+- This is the **join key for cross-language connections** (the next phase): two
+  lessons in different languages that share a root are etymologically linked.
+- Tests: roots parse through (a lesson citing none gets `[]`), and — against the
+  real curriculum — the Sanskrit root `dhanya` is carried by lessons in more
+  than one chain language (Hindi/Kannada/Telugu). Both fail if roots aren't
+  plumbed, confirmed by injection.
+
 ## 0.8.0 — the language chain and the teaching sweep (HL03 phase 2)
 
 - First implementation piece of the unified language-learning app

--- a/code/programs/typescript/script-writing-visualizer/package.json
+++ b/code/programs/typescript/script-writing-visualizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "script-writing-visualizer",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "description": "Companion study app (HL02): break a non-Latin script apart and learn to write it — and drill the whole written curriculum with a spaced-repetition schedule that remembers you",
   "type": "module",

--- a/code/programs/typescript/script-writing-visualizer/src/lessons.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/lessons.ts
@@ -51,6 +51,12 @@ export interface Lesson {
   concept: string;
   prerequisites: string[];
   reviewsOf: string[];
+  /**
+   * Etymological roots this lesson cites (e.g. `["bonus", "dies"]`). The join
+   * key for cross-language CONNECTIONS: two lessons in different languages that
+   * share a root are etymologically linked. `[]` when the lesson cites none.
+   */
+  roots: string[];
   /** Latin-script reading; equals `headword` for Latin-script tracks. */
   romanization: string;
   /** Script slug the package assigned from the track name. */
@@ -100,6 +106,7 @@ export function toLesson(parsed: ParsedLesson): Lesson | null {
     concept: r.concept,
     prerequisites: arr(fm.prerequisites),
     reviewsOf: arr(fm.reviews_of),
+    roots: arr(fm.roots),
     romanization: r.romanization,
     script: r.script,
     etymologyHook: r.etymologyHook,

--- a/code/programs/typescript/script-writing-visualizer/tests/concepts.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/concepts.test.ts
@@ -32,6 +32,7 @@ function lesson(over: Partial<Lesson> & { id: string }): Lesson {
     concept: "",
     prerequisites: [],
     reviewsOf: [],
+    roots: [],
     romanization: "",
     script: "latin",
     etymologyHook: "",

--- a/code/programs/typescript/script-writing-visualizer/tests/lessons.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/lessons.test.ts
@@ -20,6 +20,7 @@ gloss: the future
 concept_tag: ES-FUTURE
 prerequisites: [ES-C16-practice]
 reviews_of: [ES-C16-practice, ES-C06-hablar]
+roots: [futurus, esse]
 ---
 
 # body
@@ -102,6 +103,22 @@ describe("loadLessons", () => {
     const ids = loadLessons(sources).map((l) => l.id);
     expect([...ids].sort()).toEqual(ids);
   });
+
+  it("threads a lesson's etymological roots through — the cross-language join key", () => {
+    const byId = new Map(loadLessons(sources).map((l) => [l.id, l]));
+    expect(byId.get("ES-C17-futuro")!.roots).toEqual(["futurus", "esse"]);
+    // CONTROL: a lesson that cites no roots gets [], not undefined or a stray value.
+    expect(byId.get("TA-C06-dative-ukku")!.roots).toEqual([]);
+  });
+
+  it("the real curriculum carries roots (a Sanskrit root shared across the chain)", () => {
+    // `dhanya` (the Sanskrit root of "thanks") is cited by Hindi, Kannada and
+    // Telugu lessons — a real shared-root connection. If roots weren't plumbed
+    // through toLesson, every lesson's roots would be [] and this would fail.
+    const withDhanya = loadLessons().filter((l) => l.roots.includes("dhanya"));
+    const langs = new Set(withDhanya.map((l) => l.language));
+    expect(langs.size).toBeGreaterThanOrEqual(2);
+  });
 });
 
 /** A Lesson with everything defaulted, so a test only states what it cares about. */
@@ -115,6 +132,7 @@ export function lesson(over: Partial<Lesson> & { id: string }): Lesson {
     concept: "",
     prerequisites: [],
     reviewsOf: [],
+    roots: [],
     romanization: "",
     script: "latin",
     etymologyHook: "",

--- a/code/programs/typescript/script-writing-visualizer/tests/sequence.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/sequence.test.ts
@@ -24,6 +24,7 @@ function L(language: string, concept: string, chapter: number, id?: string): Les
     concept,
     prerequisites: [],
     reviewsOf: [],
+    roots: [],
     romanization: "x",
     script: language,
     etymologyHook: "",


### PR DESCRIPTION
Prerequisite for HL03 phase 3 (the session orchestrator that surfaces cross-language connections). Small, bounded.

## What & why

The app's `Lesson` now carries **`roots: string[]`** — the etymological roots a lesson cites (e.g. `["bonus", "dies"]`). `toLesson` maps them from frontmatter via `roots: arr(fm.roots)`, mirroring exactly how it already maps `prerequisites`. The human-language-data parser already extracted roots (`parse.ts:81`); they just weren't threaded into the app's `Lesson`.

This is the **join key** for cross-language etymological connections: two lessons in different languages that share a root are etymologically linked. (Recon found 34 roots span ≥2 chain languages — Dravidian roots across the four southern languages, Sanskrit roots bridging Hindi into Dravidian.)

## Tests — both fail if roots aren't plumbed (verified by injection)

- A fixture lesson's roots parse to `["futurus","esse"]`; a lesson citing none gets `[]` (not `undefined` or a stray value).
- Against the **real curriculum**, the Sanskrit root `dhanya` is carried by lessons in ≥2 chain languages — in fact **7** (Bengali/Hindi/Kannada/Marathi/Punjabi/Sanskrit/Telugu), so the assertion is safely true, not vacuous.

## The expected ripple

`roots` is a new **required** field, so `tsc` flagged three test `Lesson`-factory constructors (`lessons`/`sequence`/`concepts.test.ts`) that needed `roots: []`. Fixed so no constructor is left inconsistent — the standard consequence of adding a required field to a shared interface, caught before push. Reviewed: mapping correct, no other `Lesson` literal left missing the field, no security surface.

App CHANGELOG + version 0.8.0 → 0.8.1. **146 tests.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)