### PR TITLE
feat(app): the mistakes store — HL03 phase 5

### DIFF
--- a/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.9.3 — the mistakes store (HL03 phase 5)
+
+- `src/mistakes.ts` — records each quiz answer and, crucially, WHAT THE LEARNER
+  CHOSE when wrong (the confusion — e.g. picking the French cognate's meaning
+  for the Spanish word). `recordAnswer` appends immutably; `demote` feeds a miss
+  back into the SRS (box→0, due now, lapse++) so the item resurfaces sooner in
+  `pickNext`; `confusions` rolls the wrong answers into ranked "what you keep
+  mixing up" pairs.
+- Grounded: a confusion only ever appears if the learner actually made it — no
+  pair is inferred. Pair keys use `JSON.stringify`, not delimiter-joining, so an
+  id containing a comma can't collapse two distinct confusions into one.
+- Controls bite (fault-injected): a no-op demote fails the "missed cell
+  resurfaces" test (its draw weight must jump above a mastered cell's); a
+  fabricated pair fails the "nothing invented" control. Pure, deterministic, no
+  I/O — the caller passes the session index in.
+- This completes the pure-logic layers of HL03 (phases 2–5). Next: phase 6, the
+  UI that unifies the four modes into one curriculum-driven session.
+
 ## 0.9.2 — the SRS-weighted draw (HL03 phase 4, part 2 — quiz complete)
 
 - Extends `src/quiz.ts` with the randomised cumulative quiz's draw:

--- a/code/programs/typescript/script-writing-visualizer/package.json
+++ b/code/programs/typescript/script-writing-visualizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "script-writing-visualizer",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": true,
   "description": "Companion study app (HL02): break a non-Latin script apart and learn to write it — and drill the whole written curriculum with a spaced-repetition schedule that remembers you",
   "type": "module",

