### PR TITLE
feat(x86_64-encoder): RIP-relative lea primitives for GC stack-map registration (AOT00-T1 x86_64 PR-x3a)

### DIFF
--- a/code/packages/rust/x86_64-encoder/CHANGELOG.md
+++ b/code/packages/rust/x86_64-encoder/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changelog — `x86_64-encoder`
 
-## 0.6.0 — 2026-06-28 (AL8-sqrt — `SQRTSD xmm_dst, xmm_src`)
+## 0.7.0 — 2026-07-23 — RIP-relative `lea` primitives (GC stack-map registration)
+
+Three additive primitives the twig-aot x86-64 GC stack-map registration codegen
+(`__gc_init_stackmaps`, AOT00-T1 x86_64 PR-x3) needs to point registers at constant
+tables and cross-function code addresses — the x86-64 analogue of the aarch64 encoder's
+`adr` / `adr_placeholder` / `emit_data_word`:
+
+- **`lea_rip_label(dst, label)`** — `LEA r64, [RIP + <label>]` to a label bound later in
+  the same function, resolved at `finish()` via the existing fix-up mechanism (like a
+  `jmp`). No relocation — the target is intra-function. Points a register at a data word
+  embedded in the stream.
+- **`lea_rip_placeholder(dst) -> usize`** — `LEA r64, [RIP + #0]` returning its `disp32`
+  slot offset, for a caller that patches the displacement once a cross-function target
+  offset is known (`disp32 = target − (slot + 4)`). Base-independent (RIP cancels the
+  load base), so no relocation is needed — the x86-64 counterpart of the aarch64 `ADR`
+  used for `func_start`.
+- **`emit_data_u32(word) -> usize`** — append a raw little-endian `u32` table element
+  (constant data, not an instruction), returning its byte offset.
+
+Three unit tests (byte-exact `48 8D …` encodings + a data-pool round trip + iced-x86
+decode confirming the `lea`). Purely additive; existing encodings unchanged.
 
 ### Added — `sqrtsd`
 

--- a/code/packages/rust/x86_64-encoder/Cargo.toml
+++ b/code/packages/rust/x86_64-encoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86_64-encoder"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Pure-Rust x86-64 (AMD64 / Intel 64) instruction encoder — covers the subset needed by jit-core / aot-core to lower CIR to native machine code on Linux and Windows."
 

--- a/code/packages/rust/x86_64-encoder/src/lib.rs
+++ b/code/packages/rust/x86_64-encoder/src/lib.rs
@@ -476,6 +476,48 @@ impl Assembler {
         });
     }
 
+    /// `LEA r64, [RIP + <label>]` — load the RIP-relative address of a **label** bound
+    /// later in this same function; resolved at [`finish`](Self::finish) like a `jmp`.
+    /// Unlike [`lea_rip_rel`](Self::lea_rip_rel) this needs no relocation — the target is
+    /// intra-function, so the displacement is known once the label is bound. Used to
+    /// point a register at a constant table embedded in the instruction stream (see
+    /// [`emit_data_u32`](Self::emit_data_u32)). `0x8D /r`, RIP-relative form (7 bytes).
+    pub fn lea_rip_label(&mut self, dst: Reg, target: LabelId) {
+        self.emit_u8(rex(true, dst.high1(), false, false));
+        self.emit_u8(0x8D);
+        self.emit_u8(modrm(0b00, dst.low3(), 0b101));
+        let slot_offset = self.code.len();
+        self.emit_u32_le(0); // placeholder disp32
+        let instr_end_offset = self.code.len();
+        self.fixups.push(Fixup { slot_offset, instr_end_offset, target });
+    }
+
+    /// `LEA r64, [RIP + #0]` as a **placeholder**, returning the byte offset of its
+    /// `disp32` slot for a caller that patches it once a target offset is known — the
+    /// RIP-relative analogue of a cross-function reference. The caller writes
+    /// `disp32 = target_off − (slot + 4)` (the `+4` is the distance from the slot to the
+    /// end of the instruction = the RIP value). Base-independent: `RIP` and the target
+    /// both carry the load base, so it cancels — no relocation needed. `0x8D /r` (7
+    /// bytes). No fix-up is queued; `finish()` leaves the placeholder for the caller.
+    pub fn lea_rip_placeholder(&mut self, dst: Reg) -> usize {
+        self.emit_u8(rex(true, dst.high1(), false, false));
+        self.emit_u8(0x8D);
+        self.emit_u8(modrm(0b00, dst.low3(), 0b101));
+        let slot = self.code.len();
+        self.emit_u32_le(0); // placeholder disp32 — patched by the caller
+        slot
+    }
+
+    /// Append a raw little-endian `u32` **data word** to the stream and return its byte
+    /// offset. This is constant data (a `u32`/`i32` table element), not an instruction;
+    /// it is only safe where control flow cannot reach it (after a `ret`, or a region
+    /// referenced solely by [`lea_rip_label`](Self::lea_rip_label)).
+    pub fn emit_data_u32(&mut self, w: u32) -> usize {
+        let off = self.code.len();
+        self.emit_u32_le(w);
+        off
+    }
+
     // -----------------------------------------------------------------------
     // Arithmetic
     // -----------------------------------------------------------------------
