### PR TITLE
feat(semantic-ir-to-c): maps — SIR_MAP assoc-array (SIR16)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,63 @@
 # Changelog
 
+## 0.7.0 — maps (SIR16)
+
+Accepts `Feature::Maps`. `SirValue` gains a `SIR_MAP` tag — a heap-boxed,
+insertion-ordered **assoc-array** (`struct SirMap { struct SirMapEntry
+*entries; int64_t len; int64_t cap; }`, arena allocated), a shared mutable
+handle exactly like `SIR_SEQ`. It is a linear-scan assoc-array, NOT a hash
+table — the same representation as the Go (`[]MapEntry`) and Rust
+(`Vec<(Value, Value)>`) reference backends: lookups are O(n), but structural
+keys and insertion-ordered iteration/printing come for free, with no `Hash`/`Eq`
+requirement on the value type. Every construct the feature can surface is
+lowered:
+
+- `MapLit` (`{k => v, …}`) → `_sir_map_lit(n, k0, v0, …)`, boxing `n` key/value
+  pairs. A later duplicate key overwrites the earlier entry (`{1 => 1, 1 => 2}`
+  is `{1 => 2}`), matching Ruby's Hash literal and the Go/Rust `_sir_map_lit`.
+- `MapGet` (`h[k]`) → `_sir_map_get`: a missing key yields nil (it does NOT
+  raise — matching Ruby's default-less `Hash#[]` and the reference); keys are
+  compared by STRUCTURAL equality, so a composite key like `[1, 2]` matches by
+  value.
+- `MapSet` (`h[k] = v`) → `_sir_map_set`: insert-or-update, mutating the shared
+  box so a write through one binding is visible through every alias. A map has
+  no bounds, so — unlike `SeqSet` — there is nothing to trap on; a new key
+  APPENDS (growing the backing array, capacity doubling from 4), preserving
+  insertion order.
+
+`_sir_value_eq` gains a `SIR_MAP` arm: STRUCTURAL and POSITIONAL — equal length,
+then entry-wise in insertion order (`entries[i]` key AND value equal) — exactly
+mirroring the Go (`[]MapEntry` zip) and Rust (`iter().zip()`) backends, with an
+identical-handle fast path. `_sir_fmt` renders a map as `{k: v, k2: v2}` (brace,
+colon-space, insertion order), also matching Go/Rust.
+
+**Documented family-wide divergence from real Ruby (unchanged by this batch):**
+Ruby's own `Hash#==` is order-INsensitive and its `Hash#inspect` uses ` => ` for
+non-symbol keys (and `key:` only for symbol keys). All three source-emitting
+backends (Go, Rust, and now C) are instead positional and print a uniform `: ` —
+so the three **agree with each other**, which is the property the cross-backend
+conformance corpus checks (no corpus program prints or reorder-compares a whole
+map, so the real-Ruby form is unexercised). Aligning all three to Ruby's exact
+`Hash` semantics is a separate, family-wide change.
+
+Because `MapSet` mutates in place, a self-referential map (`m[k] = m`) is now
+constructible; both the `value_eq` and `fmt` `SIR_MAP` arms reuse the
+recursion-depth caps introduced for `SeqSet` in 0.6.0, so a cyclic map
+terminates rather than overflowing the C stack (verified adversarially).
+
+`ForEach` over a map is deliberately NOT special-cased: iterating a map is
+reference-undefined (Go's `_sir_seq_iter` panics on a non-sequence), and C's
+lenient `_sir_seq_iter` else-branch already treats a non-seq/non-cons iterable
+as an empty iteration — so the loop body runs zero times and the emitter stays
+total (no new `unreachable!`), consistent with its pre-existing handling of any
+other non-iterable.
+
+Every node verified by hand-built modules (bypassing the frontend, which does
+not yet produce these) compiled and run through a real `cc` — covering present/
+missing-key reads, insert/update/alias writes, structural composite keys,
+duplicate-key overwrite, positional structural equality, brace-list display, the
+zero-iteration `ForEach`-over-map, and the cyclic-map stack-safety guard.
+
 ## 0.6.0 — sequences (SIR16)
 
 Accepts `Feature::Sequences`. `SirValue` gains a `SIR_SEQ` tag — a heap-boxed

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -81,11 +81,14 @@ The emitter is **thin**; the semantics live in an inlined C runtime
 `OptionalTypeAnnotations`, `MutualRecursion`, `Globals`; the SIR26 integer
 conversions (`Conversions`, `SizedIntegers`, `Unsigned`, `WrappingArithmetic`);
 SIR16 control flow and mutation (`Loops` — `While`, `ForRange`, `ForEach`; and
-`MutableBindings`); and SIR16 `Sequences` — a `SIR_SEQ` heap array with
-`SeqLit`/`SeqIndex`/`SeqLen`/`SeqSet` and structural equality.
+`MutableBindings`); SIR16 `Sequences` — a `SIR_SEQ` heap array with
+`SeqLit`/`SeqIndex`/`SeqLen`/`SeqSet` and structural equality; and SIR16 `Maps`
+— a `SIR_MAP` heap assoc-array with `MapLit`/`MapGet`/`MapSet`, structural
+composite keys, positional structural equality, and `{k: v}` display (matching
+the Go/Rust backends).
 
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
-`Intrinsics`, `Maps`, `NDArrays`, `ShortCircuit`, exceptions/OOP, and every
+`Intrinsics`, `NDArrays`, `ShortCircuit`, exceptions/OOP, and every
 other not-yet-wired feature until its batch lands.  `Bignum` stays rejected
 until a bignum runtime ships — a module needing arbitrary precision is refused,
 never silently truncated.

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -439,6 +439,24 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             let _ = writeln!(out, "{ipad}}}");
             let _ = writeln!(out, "{pad}}}");
         }
