### PR TITLE
feat(semantic-ir-to-ruby): short-circuit — native && / || (SIR16)

### DIFF
--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.7.0 — short-circuit (SIR16)
+
+Accepts `Feature::ShortCircuit`. `Expr::LogicalAnd` / `Expr::LogicalOr`
+(`&&` / `||`) render as Ruby's native short-circuit operators, which ARE the
+SIR semantics exactly — no runtime helper, no coercion:
+
+- They yield the **deciding operand**, not a coerced boolean: `1 && 2` is `2`,
+  `false && 2` is `false`, `nil || 7` is `7`, `1 || 2` is `1`.
+- They **skip the right operand** when the left already decides — Ruby `&&`
+  does not evaluate its rhs when the lhs is falsy, and `||` does not when the
+  lhs is truthy.
+- Ruby truthiness is the SIR/Lisp convention (only `nil` and `false` are falsy),
+  so the operands need no `sir_truthy` wrapper — unlike the Go/C backends, which
+  must lift to an IIFE / hoisted `if` to return the operand value rather than a
+  native bool.
+
+These are distinct from the eager `and`/`or` **builtins** (which the emitter
+also renders with `&&`/`||`); the `ShortCircuit` feature is specifically the two
+short-circuit expression nodes. The unsupported-builtin pre-check
+(`scan_expr`) now recurses into both operands, so a deferred builtin nested in a
+`&&`/`||` is still reported cleanly. Two nodes, both handled → the emitter stays
+total.
+
+First of the ShortCircuit parity arc: Go/Rust/Python/JS already accept it; this
+brings the Ruby backend up (C is the last, tracked next). Verified through a
+real `ruby` with hand-built modules (the frontend constant-folds a literal
+`&&`, so the node is built directly): operand-return for both operators, and a
+short-circuit proof where the dead operand is `1 / 0` — a correct lowering skips
+it (`false && (1/0)` → `false`, exits clean), a broken eager one would raise.
+Bumps semantic-ir-to-ruby 0.6.0 → 0.7.0.
+
 ## 0.6.0 — floats (SIR16)
 
 Accepts `Feature::Floats`. Ruby has a native `Float`, so this is a one-arm

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/README.md
+++ b/code/packages/rust/semantic-ir-to-ruby/README.md
@@ -52,12 +52,15 @@ structural `Array#==`), `SeqIndex` (`a[i]`, nil on OOB), `SeqLen` (`a.length`),
 `SeqSet` (`a[i] = v`, bounds-checked via `sir_seq_set`), and `ForEach`
 (`for x in a`); SIR16 `Maps` — a native Hash for `MapLit` (`{k => v}`),
 `MapGet` (`h[k]`, nil on miss), and `MapSet` (`h[k] = v`), with structural
-composite keys; and SIR16 `Floats` — a native `Float` for `FloatLit` (rendered
+composite keys; SIR16 `Floats` — a native `Float` for `FloatLit` (rendered
 so `7.0` stays a Float, not the Integer `7`; `Infinity`/`NaN` are named), with
-native float arithmetic and division.
+native float arithmetic and division; and SIR16 `ShortCircuit` — `LogicalAnd`
+(`&&`) and `LogicalOr` (`||`) rendered as Ruby's native short-circuit
+operators, which yield the deciding operand and skip the dead branch exactly as
+SIR requires.
 Rejects `TailCalls`, `Intrinsics`, and every not-yet-wired feature (array
-indexing / slicing via `IndexGet` — `NDArrays`; array-pattern destructuring —
-`ShortCircuit`; collection methods, exceptions, OOP) until its cascade batch
+indexing / slicing via `IndexGet` — `NDArrays`; array-pattern destructuring;
+collection methods, exceptions, OOP) until its cascade batch
 lands — each a clean, source-positioned `UnsupportedFeature`.
 
 ## Verification

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -196,6 +196,9 @@ fn scan_expr(e: &Expr) -> Option<(String, semantic_ir::Span)> {
             .iter()
             .find_map(|e| scan_expr(&e.key).or_else(|| scan_expr(&e.value))),
         Expr::MapGet { map, key, .. } => scan_expr(map).or_else(|| scan_expr(key)),
+        Expr::LogicalAnd { lhs, rhs, .. } | Expr::LogicalOr { lhs, rhs, .. } => {
+            scan_expr(lhs).or_else(|| scan_expr(rhs))
+        }
         _ => None,
     }
 }
@@ -514,6 +517,20 @@ fn emit_expr(e: &Expr) -> String {
                 format!("sir_{sign}{bits}({})", emit_expr(value))
             }
         },
