### PR TITLE
feat(num): NUM-6c — to_scientific(x [, figures]) exact scientific-notation rendering

### DIFF
--- a/code/packages/rust/adj-constraint-solver/CHANGELOG.md
+++ b/code/packages/rust/adj-constraint-solver/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.14.0] - 2026-07-22 — absorb `ComputeExpr::ToScientific` (NUM-6c)
+
+### Changed
+
+- The solver's `ComputeExpr` walkers gain a `ComputeExpr::ToScientific` arm (the new
+  NUM-6c `to_scientific` rendering): it renders a number to a boundary string, so the
+  LIA/linear/CAS extractors return `None` (out of scope, exactly like a round), the
+  observed-value substitution rebuilds it with its operand substituted, and
+  `is_constant_expr` recurses into its operand. No behaviour change for existing
+  inputs — this is cross-producer totality for the new engine variant.
+
 ## [0.13.0] - 2026-07-22 — absorb `ComputeExpr::Round` (NUM-6a)
 
 ### Changed

--- a/code/packages/rust/adj-constraint-solver/Cargo.toml
+++ b/code/packages/rust/adj-constraint-solver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-constraint-solver"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Solver bridge for the adj-lang constraint sublanguage. Takes an adj-lang ConstraintSystem (symbols + constrain/solve/check), classifies it, and dispatches the linear-equality case to cas-solve's exact rational Gaussian elimination — returning solved values traced back to the constraints. The first slice (B2a) of the ADJ constraint-solving arc; SAT / linear-integer / inequality feasibility and optimization follow."
 

--- a/code/packages/rust/adj-constraint-solver/src/lib.rs
+++ b/code/packages/rust/adj-constraint-solver/src/lib.rs
@@ -366,6 +366,9 @@ fn expr_to_pred(e: &ComputeExpr) -> Option<Predicate> {
         // A `round_to(x, n)` narrowing is neither linear nor polynomial — out of
         // scope for this tactic, exactly like a unary round (NUM-6a).
         ComputeExpr::Round { .. } => None,
+        // `to_scientific(x, figures)` renders a number to a boundary string — not a
+        // linear/polynomial term, out of scope for this tactic exactly like a round (NUM-6c).
+        ComputeExpr::ToScientific { .. } => None,
     }
 }
 
@@ -659,6 +662,9 @@ fn linearize(e: &ComputeExpr) -> Option<LinForm> {
         // A `round_to(x, n)` narrowing is neither linear nor polynomial — out of
         // scope for this tactic, exactly like a unary round (NUM-6a).
         ComputeExpr::Round { .. } => None,
+        // `to_scientific(x, figures)` renders a number to a boundary string — not a
+        // linear/polynomial term, out of scope for this tactic exactly like a round (NUM-6c).
+        ComputeExpr::ToScientific { .. } => None,
     }
 }
 
@@ -2010,6 +2016,15 @@ fn substitute_observed(
             mode: *mode,
             expr: Box::new(substitute_observed(expr, variables, kb)),
         },
+        ComputeExpr::ToScientific {
+            figures,
+            mode,
+            expr,
+        } => ComputeExpr::ToScientific {
+            figures: *figures,
+            mode: *mode,
+            expr: Box::new(substitute_observed(expr, variables, kb)),
+        },
         ComputeExpr::Agg(_, _) => e.clone(),
     }
 }
@@ -2098,6 +2113,9 @@ fn poly_of(e: &ComputeExpr, x: &str) -> Option<Poly> {
         // A `round_to(x, n)` narrowing is neither linear nor polynomial — out of
         // scope for this tactic, exactly like a unary round (NUM-6a).
         ComputeExpr::Round { .. } => None,
+        // `to_scientific(x, figures)` renders a number to a boundary string — not a
+        // linear/polynomial term, out of scope for this tactic exactly like a round (NUM-6c).
+        ComputeExpr::ToScientific { .. } => None,
     }
 }
 
@@ -2306,6 +2324,9 @@ fn expr_to_ir(e: &ComputeExpr) -> Option<IRNode> {
         // A `round_to(x, n)` narrowing is neither linear nor polynomial — out of
         // scope for this tactic, exactly like a unary round (NUM-6a).
         ComputeExpr::Round { .. } => None,
+        // `to_scientific(x, figures)` renders a number to a boundary string — not a
+        // linear/polynomial term, out of scope for this tactic exactly like a round (NUM-6c).
+        ComputeExpr::ToScientific { .. } => None,
     }
 }
 
@@ -2329,6 +2350,8 @@ fn is_constant_expr(e: &ComputeExpr) -> bool {
         ComputeExpr::Unary(_, a) => is_constant_expr(a),
         // `round_to(c, n)` is constant iff its operand is — same rule as unary.
         ComputeExpr::Round { expr, .. } => is_constant_expr(expr),
+        // `to_scientific(c, n)` is likewise constant iff its operand is.
+        ComputeExpr::ToScientific { expr, .. } => is_constant_expr(expr),
     }
 }
 

