### PR TITLE
test(twig-aot): recursion GC differential — precise roots through a self-recursive frame (AOT00-T1 x86_64 PR-x5)

### DIFF
--- a/code/packages/rust/twig-aot/CHANGELOG.md
+++ b/code/packages/rust/twig-aot/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog — `twig-aot`
 
+## 0.43.1 - 2026-07-23 — recursion GC differential (AOT00-T1 x86_64 PR-x5, test-only)
+
+Adds an end-to-end differential proving precise roots reach through a **self-recursive**
+frame, not just the entry frame — the case that on x86-64 is precise only because a
+self-recursive `call` is a registered safepoint (PR-x4). A `rec(stop)` function allocates
+a 64-byte `i64` look-alike per frame and recurses once (`main → rec(0) → rec(1)`); the
+collect fires in `rec(1)`, so the collector unwinds through `rec(0)`, an intermediate
+self-recursive frame whose live look-alike is mapped only at the recursive-call return
+address. Conservative pins both look-alikes (`live_bytes == 128`); precise reclaims both
+(`== 0`) — a `precise` of `64` would mean the intermediate frame fell back to a
+conservative scan, the exact regression PR-x4 prevents.
+
+Added identically to `linux_x86_64_smoke` (runs on the native x86-64 `ubuntu-latest`
+runner — the authoritative validator, since the dev host is aarch64 macOS) and to
+`macos_arm64_smoke` (locally-runnable, validates the program shape + GC semantics; aarch64
+has always mapped recursive frames via `BL` post-scan). No production code change.
+
 ## 0.43.0 - 2026-07-23 — x86_64 GC stack-map registration, SysV (AOT00-T1 x86_64 PR-x3)
 
 Fills the x86-64 `__gc_init_stackmaps` (a no-op since PR-x2) with **real registration**

--- a/code/packages/rust/twig-aot/Cargo.toml
+++ b/code/packages/rust/twig-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-aot"
-version = "0.43.0"
+version = "0.43.1"
 edition = "2021"
 description = "Twig AOT compiler — produces native Mach-O / ELF executables from Twig source. v0.28.0 (E4d-4 fix): strip_dead_aot_string_allocs now keeps EVERY buffer bound to a live string alias — a branch-selected (multi-block) str var aliases several buffers, and the old alias-keyed map dropped all but the last, so a not-last branch read a freed/empty buffer at run time. v0.27.0 (E4-dyn E4d-4): runtime (branch-selected) strings on the native aarch64 + x86_64 columns — a str var assigned by str_const in >1 basic block is kept out of the compile-time literal map so print_str/str_len read the length from the [i64 len][bytes] buffer header at run time (field_load) instead of folding one branch's static length; the var's stack slot already carries the buffer address. v0.26.0 (E4-dyn E4d-1): runtime string helpers __twig_str_concat/_slice/_index/_len/_cmp in twig_runtime.c on the E5 length-prefixed heap block; bounds-trap on slice/index; C-driver unit tests."
 

--- a/code/packages/rust/twig-aot/tests/linux_x86_64_smoke.rs
+++ b/code/packages/rust/twig-aot/tests/linux_x86_64_smoke.rs
@@ -349,3 +349,132 @@ fn gc_stress_live_bytes_differential_on_linux() {
          (conservative kept {conservative})",
     );
 }
