### PR TITLE
feat(twig-aot): x86_64 GC stack-map registration, SysV (AOT00-T1 x86_64 PR-x3)

### DIFF
--- a/code/packages/rust/twig-aot/CHANGELOG.md
+++ b/code/packages/rust/twig-aot/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog — `twig-aot`
 
+## 0.43.0 - 2026-07-23 — x86_64 GC stack-map registration, SysV (AOT00-T1 x86_64 PR-x3)
+
+Fills the x86-64 `__gc_init_stackmaps` (a no-op since PR-x2) with **real registration**
+on System V (Linux): `compile_module_x86_64_to_text`'s pass 1 switches to
+`compile_function_with_globals_and_stackmap`, and `build_gc_init_stackmaps_x86_64`
+marshals the eight `__gc_register_stackmap` arguments per function and calls it —
+
+```
+lea  rdi, [rip + F]          ; func_start (patched pass 2b)
+mov  rsi,<F len> ; mov rdx,<records>
+lea  rcx, [rip + F.pc] ; xor r8,r8 ; xor r9,r9
+lea  rax,[rip+F.slots|0]; push rax     ; arg8 slots_flat
+lea  rax,[rip+F.counts]; push rax      ; arg7 slot_counts
+call __gc_register_stackmap ; add rsp,16
+```
+
+so `__gc_collect_precise` resolves an x86-64 return address to its exact roots. Design
+mirrors the merged aarch64 registration:
+
+- **`func_start`** via `LEA rdi, [rip+disp32]` patched in a new pass 2b from link offsets;
+  base-independent (RIP cancels the load base), no relocation — the x86-64 counterpart of
+  the aarch64 `ADR`. Uses the new x86_64-encoder 0.7.0 `lea_rip_placeholder`.
+- **The three arrays** are a data pool after the final `ret`, addressed by
+  `lea_rip_label` (RIP-relative, resolved at `finish()`); registry copies the slots.
+- **Register the wrapper too** (empty ref-slot map) — the increment-C precision fix, so
+  the precise walk never conservatively re-scans the user entry's frame.
+- `rsp` stays 16-aligned at each `call` (2 argument pushes = 16 bytes).
+
+**Windows/MsX64 keeps the no-op init** (its precise walk is a follow-up: the 4-stack-arg
++ shadow-space marshalling needs an `[rsp+disp]` store the encoder lacks, and the
+differential is Linux-only anyway) — so Windows degrades to a **safe conservative**
+collection. Also adds x86_64-backend 0.31.0 GC builtins (`gc_collect` /
+`gc_collect_precise` / `gc_live_bytes` / `gc_stackmap_count`).
+
+Verified: 57 lib tests incl. `x86_64_func_start_lea_resolves_to_target_offset` (decodes
+the patched `LEA`, base-independent) + the structural registration test; clippy clean.
+The registration-ran + `live_bytes` differential (precise reclaims the i64 look-alike
+→ 0, conservative pins it → 64) run on the native x86-64 `ubuntu-latest` CI runner
+(`linux_x86_64_smoke`), the authoritative validator for this arc (the dev host is aarch64
+macOS). Needs x86_64-encoder 0.7.0.
+
 ## 0.42.0 - 2026-07-22 — x86_64 GC entry wrapper + no-op init (AOT00-T1 x86_64 PR-x2)
 
 Ports increment A to the native x86-64 object path (`compile_module_x86_64_to_text`):

--- a/code/packages/rust/twig-aot/Cargo.toml
+++ b/code/packages/rust/twig-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-aot"
-version = "0.42.0"
+version = "0.43.0"
 edition = "2021"
 description = "Twig AOT compiler — produces native Mach-O / ELF executables from Twig source. v0.28.0 (E4d-4 fix): strip_dead_aot_string_allocs now keeps EVERY buffer bound to a live string alias — a branch-selected (multi-block) str var aliases several buffers, and the old alias-keyed map dropped all but the last, so a not-last branch read a freed/empty buffer at run time. v0.27.0 (E4-dyn E4d-4): runtime (branch-selected) strings on the native aarch64 + x86_64 columns — a str var assigned by str_const in >1 basic block is kept out of the compile-time literal map so print_str/str_len read the length from the [i64 len][bytes] buffer header at run time (field_load) instead of folding one branch's static length; the var's stack slot already carries the buffer address. v0.26.0 (E4-dyn E4d-1): runtime string helpers __twig_str_concat/_slice/_index/_len/_cmp in twig_runtime.c on the E5 length-prefixed heap block; bounds-trap on slice/index; C-driver unit tests."
 

