### PR TITLE
feat(app): the covered grid (HL03 phase 4, part 1)

### DIFF
--- a/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.9.1 — the covered grid (HL03 phase 4, part 1)
+
+- `src/quiz.ts` — `coveredGrid(covered, lessons, activeCount)` enumerates every
+  (concept × language) cell the learner has studied, each tied to the real
+  lesson that answers it. This is the pool the randomised cumulative quiz will
+  draw from ("what is 5 in Telugu? 12 in Latin?").
+- Built by **reusing the teaching sweep**, not re-deriving the concept→language
+  join: a cell exists exactly where a covered concept's sweep has a stop in an
+  active language — so the review side can only ever ask about a (concept,
+  language) the teaching side actually presents. Deterministic (concepts sorted,
+  then chain order, then chapter/id). Plus `conceptsIn` / `languagesIn` and a
+  stable `cellKey` for the SRS to track state per item.
+- Verified against the real curriculum: COURTESY-THANKS covers all ten chain
+  languages; two covered concepts interleave across both concepts and many
+  languages. Controls bite — mislabelling a cell fails the grounding test, and
+  collapsing the grid to one concept fails the interleave control. Pure, no UI.
+- Next (part 2): the SRS-weighted `pickNext` draw over this grid.
+
 ## 0.9.0 — the session orchestrator: sweep + grounded connections (HL03 phase 3)
 
 - `src/session.ts` — `buildSession(concept, lessons, activeCount)` takes the

--- a/code/programs/typescript/script-writing-visualizer/package.json
+++ b/code/programs/typescript/script-writing-visualizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "script-writing-visualizer",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "description": "Companion study app (HL02): break a non-Latin script apart and learn to write it — and drill the whole written curriculum with a spaced-repetition schedule that remembers you",
   "type": "module",

--- a/code/programs/typescript/script-writing-visualizer/src/quiz.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/quiz.ts
@@ -1,0 +1,83 @@
+// ---------------------------------------------------------------------------
+// quiz.ts — the covered grid, foundation of the randomised cumulative quiz (HL03 phase 4)
+// ---------------------------------------------------------------------------
+//
+// The teaching sweep (sequence.ts) moves the learner FORWARD, one concept across
+// the chain. Review pulls the other way: the primary review in HL03 is a
+// randomised cumulative quiz that draws, unpredictably, from EVERYTHING learned
+// so far — "what is 5 in Telugu? 12 in Latin? 3 in Arabic?" — mixing concepts
+// and languages so retrieval is interleaved, which is what makes it stick.
+//
+// Before anything can be drawn, the pool has to be enumerated: every
+// (concept, language) the learner has actually covered, each tied to the real
+// word that answers it. That pool is the COVERED GRID, and building it is this
+// file's job. The weighted draw over the grid (SRS-biased) is the next layer.
+//
+// The grid is built by REUSING the sweep, not by re-deriving the
+// concept→language join: a cell exists exactly where the teaching sweep for a
+// covered concept has a stop in an active language. So the review can only ever
+// ask about a (concept, language) the teaching side actually presents — the two
+// halves stay consistent by construction.
+//
+// Pure and deterministic: same inputs, same grid, same order.
+// ---------------------------------------------------------------------------
+
+import type { Lesson } from "./lessons";
+import { activeChain, teachingSweep, type ChainLanguage } from "./sequence";
+
+/**
+ * One quizzable item: a concept, the language it is asked in, and the lesson
+ * (the real word — its `headword`/`gloss`) that is the answer. A (concept,
+ * language) with several lessons yields one cell per lesson.
+ */
+export interface GridCell {
+  concept: string;
+  language: ChainLanguage;
+  lesson: Lesson;
+}
+
+/**
+ * Every (concept, language) cell the learner has covered, as a flat list.
+ *
+ * `covered` is the set of concept tags studied so far; `activeCount` is how far
+ * along the chain the learner has reached. For each covered concept we take its
+ * teaching sweep over the active chain prefix and emit one cell per lesson at
+ * each stop. The result is deterministic: concepts in sorted order, then chain
+ * order (from the sweep), then the sweep's own chapter/id lesson order.
+ */
+export function coveredGrid(
+  covered: Iterable<string>,
+  lessons: Lesson[],
+  activeCount: number,
+): GridCell[] {
+  const active = activeChain(activeCount);
+  const concepts = [...new Set(covered)].filter((c) => c !== "").sort();
+
+  const grid: GridCell[] = [];
+  for (const concept of concepts) {
+    for (const stop of teachingSweep(concept, lessons, active)) {
+      for (const lesson of stop.lessons) {
+        grid.push({ concept, language: stop.language, lesson });
+      }
+    }
+  }
+  return grid;
+}
+
+/** The distinct concepts present in a grid. */
+export function conceptsIn(grid: GridCell[]): string[] {
+  return [...new Set(grid.map((c) => c.concept))].sort();
+}
+
+/** The distinct languages present in a grid. */
+export function languagesIn(grid: GridCell[]): ChainLanguage[] {
+  return [...new Set(grid.map((c) => c.language))];
+}
+
+/** A stable key for a cell — used later by the SRS to track state per item. */
+export function cellKey(cell: GridCell): string {
+  // Encoded as JSON of the tuple rather than a delimiter-joined string: the repo
+  // has been bitten by composite keys where a separator inside a field made two
+  // distinct keys collide, and typed spaces here were mangled to NUL bytes.
+  return JSON.stringify([cell.concept, cell.language, cell.lesson.id]);
+}

