### PR TITLE
feat(app): session orchestrator — sweep + grounded connections (HL03 phase 3)

### DIFF
--- a/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.9.0 — the session orchestrator: sweep + grounded connections (HL03 phase 3)
+
+- `src/session.ts` — `buildSession(concept, lessons, activeCount)` takes the
+  teaching sweep (phase 2) and annotates each stop with the **connections back
+  to earlier languages in the sweep**: where two languages' lessons for the
+  concept share an etymological root, the link is surfaced. This is the payoff
+  of interleaving — meeting "thank you" in Telugu right after Kannada and Hindi,
+  and being shown all three carry the Sanskrit root *dhanya*.
+- **The grounding rule, enforced in code**: a connection exists *iff* the two
+  stops' lessons literally share a root string (from `lesson.roots`). Nothing is
+  inferred or invented; the reported `sharedRoots` is the exact set intersection,
+  sorted. Connections always point backward in chain order.
+- Verified against the real curriculum: Kannada and Telugu "thank you" link back
+  to Hindi via `dhanya`. Controls bite — asserting a connection without a shared
+  root fails the grounding test; over-reporting (union instead of intersection)
+  fails the "never from thin air" control; a concept sharing no roots surfaces
+  no link. Pure, deterministic, no UI.
+
 ## 0.8.1 — carry etymological roots on each lesson (HL03 phase 3 prerequisite)
 
 - `Lesson` now carries `roots: string[]` — the etymological roots a lesson cites

--- a/code/programs/typescript/script-writing-visualizer/package.json
+++ b/code/programs/typescript/script-writing-visualizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "script-writing-visualizer",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "private": true,
   "description": "Companion study app (HL02): break a non-Latin script apart and learn to write it — and drill the whole written curriculum with a spaced-repetition schedule that remembers you",
   "type": "module",

--- a/code/programs/typescript/script-writing-visualizer/src/session.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/session.ts
@@ -1,0 +1,101 @@
+// ---------------------------------------------------------------------------
+// session.ts — the SESSION ORCHESTRATOR (HL03 phase 3)
+// ---------------------------------------------------------------------------
+//
+// Phase 2 (`sequence.ts`) computed the TEACHING SWEEP: for one concept, the
+// active languages that teach it, walked in chain order. That is the skeleton
+// of a study session. This module puts flesh on it — the CONNECTIONS that make
+// interleaving worth doing.
+//
+// As the sweep moves forward through the chain (Spanish, then Latin, then
+// French, …), each new language is presented alongside the links back to the
+// languages already seen this pass: where a word shares an etymological ROOT
+// with one the learner just met, the app says so. Meeting "thank you" in Telugu
+// right after Kannada and Hindi, and being shown that all three carry the
+// Sanskrit root *dhanya*, is the moment the three stop being three separate
+// facts and become one.
+//
+// The rule this module keeps: a connection is only ever asserted when the DATA
+// says so. A connection between two stops exists iff their lessons literally
+// share a root string (from `lesson.roots`, sourced from the curriculum). No
+// connection is inferred, guessed, or invented — if two languages' words for a
+// concept share no root in the data, the app shows no link between them.
+//
+// Pure and deterministic, like the sequencing layer it builds on: no UI, no
+// review scheduling. Those are later phases.
+// ---------------------------------------------------------------------------
+
+import type { Lesson } from "./lessons";
+import { activeChain, teachingSweep, type ChainLanguage, type SweepStop } from "./sequence";
+
+/**
+ * A link from one stop in the sweep back to an EARLIER one, justified by the
+ * roots their lessons share. `to` is always a language that came before this
+ * step in chain order; `sharedRoots` is why they are linked.
+ */
+export interface Connection {
+  to: ChainLanguage;
+  /** The root strings both stops' lessons cite. Sorted, deduped, non-empty. */
+  sharedRoots: string[];
+}
+
+/**
+ * One step of a session: a language, the lesson(s) that teach the concept there,
+ * and the connections back to earlier languages in the same sweep. The first
+ * stop always has no connections (nothing precedes it); later stops have one
+ * connection per earlier language they share a root with.
+ */
+export interface SessionStep {
+  language: ChainLanguage;
+  lessons: Lesson[];
+  connections: Connection[];
+}
+
+/** The union of every root cited by a stop's lessons. */
+function rootsOfStop(stop: SweepStop): Set<string> {
+  const roots = new Set<string>();
+  for (const lesson of stop.lessons) for (const r of lesson.roots) roots.add(r);
+  return roots;
+}
+
+/**
+ * Assemble a session for one concept over the active chain prefix.
+ *
+ * Runs the teaching sweep, then for each stop finds its connections back to the
+ * stops already seen (earlier in chain order) whose lessons share a root. The
+ * result is the sweep annotated with grounded cross-language links.
+ */
+export function buildSession(
+  concept: string,
+  lessons: Lesson[],
+  activeCount: number,
+): SessionStep[] {
+  const sweep = teachingSweep(concept, lessons, activeChain(activeCount));
+
+  const steps: SessionStep[] = [];
+  const seen: Array<{ language: ChainLanguage; roots: Set<string> }> = [];
+
+  for (const stop of sweep) {
+    const myRoots = rootsOfStop(stop);
+    const connections: Connection[] = [];
+    for (const earlier of seen) {
+      const shared = [...myRoots].filter((r) => earlier.roots.has(r)).sort();
+      if (shared.length > 0) connections.push({ to: earlier.language, sharedRoots: shared });
+    }
+    steps.push({ language: stop.language, lessons: stop.lessons, connections });
+    seen.push({ language: stop.language, roots: myRoots });
+  }
+
+  return steps;
+}
+
+/** Every distinct connected pair in a session — handy for tests and summaries. */
+export function connectionPairs(steps: SessionStep[]): Array<{ from: ChainLanguage; to: ChainLanguage; roots: string[] }> {
+  const pairs: Array<{ from: ChainLanguage; to: ChainLanguage; roots: string[] }> = [];
+  for (const step of steps) {
+    for (const c of step.connections) {
+      pairs.push({ from: step.language, to: c.to, roots: c.sharedRoots });
+    }
+  }
+  return pairs;
+}

