### PR TITLE
fix(semantic-ir-to-javascript): matmul crashes on scalar operands (task #111)

### DIFF
--- a/code/packages/rust/scilab-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/scilab-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [0.1.2] - 2026-07-22
+
+### Fixed
+
+- **The genuine `matmul` bug 0.1.1's `tests/oracle.rs` found (task #111,
+  "finding six" in that file's own module doc comment) is now fixed
+  upstream, in `semantic-ir-to-javascript` — not in this crate.**
+  `matmul(a, b)` (`semantic-ir-to-javascript/src/runtime.rs`) now
+  normalizes both operands through `toArrayValue` as its first two
+  statements, mirroring `elementwise`'s own pattern exactly, so a plain
+  scalar variable (or function parameter) multiplied by itself no longer
+  crashes the compiled path with `TypeError: Cannot read properties of
+  undefined (reading 'length')` at `nrows`. See
+  `semantic-ir-to-javascript`'s own `CHANGELOG.md` for the fix itself.
+- **`tests/oracle.rs`: the two known-bug cases this crate's own oracle
+  suite found the bug through** —
+  `scalar_variable_self_multiplication_crashes_the_compiled_path` and
+  `function_parameter_self_multiplication_crashes_the_compiled_path` —
+  **flipped from `known_bug: Some(...)` to `known_bug: None`.** Their
+  compiled-side assertion (`scilab-to-semantic-ir` →
+  `semantic-ir-to-javascript` → an actual `node` process) now genuinely
+  runs, instead of being skipped, and passes: both resolve to `25`,
+  matching `scilab-runtime`'s own ground truth. The module doc comment's
+  "finding six" section, and the local comments on both cases, are
+  updated to reflect the fix (kept the original test names for
+  history/traceability even though they no longer crash). The other five
+  findings (three still-open shared-crate display-convention gaps, plus
+  two already-fixed-elsewhere confirmations) are unaffected and remain as
+  documented in 0.1.1 below.
+- No lowering/codegen change in this crate itself — `scilab-to-semantic-
+  ir`'s own `expr_is_known_scalar` heuristic and `build_multiplicative`
+  lowering are untouched; the fix lives entirely in the shared
+  `semantic-ir-to-javascript` runtime this crate's JS backend depends on.
+  Confirmed no regression: `cargo test -p scilab-to-semantic-ir` (full
+  suite, including `tests/oracle.rs`) still passes.
+
 ## [0.1.1] - 2026-07-23
 
 ### Added

--- a/code/packages/rust/scilab-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/scilab-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scilab-to-semantic-ir"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Scilab CST → narrow-waist Semantic IR (SIR22 array/matrix domain). MA-10e, the last item in the Scilab frontend rollout per MA10 §6."
 

--- a/code/packages/rust/scilab-to-semantic-ir/tests/oracle.rs
+++ b/code/packages/rust/scilab-to-semantic-ir/tests/oracle.rs
@@ -90,7 +90,8 @@
 //!
 //! ## Six findings, confirmed directly by running every case below through
 //! both `scilab-runtime` and an actual `node` process (not assumed from
-//! static analysis alone) — one of the six is a genuine BUG, NOT fixed here
+//! static analysis alone) — one of the six was a genuine BUG, since FIXED
+//! (task #111 — see finding six below)
 //!
 //! 1. **NOT a bug — already fixed upstream, unlike MATLAB's own history.**
 //!    Every `if`/`elseif`/`select`/`while`/`for` construct in this crate's
@@ -161,8 +162,8 @@
 //!    are integer-valued — so the compiled side prints `0`, not `0.333...`.
 //!    See `integer_literal_division_floors_a_shared_backend_gap` below.
 //! 6. **GENUINE BUG, confirmed directly by running actual `node` output —
-//!    NOT a display-convention gap, NOT fixed in this PR.** `matmul(a, b)`
-//!    in `semantic-ir-to-javascript/src/runtime.rs` reads `a.shape`/
+//!    NOT a display-convention gap. FIXED (task #111).** `matmul(a, b)` in
+//!    `semantic-ir-to-javascript/src/runtime.rs` used to read `a.shape`/
 //!    `b.shape` UNCONDITIONALLY (via its own `nrows`/`ncols` helpers) with
 //!    NO `toArrayValue` normalization step first — unlike its sibling
 //!    `elementwise(op, a, b)`, which explicitly calls `a = toArrayValue(a);
@@ -176,40 +177,49 @@
 //!    provably holds a plain number — so `build_multiplicative`'s `"*"` arm
 //!    falls to its `else` branch (`Expr::MatMul`) for ANY `x * y` where
 //!    NEITHER operand is a literal, regardless of what `x`/`y` actually
-//!    hold at runtime. When `x`/`y` turn out to be plain scalars (not array
-//!    literals), the emitted `__Sir.matmul(x, y)` call crashes at runtime:
-//!    `TypeError: Cannot read properties of undefined (reading 'length')`
-//!    at `nrows`, called from `matmul`. Confirmed three independent ways
-//!    (all reproduced by hand, running the actual generated JS through
-//!    `node`, not merely read from source): a bare top-level
-//!    `x = 5; y = x * x;` (`scalar_variable_self_multiplication_crashes_the_
-//!    compiled_path`), a function computing `y = x * x` for its own
-//!    parameter `x` (`function_parameter_self_multiplication_crashes_the_
-//!    compiled_path`), and a recursive factorial (`y = n * fact(n - 1)`) —
-//!    all three crash identically. **This is almost certainly a
-//!    pre-existing, previously-undiscovered gap in the SHARED
-//!    `semantic-ir-to-javascript` crate** (not specific to this frontend's
-//!    own lowering, which correctly mirrors `matlab_to_semantic_ir`'s own
-//!    scalar-disambiguation heuristic verbatim) — reachable through
-//!    `matlab-to-semantic-ir` too in principle (it shares the identical
-//!    heuristic and the identical `matmul` codegen path), but never
-//!    surfaced there because (a) `matlab-runtime` has no user-defined
-//!    function support at all (so a function-parameter-based repro was
-//!    never reachable), and (b) `matlab-to-semantic-ir/tests/oracle.rs`'s
-//!    own `CORPUS` only ever multiplies two variables when they hold a
-//!    genuine array LITERAL (`A = [1 2; 3 4]; B = A * A;` — always properly
-//!    NDArray-shaped by construction, never a bare scalar), never a plain
-//!    scalar variable times itself. Scilab's oracle harness is the first to
-//!    exercise this exact shape, made possible specifically because
-//!    `scilab-runtime` (unlike `matlab-runtime`) DOES support user-defined
-//!    functions, giving this crate ground truth MATLAB's own oracle file
-//!    could never have compared against even if it had tried. **Not fixed
-//!    here per this task's own scope constraints** (this PR is oracle-TEST
-//!    only; `semantic-ir-to-javascript` is explicitly out of bounds) — see
-//!    `scalar_variable_self_multiplication_crashes_the_compiled_path`/
-//!    `function_parameter_self_multiplication_crashes_the_compiled_path`
-//!    below and this PR's own CHANGELOG entry; flagged for a dedicated
-//!    follow-up task against `semantic-ir-to-javascript`'s `matmul`.
+//!    hold at runtime. When `x`/`y` turned out to be plain scalars (not
+//!    array literals), the emitted `__Sir.matmul(x, y)` call used to crash
+//!    at runtime: `TypeError: Cannot read properties of undefined (reading
+//!    'length')` at `nrows`, called from `matmul`. Confirmed three
+//!    independent ways (all reproduced by hand, running the actual
+//!    generated JS through `node`, not merely read from source): a bare
+//!    top-level `x = 5; y = x * x;`
+//!    (`scalar_variable_self_multiplication_crashes_the_compiled_path`,
+//!    below — name kept for history even though it no longer crashes), a
+//!    function computing `y = x * x` for its own parameter `x`
+//!    (`function_parameter_self_multiplication_crashes_the_compiled_path`,
+//!    same note), and a recursive factorial (`y = n * fact(n - 1)`) — all
+//!    three crashed identically before the fix. This turned out to be a
+//!    pre-existing gap in the SHARED `semantic-ir-to-javascript` crate (not
+//!    specific to this frontend's own lowering, which correctly mirrors
+//!    `matlab_to_semantic_ir`'s own scalar-disambiguation heuristic
+//!    verbatim) — reachable through `matlab-to-semantic-ir` too in
+//!    principle (it shares the identical heuristic and the identical
+//!    `matmul` codegen path), but never previously surfaced there because
+//!    (a) `matlab-runtime` has no user-defined function support at all (so
+//!    a function-parameter-based repro was never reachable), and (b)
+//!    `matlab-to-semantic-ir/tests/oracle.rs`'s own `CORPUS` only ever
+//!    multiplies two variables when they hold a genuine array LITERAL
+//!    (`A = [1 2; 3 4]; B = A * A;` — always properly NDArray-shaped by
+//!    construction, never a bare scalar), never a plain scalar variable
+//!    times itself. Scilab's oracle harness was the first to exercise this
+//!    exact shape, made possible specifically because `scilab-runtime`
+//!    (unlike `matlab-runtime`) DOES support user-defined functions, giving
+//!    this crate ground truth MATLAB's own oracle file could never have
+//!    compared against even if it had tried.
+//!
+//!    **Fixed in `semantic-ir-to-javascript` (task #111):** `matmul(a, b)`
+//!    now normalizes both operands through `toArrayValue` as its first two
+//!    statements, mirroring `elementwise`'s own pattern exactly (see that
+//!    crate's `src/runtime.rs` and its `CHANGELOG.md`). Both cases below —
+//!    `scalar_variable_self_multiplication_crashes_the_compiled_path` and
+//!    `function_parameter_self_multiplication_crashes_the_compiled_path` —
+//!    now run `known_bug: None`, exercising the compiled path for real
+//!    (not just asserting ground truth), and pass. `semantic-ir-to-
+//!    javascript`'s own `tests/sir22_array.rs` also gained two dedicated
+//!    regression tests for this exact shape
+//!    (`scalar_variable_self_multiplication_computes_the_square`,
+//!    `function_parameter_self_multiplication_computes_the_square`).
 //!
 //! ## Constructs confirmed impossible to oracle-test at all (not merely
 //! excluded from `CORPUS` as "currently buggy") — mirrors the MATLAB oracle
@@ -738,52 +748,28 @@ const CORPUS: &[Case] = &[
              identical shared runtime helper, not via any bug of its own.",
         ),
     },