+
+/// AOT00-T1 x86_64 PR-x4 / PR-x5 — precise roots reach through a **self-recursive** frame.
+///
+/// The differential above proves precise roots work for `main`'s own frame. This one
+/// proves they work for an *intermediate* frame in a recursion chain — the case that, on
+/// x86-64, is precise ONLY because a self-recursive `call` is now a registered safepoint
+/// (PR-x4). A self-recursive `call <fn>` lowers to `call rel32` with an internal label
+/// fixup and no `PltRel32` relocation, so before PR-x4 its return address was not in the
+/// stack map and the collector conservatively re-scanned that frame.
+///
+/// ```text
+///   rec(stop) -> i64:
+///       a = gc_alloc(64)          ; i64 look-alike, one per active frame
+///       if stop != 0 goto base
+///       r = rec(1)                ; SELF-RECURSIVE call — a0 sits in this frame across it
+///       ret r
+///     base:
+///       <collect>                 ; gc_collect | gc_collect_precise (fires here)
+///       ret gc_live_bytes()
+///   main() -> i64: ret rec(0)
+/// ```
+///
+/// `main → rec(0) → rec(1)`. The collect fires in `rec(1)`; unwinding passes through
+/// `rec(0)`, an intermediate self-recursive frame holding a 64-byte look-alike (`a0`).
+/// **Conservative** pins both look-alikes → `128`. **Precise** maps every frame — `rec(1)`
+/// via its builtin calls, `rec(0)` via the self-recursive-call safepoint PR-x4 added — so
+/// both `i64` look-alikes are unrooted and reclaimed → `0`. A `precise` of `64` would mean
+/// `rec(0)` fell back to a conservative scan: the exact regression PR-x4 prevents. Runs on
+/// the native x86-64 `ubuntu-latest` runner (dev host is aarch64 macOS); the identical
+/// module is validated locally on aarch64 in `macos_arm64_smoke`.
+#[test]
+fn gc_recursive_frame_live_bytes_differential_on_linux() {
+    use interpreter_ir::function::IIRFunction;
+    use interpreter_ir::instr::{IIRInstr, Operand};
+    use interpreter_ir::module::IIRModule;
+
+    fn build(collect: &str, collect_returns: bool) -> IIRModule {
+        // rec(stop: i64) -> i64
+        let mut rec_body = vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(64)], "i64"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("a".into()),
+                vec![Operand::Var("gc_alloc".into()), Operand::Var("n".into())],
+                "i64",
+            ),
+            IIRInstr::new(
+                "jmp_if_true",
+                None,
+                vec![Operand::Var("stop".into()), Operand::Var("base".into())],
+                "i64",
+            ),
+            IIRInstr::new("const", Some("one".into()), vec![Operand::Int(1)], "i64"),
+            IIRInstr::new(
+                "call",
+                Some("r".into()),
+                vec![Operand::Var("rec".into()), Operand::Var("one".into())],
+                "i64",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "i64"),
+            IIRInstr::new("label", None, vec![Operand::Var("base".into())], "i64"),
+        ];
+        rec_body.push(if collect_returns {
+            IIRInstr::new(
+                "call_builtin",
+                Some("freed".into()),
+                vec![Operand::Var(collect.into())],
+                "i64",
+            )
+        } else {
+            IIRInstr::new("call_builtin", None, vec![Operand::Var(collect.into())], "void")
+        });
+        rec_body.push(IIRInstr::new(
+            "call_builtin",
+            Some("lb".into()),
+            vec![Operand::Var("gc_live_bytes".into())],
+            "i64",
+        ));
+        rec_body.push(IIRInstr::new("ret", None, vec![Operand::Var("lb".into())], "i64"));
+
+        let main_body = vec![
+            IIRInstr::new("const", Some("z".into()), vec![Operand::Int(0)], "i64"),
+            IIRInstr::new(
+                "call",
+                Some("r".into()),
+                vec![Operand::Var("rec".into()), Operand::Var("z".into())],
+                "i64",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "i64"),
+        ];
+
+        let mut m = IIRModule::new("gc_recur", "twig");
+        m.add_or_replace(IIRFunction::new(
+            "rec",
+            vec![("stop".to_string(), "i64".to_string())],
+            "i64",
+            rec_body,
+        ));
+        m.add_or_replace(IIRFunction::new("main", vec![], "i64", main_body));
+        m.entry_point = Some("main".into());
+        m
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let run = |tag: &str, collect: &str, ret: bool| -> i32 {
+        let exe = dir.path().join(tag);
+        twig_aot::compile_module_to_linux_executable(&build(collect, ret), &exe)
+            .unwrap_or_else(|e| panic!("{tag} compiles+links: {e}"));
+        Command::new(&exe)
+            .output()
+            .unwrap_or_else(|e| panic!("{tag} runs: {e}"))
+            .status
+            .code()
+            .unwrap_or_else(|| panic!("{tag} exited by signal"))
+    };
+
+    let conservative = run("gc_recur_cons", "gc_collect", false);
+    let precise = run("gc_recur_prec", "gc_collect_precise", true);
+    assert_eq!(
+        conservative, 128,
+        "conservative pins both recursive frames' 64-byte look-alikes (got {conservative})",
+    );
+    assert_eq!(
+        precise, 0,
+        "precise reclaims both look-alikes, incl. a0 in the intermediate self-recursive \
+         frame — requires that frame be precisely mapped at the recursive-call return \
+         address (PR-x4) (got {precise}, conservative={conservative})",
+    );
+}

--- a/code/packages/rust/twig-aot/tests/macos_arm64_smoke.rs
+++ b/code/packages/rust/twig-aot/tests/macos_arm64_smoke.rs
@@ -546,6 +546,143 @@ fn end_to_end_gc_precise_keeps_ref_reclaims_lookalike() {
     );
 }
 