--- a/code/programs/typescript/script-writing-visualizer/tests/session.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/session.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import type { Lesson } from "../src/lessons";
+import { loadLessons } from "../src/lessons";
+import { buildSession, connectionPairs } from "../src/session";
+
+// Minimal Lesson factory — only the fields the orchestrator reads (language,
+// concept, chapter, roots) matter.
+function L(language: string, concept: string, roots: string[], chapter = 1): Lesson {
+  return {
+    id: `${language}-${concept}-${roots.join("+")}-${chapter}`,
+    language,
+    headword: "x",
+    gloss: "x",
+    type: "word",
+    chapter,
+    concept,
+    prerequisites: [],
+    reviewsOf: [],
+    roots,
+    romanization: "x",
+    script: language,
+    etymologyHook: "",
+  };
+}
+
+const langs = (steps: { language: string }[]) => steps.map((s) => s.language);
+
+describe("buildSession", () => {
+  it("annotates the sweep with connections back to earlier languages sharing a root", () => {
+    // spanish and french share the Latin root `cattus`; german shares nothing.
+    const lessons = [
+      L("spanish", "CAT", ["cattus"]),
+      L("french", "CAT", ["cattus"]),
+      L("german", "CAT", ["katta"]), // a different root — no link
+    ];
+    const steps = buildSession("CAT", lessons, 10);
+    expect(langs(steps)).toEqual(["spanish", "french", "german"]); // chain order (from the sweep)
+
+    // spanish is first — no earlier stop to connect to.
+    expect(steps[0].connections).toEqual([]);
+    // french links back to spanish via cattus.
+    expect(steps[1].connections).toEqual([{ to: "spanish", sharedRoots: ["cattus"] }]);
+    // german shares no root with either — no connections.
+    expect(steps[2].connections).toEqual([]);
+  });
+
+  it("links a later language to EVERY earlier one it shares a root with", () => {
+    const lessons = [
+      L("spanish", "C", ["r1"]),
+      L("french", "C", ["r1"]),
+      L("italian" /* not on chain — dropped by the sweep */, "C", ["r1"]),
+      L("hindi", "C", ["r1", "r2"]),
+    ];
+    const steps = buildSession("C", lessons, 10);
+    // italian is not a chain language, so it never appears.
+    expect(langs(steps)).toEqual(["spanish", "french", "hindi"]);
+    // hindi shares r1 with both spanish and french (in chain order).
+    expect(steps[2].connections).toEqual([
+      { to: "spanish", sharedRoots: ["r1"] },
+      { to: "french", sharedRoots: ["r1"] },
+    ]);
+  });
+
+  it("reports multiple shared roots between a pair, sorted", () => {
+    const steps = buildSession("C", [L("kannada", "C", ["dhanya", "vada"]), L("telugu", "C", ["vada", "dhanya"])], 10);
+    expect(steps[1].connections).toEqual([{ to: "kannada", sharedRoots: ["dhanya", "vada"] }]);
+  });
+
+  it("surfaces NO connection when languages share no root — the grounding rule", () => {
+    const steps = buildSession("C", [L("spanish", "C", ["a"]), L("french", "C", ["b"])], 10);
+    expect(connectionPairs(steps)).toEqual([]); // CONTROL: nothing shared → nothing asserted
+  });
+
+  it("respects the active prefix — an inactive language contributes no connection", () => {
+    const lessons = [L("spanish", "C", ["r"]), L("french", "C", ["r"])];
+    const steps = buildSession("C", lessons, 1); // only spanish active
+    expect(langs(steps)).toEqual(["spanish"]);
+    expect(connectionPairs(steps)).toEqual([]);
+  });
+});
+
+describe("buildSession against the real curriculum", () => {
+  const lessons = loadLessons();
+
+  it("links Kannada and Telugu 'thank you' back to Hindi via the Sanskrit root dhanya", () => {
+    // COURTESY-THANKS: hindi/kannada/telugu all cite the root `dhanya`.
+    // (hindi's second root is `vaada`, kannada/telugu's is `vada` — so only
+    // `dhanya` is shared with hindi, but kannada/telugu share both with each other.)
+    const steps = buildSession("COURTESY-THANKS", lessons, 10);
+    const pairs = connectionPairs(steps);
+
+    const teluguToHindi = pairs.find((p) => p.from === "telugu" && p.to === "hindi");
+    expect(teluguToHindi, "telugu should link back to hindi").toBeDefined();
+    expect(teluguToHindi!.roots).toContain("dhanya");
+
+    const teluguToKannada = pairs.find((p) => p.from === "telugu" && p.to === "kannada");
+    expect(teluguToKannada, "telugu should link back to kannada").toBeDefined();
+    expect(teluguToKannada!.roots).toEqual(expect.arrayContaining(["dhanya", "vada"]));
+  });
+
+  it("CONTROL: a connection is never asserted from thin air (from precedes to in chain order)", () => {
+    const steps = buildSession("COURTESY-THANKS", lessons, 10);
+    const chainPos = (l: string) =>
+      ["spanish", "latin", "french", "german", "arabic", "hindi", "tamil", "kannada", "telugu", "malayalam"].indexOf(l);
+    // Every connection points BACKWARD (to an earlier chain language) and every
+    // asserted shared root is really present in BOTH lessons' roots.
+    const byLang = new Map(loadLessons().filter((l) => l.concept === "COURTESY-THANKS").reduce((m, l) => {
+      const arr = m.get(l.language) ?? [];
+      arr.push(...l.roots);
+      m.set(l.language, arr);
+      return m;
+    }, new Map<string, string[]>()));
+    for (const p of connectionPairs(steps)) {
+      expect(chainPos(p.to)).toBeLessThan(chainPos(p.from)); // backward only
+      for (const r of p.roots) {
+        expect(byLang.get(p.from) ?? []).toContain(r); // root really in `from`
+        expect(byLang.get(p.to) ?? []).toContain(r); // root really in `to`
+      }
+    }
+  });
+});


