### PR TITLE
feat(adj-facts-stdlib): mass-conversions — NIST SP 811 B.9 unit→kilogram factors (RS-5 table)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -164,6 +164,48 @@ fn shipped_length_conversions_table_resolves_with_locator() {
 }
 
 // ---------------------------------------------------------------------------
+// (b2) Shipped table — reference/mass-conversions.adj resolves via import, and a
+//      unit absent from the table abstains (never a fabricated factor).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_mass_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_mass");
+    let src = stdlib().join("reference/mass-conversions.adj");
+    std::fs::copy(&src, dir.join("mass-conversions.adj"))
+        .expect("copy shipped mass-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"mass-conversions.adj\"\n\
+         ? mass_to_kilograms(pound, $Kg)\n\
+         ? mass_to_kilograms(short_ton, $Kg)\n\
+         ? mass_to_kilograms(stone, $Kg)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 factors resolve, character-for-character from the table.
+    assert!(
+        out.contains("\"Kg\":\"0.4535924\""),
+        "shipped pound factor: {out}"
+    );
+    assert!(
+        out.contains("\"Kg\":\"907.1847\""),
+        "shipped short-ton factor: {out}"
+    );
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `stone` is not a row — the engine abstains rather than inventing a factor.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "an absent unit abstains, never a fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/mass-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/mass-conversions.adj
@@ -1,0 +1,58 @@
+% ============================================================================
+% mass-conversions — customary mass-unit → kilogram factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of `length-conversions.adj`: a native tabular relation
+% ingested VERBATIM from a published NIST conversion table. Each row states the
+% factor converting one customary mass unit to kilograms:
+%
+%     ? mass_to_kilograms(pound, $Kg)        % 0.4535924
+%     ? mass_to_kilograms(short_ton, $Kg)    % 907.1847
+%
+% Why a `table` and not six hand-written `relate` clauses: this is exactly the
+% shape reference data comes in — a published table, not prose. The citable
+% artifact IS the NIST conversion-factors table at the `locator` below; every
+% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors
+% for units listed alphabetically"), and the whole table is defended by one
+% provenance envelope rather than repeating `source`/`locator`/`trust` on every
+% row. Each `row` lowers to a ground relation `mass_to_kilograms(unit, kg)`, so
+% the exact lookup above is the ordinary SLD binding query — the engine returns
+% the factor WITH this table's citation as its proof, on the CPU, with zero model
+% calls. A looked-up factor is a number, so it can feed a `let`/`formula`
+% downstream (e.g. multiply a weight by it) through the existing slot path.
+%
+% HONESTY NOTE (distinct from length-conversions, which quotes EXACT defined
+% factors): the values below are NIST SP 811's published conversion factors,
+% rounded to SEVEN significant figures, transcribed character-for-character from
+% the SP 811 B.9 table:
+%
+%     pound (avoirdupois)          4.535 924 E-01  →  0.4535924
+%     ounce (avoirdupois)          2.834 952 E-02  →  0.02834952
+%     ton, short (2000 lb)         9.071 847 E+02  →  907.1847
+%     grain                        6.479 891 E-05  →  0.00006479891
+%     slug                         1.459 390 E+01  →  14.5939
+%     pound (troy or apothecary)   3.732 417 E-01  →  0.3732417
+%
+% These are the table's printed 7-figure factors, NOT the underlying exact
+% definitions (the avoirdupois pound is defined as exactly 0.453 592 37 kg by the
+% 1959 international agreement; SP 811 rounds it to 0.4535924). The only claim this
+% table makes is "these are the factors NIST SP 811 B.9 prints" — which is exactly
+% what a byte-check against the cited table verifies. `trust authoritative` — a
+% primary, re-fetchable standards reference. (See ADJ-TABLES.md; and
+% feedback_nothing_human_authored — nothing here is asserted "from memory": every
+% factor is a verbatim cell of the cited table.)
+% ============================================================================
+
+table mass_to_kilograms {
+    columns unit, kilograms
+
+    row (pound, 0.4535924)
+    row (ounce, 0.02834952)
+    row (short_ton, 907.1847)
+    row (grain, 0.00006479891)
+    row (slug, 14.5939)
+    row (troy_pound, 0.3732417)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/mass-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/mass-conversions.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% mass-conversions.query.adj — a worked lookup over the mass-conversions table.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a "how many
+% kilograms in a pound?" question: it states no conversion fact — it only
+% `import`s the grounded table and asks binding queries. The native adj-lang
+% engine resolves each `?` against the table's rows (lowered to
+% `mass_to_kilograms` relations) and returns the binding + the table's
+% source/locator/trust. A unit not in the table abstains honestly — the engine
+% never invents a factor.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli mass-conversions.query.adj
+% ============================================================================
+
+import "mass-conversions.adj"
+
+? mass_to_kilograms(pound, $Kg)        % expect 0.4535924
+? mass_to_kilograms(short_ton, $Kg)    % expect 907.1847
+? mass_to_kilograms(grain, $Kg)        % expect 0.00006479891
+? mass_to_kilograms(stone, $Kg)        % expect abstain — not in the table


### PR DESCRIPTION
## A grounded NIST mass-conversion `table` — Facts front

A sibling of the shipped [`length-conversions.adj`](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/data/adj-formula-stdlib/reference/length-conversions.adj) (RS-5b, #8206), reusing the existing `table` construct — **no engine or grammar change**. It ingests six customary mass-unit → kilogram factors **verbatim** from a published NIST table, so a "how many kilograms in a pound?" lookup answers on the CPU, with the table's citation as its proof and **zero model calls**:

```
? mass_to_kilograms(pound, $Kg)      % 0.4535924
? mass_to_kilograms(short_ton, $Kg)  % 907.1847
```

### Grounding (fetched, not from memory)
Every factor is a **cell** of NIST Special Publication 811, Appendix B.9 ("Factors for units listed alphabetically"), transcribed character-for-character:

| unit | SP 811 B.9 cell | table value |
|------|-----------------|-------------|
| pound (avoirdupois) | `4.535 924 E-01` | 0.4535924 |
| ounce (avoirdupois) | `2.834 952 E-02` | 0.02834952 |
| ton, short (2000 lb) | `9.071 847 E+02` | 907.1847 |
| grain | `6.479 891 E-05` | 0.00006479891 |
| slug | `1.459 390 E+01` | 14.5939 |
| pound (troy/apothecary) | `3.732 417 E-01` | 0.3732417 |

The header is **explicit** that these are NIST's published *seven-significant-figure* factors, **not** the underlying exact definitions (the avoirdupois pound is defined as exactly `0.453 592 37` kg; SP 811 rounds it to `0.4535924`). The only claim the table makes is "these are the factors SP 811 B.9 prints" — exactly what a byte-check against the cited table verifies. `trust authoritative`; nothing asserted from memory ([[feedback_nothing_human_authored]]).

### What lands
- `reference/mass-conversions.adj` — the grounded table (+ a worked `.query.adj`).
- An e2e test in `rs5_table_e2e.rs` driving the **shipped** table through the built CLI: the pound and short-ton factors resolve character-for-character with the SP 811 B.9 locator riding on the answer, and a unit absent from the table (`stone`) **abstains** rather than inventing a factor.

### Verification
- All 7 `rs5_table_e2e` tests green (`cargo test -p adj-lang-cli --test rs5_table_e2e`). Data + test only — no library/executable code changed.
- `/security-review` **PASSED** (no injection / path-traversal / unsafe-temp; test mirrors existing safe conventions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)