+        // SIR16 short-circuit `&&` / `||` (distinct from the eager `and`/`or`
+        // builtins). Ruby's native operators ARE the SIR semantics exactly:
+        // they short-circuit (the rhs is not evaluated when the lhs decides) and
+        // yield the DECIDING OPERAND (not a coerced bool) — `a && b` is `a` when
+        // `a` is falsy else `b`; `a || b` is `a` when truthy else `b`. And Ruby
+        // truthiness is the SIR/Lisp convention (only `nil`/`false` are falsy),
+        // so no `sir_truthy` wrapper is needed — unlike the Go/C backends, which
+        // must lift to an IIFE / hoisted `if` to return the operand value.
+        Expr::LogicalAnd { lhs, rhs, .. } => {
+            format!("({} && {})", emit_expr(lhs), emit_expr(rhs))
+        }
+        Expr::LogicalOr { lhs, rhs, .. } => {
+            format!("({} || {})", emit_expr(lhs), emit_expr(rhs))
+        }
         other => unreachable!("Ruby backend reached unsupported expr: {other:?}"),
     }
 }

--- a/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
@@ -73,6 +73,15 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // float (integral floats keep their `.0`; `NaN`/`Infinity` are named). So
     // accepting the feature plus the one emit arm keeps the emitter total.
     Feature::Floats,
+    // ── SIR16 short-circuit ──────────────────────────────────────────
+    // `Expr::LogicalAnd` / `Expr::LogicalOr` (`&&` / `||`) render as Ruby's
+    // native short-circuit operators — which ARE the SIR semantics exactly:
+    // they yield the DECIDING OPERAND (not a bool) and skip the rhs when the
+    // lhs decides, and Ruby truthiness is the SIR convention (only `nil`/`false`
+    // falsy), so no `sir_truthy` wrapper is needed. Two nodes, both handled →
+    // the emitter stays total. (Distinct from the eager `and`/`or` builtins,
+    // which the emitter also renders with `&&`/`||`.)
+    Feature::ShortCircuit,
     // ── SIR16 control flow / mutation ────────────────────────────────
     // `Stmt::While` (loops) and `Stmt::Assign` (re-binding) render as Ruby's
     // native `while … end` and `name = value` — Ruby is fully mutable and

--- a/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
@@ -832,3 +832,90 @@ fn float_equality_is_value_based() {
         None => eprintln!("skip: no ruby on PATH"),
     }
 }