--- a/code/programs/typescript/script-writing-visualizer/tests/quiz.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/quiz.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import type { Lesson } from "../src/lessons";
+import { loadLessons } from "../src/lessons";
+import { coveredGrid, conceptsIn, languagesIn, cellKey } from "../src/quiz";
+
+function L(language: string, concept: string, id: string, chapter = 1): Lesson {
+  return {
+    id,
+    language,
+    headword: `${language}-${concept}`,
+    gloss: concept,
+    type: "word",
+    chapter,
+    concept,
+    prerequisites: [],
+    reviewsOf: [],
+    roots: [],
+    romanization: "x",
+    script: language,
+    etymologyHook: "",
+  };
+}
+
+describe("coveredGrid", () => {
+  it("emits one cell per lesson at each (covered concept × active language) stop", () => {
+    const lessons = [
+      L("spanish", "GREET", "s1"),
+      L("french", "GREET", "f1"),
+      L("spanish", "NUM5", "s5"),
+      L("german", "GREET", "g1"),
+    ];
+    // covered = {GREET}, active = spanish/latin/french (count 3) → german excluded, NUM5 not covered
+    const grid = coveredGrid(["GREET"], lessons, 3);
+    expect(grid.map((c) => [c.concept, c.language])).toEqual([
+      ["GREET", "spanish"],
+      ["GREET", "french"],
+    ]);
+  });
+
+  it("includes only COVERED concepts and only ACTIVE languages", () => {
+    const lessons = [L("spanish", "A", "a"), L("french", "A", "fa"), L("spanish", "B", "b")];
+    // covered only {A}; active only spanish (count 1)
+    const grid = coveredGrid(["A"], lessons, 1);
+    expect(languagesIn(grid)).toEqual(["spanish"]);
+    expect(conceptsIn(grid)).toEqual(["A"]); // B excluded — not covered
+  });
+
+  it("every cell's lesson genuinely has that concept and language — the grounding rule", () => {
+    const lessons = [L("spanish", "A", "a"), L("hindi", "A", "ha")];
+    const grid = coveredGrid(["A"], lessons, 10);
+    for (const cell of grid) {
+      expect(cell.lesson.concept).toBe(cell.concept); // CONTROL: no cell can mislabel its lesson
+      expect(cell.lesson.language).toBe(cell.language);
+    }
+  });
+
+  it("is deterministic: concepts sorted, then chain order, then lesson order", () => {
+    const lessons = [
+      L("french", "ZED", "fz"),
+      L("spanish", "ALPHA", "sa2", 5),
+      L("spanish", "ALPHA", "sa1", 2),
+      L("spanish", "ZED", "sz"),
+    ];
+    const grid = coveredGrid(["ZED", "ALPHA"], lessons, 10);
+    // ALPHA before ZED (sorted); within ALPHA spanish chapters 2 then 5; ZED spanish then french (chain)
+    expect(grid.map((c) => c.lesson.id)).toEqual(["sa1", "sa2", "sz", "fz"]);
+  });
+
+  it("empty covered set → empty grid", () => {
+    expect(coveredGrid([], [L("spanish", "A", "a")], 10)).toEqual([]);
+  });
+
+  it("cellKey is stable and distinguishes cells", () => {
+    const grid = coveredGrid(["A"], [L("spanish", "A", "a"), L("hindi", "A", "ha")], 10);
+    const keys = grid.map(cellKey);
+    expect(new Set(keys).size).toBe(keys.length); // all distinct
+  });
+});
+
+describe("coveredGrid against the real curriculum", () => {
+  const lessons = loadLessons();
+
+  it("COURTESY-THANKS covered over the full chain spans many languages, one concept", () => {
+    const grid = coveredGrid(["COURTESY-THANKS"], lessons, 10);
+    expect(conceptsIn(grid)).toEqual(["COURTESY-THANKS"]);
+    // COURTESY-THANKS is taught in all ten chain languages.
+    expect(languagesIn(grid).length).toBe(10);
+  });
+
+  it("two covered concepts interleave: the grid spans BOTH concepts and MANY languages", () => {
+    const grid = coveredGrid(["GREETING-HELLO", "COURTESY-THANKS"], lessons, 10);
+    // CONTROL: a broken grid that collapsed to one concept or one language fails here.
+    expect(conceptsIn(grid)).toEqual(["COURTESY-THANKS", "GREETING-HELLO"]);
+    expect(languagesIn(grid).length).toBeGreaterThan(1);
+    // and every cell is really one of the two covered concepts (no leakage)
+    for (const cell of grid) expect(["GREETING-HELLO", "COURTESY-THANKS"]).toContain(cell.concept);
+  });
+
+  it("a shorter active prefix genuinely shrinks the covered languages", () => {
+    const four = coveredGrid(["COURTESY-THANKS"], lessons, 4);
+    const ten = coveredGrid(["COURTESY-THANKS"], lessons, 10);
+    expect(languagesIn(four).length).toBeLessThan(languagesIn(ten).length);
+    expect(languagesIn(four)).toEqual(["spanish", "latin", "french", "german"]);
+  });
+});