+/// AOT00-T1 (x86_64 PR-x4 / PR-x5) — precise roots reach through a **self-recursive**
+/// frame, not just the entry frame.
+///
+/// The plain `gc_stress` differential proves precise roots work for `main`'s own frame.
+/// This one proves they work for an *intermediate* frame in a recursion chain — the case
+/// that, on x86-64, is precise only because a self-recursive `call` is now a registered
+/// safepoint (PR-x4). Two functions:
+///
+/// ```text
+///   rec(stop) -> i64:
+///       a = gc_alloc(64)          ; i64 look-alike, one per active frame
+///       if stop != 0 goto base
+///       r = rec(1)                ; SELF-RECURSIVE call — a0 sits in this frame across it
+///       ret r
+///     base:
+///       <collect>                 ; gc_collect | gc_collect_precise  (fires here)
+///       ret gc_live_bytes()
+///   main() -> i64: ret rec(0)
+/// ```
+///
+/// `main → rec(0) → rec(1)`. The collect fires inside `rec(1)`; when the collector walks
+/// out it passes through **`rec(0)`**, an intermediate self-recursive frame holding a
+/// 64-byte look-alike (`a0`) in an `i64` (non-reference) slot.
+///
+/// - **Conservative** scans every frame's stack, sees both look-alikes (`a0`, `a1`), and
+///   pins both objects → `live_bytes == 128`.
+/// - **Precise** walks each frame through its registered map. The return address live on
+///   `rec(0)`'s frame at collect time is the **self-recursive-call site**, so that frame is
+///   precise only if that PC is a mapped safepoint (aarch64 has always mapped it — it
+///   post-scans `BL`; x86-64 does so as of PR-x4). The `i64` slots are not references, so
+///   both objects are unrooted and reclaimed → `live_bytes == 0`.
+///
+/// A `precise` of `64` instead of `0` would mean the intermediate recursive frame fell
+/// back to a conservative scan — exactly the gap PR-x4 closes on x86-64. Here on aarch64
+/// it validates the program shape + GC semantics on a locally-runnable target; the
+/// identical module runs on the x86-64 CI runner (`linux_x86_64_smoke`).
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn end_to_end_gc_recursive_frame_live_bytes_differential() {
+    use interpreter_ir::instr::{IIRInstr, Operand};
+
+    fn build(collect: &str, collect_returns: bool) -> IIRModule {
+        // rec(stop: i64) -> i64
+        let mut rec_body = vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(64)], "i64"),
+            // The allocation's address lives only in this i64 (non-ref) slot.
+            IIRInstr::new(
+                "call_builtin",
+                Some("a".into()),
+                vec![Operand::Var("gc_alloc".into()), Operand::Var("n".into())],
+                "i64",
+            ),
+            // stop != 0 → base case; else fall through to the recursive path.
+            IIRInstr::new(
+                "jmp_if_true",
+                None,
+                vec![Operand::Var("stop".into()), Operand::Var("base".into())],
+                "i64",
+            ),
+            // Recursive path (stop == 0): recurse exactly once with stop = 1.
+            IIRInstr::new("const", Some("one".into()), vec![Operand::Int(1)], "i64"),
+            IIRInstr::new(
+                "call",
+                Some("r".into()),
+                vec![Operand::Var("rec".into()), Operand::Var("one".into())],
+                "i64",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "i64"),
+            // Base path (stop != 0): collect, then return live payload bytes.
+            IIRInstr::new("label", None, vec![Operand::Var("base".into())], "i64"),
+        ];
+        rec_body.push(if collect_returns {
+            IIRInstr::new(
+                "call_builtin",
+                Some("freed".into()),
+                vec![Operand::Var(collect.into())],
+                "i64",
+            )
+        } else {
+            IIRInstr::new("call_builtin", None, vec![Operand::Var(collect.into())], "void")
+        });
+        rec_body.push(IIRInstr::new(
+            "call_builtin",
+            Some("lb".into()),
+            vec![Operand::Var("gc_live_bytes".into())],
+            "i64",
+        ));
+        rec_body.push(IIRInstr::new("ret", None, vec![Operand::Var("lb".into())], "i64"));
+
+        // main() -> i64  { ret rec(0) }
+        let main_body = vec![
+            IIRInstr::new("const", Some("z".into()), vec![Operand::Int(0)], "i64"),
+            IIRInstr::new(
+                "call",
+                Some("r".into()),
+                vec![Operand::Var("rec".into()), Operand::Var("z".into())],
+                "i64",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "i64"),
+        ];
+
+        let mut m = IIRModule::new("gc_recur", "twig");
+        m.add_or_replace(IIRFunction::new(
+            "rec",
+            vec![("stop".to_string(), "i64".to_string())],
+            "i64",
+            rec_body,
+        ));
+        m.add_or_replace(IIRFunction::new("main", vec![], "i64", main_body));
+        m.entry_point = Some("main".into());
+        m
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let run = |tag: &str, collect: &str, ret: bool| -> i32 {
+        let exe = dir.path().join(tag);
+        twig_aot::compile_module_to_macos_executable(&build(collect, ret), &exe)
+            .unwrap_or_else(|e| panic!("{tag} compiles+links: {e}"));
+        let out = Command::new(&exe).output().unwrap_or_else(|e| panic!("{tag} runs: {e}"));
+        out.status.code().unwrap_or_else(|| panic!("{tag} exited by signal: {out:?}"))
+    };
+
+    let conservative = run("gc_recur_cons", "gc_collect", false);
+    let precise = run("gc_recur_prec", "gc_collect_precise", true);
+
+    assert_eq!(
+        conservative, 128,
+        "conservative must pin both recursive frames' 64-byte look-alikes (got {conservative})",
+    );
+    assert_eq!(
+        precise, 0,
+        "precise must reclaim BOTH look-alikes, including a0 in the intermediate \
+         self-recursive frame — which requires that frame be precisely mapped at the \
+         recursive-call return address (got {precise}, conservative={conservative})",
+    );
+}
+
 /// Sanity check that the AArch64Backend trait wiring goes end-to-end
 /// for a hand-built CIR-shaped function.
 #[test]