--- a/code/packages/rust/twig-aot/src/lib.rs
+++ b/code/packages/rust/twig-aot/src/lib.rs
@@ -933,7 +933,9 @@ fn sdk_lib_path() -> PathBuf {
 // Mirrors the macOS ARM64 path above, but for Linux x86-64 (ELF + cc) and
 // Windows x86-64 (PE/COFF + link.exe / lld-link / gcc).
 
-use x86_64_backend::{compile_function_with_globals as x86_64_compile_with_globals, X86_64Abi};
+use x86_64_backend::{
+    compile_function_with_globals_and_stackmap as x86_64_compile_with_stackmap, X86_64Abi,
+};
 
 /// Per-function compile for x86-64, then concatenate function bytes into a
 /// single `.text`, **patch cross-function call sites in place**, and surface
@@ -1033,6 +1035,134 @@ fn build_gc_noop_init_x86_64() -> Result<Vec<u8>, AotError> {
     })
 }
 
+/// One `LEA r64, [RIP+…]` in the x86-64 `__gc_init_stackmaps` that must be patched to a
+/// user function's runtime address (`func_start`, the first `__gc_register_stackmap`
+/// argument). `RIP`-relative in bytes, so the displacement is a link-time constant
+/// independent of the load base (see [`FuncAddrReloc`] for the aarch64 rationale — the
+/// `ADR` analogue); patched in pass 2b, no relocation.
+struct FuncAddrRelocX86 {
+    /// Byte offset (within `__gc_init_stackmaps`) of the `LEA`'s `disp32` slot.
+    disp_slot: usize,
+    /// Name of the user function whose address this `LEA` loads.
+    target: String,
+}
+
+/// Map an [`x86_64_encoder::EncodeError`] to an [`AotError`].
+fn gc_asm_err_x86(e: x86_64_encoder::EncodeError) -> AotError {
+    AotError::Linker { status: None, stderr: format!("twig-aot: x86_64 GC init codegen: {e:?}") }
+}
+
+/// Return byte offset of every call-return address in `relocs` — a `PltRel32` reloc's
+/// `patch_offset + 4` (the byte after the 5-byte `CALL rel32`). The x86-64 way to
+/// recover a function's safepoints (variable-width ISA → no post-scan); used to give
+/// the synthetic wrapper its own (empty-slot) records so its frame resolves precisely.
+fn call_return_offsets_x86_64(relocs: &[x86_64_encoder::ExternalReloc]) -> Vec<u32> {
+    relocs
+        .iter()
+        .filter(|r| matches!(r.kind, x86_64_encoder::ExternalRelocKind::PltRel32))
+        .map(|r| (r.patch_offset + 4) as u32)
+        .collect()
+}
+
+/// Build the **SysV** x86-64 `__gc_init_stackmaps`: for every function with records,
+/// marshal the eight `__gc_register_stackmap` arguments and call it. (Windows/MsX64
+/// keeps the no-op init — its precise walk is a follow-up — so Windows degrades to a
+/// safe conservative collection.)
+///
+/// ```text
+///   __gc_init_stackmaps:
+///       push rbp ; mov rbp, rsp
+///       ; ── per function F with records (System V) ──
+///       lea  rdi, [rip + F]          ; func_start   (patched in pass 2b)
+///       mov  rsi, <F byte length>    ; func_len
+///       mov  rdx, <record count>     ; num_records
+///       lea  rcx, [rip + F.pc]       ; pc_offsets[]
+///       xor  r8, r8                  ; frame_sizes  = NULL
+///       xor  r9, r9                  ; callee_masks = NULL
+///       lea  rax,[rip+F.slots|0]; push rax   ; arg8 slots_flat  (16-aligned: 2 pushes)
+///       lea  rax,[rip+F.counts]; push rax    ; arg7 slot_counts
+///       call __gc_register_stackmap
+///       add  rsp, 16
+///       ; ── … next function … ──
+///       mov rsp,rbp ; pop rbp ; ret
+///   <data pool: each function's pc_offsets / slot_counts / slots_flat words>
+/// ```
+///
+/// `rsp` is 16-aligned at each `call` (`push rbp` aligns; the two argument pushes add
+/// 16). Everything but `func_start` is a compile-time constant; the three arrays live in
+/// a pool after the final `ret` (never executed), addressed by `RIP`-relative `lea`
+/// resolved at `finish()`. The registry copies the slots, so the pool need not outlive
+/// the call.
+#[allow(clippy::type_complexity)]
+fn build_gc_init_stackmaps_x86_64(
+    fn_maps: &[FnStackMap],
+) -> Result<(Vec<u8>, Vec<x86_64_encoder::ExternalReloc>, Vec<FuncAddrRelocX86>), AotError> {
+    use x86_64_encoder::{Assembler, LabelId, Reg};
+    let mut a = Assembler::new();
+    let mut faddr: Vec<FuncAddrRelocX86> = Vec::new();
+    let mut pool: Vec<(LabelId, Vec<u32>)> = Vec::new();
+
+    a.push(Reg::Rbp);
+    a.mov_r64_r64(Reg::Rbp, Reg::Rsp);
+
+    for fm in fn_maps {
+        if fm.records.is_empty() {
+            continue; // no safepoints → nothing to register (conservative frame)
+        }
+        let mut pc_offsets: Vec<u32> = Vec::with_capacity(fm.records.len());
+        let mut slot_counts: Vec<u32> = Vec::with_capacity(fm.records.len());
+        let mut slots_flat: Vec<u32> = Vec::new();
+        for (pc, slots) in &fm.records {
+            pc_offsets.push(*pc);
+            slot_counts.push(slots.len() as u32);
+            slots_flat.extend(slots.iter().map(|&s| s as u32)); // i32 → u32 bit-cast
+        }
+        let pc_lbl = a.create_label();
+        let cnt_lbl = a.create_label();
+        let slots_lbl = if slots_flat.is_empty() { None } else { Some(a.create_label()) };
+
+        // Register args 1–6.
+        let disp_slot = a.lea_rip_placeholder(Reg::Rdi); // func_start (patched pass 2b)
+        faddr.push(FuncAddrRelocX86 { disp_slot, target: fm.name.clone() });
+        a.mov_r64_imm64(Reg::Rsi, fm.len as u64); //          func_len
+        a.mov_r64_imm64(Reg::Rdx, fm.records.len() as u64); // num_records
+        a.lea_rip_label(Reg::Rcx, pc_lbl); //                 pc_offsets
+        a.xor_(Reg::R8, Reg::R8); //                          frame_sizes  = NULL
+        a.xor_(Reg::R9, Reg::R9); //                          callee_masks = NULL
+        // Stack args 7,8 — push arg8 then arg7 so [rsp]=arg7, [rsp+8]=arg8 (SysV).
+        match slots_lbl {
+            Some(l) => a.lea_rip_label(Reg::Rax, l), // arg8 = slots_flat
+            None => a.xor_(Reg::Rax, Reg::Rax), //     arg8 = NULL
+        }
+        a.push(Reg::Rax);
+        a.lea_rip_label(Reg::Rax, cnt_lbl); //         arg7 = slot_counts
+        a.push(Reg::Rax);
+        a.call_rel32(GC_REGISTER_STACKMAP, x86_64_encoder::ExternalRelocKind::PltRel32);
+        a.add_imm32(Reg::Rsp, 16); // pop the two stack args
+
+        pool.push((pc_lbl, pc_offsets));
+        pool.push((cnt_lbl, slot_counts));
+        if let Some(l) = slots_lbl {
+            pool.push((l, slots_flat));
+        }
+    }
+
+    a.mov_r64_r64(Reg::Rsp, Reg::Rbp);
+    a.pop(Reg::Rbp);
+    a.ret();
+
+    // Constant data pool — read via `lea` above, never executed (after `ret`).
+    for (lbl, words) in &pool {
+        a.bind(*lbl).map_err(gc_asm_err_x86)?;
+        for &w in words {
+            a.emit_data_u32(w);
+        }
+    }
+
+    let relocs = std::mem::take(&mut a.external_relocs);
+    Ok((a.finish().map_err(gc_asm_err_x86)?, relocs, faddr))
+}
+
 #[allow(clippy::type_complexity)]
 fn compile_module_x86_64_to_text(
     module: &IIRModule,
@@ -1044,6 +1174,9 @@ fn compile_module_x86_64_to_text(
     let mut fn_results: Vec<(String, Vec<u8>, Vec<x86_64_encoder::ExternalReloc>)> =
         Vec::with_capacity(module.functions.len());
 
+    // Per user function, the GC stack map the SysV registration function will register
+    // (collected only for SysV; MsX64 uses the no-op init, so records are unused there).
+    let mut fn_maps: Vec<FnStackMap> = Vec::with_capacity(module.functions.len());
     for fn_ in &module.functions {
         let ctx = FunctionContext {
             name: &fn_.name,
@@ -1052,8 +1185,11 @@ fn compile_module_x86_64_to_text(
         };
         let inferred = infer_types(fn_);
         let cir = aot_specialise(fn_, Some(&inferred));
-        let (bytes, relocs) = x86_64_compile_with_globals(&ctx, &cir, abi, &global_slots)
-            .map_err(|_| AotError::BackendRefused { function: fn_.name.clone() })?;
+        let (bytes, relocs, stack_map) =
+            x86_64_compile_with_stackmap(&ctx, &cir, abi, &global_slots)
+                .map_err(|_| AotError::BackendRefused { function: fn_.name.clone() })?;
+        let records = stack_map.into_iter().map(|r| (r.pc_offset, r.slots)).collect();
+        fn_maps.push(FnStackMap { name: fn_.name.clone(), len: bytes.len(), records });
         fn_results.push((fn_.name.clone(), bytes, relocs));
     }
 
@@ -1081,8 +1217,29 @@ fn compile_module_x86_64_to_text(
             });
         }
     }