-    // Finding six: GENUINE BUG (not a display-convention gap), confirmed by
-    // actually running the generated JS through node -- see this file's
-    // module doc comment for the full root-cause writeup. NOT fixed here
-    // (semantic-ir-to-javascript is out of scope for this PR); flagged for
-    // a dedicated follow-up task.
+    // Finding six: was a GENUINE BUG (not a display-convention gap),
+    // confirmed by actually running the generated JS through node -- see
+    // this file's module doc comment for the full root-cause writeup. FIXED
+    // (task #111): `semantic-ir-to-javascript`'s `matmul` now normalizes
+    // both operands through `toArrayValue` first, mirroring `elementwise`'s
+    // own pattern. `known_bug` is now `None` for both cases below -- the
+    // compiled-side assertion actually runs (not just the ground-truth
+    // side) and passes. Names kept as-is (`_crashes_the_compiled_path`) for
+    // history/traceability even though they no longer crash.
     Case {
         name: "scalar_variable_self_multiplication_crashes_the_compiled_path",
         setup: "x = 5;\n",
         final_expr: "x * x",
         expected: "25",
-        known_bug: Some(
-            "Finding six (module doc) -- GENUINE BUG, not a display-convention gap, NOT fixed in \
-             this PR. `x * x` where x is a bare VarRef (never \"known scalar\" to this crate's own \
-             expr_is_known_scalar heuristic, even though x provably holds the literal 5) falls to \
-             build_multiplicative's `*` `else` branch, Expr::MatMul. semantic-ir-to-javascript's \
-             matmul(a, b) runtime helper (runtime.rs) reads a.shape/b.shape unconditionally, with \
-             NO toArrayValue normalization step first (unlike its sibling elementwise(), which \
-             explicitly calls toArrayValue on both operands before touching either) -- so passing \
-             two plain JS numbers crashes with `TypeError: Cannot read properties of undefined \
-             (reading 'length')` at nrows, called from matmul. Confirmed directly by running the \
-             actual generated JS through node, not read from source alone. This is almost \
-             certainly reachable through matlab-to-semantic-ir too (identical heuristic, identical \
-             matmul codegen), but was never previously discovered there because that oracle file's \
-             own CORPUS only ever multiplies two variables holding a genuine array literal (always \
-             properly NDArray-shaped), never a bare scalar. Flagged for a dedicated follow-up task \
-             against semantic-ir-to-javascript's matmul; not touched here per this PR's own scope \
-             constraints.",
-        ),
+        known_bug: None,
     },
     Case {
         name: "function_parameter_self_multiplication_crashes_the_compiled_path",
         setup: "function y = square(x)\n y = x * x;\nendfunction\n",
         final_expr: "square(5)",
         expected: "25",
-        known_bug: Some(
-            "Finding six (module doc) -- same root cause as \
-             scalar_variable_self_multiplication_crashes_the_compiled_path, reached instead through \
-             a function PARAMETER (x is Scope::Param, not Scope::Local, but expr_is_known_scalar \
-             treats every bare VarRef identically regardless of scope -- still never \"known \
-             scalar\"). Confirmed directly via node: `TypeError: Cannot read properties of \
-             undefined (reading 'length')` at nrows, called from matmul, called from the compiled \
-             `square` function. This specific repro shape (a function computing x*x for its own \
-             scalar parameter -- arguably one of the most ordinary possible Scilab/MATLAB function \
-             bodies) was only reachable here because scilab-runtime, unlike matlab-runtime, \
-             supports user-defined functions at all; not fixed in this PR.",
-        ),
+        known_bug: None,
     },
 ];
 

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## 0.51.1 — `matmul` normalizes its operands through `toArrayValue` (task #111)
+
+Found by `scilab-to-semantic-ir/tests/oracle.rs`'s oracle/golden test suite
+(front3, HML01 §7) — its "finding six" (see that file's own module doc
+comment) — while cross-checking `scilab-to-semantic-ir` against native
+`scilab-runtime`. Confirmed reachable through `matlab-to-semantic-ir` too in
+principle (identical scalar/array disambiguation heuristic, identical
+`matmul` codegen path), just never previously exercised there because that
+crate's own oracle corpus only ever multiplies array literals, never a bare
+scalar variable.
+
+### Fixed
+
+- **`runtime.rs`: `matmul(a, b)` read `a.shape`/`b.shape` (via its own
+  `nrows`/`ncols` helpers) UNCONDITIONALLY, with no `toArrayValue`
+  normalization step first** — unlike its sibling `elementwise(op, a, b)`,
+  which explicitly calls `a = toArrayValue(a); b = toArrayValue(b);` before
+  touching either operand. Every frontend crate's scalar/array
+  disambiguation heuristic (`expr_is_known_scalar` or equivalent) runs at
+  LOWERING time and can never see through a plain variable reference — a
+  bare `Expr::VarRef` is never "known scalar," even when the variable
+  provably holds a plain number — so `x * y` between two non-literal
+  operands always lowers to `Expr::MatMul`/`__Sir.Array.matmul(x, y)`
+  regardless of what `x`/`y` actually hold at runtime. When they turned out
+  to be plain scalars (not array literals) — e.g. `x = 5; y = x * x;`, or a
+  function computing `x * x` for its own scalar parameter — the emitted JS
+  crashed: `TypeError: Cannot read properties of undefined (reading
+  'length')` at `nrows`, called from `matmul`. Fixed by adding the same
+  `a = toArrayValue(a); b = toArrayValue(b);` normalization `elementwise`
+  already had, as `matmul`'s first two statements — additive only, the
+  existing `checkedShapeSize` DoS guard before allocating `out` is
+  unchanged.
+- **`tests/sir22_array.rs`: two new regression tests** —
+  `scalar_variable_self_multiplication_computes_the_square` (`x = 5; y = x *
+  x;` → `25`) and `function_parameter_self_multiplication_computes_the_square`
+  (a function squaring its own scalar parameter) — both hand-build the exact
+  `Expr::MatMul`-over-bare-`VarRef` shape the bug needed, compile to JS, and
+  run the result through an actual `node` process (mirroring this file's own
+  `elementwise_mul_with_a_bare_scalar_operand_broadcasts` convention).
+  Confirmed both crash with the exact `TypeError` above when run against the
+  pre-fix `matmul`, and pass cleanly against the fix.
+- **`scilab-to-semantic-ir/tests/oracle.rs`**: the two cases this bug was
+  found through — `scalar_variable_self_multiplication_crashes_the_compiled_
+  path` and `function_parameter_self_multiplication_crashes_the_compiled_
+  path` — flipped from `known_bug: Some(...)` to `known_bug: None`, so their
+  compiled-side assertion now actually runs (not just ground truth) and
+  passes. See that crate's own `CHANGELOG.md`.
+- Every change here is **additive only** — no existing function or
+  dispatch-table entry other than `matmul`'s own body was modified.
+  Confirmed no regression: this crate's own full test suite and every other
+  downstream consumer's (`matlab-to-semantic-ir`, `octave-to-semantic-ir`,
+  `apl-to-semantic-ir`, `j-to-semantic-ir`, `q-to-semantic-ir`,
+  `scilab-to-semantic-ir`) still pass unchanged.
+
 ## 0.51.0 — Q's five genuinely new SIR22-domain primitives (MA-11e)
 
 `q-to-semantic-ir` (new frontend crate, MA-11e) needed runtime support for

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.51.0"
+version = "0.51.1"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -4369,8 +4369,21 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
      * bounded by that alone — an outer-product-shaped call could still
      * ask for a huge output), so `checkedShapeSize` validates `[m, n]`
      * *before* allocating `out`, not after.
