### PR TITLE
feat(semantic-ir-to-javascript,derive-to-semantic-ir): SIR23 held-form execution + user-function dispatch (task #105)

### DIFF
--- a/code/packages/rust/derive-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/derive-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,67 @@
 # Changelog
 
+## [0.1.4] - 2026-07-22
+
+### Fixed (upstream — `semantic-ir-to-javascript` 0.51.2, not this crate's own lowering)
+
+`semantic-ir-to-javascript`'s SIR23 addendum item 2 (held-form execution
+— `Assign`/`Define`/`If` + user-function dispatch, that crate's own
+`CHANGELOG.md` `[0.51.2]` entry) makes the three `HELD_HEADS` real:
+`Assign` now genuinely binds a name in a shared environment and returns
+the bound value; `Define` now genuinely registers a
+`Define(name, params, body)` record and a later call now genuinely
+dispatches to it (substitute params → args, re-evaluate); `If` now
+genuinely evaluates its condition and selects a branch. This crate's own
+`src/lower.rs` is completely unchanged — every fix here is entirely
+upstream in the shared backend, confirmed by `tests/test_lower.rs`'s ~40
+pre-existing shape assertions still passing unmodified — but 6 more of
+`tests/oracle.rs`'s 38 `known_bug` cases now genuinely agree end-to-end
+(run and confirmed via `cargo test -p derive-to-semantic-ir --test oracle
+-- --nocapture`, not guessed), so their markers flip to `known_bug: None`
+here:
+
+- `variable_assignment_and_later_reference` (`x := 5; x + 1` → `5, 6`) —
+  `Assign` binds `x`, the next statement reads it back, item 1's `Add`
+  folding does the rest.
+- `single_param_function_definition_and_call` (`F(x) := x*x; F(5)` →
+  `F, 25`), `multi_param_function_definition_and_call`
+  (`G(a, b) := a + b; G(3, 4)` → `G, 7`) — `Define` registers the
+  function (displaying its bare name, never the stored record); the
+  call zips params to args by position, substitutes, and re-evaluates.
+- `if_true_branch` (`IF(1 > 0, 42, 0)` → `42`), `if_false_branch`
+  (`IF(1 > 2, 42, 99)` → `99`) — `If` evaluates the (already-comparison-
+  folded, item 1) condition and selects the matching branch.
+- `vector_assignment_persists_across_statements`
+  (`v := [1, 2, 3]; v` → `[1, 2, 3], [1, 2, 3]`) — **not** one of the 5
+  cases the SIR23 addendum's own "Rollout" section named for this item
+  in advance; flipped here because it genuinely passes once `Assign`
+  works (confirmed by running the test, not assumed) — this crate's own
+  `[0.1.3]` entry above already predicted exactly this: "once item 2
+  lands and binds `v` to an actual `List(1,2,3)`, it will already print
+  correctly."
+
+One more case, `a_worksheet_program_defines_then_differentiates`
+(`H(y) := DIF(SIN(t), t); H(0)` → `H, COS(t)`), is now genuinely closer —
+`Define` truly registers `H` and `H(0)` truly dispatches — but still
+disagrees: the substituted body, `D(Sin(t), t)`, still needs `DIF`/`SIN`
+folding (item 3, not part of this PR). It stays `known_bug`, with its
+reason text corrected in place to say so (the ORIGINAL reason, "Define
+never registers H," is no longer true).
+
+The remaining 7 `known_bug` cases (`dif_differentiates_a_power`,
+`dif_of_sin_gives_cos`, `a_worksheet_program_defines_then_differentiates`,
+`int_integrates_a_symbol`, `sin_of_zero`, `cos_of_zero`,
+`sqrt_of_a_perfect_square`) stay `known_bug`, all blocked purely by the
+calculus/elementary-function evaluation gap (item 3, not part of any PR
+so far).
+
+Verified no regression: `cargo test -p derive-to-semantic-ir` (full
+suite, including `tests/oracle.rs`) still passes; a genuine
+revert-and-confirm (temporarily restoring `semantic-ir-to-javascript`'s
+pre-item-2 inert behavior) makes exactly these 6 cases fail again with
+the documented old output, confirming the fix — not just the flag flip —
+is what makes them pass.
+
 ## [0.1.3] - 2026-07-22
 
 ### Fixed (upstream — `semantic-ir-to-javascript` 0.50.0, not this crate's own lowering)

--- a/code/packages/rust/derive-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/derive-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive-to-semantic-ir"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Derive CST → narrow-waist Semantic IR (SIR23 symbolic/pattern domain, Stream B). Third frontend to target SIR23, sibling to wolfram-to-semantic-ir and macsyma-to-semantic-ir."
 

--- a/code/packages/rust/derive-to-semantic-ir/tests/oracle.rs
+++ b/code/packages/rust/derive-to-semantic-ir/tests/oracle.rs
@@ -149,6 +149,39 @@
 //! call out that the display half is now resolved and only the
 //! evaluation half remains.
 //!
+//! ## A third finding: held-form execution (`Assign`/`Define`/`If`) + user-
+//! function dispatch — FIXED by a LATER PR (SIR23 addendum, item 2 of 4)
+//!
+//! The two findings above were written down when only items 1 and 4 had
+//! landed. A later PR lands item 2: `semantic-ir-to-javascript`'s
+//! `Symbolic` IIFE gains a `symEnv` `Map` (one per compiled program's
+//! `node` process, mirroring `symbolic-vm::BaseBackend.env`), real
+//! `Assign`/`Define`/`If` handlers (ported from `handlers.rs`'s
+//! `assign_handler`/`define_handler`/`if_handler`), a `Symbol` self-loop
+//! guard in `evalTerm` (`eval_symbol`'s own "`x := x` would recurse
+//! forever without this"), and user-function dispatch (`vm.rs::
+//! apply_user_function`'s port — zip params against call args by
+//! position, substitute into the body, re-evaluate). See that crate's own
+//! `CHANGELOG.md` for the fix itself.
+//!
+//! This closes the `Assign`/`Define`/`If` half of the "dominant finding"
+//! above for every `CORPUS` entry that needs ONLY that half (not also
+//! `DIF`/`INT`/`SIN`/`COS`/`SQRT`, which stay item 3's job): 6 more cases
+//! flip to `known_bug: None` below — the 5 the SIR23 addendum's own
+//! "Rollout" section named in advance
+//! (`variable_assignment_and_later_reference`,
+//! `single_param_function_definition_and_call`,
+//! `multi_param_function_definition_and_call`, `if_true_branch`,
+//! `if_false_branch`), plus one more confirmed by actually running this
+//! file's own oracle test rather than assumed from that count —
+//! `vector_assignment_persists_across_statements` — which this crate's
+//! own `[0.1.3]` `CHANGELOG.md` entry already predicted would flip "once
+//! item 2 lands." One more case, `a_worksheet_program_defines_then_
+//! differentiates`, is now genuinely closer (`Define` truly registers `H`
+//! and `H(0)` truly dispatches) but still disagrees — the substituted
+//! body still needs `DIF`/`SIN` folding (item 3) — so it stays
+//! `known_bug`, with its reason text corrected to say so.
+//!
 //! ## Corpus
 //!
 //! Mirrors `j-to-semantic-ir/tests/oracle.rs`'s own breadth target,
@@ -164,16 +197,17 @@
 //! fold); vectors and matrices as D-5 structural `List` data (flat,
 //! singleton, elementwise-evaluated, 2×2, and 3-row/1-column shapes); a
 //! free-symbol additive-identity simplification; free-symbol negation and
-//! equation display; and bare integer/float/symbol atoms. As of item 4
-//! (this PR), 25 of the 38 cases are `known_bug: None` — the bare atoms
-//! (never needed evaluation), every case item 1's arithmetic/comparison/
-//! logic folding alone already flipped, and the 7 cases this PR's own
-//! `SIR_DISPLAY_DERIVE` flips (`negation_of_a_free_symbol`,
+//! equation display; and bare integer/float/symbol atoms. As of item 2
+//! (the latest-landed PR), 31 of the 38 cases are `known_bug: None` — the
+//! bare atoms (never needed evaluation), every case item 1's arithmetic/
+//! comparison/logic folding alone already flipped, the 7 cases item 4's
+//! `SIR_DISPLAY_DERIVE` flipped (`negation_of_a_free_symbol`,
 //! `equation_with_a_free_variable_stays_symbolic`, the three flat/
-//! elementwise `List` cases, and the two matrix cases). The remaining 13
-//! stay `known_bug`, all blocked purely by the held-form/calculus
-//! evaluation gap (items 2/3, not part of this PR) — see each entry's own
-//! `known_bug` reason.
+//! elementwise `List` cases, and the two matrix cases), and the 6 cases
+//! item 2's held-form execution + user-function dispatch flips (see "A
+//! third finding" above). The remaining 7 stay `known_bug`, all blocked
+//! purely by the calculus/elementary-function evaluation gap (item 3, not
+//! part of any PR so far) — see each entry's own `known_bug` reason.
 
 use std::fs::OpenOptions;
 use std::io::Write as _;
@@ -343,24 +377,30 @@ const CORPUS: &[Case] = &[
         name: "variable_assignment_and_later_reference",
         source: "x := 5\nx + 1\n",
         expected: "5\n6",
-        known_bug: Some(
-            "Evaluation gap (module doc): Assign is a HELD form on the ground-truth side (binds x, \
-             displays its value, 5); the compiled side's Assign(x, 5) is inert data -- no binding \
-             ever happens -- so the SECOND statement's x is never substituted: it compiles to a bare \
-             Add(x, 1) term, still referencing the raw, unbound symbol x, never 6.",
-        ),
+        // Flipped by the SIR23 addendum's item 2 (`semantic-ir-to-
+        // javascript`'s `symEnv` + `assignHandler`): `Assign` now really
+        // binds `x` in the shared environment and returns the bound
+        // value, so the SECOND statement's `x` resolves to `5` before
+        // `Add` folds `5 + 1` to `6` (item 1's own arithmetic folding,
+        // unchanged, does the rest).
+        known_bug: None,
     },
     Case {
         name: "vector_assignment_persists_across_statements",
         source: "v := [1, 2, 3]\nv\n",
         expected: "[1, 2, 3]\n[1, 2, 3]",
-        known_bug: Some(
-            "Evaluation gap ONLY now (module doc; display half fixed by item 4): the compiled side's \
-             Assign still never binds v (item 2, not part of this PR), so the second statement still \
-             compiles to the bare, still-unbound symbol v, not the list -- once item 2 lands and binds \
-             v to an actual List(1,2,3), it will already print correctly as \"[1, 2, 3]\" via this PR's \
-             own SIR_DISPLAY_DERIVE List bracket convention.",
-        ),
+        // Flipped by item 2 -- NOT listed in the SIR23 addendum's own
+        // "Rollout" section's item 2 bullet (which names only 5 cases),
+        // but verified here to flip as a genuine, confirmed side effect:
+        // `Assign` now binds `v` to an actual `List(1, 2, 3)` term (this
+        // crate's own [0.1.3] `CHANGELOG.md` entry predicted exactly
+        // this: "once item 2 lands and binds v to an actual List(1,2,3),
+        // it will already print correctly"), and item 4's own
+        // `SIR_DISPLAY_DERIVE` bracket convention (already shipped)
+        // renders it as "[1, 2, 3]" with no further work needed. Run and
+        // confirmed via `cargo test -p derive-to-semantic-ir --test
+        // oracle -- --nocapture`, not assumed from the addendum's count.
+        known_bug: None,
     },
 
     // --- User-defined functions: definition echoes the bare name (MA07
@@ -370,21 +410,27 @@ const CORPUS: &[Case] = &[
         name: "single_param_function_definition_and_call",
         source: "F(x) := x*x\nF(5)\n",
         expected: "F\n25",
-        known_bug: Some(
-            "Evaluation gap (module doc): Define is a HELD form on the ground-truth side (registers \
-             F, displays its bare name, \"F\"); the compiled side's Define(...) is inert data -- no \
-             registration ever happens -- so the SECOND statement compiles to a bare, never-\
-             dispatched F(5) call term, not 25.",
-        ),
+        // Flipped by item 2: `Define` now stores the whole `Define(F,
+        // List(x), Mul(x, x))` record under `F` and returns the bare
+        // `Symbol("F")` (never the record itself, so `F` displays as
+        // itself, matching the ground-truth worksheet echo); `F(5)`'s
+        // user-function dispatch zips `x -> 5`, substitutes into the
+        // body (`substituteSymbols`, a bare-symbol port of
+        // `symbolic-vm::vm::substitute`, not a reuse of the pattern-
+        // matching engine's `substituteTerm` -- see that function's own
+        // doc comment in `runtime.rs`), and re-evaluates `Mul(5, 5)` to
+        // `25` via item 1's already-shipped `Mul` folding.
+        known_bug: None,
     },
     Case {
         name: "multi_param_function_definition_and_call",
         source: "G(a, b) := a + b\nG(3, 4)\n",
         expected: "G\n7",
-        known_bug: Some(
-            "Evaluation gap (module doc): same root cause as single_param_function_definition_and_\
-             call -- Define never registers G, so G(3, 4) never dispatches to 7.",
-        ),
+        // Flipped by item 2 -- same mechanism as
+        // single_param_function_definition_and_call, params zipped by
+        // POSITION (`a -> 3, b -> 4`), substituted into `Add(a, b)`, and
+        // re-evaluated to `7`.
+        known_bug: None,
     },
 
     // --- DIF / INT: the shared calculus handlers (D-4, MA07 §2/§5). ---
@@ -421,8 +467,16 @@ const CORPUS: &[Case] = &[
         source: "H(y) := DIF(SIN(t), t)\nH(0)\n",
         expected: "H\nCOS(t)",
         known_bug: Some(
-            "Evaluation gap (module doc): Define never registers H, so H(0) never dispatches and \
-             never differentiates -- it compiles to a bare, never-called H(0) term.",
+            "Evaluation gap ONLY now (module doc; the Define/dispatch half is fixed by item 2): \
+             Define now genuinely registers H and H(0) now genuinely dispatches -- substituting \
+             y -> 0 into the body, which never mentions y, so substitution is a no-op -- but the \
+             substituted body, D(Sin(t), t), still never differentiates (item 3, not part of this \
+             PR): it compiles to and evaluates as the still-unevaluated term D(Sin(t), t), not \
+             COS(t). Confirmed by direct inspection: this is no longer \"H(0) never dispatches\" \
+             (the ORIGINAL reason this case was written down for) -- it is now purely the same \
+             DIF/SIN calculus gap dif_of_sin_gives_cos documents, once item 3 lands and folds \
+             D(Sin(t), t) to Cos(t), this PR's own SIR_DISPLAY_DERIVE case-bridge will already \
+             render it as \"COS(t)\".",
         ),
     },
     Case {
@@ -442,20 +496,19 @@ const CORPUS: &[Case] = &[
         name: "if_true_branch",
         source: "IF(1 > 0, 42, 0)\n",
         expected: "42",
-        known_bug: Some(
-            "Evaluation gap (module doc): compiles to a bare If(Greater(1, 0), 42, 0) term -- IF is \
-             a HELD form on the ground-truth side (evaluates the condition, then selects a branch); \
-             the compiled side never evaluates the condition or selects anything.",
-        ),
+        // Flipped by item 2 (`ifHandler`): the condition `Greater(1, 0)`
+        // is evaluated (item 1's comparison folding, unchanged) to the
+        // `True` symbol, which now genuinely selects and evaluates the
+        // 2nd arg (`42`) instead of leaving the whole `If(...)` term inert.
+        known_bug: None,
     },
     Case {
         name: "if_false_branch",
         source: "IF(1 > 2, 42, 99)\n",
         expected: "99",
-        known_bug: Some(
-            "Evaluation gap (module doc): same root cause as if_true_branch -- compiles to a bare \
-             If(Greater(1, 2), 42, 99) term, never selects a branch.",
-        ),
+        // Flipped by item 2 -- same mechanism as if_true_branch, the
+        // condition folds to `False`, selecting the 3-arg form's 3rd arg.
+        known_bug: None,
     },
 
     // --- Comparisons: fold to the symbol True/False on the ground-truth

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,101 @@
 # Changelog
 
+## 0.51.2 — held-form execution: `Assign`/`Define`/`If` + user-function dispatch (SIR23 addendum, item 2 of 4)
+
+Item 2 of the 4-item rollout described by `SIR23-symbolic-pattern-
+semantic-ir.md`'s own "Addendum — SIR23 symbolic evaluator + per-language
+display convention" section. Item 1 (`Symbolic.evalTerm`'s arithmetic/
+comparison/logic folding, `[0.49.0]` below) declared the three
+`HELD_HEADS` (`Assign`/`Define`/`If`) but wired no handler for any of
+them, so they stayed inert data — `x := 5` never bound `x`, `F(x) :=
+x*x` never registered `F`, `IF(cond, a, b)` never selected a branch.
+This item makes them real.
+
+### Added
+
+- **`runtime.rs`: a `symEnv` `Map`**, declared once inside the `Symbolic`
+  IIFE's closure (one compiled program's `node` process = one flat
+  top-level session), porting `symbolic-vm::BaseBackend.env` — see the
+  spec addendum's "Environment / held-form execution model".
+- **`Symbolic.evalTerm`'s `Symbol` leaf case**: looks the name up in
+  `symEnv`; unbound stays unchanged (`SymbolicBackend::on_unresolved`'s
+  pass-through policy); bound checks a self-loop guard (`termEquals`
+  against the original symbol — `x := x` would recurse forever without
+  it, mirroring `eval_symbol`'s own comment) before recursively
+  evaluating the binding.
+- **`assignHandler`/`defineHandler`/`ifHandler`**, registered in a new
+  `HELD_HANDLERS` map consulted by `evalApply` before the generic
+  arg-evaluated `HANDLERS` path (held forms need the RAW args plus
+  `depth`/`evalTerm` access — a different shape than the item-1
+  handlers). Direct ports of `handlers.rs::assign_handler`/
+  `define_handler`/`if_handler`: `Assign` evaluates the RHS, binds, and
+  returns the value; `Define` stores the whole `Define(name, params,
+  body)` record and returns the bare `Symbol(name)` (never the record —
+  why `F(x) := x*x` displays as `"F"`, not `"Define(...)"`); `If`
+  evaluates the condition and branches on the `True`/`False` symbol
+  (2- or 3-arg form), rebuilding the unevaluated term if the condition
+  doesn't resolve to a boolean.
+- **User-function dispatch** in `evalApply`'s "no handler matched"
+  fallthrough: if the evaluated head is a `Symbol` bound in `symEnv` to a
+  stored `Define` record, zips `params` against the (already
+  applicative-order-evaluated) call args by position — a non-`Symbol`
+  param entry is silently dropped from the zip, and an arity mismatch
+  (post-drop) leaves the call unevaluated, both mirroring
+  `apply_user_function`'s exact `filter_map`/`None`-return quirks, not
+  an "improved" version of them — then substitutes and re-`evalTerm`s
+  the result. A direct port of `vm.rs::VM::eval_apply`'s step 4 /
+  `apply_user_function`.
+- **`substituteSymbols`**: a new, from-scratch port of
+  `symbolic-vm::vm::substitute` (a bare-`Symbol`-matching substitution),
+  used for the user-function-body substitution above. **Deliberately NOT
+  a reuse of the existing `substituteTerm`**, despite the spec addendum's
+  own "Genuine, one-place reuse" note suggesting exactly that reuse:
+  `substituteTerm` only substitutes at `Pattern(name, inner)`-wrapped
+  template nodes (the shape a `SymRule`'s RHS uses to reference a bound
+  pattern variable — confirmed by this crate's own `tests/
+  sir23_symbolic.rs`), while a `Define`'s body references its parameters
+  as ORDINARY bare `Symbol` nodes (confirmed directly in
+  `derive-to-semantic-ir::lower`'s own module doc: "never constructs
+  `SymPatternBlank`/`SymPatternNamed`/..."). Calling `substituteTerm` on
+  such a body would silently substitute nothing at all. See that
+  function's own doc comment in `runtime.rs` for the full explanation —
+  this is a corrected finding relative to the spec addendum's own
+  assumption, not an oversight.
+- **`tests/sir23_symbolic.rs`: 6 new integration tests**
+  (`assign_binds_and_reads_back_in_a_later_statement`,
+  `single_param_define_then_call_dispatches_by_substitution`,
+  `multi_param_define_then_call_dispatches_by_position`,
+  `arity_mismatch_leaves_the_user_function_call_unevaluated`,
+  `if_true_and_false_branches_select_the_right_arm`,
+  `self_referential_assign_does_not_infinite_loop`), hand-building the
+  SIR23 nodes directly and running the result through an actual `node`
+  process, mirroring this file's own established convention.
+- Every change here is **additive only**: the existing `HANDLERS` map,
+  every item-1 arithmetic/comparison/logic handler, `MAX_EVAL_DEPTH`'s
+  threading, and the pattern-matching engine (`matchPattern`/
+  `substituteTerm`/`replaceAllTerm`/`replaceRepeatedTerm`) are all
+  unchanged. Confirmed no regression: this crate's own full test suite
+  (265 tests) and every downstream Stream B frontend's
+  (`derive-to-semantic-ir`, `reduce-to-semantic-ir`, `maple-to-
+  semantic-ir`, `wolfram-to-semantic-ir`, `macsyma-to-semantic-ir`,
+  `maxima-to-semantic-ir`) still pass unchanged. Also confirmed via a
+  genuine revert-and-confirm: temporarily emptying `HELD_HANDLERS` and
+  restoring `evalTerm`'s `Symbol` case to its pre-item-2 unconditional
+  pass-through makes exactly the 6 newly-passing `derive-to-semantic-ir`
+  oracle cases (and the 6 matching new unit tests above) fail again, with
+  the OLD inert output (`"Assign(x, 5)\nAdd(x, 1)"`, etc.) — restoring
+  the change makes them pass again.
+- **`derive-to-semantic-ir/tests/oracle.rs`**: 6 cases flip from
+  `known_bug: Some(...)` to `known_bug: None` —
+  `variable_assignment_and_later_reference`,
+  `single_param_function_definition_and_call`,
+  `multi_param_function_definition_and_call`, `if_true_branch`,
+  `if_false_branch` (the 5 the SIR23 addendum's own "Rollout" section
+  named), plus `vector_assignment_persists_across_statements` (confirmed
+  by actually running the oracle test, not assumed — that crate's own
+  `[0.1.3]` `CHANGELOG.md` entry already predicted this one would flip
+  once this item landed). See that crate's own `CHANGELOG.md`.
+
 ## 0.51.1 — `matmul` normalizes its operands through `toArrayValue` (task #111)
 
 Found by `scilab-to-semantic-ir/tests/oracle.rs`'s oracle/golden test suite

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.51.1"
+version = "0.51.2"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -3404,6 +3404,65 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
       return template;
     }
 
+    // ── substituteSymbols (symbolic-vm::vm::substitute port) ─────────
+    //
+    // SIR23 addendum item 2's own "Genuine, one-place reuse" note
+    // proposed reusing `substituteTerm` above, unchanged, for
+    // user-function-body substitution (see "Function dispatch" in
+    // `code/specs/SIR23-symbolic-pattern-semantic-ir.md`'s addendum).
+    // Confirmed, by direct inspection of both this file and the
+    // frontends' own lowering, that this does not typecheck against the
+    // ACTUAL data shapes involved, so this port deliberately does NOT
+    // reuse `substituteTerm`:
+    //
+    //   - `substituteTerm`'s only substitution site is `isPattern(
+    //     template)` — a template node shaped `Apply(Symbol("Pattern"),
+    //     [Symbol(name), inner])`. That shape is how a `SymRule`'s RHS
+    //     references a bound PATTERN variable — confirmed by this crate's
+    //     own `tests/sir23_symbolic.rs`
+    //     (`replace_repeated_reduces_nested_add_zero_to_bare_symbol`
+    //     reuses the literal SAME `named("x", blank())` node for both a
+    //     rule's `lhs` and its `rhs`). A bare `Symbol` template is passed
+    //     straight through unchanged by `substituteTerm` — by design, for
+    //     that domain: a bare symbol never happens to be a stand-in for a
+    //     pattern variable in a rewrite rule's RHS.
+    //   - A `Define(name, List(params...), body)`'s `body`, by contrast,
+    //     references its parameters as ORDINARY bare `Symbol` nodes —
+    //     confirmed directly in `derive-to-semantic-ir::lower`'s own
+    //     module doc ("this frontend ... never constructs
+    //     `SymPatternBlank`/`SymPatternNamed`/..."): `F(x) := x*x` lowers
+    //     to `Define(F, List(x), Mul(Symbol(x), Symbol(x)))`, a body with
+    //     no `Pattern`-wrapping anywhere. Calling `substituteTerm` on it
+    //     would substitute nothing at all — a silent no-op, not a loud
+    //     failure — since `isPattern` never matches a bare `Symbol`.
+    //
+    // This is instead a direct, from-scratch port of the actual function
+    // `apply_user_function` calls for this purpose:
+    // `symbolic-vm/src/vm.rs::substitute` (a free function, not a method
+    // on `Handler`/`Backend`) — match a bare `Symbol` directly against
+    // `bindings`, recurse into `head`/`args` for a compound term, pass
+    // every literal through unchanged. Not depth-capped, for the same
+    // reason `substituteTerm` above isn't: the tree being walked here is
+    // `body`, an author-written (compiled-in) function-definition body —
+    // bounded by *source* nesting, not by arbitrarily-deep *runtime* data
+    // (the concern `walkOnce`/`replaceRepeatedTerm`'s `MAX_TERM_DEPTH`
+    // guards against) — `args`' own depth is irrelevant here, since a
+    // bound parameter's value is spliced in by reference, never itself
+    // walked by this function.
+    function substituteSymbols(node, bindings) {
+      if (node.kind === "symbol") {
+        const replacement = bindings.get(node.name);
+        return replacement !== undefined ? replacement : node;
+      }
+      if (node.kind === "apply") {
+        return applyTerm(
+          substituteSymbols(node.head, bindings),
+          node.args.map((a) => substituteSymbols(a, bindings)),
+        );
+      }
+      return node;
+    }
+
     function applyRuleTerm(rewriteRule, expr) {
       if (!isRule(rewriteRule)) {
         throw new TypeError("Symbolic.applyRule: expected Rule/RuleDelayed");
@@ -3548,32 +3607,34 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     // `Handler` is the right shape, not a `SymRule` whose RHS closure
     // just happens to compute a sum.
     //
-    // ## Scope: item 1 of 4 (see the addendum's "Crate layout and
+    // ## Scope: items 1-2 of 4 (see the addendum's "Crate layout and
     // rollout (one item = one PR)" section)
     //
-    // This item wires up ONLY arithmetic (`Add`/`Sub`/`Mul`/`Div`/`Pow`/
-    // `Neg`/`Inv`/`Abs`), comparison (`Equal`/`NotEqual`/`Less`/
-    // `Greater`/`LessEqual`/`GreaterEqual`), and logic (`And`/`Or`/
-    // `Not`) folding:
+    // Item 1 wired up arithmetic (`Add`/`Sub`/`Mul`/`Div`/`Pow`/`Neg`/
+    // `Inv`/`Abs`), comparison (`Equal`/`NotEqual`/`Less`/`Greater`/
+    // `LessEqual`/`GreaterEqual`), and logic (`And`/`Or`/`Not`) folding.
+    // Item 2 (this addendum) adds the environment (`symEnv` above) and
+    // real handlers for the three `HELD_HEADS` members plus user-function
+    // dispatch:
     //
-    //   item 1 (this PR)  — arithmetic / comparison / logic folding
-    //   item 2 (future)   — environment + Assign/Define/If + user functions
-    //   item 3 (future)   — calculus / elementary-function handlers
-    //   item 4 (future)   — Derive's own SIR23 display convention
+    //   item 1 (shipped) — arithmetic / comparison / logic folding
+    //   item 2 (this PR) — environment + Assign/Define/If + user functions
+    //   item 3 (future)  — calculus / elementary-function handlers
+    //   item 4 (shipped) — Derive's own SIR23 display convention
     //
-    // `HELD_HEADS` is declared now — the held-vs-evaluated ARGUMENT
-    // treatment below is exercised starting this item — but item 1 wires
-    // up NO handler for any of its three members. `Assign`/`Define`/`If`
-    // therefore always fall through to "no handler matched" below, which
+    // `HELD_HEADS` was declared by item 1 — the held-vs-evaluated
+    // ARGUMENT treatment below was exercised starting then — but item 1
+    // wired up NO handler for any of its three members, so `Assign`/
+    // `Define`/`If` always fell through to "no handler matched", which
     // rebuilds the term from the evaluated head and the ORIGINAL,
     // unevaluated args: byte-for-byte the same inert `Apply` shape
-    // today's bare `SymApply` codegen already produces. Concretely:
-    // `Assign(x, 5+1)` must NOT fold `5 + 1` to `6` in this item, even
-    // though `Add`-folding is fully wired elsewhere in the very same
-    // expression — held means held, regardless of what handlers exist
-    // for other heads. Real execution of these three (a binding
-    // environment, a self-loop guard, user-function dispatch reusing
-    // `substituteTerm` above) is item 2's job.
+    // today's bare `SymApply` codegen already produces. Item 2 (below,
+    // see `HELD_HANDLERS`) replaces that fallthrough with real execution
+    // for these three: a binding environment, a self-loop guard, and
+    // user-function dispatch (`substituteSymbols`, not a reuse of
+    // `substituteTerm` — see that function's own doc comment for exactly
+    // why the addendum's suggested reuse doesn't typecheck against the
+    // real data shapes involved).
     //
     // `List` needs, and per the addendum's own handler table gets,
     // forever, NO handler at all: applicative-order argument evaluation
@@ -3630,6 +3691,27 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     // depth-limit sentinel rather than crashing `node`, on a default,
     // un-widened stack.
     const MAX_EVAL_DEPTH = 2000;
+
+    // ── environment / held-form execution (SIR23 addendum item 2 of 4) ──
+    //
+    // `symEnv` is the JS port of `symbolic-vm`'s `BaseBackend.env: HashMap
+    // <String, IRNode>` (`code/packages/rust/symbolic-vm/src/backend.rs`)
+    // — see `code/specs/SIR23-symbolic-pattern-semantic-ir.md`'s addendum,
+    // "Environment / held-form execution model". A plain `Map`, declared
+    // once here (module scope inside this IIFE, which itself runs exactly
+    // once per compiled program's `node` process), living for the whole
+    // program's execution — one flat top-level script/session, exactly
+    // matching one `BaseBackend` instance per `symbolic_vm::VM::new()`.
+    // Not the OOP/closure machinery elsewhere in this file
+    // (`SirInstance`/`classVarBag`/`currentSelf`) — that models host JS
+    // object identity for SIR's class-instance-variable domain, a
+    // completely different value space; reusing it here would be a
+    // type-confusion hazard, not a simplification (per the addendum's own
+    // note). Every one of the 5 SIR23 frontends' currently-implemented
+    // grammars is single-session/flat (no nested `With`/`Module`/`Block`
+    // local scope reaches `SymbolicBackend` today), so one flat `Map` is a
+    // faithful, not a simplified, port of `BaseBackend.env`.
+    const symEnv = new Map();
 
     // ── numeric tower (handlers.rs::Numeric port) ───────────────────
     //
@@ -4036,15 +4118,17 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
       return applyTerm(head, args);
     }
 
-    // Per-head dispatch table (item 1's scope only — arithmetic /
-    // comparison / logic). A `Map`, not a plain object literal:
-    // `name` is derived from a compiled program's OWN term data (any
-    // source identifier can end up as a SymApply head, e.g. a user
-    // writing a call literally named `__proto__`), and a plain object's
-    // `obj[name]` lookup walks the prototype chain — `Map.prototype.get`
-    // has no such hazard. Mirrors this same file's existing preference
-    // for `Map` over object literals for name-keyed lookups (see
-    // `bindingsEmpty` above).
+    // Per-head dispatch table (arg-evaluated heads only — arithmetic /
+    // comparison / logic; see `HELD_HANDLERS` below for the three
+    // `HELD_HEADS` members, whose handlers need the RAW args plus
+    // `depth`/`evalTerm` access instead, not this shape). A `Map`, not a
+    // plain object literal: `name` is derived from a compiled program's
+    // OWN term data (any source identifier can end up as a SymApply
+    // head, e.g. a user writing a call literally named `__proto__`), and
+    // a plain object's `obj[name]` lookup walks the prototype chain —
+    // `Map.prototype.get` has no such hazard. Mirrors this same file's
+    // existing preference for `Map` over object literals for name-keyed
+    // lookups (see `bindingsEmpty` above).
     const HANDLERS = new Map([
       ["Add", addHandler],
       ["Sub", subHandler],
@@ -4065,34 +4149,171 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
       ["Not", notHandler],
     ]);
 
+    // ── held-form handlers (Assign / Define / If) — SIR23 addendum item 2
+    //
+    // Direct ports of `handlers.rs::assign_handler`/`define_handler`/
+    // `if_handler` (search that file for "Assign / Define -- binding
+    // forms" and "If handler -- held head"). Unlike the arg-evaluated
+    // `HANDLERS` above, each of these receives the ORIGINAL, unevaluated
+    // `args` (per `HELD_HEADS`) plus `depth`, since each decides FOR
+    // ITSELF what (if anything) to evaluate and how — exactly why
+    // `handlers.rs`'s own `Handler` type is `Fn(&mut VM, IRApply) ->
+    // IRNode`, giving every handler potential access to `vm.eval`; only
+    // the held ones actually use it.
+
+    // `assign_handler`'s port: `x := rhs` evaluates the RHS, binds
+    // `name -> value` in `symEnv`, returns `value`. Wrong arity (not
+    // exactly 2 args) leaves the call unevaluated, mirroring
+    // `binary_args`'s `None` early-return; a non-Symbol lhs panics in the
+    // Rust reference (`panic!("Assign lhs must be a symbol, ...")`),
+    // ported here as a thrown `TypeError` — matching this file's own
+    // existing convention of throwing on a domain error no oracle case
+    // can even construct (e.g. `divHandler`'s "division by zero" above).
+    function assignHandler(head, args, depth) {
+      if (args.length !== 2) { return applyTerm(head, args); }
+      const [lhs, rhs] = args;
+      if (lhs.kind !== "symbol") {
+        throw new TypeError("Symbolic.evalTerm: Assign lhs must be a symbol, got " + lhs.kind);
+      }
+      const value = evalTerm(rhs, depth + 1);
+      if (isDepthLimitError(value)) { return value; }
+      symEnv.set(lhs.name, value);
+      return value;
+    }
+
+    // `define_handler`'s port: `F(params) := body` stores the WHOLE
+    // `Define(name, List(params...), body)` record under `name` (so the
+    // user-function dispatch step in `evalApply` below can find it), and
+    // returns the bare `Symbol(name)` — NOT the stored record — which is
+    // why a correctly-evaluated `F(x) := x*x` displays as `"F"`, never as
+    // `"Define(...)"` (`handlers.rs::define_handler`'s own comment).
+    // Wrong arity (not exactly 3 args) leaves the call unevaluated; a
+    // non-Symbol name panics in the Rust reference, ported as a thrown
+    // `TypeError` (same convention as `assignHandler` above).
+    function defineHandler(head, args) {
+      if (args.length !== 3) { return applyTerm(head, args); }
+      const nameTerm = args[0];
+      if (nameTerm.kind !== "symbol") {
+        throw new TypeError("Symbolic.evalTerm: Define name must be a symbol, got " + nameTerm.kind);
+      }
+      symEnv.set(nameTerm.name, applyTerm(head, args));
+      return symTerm(nameTerm.name);
+    }
+
+    // `if_handler`'s port: evaluate the condition; branch on the
+    // resulting `True`/`False` SYMBOL (2- or 3-arg form, matching
+    // `symbolic-vm`'s own arity check — `args.length < 2 || > 3` panics
+    // in the Rust reference, ported as a thrown `RangeError`, same
+    // convention as above). If the condition doesn't resolve to a
+    // boolean symbol, rebuild the unevaluated `If(...)` term with the
+    // condition's own (partially-)evaluated form spliced in — matches
+    // `if_handler`'s own "predicate didn't reduce -- rebuild the
+    // expression" branch exactly, free-variable-safe.
+    function ifHandler(head, args, depth) {
+      if (args.length < 2 || args.length > 3) {
+        throw new RangeError("Symbolic.evalTerm: If expects 2 or 3 arguments, got " + args.length);
+      }
+      const predicate = evalTerm(args[0], depth + 1);
+      if (isDepthLimitError(predicate)) { return predicate; }
+      const t = isTruthy(predicate);
+      if (t === true) { return evalTerm(args[1], depth + 1); }
+      if (t === false) {
+        return args.length === 3 ? evalTerm(args[2], depth + 1) : symTerm("False");
+      }
+      return applyTerm(head, [predicate].concat(args.slice(1)));
+    }
+
+    const HELD_HANDLERS = new Map([
+      ["Assign", assignHandler],
+      ["Define", defineHandler],
+      ["If", ifHandler],
+    ]);
+
+    // `is_define_record`'s port: true iff `node` is a stored
+    // `Apply(Symbol("Define"), ...)` binding.
+    function isDefineRecord(node) {
+      return node.kind === "apply" && node.head.kind === "symbol" && node.head.name === "Define";
+    }
+
+    // `apply_user_function`'s port, exactly: `definition` is the stored
+    // `Define(name, List(params...), body)` record; `args` are the
+    // ALREADY-evaluated (applicative-order) call arguments. Zips
+    // `params` against `args` BY POSITION; a non-`Symbol` param entry is
+    // silently DROPPED from the zip (mirrors the Rust reference's own
+    // `filter_map` over `params_ir`'s elements exactly — a deliberate
+    // port of that quirk, not an improvement on it, per this task's own
+    // "don't improvise different behavior" constraint). Arity mismatch
+    // (post-drop param count != arg count) or a malformed record (not
+    // exactly 3 fields, or a middle field that isn't a `List(...)`)
+    // returns `null` — "leave the call unevaluated", mirroring the Rust
+    // reference's `Option<IRNode>` `None` exactly.
+    function applyUserFunction(definition, args) {
+      if (definition.args.length !== 3) { return null; }
+      const paramsTerm = definition.args[1];
+      const body = definition.args[2];
+      if (!(paramsTerm.kind === "apply" && paramsTerm.head.kind === "symbol" && paramsTerm.head.name === "List")) {
+        return null;
+      }
+      const paramNames = [];
+      for (const p of paramsTerm.args) {
+        if (p.kind === "symbol") { paramNames.push(p.name); }
+        // else: silently dropped, matching `apply_user_function`'s own
+        // `filter_map` over non-Symbol param entries.
+      }
+      if (paramNames.length !== args.length) { return null; } // arity mismatch
+      const bindings = new Map();
+      for (let i = 0; i < paramNames.length; i++) {
+        bindings.set(paramNames[i], args[i]);
+      }
+      return substituteSymbols(body, bindings);
+    }
+
     // `Apply(head, args)`: evaluate `head` first (mirrors `eval_apply`'s
-    // own treatment of the head), then either hold `args` unevaluated
-    // (a `HELD_HEADS` member — item 1 has no handler for any of them, so
-    // this only matters for keeping their arguments byte-for-byte
-    // unevaluated, see the module doc above) or evaluate every arg in
-    // applicative order, then dispatch on the evaluated head's name
-    // against `HANDLERS`. No handler matched (every held head in this
-    // item, plus any other unknown/future head, plus `List` forever) ->
-    // rebuild the term from the evaluated head and the args just
-    // computed — the single "arg-evaluated, pass-through" policy that
+    // own treatment of the head), then either dispatch a HELD form
+    // (`Assign`/`Define`/`If` — args passed RAW, see `HELD_HANDLERS`
+    // above) or evaluate every arg in applicative order and dispatch on
+    // the evaluated head's name against `HANDLERS`. If no core handler
+    // matches, check whether the evaluated head is a `Symbol` bound in
+    // `symEnv` to a stored `Define` record (user-function dispatch,
+    // `vm.rs::eval_apply` step 4); if so, substitute and re-`evalTerm`
+    // the result. Otherwise — every held head with no handler (can't
+    // happen post item 2, since all three now have one; kept as a
+    // defensive fallback exactly mirroring `on_unknown_head`'s
+    // pass-through policy), any other unknown/future head, plus `List`
+    // forever — rebuild the term from the evaluated head and the args
+    // just computed, the single "arg-evaluated, pass-through" policy that
     // makes `List(Add(1,1), Mul(2,3))` fold its elements "for free".
     function evalApply(term, depth) {
       const evaluatedHead = evalTerm(term.head, depth + 1);
       if (isDepthLimitError(evaluatedHead)) { return evaluatedHead; }
       const name = headName(evaluatedHead);
-      let args;
+
       if (HELD_HEADS.has(name)) {
-        args = term.args; // ORIGINAL, unevaluated -- see module doc above
-      } else {
-        args = [];
-        for (const a of term.args) {
-          const evaluated = evalTerm(a, depth + 1);
-          if (isDepthLimitError(evaluated)) { return evaluated; }
-          args.push(evaluated);
+        const heldHandler = HELD_HANDLERS.get(name);
+        return heldHandler !== undefined
+          ? heldHandler(evaluatedHead, term.args, depth) // RAW args -- held
+          : applyTerm(evaluatedHead, term.args);
+      }
+
+      const args = [];
+      for (const a of term.args) {
+        const evaluated = evalTerm(a, depth + 1);
+        if (isDepthLimitError(evaluated)) { return evaluated; }
+        args.push(evaluated);
+      }
+
+      const handler = HANDLERS.get(name);
+      if (handler !== undefined) { return handler(evaluatedHead, args); }
+
+      if (evaluatedHead.kind === "symbol") {
+        const bound = symEnv.get(evaluatedHead.name);
+        if (bound !== undefined && isDefineRecord(bound)) {
+          const substituted = applyUserFunction(bound, args);
+          if (substituted !== null) { return evalTerm(substituted, depth + 1); }
         }
       }
-      const handler = HANDLERS.get(name);
-      return handler !== undefined ? handler(evaluatedHead, args) : applyTerm(evaluatedHead, args);
+
+      return applyTerm(evaluatedHead, args);
     }
 
     // `Symbolic.evalTerm(term, depth)` — the public entry point emitted
@@ -4105,16 +4326,35 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     // use (checked by the same, unmodified `isDepthLimitError`/
     // `Symbolic.unwrap`) when `MAX_EVAL_DEPTH` is exceeded.
     //
-    // A `Symbol`/`integer`/`rational`/`float`/`string` leaf: item 1 has
-    // no environment yet (no `Symbol` lookup — that is item 2's job), so
-    // every leaf, including a bare, unbound `Symbol`, is already its own
-    // fully-reduced value and is returned unchanged.
+    // A `Symbol` leaf (SIR23 addendum item 2): look it up in `symEnv`.
+    // Unbound -> pass through unchanged, mirroring
+    // `SymbolicBackend::on_unresolved`'s pass-through policy (the only
+    // policy any of these 5 frontends use — `StrictBackend`'s
+    // panic-on-unknown policy is not used by any of them). Bound -> a
+    // self-loop guard (`x := x` would recurse forever without it,
+    // `eval_symbol`'s own comment) via `termEquals` — reusing this
+    // file's existing structural-equality check (a freshly rebuilt term
+    // with the same shape must still count as "the same value" here,
+    // exactly like every other `termEquals` call site in this IIFE) —
+    // then recursively `evalTerm`s the binding.
+    //
+    // An `integer`/`rational`/`float`/`string` leaf is already its own
+    // fully-reduced value and is returned unchanged (unaffected by item
+    // 2 — only `Symbol` gained an environment lookup).
+    function evalSymbol(term, depth) {
+      const bound = symEnv.get(term.name);
+      if (bound === undefined) { return term; }
+      if (termEquals(bound, term)) { return term; }
+      return evalTerm(bound, depth + 1);
+    }
+
     function evalTerm(term, depth) {
       if (depth === undefined) { depth = 0; }
       if (depth > MAX_EVAL_DEPTH) {
         return { kind: "depth-limit", maxDepth: MAX_EVAL_DEPTH };
       }
       if (term.kind === "apply") { return evalApply(term, depth); }
+      if (term.kind === "symbol") { return evalSymbol(term, depth); }
       return term;
     }
 

--- a/code/packages/rust/semantic-ir-to-javascript/tests/sir23_symbolic.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/sir23_symbolic.rs
@@ -435,3 +435,250 @@ fn derive_display_on_a_deeply_nested_list_of_lists_truncates_at_the_same_depth_a
         );
     }
 }
+
+// ── SIR23 addendum item 2: held-form execution (Assign/Define/If) +
+// user-function dispatch — see `code/specs/SIR23-symbolic-pattern-
+// semantic-ir.md`'s addendum, "Environment / held-form execution model" /
+// "Function dispatch". These mirror the shape of `derive-to-semantic-ir/
+// tests/oracle.rs`'s own newly-`known_bug: None` cases
+// (`variable_assignment_and_later_reference`,
+// `single_param_function_definition_and_call`,
+// `multi_param_function_definition_and_call`, `if_true_branch`,
+// `if_false_branch`) but hand-build the SIR23 nodes directly (this
+// crate's own established convention, see this file's module doc),
+// rather than routing through `derive-to-semantic-ir`'s lowering.
+
+#[test]
+fn assign_binds_and_reads_back_in_a_later_statement() {
+    // x := 5; x + 1  -- the SAME environment (`symEnv`) is shared across
+    // every top-level statement in one compiled program (one `Symbolic`
+    // IIFE evaluation = one `node` process = one flat session).
+    let stmts = vec![
+        print(sym_apply(
+            sym("Assign"),
+            vec![
+                sym("x"),
+                Expr::IntLit {
+                    value: 5,
+                    span: sp(),
+                },
+            ],
+        )),
+        print(sym_apply(
+            sym("Add"),
+            vec![
+                sym("x"),
+                Expr::IntLit {
+                    value: 1,
+                    span: sp(),
+                },
+            ],
+        )),
+    ];
+    let module = module_with_main(
+        stmts,
+        Expr::IntLit {
+            value: 0,
+            span: sp(),
+        },
+        &[Feature::SymbolicExpr],
+    );
+    if let Some(stdout) = run_module(&module, "sym_assign_read_back") {
+        assert_eq!(stdout, "5\n6");
+    }
+}
+
+#[test]
+fn single_param_define_then_call_dispatches_by_substitution() {
+    // F(x) := x*x; F(5) -- Define echoes the bare name `F` (never the
+    // stored record, `define_handler`'s own documented invariant); the
+    // call zips `params` against the call's (already-evaluated) args by
+    // position, substitutes into `body`, and re-evaluates: x*x -> 5*5 -> 25.
+    let stmts = vec![
+        print(sym_apply(
+            sym("Define"),
+            vec![
+                sym("F"),
+                sym_apply(sym("List"), vec![sym("x")]),
+                sym_apply(sym("Mul"), vec![sym("x"), sym("x")]),
+            ],
+        )),
+        print(sym_apply(
+            sym("F"),
+            vec![Expr::IntLit {
+                value: 5,
+                span: sp(),
+            }],
+        )),
+    ];
+    let module = module_with_main(
+        stmts,
+        Expr::IntLit {
+            value: 0,
+            span: sp(),
+        },
+        &[Feature::SymbolicExpr],
+    );
+    if let Some(stdout) = run_module(&module, "sym_define_call_single_param") {
+        assert_eq!(stdout, "F\n25");
+    }
+}
+
+#[test]
+fn multi_param_define_then_call_dispatches_by_position() {
+    // G(a, b) := a + b; G(3, 4) -- params zipped by POSITION, not name.
+    let stmts = vec![
+        print(sym_apply(
+            sym("Define"),
+            vec![
+                sym("G"),
+                sym_apply(sym("List"), vec![sym("a"), sym("b")]),
+                sym_apply(sym("Add"), vec![sym("a"), sym("b")]),
+            ],
+        )),
+        print(sym_apply(
+            sym("G"),
+            vec![
+                Expr::IntLit {
+                    value: 3,
+                    span: sp(),
+                },
+                Expr::IntLit {
+                    value: 4,
+                    span: sp(),
+                },
+            ],
+        )),
+    ];
+    let module = module_with_main(
+        stmts,
+        Expr::IntLit {
+            value: 0,
+            span: sp(),
+        },
+        &[Feature::SymbolicExpr],
+    );
+    if let Some(stdout) = run_module(&module, "sym_define_call_multi_param") {
+        assert_eq!(stdout, "G\n7");
+    }
+}
+
+#[test]
+fn arity_mismatch_leaves_the_user_function_call_unevaluated() {
+    // F(x) := x*x; F(1, 2) -- a 2-arg call against a 1-param definition:
+    // `apply_user_function`'s `None` return ("arity mismatch") means the
+    // call is left exactly as `evalApply`'s generic "no handler matched"
+    // fallthrough would rebuild it: the evaluated head plus the
+    // evaluated (but otherwise untouched) args, printed via the generic
+    // `head(args, ...)` convention (this module doesn't set
+    // `source_language("derive")`, so `SIR_DISPLAY_DERIVE` is off here).
+    let stmts = vec![
+        print(sym_apply(
+            sym("Define"),
+            vec![
+                sym("F"),
+                sym_apply(sym("List"), vec![sym("x")]),
+                sym_apply(sym("Mul"), vec![sym("x"), sym("x")]),
+            ],
+        )),
+        print(sym_apply(
+            sym("F"),
+            vec![
+                Expr::IntLit {
+                    value: 1,
+                    span: sp(),
+                },
+                Expr::IntLit {
+                    value: 2,
+                    span: sp(),
+                },
+            ],
+        )),
+    ];
+    let module = module_with_main(
+        stmts,
+        Expr::IntLit {
+            value: 0,
+            span: sp(),
+        },
+        &[Feature::SymbolicExpr],
+    );
+    if let Some(stdout) = run_module(&module, "sym_define_call_arity_mismatch") {
+        assert_eq!(stdout, "F\nF(1, 2)");
+    }
+}
+
+#[test]
+fn if_true_and_false_branches_select_the_right_arm() {
+    // IF(1 > 0, 42, 0) -> 42; IF(1 > 2, 42, 99) -> 99 -- `If`'s condition
+    // is evaluated (it's held, so NOT pre-evaluated by `evalApply`'s
+    // argument loop; `ifHandler` evaluates it itself), then branches.
+    let if_of = |cond_gt: (i64, i64), then_v: i64, else_v: i64| {
+        sym_apply(
+            sym("If"),
+            vec![
+                sym_apply(
+                    sym("Greater"),
+                    vec![
+                        Expr::IntLit {
+                            value: cond_gt.0,
+                            span: sp(),
+                        },
+                        Expr::IntLit {
+                            value: cond_gt.1,
+                            span: sp(),
+                        },
+                    ],
+                ),
+                Expr::IntLit {
+                    value: then_v,
+                    span: sp(),
+                },
+                Expr::IntLit {
+                    value: else_v,
+                    span: sp(),
+                },
+            ],
+        )
+    };
+    let stmts = vec![
+        print(if_of((1, 0), 42, 0)),
+        print(if_of((1, 2), 42, 99)),
+    ];
+    let module = module_with_main(
+        stmts,
+        Expr::IntLit {
+            value: 0,
+            span: sp(),
+        },
+        &[Feature::SymbolicExpr],
+    );
+    if let Some(stdout) = run_module(&module, "sym_if_branches") {
+        assert_eq!(stdout, "42\n99");
+    }
+}
+
+#[test]
+fn self_referential_assign_does_not_infinite_loop() {
+    // x := x; x -- the self-loop guard (`eval_symbol`'s own comment:
+    // "x := x would recurse forever without this"). Without the guard,
+    // the SECOND statement's lookup would recurse until `MAX_EVAL_DEPTH`
+    // fires and `Symbolic.unwrap` throws, crashing `node` with a non-zero
+    // exit (caught by `run_module`'s own `output.status.success()`
+    // assertion) -- WITH the guard, both statements return instantly.
+    let stmts = vec![
+        print(sym_apply(sym("Assign"), vec![sym("x"), sym("x")])),
+        print(sym("x")),
+    ];
+    let module = module_with_main(
+        stmts,
+        Expr::IntLit {
+            value: 0,
+            span: sp(),
+        },
+        &[Feature::SymbolicExpr],
+    );
+    if let Some(stdout) = run_module(&module, "sym_self_referential_assign") {
+        assert_eq!(stdout, "x\nx");
+    }
+}

--- a/code/specs/SIR23-symbolic-pattern-semantic-ir.md
+++ b/code/specs/SIR23-symbolic-pattern-semantic-ir.md
@@ -402,14 +402,35 @@ one `BaseBackend` instance per `VM`):
   local scope reaches `SymbolicBackend` today — those are exactly the
   decorator-layer extensions named out of scope above), so one flat `Map`
   is a faithful, not a simplified, port of `BaseBackend.env`.
