### PR TITLE
feat(fold-control-flow): split comma-sequence expression statement into separate statements (0.35.0)

### DIFF
--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.35.0] - 2026-07-22
+
+### Added - split a comma-sequence expression statement into separate statements
+
+A comma sequence used as an expression statement at a statement-LIST position
+(program body or block body) now splits into one statement per sub-expression,
+matching the reference Closure Compiler's Normalize at SIMPLE byte-for-byte (the
+inverse of the existing loop-body comma-fusion):
+
+```text
+  a(), b();        ->  a(); b();
+  a(), b(), c();   ->  a(); b(); c();
+  1, a();          ->  1; a();      (each operand kept verbatim)
+```
+
+The comma operator evaluates its operands left-to-right and discards all but the
+last; an expression statement already discards its value, so running each operand
+as its own statement is behaviour-identical. A new `split_sequence_statement`
+helper feeds `fold_block_statement` / `fold_program` (the statement-list
+processors, which already splice), NOT `fold_statement` - a single-statement body
+(`if (x) a(), b();`, `for (;;) a(), b();`) has no braces, so the sequence must
+stay fused there; those cases are verified unchanged.
+
+Not handled (declined; tracked as a follow-up): a comma sequence in a `for`
+INIT (`for(a(),b();c;)d()` -> the reference pulls `a();` out before the loop),
+which is a for-header transform rather than an expression-statement split.
+
 ## [0.34.0] - 2026-07-22
 
 ### Fixed — a dead `if` branch / `for` loop no longer DROPS a hoisted `var` (miscompile)

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -324,6 +324,17 @@ fn fold_program(prog: &Program, st: &mut FoldState) -> Program {
                 new_body.extend(body.iter().cloned().map(ProgramItem::Statement));
                 continue;
             }
+            // Split a top-level comma-sequence statement (`a(), b();` → `a(); b();`).
+            if let Some(split) = split_sequence_statement(s) {
+                st.record_fold(
+                    &statement_cv(s),
+                    "split-comma-sequence",
+                    "<a>, <b>;",
+                    "<a>; <b>;",
+                );
+                new_body.extend(split.into_iter().map(ProgramItem::Statement));
+                continue;
+            }
         }
         new_body.push(folded);
     }
@@ -596,6 +607,21 @@ fn fold_block_statement(b: &BlockStatement, st: &mut FoldState) -> BlockStatemen
             if new_body.last().map(is_terminator).unwrap_or(false) {
                 hit_terminator = true;
             }
+            continue;
+        }
+
+        // Split a comma-sequence expression statement into separate statements
+        // (`a(), b();` → `a(); b();`). A `SequenceExpression` never contains a
+        // terminator (they are statements, not expressions), so no
+        // `hit_terminator` re-check is needed.
+        if let Some(split) = split_sequence_statement(&folded) {
+            st.record_fold(
+                &statement_cv(&folded),
+                "split-comma-sequence",
+                "<a>, <b>;",
+                "<a>; <b>;",
+            );
+            new_body.extend(split);
             continue;
         }
 
@@ -884,6 +910,39 @@ fn redundant_block(folded: &Statement) -> Option<(&Option<String>, &[Statement])
         }
         _ => None,
     }
+}
+
+/// A comma sequence used as an EXPRESSION STATEMENT at a statement-list position
+/// splits into one statement per sub-expression, matching the reference Closure
+/// Compiler's Normalize (the inverse of the loop-body comma-fusion): `a(), b();`
+/// -> `a(); b();`, `1, a();` -> `1; a();`. The split is behaviour-preserving —
+/// the comma operator evaluates its operands left-to-right and discards all but
+/// the last, and an expression statement already discards its value, so running
+/// each operand as its own statement is identical.
+///
+/// This is valid ONLY at a statement-LIST position (program / block body), which
+/// is why it lives in [`fold_block_statement`] / [`fold_program`] rather than
+/// [`fold_statement`]: a single-statement body (`if (x) a(), b();`,
+/// `for (;;) a(), b();`) has no braces, so the sequence must stay fused there.
+/// Returns `None` when `folded` is not an `ExpressionStatement` wrapping a
+/// `SequenceExpression`.
+fn split_sequence_statement(folded: &Statement) -> Option<Vec<Statement>> {
+    if let Statement::Tagged(TaggedStatement::ExpressionStatement(es)) = folded {
+        if let Expression::SequenceExpression(seq) = &es.expression {
+            return Some(
+                seq.expressions
+                    .iter()
+                    .map(|e| {
+                        Statement::expression_statement(ExpressionStatement {
+                            cv: None,
+                            expression: e.clone(),
+                        })
+                    })
+                    .collect(),
+            );
+        }
+    }
+    None
 }
 
 /// Is this `else` branch safe to hoist into the enclosing block (CLOC25)?