+        // `h[k] = v` — insert/update the shared map box (via `_sir_map_set`,
+        // which traps only on a non-map; a map has no bounds to check). Operands
+        // are hoisted so left-to-right evaluation order holds; the returned
+        // value is discarded in statement position. Mirrors `SeqSet`.
+        Stmt::MapSet {
+            map, key, value, ..
+        } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let names = hoist_operands(out, &[map, key, value], inner);
+            let _ = writeln!(
+                out,
+                "{ipad}(void)_sir_map_set({}, {}, {});",
+                names[0], names[1], names[2]
+            );
+            let _ = writeln!(out, "{pad}}}");
+        }
         other => unreachable!("C backend reached unsupported statement: {other:?}"),
     }
 }
@@ -566,6 +584,34 @@ fn emit_assign(out: &mut String, dst: &str, e: &Expr, indent: usize) {
             let ipad = indent_str(inner);
             let names = hoist_operands(out, &[seq.as_ref()], inner);
             let _ = writeln!(out, "{ipad}{dst} = _sir_seq_len({});", names[0]);
+            let _ = writeln!(out, "{pad}}}");
+        }
+        // SIR16 maps with a compound operand: hoist operands into temps
+        // (preserving left-to-right order — for a `MapLit`, key/value
+        // interleaved: k0, v0, k1, v1, …), then build/read the map.
+        Expr::MapLit { entries, .. } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let mut ops: Vec<&Expr> = Vec::with_capacity(entries.len() * 2);
+            for e in entries {
+                ops.push(&e.key);
+                ops.push(&e.value);
+            }
+            let names = hoist_operands(out, &ops, inner);
+            let _ = write!(out, "{ipad}{dst} = _sir_map_lit({}", entries.len());
+            for n in &names {
+                let _ = write!(out, ", {n}");
+            }
+            out.push_str(");\n");
+            let _ = writeln!(out, "{pad}}}");
+        }
+        Expr::MapGet { map, key, .. } => {
+            let _ = writeln!(out, "{pad}{{");
+            let inner = indent + 1;
+            let ipad = indent_str(inner);
+            let names = hoist_operands(out, &[map.as_ref(), key.as_ref()], inner);
+            let _ = writeln!(out, "{ipad}{dst} = _sir_map_get({}, {});", names[0], names[1]);
             let _ = writeln!(out, "{pad}}}");
         }
         // A call whose arguments contain control flow: hoist every argument
@@ -725,6 +771,13 @@ fn is_simple(e: &Expr) -> bool {
         Expr::SeqLit { items, .. } => items.iter().all(is_simple),
         Expr::SeqIndex { seq, index, .. } => is_simple(seq) && is_simple(index),
         Expr::SeqLen { seq, .. } => is_simple(seq),
+        // SIR16 maps: a `_sir_map_*` call is simple iff every operand is (they
+        // render inline as function arguments); otherwise `emit_assign` hoists
+        // them. A `MapLit` operand set is every entry's key AND value.
+        Expr::MapLit { entries, .. } => entries
+            .iter()
+            .all(|e| is_simple(&e.key) && is_simple(&e.value)),
+        Expr::MapGet { map, key, .. } => is_simple(map) && is_simple(key),
         // SIR16+ nodes / Intrinsic are not accepted in v0 → unreachable after
         // the capability check.  Treat as non-simple defensively.
         _ => false,
@@ -804,6 +857,26 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         Expr::SeqLen { seq, .. } => {
             out.push_str("_sir_seq_len(");
             emit_expr(out, seq, indent);
+            out.push(')');
+        }
+        // SIR16 maps (simple-operand forms; compound operands are hoisted by
+        // `emit_assign`). `_sir_map_lit(N, k0, v0, …)` boxes a fresh assoc-array
+        // from N key/value pairs; `_sir_map_get(map, key)` reads it.
+        Expr::MapLit { entries, .. } => {
+            let _ = write!(out, "_sir_map_lit({}", entries.len());
+            for e in entries {
+                out.push_str(", ");
+                emit_expr(out, &e.key, indent);
+                out.push_str(", ");
+                emit_expr(out, &e.value, indent);
+            }
+            out.push(')');
+        }
+        Expr::MapGet { map, key, .. } => {
+            out.push_str("_sir_map_get(");
+            emit_expr(out, map, indent);
+            out.push_str(", ");
+            emit_expr(out, key, indent);
             out.push(')');
         }
         other => unreachable!("emit_expr on compound/unsupported node: {other:?}"),
@@ -983,6 +1056,11 @@ fn scan_block_for_builtin(b: &Block) -> Option<(String, Span)> {
             } => scan_expr_for_builtin(seq)
                 .or_else(|| scan_expr_for_builtin(index))
                 .or_else(|| scan_expr_for_builtin(value)),
+            Stmt::MapSet {
+                map, key, value, ..
+            } => scan_expr_for_builtin(map)
+                .or_else(|| scan_expr_for_builtin(key))
+                .or_else(|| scan_expr_for_builtin(value)),
             Stmt::ForEach { iter, body, .. } => {
                 scan_expr_for_builtin(iter).or_else(|| scan_block_for_builtin(body))
             }
@@ -1027,6 +1105,12 @@ fn scan_expr_for_builtin(e: &Expr) -> Option<(String, Span)> {
             scan_expr_for_builtin(seq).or_else(|| scan_expr_for_builtin(index))
         }
         Expr::SeqLen { seq, .. } => scan_expr_for_builtin(seq),
+        Expr::MapLit { entries, .. } => entries.iter().find_map(|e| {
+            scan_expr_for_builtin(&e.key).or_else(|| scan_expr_for_builtin(&e.value))
+        }),
+        Expr::MapGet { map, key, .. } => {
+            scan_expr_for_builtin(map).or_else(|| scan_expr_for_builtin(key))
+        }
         _ => None,
     }
 }