-    fn_results.push((GC_INIT_STACKMAPS.to_string(), build_gc_noop_init_x86_64()?, Vec::new()));
+    // Build the wrapper first (both ABIs), then — on SysV — register it too (empty
+    // ref-slot map) so the precise walk never conservatively re-scans the user entry's
+    // frame (the increment-C fix; [[feedback_precise_walk_maps_every_frame_in_chain]]).
     let (wrapper_bytes, wrapper_relocs) = build_gc_wrapper_x86_64(entry, abi)?;
+
+    // `__gc_init_stackmaps`: real registration on System V; a no-op on Windows/MsX64
+    // (whose precise walk is a follow-up), so Windows degrades to a safe conservative
+    // collection. `fn_addr_relocs` are the SysV `func_start` LEAs pass 2b patches.
+    let (init_bytes, init_relocs, fn_addr_relocs) = if matches!(abi, X86_64Abi::SysV) {
+        let wrapper_records = call_return_offsets_x86_64(&wrapper_relocs)
+            .into_iter()
+            .map(|pc| (pc, Vec::new()))
+            .collect();
+        fn_maps.push(FnStackMap {
+            name: GC_AOT_ENTRY.to_string(),
+            len: wrapper_bytes.len(),
+            records: wrapper_records,
+        });
+        build_gc_init_stackmaps_x86_64(&fn_maps)?
+    } else {
+        (build_gc_noop_init_x86_64()?, Vec::new(), Vec::new())
+    };
+    fn_results.push((GC_INIT_STACKMAPS.to_string(), init_bytes, init_relocs));
     fn_results.push((GC_AOT_ENTRY.to_string(), wrapper_bytes, wrapper_relocs));
 
     // Concatenate function bytes and record per-function offsets.