-- **Genuine, one-place reuse**: user-function dispatch (below) needs
-  "substitute these parameter names for these argument terms in this body,"
-  which is *exactly* what `substituteTerm` (already in the `Symbolic` IIFE,
-  built for `SymRule` RHS substitution) already does — the same helper,
-  called with a plain `name → term` bindings `Map` instead of a pattern-
-  match `Bindings` result. This is the one real piece of code-sharing
-  between the rewrite engine and the new evaluator; everything else is
-  deliberately separate per the architecture decision above.
+- **Correction (found during item 2's implementation, not during this
+  addendum's original research): NOT a reuse of `substituteTerm`.** This
+  bullet originally claimed user-function dispatch's "substitute these
+  parameter names for these argument terms in this body" need was
+  *exactly* what `substituteTerm` (already in the `Symbolic` IIFE, built
+  for `SymRule` RHS substitution) already does, callable unchanged with a
+  plain `name → term` bindings `Map` instead of a pattern-match
+  `Bindings` result. That assumption doesn't survive contact with the
+  actual data shapes: `substituteTerm` only substitutes at
+  `Pattern(name, inner)`-wrapped template nodes (the shape a `SymRule`'s
+  RHS uses to reference a bound pattern variable — confirmed by this
+  crate's own `tests/sir23_symbolic.rs`, whose rules always reuse the
+  literal same `Pattern`-wrapped node on both a rule's `lhs` and `rhs`),
+  while a `Define(name, List(params...), body)`'s `body` references its
+  parameters as ORDINARY bare `Symbol` nodes — confirmed directly in
+  `derive-to-semantic-ir::lower`'s own module doc ("never constructs
+  `SymPatternBlank`/`SymPatternNamed`/..."): `F(x) := x*x` lowers to a
+  body with no `Pattern`-wrapping anywhere. Calling `substituteTerm` on
+  such a body substitutes nothing at all — a silent no-op, not a loud
+  failure. The actual implementation (`semantic-ir-to-javascript`
+  `[0.51.2]`) instead adds `substituteSymbols`, a new, from-scratch port
+  of `symbolic-vm::vm::substitute` (the free function
+  `apply_user_function` itself calls, distinct from the `Handler`/
+  `Backend` machinery) — match a bare `Symbol` directly against
+  `bindings`, recurse into `head`/`args`, pass every literal through
+  unchanged. `substituteTerm` is unmodified and remains exactly what it
+  was: the pattern-rewrite engine's own RHS substitution, a genuinely
+  separate piece of code from the evaluator, same as everything else per
+  the architecture decision above.
 
 ### Function dispatch
 
@@ -418,8 +439,12 @@ Ports `vm.rs::VM::apply_user_function` exactly: on `Apply(head, args)` where
 env; if the stored value is a `Define(name, List(params...), body)` term,
 zip the (already-evaluated, applicative-order) `args` against `params` by
 position (arity mismatch → leave the call unevaluated, matching the Rust
-port's `None` return), build a `name → arg` bindings map, `substituteTerm`
-it into `body`, and recursively `evalTerm` the result — mirroring `apply_user_function`'s "substitute, then the VM's caller re-evaluates" contract exactly (`vm.rs` line ~144: `if let Some(node) = result { return self.eval(node); }`).
+port's `None` return), build a `name → arg` bindings map, `substituteSymbols`
+it into `body` (**not** `substituteTerm` — see the correction in
+"Environment / held-form execution model" above), and recursively
+`evalTerm` the result — mirroring `apply_user_function`'s "substitute,
+then the VM's caller re-evaluates" contract exactly (`vm.rs` line ~144:
+`if let Some(node) = result { return self.eval(node); }`).
 
 Note for implementers: neither `symbolic-vm::apply_user_function` nor this
 port has any recursion-depth guard specific to *user-function* calls — a
@@ -584,6 +609,16 @@ with any other in-flight PR in that crate (mirrors `sir-display-convention.md`'s
 own "sequenced to avoid contended crates" rollout wisdom). No other crate
 changes.
 
+**Status**: item 1 shipped (`semantic-ir-to-javascript` `[0.49.0]`), item 2
+shipped (`[0.51.2]`), item 4 shipped out of order, ahead of item 2
+(`[0.50.0]`) — item 4 has no code dependency on items 1–3, only a
+same-file merge sequencing concern, so shipping it before item 2 was
+always a legal ordering per this section's own dependency notes below.
+Item 3 (calculus/elementary-function handlers) has not shipped yet. See
+each item's own bullet below for what actually landed vs. what was
+originally planned, and each shipped item's own crate `CHANGELOG.md` for
+the authoritative detail.
+
 1. **`Symbolic.evalTerm` scaffold + arithmetic/comparison/logic folding.**
    The foundational PR: the recursive `evalTerm` dispatcher, the `emit.rs`
    `Stmt::ExprStmt` wrapping change, the `MAX_EVAL_DEPTH` guard (with its own
@@ -598,16 +633,32 @@ changes.
    `power_is_right_associative`, `inexact_division_folds_to_a_rational`,
    `comparison_true`, `three_term_and_chain_folds_n_ary` — the existing
    `toDisplayString` already renders a bare integer/rational/`True`/`False`
-   symbol correctly, so no display work is needed for these).
+   symbol correctly, so no display work is needed for these). **Shipped.**
 2. **Held-form execution: environment + `Assign`/`Define`/`If` + user-
    function dispatch.** Adds the `Map`-backed environment, the three held-
-   form handlers, the self-loop guard, and `apply_user_function`'s port
-   (reusing `substituteTerm`). **Depends on item 1's scaffold** (same
-   dispatch table/`HELD_HEADS` set), independent of item 3. Flips 5 more
-   cumulative cases (`variable_assignment_and_later_reference`,
+   form handlers, the self-loop guard, and `apply_user_function`'s port.
+   **Depends on item 1's scaffold** (same dispatch table/`HELD_HEADS`
+   set), independent of item 3. **Shipped** — flipped 6 cumulative cases,
+   not the 5 originally predicted here:
+   `variable_assignment_and_later_reference`,
    `single_param_function_definition_and_call`,
    `multi_param_function_definition_and_call`, `if_true_branch`,
