### PR TITLE
feat(num): NUM-6c — to_percent(x [, places]) exact percentage rendering

### DIFF
--- a/code/packages/rust/adj-constraint-solver/CHANGELOG.md
+++ b/code/packages/rust/adj-constraint-solver/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.15.0] - 2026-07-23 — absorb `ComputeExpr::ToPercent` (NUM-6c)
+
+### Changed
+
+- The solver's `ComputeExpr` walkers gain a `ComputeExpr::ToPercent` arm (the new NUM-6c
+  `to_percent` rendering): it renders a number to a boundary string, so the LIA/linear/CAS
+  extractors return `None` (out of scope, like the round/to_scientific family), the
+  observed-value substitution rebuilds it with its operand substituted, and
+  `is_constant_expr` recurses into its operand. No behaviour change for existing inputs —
+  cross-producer totality for the new engine variant.
+
 ## [0.14.0] - 2026-07-22 — absorb `ComputeExpr::ToScientific` (NUM-6c)
 
 ### Changed

--- a/code/packages/rust/adj-constraint-solver/Cargo.toml
+++ b/code/packages/rust/adj-constraint-solver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-constraint-solver"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Solver bridge for the adj-lang constraint sublanguage. Takes an adj-lang ConstraintSystem (symbols + constrain/solve/check), classifies it, and dispatches the linear-equality case to cas-solve's exact rational Gaussian elimination — returning solved values traced back to the constraints. The first slice (B2a) of the ADJ constraint-solving arc; SAT / linear-integer / inequality feasibility and optimization follow."
 

--- a/code/packages/rust/adj-constraint-solver/src/lib.rs
+++ b/code/packages/rust/adj-constraint-solver/src/lib.rs
@@ -369,6 +369,8 @@ fn expr_to_pred(e: &ComputeExpr) -> Option<Predicate> {
         // `to_scientific(x, figures)` renders a number to a boundary string — not a
         // linear/polynomial term, out of scope for this tactic exactly like a round (NUM-6c).
         ComputeExpr::ToScientific { .. } => None,
+        // `to_percent(x, places)` likewise renders a number to a boundary string (NUM-6c).
+        ComputeExpr::ToPercent { .. } => None,
     }
 }
 
@@ -665,6 +667,8 @@ fn linearize(e: &ComputeExpr) -> Option<LinForm> {
         // `to_scientific(x, figures)` renders a number to a boundary string — not a
         // linear/polynomial term, out of scope for this tactic exactly like a round (NUM-6c).
         ComputeExpr::ToScientific { .. } => None,
+        // `to_percent(x, places)` likewise renders a number to a boundary string (NUM-6c).
+        ComputeExpr::ToPercent { .. } => None,
     }
 }
 
@@ -2025,6 +2029,15 @@ fn substitute_observed(
             mode: *mode,
             expr: Box::new(substitute_observed(expr, variables, kb)),
         },
+        ComputeExpr::ToPercent {
+            places,
+            mode,
+            expr,
+        } => ComputeExpr::ToPercent {
+            places: *places,
+            mode: *mode,
+            expr: Box::new(substitute_observed(expr, variables, kb)),
+        },
         ComputeExpr::Agg(_, _) => e.clone(),
     }
 }
@@ -2116,6 +2129,8 @@ fn poly_of(e: &ComputeExpr, x: &str) -> Option<Poly> {
         // `to_scientific(x, figures)` renders a number to a boundary string — not a
         // linear/polynomial term, out of scope for this tactic exactly like a round (NUM-6c).
         ComputeExpr::ToScientific { .. } => None,
+        // `to_percent(x, places)` likewise renders a number to a boundary string (NUM-6c).
+        ComputeExpr::ToPercent { .. } => None,
     }
 }
 
@@ -2327,6 +2342,8 @@ fn expr_to_ir(e: &ComputeExpr) -> Option<IRNode> {
         // `to_scientific(x, figures)` renders a number to a boundary string — not a
         // linear/polynomial term, out of scope for this tactic exactly like a round (NUM-6c).
         ComputeExpr::ToScientific { .. } => None,
+        // `to_percent(x, places)` likewise renders a number to a boundary string (NUM-6c).
+        ComputeExpr::ToPercent { .. } => None,
     }
 }
 
@@ -2352,6 +2369,8 @@ fn is_constant_expr(e: &ComputeExpr) -> bool {
         ComputeExpr::Round { expr, .. } => is_constant_expr(expr),
         // `to_scientific(c, n)` is likewise constant iff its operand is.
         ComputeExpr::ToScientific { expr, .. } => is_constant_expr(expr),
+        // `to_percent(c, n)` is likewise constant iff its operand is.
+        ComputeExpr::ToPercent { expr, .. } => is_constant_expr(expr),
     }
 }
 