--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.20.0] — 2026-07-22 — NUM-6c: render `to_scientific` in the audit trail
+
+The derivation-tree renderer gains a `DerivationNode::ToScientific` arm (NUM-6c): a
+`{"node":"to_scientific","figures":n,"mode":"half_even","rendered":"6.022e23","value":…,"operand":{…}}`
+object exposing the significant-figure count, the stated mode, the rendered boundary
+string, the narrowed numeric value, and the operand subtree it narrowed — everything
+`adj-verify` needs to re-render from the exact source. Adds an end-to-end test driving
+`to_scientific(x [, figures])` through the built CLI: exact rendering across scales
+(large integer, repeating rational), the optional-`figures` default, and rejection of
+a zero / non-integer figure count.
+
 ## [0.19.0] — 2026-07-22 — NUM-6b: render `round_sig` in the audit trail
 
 The derivation-tree renderer now names the KIND of precision narrowing: `"places"`

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -177,6 +177,25 @@ fn derivation_tree_json(
                 derivation_tree_json(operand, kb)
             )
         }
+        // A `to_scientific(x, figures)` rendering (NUM-6c): the audit exposes the
+        // significant-figure count, the rounding mode, the `rendered` boundary string,
+        // the narrowed numeric `value`, and the operand subtree it narrowed — so a
+        // checker can re-narrow the operand's exact value to `figures` significant
+        // figures and confirm the rendered form (ADJ-NUMERIC-SUBSTRATE §4.3).
+        D::ToScientific {
+            figures,
+            mode,
+            rendered,
+            operand,
+            result,
+        } => format!(
+            "{{\"node\":\"to_scientific\",\"figures\":{},\"mode\":\"{}\",\"rendered\":\"{}\",\"value\":{},\"operand\":{}}}",
+            figures,
+            rounding_mode_name(*mode),
+            esc(rendered),
+            jnum(*result),
+            derivation_tree_json(operand, kb)
+        ),
     }
 }
 