-   `if_false_branch`).
+   `if_false_branch`, plus `vector_assignment_persists_across_statements`
+   (not named here in advance, but confirmed to flip by actually running
+   the oracle suite — see `derive-to-semantic-ir/CHANGELOG.md`'s `[0.1.4]`
+   entry). **One correction to this bullet's own original plan**: the
+   user-function-body substitution does NOT reuse `substituteTerm` as
+   this section originally said it would (see "Genuine, one-place reuse"
+   above) — `substituteTerm` only rewrites `Pattern(name, inner)`-wrapped
+   template nodes (the `SymRule`-RHS shape), while a `Define`'s body
+   references its parameters as ordinary bare `Symbol` nodes, so
+   `substituteTerm` would silently substitute nothing. A new function,
+   `substituteSymbols` (a direct, from-scratch port of
+   `symbolic-vm::vm::substitute`), does this instead — see
+   `runtime.rs`'s own doc comment on `substituteSymbols` for the full
+   explanation. This is the one place this rollout's own design research
+   turned out to be wrong; every other point in "Environment / held-form
+   execution model" and "Function dispatch" above ported as described.
 3. **Calculus/elementary-function handlers**, scoped exactly to the table
    above (not the full `symbolic-vm` polynomial/special-function surface).
    **Depends on item 1's scaffold**; independent of item 2 except for one