--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.21.0] — 2026-07-23 — NUM-6c: render `to_percent` in the audit trail
+
+The derivation-tree renderer gains a `DerivationNode::ToPercent` arm (NUM-6c): a
+`{"node":"to_percent","places":n,"mode":"half_even","rendered":"33.33%","value":…,"operand":{…}}`
+object exposing the decimal-place count, the stated mode, the rendered `d.dd%` string, the
+narrowed numeric value (the fraction the percentage denotes), and the operand subtree —
+everything `adj-verify` needs to re-render from the exact source. Adds an end-to-end test
+driving `to_percent(x [, places])` through the built CLI: exact rendering, trailing-zero
+padding, `0`-places (`"50%"`), the optional-`places` default, and rejection of a negative /
+non-integer place count.
+
 ## [0.20.0] — 2026-07-22 — NUM-6c: render `to_scientific` in the audit trail
 
 The derivation-tree renderer gains a `DerivationNode::ToScientific` arm (NUM-6c): a

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -196,6 +196,25 @@ fn derivation_tree_json(
             jnum(*result),
             derivation_tree_json(operand, kb)
         ),
+        // A `to_percent(x, places)` rendering (NUM-6c): the audit exposes the decimal-place
+        // count, the rounding mode, the `rendered` `d.dd%` string, the narrowed numeric
+        // `value` (the fraction the percentage denotes), and the operand subtree — so a
+        // checker can re-scale and re-round the operand's exact value and confirm the
+        // rendered form (ADJ-NUMERIC-SUBSTRATE §4.3).
+        D::ToPercent {
+            places,
+            mode,
+            rendered,
+            operand,
+            result,
+        } => format!(
+            "{{\"node\":\"to_percent\",\"places\":{},\"mode\":\"{}\",\"rendered\":\"{}\",\"value\":{},\"operand\":{}}}",
+            places,
+            rounding_mode_name(*mode),
+            esc(rendered),
+            jnum(*result),
+            derivation_tree_json(operand, kb)
+        ),
     }
 }
 