+     *
+     * Like `elementwise`, normalizes both operands through
+     * `toArrayValue` first: every frontend's scalar/array
+     * disambiguation heuristic (`expr_is_known_scalar` or equivalent)
+     * runs at lowering time and can't see through a plain variable
+     * reference, so a provably-scalar `x * y` between two non-literal
+     * operands can still lower to `Expr::MatMul` and reach here as a
+     * bare boxed number on one or both sides. Reading `.shape` off an
+     * un-normalized number before this fix threw
+     * `TypeError: Cannot read properties of undefined (reading
+     * 'length')` out of `nrows`/`ncols`.
      */
     function matmul(a, b) {
+      a = toArrayValue(a);
+      b = toArrayValue(b);
       const m = nrows(a);
       const ka = ncols(a);
       const kb = nrows(b);

--- a/code/packages/rust/semantic-ir-to-javascript/tests/sir22_array.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/sir22_array.rs
@@ -225,6 +225,157 @@ fn elementwise_mul_with_a_bare_scalar_operand_broadcasts() {
 }
 
 #[test]
+fn scalar_variable_self_multiplication_computes_the_square() {
+    // Regression test for task #111: every frontend's scalar/array
+    // disambiguation heuristic (`expr_is_known_scalar` or equivalent)
+    // runs at LOWERING time and can never see through a bare `VarRef` --
+    // so `x * x` between two non-literal operands (e.g. `x = 5; y = x *
+    // x;`) always lowers to `Expr::MatMul`/`__Sir.Array.matmul(x, x)`,
+    // even though `x` is a plain scalar at runtime. Before `matmul`
+    // normalized its operands through `toArrayValue` (mirroring
+    // `elementwise`), this crashed with `TypeError: Cannot read
+    // properties of undefined (reading 'length')` inside `nrows`, since
+    // a bare boxed `number` has no `.shape`. Mirrors
+    // `scilab-to-semantic-ir`'s oracle test
+    // `scalar_variable_self_multiplication_crashes_the_compiled_path`.
+    let product = Expr::MatMul {
+        lhs: Box::new(local("x")),
+        rhs: Box::new(local("x")),
+        span: sp(),
+    };
+    // `y`'s RHS references `x`, so it must be a `LetStarBinding` (sequential
+    // `let*`), not a second `LetBinding` -- a run of consecutive
+    // `LetBinding`s uses PARALLEL-let semantics (every RHS in that run is
+    // checked against the scope *before* the group), which would make `x`
+    // an unresolved name from `y`'s RHS's point of view.
+    let stmts = vec![
+        let_binding("x", int(5)),
+        Stmt::LetStarBinding {
+            name: "y".into(),
+            sir_type: None,
+            value: product,
+            span: sp(),
+        },
+        print(Expr::IndexGet {
+            target: Box::new(local("y")),
+            indices: vec![
+                IndexArg::Scalar(Box::new(int(0))),
+                IndexArg::Scalar(Box::new(int(0))),
+            ],
+            span: sp(),
+        }),
+    ];
+    let module = module_with_main(stmts, int(0), ARRAY_FEATURES);
+    if let Some(stdout) = run_module(&module, "scalar_self_mul") {
+        assert_eq!(stdout, "25");
+    }
+}
+
+#[test]
+fn function_parameter_self_multiplication_computes_the_square() {
+    // Regression test for task #111, function-parameter variant: mirrors
+    // `scalar_variable_self_multiplication_computes_the_square` above but
+    // through a function parameter -- `function sq(x) { return x * x; }`
+    // -- where `x` is a `Scope::Param` `VarRef`. The lowering heuristic
+    // treats a parameter reference exactly like any other non-literal
+    // `VarRef` (never "known scalar"), so `x * x` still lowers to
+    // `Expr::MatMul` and hits the same un-normalized-operand crash before
+    // the fix. Mirrors `scilab-to-semantic-ir`'s oracle test
+    // `function_parameter_self_multiplication_crashes_the_compiled_path`.
+    use semantic_ir::{Param, ParamKind};
+
+    fn param_ref(name: &str) -> Expr {
+        Expr::VarRef {
+            name: name.into(),
+            scope: Scope::Param,
+            span: sp(),
+        }
+    }
+
+    let sq = Function {
+        name: "sq".into(),
+        params: vec![Param {
+            name: "x".into(),
+            sir_type: None,
+            kind: ParamKind::Required,
+            default: None,
+            span: sp(),
+        }],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![],
+            value: Expr::MatMul {
+                lhs: Box::new(param_ref("x")),
+                rhs: Box::new(param_ref("x")),
+                span: sp(),
+            },
+            span: sp(),
+        },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+
+    let call = Expr::DirectCall {
+        fn_name: "sq".into(),
+        args: vec![int(5)],
+        effects: EffectSet::PURE,
+        span: sp(),
+    };
+
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![
+                let_binding("y", call),
+                print(Expr::IndexGet {
+                    target: Box::new(local("y")),
+                    indices: vec![
+                        IndexArg::Scalar(Box::new(int(0))),
+                        IndexArg::Scalar(Box::new(int(0))),
+                    ],
+                    span: sp(),
+                }),
+            ],
+            value: int(0),
+            span: sp(),
+        },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+
+    // `sq`'s param has `sir_type: None`, which itself observes
+    // `Feature::DynamicTyping` (see `semantic-ir/src/validator.rs`'s
+    // `check_function`), so the manifest must declare it alongside the
+    // array features or validation rejects the module before it ever
+    // reaches codegen.
+    let mut features = ARRAY_FEATURES.to_vec();
+    features.push(Feature::DynamicTyping);
+
+    let module = Module {
+        name: "sir22".into(),
+        manifest: FeatureManifest::from_features(&features),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![sq, main],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    };
+
+    if let Some(stdout) = run_module(&module, "fn_param_self_mul") {
+        assert_eq!(stdout, "25");
+    }
+}
+
+#[test]
 fn transpose_swaps_rows_and_columns() {
     // transpose([1 2 3; 4 5 6]) = [1 4; 2 5; 3 6] -- read back element
     // (2, 0) (0-based), which should be the original (0, 2) = 3.


### PR DESCRIPTION
## Summary
- Found while building `scilab-to-semantic-ir`'s oracle-test suite (PR #8829, front3): `matmul(a, b)` in the shared `semantic-ir-to-javascript` runtime read `a.shape`/`b.shape` unconditionally with no `toArrayValue` normalization step first, unlike its sibling `elementwise(op, a, b)`.
- Every frontend crate's scalar/array disambiguation heuristic (`expr_is_known_scalar` or equivalent) runs at lowering time and can never see through a plain variable reference — so `x * y` between two non-literal operands always lowers to `Expr::MatMul`, even when `x`/`y` turn out to be plain scalars at runtime. That crashed with `TypeError: Cannot read properties of undefined (reading 'length')` at `nrows`.
- Fix: `matmul` now normalizes both operands through `toArrayValue` as its first two statements, mirroring `elementwise`'s existing pattern exactly. The pre-existing `checkedShapeSize` DoS guard is untouched.
- Two new regression tests in `semantic-ir-to-javascript/tests/sir22_array.rs` (scalar self-multiplication, function-parameter self-multiplication), both hand-building the exact `Expr::MatMul`-over-bare-`VarRef` shape and running the compiled JS through `node`.
- `scilab-to-semantic-ir/tests/oracle.rs`'s two `known_bug` cases that found this (`scalar_variable_self_multiplication_crashes_the_compiled_path`, `function_parameter_self_multiplication_crashes_the_compiled_path`) flipped to `known_bug: None` — their compiled-side assertion now genuinely runs and passes.
- Version bumps: `semantic-ir-to-javascript` 0.51.0 → 0.51.1, `scilab-to-semantic-ir` 0.1.1 → 0.1.2.

## Test plan
- [x] Independently reverted the fix, confirmed both new regression tests fail with the exact predicted `TypeError`, then restored and confirmed they pass again
- [x] `cargo test -p semantic-ir-to-javascript --test sir22_array` — 12/12 pass
- [x] `cargo test -p scilab-to-semantic-ir --test oracle` — passes; confirmed via `--nocapture` that only the 4 still-open display-convention gaps remain in the "skipping compiled-side assertion" log (the two matmul cases are no longer skipped)
- [x] Zero regressions confirmed across every downstream consumer: `matlab-to-semantic-ir`, `octave-to-semantic-ir`, `apl-to-semantic-ir`, `j-to-semantic-ir`, `q-to-semantic-ir`, `scilab-to-semantic-ir` (all full suites pass)
- [x] Security review passed clean (additive-only 2-line fix mirroring an existing safe pattern; no new external input surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)