### PR TITLE
feat(semantic-ir-to-c): short-circuit — LogicalAnd/LogicalOr (SIR16)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.9.0 — short-circuit (SIR16)
+
+Accepts `Feature::ShortCircuit`. `Expr::LogicalAnd` / `Expr::LogicalOr`
+(`&&` / `||`) reuse the SAME lowering the emitter already applies to the eager
+`and`/`or` builtins — no new machinery:
+
+- assign the LEFT operand into the destination, then conditionally OVERWRITE it
+  with the right (`dst = lhs; if (_sir_truthy(dst)) { dst = rhs; }` for `&&`,
+  `if (!_sir_truthy(dst))` for `||`).
+
+Because the right operand is emitted only inside the `if` body, it is not
+evaluated when the left already decides (true short-circuit), and `dst` holds
+the DECIDING OPERAND — not a coerced bool. This is the value-returning semantics
+Go models with an IIFE and Ruby gets from native `&&`/`||`: `1 && 2` is `2`,
+`false && 2` is `false`, `nil || 7` is `7`. It is deliberately NOT lowered to a
+bare C `&&`/`||`, which would collapse to an `int` 0/1 and lose the operand.
+
+The nodes are not `is_simple`, so they route through `emit_assign` — and, in
+return position, through the existing "compute a compound value into a temp,
+then return it" tail fallback — so no other emit arm is needed and the emitter
+stays total. The `scan_expr_for_builtin` pre-check recurses into both operands,
+so a deferred builtin nested in a `&&`/`||` is still reported cleanly.
+
+This closes the ShortCircuit parity arc: with the Ruby backend's short-circuit
+(0.7.0), `Feature::ShortCircuit` is now accepted on all six backends. Verified
+with hand-built modules (the frontend constant-folds a literal `&&`) compiled
+and run through a real `cc`: operand-return for both operators, a short-circuit
+proof where the dead operand is `1 / 0` (which traps if evaluated — a correct
+lowering skips it and the program exits 0), and a `LogicalAnd` in tail position.
+Bumps semantic-ir-to-c 0.8.0 → 0.9.0.
+
 ## 0.8.0 — floats (SIR16)
 
 Accepts `Feature::Floats`. Unlike the sequences and maps batches, this needed

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -85,13 +85,16 @@ SIR16 control flow and mutation (`Loops` — `While`, `ForRange`, `ForEach`; and
 `SeqLit`/`SeqIndex`/`SeqLen`/`SeqSet` and structural equality; and SIR16 `Maps`
 — a `SIR_MAP` heap assoc-array with `MapLit`/`MapGet`/`MapSet`, structural
 composite keys, positional structural equality, and `{k: v}` display (matching
-the Go/Rust backends); and SIR16 `Floats` — a `SIR_FLOAT` `FloatLit` (`7.0`
+the Go/Rust backends); SIR16 `Floats` — a `SIR_FLOAT` `FloatLit` (`7.0`
 stays a Float, not the Integer `7`; `Infinity`/`NaN` via `<math.h>`), with
 native float arithmetic, the division frontier (Float promotes, two Integers
-floor), and IEEE non-finite results.
+floor), and IEEE non-finite results; and SIR16 `ShortCircuit` — `LogicalAnd`
+(`&&`) and `LogicalOr` (`||`) lowered to an `if (_sir_truthy(...))` overwrite
+that short-circuits the dead operand and yields the deciding operand (not a
+bool).
 
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
-`Intrinsics`, `NDArrays`, `ShortCircuit`, exceptions/OOP, and every
+`Intrinsics`, `NDArrays`, exceptions/OOP, and every
 other not-yet-wired feature until its batch lands.  `Bignum` stays rejected
 until a bignum runtime ships — a module needing arbitrary precision is refused,
 never silently truncated.

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -547,6 +547,27 @@ fn emit_assign(out: &mut String, dst: &str, e: &Expr, indent: usize) {
             emit_assign(out, dst, &args[1], indent + 1);
             let _ = writeln!(out, "{pad}}}");
         }