### PR DESCRIPTION
First half of HL03 phase 4 (the randomised cumulative quiz — your primary review mechanism). This part builds the **pool**; the SRS-weighted draw over it follows.

## What it adds — `src/quiz.ts`

`coveredGrid(covered, lessons, activeCount)` enumerates every **(concept × language)** cell the learner has studied, each tied to the real lesson that answers it — the pool the quiz draws from (*"what is 5 in Telugu? 12 in Latin?"*). Plus `conceptsIn` / `languagesIn` and a stable `cellKey`.

Built by **reusing the teaching sweep**, not re-deriving the concept→language join: a cell exists exactly where a covered concept's sweep has a stop in an active language — so the review side can only ever ask about a (concept, language) the teaching side actually presents. The two halves stay consistent by construction. Deterministic order (concepts sorted → chain order → chapter/id).

## Grounded + controlled

Verified against the real curriculum: COURTESY-THANKS covers all ten chain languages; two covered concepts interleave across both concepts and many languages. Controls bite (fault-injected): mislabelling a cell fails the grounding test; collapsing the grid to one concept fails the interleave control. Independently reviewed — grounding guaranteed by construction, no security surface.

## Two fixes beyond the happy path

- **`cellKey`** is `JSON.stringify` of the tuple, not a delimiter-joined string — the repo has been bitten by composite keys where a separator inside a field made distinct keys collide (lessons.md).
- While hardening `cellKey` I found the template literal's typed spaces had been **mangled to NUL bytes**; the JSON encoding removes them. Scanned every file I wrote this session — including the already-merged `sequence.ts`/`session.ts` — no other NUL bytes anywhere.

App CHANGELOG + version 0.9.0 → 0.9.1. **162 tests.** Next: part 2, the SRS-weighted `pickNext` draw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)