### PR TITLE
feat(semantic-ir-to-ruby): floats — native Float literals (SIR16)

### DIFF
--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 0.6.0 — floats (SIR16)
+
+Accepts `Feature::Floats`. Ruby has a native `Float`, so this is a one-arm
+addition: `Expr::FloatLit` renders directly as a Ruby float literal. The
+feature gates ONLY `FloatLit` (float arithmetic reuses the existing
+`+`/`-`/`*`/`/` builtins, which already fold to native Ruby operators), and the
+runtime's `sir_fmt_float` already rendered every float — so accepting the
+feature plus the one emit arm keeps the emitter total.
+
+The literal is produced by a new `float_to_ruby_literal` helper, which fixes two
+ways a naive `value.to_string()` would be wrong:
+
+- **Integral floats must keep their point.** Rust's `f64::to_string` renders
+  `7.0` as `"7"` — which Ruby parses as an *Integer* (a different type, with
+  floor `/` instead of true divide, and `7` instead of `7.0` on display). The
+  helper uses `{:?}` (Debug), whose shortest round-tripping form always carries
+  a decimal point or exponent (`7.0`, `-0.0`, `1e300`) — every one a valid Ruby
+  *Float* literal.
+- **Non-finite values have no numeric token.** Ruby has no `inf`/`nan` literal;
+  the values are `Float::INFINITY` / `-Float::INFINITY` / `Float::NAN`. A
+  `FloatLit` carrying one (rare — it usually arises at runtime from `1.0 / 0.0`)
+  now emits the named constant.
+
+Because display routes through the runtime's `sir_fmt_float` (Ruby's own
+`to_s`/`nan?`/`infinite?`), the printed form is native regardless of how the
+literal was spelled — the helper only has to preserve the numeric value.
+Verified end-to-end through a real `ruby` with hand-built modules (the frontend
+masks `FloatLit`): integral floats keep `.0` (`7.0`, not `7`), `-0.0` keeps its
+sign, `1.5 + 2.5 == 4.0` and `2.0 * 3.0 == 6.0` (integral results stay Float),
+`7.0 / 2 == 3.5` while `7 / 2 == 3` (division frontier preserved — a Float
+operand promotes, two Integers floor), `1.0 / 0.0 == Infinity` and `0.0 / 0.0 ==
+NaN` (Float division by zero does not raise), and `7.0 == 7` is true.
+
 ## 0.5.0 — maps (SIR16)
 
 Accepts `Feature::Maps`. Ruby has a native Hash, so the three map nodes render

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/README.md
+++ b/code/packages/rust/semantic-ir-to-ruby/README.md
@@ -50,9 +50,11 @@ SIR16 control flow and mutation (`Loops` — `While`, `ForRange` (numeric
 `Sequences` — native arrays for all five sequence nodes: `SeqLit` (`[1, 2, 3]`,
 structural `Array#==`), `SeqIndex` (`a[i]`, nil on OOB), `SeqLen` (`a.length`),
 `SeqSet` (`a[i] = v`, bounds-checked via `sir_seq_set`), and `ForEach`
-(`for x in a`); and SIR16 `Maps` — a native Hash for `MapLit` (`{k => v}`),
+(`for x in a`); SIR16 `Maps` — a native Hash for `MapLit` (`{k => v}`),
 `MapGet` (`h[k]`, nil on miss), and `MapSet` (`h[k] = v`), with structural
-composite keys.
+composite keys; and SIR16 `Floats` — a native `Float` for `FloatLit` (rendered
+so `7.0` stays a Float, not the Integer `7`; `Infinity`/`NaN` are named), with
+native float arithmetic and division.
 Rejects `TailCalls`, `Intrinsics`, and every not-yet-wired feature (array
 indexing / slicing via `IndexGet` — `NDArrays`; array-pattern destructuring —
 `ShortCircuit`; collection methods, exceptions, OOP) until its cascade batch

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -380,6 +380,39 @@ fn emit_block_inline(b: &Block) -> String {
     parts.join("; ")
 }
 
+/// Render an `f64` as a Ruby **Float** literal that round-trips to the same
+/// value.  Two things a naive `value.to_string()` gets wrong:
+///
+/// - **Integral floats lose their point.**  Rust's `f64::to_string` renders
+///   `7.0` as `"7"`, which Ruby would parse as an *Integer* — a different type
+///   with different `/` (floor vs true divide) and display (`7` vs `7.0`).
+///   Rust's `{:?}` (Debug) instead always emits a decimal point or an exponent
+///   (`7.0`, `-0.0`, `1e300`), each a valid Ruby *Float* literal, using the
+///   shortest round-tripping form.
+/// - **Non-finite values have no numeric literal.**  Ruby has no `inf`/`nan`
+///   token (those would be method calls / bare identifiers); the values are
+///   named `Float::INFINITY` / `Float::NAN`.  A `FloatLit` carrying one is rare
+///   (it usually arises at runtime from `1.0 / 0.0`), but must still emit a
+///   parseable expression.
+///
+/// The runtime's `sir_fmt_float` renders every float through Ruby's own
+/// `to_s`/`nan?`/`infinite?`, so *display* is native regardless of how the
+/// literal was spelled — this helper only has to preserve the numeric value.
+fn float_to_ruby_literal(value: f64) -> String {
+    if value.is_nan() {
+        "Float::NAN".to_string()
+    } else if value.is_infinite() {
+        if value > 0.0 {
+            "Float::INFINITY".to_string()
+        } else {
+            "-Float::INFINITY".to_string()
+        }
+    } else {
+        // `{:?}` guarantees a `.`/exponent for every finite f64 → a Ruby Float.
+        format!("{value:?}")
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Expressions (Ruby is expression-oriented → emit_expr is total)
 // ---------------------------------------------------------------------------
@@ -387,6 +420,7 @@ fn emit_block_inline(b: &Block) -> String {
 fn emit_expr(e: &Expr) -> String {
     match e {
         Expr::IntLit { value, .. } => value.to_string(),
+        Expr::FloatLit { value, .. } => float_to_ruby_literal(*value),
         Expr::BoolLit { value, .. } => value.to_string(),
         Expr::NilLit { .. } => "nil".to_string(),
         Expr::SymLit { name, .. } => emit_symbol(name),

--- a/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
@@ -63,6 +63,16 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     Feature::SizedIntegers,
     Feature::Unsigned,
     Feature::WrappingArithmetic,
+    // ── SIR16 floats ─────────────────────────────────────────────────
+    // Ruby has a native `Float`, so a `Expr::FloatLit` renders directly as a
+    // Ruby float literal (via `float_to_ruby_literal`, which guarantees the
+    // literal round-trips as a Float — `7.0`, not the Integer `7`). `Floats`
+    // gates ONLY `FloatLit`; float arithmetic reuses the same `+`/`-`/`*`/`/`
+    // builtins (native Ruby operators, so `1.5 + 2.5 == 4.0` and `7.0 / 2 ==
+    // 3.5` are exact), and the runtime's `sir_fmt_float` already renders every
+    // float (integral floats keep their `.0`; `NaN`/`Infinity` are named). So
+    // accepting the feature plus the one emit arm keeps the emitter total.
+    Feature::Floats,
     // ── SIR16 control flow / mutation ────────────────────────────────
     // `Stmt::While` (loops) and `Stmt::Assign` (re-binding) render as Ruby's
     // native `while … end` and `name = value` — Ruby is fully mutable and

--- a/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
@@ -702,3 +702,133 @@ fn for_each_over_a_map_does_not_panic() {
         assert!(!out.is_empty(), "the loop ran and printed the entry");
     }
 }
+
+// ── SIR16 floats ───────────────────────────────────────────────────────────
+// `Feature::Floats` gates ONLY `Expr::FloatLit`. Ruby has a native `Float`, so
+// the literal renders directly and arithmetic reuses the native operators. The
+// Ruby FRONTEND masks this node (its parser would emit a `FloatLit` only from
+// float SOURCE, which these tests don't go through), so — like the sequence and
+// map tests above — we hand-build producer-agnostic modules and prove the
+// emitter is total and the numbers/display match a real `ruby`.
+
+fn flit(value: f64) -> Expr {
+    Expr::FloatLit { value, span: s2() }
+}
+fn bin(name: &str, a: Expr, b: Expr) -> Expr {
+    Expr::BuiltinCall {
+        name: name.into(),
+        args: vec![a, b],
+        effects: EffectSet::PURE,
+        span: s2(),
+    }
+}
+/// A `main` module declaring only `Floats` (arithmetic/`puts` are builtins,
+/// which are gated by the builtin allowlist, not by a feature).
+fn float_module(stmts: Vec<Stmt>) -> Module {
+    let mut m = seq_module(stmts);
+    m.manifest = FeatureManifest::from_features(&[Feature::Floats]);
+    m
+}
+fn run_float(stmts: Vec<Stmt>) -> Option<String> {
+    run_ruby(&compile(&float_module(stmts)).expect("float module must compile, not panic").source)
+}
+
+#[test]
+fn float_literal_emits_a_float_not_an_integer() {
+    // THE core hazard: a naive `f64::to_string()` renders `7.0` as `"7"`, which
+    // Ruby parses as an Integer (wrong type, wrong `/`, wrong display). The
+    // emitted literal must carry a decimal point.
+    let rb = compile(&float_module(vec![puts(flit(7.0))]))
+        .expect("compile")
+        .source;
+    assert!(
+        rb.contains("7.0"),
+        "an integral FloatLit must emit `7.0`, not the Integer `7`:\n{rb}"
+    );
+}
+
+#[test]
+fn non_finite_literal_emits_a_named_constant() {
+    // Ruby has no `inf`/`nan` numeric token — the values are `Float::INFINITY` /
+    // `Float::NAN`. A `FloatLit` carrying one must still emit a parseable form.
+    let rb = compile(&float_module(vec![
+        puts(flit(f64::INFINITY)),
+        puts(flit(f64::NEG_INFINITY)),
+        puts(flit(f64::NAN)),
+    ]))
+    .expect("compile")
+    .source;
+    assert!(rb.contains("Float::INFINITY"), "positive infinity:\n{rb}");
+    assert!(rb.contains("-Float::INFINITY"), "negative infinity:\n{rb}");
+    assert!(rb.contains("Float::NAN"), "NaN:\n{rb}");
+}
+
+#[test]
+fn float_literal_displays_with_a_trailing_point() {
+    // `puts 7.0` → `7.0` (integral float keeps its `.0`), `puts 3.25` → `3.25`,
+    // `puts(-0.0)` → `-0.0` (the sign of zero survives) — all via the runtime's
+    // `sir_fmt_float`, matching a real Ruby.
+    match run_float(vec![puts(flit(7.0)), puts(flit(3.25)), puts(flit(-0.0))]) {
+        Some(out) => assert_eq!(out, "7.0\n3.25\n-0.0"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn float_arithmetic_is_native_and_exact() {
+    // Float `+`/`-`/`*` reuse the native chained operators, so an integral
+    // result stays a Float (`4.0`, not `4`) — matching every other backend.
+    match run_float(vec![
+        puts(bin("+", flit(1.5), flit(2.5))), // 4.0
+        puts(bin("*", flit(2.0), flit(3.0))), // 6.0
+        puts(bin("-", flit(7.0), flit(0.5))), // 6.5
+    ]) {
+        Some(out) => assert_eq!(out, "4.0\n6.0\n6.5"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn float_and_integer_division_follow_ruby() {
+    // `7.0 / 2` true-divides to `3.5` (Float#/); `7 / 2` floors to `3`
+    // (Integer#/) — the division frontier, preserved: a Float operand promotes,
+    // two Integers floor. A regression guard that adding floats did not disturb
+    // integer division.
+    match run_float(vec![
+        puts(bin("/", flit(7.0), ilit(2))), // 3.5
+        puts(bin("/", flit(6.0), flit(2.0))), // 3.0
+        puts(bin("/", ilit(7), ilit(2))),   // 3  (Integer floor)
+    ]) {
+        Some(out) => assert_eq!(out, "3.5\n3.0\n3"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn non_finite_arithmetic_displays_named() {
+    // Float division by zero yields `Infinity`/`-Infinity` (NOT a
+    // `ZeroDivisionError` — that is Integer-only), and `0.0/0.0` is `NaN` —
+    // rendered by `sir_fmt_float`, matching a real Ruby.
+    match run_float(vec![
+        puts(bin("/", flit(1.0), flit(0.0))),  // Infinity
+        puts(bin("/", flit(-1.0), flit(0.0))), // -Infinity
+        puts(bin("/", flit(0.0), flit(0.0))),  // NaN
+    ]) {
+        Some(out) => assert_eq!(out, "Infinity\n-Infinity\nNaN"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn float_equality_is_value_based() {
+    // `7.0 == 7.0` is true; a Float equals a numerically-equal Integer under
+    // Ruby `==` (`7.0 == 7`), routed through `sir_eq`.
+    match run_float(vec![
+        puts(bin("=", flit(7.0), flit(7.0))), // #t
+        puts(bin("=", flit(7.0), ilit(7))),   // #t (Ruby ==: 7.0 == 7)
+        puts(bin("=", flit(7.0), flit(7.5))), // #f
+    ]) {
+        Some(out) => assert_eq!(out, "#t\n#t\n#f"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}

--- a/code/specs/SIR25-semantic-ir-to-ruby.md
+++ b/code/specs/SIR25-semantic-ir-to-ruby.md
@@ -67,9 +67,17 @@ pub fn compile(module: &Module) -> Result<Artifact, BackendError>;
 
 **v0 accepts** the SIR-v0 feature set: `Closures`, `Pairs`, `Symbols`,
 `Strings`, `DynamicTyping`, `OptionalTypeAnnotations`, `MutualRecursion`,
-`Globals`.  **v0 rejects** `TailCalls`, `Intrinsics`, and every later feature
-until its batch lands (each rejection is a clean, source-positioned
-`UnsupportedFeature`).
+`Globals`.
+
+**Landed since v0** (one version-bumped batch at a time — see the roadmap): the
+SIR26 integer conversions (`Conversions`, `SizedIntegers`, `Unsigned`,
+`WrappingArithmetic`); and the SIR16 batches `Loops` + `MutableBindings`
+(0.3.0), `Sequences` (native `Array`, 0.4.0), `Maps` (native `Hash`, 0.5.0), and
+`Floats` (native `Float`, 0.6.0).
+
+**Still rejects** `TailCalls`, `Intrinsics`, `ShortCircuit`, `NDArrays`,
+exceptions/OOP, and every not-yet-landed feature (each rejection is a clean,
+source-positioned `UnsupportedFeature`).
 
 ## Value model
 
@@ -93,6 +101,7 @@ or temporaries:
 | SIR node | Emitted Ruby |
 |---|---|
 | `IntLit { value }` | `<value>` |
+| `FloatLit { value }` | `<value>` as a Ruby `Float` — `7.0` (never the Integer `7`), `Float::INFINITY` / `Float::NAN` |
 | `BoolLit { value }` | `true` / `false` |
 | `NilLit` | `nil` |
 | `SymLit { name }` | `:<name>` (or `:"<escaped>"`) |


### PR DESCRIPTION
## What

Adds SIR16 **floats** to the Ruby backend (`semantic-ir-to-ruby` 0.5.0 → 0.6.0) — the first of the Floats parity arc (Go/Rust/Python/JS already accept `Feature::Floats`; Ruby and C were the laggards, C tracked next).

Ruby has a native `Float`, so this is a **one-arm** addition: `Expr::FloatLit` renders directly as a Ruby float literal. `Feature::Floats` gates *only* `FloatLit` (float arithmetic reuses the existing `+`/`-`/`*`/`/` builtins, which already fold to native operators), and the runtime's `sir_fmt_float` already rendered every float — so accepting the feature plus one emit arm keeps the emitter total.

## The one subtlety: the literal must stay a `Float`

A new `float_to_ruby_literal` helper fixes two ways a naive `value.to_string()` is wrong:

- **Integral floats must keep their point.** Rust's `f64::to_string` renders `7.0` as `"7"` — which Ruby parses as an **Integer** (different type, floor `/` instead of true divide, `7` not `7.0` on display). The helper uses `{:?}` (Debug), whose shortest round-tripping form always carries a decimal point or exponent (`7.0`, `-0.0`, `1e300`) — every one a Ruby *Float* literal.
- **Non-finite values have no numeric token.** Ruby has no `inf`/`nan` literal; the helper emits `Float::INFINITY` / `-Float::INFINITY` / `Float::NAN`.

Display routes through the runtime's `sir_fmt_float` (Ruby's own `to_s`/`nan?`/`infinite?`), so the printed form is native regardless of how the literal was spelled — the helper only preserves the numeric value.

## Verification

- `cargo test -p semantic-ir-to-ruby` — **40 tests green** (7 new), run through a real `ruby` with hand-built modules (the frontend masks `FloatLit`): integral floats keep `.0`, `-0.0` keeps its sign, `1.5 + 2.5 == 4.0` and `2.0 * 3.0 == 6.0` (integral results stay Float), `7.0 / 2 == 3.5` while `7 / 2 == 3` (division frontier preserved — a Float operand promotes, two Integers floor), `1.0 / 0.0 == Infinity` and `0.0 / 0.0 == NaN` (Float div-by-zero does not raise), `7.0 == 7` true.
- `cargo clippy -p semantic-ir-to-ruby --all-targets` clean.
- Security review passed (the `{:?}` float format is a closed `[0-9.eE+-]` set — no Ruby-source-injection surface; round-trips exactly; no panic/DoS; totality confirmed).
- SIR25 spec capability section synced (also caught up the prior Sequences/Maps drift) + `FloatLit` row added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)