--- a/code/packages/rust/adj-lang-cli/tests/num6c_to_scientific_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/num6c_to_scientific_e2e.rs
@@ -1,0 +1,111 @@
+//! End-to-end tests for the NUM-6c `to_scientific(x [, figures])` scientific-notation
+//! rendering, driven through the built `adj-lang-cli` binary. They prove the whole path —
+//! native application surface → adapter/lower → the engine's exact significant-figure
+//! narrowing → the audit JSON — works together: the mantissa is narrowed **exactly** (no
+//! `f64` log or tie-break), the rendered `d.ddde±E` string and the narrowed exact value
+//! agree, the audit exposes the rendering (`node:to_scientific`, `figures`, `mode`,
+//! `rendered`, the operand subtree), the `figures` arg is optional (a documented default),
+//! and a bad `figures` is a clean compile error rather than a silent mis-format
+//! (ADJ-NUMERIC-SUBSTRATE §4.1, §4.3).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_num6c_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(src: &str, tag: &str) -> (bool, String) {
+    let dir = scratch(tag);
+    let p = dir.join("case.adj");
+    std::fs::write(&p, src).unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(&p)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn to_scientific_renders_exactly_and_audits_the_rendering() {
+    // 31459 to 3 significant figures = 3.15e4 (the trailing 59 rounds the 4 up), with
+    // the narrowed value held as the EXACT fraction 31500/1 — no lossy f64 hop.
+    let (ok, s) = run("let r = to_scientific(31459, 3)\n? r\n", "value");
+    assert!(ok, "cli should succeed: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The rendered boundary string is the scientific form.
+    assert!(
+        s.contains("\"rendered\":\"3.15e4\""),
+        "renders 31459 → 3.15e4: {s}"
+    );
+    // The exact sidecar is the true narrowed fraction, so an auditor re-derives it.
+    assert!(
+        s.contains("\"num\":\"31500\"") && s.contains("\"den\":\"1\""),
+        "carries the exact narrowed value 31500/1: {s}"
+    );
+    // The audit trail exposes the rendering as a first-class, checkable step: the node
+    // type, the significant-figure count, the stated mode, the rendered string, and the
+    // operand subtree it narrowed — everything `adj-verify` needs to re-render.
+    assert!(
+        s.contains("\"node\":\"to_scientific\"")
+            && s.contains("\"figures\":3")
+            && s.contains("\"mode\":\"half_even\""),
+        "audit records node/figures/mode: {s}"
+    );
+}
+
+#[test]
+fn to_scientific_narrows_a_repeating_rational_on_the_exact_path() {
+    // 1/3 = 0.333… to 4 sig-figs = 3.333e-1, held exactly as 3333/10000 — the whole
+    // point: the rendered figures come from the exact fraction, not an f64 log.
+    let (ok, s) = run("let r = to_scientific(1 / 3, 4)\n? r\n", "repeat");
+    assert!(ok, "cli should succeed: {s}");
+    assert!(
+        s.contains("\"rendered\":\"3.333e-1\""),
+        "renders 1/3 → 3.333e-1: {s}"
+    );
+    assert!(
+        s.contains("\"num\":\"3333\"") && s.contains("\"den\":\"10000\""),
+        "carries the exact narrowed value 3333/10000: {s}"
+    );
+}
+
+#[test]
+fn to_scientific_figures_argument_is_optional() {
+    // `to_scientific(x)` without a figure count uses the default mantissa precision
+    // (six significant figures) — a documented default, recorded in the audit.
+    let (ok, s) = run("let r = to_scientific(31459)\n? r\n", "default");
+    assert!(ok, "cli should succeed: {s}");
+    // 31459 at 6 sig-figs is exactly 31459 = 3.14590e4 (a padding zero at the 6th figure).
+    assert!(
+        s.contains("\"rendered\":\"3.14590e4\"") && s.contains("\"figures\":6"),
+        "the default is six significant figures: {s}"
+    );
+}
+
+#[test]
+fn a_zero_figure_count_is_a_compile_error() {
+    // A scientific mantissa has at least one significant figure, so `figures` must be
+    // ≥ 1; zero is rejected at compile time rather than producing a meaningless render.
+    let (ok, s) = run("let r = to_scientific(31459, 0)\n? r\n", "zerofig");
+    assert!(
+        !ok || s.contains("\"error\""),
+        "a zero figure count must be rejected: {s}"
+    );
+    assert!(
+        !s.contains("\"node\":\"to_scientific\""),
+        "must not emit a rendering node: {s}"
+    );
+}
+
+#[test]
+fn a_non_integer_figure_count_is_a_compile_error() {
+    let (ok, s) = run("let r = to_scientific(31459, 2.5)\n? r\n", "badfig");
+    assert!(
+        !ok || s.contains("\"error\""),
+        "a non-integer figure count must be rejected: {s}"
+    );
+}

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.59.0] — 2026-07-22
+
+### Added — NUM-6c: the `to_scientific(x [, figures])` scientific-notation rendering (ADJ-NUMERIC-SUBSTRATE §4.1, §4.3)
+
+```
+let reported = to_scientific(avogadro, 4)   % → "6.022e23"
+let quick    = to_scientific(measured)      % default 6 significant figures
+```
+
+- `to_scientific` joins `round_to`/`round_sig` as a built-in recognised during
+  `Apply` lowering (same native comma-list application surface, no new grammar). It
+  lowers to the new `logic_engine::ComputeExpr::ToScientific` node via a new
+  `ExprAst::ToScientific(expr, figures)` AST node, under the default half-even mode.
+- The `figures` argument is **optional**: `to_scientific(x)` uses the documented
+  default mantissa precision (`DEFAULT_SCI_FIGURES = 6`), resolved here at lowering so
+  the engine node always carries a concrete count and the audit records what was used.
+  A stated `to_scientific(x, n)` requires `n` a positive integer literal (`≥ 1`, since
+  a scientific mantissa has at least one significant figure) within the precision cap
+  (`MAX_ROUND_PLACES = 100`). A non-integer, zero, negative, oversized, or non-literal
+  `n`, or the wrong argument count, is a clean compile error — never a silent format.
+- All the expression walkers (`collect_refs`, `charged_clone`, `expand_rec`,
+  `substitute_expr`) carry the new node, so it composes inside formula bodies, `let`s,
+  and predicate application positions exactly like `round_to`/`round_sig`.
+
 ## [0.58.0] — 2026-07-22
 
 ### Added — NUM-6b: the `round_sig(x, n)` significant-figures narrowing (ADJ-NUMERIC-SUBSTRATE §4.1–§4.4)

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -267,6 +267,17 @@ pub enum ExprAst {
     /// as user formula applications (`quotient(a, b)`), so no new grammar or LaTeX
     /// change is needed.
     RoundTo(Box<ExprAst>, logic_engine::RoundSpec),
+    /// A **scientific-notation formatting** — `to_scientific(x [, figures])` (NUM-6c).
+    /// A rendering op: it narrows `x` to `figures` significant figures on the exact
+    /// path (like [`ExprAst::RoundTo`] with `SigFigures`) and produces the `d.ddde±E`
+    /// string alongside the narrowed value, so the audit carries both the exact source
+    /// and the rendered form (ADJ-NUMERIC-SUBSTRATE §4.1, §4.3). Lowers to the distinct
+    /// `logic_engine::ComputeExpr::ToScientific` node under the default half-even mode.
+    /// The `figures` count is validated (`≥ 1`, within the precision cap); when the
+    /// surface omits it, the default is resolved at lowering. Produced by the native
+    /// application surface `to_scientific(x [, figures])`, recognised as a built-in in
+    /// [`ExprAst::Apply`] lowering (same comma-list grammar as `round_to`/`round_sig`).
+    ToScientific(Box<ExprAst>, u32),
     /// An aggregation over every observation of a slot.
     Agg(AggOp, String),
     /// A **formula application** used as a sub-expression: `name(arg₁, …, argₙ)`

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -1221,6 +1221,16 @@ fn lower_expr(expr: &ExprAst) -> ComputeExpr {
             mode: bignum_core::RoundingMode::HalfEven,
             expr: Box::new(lower_expr(a)),
         },
+        // `to_scientific(x, figures)` (NUM-6c): the scientific-notation rendering. Lowers
+        // to the distinct engine `ToScientific` node so the significant-figure count and
+        // the default half-even mode ride along and the exact-path audit records both the
+        // exact source and the rendered string (ADJ-NUMERIC-SUBSTRATE §4.1, §4.3).
+        // `figures` was validated (≥ 1, within the cap; default applied) by the adapter.
+        ExprAst::ToScientific(a, figures) => ComputeExpr::ToScientific {
+            figures: *figures,
+            mode: bignum_core::RoundingMode::HalfEven,
+            expr: Box::new(lower_expr(a)),
+        },
         ExprAst::Call2(f, a, b) => ComputeExpr::Bin(
             lower_bin_fn(*f),
             Box::new(lower_expr(a)),
@@ -1551,6 +1561,7 @@ fn collect_refs(expr: &ExprAst, out: &mut Vec<String>) {
         | ExprAst::Ceil(a)
         | ExprAst::Round(a)
         | ExprAst::RoundTo(a, _)
+        | ExprAst::ToScientific(a, _)
         | ExprAst::Trunc(a)
         | ExprAst::Sign(a)
         | ExprAst::Call(_, a) => collect_refs(a, out),
@@ -1601,6 +1612,14 @@ const FORMULA_MAX_EXPANSION_NODES: usize = 10_000;
 /// default precision (256 bits ≈ 77 significant digits, ADJ-NUMERIC-SUBSTRATE §3)
 /// and any real measurement, so the cap constrains only pathological inputs.
 const MAX_ROUND_PLACES: u32 = 100;
+
+/// The significant-figure count `to_scientific(x)` uses when the surface omits it
+/// (NUM-6c). Six is the conventional default mantissa precision for scientific
+/// notation (`6.02214e23`) and comfortably inside [`MAX_ROUND_PLACES`]; an explicit
+/// `to_scientific(x, n)` overrides it. The default is applied here at lowering, so the
+/// engine node always carries a concrete `figures` count and the audit records what was
+/// used regardless of whether the writer stated it.
+const DEFAULT_SCI_FIGURES: u32 = 6;
 
 /// Maximum AST-nesting depth the expansion/substitution/clone walkers may descend
 /// in a single expression (ADJ-RULE-SUBSTRATE RS-1). The node budget bounds total
@@ -1684,6 +1703,9 @@ fn charged_clone(
         ExprAst::Ceil(a) => ExprAst::Ceil(Box::new(charged_clone(a, budget, d)?)),
         ExprAst::Round(a) => ExprAst::Round(Box::new(charged_clone(a, budget, d)?)),
         ExprAst::RoundTo(a, n) => ExprAst::RoundTo(Box::new(charged_clone(a, budget, d)?), *n),
+        ExprAst::ToScientific(a, n) => {
+            ExprAst::ToScientific(Box::new(charged_clone(a, budget, d)?), *n)
+        }
         ExprAst::Trunc(a) => ExprAst::Trunc(Box::new(charged_clone(a, budget, d)?)),
         ExprAst::Sign(a) => ExprAst::Sign(Box::new(charged_clone(a, budget, d)?)),
         ExprAst::Call(f, a) => ExprAst::Call(*f, Box::new(charged_clone(a, budget, d)?)),
@@ -1836,6 +1858,43 @@ fn expand_rec(
                 let value = expand_rec(&args[0], formulas, depth, chain, active, budget, d)?;
                 return Ok(ExprAst::RoundTo(Box::new(value), spec));
             }
+            // NUM-6c built-in: `to_scientific(x [, figures])` — the scientific-notation
+            // rendering. Recognised by NAME here, before the user-formula lookup, on the
+            // same comma-list application grammar. `figures` is OPTIONAL: `to_scientific(x)`
+            // uses the default mantissa precision [`DEFAULT_SCI_FIGURES`]; a stated
+            // `to_scientific(x, n)` requires `n` a positive integer literal (`≥ 1`, since a
+            // scientific mantissa has at least one significant figure) within the precision
+            // cap [`MAX_ROUND_PLACES`]. A non-integer, zero, negative, oversized, or
+            // non-literal `n`, or the wrong number of arguments, is a clean compile error.
+            if name == "to_scientific" {
+                if args.is_empty() || args.len() > 2 {
+                    return Err(LowerError::FormulaArity {
+                        formula: name.clone(),
+                        expected: 2,
+                        got: args.len(),
+                    });
+                }
+                let figures = if args.len() == 2 {
+                    match &args[1] {
+                        ExprAst::Lit(v)
+                            if v.fract() == 0.0
+                                && *v >= 1.0
+                                && *v <= MAX_ROUND_PLACES as f64 =>
+                        {
+                            *v as u32
+                        }
+                        _ => {
+                            return Err(LowerError::FormulaBadArgument {
+                                formula: name.clone(),
+                            })
+                        }
+                    }
+                } else {
+                    DEFAULT_SCI_FIGURES
+                };
+                let value = expand_rec(&args[0], formulas, depth, chain, active, budget, d)?;
+                return Ok(ExprAst::ToScientific(Box::new(value), figures));
+            }
             // Resolve the callee against the SAME registry the top-level query path
             // uses. An unknown name is a clean, specific error — distinct from an
             // aggregation or built-in call, which never reach here (they are separate
@@ -1924,6 +1983,10 @@ fn expand_rec(
             a, formulas, depth, chain, active, budget, d,
         )?))),
         ExprAst::RoundTo(a, n) => Ok(ExprAst::RoundTo(
+            Box::new(expand_rec(a, formulas, depth, chain, active, budget, d)?),
+            *n,
+        )),
+        ExprAst::ToScientific(a, n) => Ok(ExprAst::ToScientific(
             Box::new(expand_rec(a, formulas, depth, chain, active, budget, d)?),
             *n,
         )),
@@ -2107,6 +2170,9 @@ fn substitute_expr(
         ExprAst::Round(a) => ExprAst::Round(Box::new(substitute_expr(a, subst, budget, d)?)),
         ExprAst::RoundTo(a, n) => {
             ExprAst::RoundTo(Box::new(substitute_expr(a, subst, budget, d)?), *n)
+        }
+        ExprAst::ToScientific(a, n) => {
+            ExprAst::ToScientific(Box::new(substitute_expr(a, subst, budget, d)?), *n)
         }
         ExprAst::Trunc(a) => ExprAst::Trunc(Box::new(substitute_expr(a, subst, budget, d)?)),
         ExprAst::Sign(a) => ExprAst::Sign(Box::new(substitute_expr(a, subst, budget, d)?)),

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [0.47.0] — 2026-07-22 — NUM-6c: `to_scientific` — scientific-notation rendering (exact)
+
+Adds the first formatter of the precision/format family (NUM-6c,
+`ADJ-NUMERIC-SUBSTRATE.md` §4.1, §4.3): a **rendering** op that narrows a value to a
+stated number of significant figures on the exact path (reusing the NUM-6a/6b
+`round_sig` machinery) and produces the normalized `d.ddde±E` string alongside the
+narrowed exact value — both derived from one rounding so the string and the audit
+number can never disagree.
+
+### Added
+
+- `ComputeExpr::ToScientific { figures, mode, expr }` and the matching
+  `DerivationNode::ToScientific { figures, mode, rendered, operand, result }`. The
+  node carries the rendered boundary string **and** the narrowed numeric `result`
+  (so a downstream predicate over the binding still sees a number), plus the exact
+  operand subtree — everything `adj-verify` needs to re-render from the exact source.
+- `scientific(r, figures, mode)` — renders an exact rational in normalized scientific
+  notation with exactly `figures` significant figures and returns the narrowed exact
+  value beside it. The significant coefficient is `round(|r|·10^(figures−1−e))` under
+  `mode` (`e = ⌊log₁₀|x|⌋` via the exact `msd_exponent`), with a rounding **carry**
+  (`9.99 → 10.0`) bumping the exponent; zero renders `"0e0"`. All big-integer /
+  -decimal arithmetic — no `f64` log or tie-break. Dimension-preserving.
+
+### Notes
+
+- A non-finite operand (an upstream `exp` overflow) is caught by the same
+  finite-result guard the other ops apply — it returns a clean `NonFinite` error
+  rather than rendering `"inf"` as a scientific number.
+
 ## [0.46.0] — 2026-07-22 — NUM-6b: `round_sig` — significant-figures rounding (exact)
 
 Adds the significant-figures half of the precision narrowing (NUM-6b,

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.46.0"
+version = "0.47.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -423,6 +423,20 @@ pub enum ComputeExpr {
         mode: RoundingMode,
         expr: Box<ComputeExpr>,
     },
+    /// A **scientific-notation formatting** — `to_scientific(x [, figures])`
+    /// (NUM-6c). Unlike [`ComputeExpr::Round`] (which narrows to a *number*), this
+    /// is a **rendering** op: it narrows `expr` to `figures` significant figures on
+    /// the exact path (reusing the 6a/6b `round_sig` machinery), then produces the
+    /// normalized `d.ddde±E` string alongside the narrowed numeric value. Both the
+    /// exact source and the rendered string land in the audit (ADJ-NUMERIC-SUBSTRATE
+    /// §4.1, §4.3), so a checker can re-derive the rendering from the exact value.
+    /// `figures ≥ 1`; the default when the surface omits it is resolved at lowering.
+    /// Dimension-preserving (the magnitude is reformatted; its unit is untouched).
+    ToScientific {
+        figures: u32,
+        mode: RoundingMode,
+        expr: Box<ComputeExpr>,
+    },
 }
 
 /// *What* precision a [`ComputeExpr::Round`] narrows to. NUM-6a ships the
@@ -478,6 +492,20 @@ pub enum DerivationNode {
         operand: Box<DerivationNode>,
         result: f64,
     },
+    /// A **scientific-notation rendering** node (NUM-6c) — the audit record for a
+    /// `to_scientific(x, figures)`. Carries the `figures`/`mode` it narrowed under,
+    /// the `rendered` `d.ddde±E` string, and its single `operand` subtree (the exact
+    /// source), so `adj-verify` can re-narrow the operand's exact value to `figures`
+    /// significant figures and confirm the `rendered` form (ADJ-NUMERIC-SUBSTRATE
+    /// §4.3). `result` is the narrowed numeric value (so a downstream predicate over
+    /// the binding still sees a number); `rendered` is the boundary form.
+    ToScientific {
+        figures: u32,
+        mode: RoundingMode,
+        rendered: String,
+        operand: Box<DerivationNode>,
+        result: f64,
+    },
 }
 
 impl DerivationNode {
@@ -489,6 +517,7 @@ impl DerivationNode {
             DerivationNode::Lit { value } => *value,
             DerivationNode::Op { result, .. } => *result,
             DerivationNode::Round { result, .. } => *result,
+            DerivationNode::ToScientific { result, .. } => *result,
         }
     }
 }