@@ -1158,6 +1315,43 @@ fn compile_module_x86_64_to_text(
                 },
                 addend: r.addend,
             });
+        }
+    }
+
+    // ── Pass 2b: patch `__gc_init_stackmaps`' func_start LEAs (SysV) ───────────
+    //
+    // Each `lea rdi, [rip + disp32]` loads a user function's absolute runtime address.
+    // `LEA` computes `RIP + disp32`; `RIP` (= instruction end) and the target are both
+    // `base + offset`, so `disp32 = target_off − (slot + 4)` is correct for any load
+    // base — the same base-independence the aarch64 `ADR` func_start relies on. No `ld`
+    // relocation. (Empty on MsX64, whose init is the no-op.)
+    if !fn_addr_relocs.is_empty() {
+        let init_off = *offsets.get(GC_INIT_STACKMAPS).ok_or_else(|| AotError::Linker {
+            status: None,
+            stderr: "twig-aot: internal error: __gc_init_stackmaps missing from link offsets"
+                .to_string(),
+        })?;
+        for r in &fn_addr_relocs {
+            let target_off = *offsets.get(r.target.as_str()).ok_or_else(|| AotError::Linker {
+                status: None,
+                stderr: format!(
+                    "twig-aot: internal error: func_start target '{}' missing from link offsets",
+                    r.target
+                ),
+            })?;
+            let slot = init_off + r.disp_slot; // disp32 slot in the linked text
+            // disp32 = target − RIP, RIP = end of the LEA = slot + 4.
+            let disp = target_off as i64 - (slot as i64 + 4);
+            if !(i32::MIN as i64..=i32::MAX as i64).contains(&disp) {
+                return Err(AotError::Linker {
+                    status: None,
+                    stderr: format!(
+                        "twig-aot: func_start LEA displacement {disp} for '{}' exceeds 32-bit range",
+                        r.target
+                    ),
+                });
+            }
+            linked[slot..slot + 4].copy_from_slice(&(disp as i32).to_le_bytes());
         }
     }
 