+        // SIR16 short-circuit `&&` / `||` (`Expr::LogicalAnd` / `LogicalOr`) —
+        // distinct nodes from the eager `and`/`or` builtins above, but the same
+        // lowering: assign the LEFT operand into `dst`, then conditionally
+        // OVERWRITE it with the right. Because the right operand is emitted only
+        // inside the `if` body, it is not evaluated when the left already
+        // decides (true short-circuit), and `dst` holds the DECIDING OPERAND
+        // (not a coerced bool) — `a && b` is `a` when `a` is falsy else `b`;
+        // `a || b` is `a` when truthy else `b`. This matches the Go backend's
+        // short-circuit IIFE and Ruby's native `&&`/`||`.
+        Expr::LogicalAnd { lhs, rhs, .. } => {
+            emit_assign(out, dst, lhs, indent);
+            let _ = writeln!(out, "{pad}if (_sir_truthy({dst})) {{");
+            emit_assign(out, dst, rhs, indent + 1);
+            let _ = writeln!(out, "{pad}}}");
+        }
+        Expr::LogicalOr { lhs, rhs, .. } => {
+            emit_assign(out, dst, lhs, indent);
+            let _ = writeln!(out, "{pad}if (!_sir_truthy({dst})) {{");
+            emit_assign(out, dst, rhs, indent + 1);
+            let _ = writeln!(out, "{pad}}}");
+        }
         // SIR26 conversion with a compound value: compute the value into `dst`,
         // then reduce it to the target width in place.
         Expr::Convert { value, to, .. } => {
@@ -1116,6 +1137,9 @@ fn scan_expr_for_builtin(e: &Expr) -> Option<(String, Span)> {
         }),
         Expr::MapGet { map, key, .. } => {
             scan_expr_for_builtin(map).or_else(|| scan_expr_for_builtin(key))
+        }
+        Expr::LogicalAnd { lhs, rhs, .. } | Expr::LogicalOr { lhs, rhs, .. } => {
+            scan_expr_for_builtin(lhs).or_else(|| scan_expr_for_builtin(rhs))
         }
         _ => None,
     }

--- a/code/packages/rust/semantic-ir-to-c/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/lib.rs
@@ -76,6 +76,15 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // `FloatLit`; float `+`/`-`/`*`/`/` reuse the existing variadic helpers, so
     // accepting the feature plus the one emit arm keeps the emitter total.
     Feature::Floats,