--- a/code/packages/rust/adj-lang-cli/tests/num6c_to_percent_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/num6c_to_percent_e2e.rs
@@ -1,0 +1,100 @@
+//! End-to-end tests for the NUM-6c `to_percent(x [, places])` percentage rendering, driven
+//! through the built `adj-lang-cli` binary. They prove the whole path — native application
+//! surface → adapter/lower → the engine's exact scale-and-round → the audit JSON — works
+//! together: the ratio is scaled and rounded **exactly** (no `f64` hop), the rendered `d.dd%`
+//! string and the narrowed exact fraction agree, the audit exposes the rendering
+//! (`node:to_percent`, `places`, `mode`, `rendered`, the operand subtree), the `places` arg is
+//! optional (a documented default) and `0` is valid, and a bad `places` is a clean compile
+//! error rather than a silent mis-format (ADJ-NUMERIC-SUBSTRATE §4.1, §4.3).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_num6cp_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(src: &str, tag: &str) -> (bool, String) {
+    let dir = scratch(tag);
+    let p = dir.join("case.adj");
+    std::fs::write(&p, src).unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(&p)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn to_percent_renders_a_ratio_and_audits_the_rendering() {
+    // 1/3 = 0.333… → 2 places = "33.33%", the narrowed FRACTION held as 3333/10000.
+    let (ok, s) = run("let r = to_percent(1 / 3, 2)\n? r\n", "value");
+    assert!(ok, "cli should succeed: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    assert!(
+        s.contains("\"rendered\":\"33.33%\""),
+        "renders 1/3 → 33.33%: {s}"
+    );
+    // The exact sidecar is the true narrowed fraction (33.33% = 3333/10000).
+    assert!(
+        s.contains("\"num\":\"3333\"") && s.contains("\"den\":\"10000\""),
+        "carries the exact narrowed fraction 3333/10000: {s}"
+    );
+    // The audit trail exposes the rendering as a first-class, checkable step.
+    assert!(
+        s.contains("\"node\":\"to_percent\"")
+            && s.contains("\"places\":2")
+            && s.contains("\"mode\":\"half_even\""),
+        "audit records node/places/mode: {s}"
+    );
+}
+
+#[test]
+fn to_percent_pads_trailing_zeros_and_zero_places_drops_the_point() {
+    // 1/2 → 2 places pads: "50.00%".
+    let (ok, s) = run("let r = to_percent(1 / 2, 2)\n? r\n", "pad");
+    assert!(ok, "cli should succeed: {s}");
+    assert!(s.contains("\"rendered\":\"50.00%\""), "1/2 → 50.00%: {s}");
+    // 1/2 → 0 places drops the decimal point: "50%".
+    let (ok2, s2) = run("let r = to_percent(1 / 2, 0)\n? r\n", "zero");
+    assert!(ok2, "cli should succeed: {s2}");
+    assert!(s2.contains("\"rendered\":\"50%\""), "1/2 at 0 places → 50%: {s2}");
+}
+
+#[test]
+fn to_percent_places_argument_is_optional() {
+    // `to_percent(x)` without a place count uses the default (two decimal places).
+    let (ok, s) = run("let r = to_percent(1 / 8)\n? r\n", "default");
+    assert!(ok, "cli should succeed: {s}");
+    // 1/8 = 0.125 → 2 places (half-even) = "12.50%".
+    assert!(
+        s.contains("\"rendered\":\"12.50%\"") && s.contains("\"places\":2"),
+        "the default is two decimal places: {s}"
+    );
+}
+
+#[test]
+fn a_negative_place_count_is_a_compile_error() {
+    // `places` must be a non-negative integer; a negative is rejected at compile time.
+    let (ok, s) = run("let r = to_percent(1 / 3, -1)\n? r\n", "negplaces");
+    assert!(
+        !ok || s.contains("\"error\""),
+        "a negative place count must be rejected: {s}"
+    );
+    assert!(
+        !s.contains("\"node\":\"to_percent\""),
+        "must not emit a rendering node: {s}"
+    );
+}
+
+#[test]
+fn a_non_integer_place_count_is_a_compile_error() {
+    let (ok, s) = run("let r = to_percent(1 / 3, 1.5)\n? r\n", "badplaces");
+    assert!(
+        !ok || s.contains("\"error\""),
+        "a non-integer place count must be rejected: {s}"
+    );
+}

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.60.0] — 2026-07-23
+
+### Added — NUM-6c: the `to_percent(x [, places])` percentage rendering (ADJ-NUMERIC-SUBSTRATE §4.1, §4.3)
+
+```
+let share = to_percent(votes / total, 1)   % → "42.7%"
+let round = to_percent(part / whole)        % default 2 decimal places
+```
+
+- `to_percent` joins `round_to`/`round_sig`/`to_scientific` as a built-in recognised
+  during `Apply` lowering (same native comma-list surface, no new grammar). It lowers to
+  the new `logic_engine::ComputeExpr::ToPercent` node via a new `ExprAst::ToPercent(expr,
+  places)` AST node, under the default half-even mode.
+- The `places` argument is **optional**: `to_percent(x)` uses the documented default
+  (`DEFAULT_PERCENT_PLACES = 2`), resolved at lowering so the engine node always carries a
+  concrete count and the audit records what was used. A stated `to_percent(x, n)` requires
+  `n` a **non-negative** integer literal (`≥ 0` — zero places is meaningful, `"50%"`)
+  within the precision cap (`MAX_ROUND_PLACES = 100`). A non-integer, negative, oversized,
+  or non-literal `n`, or the wrong argument count, is a clean compile error.
+- All four expression walkers carry the new node, so it composes inside formula bodies,
+  `let`s, and predicate application positions exactly like the other precision ops.
+
 ## [0.59.0] — 2026-07-22
 
 ### Added — NUM-6c: the `to_scientific(x [, figures])` scientific-notation rendering (ADJ-NUMERIC-SUBSTRATE §4.1, §4.3)

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.59.0"
+version = "0.60.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -278,6 +278,16 @@ pub enum ExprAst {
     /// application surface `to_scientific(x [, figures])`, recognised as a built-in in
     /// [`ExprAst::Apply`] lowering (same comma-list grammar as `round_to`/`round_sig`).
     ToScientific(Box<ExprAst>, u32),
+    /// A **percentage formatting** — `to_percent(x [, places])` (NUM-6c). A rendering op:
+    /// it takes `x` as a dimensionless ratio, scales it by 100 and rounds to `places`
+    /// decimal places on the exact path, and produces the `d.dd%` string alongside the
+    /// narrowed fraction (ADJ-NUMERIC-SUBSTRATE §4.1, §4.3). Lowers to the distinct
+    /// `logic_engine::ComputeExpr::ToPercent` node under the default half-even mode. The
+    /// `places` count is validated (`≥ 0`, within the precision cap); when the surface
+    /// omits it, the default is resolved at lowering. Produced by the native application
+    /// surface `to_percent(x [, places])`, recognised as a built-in in [`ExprAst::Apply`]
+    /// lowering (same comma-list grammar as `round_to`/`to_scientific`).
+    ToPercent(Box<ExprAst>, u32),
     /// An aggregation over every observation of a slot.
     Agg(AggOp, String),
     /// A **formula application** used as a sub-expression: `name(arg₁, …, argₙ)`

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -1231,6 +1231,15 @@ fn lower_expr(expr: &ExprAst) -> ComputeExpr {
             mode: bignum_core::RoundingMode::HalfEven,
             expr: Box::new(lower_expr(a)),
         },