@@ -3153,6 +3347,80 @@ mod tests {
         assert!(
             matches!(&err, Err(AotError::Linker { stderr, .. }) if stderr.contains("reserved")),
             "expected reserved-name error, got {err:?}",
+        );
+    }
+
+    /// PR-x3: `build_gc_init_stackmaps_x86_64` registers exactly the functions with
+    /// records — one `call __gc_register_stackmap` + one `func_start` LEA per such
+    /// function — and embeds their arrays.
+    #[test]
+    fn gc_init_x86_64_registers_functions_with_records() {
+        let maps = vec![
+            FnStackMap { name: "f".into(), len: 64, records: vec![(8, vec![-16]), (20, vec![-16])] },
+            FnStackMap { name: "leaf".into(), len: 8, records: vec![] }, // skipped
+            FnStackMap { name: "g".into(), len: 16, records: vec![(4, vec![])] },
+        ];
+        let (bytes, relocs, faddr) = build_gc_init_stackmaps_x86_64(&maps).expect("codegen");
+        assert_eq!(
+            relocs.iter().filter(|r| r.symbol == GC_REGISTER_STACKMAP).count(),
+            2,
+            "one call per function with records (f, g)",
+        );
+        assert_eq!(faddr.len(), 2, "one func_start LEA per registered function");
+        let targets: Vec<&str> = faddr.iter().map(|r| r.target.as_str()).collect();
+        assert!(targets.contains(&"f") && targets.contains(&"g"));
+        assert!(!targets.contains(&"leaf"));
+        assert_eq!(bytes.last(), None.or(bytes.last())); // no panic on empty edge
+    }
+
+    /// PR-x3 (UAF-critical): after linking a module whose `main` calls a helper, the
+    /// `func_start` `LEA rdi, [rip+disp32]` in `__gc_init_stackmaps` decodes to `main`'s
+    /// exact `__text` offset for **any** load base — `LEA` adds its disp to RIP, so the
+    /// base cancels (like the aarch64 `ADR`). Verified without executing, by decoding.
+    #[test]
+    fn x86_64_func_start_lea_resolves_to_target_offset() {
+        let helper = IIRFunction::new(
+            "helper", vec![], "u64",
+            vec![
+                IIRInstr::new("const", Some("h".into()), vec![Operand::Int(7)], "u64"),
+                IIRInstr::new("ret", None, vec![Operand::Var("h".into())], "u64"),
+            ],
+        );
+        let main = IIRFunction::new(
+            "main", vec![], "u64",
+            vec![
+                IIRInstr::new("call", Some("r".into()), vec![Operand::Var("helper".into())], "u64"),
+                IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "u64"),
+            ],
+        );
+        let mut m = IIRModule::new("m", "twig");
+        m.add_or_replace(helper);
+        m.add_or_replace(main);
+        m.entry_point = Some("main".into());
+
+        let (linked, offsets, ..) =
+            compile_module_x86_64_to_text(&m, X86_64Abi::SysV).expect("compiles");
+        let init_off = *offsets.get(GC_INIT_STACKMAPS).expect("init present");
+        let main_off = *offsets.get("main").expect("main present");
+        let init_end = offsets.values().copied().filter(|&o| o > init_off).min().unwrap_or(linked.len());
+
+        // Find the first `lea rdi, [rip+disp32]` = 48 8D 3D <disp32> in the init — the
+        // func_start of the first registered function (`main`).
+        let mut found = None;
+        let mut i = init_off;
+        while i + 7 <= init_end {
+            if linked[i] == 0x48 && linked[i + 1] == 0x8D && linked[i + 2] == 0x3D {
+                let disp = i32::from_le_bytes(linked[i + 3..i + 7].try_into().unwrap());
+                // resolved = RIP + disp; RIP = end of the 7-byte LEA = i + 7.
+                found = Some((i + 7) as i64 + disp as i64);
+                break;
+            }
+            i += 1;
+        }
+        assert_eq!(
+            found,
+            Some(main_off as i64),
+            "func_start LEA must resolve to main's __text offset {main_off}",
         );
     }
 

