### PR TITLE
Add BJT forward excess phase support

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add BJT model-card `PTF` forward excess-phase support, rotating AC forward
+  transconductance by the configured phase at `1 / (2*pi*TF)`.
 - Add BJT model-card `AF` flicker-noise exponent support, defaulting to `1`
   and applying `KF * abs(Ib)^AF / frequency` across noise analysis.
 - Add BJT model-card `KF` flicker-noise support with a distinct `flicker`

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -612,6 +612,8 @@ class BJT:
         Flicker-noise coefficient (default 0.0, disabled).
     Af:
         Flicker-noise base-current exponent (default 1.0).
+    Ptf:
+        Excess phase at ``1 / (2*pi*Tf)`` in degrees (default 0.0).
     """
 
     name: str
@@ -648,6 +650,7 @@ class BJT:
     Tnom: float | None = None  # model nominal temperature (K); None inherits
     Kf: float = 0.0            # flicker-noise coefficient; 0 disables
     Af: float = 1.0            # flicker-noise base-current exponent
+    Ptf: float = 0.0           # excess phase at 1/(2*pi*Tf), degrees
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -605,7 +605,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr, element.Tnom, element.Kf, element.Af)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr, element.Tnom, element.Kf, element.Af, element.Ptf)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -9309,6 +9309,8 @@ def _validate_bjt(el: BJT) -> None:
         raise ValueError(f"{el.name}: BJT flicker noise coefficient must be finite and non-negative")
     if not math.isfinite(el.Af) or el.Af < 0.0:
         raise ValueError(f"{el.name}: BJT flicker noise exponent must be finite and non-negative")
+    if not math.isfinite(el.Ptf) or el.Ptf < 0.0:
+        raise ValueError(f"{el.name}: BJT forward excess phase must be finite and non-negative")
     if not math.isfinite(el.Ise) or el.Ise < 0.0:
         raise ValueError(
             f"{el.name}: BJT base-emitter leakage saturation current must be finite and non-negative"
@@ -12585,6 +12587,11 @@ def _stamp_ac(
         )
         g_pi: float = base_gm / el.beta_f + leakage_conductance
         diffusion_capacitance = el.Tf * gm_b
+        excess_phase = omega * el.Tf * el.Ptf * math.pi / 180.0
+        gm_ac = complex(
+            gm_b * math.cos(excess_phase),
+            -gm_b * math.sin(excess_phase),
+        )
         reverse_diffusion_capacitance = el.Tr * gm_reverse
         y_be = g_pi + 1j * omega * (
             _bjt_base_emitter_depletion_capacitance(el, Vjunc) + diffusion_capacitance
@@ -12601,30 +12608,30 @@ def _stamp_ac(
             if not _is_ground(el.collector):
                 c_i = node_to_idx[el.collector]
                 if not _is_ground(el.base):
-                    G[c_i][node_to_idx[el.base]] += gm_b + 0j
+                    G[c_i][node_to_idx[el.base]] += gm_ac
                 if not _is_ground(el.emitter):
-                    G[c_i][node_to_idx[el.emitter]] -= gm_b + 0j
+                    G[c_i][node_to_idx[el.emitter]] -= gm_ac
             if not _is_ground(el.emitter):
                 e_i = node_to_idx[el.emitter]
                 if not _is_ground(el.base):
-                    G[e_i][node_to_idx[el.base]] -= gm_b + 0j
+                    G[e_i][node_to_idx[el.base]] -= gm_ac
                 if not _is_ground(el.emitter):
-                    G[e_i][node_to_idx[el.emitter]] += gm_b + 0j
+                    G[e_i][node_to_idx[el.emitter]] += gm_ac
         else:  # PNP
             _stamp_g_c(G, node_to_idx, el.emitter, el.base, y_be)
             _stamp_g_c(G, node_to_idx, el.base, el.collector, y_bc)
             if not _is_ground(el.emitter):
                 e_i = node_to_idx[el.emitter]
                 if not _is_ground(el.emitter):
-                    G[e_i][node_to_idx[el.emitter]] += gm_b + 0j
+                    G[e_i][node_to_idx[el.emitter]] += gm_ac
                 if not _is_ground(el.base):
-                    G[e_i][node_to_idx[el.base]] -= gm_b + 0j
+                    G[e_i][node_to_idx[el.base]] -= gm_ac
             if not _is_ground(el.collector):
                 c_i = node_to_idx[el.collector]
                 if not _is_ground(el.emitter):
-                    G[c_i][node_to_idx[el.emitter]] -= gm_b + 0j
+                    G[c_i][node_to_idx[el.emitter]] -= gm_ac
                 if not _is_ground(el.base):
-                    G[c_i][node_to_idx[el.base]] += gm_b + 0j
+                    G[c_i][node_to_idx[el.base]] += gm_ac
 
 
 def ac_sweep(

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (29, 46, 13, 4),
-    "PNP": (29, 46, 13, 4),
+    "NPN": (30, 47, 13, 4),
+    "PNP": (30, 47, 13, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -383,6 +383,7 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "T_NOM": "TNOM",
     "KF": "KF",
     "AF": "AF",
+    "PTF": "PTF",
     "ISE": "ISE",
     "NE": "NE",
     "ISC": "ISC",
@@ -947,6 +948,7 @@ def bjt_from_model_card(
         Tnom=(p["TNOM"] + 273.15) if "TNOM" in p else None,
         Kf=p.get("KF", 0.0),
         Af=p.get("AF", 1.0),
+        Ptf=p.get("PTF", 0.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 116
+    assert len(coverage) == 118
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 116
+    assert len(records) == 118
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,9 +501,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 116
-    assert report.expected_canonical_parameter_count == 116
-    assert report.accepted_name_count == 182
+    assert report.canonical_parameter_count == 118
+    assert report.expected_canonical_parameter_count == 118
+    assert report.accepted_name_count == 184
     assert report.aliased_parameter_count == 53
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -511,7 +511,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t116\t116\t182\t53\t4\t0"
+        "true\t7\t7\t118\t118\t184\t53\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,8 +539,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 115
-    assert report.accepted_name_count == 179
+    assert report.canonical_parameter_count == 117
+    assert report.accepted_name_count == 181
     assert report.aliased_parameter_count == 52
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t115\t116\t179\t52\t4\t4\n"
+        "false\t7\t7\t117\t118\t181\t52\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,10 +647,10 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
+        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "TNOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
+    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "TNOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.beta_r == pytest.approx(0.25)
@@ -665,6 +665,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert bjt_model.Tnom == pytest.approx(323.15)
     assert bjt_model.Kf == pytest.approx(1.0e-12)
     assert bjt_model.Af == pytest.approx(1.3)
+    assert bjt_model.Ptf == pytest.approx(30.0)
     assert bjt_model.Ise == pytest.approx(3.0e-13)
     assert bjt_model.Ne == pytest.approx(1.7)
     assert bjt_model.Isc == pytest.approx(4.0e-13)
@@ -2306,7 +2307,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3, Tnom=323.15, Kf=1.0e-12, Af=1.3),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3, Tnom=323.15, Kf=1.0e-12, Af=1.3, Ptf=30.0),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2335,6 +2336,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.Tnom == pytest.approx(323.15)
     assert expanded.Kf == pytest.approx(1.0e-12)
     assert expanded.Af == pytest.approx(1.3)
+    assert expanded.Ptf == pytest.approx(30.0)
 
 
 def test_branch_current_in_voltage_source():
@@ -2586,6 +2588,13 @@ def test_dc_rejects_invalid_bjt_flicker_noise_exponent():
     circuit = Circuit()
     circuit.add(BJT("Qbad", "c", "b", "0", Af=-1.0))
     with pytest.raises(ValueError, match="flicker noise exponent must be finite and non-negative"):
+        dc_op(circuit)
+
+
+def test_dc_rejects_invalid_bjt_forward_excess_phase():
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", Ptf=-1.0))
+    with pytest.raises(ValueError, match="forward excess phase must be finite and non-negative"):
         dc_op(circuit)
 
 
@@ -4405,6 +4414,27 @@ def test_ac_bjt_transit_time_adds_diffusion_capacitance():
 
     assert without_transit_time > 0.9
     assert with_transit_time < without_transit_time / 100.0
+
+
+def test_ac_bjt_forward_excess_phase_rotates_transconductance():
+    def collector_voltage(ptf: float) -> complex:
+        tf = 1.0e-6
+        frequency = 1.0 / (2.0 * math.pi * tf)
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vac", "base", "0", 0.0, ac=AcSource(1.0)))
+        circuit.add(Resistor("Rc", "col", "0", 1.0))
+        circuit.add(BJT("Q1", "col", "base", "0", Is=25.85e-6, Tf=tf, Ptf=ptf))
+        return ac_sweep(
+            circuit, f_start=frequency, f_stop=frequency, n_points=1
+        ).points[0].node_voltages["col"]
+
+    without_excess_phase = collector_voltage(0.0)
+    with_excess_phase = collector_voltage(90.0)
+
+    assert without_excess_phase.real < -0.0009
+    assert abs(without_excess_phase.imag) < 1.0e-9
+    assert with_excess_phase.imag > 0.0009
+    assert abs(with_excess_phase.real) < 1.0e-9
 
 
 def test_ac_bjt_reverse_transit_time_adds_collector_diffusion_capacitance():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add BJT model-card `PTF` forward excess-phase support, rotating AC forward
+  transconductance by the configured phase at `1 / (2*pi*TF)`.
 - Add BJT model-card `AF` flicker-noise exponent support, defaulting to `1`
   and applying `KF * abs(Ib)^AF / frequency` across noise analysis.
 - Add BJT model-card `KF` flicker-noise support with a distinct `flicker`

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -456,6 +456,7 @@ fn clone_subckt_element(
             expanded.nominal_temperature_kelvin = element.nominal_temperature_kelvin;
             expanded.flicker_noise_coefficient = element.flicker_noise_coefficient;
             expanded.flicker_noise_exponent = element.flicker_noise_exponent;
+            expanded.forward_excess_phase_degrees = element.forward_excess_phase_degrees;
             Element::Bjt(expanded)
         }
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
@@ -2900,6 +2901,7 @@ pub struct Bjt {
     pub nominal_temperature_kelvin: Option<f64>,
     pub flicker_noise_coefficient: f64,
     pub flicker_noise_exponent: f64,
+    pub forward_excess_phase_degrees: f64,
 }
 
 impl Bjt {
@@ -3365,6 +3367,7 @@ impl Bjt {
             nominal_temperature_kelvin: None,
             flicker_noise_coefficient: 0.0,
             flicker_noise_exponent: 1.0,
+            forward_excess_phase_degrees: 0.0,
         }
     }
 }
@@ -3755,8 +3758,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 29, 46, 13, 4),
-    (ModelCardKind::Pnp, 29, 46, 13, 4),
+    (ModelCardKind::Npn, 30, 47, 13, 4),
+    (ModelCardKind::Pnp, 30, 47, 13, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3811,6 +3814,7 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("T_NOM", "TNOM"),
     ("KF", "KF"),
     ("AF", "AF"),
+    ("PTF", "PTF"),
     ("ISE", "ISE"),
     ("NE", "NE"),
     ("ISC", "ISC"),
@@ -4507,6 +4511,7 @@ pub fn bjt_from_model_card(
         .map(|temperature_celsius| temperature_celsius + 273.15);
     bjt.flicker_noise_coefficient = model_card_value(model, "KF", 0.0);
     bjt.flicker_noise_exponent = model_card_value(model, "AF", 1.0);
+    bjt.forward_excess_phase_degrees = model_card_value(model, "PTF", 0.0);
     Ok(bjt)
 }
 
@@ -22996,9 +23001,15 @@ fn stamp_ac_bjt_small_signal(
     } else {
         base_collector_current / bjt.forward_early_voltage / charge_factor
     };
-    let gm = Complex::new(forward_gm, 0.0);
+    let excess_phase =
+        omega * bjt.forward_transit_time * bjt.forward_excess_phase_degrees * std::f64::consts::PI
+            / 180.0;
+    let gm = Complex::new(
+        forward_gm * excess_phase.cos(),
+        -forward_gm * excess_phase.sin(),
+    );
     let reverse_gm = bjt.saturation_current / reverse_thermal_voltage * reverse_exponent.exp();
-    let diffusion_capacitance = bjt.forward_transit_time * gm.real;
+    let diffusion_capacitance = bjt.forward_transit_time * forward_gm;
     let reverse_diffusion_capacitance = bjt.reverse_transit_time * reverse_gm;
     let (_, leakage_conductance) = bjt_base_emitter_leakage(bjt, junction_voltage);
     let (_, collector_leakage_conductance) =
@@ -24053,6 +24064,12 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "flicker noise exponent must be finite and non-negative".to_string(),
+        });
+    }
+    if !bjt.forward_excess_phase_degrees.is_finite() || bjt.forward_excess_phase_degrees < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "forward excess phase must be finite and non-negative".to_string(),
         });
     }
     if !bjt.base_emitter_leakage_saturation_current.is_finite()

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -828,6 +828,47 @@ fn ac_bjt_uses_forward_transit_time_as_diffusion_capacitance() {
 }
 
 #[test]
+fn ac_bjt_forward_excess_phase_rotates_transconductance() {
+    fn collector_voltage(forward_excess_phase_degrees: f64) -> Complex {
+        let forward_transit_time = 1.0e-6;
+        let frequency = 1.0 / (2.0 * std::f64::consts::PI * forward_transit_time);
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "base", "0", 0.0, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new("Rc", "col", "0", 1.0)));
+        let mut transistor = Bjt::with_model(
+            "Q1",
+            "col",
+            "base",
+            "0",
+            BjtPolarity::Npn,
+            25.85e-6,
+            100.0,
+            0.02585,
+            0.0,
+            0.0,
+            forward_transit_time,
+            0.0,
+        );
+        transistor.forward_excess_phase_degrees = forward_excess_phase_degrees;
+        circuit.add(Element::Bjt(transistor));
+
+        ac_sweep(&circuit, frequency, frequency, 1).unwrap()[0]
+            .voltage("col")
+            .unwrap()
+    }
+
+    let without_excess_phase = collector_voltage(0.0);
+    let with_excess_phase = collector_voltage(90.0);
+
+    assert!(without_excess_phase.real < -0.0009);
+    assert!(without_excess_phase.imag.abs() < 1.0e-9);
+    assert!(with_excess_phase.imag > 0.0009);
+    assert!(with_excess_phase.real.abs() < 1.0e-9);
+}
+
+#[test]
 fn ac_bjt_uses_reverse_transit_time_as_base_collector_diffusion_capacitance() {
     fn base_amplitude(reverse_transit_time: f64) -> f64 {
         let mut circuit = Circuit::new();

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 116);
+    assert_eq!(coverage.len(), 118);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 116);
+    assert_eq!(records.len(), 118);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 116);
-    assert_eq!(report.expected_canonical_parameter_count, 116);
-    assert_eq!(report.accepted_name_count, 182);
+    assert_eq!(report.canonical_parameter_count, 118);
+    assert_eq!(report.expected_canonical_parameter_count, 118);
+    assert_eq!(report.accepted_name_count, 184);
     assert_eq!(report.aliased_parameter_count, 53);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t116\t116\t182\t53\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t118\t118\t184\t53\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,8 +235,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 115);
-    assert_eq!(report.accepted_name_count, 179);
+    assert_eq!(report.canonical_parameter_count, 117);
+    assert_eq!(report.accepted_name_count, 181);
     assert_eq!(report.aliased_parameter_count, 52);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t115\t116\t179\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t117\t118\t181\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -439,6 +439,7 @@ fn model_card_aliases_build_device_instances() {
             ("T_NOM", 50.0),
             ("KF", 1.0e-12),
             ("AF", 1.3),
+            ("PTF", 30.0),
             ("ISE", 3.0e-13),
             ("NE", 1.7),
             ("ISC", 4.0e-13),
@@ -467,6 +468,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("TNOM").unwrap(), 50.0);
     assert_close(*bjt_card.parameters.get("KF").unwrap(), 1.0e-12);
     assert_close(*bjt_card.parameters.get("AF").unwrap(), 1.3);
+    assert_close(*bjt_card.parameters.get("PTF").unwrap(), 30.0);
     assert_close(*bjt_card.parameters.get("ISE").unwrap(), 3.0e-13);
     assert_close(*bjt_card.parameters.get("NE").unwrap(), 1.7);
     assert_close(*bjt_card.parameters.get("ISC").unwrap(), 4.0e-13);
@@ -492,6 +494,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(bjt_model.nominal_temperature_kelvin.unwrap(), 323.15);
     assert_close(bjt_model.flicker_noise_coefficient, 1.0e-12);
     assert_close(bjt_model.flicker_noise_exponent, 1.3);
+    assert_close(bjt_model.forward_excess_phase_degrees, 30.0);
     assert_close(bjt_model.base_emitter_leakage_saturation_current, 3.0e-13);
     assert_close(bjt_model.base_emitter_leakage_emission_coefficient, 1.7);
     assert_close(bjt_model.base_collector_leakage_saturation_current, 4.0e-13);
@@ -1435,6 +1438,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     bjt.nominal_temperature_kelvin = Some(323.15);
     bjt.flicker_noise_coefficient = 1.0e-12;
     bjt.flicker_noise_exponent = 1.3;
+    bjt.forward_excess_phase_degrees = 30.0;
     let mut circuit = Circuit::new();
     circuit
         .define_subcircuit(SubcircuitDefinition::new(
@@ -1481,6 +1485,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.nominal_temperature_kelvin.unwrap(), 323.15);
     assert_close(expanded.flicker_noise_coefficient, 1.0e-12);
     assert_close(expanded.flicker_noise_exponent, 1.3);
+    assert_close(expanded.forward_excess_phase_degrees, 30.0);
 }
 
 #[test]
@@ -2024,6 +2029,18 @@ fn dc_rejects_invalid_bjt_flicker_noise_exponent() {
     assert!(error
         .to_string()
         .contains("flicker noise exponent must be finite and non-negative"));
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_forward_excess_phase() {
+    let mut transistor = Bjt::new("Qbad", "c", "b", "0");
+    transistor.forward_excess_phase_degrees = -1.0;
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Bjt(transistor));
+    let error = dc_op(&circuit).unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("forward excess phase must be finite and non-negative"));
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add BJT model-card `PTF` forward excess-phase support, rotating AC forward
+  transconductance by the configured phase at `1 / (2*pi*TF)`.
 - Add BJT model-card `AF` flicker-noise exponent support, defaulting to `1`
   and applying `KF * abs(Ib)^AF / frequency` across noise analysis.
 - Add BJT model-card `KF` flicker-noise support with a distinct `flicker`

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1732,6 +1732,7 @@ export interface Bjt {
   readonly nominalTemperatureKelvin: number | undefined;
   readonly flickerNoiseCoefficient: number;
   readonly flickerNoiseExponent: number;
+  readonly forwardExcessPhaseDegrees: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -2009,8 +2010,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [29, 46, 13, 4],
-  PNP: [29, 46, 13, 4],
+  NPN: [30, 47, 13, 4],
+  PNP: [30, 47, 13, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3600,7 +3601,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7788,6 +7789,7 @@ export function bjt(
   nominalTemperatureKelvin: number | undefined = undefined,
   flickerNoiseCoefficient = 0.0,
   flickerNoiseExponent = 1.0,
+  forwardExcessPhaseDegrees = 0.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7825,6 +7827,7 @@ export function bjt(
     nominalTemperatureKelvin,
     flickerNoiseCoefficient,
     flickerNoiseExponent,
+    forwardExcessPhaseDegrees,
   };
 }
 
@@ -7939,6 +7942,7 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   T_NOM: "TNOM",
   KF: "KF",
   AF: "AF",
+  PTF: "PTF",
   ISE: "ISE",
   NE: "NE",
   ISC: "ISC",
@@ -8475,6 +8479,7 @@ export function bjtFromModelCard(
     p.TNOM !== undefined ? p.TNOM + 273.15 : undefined,
     p.KF ?? 0.0,
     p.AF ?? 1.0,
+    p.PTF ?? 0.0,
   );
 }
 
@@ -19950,6 +19955,9 @@ function validateBjt(element: Bjt): void {
   if (!Number.isFinite(element.flickerNoiseExponent) || element.flickerNoiseExponent < 0.0) {
     throw invalidElement(element.name, "flicker noise exponent must be finite and non-negative");
   }
+  if (!Number.isFinite(element.forwardExcessPhaseDegrees) || element.forwardExcessPhaseDegrees < 0.0) {
+    throw invalidElement(element.name, "forward excess phase must be finite and non-negative");
+  }
   if (!Number.isFinite(element.baseEmitterLeakageSaturationCurrent) || element.baseEmitterLeakageSaturationCurrent < 0.0) {
     throw invalidElement(element.name, "base-emitter leakage saturation current must be finite and non-negative");
   }
@@ -21927,6 +21935,12 @@ function stampAcBjtSmallSignal(
   const junctionConductance =
     baseTransconductance / element.forwardBeta + leakage.conductance;
   const diffusionCapacitance = element.forwardTransitTime * transconductance;
+  const excessPhase =
+    omega * element.forwardTransitTime * element.forwardExcessPhaseDegrees * Math.PI / 180.0;
+  const acTransconductance = complex(
+    transconductance * Math.cos(excessPhase),
+    -transconductance * Math.sin(excessPhase),
+  );
   const reverseTransconductance =
     element.saturationCurrent / reverseThermalVoltage * Math.exp(reverseExponent);
   const reverseDiffusionCapacitance = element.reverseTransitTime * reverseTransconductance;
@@ -21958,7 +21972,7 @@ function stampAcBjtSmallSignal(
       emitter,
       base,
       emitter,
-      complex(transconductance, 0.0),
+      acTransconductance,
     );
   } else {
     stampComplexConductance(
@@ -21974,7 +21988,7 @@ function stampAcBjtSmallSignal(
       collector,
       emitter,
       base,
-      complex(transconductance, 0.0),
+      acTransconductance,
     );
   }
 }

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -575,6 +575,29 @@ describe("acSweep", () => {
     expect(withTransitTime).toBeLessThan(withoutTransitTime / 100.0);
   });
 
+  it("rotates BJT transconductance by the forward excess phase", () => {
+    function collectorVoltage(forwardExcessPhaseDegrees: number): Complex {
+      const forwardTransitTime = 1.0e-6;
+      const frequency = 1.0 / (TWO_PI_FOR_TEST * forwardTransitTime);
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "base", "0", 0.0, 1.0));
+      circuit.add(resistor("Rc", "col", "0", 1.0));
+      circuit.add({
+        ...bjt("Q1", "col", "base", "0", "NPN", 25.85e-6, 100.0, 0.02585, 0.0, 0.0, forwardTransitTime),
+        forwardExcessPhaseDegrees,
+      });
+      return acSweep(circuit, frequency, frequency, 1)[0].voltage("col")!;
+    }
+
+    const withoutExcessPhase = collectorVoltage(0.0);
+    const withExcessPhase = collectorVoltage(90.0);
+
+    expect(withoutExcessPhase.real).toBeLessThan(-0.0009);
+    expect(Math.abs(withoutExcessPhase.imag)).toBeLessThan(1.0e-9);
+    expect(withExcessPhase.imag).toBeGreaterThan(0.0009);
+    expect(Math.abs(withExcessPhase.real)).toBeLessThan(1.0e-9);
+  });
+
   it("uses BJT reverse transit time as base-collector diffusion capacitance in AC analysis", () => {
     function baseAmplitude(reverseTransitTime: number): number {
       const circuit = new Circuit();

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(116);
+    expect(coverage).toHaveLength(118);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(116);
+    expect(records).toHaveLength(118);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 116,
-      expectedCanonicalParameterCount: 116,
-      acceptedNameCount: 182,
+      canonicalParameterCount: 118,
+      expectedCanonicalParameterCount: 118,
+      acceptedNameCount: 184,
       aliasedParameterCount: 53,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t116\t116\t182\t53\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t118\t118\t184\t53\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,8 +241,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(115);
-    expect(report.acceptedNameCount).toBe(179);
+    expect(report.canonicalParameterCount).toBe(117);
+    expect(report.acceptedNameCount).toBe(181);
     expect(report.aliasedParameterCount).toBe(52);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t115\t116\t179\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t117\t118\t181\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -345,6 +345,7 @@ describe("dcOp", () => {
       T_NOM: 50.0,
       KF: 1.0e-12,
       AF: 1.3,
+      PTF: 30.0,
       ISE: 3.0e-13,
       NE: 1.7,
       ISC: 4.0e-13,
@@ -358,7 +359,7 @@ describe("dcOp", () => {
       FC: 0.4,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, TNOM: 50.0, KF: 1.0e-12, AF: 1.3, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, TNOM: 50.0, KF: 1.0e-12, AF: 1.3, PTF: 30.0, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.reverseBeta, 0.25);
@@ -373,6 +374,7 @@ describe("dcOp", () => {
     expectClose(bjtModel.nominalTemperatureKelvin, 323.15);
     expectClose(bjtModel.flickerNoiseCoefficient, 1.0e-12);
     expectClose(bjtModel.flickerNoiseExponent, 1.3);
+    expectClose(bjtModel.forwardExcessPhaseDegrees, 30.0);
     expectClose(bjtModel.baseEmitterLeakageSaturationCurrent, 3.0e-13);
     expectClose(bjtModel.baseEmitterLeakageEmissionCoefficient, 1.7);
     expectClose(bjtModel.baseCollectorLeakageSaturationCurrent, 4.0e-13);
@@ -1016,7 +1018,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3, 323.15, 1.0e-12, 1.3),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3, 323.15, 1.0e-12, 1.3, 30.0),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -1046,6 +1048,7 @@ describe("dcOp", () => {
       expectClose(expanded.nominalTemperatureKelvin, 323.15);
       expectClose(expanded.flickerNoiseCoefficient, 1.0e-12);
       expectClose(expanded.flickerNoiseExponent, 1.3);
+      expectClose(expanded.forwardExcessPhaseDegrees, 30.0);
     }
   });
 
@@ -1408,6 +1411,14 @@ describe("dcOp", () => {
     circuit.add({ ...bjt("Qbad", "c", "b", "0"), flickerNoiseExponent: -1.0 });
     expect(() => dcOp(circuit)).toThrowError(
       "flicker noise exponent must be finite and non-negative",
+    );
+  });
+
+  it("rejects invalid BJT forward excess phase", () => {
+    const circuit = new Circuit();
+    circuit.add({ ...bjt("Qbad", "c", "b", "0"), forwardExcessPhaseDegrees: -1.0 });
+    expect(() => dcOp(circuit)).toThrowError(
+      "forward excess phase must be finite and non-negative",
     );
   });
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,16 +33,16 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT flicker-noise exponent.
+1. Cross-language BJT forward excess phase.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `AF` model-card support in Rust, Python, and TypeScript,
-     defaulting to one so existing `KF` noise results remain unchanged.
-   - Apply the exponent to base-current flicker noise as
-     `KF * abs(Ib)^AF / frequency` while preserving the complete BJT model
-     through subcircuits.
-   - Extend the supported-parameter coverage gate from 114 to 116 canonical
-     rows and lock model-card behavior, validation, hierarchy, and noise
-     scaling in all engines.
+   - Add Berkeley BJT `PTF` model-card support in Rust, Python, and TypeScript,
+     defaulting to zero so existing AC results remain unchanged.
+   - Rotate forward AC transconductance by the configured excess phase at
+     `1 / (2*pi*TF)` while preserving `TF` diffusion capacitance and the
+     complete BJT model through subcircuits.
+   - Extend the supported-parameter coverage gate from 116 to 118 canonical
+     rows and lock model-card behavior, validation, hierarchy, and AC phase in
+     all engines.
 
 ## Completed Slices
 
@@ -3126,6 +3126,14 @@ the Rust, Python, and TypeScript surfaces together.
      Berkeley-default `AF=1` inverse-frequency slope.
    - Hierarchical subcircuit expansion preserves the complete BJT model, and
      the supported-parameter release gate now covers 114 canonical rows.
+
+235. Cross-language BJT flicker-noise exponent.
+   - Status: completed in PR 8815.
+   - Rust, Python, and TypeScript BJT model cards now accept `AF`, default it
+     to one, and apply it to base-current flicker noise as
+     `KF * abs(Ib)^AF / frequency`.
+   - Hierarchical subcircuit expansion preserves the complete BJT model, and
+     the supported-parameter release gate now covers 116 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- accept Berkeley BJT `PTF` model-card values across Rust, Python, and TypeScript
- rotate forward AC transconductance by the configured phase at `1 / (2*pi*TF)` while keeping diffusion capacitance unchanged
- preserve and validate `PTF` through hierarchy expansion, advance the model-card coverage gate to 118 rows, and reconcile the SPICE plan

## Verification
- `cargo fmt -p spice-engine -- --check`
- Rust: 368 tests passed across all `spice-engine` integration binaries
- Python: 560 tests passed, 88.81% coverage
- TypeScript: build passed; 318 tests passed
- Ruff passed for touched Python source and test files
- `git diff --check`