+        // `to_percent(x, places)` (NUM-6c): the percentage rendering. Lowers to the
+        // distinct engine `ToPercent` node so the decimal-place count and the default
+        // half-even mode ride along and the exact-path audit records both the exact
+        // source ratio and the rendered `d.dd%` string (ADJ-NUMERIC-SUBSTRATE §4.1, §4.3).
+        ExprAst::ToPercent(a, places) => ComputeExpr::ToPercent {
+            places: *places,
+            mode: bignum_core::RoundingMode::HalfEven,
+            expr: Box::new(lower_expr(a)),
+        },
         ExprAst::Call2(f, a, b) => ComputeExpr::Bin(
             lower_bin_fn(*f),
             Box::new(lower_expr(a)),
@@ -1562,6 +1571,7 @@ fn collect_refs(expr: &ExprAst, out: &mut Vec<String>) {
         | ExprAst::Round(a)
         | ExprAst::RoundTo(a, _)
         | ExprAst::ToScientific(a, _)
+        | ExprAst::ToPercent(a, _)
         | ExprAst::Trunc(a)
         | ExprAst::Sign(a)
         | ExprAst::Call(_, a) => collect_refs(a, out),
@@ -1620,6 +1630,14 @@ const MAX_ROUND_PLACES: u32 = 100;
 /// engine node always carries a concrete `figures` count and the audit records what was
 /// used regardless of whether the writer stated it.
 const DEFAULT_SCI_FIGURES: u32 = 6;
+
+/// The decimal-place count `to_percent(x)` uses when the surface omits it (NUM-6c). Two
+/// is the conventional default for a formatted percentage (`"33.33%"`) and matches the
+/// precision-sensitive framing of §4 (the `$100M-per-point` case); an explicit
+/// `to_percent(x, n)` overrides it. Applied at lowering, so the engine node always carries
+/// a concrete `places` count and the audit records what was used. Unlike the significant-
+/// figure ops, `places = 0` is a valid explicit argument (`to_percent(x, 0) = "50%"`).
+const DEFAULT_PERCENT_PLACES: u32 = 2;
 
 /// Maximum AST-nesting depth the expansion/substitution/clone walkers may descend
 /// in a single expression (ADJ-RULE-SUBSTRATE RS-1). The node budget bounds total
@@ -1705,6 +1723,9 @@ fn charged_clone(
         ExprAst::RoundTo(a, n) => ExprAst::RoundTo(Box::new(charged_clone(a, budget, d)?), *n),
         ExprAst::ToScientific(a, n) => {
             ExprAst::ToScientific(Box::new(charged_clone(a, budget, d)?), *n)
+        }
+        ExprAst::ToPercent(a, n) => {
+            ExprAst::ToPercent(Box::new(charged_clone(a, budget, d)?), *n)
         }
         ExprAst::Trunc(a) => ExprAst::Trunc(Box::new(charged_clone(a, budget, d)?)),
         ExprAst::Sign(a) => ExprAst::Sign(Box::new(charged_clone(a, budget, d)?)),
@@ -1895,6 +1916,43 @@ fn expand_rec(
                 let value = expand_rec(&args[0], formulas, depth, chain, active, budget, d)?;
                 return Ok(ExprAst::ToScientific(Box::new(value), figures));
             }
+            // NUM-6c built-in: `to_percent(x [, places])` — the percentage rendering.
+            // Recognised by NAME here, before the user-formula lookup, on the same
+            // comma-list application grammar. `places` is OPTIONAL: `to_percent(x)` uses
+            // the default [`DEFAULT_PERCENT_PLACES`]; a stated `to_percent(x, n)` requires
+            // `n` a NON-NEGATIVE integer literal (`≥ 0` — zero places is meaningful,
+            // `"50%"`) within the precision cap [`MAX_ROUND_PLACES`]. A non-integer,
+            // negative, oversized, or non-literal `n`, or the wrong argument count, is a
+            // clean compile error.
+            if name == "to_percent" {
+                if args.is_empty() || args.len() > 2 {
+                    return Err(LowerError::FormulaArity {
+                        formula: name.clone(),
+                        expected: 2,
+                        got: args.len(),
+                    });
+                }
+                let places = if args.len() == 2 {
+                    match &args[1] {
+                        ExprAst::Lit(v)
+                            if v.fract() == 0.0
+                                && *v >= 0.0
+                                && *v <= MAX_ROUND_PLACES as f64 =>
+                        {
+                            *v as u32
+                        }
+                        _ => {
+                            return Err(LowerError::FormulaBadArgument {
+                                formula: name.clone(),
+                            })
+                        }
+                    }
+                } else {
+                    DEFAULT_PERCENT_PLACES
+                };
+                let value = expand_rec(&args[0], formulas, depth, chain, active, budget, d)?;
+                return Ok(ExprAst::ToPercent(Box::new(value), places));
+            }
             // Resolve the callee against the SAME registry the top-level query path
             // uses. An unknown name is a clean, specific error — distinct from an
             // aggregation or built-in call, which never reach here (they are separate
@@ -1987,6 +2045,10 @@ fn expand_rec(
             *n,
         )),
         ExprAst::ToScientific(a, n) => Ok(ExprAst::ToScientific(
+            Box::new(expand_rec(a, formulas, depth, chain, active, budget, d)?),
+            *n,
+        )),
+        ExprAst::ToPercent(a, n) => Ok(ExprAst::ToPercent(
             Box::new(expand_rec(a, formulas, depth, chain, active, budget, d)?),
             *n,
         )),
@@ -2173,6 +2235,9 @@ fn substitute_expr(
         }
         ExprAst::ToScientific(a, n) => {
             ExprAst::ToScientific(Box::new(substitute_expr(a, subst, budget, d)?), *n)
+        }
+        ExprAst::ToPercent(a, n) => {
+            ExprAst::ToPercent(Box::new(substitute_expr(a, subst, budget, d)?), *n)
         }
         ExprAst::Trunc(a) => ExprAst::Trunc(Box::new(substitute_expr(a, subst, budget, d)?)),
         ExprAst::Sign(a) => ExprAst::Sign(Box::new(substitute_expr(a, subst, budget, d)?)),

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.48.0] — 2026-07-23 — NUM-6c: `to_percent` — percentage rendering (exact)
+
+Adds the second NUM-6c formatter (`ADJ-NUMERIC-SUBSTRATE.md` §4.1, §4.3): a **rendering**
+op that takes a dimensionless ratio, scales it by 100 and rounds to a stated number of
+decimal places on the exact path, and renders the fixed-point `d.dd%` string — with the
+narrowed **fraction** carried beside it so a downstream predicate over the binding still
+sees the ratio and the audit backs the render from the exact source.
+
+### Added
+
+- `ComputeExpr::ToPercent { places, mode, expr }` and the matching
+  `DerivationNode::ToPercent { places, mode, rendered, operand, result }`. `result` is the
+  fraction the percentage denotes (`"33.33%"` → `3333/10000`).
+- `percent(r, places, mode)` — renders an exact ratio as a fixed-point percentage with a
+  `%` suffix and returns the narrowed fraction alongside, both from one rounding. The scaled
+  integer is `C = round(r · 10^(places+2))` under `mode`; the string places the decimal
+  point `places` from `C`'s right (padding to a leading zero for sub-1% values), and the
+  narrowed fraction is `C / 10^(places+2)`. `places = 0` drops the decimal point (`"50%"`);
+  zero renders `"0.00%"`. All big-integer/-decimal — no `f64` hop. Dimension-preserving.
+
 ## [0.47.0] — 2026-07-22 — NUM-6c: `to_scientific` — scientific-notation rendering (exact)
 
 Adds the first formatter of the precision/format family (NUM-6c,

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.47.0"
+version = "0.48.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -437,6 +437,21 @@ pub enum ComputeExpr {
         mode: RoundingMode,
         expr: Box<ComputeExpr>,
     },
+    /// A **percentage formatting** — `to_percent(x [, places])` (NUM-6c). A rendering
+    /// op like [`ComputeExpr::ToScientific`]: it takes `x` as a dimensionless *ratio*
+    /// (`0.5 → "50%"`), scales it by 100, rounds to `places` decimal places on the
+    /// exact path under `mode`, and renders the fixed-point string with a `%` suffix
+    /// (`to_percent(1/3, 2) = "33.33%"`). The narrowed numeric value is the *fraction*
+    /// the string denotes (`"33.33%"` → `3333/10000`), so a downstream predicate over
+    /// the binding still sees the ratio, and the audit carries both the exact source
+    /// and the rendered form (ADJ-NUMERIC-SUBSTRATE §4.1, §4.3). `places ≥ 0`
+    /// (`to_percent(x, 0) = "50%"`); the default when the surface omits it is resolved
+    /// at lowering. Dimension-preserving.
+    ToPercent {
+        places: u32,
+        mode: RoundingMode,
+        expr: Box<ComputeExpr>,
+    },
 }
 
 /// *What* precision a [`ComputeExpr::Round`] narrows to. NUM-6a ships the