--- a/code/packages/rust/semantic-ir-to-c/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/lib.rs
@@ -82,6 +82,21 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // as it was in 0.5.0). Structural `_sir_value_eq` makes `[1, 2] == [1, 2]`
     // true, matching every backend that carries sequences.
     Feature::Sequences,
+    // ── SIR16 maps ───────────────────────────────────────────────────
+    // `SirValue` gains a `SIR_MAP` heap-boxed, insertion-ordered ASSOC-ARRAY
+    // (linear scan, structural keys — like the Go/Rust `[]MapEntry` /
+    // `Vec<(Value, Value)>` reference, not a hash table). The emitter handles
+    // every construct the feature can surface: `MapLit` (`{k => v}`,
+    // `_sir_map_lit`), `MapGet` (`h[k]`, nil-on-miss, `_sir_map_get`), and
+    // `MapSet` (`h[k] = v`, insert/update the shared box, `_sir_map_set`). No
+    // `MapLen` node exists. `value_eq`/`fmt` gain `SIR_MAP` arms (positional
+    // structural equality and `{k: v}` display, matching Go/Rust), reusing the
+    // `SeqSet`-era depth caps to bound a cyclic map (`m[k] = m`, now
+    // constructible via the mutable `MapSet`). `ForEach` over a map is NOT
+    // special-cased — iterating a map is reference-undefined (Go's
+    // `_sir_seq_iter` panics on it); C's lenient `_sir_seq_iter` else-branch
+    // (empty iteration) already covers it without an emitter `unreachable!`.
+    Feature::Maps,
 ];
 
 impl Backend for CBackend {

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -42,13 +42,14 @@ pub const RUNTIME: &str = r####"/* =============================================
 
 typedef enum {
     SIR_NIL, SIR_BOOL, SIR_INT, SIR_FLOAT,
-    SIR_STR, SIR_SYM, SIR_PAIR, SIR_CLOSURE, SIR_SEQ
+    SIR_STR, SIR_SYM, SIR_PAIR, SIR_CLOSURE, SIR_SEQ, SIR_MAP
 } SirTag;
 
 typedef struct SirValue SirValue;
 typedef struct SirPair SirPair;
 typedef struct SirClosure SirClosure;
 typedef struct SirSeq SirSeq;
+typedef struct SirMap SirMap;
 
 struct SirValue {
     SirTag tag;
@@ -60,6 +61,7 @@ struct SirValue {
         SirPair *pair;    /* SIR_PAIR */
         SirClosure *clo;  /* SIR_CLOSURE */
         SirSeq *seq;      /* SIR_SEQ */
+        SirMap *map;      /* SIR_MAP */
     } as;
 };
 
@@ -70,6 +72,18 @@ struct SirPair { SirValue car; SirValue cdr; };
  * value). Boxed so the value is a shared, mutable handle: a `SeqSet` through
  * one binding is visible through every alias (matching the Go/Rust `*Seq`). */
 struct SirSeq { SirValue *items; int64_t len; };
