### PR TITLE
feat(spice): add BJT transit-time voltage scaling

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add BJT model-card `VTF` forward transit-time voltage-scale support, applying
+  `exp(Vbc / (1.44 * VTF))` to the `XTF` AC and transient storage enhancement.
+
 - Add BJT model-card `ITF` forward transit-time current-scale support, applying
   `(If / (If + ITF))^2` to the `XTF` AC and transient storage enhancement.
 - Add BJT model-card `XTF` forward transit-time bias-coefficient support,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -618,6 +618,8 @@ class BJT:
         Coefficient for forward transit-time bias dependence (default 0.0).
     Itf:
         Forward-current scale for transit-time bias dependence (default 0.0).
+    Vtf:
+        Base-collector voltage scale for transit-time bias dependence (default 0.0).
     """
 
     name: str
@@ -657,6 +659,7 @@ class BJT:
     Ptf: float = 0.0           # excess phase at 1/(2*pi*Tf), degrees
     Xtf: float = 0.0           # forward transit-time bias coefficient
     Itf: float = 0.0           # forward transit-time current scale (A)
+    Vtf: float = 0.0           # forward transit-time voltage scale (V)
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -605,7 +605,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr, element.Tnom, element.Kf, element.Af, element.Ptf, element.Xtf, element.Itf)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr, element.Tnom, element.Kf, element.Af, element.Ptf, element.Xtf, element.Itf, element.Vtf)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -8743,7 +8743,11 @@ def _bjt_junction_transconductance(el: BJT, voltage: float, emission_coefficient
     return (el.Is / effective_thermal_voltage) * math.exp(exponent)
 
 
-def _bjt_forward_transit_time_scale(el: BJT, voltage: float) -> float:
+def _bjt_forward_transit_time_scale(
+    el: BJT,
+    voltage: float,
+    reverse_junction_voltage: float,
+) -> float:
     effective_thermal_voltage = el.Vt * el.Nf
     forward_current = max(
         el.Is * (math.exp(max(-40.0, min(40.0, voltage / effective_thermal_voltage))) - 1.0),
@@ -8753,15 +8757,26 @@ def _bjt_forward_transit_time_scale(el: BJT, voltage: float) -> float:
     if el.Itf > 0.0:
         ratio = forward_current / (forward_current + el.Itf)
         current_factor = ratio * ratio
-    return 1.0 + el.Xtf * current_factor
+    voltage_factor = 1.0
+    if el.Vtf > 0.0:
+        voltage_exponent = max(-40.0, min(40.0, reverse_junction_voltage / (1.44 * el.Vtf)))
+        voltage_factor = math.exp(voltage_exponent)
+    return 1.0 + el.Xtf * current_factor * voltage_factor
 
 
-def _bjt_charge_dynamic_capacitance(el: BJT, state_kind: str, voltage: float) -> float:
+def _bjt_charge_dynamic_capacitance(
+    el: BJT,
+    state_kind: str,
+    voltage: float,
+    reverse_junction_voltage: float,
+) -> float:
     if state_kind == "be":
         conductance = _bjt_junction_transconductance(el, voltage, el.Nf)
         return (
             _bjt_base_emitter_depletion_capacitance(el, voltage)
-            + el.Tf * _bjt_forward_transit_time_scale(el, voltage) * conductance
+            + el.Tf
+            * _bjt_forward_transit_time_scale(el, voltage, reverse_junction_voltage)
+            * conductance
         )
     conductance = _bjt_junction_transconductance(el, voltage, el.Nr)
     return _bjt_base_collector_depletion_capacitance(el, voltage) + el.Tr * conductance
@@ -8798,7 +8813,7 @@ def _bjt_charge_state_specs(el: BJT) -> list[tuple[str, str, str, str]]:
             specs.append((_bjt_base_emitter_charge_state_name(el), el.base, el.emitter, "be"))
         else:
             specs.append((_bjt_base_emitter_charge_state_name(el), el.emitter, el.base, "be"))
-    if el.Cjc > 0.0 or el.Tr > 0.0:
+    if el.Cjc > 0.0 or el.Tr > 0.0 or (el.Tf > 0.0 and el.Xtf > 0.0 and el.Vtf > 0.0):
         if el.polarity == "NPN":
             specs.append((_bjt_base_collector_charge_state_name(el), el.base, el.collector, "bc"))
         else:
@@ -9334,6 +9349,10 @@ def _validate_bjt(el: BJT) -> None:
     if not math.isfinite(el.Itf) or el.Itf < 0.0:
         raise ValueError(
             f"{el.name}: BJT forward transit-time current must be finite and non-negative"
+        )
+    if not math.isfinite(el.Vtf) or el.Vtf < 0.0:
+        raise ValueError(
+            f"{el.name}: BJT forward transit-time voltage must be finite and non-negative"
         )
     if not math.isfinite(el.Ise) or el.Ise < 0.0:
         raise ValueError(
@@ -10073,9 +10092,18 @@ def _build_transient_companions(
 
         # ---- BJT model-card charge companions ------------------------------
         elif isinstance(el, BJT):
+            reverse_junction_voltage = cap_voltages.get(
+                _bjt_base_collector_charge_state_name(el),
+                0.0,
+            )
             for state_name, n_plus, n_minus, state_kind in _bjt_charge_state_specs(el):
                 v_prev = cap_voltages.get(state_name, 0.0)
-                capacitance = _bjt_charge_dynamic_capacitance(el, state_kind, v_prev)
+                capacitance = _bjt_charge_dynamic_capacitance(
+                    el,
+                    state_kind,
+                    v_prev,
+                    reverse_junction_voltage,
+                )
                 if capacitance <= 0.0:
                     continue
                 if method == "trap":
@@ -10315,11 +10343,20 @@ def _update_reactive_state(
                 cap_voltages[state_name] = v_new
 
         elif isinstance(el, BJT):
+            reverse_junction_voltage = cap_voltages.get(
+                _bjt_base_collector_charge_state_name(el),
+                0.0,
+            )
             for state_name, n_plus, n_minus, state_kind in _bjt_charge_state_specs(el):
                 v_new = _bjt_charge_state_voltage(n_plus, n_minus, op.node_voltages)
                 v_prev = cap_voltages.get(state_name, v_new)
                 v_older = cap_voltages_older.get(state_name, v_prev)
-                capacitance = _bjt_charge_dynamic_capacitance(el, state_kind, v_prev)
+                capacitance = _bjt_charge_dynamic_capacitance(
+                    el,
+                    state_kind,
+                    v_prev,
+                    reverse_junction_voltage,
+                )
 
                 if capacitance > 0.0:
                     if method == "trap":
@@ -12611,7 +12648,7 @@ def _stamp_ac(
         )
         g_pi: float = base_gm / el.beta_f + leakage_conductance
         diffusion_capacitance = (
-            el.Tf * _bjt_forward_transit_time_scale(el, Vjunc) * gm_b
+            el.Tf * _bjt_forward_transit_time_scale(el, Vjunc, Vreverse) * gm_b
         )
         excess_phase = omega * el.Tf * el.Ptf * math.pi / 180.0
         gm_ac = complex(

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (32, 49, 13, 4),
-    "PNP": (32, 49, 13, 4),
+    "NPN": (33, 50, 13, 4),
+    "PNP": (33, 50, 13, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -386,6 +386,7 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "PTF": "PTF",
     "XTF": "XTF",
     "ITF": "ITF",
+    "VTF": "VTF",
     "ISE": "ISE",
     "NE": "NE",
     "ISC": "ISC",
@@ -953,6 +954,7 @@ def bjt_from_model_card(
         Ptf=p.get("PTF", 0.0),
         Xtf=p.get("XTF", 0.0),
         Itf=p.get("ITF", 0.0),
+        Vtf=p.get("VTF", 0.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 122
+    assert len(coverage) == 124
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 122
+    assert len(records) == 124
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,9 +501,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 122
-    assert report.expected_canonical_parameter_count == 122
-    assert report.accepted_name_count == 188
+    assert report.canonical_parameter_count == 124
+    assert report.expected_canonical_parameter_count == 124
+    assert report.accepted_name_count == 190
     assert report.aliased_parameter_count == 53
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -511,7 +511,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t122\t122\t188\t53\t4\t0"
+        "true\t7\t7\t124\t124\t190\t53\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,8 +539,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 121
-    assert report.accepted_name_count == 185
+    assert report.canonical_parameter_count == 123
+    assert report.accepted_name_count == 187
     assert report.aliased_parameter_count == 52
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t121\t122\t185\t52\t4\t4\n"
+        "false\t7\t7\t123\t124\t187\t52\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,10 +647,10 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
+        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "VTF": 0.6, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "TNOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
+    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "TNOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "VTF": 0.6, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.beta_r == pytest.approx(0.25)
@@ -668,6 +668,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert bjt_model.Ptf == pytest.approx(30.0)
     assert bjt_model.Xtf == pytest.approx(2.0)
     assert bjt_model.Itf == pytest.approx(4.0e-3)
+    assert bjt_model.Vtf == pytest.approx(0.6)
     assert bjt_model.Ise == pytest.approx(3.0e-13)
     assert bjt_model.Ne == pytest.approx(1.7)
     assert bjt_model.Isc == pytest.approx(4.0e-13)
@@ -1602,9 +1603,11 @@ def test_transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() -> No
         forward_transit_time: float,
         forward_transit_time_bias_coefficient: float = 0.0,
         forward_transit_time_current: float = 0.0,
+        forward_transit_time_voltage: float = 0.0,
+        collector_voltage: float = 5.0,
     ) -> TransientResult:
         circuit = Circuit()
-        circuit.add(VoltageSource("Vcc", "collector", "0", 5.0))
+        circuit.add(VoltageSource("Vcc", "collector", "0", collector_voltage))
         circuit.add(CurrentSource(
             "Istep",
             "0",
@@ -1622,6 +1625,7 @@ def test_transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() -> No
             Tf=forward_transit_time,
             Xtf=forward_transit_time_bias_coefficient,
             Itf=forward_transit_time_current,
+            Vtf=forward_transit_time_voltage,
         ))
         return transient(circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler")
 
@@ -1629,6 +1633,7 @@ def test_transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() -> No
     stored = run(1.0e-9)
     bias_scaled = run(1.0e-9, 9.0)
     current_limited = run(1.0e-9, 9.0, 1.0)
+    voltage_limited = run(1.0e-9, 9.0, 0.0, 0.5, 10.0)
 
     assert no_storage.converged
     assert stored.converged
@@ -1641,6 +1646,13 @@ def test_transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() -> No
     ) > 1.0e-12
     assert abs(
         current_limited.points[-1].node_voltages["base"]
+        - stored.points[-1].node_voltages["base"]
+    ) < abs(
+        bias_scaled.points[-1].node_voltages["base"]
+        - stored.points[-1].node_voltages["base"]
+    )
+    assert abs(
+        voltage_limited.points[-1].node_voltages["base"]
         - stored.points[-1].node_voltages["base"]
     ) < abs(
         bias_scaled.points[-1].node_voltages["base"]
@@ -2328,7 +2340,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3, Tnom=323.15, Kf=1.0e-12, Af=1.3, Ptf=30.0, Xtf=2.0, Itf=4.0e-3),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3, Tnom=323.15, Kf=1.0e-12, Af=1.3, Ptf=30.0, Xtf=2.0, Itf=4.0e-3, Vtf=0.6),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2360,6 +2372,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.Ptf == pytest.approx(30.0)
     assert expanded.Xtf == pytest.approx(2.0)
     assert expanded.Itf == pytest.approx(4.0e-3)
+    assert expanded.Vtf == pytest.approx(0.6)
 
 
 def test_branch_current_in_voltage_source():
@@ -2637,6 +2650,16 @@ def test_dc_rejects_invalid_bjt_forward_transit_time_current():
     with pytest.raises(
         ValueError,
         match="forward transit-time current must be finite and non-negative",
+    ):
+        dc_op(circuit)
+
+
+def test_dc_rejects_invalid_bjt_forward_transit_time_voltage():
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", Vtf=-1.0))
+    with pytest.raises(
+        ValueError,
+        match="forward transit-time voltage must be finite and non-negative",
     ):
         dc_op(circuit)
 
@@ -4481,11 +4504,16 @@ def test_ac_bjt_forward_excess_phase_rotates_transconductance():
 
 
 def test_ac_bjt_forward_transit_time_bias_coefficient_scales_diffusion_capacitance():
-    def base_amplitude(xtf: float, itf: float = 0.0) -> float:
+    def base_amplitude(
+        xtf: float,
+        itf: float = 0.0,
+        vtf: float = 0.0,
+        collector_voltage: float = 0.0,
+    ) -> float:
         circuit = Circuit()
         circuit.add(VoltageSource("Vac", "in", "0", 0.0, ac=AcSource(1.0)))
         circuit.add(Resistor("Rin", "in", "base", 1000.0))
-        circuit.add(Resistor("Rc", "col", "0", 1000.0))
+        circuit.add(VoltageSource("Vcol", "col", "0", collector_voltage))
         circuit.add(
             BJT(
                 "Q1",
@@ -4496,6 +4524,7 @@ def test_ac_bjt_forward_transit_time_bias_coefficient_scales_diffusion_capacitan
                 Tf=1.0e-6,
                 Xtf=xtf,
                 Itf=itf,
+                Vtf=vtf,
             )
         )
         return abs(
@@ -4507,9 +4536,11 @@ def test_ac_bjt_forward_transit_time_bias_coefficient_scales_diffusion_capacitan
     nominal = base_amplitude(0.0)
     bias_scaled = base_amplitude(9.0)
     current_limited = base_amplitude(9.0, 1.0)
+    voltage_limited = base_amplitude(9.0, vtf=0.1, collector_voltage=1.0)
 
     assert bias_scaled < nominal / 5.0
     assert current_limited > bias_scaled * 5.0
+    assert voltage_limited > bias_scaled * 5.0
 
 
 def test_ac_bjt_reverse_transit_time_adds_collector_diffusion_capacitance():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add BJT model-card `VTF` forward transit-time voltage-scale support, applying
+  `exp(Vbc / (1.44 * VTF))` to the `XTF` AC and transient storage enhancement.
+
 - Add BJT model-card `ITF` forward transit-time current-scale support, applying
   `(If / (If + ITF))^2` to the `XTF` AC and transient storage enhancement.
 - Add BJT model-card `XTF` forward transit-time bias-coefficient support,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -460,6 +460,7 @@ fn clone_subckt_element(
             expanded.forward_transit_time_bias_coefficient =
                 element.forward_transit_time_bias_coefficient;
             expanded.forward_transit_time_current = element.forward_transit_time_current;
+            expanded.forward_transit_time_voltage = element.forward_transit_time_voltage;
             Element::Bjt(expanded)
         }
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
@@ -2907,6 +2908,7 @@ pub struct Bjt {
     pub forward_excess_phase_degrees: f64,
     pub forward_transit_time_bias_coefficient: f64,
     pub forward_transit_time_current: f64,
+    pub forward_transit_time_voltage: f64,
 }
 
 impl Bjt {
@@ -3375,6 +3377,7 @@ impl Bjt {
             forward_excess_phase_degrees: 0.0,
             forward_transit_time_bias_coefficient: 0.0,
             forward_transit_time_current: 0.0,
+            forward_transit_time_voltage: 0.0,
         }
     }
 }
@@ -3765,8 +3768,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 32, 49, 13, 4),
-    (ModelCardKind::Pnp, 32, 49, 13, 4),
+    (ModelCardKind::Npn, 33, 50, 13, 4),
+    (ModelCardKind::Pnp, 33, 50, 13, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3824,6 +3827,7 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("PTF", "PTF"),
     ("XTF", "XTF"),
     ("ITF", "ITF"),
+    ("VTF", "VTF"),
     ("ISE", "ISE"),
     ("NE", "NE"),
     ("ISC", "ISC"),
@@ -4523,6 +4527,7 @@ pub fn bjt_from_model_card(
     bjt.forward_excess_phase_degrees = model_card_value(model, "PTF", 0.0);
     bjt.forward_transit_time_bias_coefficient = model_card_value(model, "XTF", 0.0);
     bjt.forward_transit_time_current = model_card_value(model, "ITF", 0.0);
+    bjt.forward_transit_time_voltage = model_card_value(model, "VTF", 0.0);
     Ok(bjt)
 }
 
@@ -22857,6 +22862,11 @@ fn stamp_bjt_charge(
     matrix: &mut [Vec<f64>],
     rhs: &mut [f64],
 ) -> Result<(), SpiceError> {
+    let reverse_junction_voltage = capacitor_states
+        .iter()
+        .find(|state| state.name == bjt_base_collector_charge_state_name(bjt))
+        .map(|state| state.previous_voltage)
+        .unwrap_or(0.0);
     for spec in bjt_charge_state_specs(bjt) {
         let Some(state) = capacitor_states
             .iter()
@@ -22864,7 +22874,12 @@ fn stamp_bjt_charge(
         else {
             continue;
         };
-        let capacitance = bjt_charge_dynamic_capacitance(bjt, spec.kind, state.previous_voltage);
+        let capacitance = bjt_charge_dynamic_capacitance(
+            bjt,
+            spec.kind,
+            state.previous_voltage,
+            reverse_junction_voltage,
+        );
         if capacitance <= 0.0 {
             continue;
         }
@@ -23021,7 +23036,7 @@ fn stamp_ac_bjt_small_signal(
     );
     let reverse_gm = bjt.saturation_current / reverse_thermal_voltage * reverse_exponent.exp();
     let diffusion_capacitance = bjt.forward_transit_time
-        * bjt_forward_transit_time_scale(bjt, junction_voltage)
+        * bjt_forward_transit_time_scale(bjt, junction_voltage, reverse_junction_voltage)
         * forward_gm;
     let reverse_diffusion_capacitance = bjt.reverse_transit_time * reverse_gm;
     let (_, leakage_conductance) = bjt_base_emitter_leakage(bjt, junction_voltage);
@@ -23637,7 +23652,7 @@ fn bjt_junction_transconductance(bjt: &Bjt, voltage: f64, emission_coefficient: 
             .exp()
 }
 
-fn bjt_forward_transit_time_scale(bjt: &Bjt, voltage: f64) -> f64 {
+fn bjt_forward_transit_time_scale(bjt: &Bjt, voltage: f64, reverse_junction_voltage: f64) -> f64 {
     let effective_thermal_voltage = bjt.thermal_voltage * bjt.forward_emission_coefficient;
     let forward_current = (bjt.saturation_current
         * ((voltage / effective_thermal_voltage)
@@ -23651,17 +23666,29 @@ fn bjt_forward_transit_time_scale(bjt: &Bjt, voltage: f64) -> f64 {
         let ratio = forward_current / (forward_current + bjt.forward_transit_time_current);
         ratio * ratio
     };
-    1.0 + bjt.forward_transit_time_bias_coefficient * current_factor
+    let voltage_factor = if bjt.forward_transit_time_voltage == 0.0 {
+        1.0
+    } else {
+        (reverse_junction_voltage / (1.44 * bjt.forward_transit_time_voltage))
+            .clamp(-40.0, 40.0)
+            .exp()
+    };
+    1.0 + bjt.forward_transit_time_bias_coefficient * current_factor * voltage_factor
 }
 
-fn bjt_charge_dynamic_capacitance(bjt: &Bjt, kind: BjtChargeStateKind, voltage: f64) -> f64 {
+fn bjt_charge_dynamic_capacitance(
+    bjt: &Bjt,
+    kind: BjtChargeStateKind,
+    voltage: f64,
+    reverse_junction_voltage: f64,
+) -> f64 {
     match kind {
         BjtChargeStateKind::BaseEmitter => {
             let conductance =
                 bjt_junction_transconductance(bjt, voltage, bjt.forward_emission_coefficient);
             bjt_base_emitter_depletion_capacitance(bjt, voltage)
                 + bjt.forward_transit_time
-                    * bjt_forward_transit_time_scale(bjt, voltage)
+                    * bjt_forward_transit_time_scale(bjt, voltage, reverse_junction_voltage)
                     * conductance
         }
         BjtChargeStateKind::BaseCollector => {
@@ -23720,7 +23747,12 @@ fn bjt_charge_state_specs(bjt: &Bjt) -> Vec<BjtChargeStateSpec<'_>> {
             kind: BjtChargeStateKind::BaseEmitter,
         });
     }
-    if bjt.base_collector_capacitance > 0.0 || bjt.reverse_transit_time > 0.0 {
+    if bjt.base_collector_capacitance > 0.0
+        || bjt.reverse_transit_time > 0.0
+        || (bjt.forward_transit_time > 0.0
+            && bjt.forward_transit_time_bias_coefficient > 0.0
+            && bjt.forward_transit_time_voltage > 0.0)
+    {
         let (positive, negative) = match bjt.polarity {
             BjtPolarity::Npn => (bjt.base.as_str(), bjt.collector.as_str()),
             BjtPolarity::Pnp => (bjt.collector.as_str(), bjt.base.as_str()),
@@ -24117,6 +24149,12 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "forward transit-time current must be finite and non-negative".to_string(),
+        });
+    }
+    if !bjt.forward_transit_time_voltage.is_finite() || bjt.forward_transit_time_voltage < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "forward transit-time voltage must be finite and non-negative".to_string(),
         });
     }
     if !bjt.base_emitter_leakage_saturation_current.is_finite()
@@ -24787,7 +24825,11 @@ fn update_capacitor_states(
     node_voltages: &BTreeMap<String, f64>,
     capacitor_states: &mut [CapacitorState],
 ) {
-    for state in capacitor_states {
+    let previous_voltages: HashMap<String, f64> = capacitor_states
+        .iter()
+        .map(|state| (state.name.clone(), state.previous_voltage))
+        .collect();
+    for state in capacitor_states.iter_mut() {
         let update = circuit.elements().iter().find_map(|element| match element {
             Element::Capacitor(capacitor) if capacitor.name == state.name => Some((
                 voltage_at(node_voltages, &capacitor.n1) - voltage_at(node_voltages, &capacitor.n2),
@@ -24801,9 +24843,18 @@ fn update_capacitor_states(
                 .into_iter()
                 .find(|spec| spec.name == state.name)
                 .map(|spec| {
+                    let reverse_junction_voltage = previous_voltages
+                        .get(&bjt_base_collector_charge_state_name(bjt))
+                        .copied()
+                        .unwrap_or(0.0);
                     (
                         bjt_charge_state_voltage(&spec, node_voltages),
-                        bjt_charge_dynamic_capacitance(bjt, spec.kind, state.previous_voltage),
+                        bjt_charge_dynamic_capacitance(
+                            bjt,
+                            spec.kind,
+                            state.previous_voltage,
+                            reverse_junction_voltage,
+                        ),
                     )
                 }),
             Element::Jfet(jfet) => jfet_charge_state_specs(jfet)

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -870,7 +870,12 @@ fn ac_bjt_forward_excess_phase_rotates_transconductance() {
 
 #[test]
 fn ac_bjt_forward_transit_time_bias_coefficient_scales_diffusion_capacitance() {
-    fn base_amplitude(coefficient: f64, transit_time_current: f64) -> f64 {
+    fn base_amplitude(
+        coefficient: f64,
+        transit_time_current: f64,
+        transit_time_voltage: f64,
+        collector_voltage: f64,
+    ) -> f64 {
         let mut circuit = Circuit::new();
         circuit.add(Element::VoltageSource(VoltageSource::with_ac(
             "Vac", "in", "0", 0.0, 1.0, 0.0,
@@ -878,7 +883,12 @@ fn ac_bjt_forward_transit_time_bias_coefficient_scales_diffusion_capacitance() {
         circuit.add(Element::Resistor(Resistor::new(
             "Rin", "in", "base", 1_000.0,
         )));
-        circuit.add(Element::Resistor(Resistor::new("Rc", "col", "0", 1_000.0)));
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vcol",
+            "col",
+            "0",
+            collector_voltage,
+        )));
         let mut transistor = Bjt::with_model(
             "Q1",
             "col",
@@ -895,6 +905,7 @@ fn ac_bjt_forward_transit_time_bias_coefficient_scales_diffusion_capacitance() {
         );
         transistor.forward_transit_time_bias_coefficient = coefficient;
         transistor.forward_transit_time_current = transit_time_current;
+        transistor.forward_transit_time_voltage = transit_time_voltage;
         circuit.add(Element::Bjt(transistor));
 
         ac_sweep(&circuit, 100_000.0, 100_000.0, 1).unwrap()[0]
@@ -903,12 +914,14 @@ fn ac_bjt_forward_transit_time_bias_coefficient_scales_diffusion_capacitance() {
             .abs()
     }
 
-    let nominal = base_amplitude(0.0, 0.0);
-    let bias_scaled = base_amplitude(9.0, 0.0);
-    let current_limited = base_amplitude(9.0, 1.0);
+    let nominal = base_amplitude(0.0, 0.0, 0.0, 0.0);
+    let bias_scaled = base_amplitude(9.0, 0.0, 0.0, 0.0);
+    let current_limited = base_amplitude(9.0, 1.0, 0.0, 0.0);
+    let voltage_limited = base_amplitude(9.0, 0.0, 0.1, 1.0);
 
     assert!(bias_scaled < nominal / 5.0);
     assert!(current_limited > bias_scaled * 5.0);
+    assert!(voltage_limited > bias_scaled * 5.0);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 122);
+    assert_eq!(coverage.len(), 124);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 122);
+    assert_eq!(records.len(), 124);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 122);
-    assert_eq!(report.expected_canonical_parameter_count, 122);
-    assert_eq!(report.accepted_name_count, 188);
+    assert_eq!(report.canonical_parameter_count, 124);
+    assert_eq!(report.expected_canonical_parameter_count, 124);
+    assert_eq!(report.accepted_name_count, 190);
     assert_eq!(report.aliased_parameter_count, 53);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t122\t122\t188\t53\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t124\t124\t190\t53\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,8 +235,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 121);
-    assert_eq!(report.accepted_name_count, 185);
+    assert_eq!(report.canonical_parameter_count, 123);
+    assert_eq!(report.accepted_name_count, 187);
     assert_eq!(report.aliased_parameter_count, 52);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t121\t122\t185\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t123\t124\t187\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -442,6 +442,7 @@ fn model_card_aliases_build_device_instances() {
             ("PTF", 30.0),
             ("XTF", 2.0),
             ("ITF", 4.0e-3),
+            ("VTF", 0.6),
             ("ISE", 3.0e-13),
             ("NE", 1.7),
             ("ISC", 4.0e-13),
@@ -473,6 +474,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("PTF").unwrap(), 30.0);
     assert_close(*bjt_card.parameters.get("XTF").unwrap(), 2.0);
     assert_close(*bjt_card.parameters.get("ITF").unwrap(), 4.0e-3);
+    assert_close(*bjt_card.parameters.get("VTF").unwrap(), 0.6);
     assert_close(*bjt_card.parameters.get("ISE").unwrap(), 3.0e-13);
     assert_close(*bjt_card.parameters.get("NE").unwrap(), 1.7);
     assert_close(*bjt_card.parameters.get("ISC").unwrap(), 4.0e-13);
@@ -501,6 +503,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(bjt_model.forward_excess_phase_degrees, 30.0);
     assert_close(bjt_model.forward_transit_time_bias_coefficient, 2.0);
     assert_close(bjt_model.forward_transit_time_current, 4.0e-3);
+    assert_close(bjt_model.forward_transit_time_voltage, 0.6);
     assert_close(bjt_model.base_emitter_leakage_saturation_current, 3.0e-13);
     assert_close(bjt_model.base_emitter_leakage_emission_coefficient, 1.7);
     assert_close(bjt_model.base_collector_leakage_saturation_current, 4.0e-13);
@@ -1447,6 +1450,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     bjt.forward_excess_phase_degrees = 30.0;
     bjt.forward_transit_time_bias_coefficient = 2.0;
     bjt.forward_transit_time_current = 4.0e-3;
+    bjt.forward_transit_time_voltage = 0.6;
     let mut circuit = Circuit::new();
     circuit
         .define_subcircuit(SubcircuitDefinition::new(
@@ -1496,6 +1500,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.forward_excess_phase_degrees, 30.0);
     assert_close(expanded.forward_transit_time_bias_coefficient, 2.0);
     assert_close(expanded.forward_transit_time_current, 4.0e-3);
+    assert_close(expanded.forward_transit_time_voltage, 0.6);
 }
 
 #[test]
@@ -2075,6 +2080,18 @@ fn dc_rejects_invalid_bjt_forward_transit_time_current() {
     assert!(error
         .to_string()
         .contains("forward transit-time current must be finite and non-negative"));
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_forward_transit_time_voltage() {
+    let mut transistor = Bjt::new("Qbad", "c", "b", "0");
+    transistor.forward_transit_time_voltage = -1.0;
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Bjt(transistor));
+    let error = dc_op(&circuit).unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("forward transit-time voltage must be finite and non-negative"));
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -693,13 +693,15 @@ fn transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() {
         forward_transit_time: f64,
         forward_transit_time_bias_coefficient: f64,
         forward_transit_time_current: f64,
+        forward_transit_time_voltage: f64,
+        collector_voltage: f64,
     ) -> Vec<TransientPoint> {
         let mut circuit = Circuit::new();
         circuit.add(Element::VoltageSource(VoltageSource::new(
             "Vcc",
             "collector",
             "0",
-            5.0,
+            collector_voltage,
         )));
         circuit.add(Element::CurrentSource(CurrentSource::with_waveform(
             "Istep",
@@ -731,14 +733,16 @@ fn transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() {
         );
         transistor.forward_transit_time_bias_coefficient = forward_transit_time_bias_coefficient;
         transistor.forward_transit_time_current = forward_transit_time_current;
+        transistor.forward_transit_time_voltage = forward_transit_time_voltage;
         circuit.add(Element::Bjt(transistor));
         transient(&circuit, 1.0e-9, 5.0e-9).unwrap()
     }
 
-    let no_storage = run(0.0, 0.0, 0.0);
-    let stored = run(1.0e-9, 0.0, 0.0);
-    let bias_scaled = run(1.0e-9, 9.0, 0.0);
-    let current_limited = run(1.0e-9, 9.0, 1.0);
+    let no_storage = run(0.0, 0.0, 0.0, 0.0, 5.0);
+    let stored = run(1.0e-9, 0.0, 0.0, 0.0, 5.0);
+    let bias_scaled = run(1.0e-9, 9.0, 0.0, 0.0, 5.0);
+    let current_limited = run(1.0e-9, 9.0, 1.0, 0.0, 5.0);
+    let voltage_limited = run(1.0e-9, 9.0, 0.0, 0.5, 10.0);
     let no_storage_first = no_storage[0].voltage("base").unwrap();
     let stored_first = stored[0].voltage("base").unwrap();
 
@@ -765,6 +769,11 @@ fn transient_bjt_forward_transit_time_holds_base_charge_on_turnoff() {
         .and_then(|point| point.voltage("base"))
         .unwrap();
     assert!((current_limited_last - stored_last).abs() < (bias_scaled_last - stored_last).abs());
+    let voltage_limited_last = voltage_limited
+        .last()
+        .and_then(|point| point.voltage("base"))
+        .unwrap();
+    assert!((voltage_limited_last - stored_last).abs() < (bias_scaled_last - stored_last).abs());
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add BJT model-card `VTF` forward transit-time voltage-scale support, applying
+  `exp(Vbc / (1.44 * VTF))` to the `XTF` AC and transient storage enhancement.
+
 - Add BJT model-card `ITF` forward transit-time current-scale support, applying
   `(If / (If + ITF))^2` to the `XTF` AC and transient storage enhancement.
 - Add BJT model-card `XTF` forward transit-time bias-coefficient support,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1735,6 +1735,7 @@ export interface Bjt {
   readonly forwardExcessPhaseDegrees: number;
   readonly forwardTransitTimeBiasCoefficient: number;
   readonly forwardTransitTimeCurrent: number;
+  readonly forwardTransitTimeVoltage: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -2012,8 +2013,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [32, 49, 13, 4],
-  PNP: [32, 49, 13, 4],
+  NPN: [33, 50, 13, 4],
+  PNP: [33, 50, 13, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3603,7 +3604,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees, element.forwardTransitTimeBiasCoefficient, element.forwardTransitTimeCurrent);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees, element.forwardTransitTimeBiasCoefficient, element.forwardTransitTimeCurrent, element.forwardTransitTimeVoltage);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7794,6 +7795,7 @@ export function bjt(
   forwardExcessPhaseDegrees = 0.0,
   forwardTransitTimeBiasCoefficient = 0.0,
   forwardTransitTimeCurrent = 0.0,
+  forwardTransitTimeVoltage = 0.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7834,6 +7836,7 @@ export function bjt(
     forwardExcessPhaseDegrees,
     forwardTransitTimeBiasCoefficient,
     forwardTransitTimeCurrent,
+    forwardTransitTimeVoltage,
   };
 }
 
@@ -7951,6 +7954,7 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   PTF: "PTF",
   XTF: "XTF",
   ITF: "ITF",
+  VTF: "VTF",
   ISE: "ISE",
   NE: "NE",
   ISC: "ISC",
@@ -8490,6 +8494,7 @@ export function bjtFromModelCard(
     p.PTF ?? 0.0,
     p.XTF ?? 0.0,
     p.ITF ?? 0.0,
+    p.VTF ?? 0.0,
   );
 }
 
@@ -19133,12 +19138,21 @@ function stampBjtCharge(
   matrix: number[][],
   rhs: number[],
 ): void {
+  const reverseJunctionVoltage =
+    capacitorStates.find(
+      (state) => state.name === bjtBaseCollectorChargeStateName(element),
+    )?.previousVoltage ?? 0.0;
   for (const spec of bjtChargeStateSpecs(element)) {
     const state = capacitorStates.find((candidate) => candidate.name === spec.name);
     if (state === undefined) {
       continue;
     }
-    const capacitance = bjtChargeDynamicCapacitance(element, spec.kind, state.previousVoltage);
+    const capacitance = bjtChargeDynamicCapacitance(
+      element,
+      spec.kind,
+      state.previousVoltage,
+      reverseJunctionVoltage,
+    );
     if (capacitance <= 0.0) {
       continue;
     }
@@ -19663,7 +19677,11 @@ function bjtJunctionTransconductance(
   return (element.saturationCurrent / effectiveThermalVoltage) * Math.exp(exponent);
 }
 
-function bjtForwardTransitTimeScale(element: Bjt, voltage: number): number {
+function bjtForwardTransitTimeScale(
+  element: Bjt,
+  voltage: number,
+  reverseJunctionVoltage: number,
+): number {
   const effectiveThermalVoltage =
     element.thermalVoltage * element.forwardEmissionCoefficient;
   const exponent = Math.max(-40.0, Math.min(40.0, voltage / effectiveThermalVoltage));
@@ -19676,13 +19694,21 @@ function bjtForwardTransitTimeScale(element: Bjt, voltage: number): number {
     const ratio = forwardCurrent / (forwardCurrent + element.forwardTransitTimeCurrent);
     currentFactor = ratio * ratio;
   }
-  return 1.0 + element.forwardTransitTimeBiasCoefficient * currentFactor;
+  const voltageFactor = element.forwardTransitTimeVoltage === 0.0
+    ? 1.0
+    : Math.exp(Math.max(
+        -40.0,
+        Math.min(40.0, reverseJunctionVoltage / (1.44 * element.forwardTransitTimeVoltage)),
+      ));
+  return 1.0 +
+    element.forwardTransitTimeBiasCoefficient * currentFactor * voltageFactor;
 }
 
 function bjtChargeDynamicCapacitance(
   element: Bjt,
   kind: BjtChargeStateKind,
   voltage: number,
+  reverseJunctionVoltage: number,
 ): number {
   if (kind === "base-emitter") {
     const conductance = bjtJunctionTransconductance(
@@ -19692,7 +19718,7 @@ function bjtChargeDynamicCapacitance(
     );
     return bjtBaseEmitterDepletionCapacitance(element, voltage) +
       element.forwardTransitTime *
-        bjtForwardTransitTimeScale(element, voltage) *
+        bjtForwardTransitTimeScale(element, voltage, reverseJunctionVoltage) *
         conductance;
   }
   const conductance = bjtJunctionTransconductance(
@@ -19752,7 +19778,15 @@ function bjtChargeStateSpecs(element: Bjt): BjtChargeStateSpec[] {
       kind: "base-emitter",
     });
   }
-  if (element.baseCollectorCapacitance > 0.0 || element.reverseTransitTime > 0.0) {
+  if (
+    element.baseCollectorCapacitance > 0.0 ||
+    element.reverseTransitTime > 0.0 ||
+    (
+      element.forwardTransitTime > 0.0 &&
+      element.forwardTransitTimeBiasCoefficient > 0.0 &&
+      element.forwardTransitTimeVoltage > 0.0
+    )
+  ) {
     const [positive, negative] =
       element.polarity === "NPN"
         ? [element.base, element.collector]
@@ -19991,6 +20025,9 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.forwardTransitTimeCurrent) || element.forwardTransitTimeCurrent < 0.0) {
     throw invalidElement(element.name, "forward transit-time current must be finite and non-negative");
+  }
+  if (!Number.isFinite(element.forwardTransitTimeVoltage) || element.forwardTransitTimeVoltage < 0.0) {
+    throw invalidElement(element.name, "forward transit-time voltage must be finite and non-negative");
   }
   if (!Number.isFinite(element.baseEmitterLeakageSaturationCurrent) || element.baseEmitterLeakageSaturationCurrent < 0.0) {
     throw invalidElement(element.name, "base-emitter leakage saturation current must be finite and non-negative");
@@ -20411,6 +20448,9 @@ function updateCapacitorStates(
   nodeVoltages: ReadonlyMap<string, number>,
   capacitorStates: CapacitorState[],
 ): void {
+  const previousVoltages = new Map(
+    capacitorStates.map((state) => [state.name, state.previousVoltage]),
+  );
   for (const state of capacitorStates) {
     const capacitorElement = circuit
       .elements()
@@ -20499,7 +20539,12 @@ function updateCapacitorStates(
         : diodeElement !== undefined
           ? diodeDynamicCapacitance(diodeElement, previousVoltage)
           : bjtSpec !== undefined
-            ? bjtChargeDynamicCapacitance(bjtElement!, bjtSpec.kind, previousVoltage)
+            ? bjtChargeDynamicCapacitance(
+                bjtElement!,
+                bjtSpec.kind,
+                previousVoltage,
+                previousVoltages.get(bjtBaseCollectorChargeStateName(bjtElement!)) ?? 0.0,
+              )
             : jfetSpec !== undefined
               ? jfetSpec.capacitance
               : mosfetChargeDynamicCapacitance(
@@ -21970,7 +22015,7 @@ function stampAcBjtSmallSignal(
     baseTransconductance / element.forwardBeta + leakage.conductance;
   const diffusionCapacitance =
     element.forwardTransitTime *
-    bjtForwardTransitTimeScale(element, junctionVoltage) *
+    bjtForwardTransitTimeScale(element, junctionVoltage, reverseJunctionVoltage) *
     transconductance;
   const excessPhase =
     omega * element.forwardTransitTime * element.forwardExcessPhaseDegrees * Math.PI / 180.0;

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -599,15 +599,21 @@ describe("acSweep", () => {
   });
 
   it("scales BJT diffusion capacitance by the forward transit-time bias coefficient", () => {
-    function baseAmplitude(coefficient: number, transitTimeCurrent = 0.0): number {
+    function baseAmplitude(
+      coefficient: number,
+      transitTimeCurrent = 0.0,
+      transitTimeVoltage = 0.0,
+      collectorVoltage = 0.0,
+    ): number {
       const circuit = new Circuit();
       circuit.add(voltageSourceWithAc("Vac", "in", "0", 0.0, 1.0));
       circuit.add(resistor("Rin", "in", "base", 1_000.0));
-      circuit.add(resistor("Rc", "col", "0", 1_000.0));
+      circuit.add(voltageSource("Vcol", "col", "0", collectorVoltage));
       circuit.add({
         ...bjt("Q1", "col", "base", "0", "NPN", 25.85e-6, 100.0, 0.02585, 0.0, 0.0, 1.0e-6),
         forwardTransitTimeBiasCoefficient: coefficient,
         forwardTransitTimeCurrent: transitTimeCurrent,
+        forwardTransitTimeVoltage: transitTimeVoltage,
       });
       return complexAbs(acSweep(circuit, 100_000.0, 100_000.0, 1)[0].voltage("base")!);
     }
@@ -615,9 +621,11 @@ describe("acSweep", () => {
     const nominal = baseAmplitude(0.0);
     const biasScaled = baseAmplitude(9.0);
     const currentLimited = baseAmplitude(9.0, 1.0);
+    const voltageLimited = baseAmplitude(9.0, 0.0, 0.1, 1.0);
 
     expect(biasScaled).toBeLessThan(nominal / 5.0);
     expect(currentLimited).toBeGreaterThan(biasScaled * 5.0);
+    expect(voltageLimited).toBeGreaterThan(biasScaled * 5.0);
   });
 
   it("uses BJT reverse transit time as base-collector diffusion capacitance in AC analysis", () => {

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(122);
+    expect(coverage).toHaveLength(124);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(122);
+    expect(records).toHaveLength(124);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 122,
-      expectedCanonicalParameterCount: 122,
-      acceptedNameCount: 188,
+      canonicalParameterCount: 124,
+      expectedCanonicalParameterCount: 124,
+      acceptedNameCount: 190,
       aliasedParameterCount: 53,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t122\t122\t188\t53\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t124\t124\t190\t53\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,8 +241,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(121);
-    expect(report.acceptedNameCount).toBe(185);
+    expect(report.canonicalParameterCount).toBe(123);
+    expect(report.acceptedNameCount).toBe(187);
     expect(report.aliasedParameterCount).toBe(52);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t121\t122\t185\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t123\t124\t187\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -348,6 +348,7 @@ describe("dcOp", () => {
       PTF: 30.0,
       XTF: 2.0,
       ITF: 4.0e-3,
+      VTF: 0.6,
       ISE: 3.0e-13,
       NE: 1.7,
       ISC: 4.0e-13,
@@ -361,7 +362,7 @@ describe("dcOp", () => {
       FC: 0.4,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, TNOM: 50.0, KF: 1.0e-12, AF: 1.3, PTF: 30.0, XTF: 2.0, ITF: 4.0e-3, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, TNOM: 50.0, KF: 1.0e-12, AF: 1.3, PTF: 30.0, XTF: 2.0, ITF: 4.0e-3, VTF: 0.6, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.reverseBeta, 0.25);
@@ -379,6 +380,7 @@ describe("dcOp", () => {
     expectClose(bjtModel.forwardExcessPhaseDegrees, 30.0);
     expectClose(bjtModel.forwardTransitTimeBiasCoefficient, 2.0);
     expectClose(bjtModel.forwardTransitTimeCurrent, 4.0e-3);
+    expectClose(bjtModel.forwardTransitTimeVoltage, 0.6);
     expectClose(bjtModel.baseEmitterLeakageSaturationCurrent, 3.0e-13);
     expectClose(bjtModel.baseEmitterLeakageEmissionCoefficient, 1.7);
     expectClose(bjtModel.baseCollectorLeakageSaturationCurrent, 4.0e-13);
@@ -1022,7 +1024,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3, 323.15, 1.0e-12, 1.3, 30.0, 2.0, 4.0e-3),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3, 323.15, 1.0e-12, 1.3, 30.0, 2.0, 4.0e-3, 0.6),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -1055,6 +1057,7 @@ describe("dcOp", () => {
       expectClose(expanded.forwardExcessPhaseDegrees, 30.0);
       expectClose(expanded.forwardTransitTimeBiasCoefficient, 2.0);
       expectClose(expanded.forwardTransitTimeCurrent, 4.0e-3);
+      expectClose(expanded.forwardTransitTimeVoltage, 0.6);
     }
   });
 
@@ -1447,6 +1450,17 @@ describe("dcOp", () => {
     });
     expect(() => dcOp(circuit)).toThrowError(
       "forward transit-time current must be finite and non-negative",
+    );
+  });
+
+  it("rejects invalid BJT forward transit-time voltages", () => {
+    const circuit = new Circuit();
+    circuit.add({
+      ...bjt("Qbad", "c", "b", "0"),
+      forwardTransitTimeVoltage: -1.0,
+    });
+    expect(() => dcOp(circuit)).toThrowError(
+      "forward transit-time voltage must be finite and non-negative",
     );
   });
 

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -518,9 +518,11 @@ describe("transient", () => {
       forwardTransitTime: number,
       forwardTransitTimeBiasCoefficient = 0.0,
       forwardTransitTimeCurrent = 0.0,
+      forwardTransitTimeVoltage = 0.0,
+      collectorVoltage = 5.0,
     ): TransientPoint[] {
       const circuit = new Circuit();
-      circuit.add(voltageSource("Vcc", "collector", "0", 5.0));
+      circuit.add(voltageSource("Vcc", "collector", "0", collectorVoltage));
       circuit.add(currentSourceWithWaveform(
         "Istep",
         "0",
@@ -549,6 +551,7 @@ describe("transient", () => {
         ),
         forwardTransitTimeBiasCoefficient,
         forwardTransitTimeCurrent,
+        forwardTransitTimeVoltage,
       });
       return transient(circuit, 1.0e-9, 5.0e-9);
     }
@@ -557,6 +560,7 @@ describe("transient", () => {
     const stored = run(1.0e-9);
     const biasScaled = run(1.0e-9, 9.0);
     const currentLimited = run(1.0e-9, 9.0, 1.0);
+    const voltageLimited = run(1.0e-9, 9.0, 0.0, 0.5, 10.0);
     expectClose(noStorage[0].voltage("base"), 0.0);
     expect(stored[0].voltage("base")!).toBeGreaterThan(0.6);
     expect(stored[stored.length - 1].voltage("base")!).toBeLessThan(stored[0].voltage("base")!);
@@ -566,6 +570,13 @@ describe("transient", () => {
     )).toBeGreaterThan(1.0e-12);
     expect(Math.abs(
       currentLimited[currentLimited.length - 1].voltage("base")! -
+        stored[stored.length - 1].voltage("base")!,
+    )).toBeLessThan(Math.abs(
+      biasScaled[biasScaled.length - 1].voltage("base")! -
+        stored[stored.length - 1].voltage("base")!,
+    ));
+    expect(Math.abs(
+      voltageLimited[voltageLimited.length - 1].voltage("base")! -
         stored[stored.length - 1].voltage("base")!,
     )).toBeLessThan(Math.abs(
       biasScaled[biasScaled.length - 1].voltage("base")! -

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT forward transit-time current scale.
+1. Cross-language BJT forward transit-time voltage scale.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `ITF` model-card support in Rust, Python, and TypeScript,
+   - Add Berkeley BJT `VTF` model-card support in Rust, Python, and TypeScript,
      defaulting to zero so existing AC and transient results remain unchanged.
-   - Apply the Berkeley forward-current factor
-     `(If / (If + ITF))^2` to the `XTF` diffusion-capacitance and transient
+   - Apply the Berkeley base-collector voltage factor
+     `exp(Vbc / (1.44 * VTF))` to the `XTF` diffusion-capacitance and transient
      stored-charge enhancement while preserving the complete BJT model through
-     subcircuits.
-   - Extend the supported-parameter coverage gate from 120 to 122 canonical
+     subcircuits and tracking the control voltage in transient state.
+   - Extend the supported-parameter coverage gate from 122 to 124 canonical
      rows and lock model-card behavior, validation, hierarchy, AC loading, and
      transient stored-charge behavior in all engines.
 
@@ -3151,6 +3151,14 @@ the Rust, Python, and TypeScript surfaces together.
      charge by `TF * (1 + XTF)`.
    - Hierarchical subcircuit expansion preserves the complete BJT model, and
      the supported-parameter release gate now covers 120 canonical rows.
+
+238. Cross-language BJT forward transit-time current scale.
+   - Status: completed in PR 8844.
+   - Rust, Python, and TypeScript BJT model cards now accept `ITF`, default it
+     to zero, and apply `(If / (If + ITF))^2` to the `XTF` AC and transient
+     storage enhancement.
+   - Hierarchical subcircuit expansion preserves the complete BJT model, and
+     the supported-parameter release gate now covers 122 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley BJT `VTF` model-card support in Rust, Python, and TypeScript
- apply `exp(Vbc / (1.44 * VTF))` to the existing `XTF` forward charge-storage enhancement in AC and transient analysis
- preserve `VTF` through hierarchy, validate it, extend the supported-parameter gate to 124 rows, and reconcile the SPICE implementation plan

## Verification
- `cargo test -p spice-engine` (372 passed)
- Python `pytest` (564 passed, 88.85% coverage)
- TypeScript `npm test -- --run` (322 passed)
- TypeScript `npm run build`
- `cargo fmt -p spice-engine -- --check`
- Ruff on touched Python sources and tests
- `git diff --check`