@@ -506,6 +521,19 @@ pub enum DerivationNode {
         operand: Box<DerivationNode>,
         result: f64,
     },
+    /// A **percentage rendering** node (NUM-6c) — the audit record for a
+    /// `to_percent(x, places)`. Carries the `places`/`mode` it rounded under, the
+    /// `rendered` `d.dd%` string, and its single `operand` subtree (the exact source
+    /// ratio), so `adj-verify` can re-scale and re-round the operand's exact value and
+    /// confirm the `rendered` form (ADJ-NUMERIC-SUBSTRATE §4.3). `result` is the
+    /// narrowed numeric value — the *fraction* the percentage denotes.
+    ToPercent {
+        places: u32,
+        mode: RoundingMode,
+        rendered: String,
+        operand: Box<DerivationNode>,
+        result: f64,
+    },
 }
 
 impl DerivationNode {
@@ -518,6 +546,7 @@ impl DerivationNode {
             DerivationNode::Op { result, .. } => *result,
             DerivationNode::Round { result, .. } => *result,
             DerivationNode::ToScientific { result, .. } => *result,
+            DerivationNode::ToPercent { result, .. } => *result,
         }
     }
 }
@@ -924,6 +953,12 @@ fn eval(
             mode,
             expr,
         } => eval_to_scientific(*figures, *mode, expr, kb, depth),