+
+/* A SIR16 map (`{k => v, …}`) — a heap-boxed, insertion-ordered ASSOC-ARRAY:
+ * `entries[0 .. len)` are the key/value pairs in first-insertion order, backed
+ * by a `cap`-slot array that DOUBLES on overflow (a `MapSet` of a new key
+ * appends — unlike the fixed-length `SeqSet`). It is a linear-scan assoc-array,
+ * NOT a hash table, exactly like the Go/Rust reference (`[]MapEntry` /
+ * `Vec<(Value, Value)>`): lookups are O(n) but structural keys (`[1, 2]`) and
+ * insertion-order iteration/printing come for free with no `Hash`/`Eq` bound on
+ * the value type. Boxed so it is a shared, mutable handle: a `MapSet` through
+ * one binding is visible through every alias (matching the Go/Rust `*Map`). */
+struct SirMapEntry { SirValue key; SirValue val; };
+struct SirMap { struct SirMapEntry *entries; int64_t len; int64_t cap; };
 
 /* A closure's function takes its captured environment and the call args. */
 typedef SirValue (*SirFn)(SirValue *caps, SirValue *args, int argc);
@@ -347,6 +361,26 @@ int _sir_value_eq_d(SirValue a, SirValue b, int depth) {
                 if (!_sir_value_eq_d(sa->items[i], sb->items[i], depth + 1)) return 0;
             return 1;
         }
+        case SIR_MAP: {
+            /* STRUCTURAL and POSITIONAL: equal length, then entry-wise in
+             * INSERTION ORDER — `entries[i]` keys AND values equal — exactly
+             * mirroring the Go (`[]MapEntry` zip) and Rust (`iter().zip()`)
+             * reference backends. (Ruby's own `Hash#==` is order-INsensitive;
+             * all three source-emitting backends are positional, so they agree
+             * with each other — a uniform, documented divergence from real Ruby
+             * on the untested reordered-map case, not a C-only bug.) The
+             * identical-handle fast path short-circuits `m == m` and the
+             * self-referential `m[k] = m`; the depth cap bounds two DISTINCT
+             * cyclic maps (constructible now that `MapSet` mutates in place). */
+            SirMap *ma = a.as.map, *mb = b.as.map;
+            if (ma == mb) return 1;
+            if (ma->len != mb->len) return 0;
+            for (int64_t i = 0; i < ma->len; i++) {
+                if (!_sir_value_eq_d(ma->entries[i].key, mb->entries[i].key, depth + 1)) return 0;
+                if (!_sir_value_eq_d(ma->entries[i].val, mb->entries[i].val, depth + 1)) return 0;
+            }
+            return 1;
+        }
         case SIR_CLOSURE: return a.as.clo == b.as.clo;
         default:          return 0;
     }
@@ -457,6 +491,90 @@ SirValue _sir_seq_iter(SirValue it) {
     return v;
 }
 
+/* ---- SIR16 maps --------------------------------------------- */
+
+/* A fresh map with room for `cap` entries (cap 0 => NULL backing store). */
+static SirMap *_sir_map_new(int64_t cap) {
+    SirMap *m = (SirMap *)_sir_alloc(sizeof(SirMap));
+    m->len = 0;
+    m->cap = cap;
+    m->entries = (cap > 0)
+        ? (struct SirMapEntry *)_sir_alloc(sizeof(struct SirMapEntry) * (size_t)cap)
+        : NULL;
+    return m;
+}
+
+/* Linear scan for `key` by STRUCTURAL equality (`_sir_value_eq`, so a composite
+ * key like `[1, 2]` matches by value, not identity). Returns the entry index,
+ * or -1 if absent. O(n) — an assoc-array, matching the Go/Rust reference. */
+static int64_t _sir_map_find(SirMap *m, SirValue key) {
+    for (int64_t i = 0; i < m->len; i++)
+        if (_sir_value_eq(m->entries[i].key, key)) return i;
+    return -1;
+}
+
+/* Insert or update `key => val`, PRESERVING insertion order: an existing key's
+ * value is overwritten in its current slot; a new key is APPENDED, growing the
+ * backing array (capacity doubles, from 4, when full). The arena never frees,
+ * so the outgrown array simply leaks like every other reallocation here. */
+static void _sir_map_put(SirMap *m, SirValue key, SirValue val) {
+    int64_t at = _sir_map_find(m, key);
+    if (at >= 0) { m->entries[at].val = val; return; }
+    if (m->len == m->cap) {
+        int64_t ncap = (m->cap > 0) ? m->cap * 2 : 4;
+        struct SirMapEntry *ne =
+            (struct SirMapEntry *)_sir_alloc(sizeof(struct SirMapEntry) * (size_t)ncap);
+        for (int64_t i = 0; i < m->len; i++) ne[i] = m->entries[i];
+        m->entries = ne;
+        m->cap = ncap;
+    }
+    m->entries[m->len].key = key;
+    m->entries[m->len].val = val;
+    m->len++;
+}
+
+/* `{k0 => v0, k1 => v1, …}` — build a map from `n` key/value pairs passed as
+ * `2*n` variadic `SirValue`s in `k0, v0, k1, v1, …` order. A later duplicate
+ * key OVERWRITES the earlier entry (via `_sir_map_put`), matching Ruby's Hash
+ * literal and the Go/Rust `_sir_map_lit`, so `{1 => 1, 1 => 2}` is `{1 => 2}`. */
+SirValue _sir_map_lit(int n, ...) {
+    SirMap *m = _sir_map_new((int64_t)n);
+    va_list ap;
+    va_start(ap, n);
+    for (int i = 0; i < n; i++) {
+        SirValue k = va_arg(ap, SirValue);
+        SirValue val = va_arg(ap, SirValue);
+        _sir_map_put(m, k, val);
+    }
+    va_end(ap);
+    SirValue v;
+    v.tag = SIR_MAP; v.as.map = m;
+    return v;
+}
+
+/* `h[k]` (read). A MISSING key yields nil — Ruby's default-less `Hash#[]` does
+ * not raise, matching the Go/Rust `_sir_map_get`. A non-map also yields nil
+ * (the lenient read, mirroring this backend's own `_sir_seq_index`). */
+SirValue _sir_map_get(SirValue map, SirValue key) {
+    if (map.tag != SIR_MAP) return _sir_nil();
+    int64_t at = _sir_map_find(map.as.map, key);
+    return (at >= 0) ? map.as.map->entries[at].val : _sir_nil();
+}
+
+/* `h[k] = v` (write). Insert-or-update, mutating the SHARED map so a write
+ * through one binding is visible through every alias (the value is a handle,
+ * like the Go/Rust `*Map`). A map has no bounds, so — unlike `_sir_seq_set` —
+ * there is no index to trap on; a non-map is the only error. Returns the
+ * assigned value (an indexed assignment evaluates to its RHS). */
+SirValue _sir_map_set(SirValue map, SirValue key, SirValue val) {
+    if (map.tag != SIR_MAP) {
+        fprintf(stderr, "sir: []= on a non-map\n");
+        exit(1);
+    }
+    _sir_map_put(map.as.map, key, val);
+    return val;
+}
+
 SirValue _sir_is_null(SirValue v)   { return _sir_bool(v.tag == SIR_NIL); }
 SirValue _sir_is_pair(SirValue v)   { return _sir_bool(v.tag == SIR_PAIR); }
 SirValue _sir_is_number(SirValue v) { return _sir_bool(_sir_is_num(v)); }
