### PR TITLE
feat(semantic-ir-to-c): floats — FloatLit on the v0 SIR_FLOAT tag (SIR16)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## 0.8.0 — floats (SIR16)
+
+Accepts `Feature::Floats`. Unlike the sequences and maps batches, this needed
+**no new runtime**: `SirValue` has carried a `SIR_FLOAT` tag since v0, and the
+runtime already handled floats throughout — `_sir_float` constructor,
+`_sir_is_num`/`_sir_as_num`, int→float promotion in `_sir_plus_v`/`_sir_minus_v`/
+`_sir_times_v`, an IEEE float path in `_sir_divide_v`, and `_sir_fmt_float`. The
+one missing piece was the emitter: a `FloatLit` had no arm and hit
+`unreachable!`. `Feature::Floats` gates ONLY `FloatLit`, so this batch is a
+single emit arm plus accepting the feature — the emitter stays total.
+
+- `Expr::FloatLit` → `_sir_float(<literal>)` via a new `emit_float_literal`:
+  - a **finite** value is spelled with Rust's `{:?}` (Debug) form, whose
+    shortest round-tripping text always carries a decimal point or exponent
+    (`7.0`, `-0.0`, `1e300`) — a valid C `double` literal that `strtod` parses
+    back to the identical bit pattern;
+  - a **non-finite** value (which a literal can only carry when hand-built —
+    normal arithmetic produces `inf`/`nan` at runtime) uses the C99 `<math.h>`
+    macros `INFINITY` / `-INFINITY` / `NAN`, mirroring the Ruby backend's
+    `Float::INFINITY` / `Float::NAN`. A single `#include <math.h>` is added to
+    the emitted preamble for these (standard, available on every C99 compiler
+    including MSVC).
+
+Float arithmetic reuses the existing `+`/`-`/`*`/`/` variadic helpers: an
+integral result of a float operation stays a Float (`1.5 + 2.5 == 4.0`, not
+`4`), and the division frontier is preserved — a Float operand promotes to true
+division (`7.0 / 2 == 3.5`) while two Integers floor (`7 / 2 == 3`); Float
+division by zero yields IEEE `Infinity`/`NaN` (no trap — that is Integer-only).
+`_sir_fmt_float` renders integral floats with a trailing `.0`, `-0.0` with its
+sign, and non-finite values as `Infinity`/`-Infinity`/`NaN`.
+
+This closes the Floats parity arc: with the Ruby backend's floats (0.6.0),
+`Feature::Floats` is now accepted on all six backends. Verified with hand-built
+modules (the frontend masks `FloatLit`) compiled and run through a real `cc`:
+literal display incl. `-0.0`, native arithmetic staying Float, the division
+frontier, non-finite results AND non-finite literals, and value-based equality
+(`7.0 == 7`). Bumps semantic-ir-to-c 0.7.0 → 0.8.0.
+
 ## 0.7.0 — maps (SIR16)
 
 Accepts `Feature::Maps`. `SirValue` gains a `SIR_MAP` tag — a heap-boxed,

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -85,7 +85,10 @@ SIR16 control flow and mutation (`Loops` — `While`, `ForRange`, `ForEach`; and
 `SeqLit`/`SeqIndex`/`SeqLen`/`SeqSet` and structural equality; and SIR16 `Maps`
 — a `SIR_MAP` heap assoc-array with `MapLit`/`MapGet`/`MapSet`, structural
 composite keys, positional structural equality, and `{k: v}` display (matching
-the Go/Rust backends).
+the Go/Rust backends); and SIR16 `Floats` — a `SIR_FLOAT` `FloatLit` (`7.0`
+stays a Float, not the Integer `7`; `Infinity`/`NaN` via `<math.h>`), with
+native float arithmetic, the division frontier (Float promotes, two Integers
+floor), and IEEE non-finite results.
 
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
 `Intrinsics`, `NDArrays`, `ShortCircuit`, exceptions/OOP, and every

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -46,7 +46,11 @@ pub fn emit_module(m: &Module) -> String {
     out.push_str("#include <stdlib.h>\n");
     out.push_str("#include <string.h>\n");
     out.push_str("#include <stdarg.h>\n");
-    out.push_str("#include <stdint.h>\n\n");
+    out.push_str("#include <stdint.h>\n");
+    // `<math.h>` supplies the C99 `INFINITY` / `NAN` macros used to spell a
+    // non-finite `FloatLit` (a finite literal needs no macro). Standard and
+    // available on every C99 compiler including MSVC.
+    out.push_str("#include <math.h>\n\n");
 
     // The runtime, with the display-convention placeholder resolved to a
     // boolean-selected LITERAL (never source text — see the security note in
@@ -746,6 +750,7 @@ fn push_joined(out: &mut String, names: &[String]) {
 fn is_simple(e: &Expr) -> bool {
     match e {
         Expr::IntLit { .. }
+        | Expr::FloatLit { .. }
         | Expr::BoolLit { .. }
         | Expr::NilLit { .. }
         | Expr::SymLit { .. }
@@ -789,6 +794,7 @@ fn is_simple(e: &Expr) -> bool {
 fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
     match e {
         Expr::IntLit { value, .. } => emit_int_literal(out, *value),
+        Expr::FloatLit { value, .. } => emit_float_literal(out, *value),
         Expr::BoolLit { value, .. } => {
             let _ = write!(out, "_sir_bool({})", if *value { 1 } else { 0 });
         }
@@ -1151,6 +1157,35 @@ fn emit_int_literal(out: &mut String, value: i64) {
         out.push_str("_sir_int((-9223372036854775807LL - 1))");
     } else {
         let _ = write!(out, "_sir_int({value}LL)");
+    }
+}
+
+/// Render a `FloatLit` as a `_sir_float(<C double>)` constructor call.
+///
+/// - **Non-finite** values have no C floating literal (a program cannot write
+///   `inf` / `nan` as tokens), so they use the C99 `<math.h>` macros
+///   `INFINITY` / `NAN` (mirroring the Ruby backend's `Float::INFINITY` /
+///   `Float::NAN`). These arise only from a hand-built module — normal float
+///   arithmetic produces them at runtime, where `_sir_divide_v` already yields
+///   IEEE `inf`/`nan` without any literal.
+/// - **Finite** values use Rust's `{:?}` (Debug) form, whose shortest
+///   round-tripping spelling always carries a decimal point or exponent
+///   (`7.0`, `-0.0`, `1e300`) — each a valid C `double` literal that `strtod`
+///   parses back to the identical bit pattern. (A plain `{}` would drop the
+///   point on an integral value, but C would still read `7` as a `double` in
+///   this context; `{:?}` is used for parity with the value model and to keep
+///   the emitted text unambiguously floating-point.)
+fn emit_float_literal(out: &mut String, value: f64) {
+    if value.is_nan() {
+        out.push_str("_sir_float(NAN)");
+    } else if value.is_infinite() {
+        out.push_str(if value > 0.0 {
+            "_sir_float(INFINITY)"
+        } else {
+            "_sir_float(-INFINITY)"
+        });
+    } else {
+        let _ = write!(out, "_sir_float({value:?})");
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-c/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/lib.rs
@@ -66,6 +66,16 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     Feature::SizedIntegers,
     Feature::Unsigned,
     Feature::WrappingArithmetic,
+    // ── SIR16 floats ─────────────────────────────────────────────────
+    // `SirValue` has carried a `SIR_FLOAT` tag since v0 (`_sir_float`, the
+    // arithmetic helpers' int→float promotion, `_sir_divide_v`'s IEEE float
+    // path, `_sir_fmt_float`), so this batch is purely an EMITTER addition:
+    // `Expr::FloatLit` → `_sir_float(<literal>)` (via `emit_float_literal`,
+    // which spells a finite value as a C `double` literal and a non-finite one
+    // with the `<math.h>` `INFINITY`/`NAN` macros). `Floats` gates ONLY
+    // `FloatLit`; float `+`/`-`/`*`/`/` reuse the existing variadic helpers, so
+    // accepting the feature plus the one emit arm keeps the emitter total.
+    Feature::Floats,
     // ── SIR16 control flow / mutation ────────────────────────────────
     // `Stmt::While` renders as a portable `for (;;) { … if (!truthy) break; }`
     // (the condition is re-evaluated each iteration, so it may be compound);

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_floats.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_floats.rs
@@ -1,0 +1,215 @@
+//! Execution proof for SIR16 floats on the C backend — hand-build modules
+//! (producer-agnostic), emit C, compile with a real gcc/clang-style compiler,
+//! run, assert stdout. Skips gracefully when no `cc` is present.
+//!
+//! `Feature::Floats` gates ONLY `Expr::FloatLit`. The `SIR_FLOAT` tag and its
+//! runtime (constructor, arithmetic int→float promotion, IEEE division,
+//! `_sir_fmt_float`) have existed since v0, so this batch is purely the emitter
+//! arm — but the tests still exercise the whole float path end-to-end through a
+//! real `cc`: literal display (integral floats keep `.0`), native arithmetic,
+//! the division frontier (Float promotes, two Integers floor), non-finite
+//! results and non-finite LITERALS (the `<math.h>` `INFINITY`/`NAN` macros).
+//! Hand-built to bypass the frontend, which masks `FloatLit`.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span, Stmt,
+    CURRENT_SIR_VERSION,
+};
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    for cand in ["cc", "clang", "gcc"] {
+        if Command::new(cand)
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+        {
+            return Some(cand.to_string());
+        }
+    }
+    None
+}
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn run(module: &Module) -> Option<String> {
+    let cc = find_cc()?;
+    let artifact = semantic_ir_to_c::compile(module).expect("C backend compile (no panic)");
+    let dir = std::env::temp_dir();
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let stem = format!("sirc_flt_{}_{}", std::process::id(), n);
+    let cpath: PathBuf = dir.join(format!("{stem}.c"));
+    let exe: PathBuf = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::File::create(&cpath)
+        .and_then(|mut f| f.write_all(artifact.source.as_bytes()))
+        .expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-Werror=unused-variable", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        artifact.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "run failed (exit {:?})", r.status.code());
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+fn s() -> Span {
+    Span::synthetic()
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn flit(value: f64) -> Expr {
+    Expr::FloatLit { value, span: s() }
+}
+fn bc(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+fn bin(name: &str, a: Expr, b: Expr) -> Expr {
+    bc(name, vec![a, b])
+}
+fn puts(arg: Expr) -> Stmt {
+    Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: s() }
+}
+/// A `main` module declaring only `Floats` (arithmetic / `puts` are builtins,
+/// gated by the builtin allowlist rather than by a feature).
+fn float_module(stmts: Vec<Stmt>) -> Module {
+    Module {
+        name: "fltprog".into(),
+        manifest: FeatureManifest::from_features(&[Feature::Floats]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+#[test]
+fn float_literal_emits_a_float_constructor() {
+    // Emit-shape: an integral `FloatLit` must build a `_sir_float(7.0)` — a
+    // `double` literal with a point, never the Integer path `_sir_int(7LL)`.
+    let src = semantic_ir_to_c::compile(&float_module(vec![puts(flit(7.0))]))
+        .expect("compile")
+        .source;
+    assert!(
+        src.contains("_sir_float(7.0)"),
+        "integral FloatLit builds a double constructor:\n{src}"
+    );
+    // The `<math.h>` include is present for the non-finite macros.
+    assert!(src.contains("#include <math.h>"), "math.h is included:\n{src}");
+}
+
+#[test]
+fn non_finite_literal_emits_the_math_macros() {
+    // A non-finite `FloatLit` has no C floating token — it uses `INFINITY`/`NAN`.
+    let src = semantic_ir_to_c::compile(&float_module(vec![
+        puts(flit(f64::INFINITY)),
+        puts(flit(f64::NEG_INFINITY)),
+        puts(flit(f64::NAN)),
+    ]))
+    .expect("compile")
+    .source;
+    assert!(src.contains("_sir_float(INFINITY)"), "positive infinity:\n{src}");
+    assert!(src.contains("_sir_float(-INFINITY)"), "negative infinity:\n{src}");
+    assert!(src.contains("_sir_float(NAN)"), "NaN:\n{src}");
+}
+
+#[test]
+fn float_literal_displays_with_a_trailing_point() {
+    // `puts 7.0` → `7.0` (integral float keeps its `.0`), `3.25` → `3.25`,
+    // `-0.0` → `-0.0` (the sign of zero survives), all via `_sir_fmt_float`.
+    match run(&float_module(vec![puts(flit(7.0)), puts(flit(3.25)), puts(flit(-0.0))])) {
+        Some(out) => assert_eq!(out, "7.0\n3.25\n-0.0\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn float_arithmetic_promotes_and_stays_float() {
+    // `+`/`-`/`*` on floats stay Float even when the result is integral (`4.0`,
+    // not `4`) — the runtime's int→float promotion, matching every backend.
+    match run(&float_module(vec![
+        puts(bin("+", flit(1.5), flit(2.5))), // 4.0
+        puts(bin("*", flit(2.0), flit(3.0))), // 6.0
+        puts(bin("-", flit(7.0), flit(0.5))), // 6.5
+    ])) {
+        Some(out) => assert_eq!(out, "4.0\n6.0\n6.5\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn float_and_integer_division_follow_the_frontier() {
+    // A Float operand promotes to true division (`7.0 / 2 == 3.5`); two Integers
+    // floor (`7 / 2 == 3`). A regression guard that adding floats did not
+    // disturb the integer division frontier.
+    match run(&float_module(vec![
+        puts(bin("/", flit(7.0), ilit(2))),   // 3.5
+        puts(bin("/", flit(6.0), flit(2.0))), // 3.0
+        puts(bin("/", ilit(7), ilit(2))),     // 3 (Integer floor)
+    ])) {
+        Some(out) => assert_eq!(out, "3.5\n3.0\n3\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn non_finite_arithmetic_and_literals_display_named() {
+    // Float division by zero yields IEEE `Infinity`/`-Infinity` (NOT a trap —
+    // that is Integer-only), `0.0/0.0` is `NaN`, and a non-finite LITERAL
+    // round-trips through the `INFINITY`/`NAN` macros — all rendered by
+    // `_sir_fmt_float`.
+    match run(&float_module(vec![
+        puts(bin("/", flit(1.0), flit(0.0))),  // Infinity
+        puts(bin("/", flit(-1.0), flit(0.0))), // -Infinity
+        puts(bin("/", flit(0.0), flit(0.0))),  // NaN
+        puts(flit(f64::INFINITY)),             // Infinity (literal)
+        puts(flit(f64::NAN)),                  // NaN (literal)
+    ])) {
+        Some(out) => assert_eq!(out, "Infinity\n-Infinity\nNaN\nInfinity\nNaN\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn float_equality_is_value_based() {
+    // `7.0 == 7.0` is true; a Float equals a numerically-equal Integer
+    // (`7.0 == 7`, both numeric); `7.0 == 7.5` is false. Displayed in the
+    // default (Lisp) convention as `#t`/`#f`.
+    match run(&float_module(vec![
+        puts(bin("=", flit(7.0), flit(7.0))), // #t
+        puts(bin("=", flit(7.0), ilit(7))),   // #t (numeric cross-type)
+        puts(bin("=", flit(7.0), flit(7.5))), // #f
+    ])) {
+        Some(out) => assert_eq!(out, "#t\n#t\n#f\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}

--- a/code/specs/SIR24-semantic-ir-to-c.md
+++ b/code/specs/SIR24-semantic-ir-to-c.md
@@ -77,12 +77,14 @@ then (4) `emit::emit_module`.
 **Landed since v0** (`ACCEPTED_FEATURES` grows one version-bumped batch at a
 time — see the roadmap): the SIR26 integer conversions (`Conversions`,
 `SizedIntegers`, `Unsigned`, `WrappingArithmetic`); and the SIR16 batches
-`Loops` + `MutableBindings` (0.3.0–0.5.0), `Sequences` (0.6.0), and `Maps`
-(0.7.0 — the `SIR_MAP` assoc-array with `MapLit`/`MapGet`/`MapSet`).
+`Loops` + `MutableBindings` (0.3.0–0.5.0), `Sequences` (0.6.0), `Maps`
+(0.7.0 — the `SIR_MAP` assoc-array with `MapLit`/`MapGet`/`MapSet`), and
+`Floats` (0.8.0 — `FloatLit` on the v0 `SIR_FLOAT` tag; emitter-only, the
+runtime already carried the float path).
 
 **Still rejects** (clean, source-positioned `UnsupportedFeature`):
 `TailCalls` (C does not guarantee TCO), `Intrinsics` (empty whitelist), and
-every not-yet-landed feature (`Floats`, `ShortCircuit`, `NDArrays`,
+every not-yet-landed feature (`ShortCircuit`, `NDArrays`,
 `Exceptions`, `Classes`, … — see the roadmap).  `Bignum` stays
 rejected until a bignum runtime ships, so a module that *needs* arbitrary
 precision is refused rather than silently truncated.


### PR DESCRIPTION
## What

Adds SIR16 **floats** to the C backend (`semantic-ir-to-c` 0.7.0 → 0.8.0) — the **last** of the Floats parity arc. With the Ruby backend's floats (#8834), `Feature::Floats` is now accepted on **all six** backends.

Unlike sequences/maps, this needs **no new runtime**: `SirValue` has carried a `SIR_FLOAT` tag since v0, and the runtime already handled floats throughout — `_sir_float`, `_sir_is_num`/`_sir_as_num`, int→float promotion in the `+`/`-`/`*` variadic helpers, an IEEE float path in `_sir_divide_v`, and `_sir_fmt_float`. The only gap was the emitter: a `FloatLit` had no arm and hit `unreachable!`. `Feature::Floats` gates *only* `FloatLit`, so this is a single emit arm + accepting the feature — the emitter stays total.

## The emit arm

`Expr::FloatLit` → `_sir_float(<literal>)` via a new `emit_float_literal`:

- a **finite** value is spelled with Rust's `{:?}` (Debug), whose shortest round-tripping text always carries a decimal point or exponent (`7.0`, `-0.0`, `1e300`) — a valid C `double` literal that `strtod` parses back to the identical bit pattern;
- a **non-finite** value (reachable only from a hand-built module — arithmetic produces `inf`/`nan` at runtime) uses the C99 `<math.h>` macros `INFINITY` / `-INFINITY` / `NAN`, mirroring the Ruby backend's `Float::INFINITY` / `Float::NAN`. One `#include <math.h>` is added to the emitted preamble (standard, portable incl. MSVC).

## Semantics (all pre-existing runtime, now reachable)

- Integral result of a float op stays a Float: `1.5 + 2.5 == 4.0` (not `4`).
- Division frontier preserved: a Float operand promotes to true division (`7.0 / 2 == 3.5`) while two Integers floor (`7 / 2 == 3`).
- Float division by zero → IEEE `Infinity`/`NaN` (no trap — that is Integer-only).
- `_sir_fmt_float` renders integral floats with `.0`, `-0.0` with its sign, non-finite as `Infinity`/`-Infinity`/`NaN`.

## Verification

- `cargo test -p semantic-ir-to-c` — **40 tests green** (7 new), hand-built modules (the frontend masks `FloatLit`) compiled and run through a real `cc`: literal display incl. `-0.0`, native arithmetic staying Float, the division frontier, non-finite results **and** non-finite literals, value-based equality (`7.0 == 7`).
- `cargo clippy -p semantic-ir-to-c --all-targets` clean.
- Security review passed — a 5M-random-pattern sweep confirmed the `{:?}` float spelling stays in the closed `[0-9.eE+-]` set (no C-source-injection surface), round-trips bit-exact, and compiles clean under `-Wall`.
- SIR24 spec capability section updated (Floats → landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)