+
+        ComputeExpr::ToPercent {
+            places,
+            mode,
+            expr,
+        } => eval_to_percent(*places, *mode, expr, kb, depth),
 
         ComputeExpr::Agg(op, slot) => {
             let observations = kb.observed_values_all(slot);
@@ -1379,6 +1414,96 @@ fn bigdecimal_to_integer(bd: &BigDecimal) -> BigInteger {
     } else {
         bd.mantissa().clone()
     }
+}
+
+/// Evaluate `to_percent(x, places)` (NUM-6c): render the dimensionless ratio `x` as a
+/// percentage to `places` decimal places (`0.5 → "50%"`, `1/3 → "33.33%"` at 2 places).
+/// A **rendering** op — the narrowed numeric value is the *fraction* the string denotes
+/// (so a downstream predicate over the binding still sees the ratio) and the exact sidecar
+/// backs the audit, per ADJ-NUMERIC-SUBSTRATE §4.1, §4.3. Dimension-preserving.
+#[inline(never)]
+fn eval_to_percent(
+    places: u32,
+    mode: RoundingMode,
+    expr: &ComputeExpr,
+    kb: &KnowledgeBase,
+    depth: usize,
+) -> Result<(DerivationNode, Dimension, Option<ExactRational>), ComputeError> {
+    let (operand, dim, exact) = eval(expr, kb, depth + 1)?;
+    let (rendered, exact_out, result) = match &exact {
+        Some(r) => {
+            let (s, narrowed) = percent(r, places, mode);
+            let value = narrowed.to_f64();
+            (s, Some(narrowed), value)
+        }
+        None => {
+            // Already-inexact operand (a transcendental ratio): format the lossy `f64`
+            // scaled to a percentage. `result` stays the fraction the string denotes.
+            let value = operand.value();
+            let s = format!("{:.*}%", places as usize, value * 100.0);
+            (s, None, value)
+        }
+    };
+    // A non-finite operand must not render as a clean percentage — same guard as the
+    // other ops (op label reuses `Round`: `to_percent` is a rounding-based narrowing).
+    if !result.is_finite() {
+        return Err(ComputeError::NonFinite {
+            op: ComputeOp::Round,
+        });
+    }
+    Ok((
+        DerivationNode::ToPercent {
+            places,
+            mode,
+            rendered,
+            operand: Box::new(operand),
+            result,
+        },
+        dim,
+        exact_out,
+    ))
+}
+
+/// Render an exact ratio as a fixed-point percentage string with exactly `places` decimal
+/// places and a `%` suffix, and return the **narrowed fraction** alongside — both from one
+/// rounding so they always agree. The percentage magnitude is `x · 100`, so the scaled
+/// integer is `C = round(x · 10^(places+2))` under `mode`; the string places the decimal
+/// point `places` from `C`'s right (`"33.33%"`), and the narrowed fraction is `C / 10^(places+2)`
+/// (`= "33.33%" / 100`). Zero and `places = 0` are handled by the same padding path. All
+/// arithmetic is exact big-integer/-decimal.
+fn percent(r: &ExactRational, places: u32, mode: RoundingMode) -> (String, ExactRational) {
+    // `C = round(r · 10^(places+2))` — the percentage's digits scaled to an integer.
+    let scale_pow = places + 2;
+    let dividend = r.numerator() * &ten_to(scale_pow);
+    let c_bd = BigDecimal::from_integer(dividend).div_round(
+        &BigDecimal::from_integer(r.denominator().clone()),
+        0,
+        mode,
+    );
+    let c = bigdecimal_to_integer(&c_bd);
+    let neg = c.is_negative();
+    let mag = c.abs().to_string();
+
+    // Place the decimal point `places` from the right of the magnitude digits, padding on
+    // the left so there is always at least one integer digit (`0.05`, not `.05`).
+    let body = if places == 0 {
+        mag
+    } else {
+        let p = places as usize;
+        let mag = if mag.len() <= p {
+            format!("{}{}", "0".repeat(p + 1 - mag.len()), mag)
+        } else {
+            mag
+        };
+        let split = mag.len() - p;
+        format!("{}.{}", &mag[..split], &mag[split..])
+    };
+    let sign = if neg { "-" } else { "" };
+    let rendered = format!("{sign}{body}%");
+
+    // Narrowed fraction = C / 10^(places+2) (the percentage magnitude divided back by 100).
+    let narrowed = ExactRational::from_ratio(BigRational::new(c, ten_to(scale_pow)));
+    (rendered, narrowed)
 }
 
 /// Round an `f64` to `spec`'s precision — the fallback for an operand that carried