@@ -532,6 +650,25 @@ void _sir_fmt_seq(FILE *out, SirValue v) {
     fputc(']', out);
 }
 
+/* A map renders as `{k0: v0, k1: v1, …}` in insertion order — a brace-wrapped,
+ * colon-space entry list, EXACTLY mirroring the Go (`_sir_format_map`) and Rust
+ * (`format_map_d`) backends so the three source targets print maps identically.
+ * (Real Ruby's `Hash#inspect` uses ` => ` for non-symbol keys and `key:` only
+ * for symbol keys; all three emitting backends use a uniform `: ` — a
+ * documented family-wide divergence on the untested whole-map print, kept for
+ * cross-backend agreement.) Keys and values render through `_sir_fmt`, whose
+ * depth counter bounds a self-referential map (constructible via `MapSet`). */
+void _sir_fmt_map(FILE *out, SirValue v) {
+    fputc('{', out);
+    for (int64_t i = 0; i < v.as.map->len; i++) {
+        if (i) fputs(", ", out);
+        _sir_fmt(out, v.as.map->entries[i].key);
+        fputs(": ", out);
+        _sir_fmt(out, v.as.map->entries[i].val);
+    }
+    fputc('}', out);
+}
+
 void _sir_fmt_float(FILE *out, double f) {
     /* Ruby keeps a trailing .0 on integral floats and prints non-finite
      * values as Infinity / NaN.  A plain "%g" would drop the .0, so format
@@ -594,6 +731,7 @@ void _sir_fmt(FILE *out, SirValue v) {
         case SIR_SYM:   fputs(v.as.s, out); break;
         case SIR_PAIR:  _sir_fmt_pair(out, v); break;
         case SIR_SEQ:   _sir_fmt_seq(out, v); break;
+        case SIR_MAP:   _sir_fmt_map(out, v); break;
         case SIR_CLOSURE: fputs("#<closure>", out); break;
         default: break;
     }

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_maps.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_maps.rs
@@ -1,0 +1,328 @@
+//! Execution proof for SIR16 maps on the C backend — hand-build modules
+//! (producer-agnostic), emit C, compile with a real gcc/clang-style compiler,
+//! run, assert stdout. Skips gracefully when no `cc` is present.
+//!
+//! Covers every `Feature::Maps`-gated node — `MapLit`, `MapGet`, `MapSet` —
+//! plus structural composite keys, insertion-order display, and the
+//! newly-reachable cyclic-map case (`m[k] = m`, constructible via the mutable
+//! `MapSet`). Hand-built to bypass any frontend that masks these nodes (the
+//! totality lesson: accepting a feature obligates handling every node it can
+//! surface for a producer-agnostic module, not just the ones a frontend emits).
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, MapEntry, Metadata, Module, Scope,
+    Span, Stmt, CURRENT_SIR_VERSION,
+};
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    for cand in ["cc", "clang", "gcc"] {
+        if Command::new(cand)
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+        {
+            return Some(cand.to_string());
+        }
+    }
+    None
+}
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn run(module: &Module) -> Option<String> {
+    let cc = find_cc()?;
+    let artifact = semantic_ir_to_c::compile(module).expect("C backend compile (no panic)");
+    let dir = std::env::temp_dir();
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let stem = format!("sirc_map_{}_{}", std::process::id(), n);
+    let cpath: PathBuf = dir.join(format!("{stem}.c"));
+    let exe: PathBuf = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::File::create(&cpath)
+        .and_then(|mut f| f.write_all(artifact.source.as_bytes()))
+        .expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-Werror=unused-variable", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        artifact.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "run failed (exit {:?})", r.status.code());
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+fn s() -> Span {
+    Span::synthetic()
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn strlit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+fn seq(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+fn maplit(entries: Vec<(Expr, Expr)>) -> Expr {
+    Expr::MapLit {
+        entries: entries
+            .into_iter()
+            .map(|(key, value)| MapEntry { key, value })
+            .collect(),
+        span: s(),
+    }
+}
+fn mapget(map: Expr, key: Expr) -> Expr {
+    Expr::MapGet { map: Box::new(map), key: Box::new(key), span: s() }
+}
+fn local(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
+}
+fn bc(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+fn puts(arg: Expr) -> Stmt {
+    Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: s() }
+}
+fn let_(name: &str, value: Expr) -> Stmt {
+    Stmt::LetBinding { name: name.into(), sir_type: None, value, span: s() }
+}
+/// A `main` module declaring Maps + Loops + Sequences + Strings. Sequences lets
+/// a composite `[1, 2]` map key be built; Strings lets a `"found"` value be
+/// used — both exercised below.
+fn map_module(stmts: Vec<Stmt>) -> Module {
+    Module {
+        name: "mapprog".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Maps,
+            Feature::Loops,
+            Feature::Sequences,
+            Feature::Strings,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+#[test]
+fn map_get_reads_present_and_missing_keys() {
+    // `h = {10 => 100, 20 => 200}; puts h[10]; puts h[30]` → `100`, then `nil`
+    // (a missing key yields nil, not an error — matching the Go/Rust reference).
+    let m = map_module(vec![
+        let_("h", maplit(vec![(ilit(10), ilit(100)), (ilit(20), ilit(200))])),
+        puts(mapget(local("h"), ilit(10))),
+        puts(mapget(local("h"), ilit(30))),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "100\nnil\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn map_set_inserts_updates_and_shares_the_box() {
+    // `h = {1 => 1}; h[1] = 99 (update in place); h[2] = 2 (append new key)`.
+    // Aliasing: `g = h` shares the box, so `g[3] = 3` is visible through `h`.
+    let m = map_module(vec![
+        let_("h", maplit(vec![(ilit(1), ilit(1))])),
+        Stmt::MapSet { map: local("h"), key: ilit(1), value: ilit(99), span: s() },
+        Stmt::MapSet { map: local("h"), key: ilit(2), value: ilit(2), span: s() },
+        let_("g", local("h")),
+        Stmt::MapSet { map: local("g"), key: ilit(3), value: ilit(3), span: s() },
+        puts(mapget(local("h"), ilit(1))), // updated → 99
+        puts(mapget(local("h"), ilit(2))), // inserted → 2
+        puts(mapget(local("h"), ilit(3))), // written through the alias → 3
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "99\n2\n3\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn map_composite_key_is_structural() {
+    // `{[1, 2] => "found"}[[1, 2]]` → `found`: keys are compared by STRUCTURAL
+    // equality (`_sir_value_eq`), so a DISTINCT `[1, 2]` literal still matches —
+    // the whole point of an assoc-array over a pointer-identity table.
+    let m = map_module(vec![
+        let_("h", maplit(vec![(seq(vec![ilit(1), ilit(2)]), strlit("found"))])),
+        puts(mapget(local("h"), seq(vec![ilit(1), ilit(2)]))),
+        // A key that differs by value misses → nil.
+        puts(mapget(local("h"), seq(vec![ilit(1), ilit(3)]))),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "found\nnil\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn map_literal_displays_as_a_brace_list() {
+    // `puts({1 => 2, 3 => 4})` → `{1: 2, 3: 4}` — brace-wrapped, colon-space,
+    // insertion order, matching the Go/Rust backends (a uniform, documented
+    // divergence from real Ruby's ` => `, kept for cross-backend agreement).
+    let m = map_module(vec![puts(maplit(vec![
+        (ilit(1), ilit(2)),
+        (ilit(3), ilit(4)),
+    ]))]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "{1: 2, 3: 4}\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn map_literal_duplicate_key_overwrites() {
+    // `{1 => 1, 1 => 2}` collapses to a single entry `1 => 2` (a later duplicate
+    // key overwrites), matching Ruby's Hash literal and the Go/Rust `_sir_map_lit`.
+    let m = map_module(vec![puts(maplit(vec![
+        (ilit(1), ilit(1)),
+        (ilit(1), ilit(2)),
+    ]))]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "{1: 2}\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn map_equality_is_structural_and_positional() {
+    // Two DISTINCT maps with equal entries in the SAME insertion order compare
+    // equal; a different value (or a different order) is unequal — positional
+    // structural equality, matching Go's `[]MapEntry` zip and Rust's `zip`.
+    let if_eq = |a: Expr, b: Expr, then: &str, els: &str| Stmt::ExprStmt {
+        expr: Expr::If {
+            cond: Box::new(bc("=", vec![a, b])),
+            then_branch: Box::new(Block {
+                stmts: vec![puts(strlit(then))],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            }),
+            else_branch: Box::new(Block {
+                stmts: vec![puts(strlit(els))],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            }),
+            span: s(),
+        },
+        span: s(),
+    };
+    let m = map_module(vec![
+        // equal entries, same order → same
+        if_eq(
+            maplit(vec![(ilit(1), ilit(2)), (ilit(3), ilit(4))]),
+            maplit(vec![(ilit(1), ilit(2)), (ilit(3), ilit(4))]),
+            "same",
+            "diff",
+        ),
+        // a differing value → diff
+        if_eq(
+            maplit(vec![(ilit(1), ilit(2))]),
+            maplit(vec![(ilit(1), ilit(9))]),
+            "same",
+            "diff",
+        ),
+        // different length → diff
+        if_eq(
+            maplit(vec![(ilit(1), ilit(2))]),
+            maplit(vec![(ilit(1), ilit(2)), (ilit(3), ilit(4))]),
+            "same",
+            "diff",
+        ),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "same\ndiff\ndiff\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn for_each_over_a_map_does_not_panic() {
+    // `ForEach` becomes reachable once `Loops` is accepted, and its iterable may
+    // now be a map. Iterating a map is REFERENCE-UNDEFINED (Go's `_sir_seq_iter`
+    // panics on it); C's lenient `_sir_seq_iter` else-branch treats a non-seq /
+    // non-cons as an empty iteration — so the loop body runs zero times and the
+    // emitter stays total (no `unreachable!`). The guard printed before and
+    // after must both appear, with nothing from the body between them.
+    let m = map_module(vec![
+        puts(strlit("before")),
+        Stmt::ForEach {
+            var: "kv".into(),
+            iter: maplit(vec![(ilit(1), ilit(2))]),
+            body: Block {
+                stmts: vec![puts(strlit("body"))],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            span: s(),
+        },
+        puts(strlit("after")),
+    ]);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "before\nafter\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn cyclic_map_does_not_stack_overflow() {
+    // `MapSet` mutates in place, so a map can be made self-referential
+    // (`h[0] = h`) — a newly-reachable cycle. Equality and display must
+    // TERMINATE (via the `SeqSet`-era depth caps), not crash the stack. `run`
+    // asserts the process exits 0; a stack overflow would be a non-zero exit.
+    let nil = || Expr::NilLit { span: s() };
+    let m = map_module(vec![
+        // h = {0 => nil}; h[0] = h  → a self-referential map
+        let_("h", maplit(vec![(ilit(0), nil())])),
+        Stmt::MapSet { map: local("h"), key: ilit(0), value: local("h"), span: s() },
+        // h == h → #t via the identical-handle fast path (no walk)
+        puts(bc("=", vec![local("h"), local("h")])),
+        // print(h) → terminates via the fmt depth cap (bounded string)
+        puts(local("h")),
+        // two DISTINCT mutually-cyclic maps: h[0]=g, g[0]=h
+        let_("g", maplit(vec![(ilit(0), nil())])),
+        Stmt::MapSet { map: local("g"), key: ilit(0), value: local("h"), span: s() },
+        Stmt::MapSet { map: local("h"), key: ilit(0), value: local("g"), span: s() },
+        // h == g → terminates via the eq depth cap (result is cap-defined; the
+        // point is it does not stack-overflow)
+        puts(bc("=", vec![local("h"), local("g")])),
+    ]);
+    match run(&m) {
+        Some(out) => {
+            let lines: Vec<&str> = out.lines().collect();
+            assert_eq!(lines.first().copied(), Some("#t"), "h == h is true (fast path)");
+            assert_eq!(lines.len(), 3, "all three puts ran — no stack overflow");
+        }
+        None => eprintln!("skip: no cc"),
+    }
+}

--- a/code/packages/rust/semantic-ir-to-c/tests/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/emit.rs
@@ -114,11 +114,13 @@ fn self_contained_no_external_headers() {
 
 #[test]
 fn unaccepted_feature_is_rejected_cleanly() {
-    // A hash literal declares Feature::Maps, which this backend does not accept
-    // (arrays now declare the accepted Sequences feature, so they no longer
-    // exercise the rejection path — a hash still does).
-    let m = lower_ruby("h = {1 => 2}\nputs h");
-    let err = compile(&m).expect_err("backend rejects Maps");
+    // An (empty) class declaration declares Feature::Classes, which this
+    // backend does not accept. (Arrays now declare the accepted Sequences
+    // feature and hashes the accepted Maps feature, so neither exercises the
+    // rejection path any longer — a class still does. A class is a declaration,
+    // so — unlike a `true && false` short-circuit — it is not folded away.)
+    let m = lower_ruby("class Foo\nend");
+    let err = compile(&m).expect_err("backend rejects Classes");
     assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
 }
 

--- a/code/specs/SIR24-semantic-ir-to-c.md
+++ b/code/specs/SIR24-semantic-ir-to-c.md
@@ -74,10 +74,16 @@ then (4) `emit::emit_module`.
 `Closures`, `Pairs`, `Symbols`, `Strings`, `DynamicTyping`,
 `OptionalTypeAnnotations`, `MutualRecursion`, `Globals`.
 
-**v0 rejects** (clean, source-positioned `UnsupportedFeature`):
+**Landed since v0** (`ACCEPTED_FEATURES` grows one version-bumped batch at a
+time — see the roadmap): the SIR26 integer conversions (`Conversions`,
+`SizedIntegers`, `Unsigned`, `WrappingArithmetic`); and the SIR16 batches
+`Loops` + `MutableBindings` (0.3.0–0.5.0), `Sequences` (0.6.0), and `Maps`
+(0.7.0 — the `SIR_MAP` assoc-array with `MapLit`/`MapGet`/`MapSet`).
+
+**Still rejects** (clean, source-positioned `UnsupportedFeature`):
 `TailCalls` (C does not guarantee TCO), `Intrinsics` (empty whitelist), and
-every later feature until its batch lands (`Floats`, `Loops`, `Sequences`,
-`Maps`, `Exceptions`, `Classes`, … — see the roadmap).  `Bignum` stays
+every not-yet-landed feature (`Floats`, `ShortCircuit`, `NDArrays`,
+`Exceptions`, `Classes`, … — see the roadmap).  `Bignum` stays
 rejected until a bignum runtime ships, so a module that *needs* arbitrary
 precision is refused rather than silently truncated.
 


### PR DESCRIPTION
## What

Adds SIR16 **maps** to the C backend (`semantic-ir-to-c` 0.6.0 → 0.7.0), so `SIR_MAP` joins `SIR_SEQ` from the merged sequences batch (#8819). C now emits every SIR16 collection node the Go/Rust/Ruby backends do.

`SirValue` gains a `SIR_MAP` tag — a heap-boxed, insertion-ordered **assoc-array** (`struct SirMap { SirMapEntry *entries; int64_t len; int64_t cap; }`), a shared mutable handle like `SIR_SEQ`. Linear-scan, not a hash table — the same representation as the Go (`[]MapEntry`) and Rust (`Vec<(Value, Value)>`) reference backends, so structural keys and insertion-ordered iteration come for free.

Every `Maps`-gated node is lowered:

| Node | Lowering | Semantics |
|------|----------|-----------|
| `MapLit` `{k => v}` | `_sir_map_lit(n, k0, v0, …)` | later duplicate key overwrites |
| `MapGet` `h[k]` | `_sir_map_get` | missing → nil (no raise); **structural** key match |
| `MapSet` `h[k] = v` | `_sir_map_set` | insert-or-update the shared box; new key appends (cap doubles from 4) |

`_sir_value_eq` gains a positional structural `SIR_MAP` arm; `_sir_fmt` a `{k: v}` display arm — both mirroring Go/Rust exactly.

## Safety

- **Cyclic maps**: `MapSet` mutates in place, so `m[k] = m` is now constructible. Both the `value_eq` and `fmt` `SIR_MAP` arms reuse the recursion-depth caps introduced for `SeqSet` in 0.6.0 — a cyclic map terminates instead of overflowing the C stack (adversarial test included).
- **`ForEach` over a map** is deliberately not special-cased: iterating a map is reference-undefined (Go's `_sir_seq_iter` panics), and C's lenient else-branch already treats it as an empty iteration, so the emitter stays **total** (no new `unreachable!`).
- Security review passed (memory safety of the realloc-grow path, varargs count, depth caps, and string-operand escaping all verified).

## Documented divergence (unchanged by this PR)

All three source-emitting backends (Go, Rust, C) use **positional** equality and a `: ` display separator — agreeing with each other rather than with real Ruby's order-insensitive `Hash#==` / ` => ` inspect. No corpus program prints or reorder-compares a whole map, so the real-Ruby form is unexercised; aligning all three is a separate family-wide change.

## Also

- Fixes a pre-existing **stale test**: `unaccepted_feature_is_rejected_cleanly` used a hash literal as its "unaccepted feature" example — now that Maps is accepted, it uses an empty class declaration (`Feature::Classes`).
- Updates the **SIR24 spec** capability section to reflect the landed Conversions/Loops/Sequences/Maps batches (drift left from the sequences batch).

## Verification

- `cargo test -p semantic-ir-to-c` — **33 tests green**, incl. 8 new map exec-proofs (hand-built modules bypassing the frontend, compiled and run through a real `cc`): present/missing reads, insert/update/alias writes, structural composite keys, duplicate-key overwrite, positional equality, brace-list display, zero-iteration `ForEach`-over-map, cyclic-map stack safety.
- `cargo clippy -p semantic-ir-to-c --all-targets` clean; `sir-conformance` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)