@@ -890,6 +919,12 @@ fn eval(
 
         ComputeExpr::Round { spec, mode, expr } => eval_round(*spec, *mode, expr, kb, depth),
 
+        ComputeExpr::ToScientific {
+            figures,
+            mode,
+            expr,
+        } => eval_to_scientific(*figures, *mode, expr, kb, depth),
+
         ComputeExpr::Agg(op, slot) => {
             let observations = kb.observed_values_all(slot);
             // `count` is defined even when there are no observations (it's 0);
@@ -1208,6 +1243,141 @@ fn msd_exponent(num: &BigInteger, den: &BigInteger) -> i64 {
         e0
     } else {
         e0 - 1
+    }
+}
+
+/// Evaluate `to_scientific(x, figures)` (NUM-6c): narrow `x` to `figures` significant
+/// figures on the exact path and render the normalized scientific-notation string.
+/// A **rendering** op — it produces a boundary string (`"6.022e23"`) while keeping the
+/// narrowed numeric value for `value()` and the exact sidecar for the audit, so
+/// `adj-verify` can re-derive the string from the exact source (ADJ-NUMERIC-SUBSTRATE
+/// §4.1, §4.3). Dimension-preserving, like the round family (the magnitude is
+/// reformatted; its unit is untouched).
+#[inline(never)]
+fn eval_to_scientific(
+    figures: u32,
+    mode: RoundingMode,
+    expr: &ComputeExpr,
+    kb: &KnowledgeBase,
+    depth: usize,
+) -> Result<(DerivationNode, Dimension, Option<ExactRational>), ComputeError> {
+    let (operand, dim, exact) = eval(expr, kb, depth + 1)?;
+    // With an exact sidecar (every rational formula), the rendering and the narrowed
+    // exact value are derived TOGETHER from one rounding, so the string and the audit
+    // number can never disagree. A genuinely-inexact operand (a transcendental with no
+    // exact sidecar) falls back to formatting the already-approximate `f64`.
+    let (rendered, exact_out, result) = match &exact {
+        Some(r) => {
+            let (s, narrowed) = scientific(r, figures, mode);
+            let value = narrowed.to_f64();
+            (s, Some(narrowed), value)
+        }
+        None => {
+            let value = operand.value();
+            // `{:e}` with `figures − 1` fractional digits yields `d.ddde±E`; the
+            // operand is already approximate, so this is the labeled-lossy path.
+            let s = format!("{:.*e}", (figures.saturating_sub(1)) as usize, value);
+            (s, None, value)
+        }
+    };
+    // A non-finite operand (an `exp` overflow upstream) must not render as a clean
+    // scientific number — the same "no silently-wrong number" guard the other ops apply.
+    // (The op label reuses `Round`: `to_scientific` is a rounding-based narrowing.)
+    if !result.is_finite() {
+        return Err(ComputeError::NonFinite {
+            op: ComputeOp::Round,
+        });
+    }
+    Ok((
+        DerivationNode::ToScientific {
+            figures,
+            mode,
+            rendered,
+            operand: Box::new(operand),
+            result,
+        },
+        dim,
+        exact_out,
+    ))
+}
+
+/// Render an exact rational in normalized scientific notation `d.ddde±E` with exactly
+/// `figures` significant figures, and return the **narrowed exact value** alongside — both
+/// derived from one rounding so they always agree. `figures ≥ 1`.
+///
+/// The significant coefficient `C` is `round(|r| · 10^(figures−1−e))` under `mode`, where
+/// `e = ⌊log₁₀|r|⌋` ([`msd_exponent`]); `C` has exactly `figures` digits, except when a
+/// carry (`9.99 → 10.0`) makes it `10^figures`, which bumps the exponent and resets `C`
+/// to `10^(figures−1)`. The mantissa is `C`'s digit string with a point after the first
+/// digit (`"6.022"`); the narrowed value is `±C · 10^(e−figures+1)`. Zero renders `"0e0"`.
+/// All arithmetic is exact big-integer/-decimal, so no `f64` log or tie-break is involved.
+fn scientific(r: &ExactRational, figures: u32, mode: RoundingMode) -> (String, ExactRational) {
+    if r.numerator().is_zero() {
+        return ("0e0".to_string(), ExactRational::from_i128(0));
+    }
+    let neg = r.numerator().is_negative();
+    let num = r.numerator().abs();
+    let den = r.denominator().clone(); // always > 0 (canonical rational)
+    let mut e = msd_exponent(&num, &den);
+
+    // C = round(|r| · 10^(figures−1−e)) to the nearest integer under `mode`, computed as an
+    // exact integer division via `div_round` to scale 0 (so half-even etc. are honored).
+    let p: i64 = figures as i64 - 1 - e;
+    let (dividend, divisor) = if p >= 0 {
+        (&num * &ten_to(p as u32), den)
+    } else {
+        (num, &den * &ten_to((-p) as u32))
+    };
+    let c_bd = BigDecimal::from_integer(dividend).div_round(
+        &BigDecimal::from_integer(divisor),
+        0,
+        mode,
+    );
+    let mut c = bigdecimal_to_integer(&c_bd);
+
+    // Rounding carry: `9.99…` at 3 figs rounds to `10.0…` = `10^figures`. Bump the
+    // exponent and collapse the coefficient back to `figures` digits (`10^(figures−1)`).
+    if c >= ten_to(figures) {
+        c = ten_to(figures - 1);
+        e += 1;
+    }
+
+    let digits = c.to_string(); // exactly `figures` digits (`c ≥ 0`, in `[10^(f−1), 10^f)`)
+    let mantissa = if figures == 1 {
+        digits.clone()
+    } else {
+        format!("{}.{}", &digits[..1], &digits[1..])
+    };
+    let sign = if neg { "-" } else { "" };
+    let rendered = format!("{sign}{mantissa}e{e}");
+
+    // Narrowed exact value = ±C · 10^(e − figures + 1) (the place value of the last digit).
+    let place = e - figures as i64 + 1;
+    let signed_c = if neg { -&c } else { c };
+    let narrowed = if place >= 0 {
+        ExactRational::from_ratio(BigRational::from_integer(&signed_c * &ten_to(place as u32)))
+    } else {
+        ExactRational::from_ratio(BigRational::new(signed_c, ten_to((-place) as u32)))
+    };
+    (rendered, narrowed)
+}
+
+/// `10^n` as a [`BigInteger`]. A thin wrapper over [`BigInteger::pow`] used by the
+/// scientific-notation renderer; `n` is bounded by the operand's own magnitude (the same
+/// materialization `round_sig` already performs), not by any new user-controlled amplifier.
+fn ten_to(n: u32) -> BigInteger {
+    BigInteger::from_i64(10).pow(n)
+}
+
+/// The integer value of a `BigDecimal` known to be integral (produced by a `div_round` to
+/// scale 0). `value = mant · 10^(−scale)`, and an integral value normalizes to `scale ≤ 0`,
+/// so this is `mant · 10^|scale|`.
+fn bigdecimal_to_integer(bd: &BigDecimal) -> BigInteger {
+    let scale = bd.scale();
+    if scale < 0 {
+        bd.mantissa() * &ten_to((-scale) as u32)
+    } else {
+        bd.mantissa().clone()
     }
 }
 
@@ -2696,5 +2866,83 @@ mod tests {
             }
             other => panic!("expected Round node, got {other:?}"),
         }