### PR DESCRIPTION
Phase 3 of the unified language-learning app: the **session orchestrator** that turns a teaching sweep into an interleaved lesson with cross-language connections.

## What it adds — `src/session.ts`

`buildSession(concept, lessons, activeCount)` runs the phase-2 teaching sweep (the concept across the active chain prefix, in chain order), then annotates each language stop with the **connections back to earlier stops** whose lessons share an etymological root.

This is the payoff of interleaving: meeting *"thank you"* in Telugu right after Kannada and Hindi, and being shown all three carry the Sanskrit root **`dhanya`** — the moment three separate facts become one.

## The grounding rule, enforced in code

A connection exists **iff** the two stops' lessons literally share a root string (from `lesson.roots`). `sharedRoots` is the exact set **intersection**, sorted and deduped; connections point **backward** in chain order only. Nothing is inferred or invented.

## Grounded against the real curriculum

Kannada and Telugu "thank you" link back to Hindi via `dhanya`. The data is precise: Hindi cites `[dhanya, vaada]`, Kannada/Telugu cite `[dhanya, vada]` — so Telugu↔Hindi share only `dhanya`, while Telugu↔Kannada share both. The test asserts exactly that.

## Controls that bite (verified by injection)

- Asserting a connection with no shared root → fails the grounding test.
- Over-reporting (union instead of intersection) → fails the **"never from thin air"** control, which checks every asserted root really lives in *both* lessons. The permissive `dhanya` matchers alone wouldn't catch this — which is why the control exists.
- A concept sharing no roots surfaces no link.

Independently reviewed: correctness clean across all edge cases (empty sweep, empty roots, single active language, 3+-way shared roots), no security surface. Pure, deterministic, no UI.

App CHANGELOG + version 0.8.1 → 0.9.0. **153 tests.** Next: phase 4, the randomised cumulative quiz over the covered (concept × language) grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)