--- a/code/programs/typescript/script-writing-visualizer/src/mistakes.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/mistakes.ts
@@ -1,0 +1,91 @@
+// ---------------------------------------------------------------------------
+// mistakes.ts — the mistakes store (HL03 phase 5)
+// ---------------------------------------------------------------------------
+//
+// A quiz that only says "wrong" and moves on wastes the most useful signal a
+// learner produces: WHAT they picked instead. Choosing the French cognate's
+// meaning for the Spanish word is not noise — it is the exact cross-language
+// confusion the interleaving is meant to expose, and it is worth surfacing back
+// ("the ones you keep mixing up") rather than discarding.
+//
+// This module records each answer, feeds a miss back into the SRS so the item
+// returns sooner, and rolls the wrong answers up into ranked confusions. Every
+// number it reports is GROUNDED in something actually recorded — a confusion is
+// a real (chosen, correct) pair the learner produced, never an inferred one.
+//
+// Pure and deterministic: recording appends to a fresh log, demote returns fresh
+// state, confusions is a pure fold. No I/O, no clock — the caller passes the
+// session index in.
+// ---------------------------------------------------------------------------
+
+import type { QuizState } from "./quiz";
+
+/**
+ * One answer the learner gave. `cellKey` is the item asked; `correct` is whether
+ * they got it right; `chosenKey` is what they picked WHEN WRONG (the confusion) —
+ * omitted for a correct answer or a typed/free answer with no distractor.
+ */
+export interface AnswerRecord {
+  cellKey: string;
+  correct: boolean;
+  chosenKey?: string;
+}
+
+/** Append an answer to the log, returning a new log (the old one is untouched). */
+export function recordAnswer(
+  log: AnswerRecord[],
+  cellKey: string,
+  correct: boolean,
+  chosenKey?: string,
+): AnswerRecord[] {
+  const record: AnswerRecord = { cellKey, correct };
+  if (!correct && chosenKey !== undefined) record.chosenKey = chosenKey;
+  return [...log, record];
+}
+
+/**
+ * Demote a cell after a MISS: reset it to Leitner box 0, make it due right now
+ * (so `pickNext` weights it heavily and it resurfaces soon), and count the
+ * lapse. Returns fresh state; the caller applies this only on a wrong answer.
+ */
+export function demote(state: QuizState, session: number): QuizState {
+  return {
+    box: 0,
+    dueAtSession: session,
+    lapses: state.lapses + 1,
+    reps: state.reps + 1,
+  };
+}
+
+/** A pair the learner mixed up, and how often. */
+export interface Confusion {
+  /** The item that was asked. */
+  correct: string;
+  /** The item they picked instead. */
+  chosen: string;
+  count: number;
+}
+
+/**
+ * Roll the wrong answers up into ranked confusions — for each (chosen instead of
+ * correct) pair, how many times it happened, most frequent first. Only wrong
+ * answers that recorded a `chosenKey` contribute; correct answers and misses
+ * without a chosen distractor are ignored, so a confusion never appears unless
+ * the learner actually made it.
+ */
+export function confusions(log: AnswerRecord[]): Confusion[] {
+  const counts = new Map<string, number>();
+  for (const r of log) {
+    if (r.correct || r.chosenKey === undefined) continue;
+    const key = JSON.stringify([r.cellKey, r.chosenKey]);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  const out: Confusion[] = [];
+  for (const [key, count] of counts) {
+    const [correct, chosen] = JSON.parse(key) as [string, string];
+    out.push({ correct, chosen, count });
+  }
+  // Most-confused first; ties broken by the pair encoding for determinism.
+  out.sort((a, b) => b.count - a.count || (a.correct < b.correct ? -1 : a.correct > b.correct ? 1 : a.chosen < b.chosen ? -1 : 1));
+  return out;
+}

--- a/code/programs/typescript/script-writing-visualizer/tests/mistakes.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/mistakes.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { recordAnswer, demote, confusions, type AnswerRecord } from "../src/mistakes";
+import { cellWeight, type QuizState } from "../src/quiz";
+
+describe("recordAnswer", () => {
+  it("appends without mutating the previous log", () => {
+    const a = recordAnswer([], "k1", true);
+    const b = recordAnswer(a, "k2", false, "picked");
+    expect(a).toEqual([{ cellKey: "k1", correct: true }]); // a is untouched
+    expect(b).toEqual([
+      { cellKey: "k1", correct: true },
+      { cellKey: "k2", correct: false, chosenKey: "picked" },
+    ]);
+  });
+
+  it("drops chosenKey for a correct answer (a right answer is not a confusion)", () => {
+    // even if a chosenKey is passed on a correct answer, it isn't a confusion.
+    expect(recordAnswer([], "k", true, "whatever")).toEqual([{ cellKey: "k", correct: true }]);
+  });
+});
+
+describe("demote — feeding a miss back into the SRS", () => {
+  const session = 20;
+  const mastered: QuizState = { box: 5, dueAtSession: 999, lapses: 0, reps: 8 };
+
+  it("a missed cell resurfaces sooner: its draw weight jumps above its mastered weight", () => {
+    const before = cellWeight(mastered, session); // mastered, not due → floor
+    const after = cellWeight(demote(mastered, session), session); // box 0, due now
+    expect(after).toBeGreaterThan(before); // CONTROL: a no-op demote leaves after == before → fails
+  });
+
+  it("resets the box, makes it due now, and counts the lapse", () => {
+    const d = demote(mastered, session);
+    expect(d.box).toBe(0);
+    expect(d.dueAtSession).toBe(session); // due at (not after) the current session
+    expect(d.lapses).toBe(1);
+    expect(d.reps).toBe(9);
+  });
+
+  it("does not mutate the input state", () => {
+    demote(mastered, session);
+    expect(mastered).toEqual({ box: 5, dueAtSession: 999, lapses: 0, reps: 8 });
+  });
+});
+
+describe("confusions — what the learner keeps mixing up", () => {
+  it("ranks the (chosen instead of correct) pairs by frequency", () => {
+    let log: AnswerRecord[] = [];
+    log = recordAnswer(log, "es:gato", false, "fr:chat"); // mixed es cat with fr cat
+    log = recordAnswer(log, "es:gato", false, "fr:chat"); // again
+    log = recordAnswer(log, "de:hund", false, "en:hound");
+    log = recordAnswer(log, "es:gato", true); // a correct answer — ignored
+    const c = confusions(log);
+    expect(c).toEqual([
+      { correct: "es:gato", chosen: "fr:chat", count: 2 },
+      { correct: "de:hund", chosen: "en:hound", count: 1 },
+    ]);
+  });
+
+  it("CONTROL: only surfaces pairs actually recorded wrong — nothing invented", () => {
+    let log: AnswerRecord[] = [];
+    log = recordAnswer(log, "a", true); // correct — no confusion
+    log = recordAnswer(log, "b", false); // wrong but no chosenKey — no pair
+    const c = confusions(log);
+    expect(c).toEqual([]); // a fabricated pair would make this non-empty and fail
+  });
+
+  it("separates distinct chosen-answers for the same asked item", () => {
+    let log: AnswerRecord[] = [];
+    log = recordAnswer(log, "es:gato", false, "fr:chat");
+    log = recordAnswer(log, "es:gato", false, "it:gatto");
+    const c = confusions(log);
+    expect(c.map((x) => x.chosen).sort()).toEqual(["fr:chat", "it:gatto"]);
+    expect(c.every((x) => x.count === 1)).toBe(true);
+  });
+
+  it("keys are collision-safe even if an id contains the delimiter characters", () => {
+    // JSON encoding, not delimiter-joining: these two must stay distinct.
+    let log: AnswerRecord[] = [];
+    log = recordAnswer(log, "a", false, "b,c");
+    log = recordAnswer(log, "a,b", false, "c");
+    expect(confusions(log).length).toBe(2); // would collapse to 1 under a naive "a,b,c" join
+  });
+});


### PR DESCRIPTION
Phase 5 of the unified language-learning app — the mistakes layer. Completes the pure-logic core (phases 2–5); phase 6 is the UI that ties it together.

## What it adds — `src/mistakes.ts`

A quiz that only says "wrong" throws away the most useful signal: **what you picked instead**. Choosing the French cognate's meaning for the Spanish word is the exact cross-language confusion interleaving exists to expose.

- **`recordAnswer(log, cellKey, correct, chosenKey?)`** — appends immutably. A correct answer never carries a `chosenKey` (a right answer isn't a confusion).
- **`demote(state, session)`** — feeds a miss back into the SRS (box→0, due now, lapse++), which raises the cell's draw weight from 1 (mastered, not due) to 10, so `pickNext` resurfaces it soon.
- **`confusions(log)`** — rolls the wrong answers into ranked `(correct, chosen, count)` pairs: *"what you keep mixing up."*

## Grounded + collision-safe

A confusion appears **only if the learner actually made it** — nothing inferred. Pair keys use `JSON.stringify`, not delimiter-joining, so an id containing a comma can't collapse two distinct confusions into one (there's a test for exactly `("a","b,c")` vs `("a,b","c")`).

## Controls that bite (fault-injected)

- A no-op `demote` fails the "missed cell resurfaces" test (weight 1 not > 1).
- A fabricated pair fails the "nothing invented" control.

Independently reviewed: immutability, demote resurfacing, and confusion grounding/collision-safety all correct; `JSON.parse` only round-trips keys the module itself produced; no security surface; no NUL bytes.

App CHANGELOG + version 0.9.2 → 0.9.3. **177 tests.**

With this the whole engine — teaching sweep, connections, covered grid, SRS-weighted quiz, mistakes — is built, pure, and grounded in the real curriculum. Next: phase 6, unifying the four modes into one session flow (UI, verified in-browser), renaming the app, and retiring the standalone artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)