@@ -4455,6 +4514,46 @@ mod tests {
         let (out, _c, changed, _n) = run_pass(prog);
         assert!(changed);
         assert_eq!(out.body.len(), 2, "both inner statements spliced in");
+    }
+
+    #[test]
+    fn split_comma_sequence_at_program_level() {
+        // `x, y, z;` → `x; y; z;` — a comma-sequence expression STATEMENT at a
+        // statement-list position splits into one statement per sub-expression.
+        let seq = Expression::SequenceExpression(SequenceExpression {
+            cv: None,
+            expressions: vec![ident("x"), ident("y"), ident("z")],
+        });
+        let prog = program().with_body(vec![ProgramItem::Statement(expr_stmt(seq, None))]);
+        let (out, _c, changed, _n) = run_pass(prog);
+        assert!(changed);
+        assert_eq!(out.body.len(), 3, "expected 3 split statements; got {:?}", out.body);
+        for (i, name) in ["x", "y", "z"].iter().enumerate() {
+            match &out.body[i] {
+                ProgramItem::Statement(Statement::Tagged(
+                    TaggedStatement::ExpressionStatement(es),
+                )) => assert!(
+                    matches!(&es.expression, Expression::Identifier(id) if &id.name == name),
+                    "stmt {i} should be `{name};`; got {:?}",
+                    es.expression
+                ),
+                other => panic!("expected ExpressionStatement for `{name}`; got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn split_comma_sequence_in_block() {
+        // `{ a, b; }` → the block flattens and the sequence splits: `a; b;`.
+        let seq = Expression::SequenceExpression(SequenceExpression {
+            cv: None,
+            expressions: vec![ident("a"), ident("b")],
+        });
+        let prog =
+            program().with_body(vec![ProgramItem::Statement(block(None, vec![expr_stmt(seq, None)]))]);
+        let (out, _c, changed, _n) = run_pass(prog);
+        assert!(changed);
+        assert_eq!(out.body.len(), 2, "expected [a; b;]; got {:?}", out.body);
     }
 
     #[test]

--- a/code/programs/rust/closurec/tests/diff/simple-fold-comma-split/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-comma-split/README.md
@@ -1,0 +1,34 @@
+# simple-fold-comma-split
+
+End-to-end oracle for **comma-sequence statement splitting** in
+`closure-pass-fold-control-flow` (fcf 0.35.0).
+
+A comma sequence used as an *expression statement* at a statement-list position
+(a function body or the program body) splits into one statement per operand,
+because the comma operator discards every value but the last and an expression
+statement already discards its value:
+
+```text
+a(), b();        ->  a(); b();
+x(), y(), z();   ->  x(); y(); z();
+```
+
+A comma sequence in a **single-statement body** (an `if`/`for` with no braces)
+has no statement list to splice into, so it stays fused. In this fixture the
+`if (cond) p(), q();` first collapses (fcf if -> `&&`) to `cond&&(p(),q())` with
+the comma preserved, and the `for` body keeps `step(),tick()` fused.
+
+## Files
+
+- `input/a.js` — the source, exercising both the split and the kept cases.
+- `flags.txt` — `--compilation_level SIMPLE --js input/a.js`.
+- `expected.stdout` — byte-identical to the reference Closure Compiler
+  (`v20260712`, `SIMPLE_OPTIMIZATIONS`, `ECMASCRIPT_2020`, `NO_TRANSPILE`).
+
+## Expected output
+
+```text
+function f(){a();b()}x();y();z();cond&&(p(),q());for(;run();)step(),tick();
+```
+
+Verified against the oracle jar with `xxd` (exact bytes).

--- a/code/programs/rust/closurec/tests/diff/simple-fold-comma-split/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-comma-split/expected.stdout
@@ -1,0 +1,1 @@
+function f(){a();b()}x();y();z();cond&&(p(),q());for(;run();)step(),tick();

--- a/code/programs/rust/closurec/tests/diff/simple-fold-comma-split/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-comma-split/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-fold-comma-split/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-fold-comma-split/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-comma-split/input/a.js
@@ -1,0 +1,26 @@
+// SIMPLE-level split of a comma-sequence EXPRESSION STATEMENT into one
+// statement per operand -- the inverse of loop-body comma-fusion.
+//
+// The comma operator evaluates its operands left-to-right and discards every
+// value but the last. An expression statement already discards its value, so at
+// a statement-LIST position (a function body or the program body) running each
+// operand as its own `;`-terminated statement is behaviour-identical, and the
+// reference compiler normalizes to that form:
+//
+//   a(), b();          ->  a(); b();      (inside function f)
+//   x(), y(), z();     ->  x(); y(); z(); (program body)
+//
+// A comma sequence in a SINGLE-statement body (an `if`/`for` with no braces) has
+// no statement list to splice into, so the sequence stays FUSED there:
+//
+//   if (cond) p(), q();       -> cond&&(p(),q());   (if collapses to &&, comma kept)
+//   for (; run();) step(),tick();  -> comma stays fused as the loop's one body stmt
+//
+// All call targets are open-world globals, so nothing is removed -- only the
+// statement-list splits are observable.
+function f() {
+  a(), b();
+}
+x(), y(), z();
+if (cond) p(), q();
+for (; run(); ) step(), tick();

--- a/code/programs/rust/closurec/tests/diff_simple_fold_comma_split.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_comma_split.rs
@@ -1,0 +1,53 @@
+//! Integration test for the `tests/diff/simple-fold-comma-split/` fixture.
+//!
+//! End-to-end oracle for comma-sequence statement splitting in
+//! `closure-pass-fold-control-flow`: a comma sequence used as an expression
+//! statement at a statement-LIST position (a function body or the program body)
+//! splits into one statement per operand, because the comma operator discards
+//! every value but the last and an expression statement already discards its
+//! value. A comma sequence in a single-statement body (an `if`/`for` with no
+//! braces) has no statement list to splice into, so it stays fused.
+//!
+//! At SIMPLE the fixture optimizes to:
+//!
+//! ```text
+//! function f(){a();b()}x();y();z();cond&&(p(),q());for(;run();)step(),tick();
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-fold-comma-split/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_fold_comma_split_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-fold-comma-split/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}


### PR DESCRIPTION
## What

`fold-control-flow` (0.35.0): a comma-sequence used as an **expression statement** at a statement-LIST position (a program body or a block body) now splits into one statement per operand, matching the reference Closure Compiler's Normalize at SIMPLE byte-for-byte. This is the inverse of the existing loop-body comma-fusion (0.32.0, #187).

```text
a(), b();        ->  a(); b();
x(), y(), z();   ->  x(); y(); z();
1, a();          ->  1; a();
```

The comma operator evaluates its operands left-to-right and discards all but the last; an expression statement already discards its value, so running each operand as its own statement is behaviour-identical.

## How

A new `split_sequence_statement` helper feeds `fold_block_statement` and `fold_program` (the statement-list processors, which already splice). It is deliberately **not** wired into `fold_statement`: a single-statement body (`if (x) a(), b();`, `for (;;) a(), b();`) has no braces, so the sequence must stay fused there. The e2e fixture verifies both directions — `if (cond) p(), q();` folds to `cond&&(p(),q())` with the comma preserved, and the `for` body keeps `step(),tick()` fused.

## Not handled (follow-up #224)

A comma sequence in a `for` **init** (`for(a(),b();c;)d()` -> the reference pulls `a();` out before the loop) is a for-header transform, not an expression-statement split. Tracked separately.

## Verification

- 90 fold-control-flow unit tests (2 new: program-level split, in-block split) + 13 integration — zero regressions.
- New closurec e2e fixture `simple-fold-comma-split`, byte-identical to the oracle jar (`v20260712`, `SIMPLE`, `ECMASCRIPT_2020`, `NO_TRANSPILE`), verified with `xxd`.
- Full closurec suite: **160 suites / 957 tests, zero failures, zero drift.**
- `cargo clippy -- -D warnings` clean in both workspaces (packages + closurec).
- Inline security review: **PASSED** — no panics/DoS; the pipeline's 100-sweep cap bounds any oscillation with the reverse fusion fold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