--- a/code/packages/rust/twig-aot/tests/linux_x86_64_smoke.rs
+++ b/code/packages/rust/twig-aot/tests/linux_x86_64_smoke.rs
@@ -255,3 +255,97 @@ fn elf_object_has_correct_machine_field() {
     let e_machine = u16::from_le_bytes([obj[18], obj[19]]);
     assert_eq!(e_machine, 62);
 }
+
+// ── AOT00-T1 x86_64 PR-x3: precise-roots registration, end to end ──────────
+//
+// These run on the native x86-64 `ubuntu-latest` runner — the authoritative
+// validator for the x86-64 GC path (the dev host is aarch64 macOS). They prove the
+// SysV `__gc_init_stackmaps` registration codegen runs correctly and is load-bearing.
+
+/// The start-up registration actually ran in the linked image: a program that returns
+/// `__gc_stackmap_count()` exits > 0.
+#[test]
+fn gc_stackmap_registration_ran_on_linux() {
+    use interpreter_ir::function::IIRFunction;
+    use interpreter_ir::instr::{IIRInstr, Operand};
+    use interpreter_ir::module::IIRModule;
+
+    let main = IIRFunction::new(
+        "main", vec![], "i64",
+        vec![
+            IIRInstr::new(
+                "call_builtin",
+                Some("c".into()),
+                vec![Operand::Var("gc_stackmap_count".into())],
+                "i64",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("c".into())], "i64"),
+        ],
+    );
+    let mut m = IIRModule::new("gc_count", "twig");
+    m.add_or_replace(main);
+    m.entry_point = Some("main".into());
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let exe = dir.path().join("gc_count");
+    twig_aot::compile_module_to_linux_executable(&m, &exe).expect("count compiles+links");
+    let code = Command::new(&exe).output().expect("count runs").status.code().unwrap();
+    assert!(code > 0, "registration must have run at start-up (count={code})");
+}
+
+/// The GC-stress `live_bytes` differential on x86-64: a 64-byte allocation whose address
+/// lives only in an `i64` (non-reference) slot is reclaimed by a precise collect but
+/// pinned by a conservative one. Precise → `live_bytes == 0`, conservative → `== 64`.
+/// This is the headline proof that precise roots are load-bearing on native x86-64.
+#[test]
+fn gc_stress_live_bytes_differential_on_linux() {
+    use interpreter_ir::function::IIRFunction;
+    use interpreter_ir::instr::{IIRInstr, Operand};
+    use interpreter_ir::module::IIRModule;
+
+    fn build(collect: &str, collect_returns: bool) -> IIRModule {
+        let mut body = vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(64)], "i64"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("a".into()),
+                vec![Operand::Var("gc_alloc".into()), Operand::Var("n".into())],
+                "i64",
+            ),
+        ];
+        body.push(if collect_returns {
+            IIRInstr::new("call_builtin", Some("f".into()), vec![Operand::Var(collect.into())], "i64")
+        } else {
+            IIRInstr::new("call_builtin", None, vec![Operand::Var(collect.into())], "void")
+        });
+        body.push(IIRInstr::new(
+            "call_builtin",
+            Some("lb".into()),
+            vec![Operand::Var("gc_live_bytes".into())],
+            "i64",
+        ));
+        body.push(IIRInstr::new("ret", None, vec![Operand::Var("lb".into())], "i64"));
+        let mut m = IIRModule::new("gc_stress", "twig");
+        m.add_or_replace(IIRFunction::new("main", vec![], "i64", body));
+        m.entry_point = Some("main".into());
+        m
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let run = |tag: &str, collect: &str, ret: bool| -> i32 {
+        let exe = dir.path().join(tag);
+        twig_aot::compile_module_to_linux_executable(&build(collect, ret), &exe)
+            .unwrap_or_else(|e| panic!("{tag} compiles+links: {e}"));
+        Command::new(&exe).output().unwrap_or_else(|e| panic!("{tag} runs: {e}"))
+            .status.code().unwrap_or_else(|| panic!("{tag} exited by signal"))
+    };
+
+    let conservative = run("gc_stress_cons", "gc_collect", false);
+    let precise = run("gc_stress_prec", "gc_collect_precise", true);
+    assert_eq!(conservative, 64, "conservative retains the 64-byte look-alike-pinned object");
+    assert_eq!(
+        precise, 0,
+        "precise reclaims the object reachable only via a non-reference i64 slot \
+         (conservative kept {conservative})",
+    );
+}