@@ -1464,6 +1506,55 @@ mod tests {
             0x48, 0x01, 0xD0,
             0xC3,
         ]);
+    }
+
+    // ---- RIP-relative lea (GC stack-map registration) ----
+
+    #[test]
+    fn lea_rip_label_resolves_to_embedded_data() {
+        // lea rcx, [rip + <data>]  =  48 8D 0D <disp32>
+        // ret ; then a data word the lea points at.
+        let mut a = Assembler::new();
+        let lbl = a.create_label();
+        a.lea_rip_label(Reg::Rcx, lbl);
+        a.ret();
+        a.bind(lbl).unwrap();
+        a.emit_data_u32(0xDEAD_BEEF);
+        let bytes = finish(a);
+        assert_eq!(&bytes[0..3], &[0x48, 0x8D, 0x0D], "REX.W lea rcx, [rip+...]");
+        // The lea is 7 bytes; instr_end = 7; the data label is bound at offset 8 (after
+        // the 1-byte ret). disp32 = 8 - 7 = 1.
+        assert_eq!(&bytes[3..7], &1i32.to_le_bytes(), "disp32 = data_off - instr_end");
+        assert_eq!(&bytes[7..8], &[0xC3], "ret");
+        assert_eq!(&bytes[8..12], &0xDEAD_BEEFu32.to_le_bytes(), "data word verbatim");
+    }
+
+    #[test]
+    fn lea_rip_placeholder_returns_disp_slot() {
+        // lea rdi, [rip + #0]  =  48 8D 3D 00 00 00 00 ; slot at offset 3.
+        let mut a = Assembler::new();
+        let slot = a.lea_rip_placeholder(Reg::Rdi);
+        assert_eq!(slot, 3, "disp32 slot is 3 bytes into the instruction");
+        let bytes = finish(a);
+        assert_eq!(bytes, vec![0x48, 0x8D, 0x3D, 0x00, 0x00, 0x00, 0x00]);
+    }
+
+    #[test]
+    fn iced_roundtrip_rip_lea() {
+        use iced_x86::{Decoder, DecoderOptions, Formatter, IntelFormatter};
+        let mut a = Assembler::new();
+        let lbl = a.create_label();
+        a.lea_rip_label(Reg::Rsi, lbl);
+        a.ret();
+        a.bind(lbl).unwrap();
+        a.emit_data_u32(0);
+        let bytes = finish(a);
+        let mut decoder = Decoder::with_ip(64, &bytes, 0, DecoderOptions::NONE);
+        let mut f = IntelFormatter::new();
+        let mut s = String::new();
+        f.format(&decoder.decode(), &mut s);
+        assert!(s.starts_with("lea "), "decodes as lea, got {s}");
+        assert!(s.contains("rsi"), "targets rsi, got {s}");
     }
 
     // ---- Round-trip decode via iced-x86 ----


### PR DESCRIPTION
## Encoder foundation for x86_64 GC registration

Split out from PR-x3 (the x86_64 `__gc_init_stackmaps` registration codegen) as a small, self-contained, **fully-locally-tested** unit — the x86-64 analogue of the aarch64 encoder's `adr`/`adr_placeholder`/`emit_data_word` (from the merged aarch64 increment B).

Three additive primitives:
- **`lea_rip_label(dst, label)`** — `LEA r64, [RIP + <label>]` to a same-function label, resolved at `finish()` via the existing fix-up mechanism (like `jmp`). No relocation. Points a register at a data word embedded in the stream.
- **`lea_rip_placeholder(dst) -> usize`** — `LEA r64, [RIP + #0]` returning its `disp32` slot, for a caller that patches `disp32 = target − (slot + 4)` once a cross-function offset is known. **Base-independent** (RIP cancels the load base) → no relocation — the x86-64 counterpart of the aarch64 `ADR` used for `func_start`.
- **`emit_data_u32(word) -> usize`** — append a raw LE `u32` table element.

### Verification
- 3 new unit tests: byte-exact `48 8D …` encodings, a data-pool round trip (lea → embedded data word), and an `iced-x86` decode confirming the `lea`.
- 48 encoder tests green; clippy clean. Purely additive — existing encodings unchanged.

No security surface (pure instruction-encoding methods); the UAF-sensitive review lands on **PR-x3b** (the twig-aot codegen that *uses* these to marshal the 8-arg `__gc_register_stackmap` call + RIP-relative `func_start`).

x86_64-encoder 0.6.0 → 0.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)