+
+// ── SIR16 short-circuit ─────────────────────────────────────────────────────
+// `Feature::ShortCircuit` gates `Expr::LogicalAnd` / `Expr::LogicalOr`. Ruby's
+// native `&&`/`||` ARE the SIR semantics (yield the deciding operand, skip the
+// rhs when the lhs decides). The frontend CONSTANT-FOLDS `true && false`, so a
+// `LogicalAnd` node only survives from a non-constant source — these tests
+// hand-build the node directly to prove the emitter is total and short-circuits.
+
+fn blit(value: bool) -> Expr {
+    Expr::BoolLit { value, span: s2() }
+}
+fn nil_lit() -> Expr {
+    Expr::NilLit { span: s2() }
+}
+fn land(lhs: Expr, rhs: Expr) -> Expr {
+    Expr::LogicalAnd { lhs: Box::new(lhs), rhs: Box::new(rhs), span: s2() }
+}
+fn lor(lhs: Expr, rhs: Expr) -> Expr {
+    Expr::LogicalOr { lhs: Box::new(lhs), rhs: Box::new(rhs), span: s2() }
+}
+/// A `main` module declaring only `ShortCircuit`.
+fn sc_module(stmts: Vec<Stmt>) -> Module {
+    let mut m = seq_module(stmts);
+    m.manifest = FeatureManifest::from_features(&[Feature::ShortCircuit]);
+    m
+}
+fn run_sc(stmts: Vec<Stmt>) -> Option<String> {
+    run_ruby(&compile(&sc_module(stmts)).expect("short-circuit module must compile, not panic").source)
+}
+
+#[test]
+fn logical_and_returns_the_deciding_operand() {
+    // `a && b` is the OPERAND, not a bool: `1 && 2` → `2` (lhs truthy → rhs);
+    // `false && 2` → `false` (lhs falsy → lhs); `nil && 2` → `nil`.
+    match run_sc(vec![
+        puts(land(ilit(1), ilit(2))),     // 2
+        puts(land(blit(false), ilit(2))), // #f
+        puts(land(nil_lit(), ilit(2))),   // nil
+    ]) {
+        Some(out) => assert_eq!(out, "2\n#f\nnil"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn logical_or_returns_the_deciding_operand() {
+    // `a || b`: `1 || 2` → `1` (lhs truthy → lhs); `false || 5` → `5`
+    // (lhs falsy → rhs); `nil || 7` → `7`.
+    match run_sc(vec![
+        puts(lor(ilit(1), ilit(2))),     // 1
+        puts(lor(blit(false), ilit(5))), // 5
+        puts(lor(nil_lit(), ilit(7))),   // 7
+    ]) {
+        Some(out) => assert_eq!(out, "1\n5\n7"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn short_circuit_does_not_evaluate_the_dead_operand() {
+    // The RHS must NOT run when the LHS already decides. The dead operand here
+    // is `1 / 0`, which RAISES `ZeroDivisionError` if evaluated — so a broken
+    // (eager) lowering makes the emitted Ruby exit non-zero and `run_ruby`
+    // panics. A correct short-circuit skips it: `false && (1/0)` → `false`,
+    // `true || (1/0)` → `true`, both exit clean.
+    let div_by_zero = || bin("/", ilit(1), ilit(0));
+    match run_sc(vec![
+        puts(land(blit(false), div_by_zero())), // #f, no raise
+        puts(lor(blit(true), div_by_zero())),   // #t, no raise
+    ]) {
+        Some(out) => assert_eq!(out, "#f\n#t"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn short_circuit_emits_native_operators() {
+    // Emit-shape: the nodes render as Ruby `&&` / `||` (native short-circuit).
+    let rb = compile(&sc_module(vec![
+        puts(land(ilit(1), ilit(2))),
+        puts(lor(ilit(1), ilit(2))),
+    ]))
+    .expect("compile")
+    .source;
+    assert!(rb.contains("(1 && 2)"), "LogicalAnd → `&&`:\n{rb}");
+    assert!(rb.contains("(1 || 2)"), "LogicalOr → `||`:\n{rb}");
+}

--- a/code/specs/SIR25-semantic-ir-to-ruby.md
+++ b/code/specs/SIR25-semantic-ir-to-ruby.md
@@ -72,10 +72,10 @@ pub fn compile(module: &Module) -> Result<Artifact, BackendError>;
 **Landed since v0** (one version-bumped batch at a time — see the roadmap): the
 SIR26 integer conversions (`Conversions`, `SizedIntegers`, `Unsigned`,
 `WrappingArithmetic`); and the SIR16 batches `Loops` + `MutableBindings`
-(0.3.0), `Sequences` (native `Array`, 0.4.0), `Maps` (native `Hash`, 0.5.0), and
-`Floats` (native `Float`, 0.6.0).
+(0.3.0), `Sequences` (native `Array`, 0.4.0), `Maps` (native `Hash`, 0.5.0),
+`Floats` (native `Float`, 0.6.0), and `ShortCircuit` (native `&&`/`||`, 0.7.0).
 
-**Still rejects** `TailCalls`, `Intrinsics`, `ShortCircuit`, `NDArrays`,
+**Still rejects** `TailCalls`, `Intrinsics`, `NDArrays`,
 exceptions/OOP, and every not-yet-landed feature (each rejection is a clean,
 source-positioned `UnsupportedFeature`).
 
@@ -110,6 +110,8 @@ or temporaries:
 | `VarRef { Global }` | `sir_global_get("<name>")` |
 | `VarRef { Builtin }` | `sir_builtin_closure("<name>")` |
 | `If` | `(if sir_truthy(<cond>) then <then> else <else> end)` |
+| `LogicalAnd { lhs, rhs }` | `(<lhs> && <rhs>)` — native short-circuit, yields the deciding operand |
+| `LogicalOr { lhs, rhs }` | `(<lhs> \|\| <rhs>)` — native short-circuit, yields the deciding operand |
 | `Block` (stmts + value) | method body: `<stmts>` then `<value>`; as an expression: `(begin; <stmts>; <value>; end)` |
 | `LetBinding` / `LetStarBinding` | `<name> = <value>` |
 | `ExprStmt` | `<expr>` |


### PR DESCRIPTION
## What

Adds SIR16 **short-circuit** to the Ruby backend (`semantic-ir-to-ruby` 0.6.0 → 0.7.0) — the first of the ShortCircuit parity arc (Go/Rust/Python/JS already accept `Feature::ShortCircuit`; Ruby and C were the laggards, C tracked next).

`Expr::LogicalAnd` / `Expr::LogicalOr` (`&&` / `||`) render as Ruby's native short-circuit operators, which **are** the SIR semantics exactly — no runtime helper, no coercion:

- They yield the **deciding operand**, not a coerced boolean: `1 && 2` is `2`, `false && 2` is `false`, `nil || 7` is `7`, `1 || 2` is `1`.
- They **skip the right operand** when the left already decides.
- Ruby truthiness is the SIR/Lisp convention (only `nil`/`false` falsy), so the operands need no `sir_truthy` wrapper — unlike the Go/C backends, which must lift to an IIFE / hoisted `if` to return the operand value rather than a native bool.

These are distinct from the eager `and`/`or` **builtins** (which the emitter also renders with `&&`/`||`); `ShortCircuit` is specifically the two short-circuit expression nodes. The `scan_expr` unsupported-builtin pre-check recurses into both operands. Two nodes, both handled → the emitter stays total.

## Verification

- `cargo test -p semantic-ir-to-ruby` — **44 tests green** (4 new), through a real `ruby` with hand-built modules (the frontend constant-folds a literal `&&`, so the node is built directly): operand-return for both operators, and a **short-circuit proof** where the dead operand is `1 / 0` — a correct lowering skips it (`false && (1/0)` → `false`, exits clean), a broken eager one would raise `ZeroDivisionError` and fail the test.
- `cargo clippy -p semantic-ir-to-ruby --all-targets` clean.
- Security review passed — operands are self-contained and paren-wrapped (no injection/precedence break), short-circuit is genuine, and the validator's `MAX_IR_DEPTH` bounds the recursive emit (no adversarial stack overflow).
- SIR25 spec capability section + node table synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)