### PR TITLE
Add BJT XTF transit-time bias coefficient

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add BJT model-card `XTF` forward transit-time bias-coefficient support,
+  scaling forward diffusion capacitance and transient stored charge by
+  `TF * (1 + XTF)` with the Berkeley default of zero.
 - Add BJT model-card `PTF` forward excess-phase support, rotating AC forward
   transconductance by the configured phase at `1 / (2*pi*TF)`.
 - Add BJT model-card `AF` flicker-noise exponent support, defaulting to `1`

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -614,6 +614,8 @@ class BJT:
         Flicker-noise base-current exponent (default 1.0).
     Ptf:
         Excess phase at ``1 / (2*pi*Tf)`` in degrees (default 0.0).
+    Xtf:
+        Coefficient for forward transit-time bias dependence (default 0.0).
     """
 
     name: str
@@ -651,6 +653,7 @@ class BJT:
     Kf: float = 0.0            # flicker-noise coefficient; 0 disables
     Af: float = 1.0            # flicker-noise base-current exponent
     Ptf: float = 0.0           # excess phase at 1/(2*pi*Tf), degrees
+    Xtf: float = 0.0           # forward transit-time bias coefficient
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -605,7 +605,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr, element.Tnom, element.Kf, element.Af, element.Ptf)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr, element.Tnom, element.Kf, element.Af, element.Ptf, element.Xtf)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -8746,7 +8746,10 @@ def _bjt_junction_transconductance(el: BJT, voltage: float, emission_coefficient
 def _bjt_charge_dynamic_capacitance(el: BJT, state_kind: str, voltage: float) -> float:
     if state_kind == "be":
         conductance = _bjt_junction_transconductance(el, voltage, el.Nf)
-        return _bjt_base_emitter_depletion_capacitance(el, voltage) + el.Tf * conductance
+        return (
+            _bjt_base_emitter_depletion_capacitance(el, voltage)
+            + el.Tf * (1.0 + el.Xtf) * conductance
+        )
     conductance = _bjt_junction_transconductance(el, voltage, el.Nr)
     return _bjt_base_collector_depletion_capacitance(el, voltage) + el.Tr * conductance
 
@@ -9311,6 +9314,10 @@ def _validate_bjt(el: BJT) -> None:
         raise ValueError(f"{el.name}: BJT flicker noise exponent must be finite and non-negative")
     if not math.isfinite(el.Ptf) or el.Ptf < 0.0:
         raise ValueError(f"{el.name}: BJT forward excess phase must be finite and non-negative")
+    if not math.isfinite(el.Xtf) or el.Xtf < 0.0:
+        raise ValueError(
+            f"{el.name}: BJT forward transit-time bias coefficient must be finite and non-negative"
+        )
     if not math.isfinite(el.Ise) or el.Ise < 0.0:
         raise ValueError(
             f"{el.name}: BJT base-emitter leakage saturation current must be finite and non-negative"
@@ -12586,7 +12593,7 @@ def _stamp_ac(
             el, Vcollector_leakage
         )
         g_pi: float = base_gm / el.beta_f + leakage_conductance
-        diffusion_capacitance = el.Tf * gm_b
+        diffusion_capacitance = el.Tf * (1.0 + el.Xtf) * gm_b
         excess_phase = omega * el.Tf * el.Ptf * math.pi / 180.0
         gm_ac = complex(
             gm_b * math.cos(excess_phase),

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (30, 47, 13, 4),
-    "PNP": (30, 47, 13, 4),
+    "NPN": (31, 48, 13, 4),
+    "PNP": (31, 48, 13, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -384,6 +384,7 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "KF": "KF",
     "AF": "AF",
     "PTF": "PTF",
+    "XTF": "XTF",
     "ISE": "ISE",
     "NE": "NE",
     "ISC": "ISC",
@@ -949,6 +950,7 @@ def bjt_from_model_card(
         Kf=p.get("KF", 0.0),
         Af=p.get("AF", 1.0),
         Ptf=p.get("PTF", 0.0),
+        Xtf=p.get("XTF", 0.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 118
+    assert len(coverage) == 120
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 118
+    assert len(records) == 120
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,9 +501,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 118
-    assert report.expected_canonical_parameter_count == 118
-    assert report.accepted_name_count == 184
+    assert report.canonical_parameter_count == 120
+    assert report.expected_canonical_parameter_count == 120
+    assert report.accepted_name_count == 186
     assert report.aliased_parameter_count == 53
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -511,7 +511,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t118\t118\t184\t53\t4\t0"
+        "true\t7\t7\t120\t120\t186\t53\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,8 +539,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 117
-    assert report.accepted_name_count == 181
+    assert report.canonical_parameter_count == 119
+    assert report.accepted_name_count == 183
     assert report.aliased_parameter_count == 52
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t117\t118\t181\t52\t4\t4\n"
+        "false\t7\t7\t119\t120\t183\t52\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,10 +647,10 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
+        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "TNOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
+    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "TNOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.beta_r == pytest.approx(0.25)
@@ -666,6 +666,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert bjt_model.Kf == pytest.approx(1.0e-12)
     assert bjt_model.Af == pytest.approx(1.3)
     assert bjt_model.Ptf == pytest.approx(30.0)
+    assert bjt_model.Xtf == pytest.approx(2.0)
     assert bjt_model.Ise == pytest.approx(3.0e-13)
     assert bjt_model.Ne == pytest.approx(1.7)
     assert bjt_model.Isc == pytest.approx(4.0e-13)
@@ -1596,7 +1597,10 @@ def test_transient_bjt_forward_bias_depletion_coefficient_shapes_both_junctions(
 
 
 def test_transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() -> None:
-    def run(forward_transit_time: float) -> TransientResult:
+    def run(
+        forward_transit_time: float,
+        forward_transit_time_bias_coefficient: float = 0.0,
+    ) -> TransientResult:
         circuit = Circuit()
         circuit.add(VoltageSource("Vcc", "collector", "0", 5.0))
         circuit.add(CurrentSource(
@@ -1614,17 +1618,23 @@ def test_transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() -> No
             emitter="0",
             Is=1.0e-15,
             Tf=forward_transit_time,
+            Xtf=forward_transit_time_bias_coefficient,
         ))
         return transient(circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler")
 
     no_storage = run(0.0)
     stored = run(1.0e-9)
+    bias_scaled = run(1.0e-9, 9.0)
 
     assert no_storage.converged
     assert stored.converged
     assert no_storage.points[1].node_voltages["base"] == pytest.approx(0.0, abs=1.0e-12)
     assert stored.points[1].node_voltages["base"] > 0.6
     assert stored.points[1].node_voltages["base"] < stored.points[0].node_voltages["base"]
+    assert abs(
+        bias_scaled.points[-1].node_voltages["base"]
+        - stored.points[-1].node_voltages["base"]
+    ) > 1.0e-12
 
 
 def test_non_level_one_mos_model_cards_are_explicitly_rejected() -> None:
@@ -2307,7 +2317,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3, Tnom=323.15, Kf=1.0e-12, Af=1.3, Ptf=30.0),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3, Tnom=323.15, Kf=1.0e-12, Af=1.3, Ptf=30.0, Xtf=2.0),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2337,6 +2347,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.Kf == pytest.approx(1.0e-12)
     assert expanded.Af == pytest.approx(1.3)
     assert expanded.Ptf == pytest.approx(30.0)
+    assert expanded.Xtf == pytest.approx(2.0)
 
 
 def test_branch_current_in_voltage_source():
@@ -2595,6 +2606,16 @@ def test_dc_rejects_invalid_bjt_forward_excess_phase():
     circuit = Circuit()
     circuit.add(BJT("Qbad", "c", "b", "0", Ptf=-1.0))
     with pytest.raises(ValueError, match="forward excess phase must be finite and non-negative"):
+        dc_op(circuit)
+
+
+def test_dc_rejects_invalid_bjt_forward_transit_time_bias_coefficient():
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", Xtf=-1.0))
+    with pytest.raises(
+        ValueError,
+        match="forward transit-time bias coefficient must be finite and non-negative",
+    ):
         dc_op(circuit)
 
 
@@ -4435,6 +4456,35 @@ def test_ac_bjt_forward_excess_phase_rotates_transconductance():
     assert abs(without_excess_phase.imag) < 1.0e-9
     assert with_excess_phase.imag > 0.0009
     assert abs(with_excess_phase.real) < 1.0e-9
+
+
+def test_ac_bjt_forward_transit_time_bias_coefficient_scales_diffusion_capacitance():
+    def base_amplitude(xtf: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vac", "in", "0", 0.0, ac=AcSource(1.0)))
+        circuit.add(Resistor("Rin", "in", "base", 1000.0))
+        circuit.add(Resistor("Rc", "col", "0", 1000.0))
+        circuit.add(
+            BJT(
+                "Q1",
+                "col",
+                "base",
+                "0",
+                Is=25.85e-6,
+                Tf=1.0e-6,
+                Xtf=xtf,
+            )
+        )
+        return abs(
+            ac_sweep(
+                circuit, f_start=100000.0, f_stop=100000.0, n_points=1
+            ).points[0].node_voltages["base"]
+        )
+
+    nominal = base_amplitude(0.0)
+    bias_scaled = base_amplitude(9.0)
+
+    assert bias_scaled < nominal / 5.0
 
 
 def test_ac_bjt_reverse_transit_time_adds_collector_diffusion_capacitance():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add BJT model-card `XTF` forward transit-time bias-coefficient support,
+  scaling forward diffusion capacitance and transient stored charge by
+  `TF * (1 + XTF)` with the Berkeley default of zero.
 - Add BJT model-card `PTF` forward excess-phase support, rotating AC forward
   transconductance by the configured phase at `1 / (2*pi*TF)`.
 - Add BJT model-card `AF` flicker-noise exponent support, defaulting to `1`

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -457,6 +457,8 @@ fn clone_subckt_element(
             expanded.flicker_noise_coefficient = element.flicker_noise_coefficient;
             expanded.flicker_noise_exponent = element.flicker_noise_exponent;
             expanded.forward_excess_phase_degrees = element.forward_excess_phase_degrees;
+            expanded.forward_transit_time_bias_coefficient =
+                element.forward_transit_time_bias_coefficient;
             Element::Bjt(expanded)
         }
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
@@ -2902,6 +2904,7 @@ pub struct Bjt {
     pub flicker_noise_coefficient: f64,
     pub flicker_noise_exponent: f64,
     pub forward_excess_phase_degrees: f64,
+    pub forward_transit_time_bias_coefficient: f64,
 }
 
 impl Bjt {
@@ -3368,6 +3371,7 @@ impl Bjt {
             flicker_noise_coefficient: 0.0,
             flicker_noise_exponent: 1.0,
             forward_excess_phase_degrees: 0.0,
+            forward_transit_time_bias_coefficient: 0.0,
         }
     }
 }
@@ -3758,8 +3762,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 30, 47, 13, 4),
-    (ModelCardKind::Pnp, 30, 47, 13, 4),
+    (ModelCardKind::Npn, 31, 48, 13, 4),
+    (ModelCardKind::Pnp, 31, 48, 13, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3815,6 +3819,7 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("KF", "KF"),
     ("AF", "AF"),
     ("PTF", "PTF"),
+    ("XTF", "XTF"),
     ("ISE", "ISE"),
     ("NE", "NE"),
     ("ISC", "ISC"),
@@ -4512,6 +4517,7 @@ pub fn bjt_from_model_card(
     bjt.flicker_noise_coefficient = model_card_value(model, "KF", 0.0);
     bjt.flicker_noise_exponent = model_card_value(model, "AF", 1.0);
     bjt.forward_excess_phase_degrees = model_card_value(model, "PTF", 0.0);
+    bjt.forward_transit_time_bias_coefficient = model_card_value(model, "XTF", 0.0);
     Ok(bjt)
 }
 
@@ -23009,7 +23015,8 @@ fn stamp_ac_bjt_small_signal(
         -forward_gm * excess_phase.sin(),
     );
     let reverse_gm = bjt.saturation_current / reverse_thermal_voltage * reverse_exponent.exp();
-    let diffusion_capacitance = bjt.forward_transit_time * forward_gm;
+    let diffusion_capacitance =
+        bjt.forward_transit_time * (1.0 + bjt.forward_transit_time_bias_coefficient) * forward_gm;
     let reverse_diffusion_capacitance = bjt.reverse_transit_time * reverse_gm;
     let (_, leakage_conductance) = bjt_base_emitter_leakage(bjt, junction_voltage);
     let (_, collector_leakage_conductance) =
@@ -23630,7 +23637,9 @@ fn bjt_charge_dynamic_capacitance(bjt: &Bjt, kind: BjtChargeStateKind, voltage: 
             let conductance =
                 bjt_junction_transconductance(bjt, voltage, bjt.forward_emission_coefficient);
             bjt_base_emitter_depletion_capacitance(bjt, voltage)
-                + bjt.forward_transit_time * conductance
+                + bjt.forward_transit_time
+                    * (1.0 + bjt.forward_transit_time_bias_coefficient)
+                    * conductance
         }
         BjtChargeStateKind::BaseCollector => {
             let conductance =
@@ -24070,6 +24079,15 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "forward excess phase must be finite and non-negative".to_string(),
+        });
+    }
+    if !bjt.forward_transit_time_bias_coefficient.is_finite()
+        || bjt.forward_transit_time_bias_coefficient < 0.0
+    {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "forward transit-time bias coefficient must be finite and non-negative"
+                .to_string(),
         });
     }
     if !bjt.base_emitter_leakage_saturation_current.is_finite()

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -869,6 +869,46 @@ fn ac_bjt_forward_excess_phase_rotates_transconductance() {
 }
 
 #[test]
+fn ac_bjt_forward_transit_time_bias_coefficient_scales_diffusion_capacitance() {
+    fn base_amplitude(coefficient: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "in", "0", 0.0, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "base", 1_000.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new("Rc", "col", "0", 1_000.0)));
+        let mut transistor = Bjt::with_model(
+            "Q1",
+            "col",
+            "base",
+            "0",
+            BjtPolarity::Npn,
+            25.85e-6,
+            100.0,
+            0.02585,
+            0.0,
+            0.0,
+            1.0e-6,
+            0.0,
+        );
+        transistor.forward_transit_time_bias_coefficient = coefficient;
+        circuit.add(Element::Bjt(transistor));
+
+        ac_sweep(&circuit, 100_000.0, 100_000.0, 1).unwrap()[0]
+            .voltage("base")
+            .unwrap()
+            .abs()
+    }
+
+    let nominal = base_amplitude(0.0);
+    let bias_scaled = base_amplitude(9.0);
+
+    assert!(bias_scaled < nominal / 5.0);
+}
+
+#[test]
 fn ac_bjt_uses_reverse_transit_time_as_base_collector_diffusion_capacitance() {
     fn base_amplitude(reverse_transit_time: f64) -> f64 {
         let mut circuit = Circuit::new();

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 118);
+    assert_eq!(coverage.len(), 120);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 118);
+    assert_eq!(records.len(), 120);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 118);
-    assert_eq!(report.expected_canonical_parameter_count, 118);
-    assert_eq!(report.accepted_name_count, 184);
+    assert_eq!(report.canonical_parameter_count, 120);
+    assert_eq!(report.expected_canonical_parameter_count, 120);
+    assert_eq!(report.accepted_name_count, 186);
     assert_eq!(report.aliased_parameter_count, 53);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t118\t118\t184\t53\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t120\t120\t186\t53\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,8 +235,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 117);
-    assert_eq!(report.accepted_name_count, 181);
+    assert_eq!(report.canonical_parameter_count, 119);
+    assert_eq!(report.accepted_name_count, 183);
     assert_eq!(report.aliased_parameter_count, 52);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t117\t118\t181\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t119\t120\t183\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -440,6 +440,7 @@ fn model_card_aliases_build_device_instances() {
             ("KF", 1.0e-12),
             ("AF", 1.3),
             ("PTF", 30.0),
+            ("XTF", 2.0),
             ("ISE", 3.0e-13),
             ("NE", 1.7),
             ("ISC", 4.0e-13),
@@ -469,6 +470,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("KF").unwrap(), 1.0e-12);
     assert_close(*bjt_card.parameters.get("AF").unwrap(), 1.3);
     assert_close(*bjt_card.parameters.get("PTF").unwrap(), 30.0);
+    assert_close(*bjt_card.parameters.get("XTF").unwrap(), 2.0);
     assert_close(*bjt_card.parameters.get("ISE").unwrap(), 3.0e-13);
     assert_close(*bjt_card.parameters.get("NE").unwrap(), 1.7);
     assert_close(*bjt_card.parameters.get("ISC").unwrap(), 4.0e-13);
@@ -495,6 +497,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(bjt_model.flicker_noise_coefficient, 1.0e-12);
     assert_close(bjt_model.flicker_noise_exponent, 1.3);
     assert_close(bjt_model.forward_excess_phase_degrees, 30.0);
+    assert_close(bjt_model.forward_transit_time_bias_coefficient, 2.0);
     assert_close(bjt_model.base_emitter_leakage_saturation_current, 3.0e-13);
     assert_close(bjt_model.base_emitter_leakage_emission_coefficient, 1.7);
     assert_close(bjt_model.base_collector_leakage_saturation_current, 4.0e-13);
@@ -1439,6 +1442,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     bjt.flicker_noise_coefficient = 1.0e-12;
     bjt.flicker_noise_exponent = 1.3;
     bjt.forward_excess_phase_degrees = 30.0;
+    bjt.forward_transit_time_bias_coefficient = 2.0;
     let mut circuit = Circuit::new();
     circuit
         .define_subcircuit(SubcircuitDefinition::new(
@@ -1486,6 +1490,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.flicker_noise_coefficient, 1.0e-12);
     assert_close(expanded.flicker_noise_exponent, 1.3);
     assert_close(expanded.forward_excess_phase_degrees, 30.0);
+    assert_close(expanded.forward_transit_time_bias_coefficient, 2.0);
 }
 
 #[test]
@@ -2041,6 +2046,18 @@ fn dc_rejects_invalid_bjt_forward_excess_phase() {
     assert!(error
         .to_string()
         .contains("forward excess phase must be finite and non-negative"));
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_forward_transit_time_bias_coefficient() {
+    let mut transistor = Bjt::new("Qbad", "c", "b", "0");
+    transistor.forward_transit_time_bias_coefficient = -1.0;
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Bjt(transistor));
+    let error = dc_op(&circuit).unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("forward transit-time bias coefficient must be finite and non-negative"));
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -689,7 +689,10 @@ fn transient_bjt_forward_bias_depletion_coefficient_shapes_both_junctions() {
 
 #[test]
 fn transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() {
-    fn run(forward_transit_time: f64) -> Vec<TransientPoint> {
+    fn run(
+        forward_transit_time: f64,
+        forward_transit_time_bias_coefficient: f64,
+    ) -> Vec<TransientPoint> {
         let mut circuit = Circuit::new();
         circuit.add(Element::VoltageSource(VoltageSource::new(
             "Vcc",
@@ -711,7 +714,7 @@ fn transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() {
         circuit.add(Element::Resistor(Resistor::new(
             "Rshunt", "base", "0", 1.0e12,
         )));
-        circuit.add(Element::Bjt(Bjt::with_model(
+        let mut transistor = Bjt::with_model(
             "Q1",
             "collector",
             "base",
@@ -724,12 +727,15 @@ fn transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() {
             0.0,
             forward_transit_time,
             0.0,
-        )));
+        );
+        transistor.forward_transit_time_bias_coefficient = forward_transit_time_bias_coefficient;
+        circuit.add(Element::Bjt(transistor));
         transient(&circuit, 1.0e-9, 5.0e-9).unwrap()
     }
 
-    let no_storage = run(0.0);
-    let stored = run(1.0e-9);
+    let no_storage = run(0.0, 0.0);
+    let stored = run(1.0e-9, 0.0);
+    let bias_scaled = run(1.0e-9, 9.0);
     let no_storage_first = no_storage[0].voltage("base").unwrap();
     let stored_first = stored[0].voltage("base").unwrap();
 
@@ -742,6 +748,15 @@ fn transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() {
             .unwrap()
             < stored_first
     );
+    let bias_scaled_last = bias_scaled
+        .last()
+        .and_then(|point| point.voltage("base"))
+        .unwrap();
+    let stored_last = stored
+        .last()
+        .and_then(|point| point.voltage("base"))
+        .unwrap();
+    assert!((bias_scaled_last - stored_last).abs() > 1.0e-12);
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add BJT model-card `XTF` forward transit-time bias-coefficient support,
+  scaling forward diffusion capacitance and transient stored charge by
+  `TF * (1 + XTF)` with the Berkeley default of zero.
 - Add BJT model-card `PTF` forward excess-phase support, rotating AC forward
   transconductance by the configured phase at `1 / (2*pi*TF)`.
 - Add BJT model-card `AF` flicker-noise exponent support, defaulting to `1`

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1733,6 +1733,7 @@ export interface Bjt {
   readonly flickerNoiseCoefficient: number;
   readonly flickerNoiseExponent: number;
   readonly forwardExcessPhaseDegrees: number;
+  readonly forwardTransitTimeBiasCoefficient: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -2010,8 +2011,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [30, 47, 13, 4],
-  PNP: [30, 47, 13, 4],
+  NPN: [31, 48, 13, 4],
+  PNP: [31, 48, 13, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3601,7 +3602,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees, element.forwardTransitTimeBiasCoefficient);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7790,6 +7791,7 @@ export function bjt(
   flickerNoiseCoefficient = 0.0,
   flickerNoiseExponent = 1.0,
   forwardExcessPhaseDegrees = 0.0,
+  forwardTransitTimeBiasCoefficient = 0.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7828,6 +7830,7 @@ export function bjt(
     flickerNoiseCoefficient,
     flickerNoiseExponent,
     forwardExcessPhaseDegrees,
+    forwardTransitTimeBiasCoefficient,
   };
 }
 
@@ -7943,6 +7946,7 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   KF: "KF",
   AF: "AF",
   PTF: "PTF",
+  XTF: "XTF",
   ISE: "ISE",
   NE: "NE",
   ISC: "ISC",
@@ -8480,6 +8484,7 @@ export function bjtFromModelCard(
     p.KF ?? 0.0,
     p.AF ?? 1.0,
     p.PTF ?? 0.0,
+    p.XTF ?? 0.0,
   );
 }
 
@@ -19665,7 +19670,9 @@ function bjtChargeDynamicCapacitance(
       element.forwardEmissionCoefficient,
     );
     return bjtBaseEmitterDepletionCapacitance(element, voltage) +
-      element.forwardTransitTime * conductance;
+      element.forwardTransitTime *
+        (1.0 + element.forwardTransitTimeBiasCoefficient) *
+        conductance;
   }
   const conductance = bjtJunctionTransconductance(
     element,
@@ -19957,6 +19964,9 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.forwardExcessPhaseDegrees) || element.forwardExcessPhaseDegrees < 0.0) {
     throw invalidElement(element.name, "forward excess phase must be finite and non-negative");
+  }
+  if (!Number.isFinite(element.forwardTransitTimeBiasCoefficient) || element.forwardTransitTimeBiasCoefficient < 0.0) {
+    throw invalidElement(element.name, "forward transit-time bias coefficient must be finite and non-negative");
   }
   if (!Number.isFinite(element.baseEmitterLeakageSaturationCurrent) || element.baseEmitterLeakageSaturationCurrent < 0.0) {
     throw invalidElement(element.name, "base-emitter leakage saturation current must be finite and non-negative");
@@ -21934,7 +21944,10 @@ function stampAcBjtSmallSignal(
   const reverseBase = bjtReverseBaseCurrent(element, reverseJunctionVoltage);
   const junctionConductance =
     baseTransconductance / element.forwardBeta + leakage.conductance;
-  const diffusionCapacitance = element.forwardTransitTime * transconductance;
+  const diffusionCapacitance =
+    element.forwardTransitTime *
+    (1.0 + element.forwardTransitTimeBiasCoefficient) *
+    transconductance;
   const excessPhase =
     omega * element.forwardTransitTime * element.forwardExcessPhaseDegrees * Math.PI / 180.0;
   const acTransconductance = complex(

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -598,6 +598,25 @@ describe("acSweep", () => {
     expect(Math.abs(withExcessPhase.real)).toBeLessThan(1.0e-9);
   });
 
+  it("scales BJT diffusion capacitance by the forward transit-time bias coefficient", () => {
+    function baseAmplitude(coefficient: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "in", "0", 0.0, 1.0));
+      circuit.add(resistor("Rin", "in", "base", 1_000.0));
+      circuit.add(resistor("Rc", "col", "0", 1_000.0));
+      circuit.add({
+        ...bjt("Q1", "col", "base", "0", "NPN", 25.85e-6, 100.0, 0.02585, 0.0, 0.0, 1.0e-6),
+        forwardTransitTimeBiasCoefficient: coefficient,
+      });
+      return complexAbs(acSweep(circuit, 100_000.0, 100_000.0, 1)[0].voltage("base")!);
+    }
+
+    const nominal = baseAmplitude(0.0);
+    const biasScaled = baseAmplitude(9.0);
+
+    expect(biasScaled).toBeLessThan(nominal / 5.0);
+  });
+
   it("uses BJT reverse transit time as base-collector diffusion capacitance in AC analysis", () => {
     function baseAmplitude(reverseTransitTime: number): number {
       const circuit = new Circuit();

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(118);
+    expect(coverage).toHaveLength(120);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(118);
+    expect(records).toHaveLength(120);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 118,
-      expectedCanonicalParameterCount: 118,
-      acceptedNameCount: 184,
+      canonicalParameterCount: 120,
+      expectedCanonicalParameterCount: 120,
+      acceptedNameCount: 186,
       aliasedParameterCount: 53,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t118\t118\t184\t53\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t120\t120\t186\t53\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,8 +241,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(117);
-    expect(report.acceptedNameCount).toBe(181);
+    expect(report.canonicalParameterCount).toBe(119);
+    expect(report.acceptedNameCount).toBe(183);
     expect(report.aliasedParameterCount).toBe(52);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t117\t118\t181\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t119\t120\t183\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -346,6 +346,7 @@ describe("dcOp", () => {
       KF: 1.0e-12,
       AF: 1.3,
       PTF: 30.0,
+      XTF: 2.0,
       ISE: 3.0e-13,
       NE: 1.7,
       ISC: 4.0e-13,
@@ -359,7 +360,7 @@ describe("dcOp", () => {
       FC: 0.4,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, TNOM: 50.0, KF: 1.0e-12, AF: 1.3, PTF: 30.0, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, TNOM: 50.0, KF: 1.0e-12, AF: 1.3, PTF: 30.0, XTF: 2.0, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.reverseBeta, 0.25);
@@ -375,6 +376,7 @@ describe("dcOp", () => {
     expectClose(bjtModel.flickerNoiseCoefficient, 1.0e-12);
     expectClose(bjtModel.flickerNoiseExponent, 1.3);
     expectClose(bjtModel.forwardExcessPhaseDegrees, 30.0);
+    expectClose(bjtModel.forwardTransitTimeBiasCoefficient, 2.0);
     expectClose(bjtModel.baseEmitterLeakageSaturationCurrent, 3.0e-13);
     expectClose(bjtModel.baseEmitterLeakageEmissionCoefficient, 1.7);
     expectClose(bjtModel.baseCollectorLeakageSaturationCurrent, 4.0e-13);
@@ -1018,7 +1020,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3, 323.15, 1.0e-12, 1.3, 30.0),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3, 323.15, 1.0e-12, 1.3, 30.0, 2.0),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -1049,6 +1051,7 @@ describe("dcOp", () => {
       expectClose(expanded.flickerNoiseCoefficient, 1.0e-12);
       expectClose(expanded.flickerNoiseExponent, 1.3);
       expectClose(expanded.forwardExcessPhaseDegrees, 30.0);
+      expectClose(expanded.forwardTransitTimeBiasCoefficient, 2.0);
     }
   });
 
@@ -1419,6 +1422,17 @@ describe("dcOp", () => {
     circuit.add({ ...bjt("Qbad", "c", "b", "0"), forwardExcessPhaseDegrees: -1.0 });
     expect(() => dcOp(circuit)).toThrowError(
       "forward excess phase must be finite and non-negative",
+    );
+  });
+
+  it("rejects invalid BJT forward transit-time bias coefficients", () => {
+    const circuit = new Circuit();
+    circuit.add({
+      ...bjt("Qbad", "c", "b", "0"),
+      forwardTransitTimeBiasCoefficient: -1.0,
+    });
+    expect(() => dcOp(circuit)).toThrowError(
+      "forward transit-time bias coefficient must be finite and non-negative",
     );
   });
 

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -514,7 +514,10 @@ describe("transient", () => {
   });
 
   it("uses BJT forward transit time to hold base charge on turnoff", () => {
-    function run(forwardTransitTime: number): TransientPoint[] {
+    function run(
+      forwardTransitTime: number,
+      forwardTransitTimeBiasCoefficient = 0.0,
+    ): TransientPoint[] {
       const circuit = new Circuit();
       circuit.add(voltageSource("Vcc", "collector", "0", 5.0));
       circuit.add(currentSourceWithWaveform(
@@ -529,27 +532,35 @@ describe("transient", () => {
         ]),
       ));
       circuit.add(resistor("Rshunt", "base", "0", 1.0e12));
-      circuit.add(bjt(
-        "Q1",
-        "collector",
-        "base",
-        "0",
-        "NPN",
-        1.0e-15,
-        100.0,
-        0.02585,
-        0.0,
-        0.0,
-        forwardTransitTime,
-      ));
+      circuit.add({
+        ...bjt(
+          "Q1",
+          "collector",
+          "base",
+          "0",
+          "NPN",
+          1.0e-15,
+          100.0,
+          0.02585,
+          0.0,
+          0.0,
+          forwardTransitTime,
+        ),
+        forwardTransitTimeBiasCoefficient,
+      });
       return transient(circuit, 1.0e-9, 5.0e-9);
     }
 
     const noStorage = run(0.0);
     const stored = run(1.0e-9);
+    const biasScaled = run(1.0e-9, 9.0);
     expectClose(noStorage[0].voltage("base"), 0.0);
     expect(stored[0].voltage("base")!).toBeGreaterThan(0.6);
     expect(stored[stored.length - 1].voltage("base")!).toBeLessThan(stored[0].voltage("base")!);
+    expect(Math.abs(
+      biasScaled[biasScaled.length - 1].voltage("base")! -
+        stored[stored.length - 1].voltage("base")!,
+    )).toBeGreaterThan(1.0e-12);
   });
 
   it("reports periods for periodic source waveforms", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,16 +33,16 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT forward excess phase.
+1. Cross-language BJT forward transit-time bias coefficient.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `PTF` model-card support in Rust, Python, and TypeScript,
-     defaulting to zero so existing AC results remain unchanged.
-   - Rotate forward AC transconductance by the configured excess phase at
-     `1 / (2*pi*TF)` while preserving `TF` diffusion capacitance and the
-     complete BJT model through subcircuits.
-   - Extend the supported-parameter coverage gate from 116 to 118 canonical
-     rows and lock model-card behavior, validation, hierarchy, and AC phase in
-     all engines.
+   - Add Berkeley BJT `XTF` model-card support in Rust, Python, and TypeScript,
+     defaulting to zero so existing AC and transient results remain unchanged.
+   - Scale forward diffusion capacitance and transient base-emitter stored
+     charge by `TF * (1 + XTF)` while preserving the ideal `TF` basis for
+     `PTF` excess phase and the complete BJT model through subcircuits.
+   - Extend the supported-parameter coverage gate from 118 to 120 canonical
+     rows and lock model-card behavior, validation, hierarchy, AC loading, and
+     transient stored-charge behavior in all engines.
 
 ## Completed Slices
 
@@ -3134,6 +3134,14 @@ the Rust, Python, and TypeScript surfaces together.
      `KF * abs(Ib)^AF / frequency`.
    - Hierarchical subcircuit expansion preserves the complete BJT model, and
      the supported-parameter release gate now covers 116 canonical rows.
+
+236. Cross-language BJT forward excess phase.
+   - Status: completed in PR 8828.
+   - Rust, Python, and TypeScript BJT model cards now accept `PTF`, default it
+     to zero, and rotate forward AC transconductance by the configured excess
+     phase at `1 / (2*pi*TF)`.
+   - Hierarchical subcircuit expansion preserves the complete BJT model, and
+     the supported-parameter release gate now covers 118 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley BJT `XTF` model-card support in Rust, Python, and TypeScript
- scale forward AC diffusion capacitance and transient stored charge by `TF * (1 + XTF)` while keeping `PTF` based on ideal `TF`
- extend the supported-parameter gate from 118 to 120 canonical rows and reconcile the implementation plan after PR #8828

## Verification
- `cargo test -p spice-engine` (370 passed)
- `pytest -q` (562 passed, 88.81% coverage)
- `npm test` (320 passed)
- `npm run build`
- package-local Rust format check and Python Ruff lint