### PR TITLE
Add BJT ITF transit-time current scale

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add BJT model-card `ITF` forward transit-time current-scale support, applying
+  `(If / (If + ITF))^2` to the `XTF` AC and transient storage enhancement.
 - Add BJT model-card `XTF` forward transit-time bias-coefficient support,
   scaling forward diffusion capacitance and transient stored charge by
   `TF * (1 + XTF)` with the Berkeley default of zero.

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -616,6 +616,8 @@ class BJT:
         Excess phase at ``1 / (2*pi*Tf)`` in degrees (default 0.0).
     Xtf:
         Coefficient for forward transit-time bias dependence (default 0.0).
+    Itf:
+        Forward-current scale for transit-time bias dependence (default 0.0).
     """
 
     name: str
@@ -654,6 +656,7 @@ class BJT:
     Af: float = 1.0            # flicker-noise base-current exponent
     Ptf: float = 0.0           # excess phase at 1/(2*pi*Tf), degrees
     Xtf: float = 0.0           # forward transit-time bias coefficient
+    Itf: float = 0.0           # forward transit-time current scale (A)
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -605,7 +605,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr, element.Tnom, element.Kf, element.Af, element.Ptf, element.Xtf)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr, element.Tnom, element.Kf, element.Af, element.Ptf, element.Xtf, element.Itf)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -8743,12 +8743,25 @@ def _bjt_junction_transconductance(el: BJT, voltage: float, emission_coefficient
     return (el.Is / effective_thermal_voltage) * math.exp(exponent)
 
 
+def _bjt_forward_transit_time_scale(el: BJT, voltage: float) -> float:
+    effective_thermal_voltage = el.Vt * el.Nf
+    forward_current = max(
+        el.Is * (math.exp(max(-40.0, min(40.0, voltage / effective_thermal_voltage))) - 1.0),
+        0.0,
+    )
+    current_factor = 1.0
+    if el.Itf > 0.0:
+        ratio = forward_current / (forward_current + el.Itf)
+        current_factor = ratio * ratio
+    return 1.0 + el.Xtf * current_factor
+
+
 def _bjt_charge_dynamic_capacitance(el: BJT, state_kind: str, voltage: float) -> float:
     if state_kind == "be":
         conductance = _bjt_junction_transconductance(el, voltage, el.Nf)
         return (
             _bjt_base_emitter_depletion_capacitance(el, voltage)
-            + el.Tf * (1.0 + el.Xtf) * conductance
+            + el.Tf * _bjt_forward_transit_time_scale(el, voltage) * conductance
         )
     conductance = _bjt_junction_transconductance(el, voltage, el.Nr)
     return _bjt_base_collector_depletion_capacitance(el, voltage) + el.Tr * conductance
@@ -9317,6 +9330,10 @@ def _validate_bjt(el: BJT) -> None:
     if not math.isfinite(el.Xtf) or el.Xtf < 0.0:
         raise ValueError(
             f"{el.name}: BJT forward transit-time bias coefficient must be finite and non-negative"
+        )
+    if not math.isfinite(el.Itf) or el.Itf < 0.0:
+        raise ValueError(
+            f"{el.name}: BJT forward transit-time current must be finite and non-negative"
         )
     if not math.isfinite(el.Ise) or el.Ise < 0.0:
         raise ValueError(
@@ -12593,7 +12610,9 @@ def _stamp_ac(
             el, Vcollector_leakage
         )
         g_pi: float = base_gm / el.beta_f + leakage_conductance
-        diffusion_capacitance = el.Tf * (1.0 + el.Xtf) * gm_b
+        diffusion_capacitance = (
+            el.Tf * _bjt_forward_transit_time_scale(el, Vjunc) * gm_b
+        )
         excess_phase = omega * el.Tf * el.Ptf * math.pi / 180.0
         gm_ac = complex(
             gm_b * math.cos(excess_phase),

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (31, 48, 13, 4),
-    "PNP": (31, 48, 13, 4),
+    "NPN": (32, 49, 13, 4),
+    "PNP": (32, 49, 13, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -385,6 +385,7 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "AF": "AF",
     "PTF": "PTF",
     "XTF": "XTF",
+    "ITF": "ITF",
     "ISE": "ISE",
     "NE": "NE",
     "ISC": "ISC",
@@ -951,6 +952,7 @@ def bjt_from_model_card(
         Af=p.get("AF", 1.0),
         Ptf=p.get("PTF", 0.0),
         Xtf=p.get("XTF", 0.0),
+        Itf=p.get("ITF", 0.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 120
+    assert len(coverage) == 122
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 120
+    assert len(records) == 122
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,9 +501,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 120
-    assert report.expected_canonical_parameter_count == 120
-    assert report.accepted_name_count == 186
+    assert report.canonical_parameter_count == 122
+    assert report.expected_canonical_parameter_count == 122
+    assert report.accepted_name_count == 188
     assert report.aliased_parameter_count == 53
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -511,7 +511,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t120\t120\t186\t53\t4\t0"
+        "true\t7\t7\t122\t122\t188\t53\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,8 +539,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 119
-    assert report.accepted_name_count == 183
+    assert report.canonical_parameter_count == 121
+    assert report.accepted_name_count == 185
     assert report.aliased_parameter_count == 52
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t119\t120\t183\t52\t4\t4\n"
+        "false\t7\t7\t121\t122\t185\t52\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,10 +647,10 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
+        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "TNOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
+    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "TNOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.beta_r == pytest.approx(0.25)
@@ -667,6 +667,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert bjt_model.Af == pytest.approx(1.3)
     assert bjt_model.Ptf == pytest.approx(30.0)
     assert bjt_model.Xtf == pytest.approx(2.0)
+    assert bjt_model.Itf == pytest.approx(4.0e-3)
     assert bjt_model.Ise == pytest.approx(3.0e-13)
     assert bjt_model.Ne == pytest.approx(1.7)
     assert bjt_model.Isc == pytest.approx(4.0e-13)
@@ -1600,6 +1601,7 @@ def test_transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() -> No
     def run(
         forward_transit_time: float,
         forward_transit_time_bias_coefficient: float = 0.0,
+        forward_transit_time_current: float = 0.0,
     ) -> TransientResult:
         circuit = Circuit()
         circuit.add(VoltageSource("Vcc", "collector", "0", 5.0))
@@ -1619,12 +1621,14 @@ def test_transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() -> No
             Is=1.0e-15,
             Tf=forward_transit_time,
             Xtf=forward_transit_time_bias_coefficient,
+            Itf=forward_transit_time_current,
         ))
         return transient(circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler")
 
     no_storage = run(0.0)
     stored = run(1.0e-9)
     bias_scaled = run(1.0e-9, 9.0)
+    current_limited = run(1.0e-9, 9.0, 1.0)
 
     assert no_storage.converged
     assert stored.converged
@@ -1635,6 +1639,13 @@ def test_transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() -> No
         bias_scaled.points[-1].node_voltages["base"]
         - stored.points[-1].node_voltages["base"]
     ) > 1.0e-12
+    assert abs(
+        current_limited.points[-1].node_voltages["base"]
+        - stored.points[-1].node_voltages["base"]
+    ) < abs(
+        bias_scaled.points[-1].node_voltages["base"]
+        - stored.points[-1].node_voltages["base"]
+    )
 
 
 def test_non_level_one_mos_model_cards_are_explicitly_rejected() -> None:
@@ -2317,7 +2328,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3, Tnom=323.15, Kf=1.0e-12, Af=1.3, Ptf=30.0, Xtf=2.0),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3, Tnom=323.15, Kf=1.0e-12, Af=1.3, Ptf=30.0, Xtf=2.0, Itf=4.0e-3),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2348,6 +2359,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.Af == pytest.approx(1.3)
     assert expanded.Ptf == pytest.approx(30.0)
     assert expanded.Xtf == pytest.approx(2.0)
+    assert expanded.Itf == pytest.approx(4.0e-3)
 
 
 def test_branch_current_in_voltage_source():
@@ -2615,6 +2627,16 @@ def test_dc_rejects_invalid_bjt_forward_transit_time_bias_coefficient():
     with pytest.raises(
         ValueError,
         match="forward transit-time bias coefficient must be finite and non-negative",
+    ):
+        dc_op(circuit)
+
+
+def test_dc_rejects_invalid_bjt_forward_transit_time_current():
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", Itf=-1.0))
+    with pytest.raises(
+        ValueError,
+        match="forward transit-time current must be finite and non-negative",
     ):
         dc_op(circuit)
 
@@ -4459,7 +4481,7 @@ def test_ac_bjt_forward_excess_phase_rotates_transconductance():
 
 
 def test_ac_bjt_forward_transit_time_bias_coefficient_scales_diffusion_capacitance():
-    def base_amplitude(xtf: float) -> float:
+    def base_amplitude(xtf: float, itf: float = 0.0) -> float:
         circuit = Circuit()
         circuit.add(VoltageSource("Vac", "in", "0", 0.0, ac=AcSource(1.0)))
         circuit.add(Resistor("Rin", "in", "base", 1000.0))
@@ -4473,6 +4495,7 @@ def test_ac_bjt_forward_transit_time_bias_coefficient_scales_diffusion_capacitan
                 Is=25.85e-6,
                 Tf=1.0e-6,
                 Xtf=xtf,
+                Itf=itf,
             )
         )
         return abs(
@@ -4483,8 +4506,10 @@ def test_ac_bjt_forward_transit_time_bias_coefficient_scales_diffusion_capacitan
 
     nominal = base_amplitude(0.0)
     bias_scaled = base_amplitude(9.0)
+    current_limited = base_amplitude(9.0, 1.0)
 
     assert bias_scaled < nominal / 5.0
+    assert current_limited > bias_scaled * 5.0
 
 
 def test_ac_bjt_reverse_transit_time_adds_collector_diffusion_capacitance():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add BJT model-card `ITF` forward transit-time current-scale support, applying
+  `(If / (If + ITF))^2` to the `XTF` AC and transient storage enhancement.
 - Add BJT model-card `XTF` forward transit-time bias-coefficient support,
   scaling forward diffusion capacitance and transient stored charge by
   `TF * (1 + XTF)` with the Berkeley default of zero.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -459,6 +459,7 @@ fn clone_subckt_element(
             expanded.forward_excess_phase_degrees = element.forward_excess_phase_degrees;
             expanded.forward_transit_time_bias_coefficient =
                 element.forward_transit_time_bias_coefficient;
+            expanded.forward_transit_time_current = element.forward_transit_time_current;
             Element::Bjt(expanded)
         }
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
@@ -2905,6 +2906,7 @@ pub struct Bjt {
     pub flicker_noise_exponent: f64,
     pub forward_excess_phase_degrees: f64,
     pub forward_transit_time_bias_coefficient: f64,
+    pub forward_transit_time_current: f64,
 }
 
 impl Bjt {
@@ -3372,6 +3374,7 @@ impl Bjt {
             flicker_noise_exponent: 1.0,
             forward_excess_phase_degrees: 0.0,
             forward_transit_time_bias_coefficient: 0.0,
+            forward_transit_time_current: 0.0,
         }
     }
 }
@@ -3762,8 +3765,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 31, 48, 13, 4),
-    (ModelCardKind::Pnp, 31, 48, 13, 4),
+    (ModelCardKind::Npn, 32, 49, 13, 4),
+    (ModelCardKind::Pnp, 32, 49, 13, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3820,6 +3823,7 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("AF", "AF"),
     ("PTF", "PTF"),
     ("XTF", "XTF"),
+    ("ITF", "ITF"),
     ("ISE", "ISE"),
     ("NE", "NE"),
     ("ISC", "ISC"),
@@ -4518,6 +4522,7 @@ pub fn bjt_from_model_card(
     bjt.flicker_noise_exponent = model_card_value(model, "AF", 1.0);
     bjt.forward_excess_phase_degrees = model_card_value(model, "PTF", 0.0);
     bjt.forward_transit_time_bias_coefficient = model_card_value(model, "XTF", 0.0);
+    bjt.forward_transit_time_current = model_card_value(model, "ITF", 0.0);
     Ok(bjt)
 }
 
@@ -23015,8 +23020,9 @@ fn stamp_ac_bjt_small_signal(
         -forward_gm * excess_phase.sin(),
     );
     let reverse_gm = bjt.saturation_current / reverse_thermal_voltage * reverse_exponent.exp();
-    let diffusion_capacitance =
-        bjt.forward_transit_time * (1.0 + bjt.forward_transit_time_bias_coefficient) * forward_gm;
+    let diffusion_capacitance = bjt.forward_transit_time
+        * bjt_forward_transit_time_scale(bjt, junction_voltage)
+        * forward_gm;
     let reverse_diffusion_capacitance = bjt.reverse_transit_time * reverse_gm;
     let (_, leakage_conductance) = bjt_base_emitter_leakage(bjt, junction_voltage);
     let (_, collector_leakage_conductance) =
@@ -23631,6 +23637,23 @@ fn bjt_junction_transconductance(bjt: &Bjt, voltage: f64, emission_coefficient: 
             .exp()
 }
 
+fn bjt_forward_transit_time_scale(bjt: &Bjt, voltage: f64) -> f64 {
+    let effective_thermal_voltage = bjt.thermal_voltage * bjt.forward_emission_coefficient;
+    let forward_current = (bjt.saturation_current
+        * ((voltage / effective_thermal_voltage)
+            .clamp(-40.0, 40.0)
+            .exp()
+            - 1.0))
+        .max(0.0);
+    let current_factor = if bjt.forward_transit_time_current == 0.0 {
+        1.0
+    } else {
+        let ratio = forward_current / (forward_current + bjt.forward_transit_time_current);
+        ratio * ratio
+    };
+    1.0 + bjt.forward_transit_time_bias_coefficient * current_factor
+}
+
 fn bjt_charge_dynamic_capacitance(bjt: &Bjt, kind: BjtChargeStateKind, voltage: f64) -> f64 {
     match kind {
         BjtChargeStateKind::BaseEmitter => {
@@ -23638,7 +23661,7 @@ fn bjt_charge_dynamic_capacitance(bjt: &Bjt, kind: BjtChargeStateKind, voltage: 
                 bjt_junction_transconductance(bjt, voltage, bjt.forward_emission_coefficient);
             bjt_base_emitter_depletion_capacitance(bjt, voltage)
                 + bjt.forward_transit_time
-                    * (1.0 + bjt.forward_transit_time_bias_coefficient)
+                    * bjt_forward_transit_time_scale(bjt, voltage)
                     * conductance
         }
         BjtChargeStateKind::BaseCollector => {
@@ -24088,6 +24111,12 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
             name: bjt.name.clone(),
             reason: "forward transit-time bias coefficient must be finite and non-negative"
                 .to_string(),
+        });
+    }
+    if !bjt.forward_transit_time_current.is_finite() || bjt.forward_transit_time_current < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "forward transit-time current must be finite and non-negative".to_string(),
         });
     }
     if !bjt.base_emitter_leakage_saturation_current.is_finite()

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -870,7 +870,7 @@ fn ac_bjt_forward_excess_phase_rotates_transconductance() {
 
 #[test]
 fn ac_bjt_forward_transit_time_bias_coefficient_scales_diffusion_capacitance() {
-    fn base_amplitude(coefficient: f64) -> f64 {
+    fn base_amplitude(coefficient: f64, transit_time_current: f64) -> f64 {
         let mut circuit = Circuit::new();
         circuit.add(Element::VoltageSource(VoltageSource::with_ac(
             "Vac", "in", "0", 0.0, 1.0, 0.0,
@@ -894,6 +894,7 @@ fn ac_bjt_forward_transit_time_bias_coefficient_scales_diffusion_capacitance() {
             0.0,
         );
         transistor.forward_transit_time_bias_coefficient = coefficient;
+        transistor.forward_transit_time_current = transit_time_current;
         circuit.add(Element::Bjt(transistor));
 
         ac_sweep(&circuit, 100_000.0, 100_000.0, 1).unwrap()[0]
@@ -902,10 +903,12 @@ fn ac_bjt_forward_transit_time_bias_coefficient_scales_diffusion_capacitance() {
             .abs()
     }
 
-    let nominal = base_amplitude(0.0);
-    let bias_scaled = base_amplitude(9.0);
+    let nominal = base_amplitude(0.0, 0.0);
+    let bias_scaled = base_amplitude(9.0, 0.0);
+    let current_limited = base_amplitude(9.0, 1.0);
 
     assert!(bias_scaled < nominal / 5.0);
+    assert!(current_limited > bias_scaled * 5.0);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 120);
+    assert_eq!(coverage.len(), 122);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 120);
+    assert_eq!(records.len(), 122);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 120);
-    assert_eq!(report.expected_canonical_parameter_count, 120);
-    assert_eq!(report.accepted_name_count, 186);
+    assert_eq!(report.canonical_parameter_count, 122);
+    assert_eq!(report.expected_canonical_parameter_count, 122);
+    assert_eq!(report.accepted_name_count, 188);
     assert_eq!(report.aliased_parameter_count, 53);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t120\t120\t186\t53\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t122\t122\t188\t53\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,8 +235,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 119);
-    assert_eq!(report.accepted_name_count, 183);
+    assert_eq!(report.canonical_parameter_count, 121);
+    assert_eq!(report.accepted_name_count, 185);
     assert_eq!(report.aliased_parameter_count, 52);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t119\t120\t183\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t121\t122\t185\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -441,6 +441,7 @@ fn model_card_aliases_build_device_instances() {
             ("AF", 1.3),
             ("PTF", 30.0),
             ("XTF", 2.0),
+            ("ITF", 4.0e-3),
             ("ISE", 3.0e-13),
             ("NE", 1.7),
             ("ISC", 4.0e-13),
@@ -471,6 +472,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("AF").unwrap(), 1.3);
     assert_close(*bjt_card.parameters.get("PTF").unwrap(), 30.0);
     assert_close(*bjt_card.parameters.get("XTF").unwrap(), 2.0);
+    assert_close(*bjt_card.parameters.get("ITF").unwrap(), 4.0e-3);
     assert_close(*bjt_card.parameters.get("ISE").unwrap(), 3.0e-13);
     assert_close(*bjt_card.parameters.get("NE").unwrap(), 1.7);
     assert_close(*bjt_card.parameters.get("ISC").unwrap(), 4.0e-13);
@@ -498,6 +500,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(bjt_model.flicker_noise_exponent, 1.3);
     assert_close(bjt_model.forward_excess_phase_degrees, 30.0);
     assert_close(bjt_model.forward_transit_time_bias_coefficient, 2.0);
+    assert_close(bjt_model.forward_transit_time_current, 4.0e-3);
     assert_close(bjt_model.base_emitter_leakage_saturation_current, 3.0e-13);
     assert_close(bjt_model.base_emitter_leakage_emission_coefficient, 1.7);
     assert_close(bjt_model.base_collector_leakage_saturation_current, 4.0e-13);
@@ -1443,6 +1446,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     bjt.flicker_noise_exponent = 1.3;
     bjt.forward_excess_phase_degrees = 30.0;
     bjt.forward_transit_time_bias_coefficient = 2.0;
+    bjt.forward_transit_time_current = 4.0e-3;
     let mut circuit = Circuit::new();
     circuit
         .define_subcircuit(SubcircuitDefinition::new(
@@ -1491,6 +1495,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.flicker_noise_exponent, 1.3);
     assert_close(expanded.forward_excess_phase_degrees, 30.0);
     assert_close(expanded.forward_transit_time_bias_coefficient, 2.0);
+    assert_close(expanded.forward_transit_time_current, 4.0e-3);
 }
 
 #[test]
@@ -2058,6 +2063,18 @@ fn dc_rejects_invalid_bjt_forward_transit_time_bias_coefficient() {
     assert!(error
         .to_string()
         .contains("forward transit-time bias coefficient must be finite and non-negative"));
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_forward_transit_time_current() {
+    let mut transistor = Bjt::new("Qbad", "c", "b", "0");
+    transistor.forward_transit_time_current = -1.0;
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Bjt(transistor));
+    let error = dc_op(&circuit).unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("forward transit-time current must be finite and non-negative"));
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -692,6 +692,7 @@ fn transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() {
     fn run(
         forward_transit_time: f64,
         forward_transit_time_bias_coefficient: f64,
+        forward_transit_time_current: f64,
     ) -> Vec<TransientPoint> {
         let mut circuit = Circuit::new();
         circuit.add(Element::VoltageSource(VoltageSource::new(
@@ -729,13 +730,15 @@ fn transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() {
             0.0,
         );
         transistor.forward_transit_time_bias_coefficient = forward_transit_time_bias_coefficient;
+        transistor.forward_transit_time_current = forward_transit_time_current;
         circuit.add(Element::Bjt(transistor));
         transient(&circuit, 1.0e-9, 5.0e-9).unwrap()
     }
 
-    let no_storage = run(0.0, 0.0);
-    let stored = run(1.0e-9, 0.0);
-    let bias_scaled = run(1.0e-9, 9.0);
+    let no_storage = run(0.0, 0.0, 0.0);
+    let stored = run(1.0e-9, 0.0, 0.0);
+    let bias_scaled = run(1.0e-9, 9.0, 0.0);
+    let current_limited = run(1.0e-9, 9.0, 1.0);
     let no_storage_first = no_storage[0].voltage("base").unwrap();
     let stored_first = stored[0].voltage("base").unwrap();
 
@@ -757,6 +760,11 @@ fn transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() {
         .and_then(|point| point.voltage("base"))
         .unwrap();
     assert!((bias_scaled_last - stored_last).abs() > 1.0e-12);
+    let current_limited_last = current_limited
+        .last()
+        .and_then(|point| point.voltage("base"))
+        .unwrap();
+    assert!((current_limited_last - stored_last).abs() < (bias_scaled_last - stored_last).abs());
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add BJT model-card `ITF` forward transit-time current-scale support, applying
+  `(If / (If + ITF))^2` to the `XTF` AC and transient storage enhancement.
 - Add BJT model-card `XTF` forward transit-time bias-coefficient support,
   scaling forward diffusion capacitance and transient stored charge by
   `TF * (1 + XTF)` with the Berkeley default of zero.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1734,6 +1734,7 @@ export interface Bjt {
   readonly flickerNoiseExponent: number;
   readonly forwardExcessPhaseDegrees: number;
   readonly forwardTransitTimeBiasCoefficient: number;
+  readonly forwardTransitTimeCurrent: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -2011,8 +2012,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [31, 48, 13, 4],
-  PNP: [31, 48, 13, 4],
+  NPN: [32, 49, 13, 4],
+  PNP: [32, 49, 13, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3602,7 +3603,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees, element.forwardTransitTimeBiasCoefficient);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees, element.forwardTransitTimeBiasCoefficient, element.forwardTransitTimeCurrent);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7792,6 +7793,7 @@ export function bjt(
   flickerNoiseExponent = 1.0,
   forwardExcessPhaseDegrees = 0.0,
   forwardTransitTimeBiasCoefficient = 0.0,
+  forwardTransitTimeCurrent = 0.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7831,6 +7833,7 @@ export function bjt(
     flickerNoiseExponent,
     forwardExcessPhaseDegrees,
     forwardTransitTimeBiasCoefficient,
+    forwardTransitTimeCurrent,
   };
 }
 
@@ -7947,6 +7950,7 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   AF: "AF",
   PTF: "PTF",
   XTF: "XTF",
+  ITF: "ITF",
   ISE: "ISE",
   NE: "NE",
   ISC: "ISC",
@@ -8485,6 +8489,7 @@ export function bjtFromModelCard(
     p.AF ?? 1.0,
     p.PTF ?? 0.0,
     p.XTF ?? 0.0,
+    p.ITF ?? 0.0,
   );
 }
 
@@ -19658,6 +19663,22 @@ function bjtJunctionTransconductance(
   return (element.saturationCurrent / effectiveThermalVoltage) * Math.exp(exponent);
 }
 
+function bjtForwardTransitTimeScale(element: Bjt, voltage: number): number {
+  const effectiveThermalVoltage =
+    element.thermalVoltage * element.forwardEmissionCoefficient;
+  const exponent = Math.max(-40.0, Math.min(40.0, voltage / effectiveThermalVoltage));
+  const forwardCurrent = Math.max(
+    element.saturationCurrent * (Math.exp(exponent) - 1.0),
+    0.0,
+  );
+  let currentFactor = 1.0;
+  if (element.forwardTransitTimeCurrent > 0.0) {
+    const ratio = forwardCurrent / (forwardCurrent + element.forwardTransitTimeCurrent);
+    currentFactor = ratio * ratio;
+  }
+  return 1.0 + element.forwardTransitTimeBiasCoefficient * currentFactor;
+}
+
 function bjtChargeDynamicCapacitance(
   element: Bjt,
   kind: BjtChargeStateKind,
@@ -19671,7 +19692,7 @@ function bjtChargeDynamicCapacitance(
     );
     return bjtBaseEmitterDepletionCapacitance(element, voltage) +
       element.forwardTransitTime *
-        (1.0 + element.forwardTransitTimeBiasCoefficient) *
+        bjtForwardTransitTimeScale(element, voltage) *
         conductance;
   }
   const conductance = bjtJunctionTransconductance(
@@ -19967,6 +19988,9 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.forwardTransitTimeBiasCoefficient) || element.forwardTransitTimeBiasCoefficient < 0.0) {
     throw invalidElement(element.name, "forward transit-time bias coefficient must be finite and non-negative");
+  }
+  if (!Number.isFinite(element.forwardTransitTimeCurrent) || element.forwardTransitTimeCurrent < 0.0) {
+    throw invalidElement(element.name, "forward transit-time current must be finite and non-negative");
   }
   if (!Number.isFinite(element.baseEmitterLeakageSaturationCurrent) || element.baseEmitterLeakageSaturationCurrent < 0.0) {
     throw invalidElement(element.name, "base-emitter leakage saturation current must be finite and non-negative");
@@ -21946,7 +21970,7 @@ function stampAcBjtSmallSignal(
     baseTransconductance / element.forwardBeta + leakage.conductance;
   const diffusionCapacitance =
     element.forwardTransitTime *
-    (1.0 + element.forwardTransitTimeBiasCoefficient) *
+    bjtForwardTransitTimeScale(element, junctionVoltage) *
     transconductance;
   const excessPhase =
     omega * element.forwardTransitTime * element.forwardExcessPhaseDegrees * Math.PI / 180.0;

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -599,7 +599,7 @@ describe("acSweep", () => {
   });
 
   it("scales BJT diffusion capacitance by the forward transit-time bias coefficient", () => {
-    function baseAmplitude(coefficient: number): number {
+    function baseAmplitude(coefficient: number, transitTimeCurrent = 0.0): number {
       const circuit = new Circuit();
       circuit.add(voltageSourceWithAc("Vac", "in", "0", 0.0, 1.0));
       circuit.add(resistor("Rin", "in", "base", 1_000.0));
@@ -607,14 +607,17 @@ describe("acSweep", () => {
       circuit.add({
         ...bjt("Q1", "col", "base", "0", "NPN", 25.85e-6, 100.0, 0.02585, 0.0, 0.0, 1.0e-6),
         forwardTransitTimeBiasCoefficient: coefficient,
+        forwardTransitTimeCurrent: transitTimeCurrent,
       });
       return complexAbs(acSweep(circuit, 100_000.0, 100_000.0, 1)[0].voltage("base")!);
     }
 
     const nominal = baseAmplitude(0.0);
     const biasScaled = baseAmplitude(9.0);
+    const currentLimited = baseAmplitude(9.0, 1.0);
 
     expect(biasScaled).toBeLessThan(nominal / 5.0);
+    expect(currentLimited).toBeGreaterThan(biasScaled * 5.0);
   });
 
   it("uses BJT reverse transit time as base-collector diffusion capacitance in AC analysis", () => {

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(120);
+    expect(coverage).toHaveLength(122);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(120);
+    expect(records).toHaveLength(122);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 120,
-      expectedCanonicalParameterCount: 120,
-      acceptedNameCount: 186,
+      canonicalParameterCount: 122,
+      expectedCanonicalParameterCount: 122,
+      acceptedNameCount: 188,
       aliasedParameterCount: 53,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t120\t120\t186\t53\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t122\t122\t188\t53\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,8 +241,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(119);
-    expect(report.acceptedNameCount).toBe(183);
+    expect(report.canonicalParameterCount).toBe(121);
+    expect(report.acceptedNameCount).toBe(185);
     expect(report.aliasedParameterCount).toBe(52);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t119\t120\t183\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t121\t122\t185\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -347,6 +347,7 @@ describe("dcOp", () => {
       AF: 1.3,
       PTF: 30.0,
       XTF: 2.0,
+      ITF: 4.0e-3,
       ISE: 3.0e-13,
       NE: 1.7,
       ISC: 4.0e-13,
@@ -360,7 +361,7 @@ describe("dcOp", () => {
       FC: 0.4,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, TNOM: 50.0, KF: 1.0e-12, AF: 1.3, PTF: 30.0, XTF: 2.0, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, TNOM: 50.0, KF: 1.0e-12, AF: 1.3, PTF: 30.0, XTF: 2.0, ITF: 4.0e-3, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.reverseBeta, 0.25);
@@ -377,6 +378,7 @@ describe("dcOp", () => {
     expectClose(bjtModel.flickerNoiseExponent, 1.3);
     expectClose(bjtModel.forwardExcessPhaseDegrees, 30.0);
     expectClose(bjtModel.forwardTransitTimeBiasCoefficient, 2.0);
+    expectClose(bjtModel.forwardTransitTimeCurrent, 4.0e-3);
     expectClose(bjtModel.baseEmitterLeakageSaturationCurrent, 3.0e-13);
     expectClose(bjtModel.baseEmitterLeakageEmissionCoefficient, 1.7);
     expectClose(bjtModel.baseCollectorLeakageSaturationCurrent, 4.0e-13);
@@ -1020,7 +1022,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3, 323.15, 1.0e-12, 1.3, 30.0, 2.0),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3, 323.15, 1.0e-12, 1.3, 30.0, 2.0, 4.0e-3),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -1052,6 +1054,7 @@ describe("dcOp", () => {
       expectClose(expanded.flickerNoiseExponent, 1.3);
       expectClose(expanded.forwardExcessPhaseDegrees, 30.0);
       expectClose(expanded.forwardTransitTimeBiasCoefficient, 2.0);
+      expectClose(expanded.forwardTransitTimeCurrent, 4.0e-3);
     }
   });
 
@@ -1433,6 +1436,17 @@ describe("dcOp", () => {
     });
     expect(() => dcOp(circuit)).toThrowError(
       "forward transit-time bias coefficient must be finite and non-negative",
+    );
+  });
+
+  it("rejects invalid BJT forward transit-time currents", () => {
+    const circuit = new Circuit();
+    circuit.add({
+      ...bjt("Qbad", "c", "b", "0"),
+      forwardTransitTimeCurrent: -1.0,
+    });
+    expect(() => dcOp(circuit)).toThrowError(
+      "forward transit-time current must be finite and non-negative",
     );
   });
 

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -517,6 +517,7 @@ describe("transient", () => {
     function run(
       forwardTransitTime: number,
       forwardTransitTimeBiasCoefficient = 0.0,
+      forwardTransitTimeCurrent = 0.0,
     ): TransientPoint[] {
       const circuit = new Circuit();
       circuit.add(voltageSource("Vcc", "collector", "0", 5.0));
@@ -547,6 +548,7 @@ describe("transient", () => {
           forwardTransitTime,
         ),
         forwardTransitTimeBiasCoefficient,
+        forwardTransitTimeCurrent,
       });
       return transient(circuit, 1.0e-9, 5.0e-9);
     }
@@ -554,6 +556,7 @@ describe("transient", () => {
     const noStorage = run(0.0);
     const stored = run(1.0e-9);
     const biasScaled = run(1.0e-9, 9.0);
+    const currentLimited = run(1.0e-9, 9.0, 1.0);
     expectClose(noStorage[0].voltage("base"), 0.0);
     expect(stored[0].voltage("base")!).toBeGreaterThan(0.6);
     expect(stored[stored.length - 1].voltage("base")!).toBeLessThan(stored[0].voltage("base")!);
@@ -561,6 +564,13 @@ describe("transient", () => {
       biasScaled[biasScaled.length - 1].voltage("base")! -
         stored[stored.length - 1].voltage("base")!,
     )).toBeGreaterThan(1.0e-12);
+    expect(Math.abs(
+      currentLimited[currentLimited.length - 1].voltage("base")! -
+        stored[stored.length - 1].voltage("base")!,
+    )).toBeLessThan(Math.abs(
+      biasScaled[biasScaled.length - 1].voltage("base")! -
+        stored[stored.length - 1].voltage("base")!,
+    ));
   });
 
   it("reports periods for periodic source waveforms", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,14 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT forward transit-time bias coefficient.
+1. Cross-language BJT forward transit-time current scale.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `XTF` model-card support in Rust, Python, and TypeScript,
+   - Add Berkeley BJT `ITF` model-card support in Rust, Python, and TypeScript,
      defaulting to zero so existing AC and transient results remain unchanged.
-   - Scale forward diffusion capacitance and transient base-emitter stored
-     charge by `TF * (1 + XTF)` while preserving the ideal `TF` basis for
-     `PTF` excess phase and the complete BJT model through subcircuits.
-   - Extend the supported-parameter coverage gate from 118 to 120 canonical
+   - Apply the Berkeley forward-current factor
+     `(If / (If + ITF))^2` to the `XTF` diffusion-capacitance and transient
+     stored-charge enhancement while preserving the complete BJT model through
+     subcircuits.
+   - Extend the supported-parameter coverage gate from 120 to 122 canonical
      rows and lock model-card behavior, validation, hierarchy, AC loading, and
      transient stored-charge behavior in all engines.
 
@@ -3142,6 +3143,14 @@ the Rust, Python, and TypeScript surfaces together.
      phase at `1 / (2*pi*TF)`.
    - Hierarchical subcircuit expansion preserves the complete BJT model, and
      the supported-parameter release gate now covers 118 canonical rows.
+
+237. Cross-language BJT forward transit-time bias coefficient.
+   - Status: completed in PR 8836.
+   - Rust, Python, and TypeScript BJT model cards now accept `XTF`, default it
+     to zero, and scale forward diffusion capacitance and transient stored
+     charge by `TF * (1 + XTF)`.
+   - Hierarchical subcircuit expansion preserves the complete BJT model, and
+     the supported-parameter release gate now covers 120 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add cross-language Berkeley BJT `ITF` model-card support and preserve it through subcircuits
- apply `(If / (If + ITF))^2` to the `XTF` forward diffusion-storage enhancement in AC and transient analyses
- advance the supported-parameter gate to 122 canonical rows and reconcile the SPICE completion plan after PR #8836

## Verification
- `cargo test -p spice-engine` (371 tests)
- Python `pytest -q` (563 tests, 88.83% coverage)
- TypeScript `npm test` (321 tests)
- TypeScript `npm run build`
- package-local Rust fmt check and Python Ruff checks