+    }
+
+    // ---- NUM-6c: to_scientific(x, figures) — the scientific-notation rendering ----
+
+    fn to_sci(figures: u32, inner: ComputeExpr) -> ComputeExpr {
+        ComputeExpr::ToScientific {
+            figures,
+            mode: RoundingMode::HalfEven,
+            expr: Box::new(inner),
+        }
+    }
+    fn rendered_of(d: &Derived) -> String {
+        match &d.tree {
+            DerivationNode::ToScientific { rendered, .. } => rendered.clone(),
+            other => panic!("expected ToScientific node, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn to_scientific_renders_and_narrows_across_scales() {
+        let kb = KnowledgeBase::new();
+        // A large integer: 31459 to 3 sig-figs = 31500 = 3.15e4 (the 59 rounds the 4 up).
+        let a = compute("r", &to_sci(3, ComputeExpr::Lit(31459.0)), &kb).unwrap();
+        assert_eq!(rendered_of(&a), "3.15e4");
+        assert_eq!(a.exact, ExactRational::new(31500, 1));
+        // A repeating rational: 1/3 to 4 sig-figs = 0.3333 = 3.333e-1, EXACTLY.
+        let b = compute("r", &to_sci(4, frac(1, 3)), &kb).unwrap();
+        assert_eq!(rendered_of(&b), "3.333e-1");
+        assert_eq!(b.exact, ExactRational::new(3333, 10000));
+        // A sub-1 terminating value: 3.14159 to 3 sig-figs = 3.14 = 157/50 = 3.14e0.
+        let c = compute("r", &to_sci(3, frac(314159, 100000)), &kb).unwrap();
+        assert_eq!(rendered_of(&c), "3.14e0");
+        assert_eq!(c.exact, ExactRational::new(157, 50));
+    }
+
+    #[test]
+    fn to_scientific_handles_rounding_carry_into_a_new_exponent() {
+        let kb = KnowledgeBase::new();
+        // 999 to 2 sig-figs rounds 9.99e2 UP to 1.0e3 — the carry must bump the
+        // exponent and keep exactly `figures` mantissa digits (`"1.0"`, not `"10"`).
+        let d = compute("r", &to_sci(2, ComputeExpr::Lit(999.0)), &kb).unwrap();
+        assert_eq!(rendered_of(&d), "1.0e3");
+        assert_eq!(d.exact, ExactRational::new(1000, 1));
+    }
+
+    #[test]
+    fn to_scientific_handles_sign_single_figure_and_zero() {
+        let kb = KnowledgeBase::new();
+        // Negative, 3 figs: −1/8 = −0.125 → −1.25e−1, narrowed value exactly −1/8.
+        let neg = compute("r", &to_sci(3, frac(-1, 8)), &kb).unwrap();
+        assert_eq!(rendered_of(&neg), "-1.25e-1");
+        assert_eq!(neg.exact, ExactRational::new(-1, 8));
+        // A single significant figure has no decimal point: 602 → 6e2.
+        let one = compute("r", &to_sci(1, ComputeExpr::Lit(602.0)), &kb).unwrap();
+        assert_eq!(rendered_of(&one), "6e2");
+        assert_eq!(one.exact, ExactRational::new(600, 1));
+        // Zero has no significant digits — rendered "0e0", exact 0.
+        let z = compute("r", &to_sci(4, ComputeExpr::Lit(0.0)), &kb).unwrap();
+        assert_eq!(rendered_of(&z), "0e0");
+        assert_eq!(z.exact, ExactRational::new(0, 1));
+    }
+
+    #[test]
+    fn to_scientific_preserves_dimension() {
+        // Rendering a dimensioned value reformats the magnitude; the unit survives.
+        let kb = kb_with(vec![money("bal", 10, "usd")]);
+        let expr = to_sci(
+            3,
+            ComputeExpr::Bin(
+                ComputeOp::Div,
+                Box::new(refexpr("bal")),
+                Box::new(ComputeExpr::Lit(3.0)),
+            ),
+        );
+        let d = compute("r", &expr, &kb).unwrap();
+        assert_eq!(rendered_of(&d), "3.33e0"); // 10/3 usd → 3.33e0
+        assert_eq!(d.dim, Dimension::Money("usd".into()));
+        assert_eq!(d.exact, ExactRational::new(333, 100));
     }
 }

--- a/code/specs/ADJ-NUMERIC-SUBSTRATE.md
+++ b/code/specs/ADJ-NUMERIC-SUBSTRATE.md
@@ -165,7 +165,14 @@ tests → impl → security-review → babysit:
   `n ≥ 1`.
 - **NUM-6c** — the formatters `to_scientific` / `to_percent` / `to_currency` (rendering, on the
   6a/6b core) and per-`KnowledgeBase` `BigDouble` precision (the configurable default §3 defers
-  here).
+  here). Lands incrementally: **`to_scientific(x [, figures])`** ✅ **shipped** — the
+  `ComputeExpr::ToScientific { figures, mode, expr }` engine node (a *rendering* op: it narrows
+  to `figures` significant figures on the 6b exact path, then produces the normalized `d.ddde±E`
+  string beside the narrowed exact value, both from one rounding so they can never disagree), the
+  native `to_scientific(x [, figures])` application surface (optional `figures`, default 6; `≥ 1`,
+  within the precision cap), the §4.3 audit record (`node:to_scientific`, `figures`, `mode`,
+  `rendered`, operand subtree), and an end-to-end formula test. `to_percent` / `to_currency` and
+  per-`KnowledgeBase` precision follow.
 
 ---
 