### PR DESCRIPTION
## What

End-to-end proof that precise roots reach through an **intermediate self-recursive frame**, not just the entry frame — the payoff of [PR-x4](https://github.com/adhithyan15/coding-adventures/pull/8846), which made an x86-64 self-recursive `call` a registered GC safepoint. The existing `gc_stress` differential only exercises `main`'s own frame.

## The program (hand-built IIR, two functions)

```text
rec(stop) -> i64:
    a = gc_alloc(64)          ; i64 look-alike, one per active frame
    if stop != 0 goto base
    r = rec(1)                ; SELF-RECURSIVE call — a0 sits in this frame across it
    ret r
  base:
    <collect>                 ; gc_collect | gc_collect_precise  (fires here)
    ret gc_live_bytes()
main() -> i64: ret rec(0)
```

`main → rec(0) → rec(1)`. The collect fires in `rec(1)`; unwinding passes through `rec(0)`, an intermediate self-recursive frame whose live look-alike sits at the self-recursive-call return address.

- **Conservative** scans every frame's stack → pins both look-alikes → `live_bytes == 128`.
- **Precise** maps every frame — `rec(1)` via its builtin calls, `rec(0)` via the self-recursive-call safepoint PR-x4 added — so both `i64` look-alikes are unrooted and reclaimed → `live_bytes == 0`.

A `precise` of `64` would mean `rec(0)` fell back to a conservative scan: **the exact regression PR-x4 prevents.**

## Where it runs

Added *identically* to two suites:
- **`linux_x86_64_smoke`** — runs on the native x86-64 `ubuntu-latest` CI runner, the authoritative validator (dev host is aarch64 macOS, can't execute x86-64). This is the end-to-end proof of PR-x4.
- **`macos_arm64_smoke`** — locally runnable; validates the program shape + GC semantics on a runnable target (aarch64 has always mapped recursive frames by post-scanning `BL`). **Confirmed passing locally: conservative=128, precise=0.**

## Validation

- Local aarch64 run passes (128 / 0); the x86-64 module is byte-for-byte the same IIR, differing only in the platform entry point.
- Validity review: the two asserts are **mutually self-guarding** — flattening/inlining/DCE or a stuck `live_bytes` would break the `128` assert; the `0` assert specifically requires `rec(0)` be precisely mapped. No flakiness (live_bytes counts payload not addresses; signals panic; distinct exe names). Accepted `call`/param IIR shape.

Test-only; no production code changes. twig-aot 0.43.0 → 0.43.1.

> A pre-existing local-only failure (`end_to_end_typed_twig_returns_42` — a bare-`ld` link that doesn't pull the gc_runtime archive on the aarch64 dev host) is unrelated to this change and passes on CI; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)