--- a/code/packages/rust/x86_64-backend/CHANGELOG.md
+++ b/code/packages/rust/x86_64-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — `x86_64-backend`
 
+## 0.31.0 - 2026-07-23 — V1_BUILTINS: GC collection + observability (AOT00-T1 x86_64 PR-x3)
+
+Four `call_builtin` entries the native GC-stress differential drives (→ `__twig_gc_*`
+aliases in gc-core-capi), mirroring the aarch64 backend: `gc_collect` (forced
+conservative full collect, void), `gc_collect_precise` (precise-roots frame walk,
+returns freed count), `gc_live_bytes` (live payload bytes), `gc_stackmap_count`
+(registered-function count). No new lowering — the generic `call_builtin` marshaller
+emits the `CALL`.
+
 ## 0.30.0 - 2026-07-22 — GC precise-roots stack-map emission (AOT00-T1)
 
 `compile_function_with_globals_and_stackmap` — the x86-64 analogue of the aarch64

--- a/code/packages/rust/x86_64-backend/Cargo.toml
+++ b/code/packages/rust/x86_64-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86_64-backend"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 description = "x86-64 (AMD64) backend for jit-core / aot-core — lowers CIR to native machine code via x86_64-encoder, with both System V (Linux) and Microsoft x64 (Windows) ABIs."
 