@@ -2944,5 +3069,80 @@ mod tests {
         assert_eq!(rendered_of(&d), "3.33e0"); // 10/3 usd → 3.33e0
         assert_eq!(d.dim, Dimension::Money("usd".into()));
         assert_eq!(d.exact, ExactRational::new(333, 100));
+    }
+
+    // ---- NUM-6c: to_percent(x, places) — the percentage rendering ----
+
+    fn to_pct(places: u32, inner: ComputeExpr) -> ComputeExpr {
+        ComputeExpr::ToPercent {
+            places,
+            mode: RoundingMode::HalfEven,
+            expr: Box::new(inner),
+        }
+    }
+    fn pct_rendered_of(d: &Derived) -> String {
+        match &d.tree {
+            DerivationNode::ToPercent { rendered, .. } => rendered.clone(),
+            other => panic!("expected ToPercent node, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn to_percent_renders_a_ratio_to_the_stated_places() {
+        let kb = KnowledgeBase::new();
+        // 1/3 = 0.333… → 2 places = "33.33%", the narrowed FRACTION held as 3333/10000.
+        let a = compute("r", &to_pct(2, frac(1, 3)), &kb).unwrap();
+        assert_eq!(pct_rendered_of(&a), "33.33%");
+        assert_eq!(a.exact, ExactRational::new(3333, 10000));
+        // 1/2 = 0.5 → 2 places pads the trailing zeros: "50.00%", value exactly 1/2.
+        let b = compute("r", &to_pct(2, frac(1, 2)), &kb).unwrap();
+        assert_eq!(pct_rendered_of(&b), "50.00%");
+        assert_eq!(b.exact, ExactRational::new(1, 2));
+    }
+
+    #[test]
+    fn to_percent_zero_places_drops_the_decimal_point() {
+        let kb = KnowledgeBase::new();
+        // 1/2 → 0 places = "50%" (no decimal point), value exactly 1/2.
+        let d = compute("r", &to_pct(0, frac(1, 2)), &kb).unwrap();
+        assert_eq!(pct_rendered_of(&d), "50%");
+        assert_eq!(d.exact, ExactRational::new(1, 2));
+    }
+
+    #[test]
+    fn to_percent_handles_sub_one_percent_sign_and_zero() {
+        let kb = KnowledgeBase::new();
+        // 1/2000 = 0.0005 → 2 places = "0.05%" (integer part padded to a leading 0).
+        let small = compute("r", &to_pct(2, frac(1, 2000)), &kb).unwrap();
+        assert_eq!(pct_rendered_of(&small), "0.05%");
+        assert_eq!(small.exact, ExactRational::new(5, 10000)); // 0.0005
+        // Negative: −1/4 = −0.25 → 1 place = "-25.0%", value exactly −1/4.
+        let neg = compute("r", &to_pct(1, frac(-1, 4)), &kb).unwrap();
+        assert_eq!(pct_rendered_of(&neg), "-25.0%");
+        assert_eq!(neg.exact, ExactRational::new(-1, 4));
+        // Zero → "0.00%", exact 0.
+        let z = compute("r", &to_pct(2, ComputeExpr::Lit(0.0)), &kb).unwrap();
+        assert_eq!(pct_rendered_of(&z), "0.00%");
+        assert_eq!(z.exact, ExactRational::new(0, 1));
+    }
+
+    #[test]
+    fn to_percent_preserves_dimension_and_is_exact_on_a_percentage_point_case() {
+        // The "$100M-per-point" case: an exact ratio, rounded only at render. A budget
+        // fraction 1/7 of a dimensioned quantity narrows the magnitude, keeps the unit.
+        let kb = kb_with(vec![money("share", 1, "usd")]);
+        let expr = to_pct(
+            3,
+            ComputeExpr::Bin(
+                ComputeOp::Div,
+                Box::new(refexpr("share")),
+                Box::new(ComputeExpr::Lit(7.0)),
+            ),
+        );
+        let d = compute("r", &expr, &kb).unwrap();
+        // 1/7 = 0.142857… → 3 places = "14.286%" (half-even on the 4th place: …57→6).
+        assert_eq!(pct_rendered_of(&d), "14.286%");
+        assert_eq!(d.exact, ExactRational::new(14286, 100000)); // 0.14286
+        assert_eq!(d.dim, Dimension::Money("usd".into()));
     }
 }

--- a/code/specs/ADJ-NUMERIC-SUBSTRATE.md
+++ b/code/specs/ADJ-NUMERIC-SUBSTRATE.md
@@ -171,8 +171,13 @@ tests → impl → security-review → babysit:
   string beside the narrowed exact value, both from one rounding so they can never disagree), the
   native `to_scientific(x [, figures])` application surface (optional `figures`, default 6; `≥ 1`,
   within the precision cap), the §4.3 audit record (`node:to_scientific`, `figures`, `mode`,
-  `rendered`, operand subtree), and an end-to-end formula test. `to_percent` / `to_currency` and
-  per-`KnowledgeBase` precision follow.
+  `rendered`, operand subtree), and an end-to-end formula test. **`to_percent(x [, places])`**
+  ✅ **shipped** — `ComputeExpr::ToPercent { places, mode, expr }`: takes `x` as a dimensionless
+  ratio, scales by 100 and rounds to `places` decimal places on the exact path, renders the
+  fixed-point `d.dd%` string, and carries the narrowed *fraction* as the numeric value
+  (`"33.33%"` → `3333/10000`); native `to_percent(x [, places])` surface (optional `places`,
+  default 2; `≥ 0`, so `to_percent(x, 0) = "50%"`), the §4.3 audit record (`node:to_percent`),
+  and an end-to-end formula test. `to_currency` and per-`KnowledgeBase` precision follow.
 
 ---
 