### PR DESCRIPTION
## NUM-6c — `to_scientific(x [, figures])`: the first formatter of the precision/format family

Follows NUM-6a (`round_to`, #8806) and NUM-6b (`round_sig`, #8820). Where those narrow to a **number**, `to_scientific` is a **rendering** op: it narrows `x` to `figures` significant figures on the 6b exact path and produces the normalized `d.ddde±E` boundary string **alongside** the narrowed exact value — both derived from *one* rounding, so the string an auditor reads and the number `adj-verify` re-derives can never disagree (ADJ-NUMERIC-SUBSTRATE §4.1, §4.3).

```
let reported = to_scientific(avogadro, 4)   % → "6.022e23"
let quick    = to_scientific(measured)      % default 6 significant figures
```

### What lands
- **logic-engine (0.47.0):** `ComputeExpr::ToScientific { figures, mode, expr }` + `DerivationNode::ToScientific { figures, mode, rendered, operand, result }` (the node carries the rendered string **and** the narrowed numeric `result`, so a downstream predicate over the binding still sees a number). `scientific(r, figures, mode) -> (String, ExactRational)` is the single source of truth: the significant coefficient `C = round(|r|·10^(figures−1−e))` via `div_round` to scale 0 (`e = ⌊log₁₀|x|⌋` from the exact `msd_exponent`), a rounding carry (`9.99→10.0`) bumps the exponent, zero renders `"0e0"`. All big-integer/-decimal — **no `f64` log or tie-break**. Dimension-preserving; a non-finite operand hits the finite-result guard.
- **adj-lang (0.59.0):** `ExprAst::ToScientific(expr, figures)` + the `to_scientific` Apply-intercept (figures **optional**, default `DEFAULT_SCI_FIGURES = 6`, `≥ 1`, `≤ MAX_ROUND_PLACES = 100`; a non-integer / zero / negative / oversized / non-literal `n` or wrong arity is a clean compile error) + all 4 expression walkers.
- **adj-constraint-solver (0.14.0):** cross-producer totality — the new variant in all 6 `ComputeExpr` match sites (5 out-of-scope `None`, `substitute_observed` rebuild, `is_constant_expr` recurse). No behaviour change for existing inputs.
- **adj-lang-cli (0.20.0):** renders `{"node":"to_scientific","figures":n,"mode":…,"rendered":…,"value":…,"operand":…}` + an end-to-end test.
- **Spec** §4.4 marks `to_scientific` shipped (`to_percent` / `to_currency` / per-KB precision follow).

### Verification
- Full `cargo test` across all four consumers — **green** (7 suites, 0 failures; 4 engine unit tests + a 5-case e2e).
- Exact values checked: `31459→"3.15e4"` (31500/1), `1/3→"3.333e-1"` (3333/10000), default `31459→"3.14590e4"`, carry `999→"1.0e3"`, negative `−1/8→"-1.25e-1"`, `602→"6e2"` (1 fig), `0→"0e0"`.
- `cargo clippy` clean; `/security-review` **PASSED** (no new DoS amplification — materialization is proportional to the already-materialized operand, same as shipped `round_sig`; `figures` trust boundary airtight; no panicking casts/slices; no div-by-zero).

🤖 Generated with [Claude Code](https://claude.com/claude-code)