--- a/code/packages/rust/x86_64-backend/src/lib.rs
+++ b/code/packages/rust/x86_64-backend/src/lib.rs
@@ -396,6 +396,15 @@ const V1_BUILTINS: &[BuiltinSig] = &[
     // TWIG-GC (native-aot-substrate PR-1) — GC-managed allocation and safepoint.
     BuiltinSig { name: "gc_alloc",     n_args: 1, returns: true  },
     BuiltinSig { name: "gc_safepoint", n_args: 0, returns: false },
+    // AOT00-T1 increment C / x86_64 PR-x3 — GC collection + observability entry points
+    // a native program uses to drive and measure a collection (→ `__twig_gc_*` aliases
+    // in gc-core-capi). `gc_collect` = forced conservative full collect; `gc_collect_precise`
+    // = precise-roots stack walk (returns objects freed); `gc_live_bytes` = live payload
+    // bytes; `gc_stackmap_count` = registered-function count. Mirrors the aarch64 backend.
+    BuiltinSig { name: "gc_collect",         n_args: 0, returns: false },
+    BuiltinSig { name: "gc_collect_precise", n_args: 0, returns: true  },
+    BuiltinSig { name: "gc_live_bytes",      n_args: 0, returns: true  },
+    BuiltinSig { name: "gc_stackmap_count",  n_args: 0, returns: true  },
 ];
 
 fn lookup_builtin(name: &str) -> Option<BuiltinSig> {


### PR DESCRIPTION
## What

Fills the x86-64 `__gc_init_stackmaps` (a no-op placeholder since PR-x2) with **real** `__gc_register_stackmap` calls on **System V (Linux)**, so `__gc_collect_precise` can resolve an x86-64 return address to its exact GC roots — the x86-64 counterpart of the merged aarch64 precise-roots registration.

## How

`compile_module_x86_64_to_text`'s pass 1 switches to `compile_function_with_globals_and_stackmap`; the new `build_gc_init_stackmaps_x86_64` marshals the eight-arg C ABI per function:

```
lea rdi,[rip+F]   ; mov rsi,<len> ; mov rdx,<records>
lea rcx,[rip+F.pc]; xor r8,r8     ; xor r9,r9
lea rax,[rip+F.slots|0]; push rax  ; arg8 slots_flat
lea rax,[rip+F.counts]; push rax   ; arg7 slot_counts
call __gc_register_stackmap ; add rsp,16
```

Mirrors the reviewed aarch64 design:
- **func_start** via `LEA rdi,[rip+disp32]`, patched in a new **pass-2b** from link offsets. Base-independent (RIP cancels the load base) → no relocation, the x86-64 analogue of the aarch64 base-independent ADR. Uses x86_64-encoder 0.7.0 `lea_rip_placeholder`.
- the three arrays live in a **data pool after the final `ret`**, addressed by `lea_rip_label` (RIP-relative, resolved at `finish()`); the registry copies the slots.
- **register the wrapper too** (empty ref-slot map) — the increment-C precision fix, so the precise walk never conservatively re-scans the user entry's frame.
- `rsp` stays 16-aligned at each call (2 argument pushes = 16 bytes).

**Windows/MsX64 keeps the no-op init** (its precise walk is a follow-up: 4-stack-arg + shadow-space marshalling needs an `[rsp+disp]` store the encoder lacks, and the differential is Linux-only) → Windows degrades to a **safe conservative** collection.

Adds x86_64-backend 0.31.0 GC builtins (`gc_collect` / `gc_collect_precise` / `gc_live_bytes` / `gc_stackmap_count`).

## Validation

- 57 lib tests incl. `x86_64_func_start_lea_resolves_to_target_offset` (decodes the patched LEA, confirms base-independence) + a structural registration test. clippy clean.
- Adversarial `/security-review`: **no exploitable defect** — byte-verified port of the reviewed aarch64 reference (SysV arg mapping, 16-byte alignment, func_start, data pool, wrapper reg, reloc pass-through all sound).
- **The end-to-end differential runs on the native x86-64 `ubuntu-latest` CI runner** (`linux_x86_64_smoke`): `gc_stackmap_registration_ran_on_linux` (count > 0) and `gc_stress_live_bytes_differential_on_linux` (precise reclaims the i64 look-alike → 0 live bytes, conservative pins it → 64). The dev host is aarch64 macOS, so CI is the authoritative validator of this blind codegen.

Needs x86_64-encoder 0.7.0 (merged). twig-aot 0.42.0 → 0.43.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)