### PR DESCRIPTION
## NUM-6c — `to_percent(x [, places])`: the second precision/format formatter

Follows `to_scientific` ([#8833](https://github.com/adhithyan15/coding-adventures/pull/8833)). Where the precision *narrowings* (`round_to`/`round_sig`) return a number, `to_percent` is a **rendering** op: it takes `x` as a dimensionless ratio, scales by 100 and rounds to `places` decimal places on the exact path, and emits the fixed-point `d.dd%` string — carrying the narrowed **fraction** beside it, so a downstream predicate over the binding still sees the ratio and `adj-verify` re-derives the string from the exact source (ADJ-NUMERIC-SUBSTRATE §4.1, §4.3).

```
let share = to_percent(votes / total, 1)   % → "42.7%"
let round = to_percent(part / whole)        % default 2 decimal places
```

### What lands
- **logic-engine (0.48.0):** `ComputeExpr::ToPercent { places, mode, expr }` + `DerivationNode::ToPercent { places, mode, rendered, operand, result }` (`result` = the fraction the % denotes: `"33.33%"` → `3333/10000`). `percent(r, places, mode)`: scaled integer `C = round(r·10^(places+2))` via `div_round` to scale 0; the string places the point `places` from `C`'s right (padding to a leading zero for sub-1% values, `"0.05%"`), `places = 0` drops the point (`"50%"`), zero → `"0.00%"`; narrowed fraction `= C / 10^(places+2)`. All big-integer/-decimal — **no `f64` hop**. Dimension-preserving.
- **adj-lang (0.60.0):** `ExprAst::ToPercent(expr, places)` + the `to_percent` Apply-intercept (places **optional**, default 2; **non-negative** — `0` is valid, unlike the sig-figure ops — within the cap; bad `n` or arity is a clean compile error) + all 4 walkers.
- **adj-constraint-solver (0.15.0):** cross-producer totality — the new variant in all 6 `ComputeExpr` match sites. No behaviour change for existing inputs.
- **adj-lang-cli (0.21.0):** renders `{"node":"to_percent","places":n,"mode":…,"rendered":…,"value":…,"operand":…}` + e2e test.
- **Spec** §4.4 marks `to_percent` shipped (`to_currency` + per-KB precision follow).

### Verification
- Full `cargo test` across all four consumers — **green** (7 suites, 0 failures; 4 engine unit tests + a 5-case e2e).
- Exact values checked: `1/3→"33.33%"` (3333/10000), `1/2→"50.00%"`/`"50%"`, `1/8` default → `"12.50%"`, `1/2000→"0.05%"`, `−1/4→"-25.0%"`, `0→"0.00%"`, `1/7 at 3 → "14.286%"`.
- `cargo clippy` clean; `/security-review` **PASSED** (no string-slice/underflow panics; `scale_pow` bounded by `places ≤ 100` with **no operand-driven amplification**; airtight `places` trust boundary; no div-by-zero).

🤖 Generated with [Claude Code](https://claude.com/claude-code)