### PR DESCRIPTION
## Summary
- SIR23 addendum item 2 of 4 (see `code/specs/SIR23-symbolic-pattern-semantic-ir.md`'s addendum): adds real execution for the three `HELD_HEADS` (`Assign`/`Define`/`If`) plus user-defined-function dispatch to the shared `Symbolic` evaluator in `semantic-ir-to-javascript`'s `runtime.rs`, ported 1:1 from `symbolic-vm`'s `vm.rs`/`handlers.rs` reference implementation.
- A `Map`-backed `symEnv` (one per compiled program's `node` process, mirroring `symbolic-vm::BaseBackend.env`), a `Symbol` self-loop guard in `evalTerm` (`x := x` doesn't recurse forever), and user-function dispatch (zip params/args by position, substitute into the body, re-evaluate).
- **One deviation from the spec, caught and corrected during implementation**: the spec proposed reusing the existing `substituteTerm` for user-function-body substitution. This doesn't typecheck against the actual data shapes — `substituteTerm` only rewrites `Pattern(name, inner)`-wrapped nodes (the `SymRule`-RHS shape), while a `Define`'s body references params as ordinary bare `Symbol` nodes. Added a new `substituteSymbols` (a direct port of `symbolic-vm::vm::substitute`) instead, and corrected the spec doc to document this.
- Flips 6 `known_bug` cases in `derive-to-semantic-ir/tests/oracle.rs` to `known_bug: None` — the 5 the spec named in advance (`variable_assignment_and_later_reference`, `single_param_function_definition_and_call`, `multi_param_function_definition_and_call`, `if_true_branch`, `if_false_branch`) plus one more confirmed by actually running the suite (`vector_assignment_persists_across_statements`). 7 cases remain, all blocked by the still-open calculus/elementary-function gap (item 3, task #106).
- 6 new integration tests in `semantic-ir-to-javascript/tests/sir23_symbolic.rs`, including an explicit self-loop-guard regression test and an arity-mismatch test.
- Version bumps: `semantic-ir-to-javascript` 0.51.1 → 0.51.2, `derive-to-semantic-ir` 0.1.3 → 0.1.4.

## Test plan
- [x] Independently reverted the `HELD_HANDLERS` registration, confirmed the derive oracle test fails exactly as predicted (`Assign` never binds: `"Assign(x, 5)\nx + 1"` instead of `"5\n6"`), then restored and confirmed it passes again
- [x] `cargo test -p semantic-ir-to-javascript --test sir23_symbolic` — 11/11 pass
- [x] `cargo test -p derive-to-semantic-ir --test oracle -- --nocapture` — confirmed exactly the 6 named cases are no longer in the "skipping compiled-side assertion" log; 7 remain, all item-3/calculus-related
- [x] Zero regressions confirmed across every downstream Stream B consumer: `reduce-to-semantic-ir`, `maple-to-semantic-ir`, `wolfram-to-semantic-ir`, `macsyma-to-semantic-ir`, `maxima-to-semantic-ir` (all full suites pass)
- [x] Security review passed clean — traced every new recursion path against the existing `MAX_EVAL_DEPTH` guard, confirmed `Map`-backed `symEnv` has no prototype-pollution surface, confirmed the self-loop guard handles the general case (not just the literal `x := x` shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)