+    // ── SIR16 short-circuit ──────────────────────────────────────────
+    // `Expr::LogicalAnd` / `Expr::LogicalOr` (`&&` / `||`) — the same lowering
+    // the emitter already uses for the eager `and`/`or` builtins: assign the
+    // left operand into `dst`, then conditionally OVERWRITE with the right, so
+    // the right is not evaluated when the left decides (true short-circuit) and
+    // `dst` holds the DECIDING OPERAND (not a bool). Because the nodes are not
+    // `is_simple`, they route through `emit_assign` (and, in tail position,
+    // through the compute-into-a-temp fallback), so no other arm is needed.
+    Feature::ShortCircuit,
     // ── SIR16 control flow / mutation ────────────────────────────────
     // `Stmt::While` renders as a portable `for (;;) { … if (!truthy) break; }`
     // (the condition is re-evaluated each iteration, so it may be compound);

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_shortcircuit.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_shortcircuit.rs
@@ -1,0 +1,231 @@
+//! Execution proof for SIR16 short-circuit on the C backend — hand-build
+//! modules (producer-agnostic), emit C, compile with a real gcc/clang-style
+//! compiler, run, assert stdout. Skips gracefully when no `cc` is present.
+//!
+//! `Feature::ShortCircuit` gates `Expr::LogicalAnd` / `Expr::LogicalOr`. The C
+//! backend already short-circuits the eager `and`/`or` builtins the same way,
+//! so the node lowering is a mirror: assign the left operand into the
+//! destination, then conditionally overwrite with the right — the right is
+//! never evaluated when the left decides, and the result is the DECIDING
+//! OPERAND (not a bool). Hand-built to bypass the frontend, which constant-folds
+//! a literal `&&`/`||`.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span, Stmt,
+    CURRENT_SIR_VERSION,
+};
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    for cand in ["cc", "clang", "gcc"] {
+        if Command::new(cand)
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+        {
+            return Some(cand.to_string());
+        }
+    }
+    None
+}
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn run(module: &Module) -> Option<String> {
+    let cc = find_cc()?;
+    let artifact = semantic_ir_to_c::compile(module).expect("C backend compile (no panic)");
+    let dir = std::env::temp_dir();
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let stem = format!("sirc_sc_{}_{}", std::process::id(), n);
+    let cpath: PathBuf = dir.join(format!("{stem}.c"));
+    let exe: PathBuf = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::File::create(&cpath)
+        .and_then(|mut f| f.write_all(artifact.source.as_bytes()))
+        .expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-Werror=unused-variable", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        artifact.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "run failed (exit {:?})", r.status.code());
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+fn s() -> Span {
+    Span::synthetic()
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn blit(value: bool) -> Expr {
+    Expr::BoolLit { value, span: s() }
+}
+fn nil_lit() -> Expr {
+    Expr::NilLit { span: s() }
+}
+fn land(lhs: Expr, rhs: Expr) -> Expr {
+    Expr::LogicalAnd { lhs: Box::new(lhs), rhs: Box::new(rhs), span: s() }
+}
+fn lor(lhs: Expr, rhs: Expr) -> Expr {
+    Expr::LogicalOr { lhs: Box::new(lhs), rhs: Box::new(rhs), span: s() }
+}
+fn bc(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+fn puts(arg: Expr) -> Stmt {
+    Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: s() }
+}
+/// A `main` module declaring only `ShortCircuit`.
+fn sc_module(stmts: Vec<Stmt>) -> Module {
+    Module {
+        name: "scprog".into(),
+        manifest: FeatureManifest::from_features(&[Feature::ShortCircuit]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+#[test]
+fn logical_and_returns_the_deciding_operand() {
+    // `a && b` is the OPERAND: `1 && 2` → `2` (lhs truthy → rhs); `false && 2` →
+    // `false` (lhs falsy → lhs); `nil && 2` → `nil`.
+    match run(&sc_module(vec![
+        puts(land(ilit(1), ilit(2))),     // 2
+        puts(land(blit(false), ilit(2))), // #f
+        puts(land(nil_lit(), ilit(2))),   // nil
+    ])) {
+        Some(out) => assert_eq!(out, "2\n#f\nnil\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn logical_or_returns_the_deciding_operand() {
+    // `a || b`: `1 || 2` → `1` (lhs truthy → lhs); `false || 5` → `5` (lhs
+    // falsy → rhs); `nil || 7` → `7`.
+    match run(&sc_module(vec![
+        puts(lor(ilit(1), ilit(2))),     // 1
+        puts(lor(blit(false), ilit(5))), // 5
+        puts(lor(nil_lit(), ilit(7))),   // 7
+    ])) {
+        Some(out) => assert_eq!(out, "1\n5\n7\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn short_circuit_does_not_evaluate_the_dead_operand() {
+    // The RHS must NOT run when the LHS decides. The dead operand is `1 / 0`,
+    // which TRAPS (`_sir_ifloordiv` → `stderr` + `exit(1)`) if evaluated — so a
+    // broken eager lowering exits non-zero and `run` (which asserts success)
+    // fails. A correct short-circuit skips it: `false && (1/0)` → `false`,
+    // `true || (1/0)` → `true`, both exit 0.
+    let div_by_zero = || bc("/", vec![ilit(1), ilit(0)]);
+    match run(&sc_module(vec![
+        puts(land(blit(false), div_by_zero())), // #f, no trap
+        puts(lor(blit(true), div_by_zero())),   // #t, no trap
+    ])) {
+        Some(out) => assert_eq!(out, "#f\n#t\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn logical_and_in_tail_position() {
+    // A short-circuit in a function's RETURN position exercises `emit_tail`
+    // (which routes a compound value into a temp, then returns it) rather than
+    // `emit_assign` — it must stay total there too. `sc()` returns `1 && 2` (→
+    // `2`), and `main` prints the call result.
+    let m = Module {
+        name: "sctail".into(),
+        manifest: FeatureManifest::from_features(&[Feature::ShortCircuit]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![
+            Function {
+                name: "main".into(),
+                params: vec![],
+                return_type: None,
+                captures: vec![],
+                body: Block {
+                    stmts: vec![puts(Expr::DirectCall {
+                        fn_name: "sc".into(),
+                        args: vec![],
+                        effects: EffectSet::PURE,
+                        span: s(),
+                    })],
+                    value: Expr::NilLit { span: s() },
+                    span: s(),
+                },
+                effects: EffectSet::PURE,
+                metadata: Metadata::new(),
+                span: s(),
+            },
+            Function {
+                name: "sc".into(),
+                params: vec![],
+                return_type: None,
+                captures: vec![],
+                body: Block {
+                    stmts: vec![],
+                    value: land(ilit(1), ilit(2)),
+                    span: s(),
+                },
+                effects: EffectSet::PURE,
+                metadata: Metadata::new(),
+                span: s(),
+            },
+        ],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s(),
+    };
+    match run(&m) {
+        Some(out) => assert_eq!(out, "2\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn short_circuit_emits_a_truthiness_branch() {
+    // Emit-shape: the node lowers to an `if (_sir_truthy(...))` overwrite, not a
+    // bare C `&&` (which would yield an int 0/1, not the operand).
+    let src = semantic_ir_to_c::compile(&sc_module(vec![puts(land(ilit(1), ilit(2)))]))
+        .expect("compile")
+        .source;
+    assert!(
+        src.contains("if (_sir_truthy("),
+        "LogicalAnd lowers to a truthiness branch:\n{src}"
+    );
+}

--- a/code/specs/SIR24-semantic-ir-to-c.md
+++ b/code/specs/SIR24-semantic-ir-to-c.md
@@ -78,13 +78,15 @@ then (4) `emit::emit_module`.
 time — see the roadmap): the SIR26 integer conversions (`Conversions`,
 `SizedIntegers`, `Unsigned`, `WrappingArithmetic`); and the SIR16 batches
 `Loops` + `MutableBindings` (0.3.0–0.5.0), `Sequences` (0.6.0), `Maps`
-(0.7.0 — the `SIR_MAP` assoc-array with `MapLit`/`MapGet`/`MapSet`), and
-`Floats` (0.8.0 — `FloatLit` on the v0 `SIR_FLOAT` tag; emitter-only, the
-runtime already carried the float path).
+(0.7.0 — the `SIR_MAP` assoc-array with `MapLit`/`MapGet`/`MapSet`), `Floats`
+(0.8.0 — `FloatLit` on the v0 `SIR_FLOAT` tag; emitter-only, the runtime
+already carried the float path), and `ShortCircuit` (0.9.0 — `LogicalAnd`/
+`LogicalOr` lowered to a truthiness-branch overwrite, reusing the eager
+`and`/`or` builtin lowering; yields the deciding operand).
 
 **Still rejects** (clean, source-positioned `UnsupportedFeature`):
 `TailCalls` (C does not guarantee TCO), `Intrinsics` (empty whitelist), and
-every not-yet-landed feature (`ShortCircuit`, `NDArrays`,
+every not-yet-landed feature (`NDArrays`,
 `Exceptions`, `Classes`, … — see the roadmap).  `Bignum` stays
 rejected until a bignum runtime ships, so a module that *needs* arbitrary
 precision is refused rather than silently truncated.


### PR DESCRIPTION
## What

Adds SIR16 **short-circuit** to the C backend (`semantic-ir-to-c` 0.8.0 → 0.9.0) — the **last** of the ShortCircuit parity arc. With the Ruby backend's short-circuit (#8848), `Feature::ShortCircuit` is now accepted on **all six** backends.

`Expr::LogicalAnd` / `Expr::LogicalOr` (`&&` / `||`) reuse the **same** lowering the emitter already applies to the eager `and`/`or` builtins — no new machinery:

```c
dst = lhs; if (_sir_truthy(dst)) { dst = rhs; }   // &&
dst = lhs; if (!_sir_truthy(dst)) { dst = rhs; }  // ||
```

Because the right operand is emitted **only inside the `if` body**, it is not evaluated when the left already decides (true short-circuit), and `dst` holds the **deciding operand** — not a coerced bool. This is the value-returning semantics Go models with an IIFE and Ruby gets from native `&&`/`||`: `1 && 2` is `2`, `false && 2` is `false`, `nil || 7` is `7`. Deliberately **not** a bare C `&&`/`||`, which would collapse to an `int` 0/1 and lose the operand.

The nodes are not `is_simple`, so they route through `emit_assign` — and, in return position, through the existing "compute a compound value into a temp, then return it" tail fallback — so no other emit arm is needed and the emitter stays **total**. `scan_expr_for_builtin` recurses into both operands.

## Verification

- `cargo test -p semantic-ir-to-c` — **45 tests green** (5 new), hand-built modules (the frontend constant-folds a literal `&&`) compiled and run through a real `cc`: operand-return for both operators, a **short-circuit proof** where the dead operand is `1 / 0` (traps via `_sir_ifloordiv` if evaluated — a correct lowering skips it and the program exits 0), and a `LogicalAnd` in **tail position** (exercises `emit_tail`).
- `cargo clippy -p semantic-ir-to-c --all-targets` clean.
- Security review passed — identical safety to the vetted `and`/`or` builtin lowering: rhs emitted only in the if-body, no `dst` aliasing (hoisted temps use unique `fresh_id` names), always-braced codegen, and the validator's `MAX_IR_DEPTH` bounds the recursive emit.
- SIR24 spec capability section updated (ShortCircuit → landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)