### PR TITLE
feat(spice): add BJT emitter resistance

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add BJT model-card `RE` emitter-resistance support with an intrinsic emitter
+  node in DC, AC, and transient analysis plus thermal noise in noise analysis.
 - Add BJT model-card `VTF` forward transit-time voltage-scale support, applying
   `exp(Vbc / (1.44 * VTF))` to the `XTF` AC and transient storage enhancement.
 

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -620,6 +620,8 @@ class BJT:
         Forward-current scale for transit-time bias dependence (default 0.0).
     Vtf:
         Base-collector voltage scale for transit-time bias dependence (default 0.0).
+    Re:
+        Constant external-to-intrinsic emitter resistance in Ohms (default 0.0).
     """
 
     name: str
@@ -660,6 +662,7 @@ class BJT:
     Xtf: float = 0.0           # forward transit-time bias coefficient
     Itf: float = 0.0           # forward transit-time current scale (A)
     Vtf: float = 0.0           # forward transit-time voltage scale (V)
+    Re: float = 0.0            # emitter resistance (ohms)
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -605,7 +605,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr, element.Tnom, element.Kf, element.Af, element.Ptf, element.Xtf, element.Itf, element.Vtf)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr, element.Tnom, element.Kf, element.Af, element.Ptf, element.Xtf, element.Itf, element.Vtf, element.Re)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -7260,7 +7260,10 @@ def _element_nodes(el: Element) -> list[str]:
     if isinstance(el, Mosfet):
         return [el.drain, el.gate, el.source, el.body]
     if isinstance(el, BJT):
-        return [el.collector, el.base, el.emitter]
+        nodes = [el.collector, el.base, el.emitter]
+        if el.Re > 0.0:
+            nodes.append(_bjt_intrinsic_emitter_node(el))
+        return nodes
     if isinstance(el, TransmissionLine):
         return [el.n1, el.n2, el.n3, el.n4]
     if isinstance(el, (VCVS, VCCS)):
@@ -8737,6 +8740,10 @@ def _bjt_base_collector_charge_state_name(el: BJT) -> str:
     return f"_Q_{el.name}_bc_charge"
 
 
+def _bjt_intrinsic_emitter_node(el: BJT) -> str:
+    return el.emitter if el.Re == 0.0 else f"__spice_{el.name}_emitter"
+
+
 def _bjt_junction_transconductance(el: BJT, voltage: float, emission_coefficient: float) -> float:
     effective_thermal_voltage = el.Vt * emission_coefficient
     exponent = max(-40.0, min(40.0, voltage / effective_thermal_voltage))
@@ -8808,11 +8815,12 @@ def _bjt_base_collector_depletion_capacitance(el: BJT, voltage: float) -> float:
 
 def _bjt_charge_state_specs(el: BJT) -> list[tuple[str, str, str, str]]:
     specs: list[tuple[str, str, str, str]] = []
+    emitter = _bjt_intrinsic_emitter_node(el)
     if el.Cje > 0.0 or el.Tf > 0.0:
         if el.polarity == "NPN":
-            specs.append((_bjt_base_emitter_charge_state_name(el), el.base, el.emitter, "be"))
+            specs.append((_bjt_base_emitter_charge_state_name(el), el.base, emitter, "be"))
         else:
-            specs.append((_bjt_base_emitter_charge_state_name(el), el.emitter, el.base, "be"))
+            specs.append((_bjt_base_emitter_charge_state_name(el), emitter, el.base, "be"))
     if el.Cjc > 0.0 or el.Tr > 0.0 or (el.Tf > 0.0 and el.Xtf > 0.0 and el.Vtf > 0.0):
         if el.polarity == "NPN":
             specs.append((_bjt_base_collector_charge_state_name(el), el.base, el.collector, "bc"))
@@ -9187,6 +9195,10 @@ def _stamp_bjt(
     the control voltage (Ve - Vb vs Vb - Ve) yields the correct KCL stamps.
     """
     _validate_bjt(el)
+    if el.Re > 0.0:
+        intrinsic_emitter = _bjt_intrinsic_emitter_node(el)
+        _stamp_g(G, node_to_idx, el.emitter, intrinsic_emitter, 1.0 / el.Re)
+        el = replace(el, emitter=intrinsic_emitter, Re=0.0)
     # --- Resolve node voltages at the current Newton iterate -----------------
     Vb = 0.0 if _is_ground(el.base) else x[node_to_idx[el.base]]
     Ve = 0.0 if _is_ground(el.emitter) else x[node_to_idx[el.emitter]]
@@ -9353,6 +9365,10 @@ def _validate_bjt(el: BJT) -> None:
     if not math.isfinite(el.Vtf) or el.Vtf < 0.0:
         raise ValueError(
             f"{el.name}: BJT forward transit-time voltage must be finite and non-negative"
+        )
+    if not math.isfinite(el.Re) or el.Re < 0.0:
+        raise ValueError(
+            f"{el.name}: BJT emitter resistance must be finite and non-negative"
         )
     if not math.isfinite(el.Ise) or el.Ise < 0.0:
         raise ValueError(
@@ -12609,6 +12625,16 @@ def _stamp_ac(
         # VCCS).  Mirror the DC _stamp_bjt stamps but in the complex domain and
         # without the Norton offsets (which are DC bias terms, zero in AC).
         _validate_bjt(el)
+        if el.Re > 0.0:
+            intrinsic_emitter = _bjt_intrinsic_emitter_node(el)
+            _stamp_g_c(
+                G,
+                node_to_idx,
+                el.emitter,
+                intrinsic_emitter,
+                complex(1.0 / el.Re),
+            )
+            el = replace(el, emitter=intrinsic_emitter, Re=0.0)
         Vc_dc = 0.0 if _is_ground(el.collector) else dc_x[node_to_idx[el.collector]]
         Vb_dc = 0.0 if _is_ground(el.base) else dc_x[node_to_idx[el.base]]
         Ve_dc = 0.0 if _is_ground(el.emitter) else dc_x[node_to_idx[el.emitter]]
@@ -13254,6 +13280,17 @@ def _build_ss_matrix(
         elif isinstance(el, BJT):
             # Small-signal model: g_π (junction conductance) + gm VCCS.
             # Mirrors the AC _stamp_ac BJT block in the real domain.
+            _validate_bjt(el)
+            if el.Re > 0.0:
+                intrinsic_emitter = _bjt_intrinsic_emitter_node(el)
+                _stamp_g(
+                    G,
+                    node_to_idx,
+                    el.emitter,
+                    intrinsic_emitter,
+                    1.0 / el.Re,
+                )
+                el = replace(el, emitter=intrinsic_emitter, Re=0.0)
             Vc_dc = 0.0 if _is_ground(el.collector) else dc_x[node_to_idx[el.collector]]
             Vb_dc = 0.0 if _is_ground(el.base) else dc_x[node_to_idx[el.base]]
             Ve_dc = 0.0 if _is_ground(el.emitter) else dc_x[node_to_idx[el.emitter]]
@@ -14180,6 +14217,7 @@ def sens_dc(
                     Xtb=el.Xtb,
                     beta_r=el.beta_r,
                     Ikr=el.Ikr,
+                    Re=el.Re,
                 ),
             )
             delta_beta = max(abs(el.beta_f) * perturbation, abs_floor)
@@ -14215,6 +14253,7 @@ def sens_dc(
                     Xtb=el.Xtb,
                     beta_r=el.beta_r,
                     Ikr=el.Ikr,
+                    Re=el.Re,
                 ),
             )
 
@@ -14460,6 +14499,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             Xtb=el.Xtb,
             beta_r=el.beta_r,
             Ikr=el.Ikr,
+            Re=el.Re,
         )
 
     # Capacitor, Inductor, Mosfet — no tunable DC parameter; return unchanged.
@@ -14896,6 +14936,17 @@ def _collect_noise_sources(
             # Shot noise on the base-emitter junction: S_i = 2q |I_C|
             # I_C ≈ Is × exp(V_BE / Vt)  (dominates for forward-active BJT)
             # Use actual converged dc_x voltages — no clamp — same reasoning as Diode.
+            if el.Re > 0.0:
+                intrinsic_emitter = _bjt_intrinsic_emitter_node(el)
+                sources.append((
+                    f"{el.name}:RE",
+                    "thermal",
+                    node_to_idx.get(el.emitter),
+                    node_to_idx.get(intrinsic_emitter),
+                    kT4 / el.Re,
+                    0.0,
+                ))
+                el = replace(el, emitter=intrinsic_emitter, Re=0.0)
             Vb = 0.0 if _is_ground(el.base) else dc_x[node_to_idx[el.base]]
             Ve = 0.0 if _is_ground(el.emitter) else dc_x[node_to_idx[el.emitter]]
             Vc = 0.0 if _is_ground(el.collector) else dc_x[node_to_idx[el.collector]]

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (33, 50, 13, 4),
-    "PNP": (33, 50, 13, 4),
+    "NPN": (34, 51, 13, 4),
+    "PNP": (34, 51, 13, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -387,6 +387,7 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "XTF": "XTF",
     "ITF": "ITF",
     "VTF": "VTF",
+    "RE": "RE",
     "ISE": "ISE",
     "NE": "NE",
     "ISC": "ISC",
@@ -955,6 +956,7 @@ def bjt_from_model_card(
         Xtf=p.get("XTF", 0.0),
         Itf=p.get("ITF", 0.0),
         Vtf=p.get("VTF", 0.0),
+        Re=p.get("RE", 0.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 124
+    assert len(coverage) == 126
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 124
+    assert len(records) == 126
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,9 +501,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 124
-    assert report.expected_canonical_parameter_count == 124
-    assert report.accepted_name_count == 190
+    assert report.canonical_parameter_count == 126
+    assert report.expected_canonical_parameter_count == 126
+    assert report.accepted_name_count == 192
     assert report.aliased_parameter_count == 53
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -511,7 +511,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t124\t124\t190\t53\t4\t0"
+        "true\t7\t7\t126\t126\t192\t53\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,8 +539,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 123
-    assert report.accepted_name_count == 187
+    assert report.canonical_parameter_count == 125
+    assert report.accepted_name_count == 189
     assert report.aliased_parameter_count == 52
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t123\t124\t187\t52\t4\t4\n"
+        "false\t7\t7\t125\t126\t189\t52\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,10 +647,10 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "VTF": 0.6, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
+        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "VTF": 0.6, "RE": 12.0, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "TNOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "VTF": 0.6, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
+    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "TNOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "VTF": 0.6, "RE": 12.0, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.beta_r == pytest.approx(0.25)
@@ -669,6 +669,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert bjt_model.Xtf == pytest.approx(2.0)
     assert bjt_model.Itf == pytest.approx(4.0e-3)
     assert bjt_model.Vtf == pytest.approx(0.6)
+    assert bjt_model.Re == pytest.approx(12.0)
     assert bjt_model.Ise == pytest.approx(3.0e-13)
     assert bjt_model.Ne == pytest.approx(1.7)
     assert bjt_model.Isc == pytest.approx(4.0e-13)
@@ -2340,7 +2341,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3, Tnom=323.15, Kf=1.0e-12, Af=1.3, Ptf=30.0, Xtf=2.0, Itf=4.0e-3, Vtf=0.6),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3, Tnom=323.15, Kf=1.0e-12, Af=1.3, Ptf=30.0, Xtf=2.0, Itf=4.0e-3, Vtf=0.6, Re=12.0),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2373,6 +2374,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.Xtf == pytest.approx(2.0)
     assert expanded.Itf == pytest.approx(4.0e-3)
     assert expanded.Vtf == pytest.approx(0.6)
+    assert expanded.Re == pytest.approx(12.0)
 
 
 def test_branch_current_in_voltage_source():
@@ -2660,6 +2662,16 @@ def test_dc_rejects_invalid_bjt_forward_transit_time_voltage():
     with pytest.raises(
         ValueError,
         match="forward transit-time voltage must be finite and non-negative",
+    ):
+        dc_op(circuit)
+
+
+def test_dc_rejects_invalid_bjt_emitter_resistance():
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", Re=-1.0))
+    with pytest.raises(
+        ValueError,
+        match="emitter resistance must be finite and non-negative",
     ):
         dc_op(circuit)
 
@@ -3551,6 +3563,18 @@ def test_bjt_npn_forward_active():
     assert isclose(Ic_from_vcol, Ic_expected, rel_tol=0.01), (
         f"Ic from voltages ({Ic_from_vcol:.6e} A) != expected ({Ic_expected:.6e} A)"
     )
+
+
+def test_bjt_emitter_resistance_reduces_fixed_base_collector_current():
+    def collector_voltage(emitter_resistance: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vcc", "vcc", "0", voltage=5.0))
+        circuit.add(VoltageSource("Vbase", "base", "0", voltage=0.7))
+        circuit.add(Resistor("Rc", "vcc", "collector", 1_000.0))
+        circuit.add(BJT("Q1", "collector", "base", "0", Re=emitter_resistance))
+        return dc_op(circuit).node_voltages["collector"]
+
+    assert collector_voltage(100.0) > collector_voltage(0.0) + 0.5
 
 
 def test_bjt_npn_beta_ratio():
@@ -7076,6 +7100,21 @@ def test_noise_bjt_shot_noise_type_string() -> None:
     )
     assert bjt_entry is not None, "No entry for Q1"
     assert bjt_entry.noise_type == "shot"
+
+
+def test_noise_bjt_emitter_resistance_adds_thermal_noise() -> None:
+    circuit = Circuit()
+    circuit.add(VoltageSource("Vbase", "base", "0", 0.65))
+    circuit.add(Resistor("Rload", "out", "0", 1_000.0))
+    circuit.add(BJT("Q1", "out", "base", "0", Re=100.0))
+
+    result = noise_ac(circuit, "out", "Vbase", freqs=[1_000.0])
+    emitter_resistance = next(
+        entry for entry in result.points[0].entries if entry.element_name == "Q1:RE"
+    )
+
+    assert emitter_resistance.noise_type == "thermal"
+    assert emitter_resistance.source_psd > 0.0
 
 
 def test_noise_bjt_kf_adds_inverse_frequency_flicker_noise() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add BJT model-card `RE` emitter-resistance support with an intrinsic emitter
+  node in DC, AC, and transient analysis plus thermal noise in noise analysis.
 - Add BJT model-card `VTF` forward transit-time voltage-scale support, applying
   `exp(Vbc / (1.44 * VTF))` to the `XTF` AC and transient storage enhancement.
 

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -461,6 +461,7 @@ fn clone_subckt_element(
                 element.forward_transit_time_bias_coefficient;
             expanded.forward_transit_time_current = element.forward_transit_time_current;
             expanded.forward_transit_time_voltage = element.forward_transit_time_voltage;
+            expanded.emitter_resistance = element.emitter_resistance;
             Element::Bjt(expanded)
         }
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
@@ -2909,6 +2910,7 @@ pub struct Bjt {
     pub forward_transit_time_bias_coefficient: f64,
     pub forward_transit_time_current: f64,
     pub forward_transit_time_voltage: f64,
+    pub emitter_resistance: f64,
 }
 
 impl Bjt {
@@ -3378,6 +3380,7 @@ impl Bjt {
             forward_transit_time_bias_coefficient: 0.0,
             forward_transit_time_current: 0.0,
             forward_transit_time_voltage: 0.0,
+            emitter_resistance: 0.0,
         }
     }
 }
@@ -3768,8 +3771,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 33, 50, 13, 4),
-    (ModelCardKind::Pnp, 33, 50, 13, 4),
+    (ModelCardKind::Npn, 34, 51, 13, 4),
+    (ModelCardKind::Pnp, 34, 51, 13, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3828,6 +3831,7 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("XTF", "XTF"),
     ("ITF", "ITF"),
     ("VTF", "VTF"),
+    ("RE", "RE"),
     ("ISE", "ISE"),
     ("NE", "NE"),
     ("ISC", "ISC"),
@@ -4528,6 +4532,7 @@ pub fn bjt_from_model_card(
     bjt.forward_transit_time_bias_coefficient = model_card_value(model, "XTF", 0.0);
     bjt.forward_transit_time_current = model_card_value(model, "ITF", 0.0);
     bjt.forward_transit_time_voltage = model_card_value(model, "VTF", 0.0);
+    bjt.emitter_resistance = model_card_value(model, "RE", 0.0);
     Ok(bjt)
 }
 
@@ -21965,6 +21970,9 @@ fn collect_node_indices(circuit: &Circuit) -> HashMap<String, usize> {
                 insert_node(&mut names, &bjt.collector);
                 insert_node(&mut names, &bjt.base);
                 insert_node(&mut names, &bjt.emitter);
+                if bjt.emitter_resistance > 0.0 {
+                    insert_node(&mut names, &bjt_intrinsic_emitter_node(bjt));
+                }
             }
             Element::Mosfet(mosfet) => {
                 insert_node(&mut names, &mosfet.drain);
@@ -22172,6 +22180,24 @@ fn collect_noise_sources(
             }
             Element::Bjt(bjt) => {
                 validate_bjt(bjt)?;
+                let intrinsic_bjt = if bjt.emitter_resistance > 0.0 {
+                    let intrinsic_emitter = bjt_intrinsic_emitter_node(bjt);
+                    sources.push(NoiseSource {
+                        element_name: format!("{}:RE", bjt.name),
+                        noise_type: NoiseType::Thermal,
+                        positive: node_index(node_indices, &bjt.emitter),
+                        negative: node_index(node_indices, &intrinsic_emitter),
+                        source_psd: 4.0 * BOLTZMANN * temperature_kelvin / bjt.emitter_resistance,
+                        frequency_exponent: 0.0,
+                    });
+                    let mut intrinsic = bjt.clone();
+                    intrinsic.emitter = intrinsic_emitter;
+                    intrinsic.emitter_resistance = 0.0;
+                    Some(intrinsic)
+                } else {
+                    None
+                };
+                let bjt = intrinsic_bjt.as_ref().unwrap_or(bjt);
                 let base = node_index(node_indices, &bjt.base);
                 let emitter = node_index(node_indices, &bjt.emitter);
                 let collector = node_index(node_indices, &bjt.collector);
@@ -22776,6 +22802,22 @@ fn stamp_bjt(
     operating_point: &[f64],
 ) -> Result<(), SpiceError> {
     validate_bjt(bjt)?;
+    let intrinsic_bjt = if bjt.emitter_resistance > 0.0 {
+        let intrinsic_emitter = bjt_intrinsic_emitter_node(bjt);
+        stamp_conductance(
+            matrix,
+            node_index(node_indices, &bjt.emitter),
+            node_index(node_indices, &intrinsic_emitter),
+            1.0 / bjt.emitter_resistance,
+        );
+        let mut intrinsic = bjt.clone();
+        intrinsic.emitter = intrinsic_emitter;
+        intrinsic.emitter_resistance = 0.0;
+        Some(intrinsic)
+    } else {
+        None
+    };
+    let bjt = intrinsic_bjt.as_ref().unwrap_or(bjt);
     let collector = node_index(node_indices, &bjt.collector);
     let base = node_index(node_indices, &bjt.base);
     let emitter = node_index(node_indices, &bjt.emitter);
@@ -22896,8 +22938,8 @@ fn stamp_bjt_charge(
             }
             TransientMethod::Euler => conductance * state.previous_voltage,
         };
-        let positive = node_index(node_indices, spec.positive);
-        let negative = node_index(node_indices, spec.negative);
+        let positive = node_index(node_indices, &spec.positive);
+        let negative = node_index(node_indices, &spec.negative);
         stamp_conductance(matrix, positive, negative, conductance);
         if let Some(index) = positive {
             rhs[index] += history_current;
@@ -22930,6 +22972,22 @@ fn stamp_bjt_small_signal(
     operating_point: &[f64],
 ) -> Result<(), SpiceError> {
     validate_bjt(bjt)?;
+    let intrinsic_bjt = if bjt.emitter_resistance > 0.0 {
+        let intrinsic_emitter = bjt_intrinsic_emitter_node(bjt);
+        stamp_conductance(
+            matrix,
+            node_index(node_indices, &bjt.emitter),
+            node_index(node_indices, &intrinsic_emitter),
+            1.0 / bjt.emitter_resistance,
+        );
+        let mut intrinsic = bjt.clone();
+        intrinsic.emitter = intrinsic_emitter;
+        intrinsic.emitter_resistance = 0.0;
+        Some(intrinsic)
+    } else {
+        None
+    };
+    let bjt = intrinsic_bjt.as_ref().unwrap_or(bjt);
     let collector = node_index(node_indices, &bjt.collector);
     let base = node_index(node_indices, &bjt.base);
     let emitter = node_index(node_indices, &bjt.emitter);
@@ -22994,6 +23052,22 @@ fn stamp_ac_bjt_small_signal(
     omega: f64,
 ) -> Result<(), SpiceError> {
     validate_bjt(bjt)?;
+    let intrinsic_bjt = if bjt.emitter_resistance > 0.0 {
+        let intrinsic_emitter = bjt_intrinsic_emitter_node(bjt);
+        stamp_complex_conductance(
+            matrix,
+            node_index(node_indices, &bjt.emitter),
+            node_index(node_indices, &intrinsic_emitter),
+            Complex::new(1.0 / bjt.emitter_resistance, 0.0),
+        );
+        let mut intrinsic = bjt.clone();
+        intrinsic.emitter = intrinsic_emitter;
+        intrinsic.emitter_resistance = 0.0;
+        Some(intrinsic)
+    } else {
+        None
+    };
+    let bjt = intrinsic_bjt.as_ref().unwrap_or(bjt);
     let collector = node_index(node_indices, &bjt.collector);
     let base = node_index(node_indices, &bjt.base);
     let emitter = node_index(node_indices, &bjt.emitter);
@@ -23629,10 +23703,10 @@ enum BjtChargeStateKind {
     BaseCollector,
 }
 
-struct BjtChargeStateSpec<'a> {
+struct BjtChargeStateSpec {
     name: String,
-    positive: &'a str,
-    negative: &'a str,
+    positive: String,
+    negative: String,
     kind: BjtChargeStateKind,
 }
 
@@ -23642,6 +23716,14 @@ fn bjt_base_emitter_charge_state_name(bjt: &Bjt) -> String {
 
 fn bjt_base_collector_charge_state_name(bjt: &Bjt) -> String {
     format!("_Q_{}_bc_charge", bjt.name)
+}
+
+fn bjt_intrinsic_emitter_node(bjt: &Bjt) -> String {
+    if bjt.emitter_resistance == 0.0 {
+        bjt.emitter.clone()
+    } else {
+        format!("__spice_{}_emitter", bjt.name)
+    }
 }
 
 fn bjt_junction_transconductance(bjt: &Bjt, voltage: f64, emission_coefficient: f64) -> f64 {
@@ -23733,12 +23815,13 @@ fn bjt_base_collector_depletion_capacitance(bjt: &Bjt, voltage: f64) -> f64 {
     bjt.base_collector_capacitance * continuation / transition_scale
 }
 
-fn bjt_charge_state_specs(bjt: &Bjt) -> Vec<BjtChargeStateSpec<'_>> {
+fn bjt_charge_state_specs(bjt: &Bjt) -> Vec<BjtChargeStateSpec> {
     let mut specs = Vec::new();
     if bjt.base_emitter_capacitance > 0.0 || bjt.forward_transit_time > 0.0 {
+        let emitter = bjt_intrinsic_emitter_node(bjt);
         let (positive, negative) = match bjt.polarity {
-            BjtPolarity::Npn => (bjt.base.as_str(), bjt.emitter.as_str()),
-            BjtPolarity::Pnp => (bjt.emitter.as_str(), bjt.base.as_str()),
+            BjtPolarity::Npn => (bjt.base.clone(), emitter),
+            BjtPolarity::Pnp => (emitter, bjt.base.clone()),
         };
         specs.push(BjtChargeStateSpec {
             name: bjt_base_emitter_charge_state_name(bjt),
@@ -23754,8 +23837,8 @@ fn bjt_charge_state_specs(bjt: &Bjt) -> Vec<BjtChargeStateSpec<'_>> {
             && bjt.forward_transit_time_voltage > 0.0)
     {
         let (positive, negative) = match bjt.polarity {
-            BjtPolarity::Npn => (bjt.base.as_str(), bjt.collector.as_str()),
-            BjtPolarity::Pnp => (bjt.collector.as_str(), bjt.base.as_str()),
+            BjtPolarity::Npn => (bjt.base.clone(), bjt.collector.clone()),
+            BjtPolarity::Pnp => (bjt.collector.clone(), bjt.base.clone()),
         };
         specs.push(BjtChargeStateSpec {
             name: bjt_base_collector_charge_state_name(bjt),
@@ -23768,10 +23851,10 @@ fn bjt_charge_state_specs(bjt: &Bjt) -> Vec<BjtChargeStateSpec<'_>> {
 }
 
 fn bjt_charge_state_voltage(
-    spec: &BjtChargeStateSpec<'_>,
+    spec: &BjtChargeStateSpec,
     node_voltages: &BTreeMap<String, f64>,
 ) -> f64 {
-    voltage_at(node_voltages, spec.positive) - voltage_at(node_voltages, spec.negative)
+    voltage_at(node_voltages, &spec.positive) - voltage_at(node_voltages, &spec.negative)
 }
 
 struct JfetChargeStateSpec<'a> {
@@ -24155,6 +24238,12 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "forward transit-time voltage must be finite and non-negative".to_string(),
+        });
+    }
+    if !bjt.emitter_resistance.is_finite() || bjt.emitter_resistance < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "emitter resistance must be finite and non-negative".to_string(),
         });
     }
     if !bjt.base_emitter_leakage_saturation_current.is_finite()

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 124);
+    assert_eq!(coverage.len(), 126);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 124);
+    assert_eq!(records.len(), 126);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 124);
-    assert_eq!(report.expected_canonical_parameter_count, 124);
-    assert_eq!(report.accepted_name_count, 190);
+    assert_eq!(report.canonical_parameter_count, 126);
+    assert_eq!(report.expected_canonical_parameter_count, 126);
+    assert_eq!(report.accepted_name_count, 192);
     assert_eq!(report.aliased_parameter_count, 53);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t124\t124\t190\t53\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t126\t126\t192\t53\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,8 +235,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 123);
-    assert_eq!(report.accepted_name_count, 187);
+    assert_eq!(report.canonical_parameter_count, 125);
+    assert_eq!(report.accepted_name_count, 189);
     assert_eq!(report.aliased_parameter_count, 52);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t123\t124\t187\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t125\t126\t189\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -443,6 +443,7 @@ fn model_card_aliases_build_device_instances() {
             ("XTF", 2.0),
             ("ITF", 4.0e-3),
             ("VTF", 0.6),
+            ("RE", 12.0),
             ("ISE", 3.0e-13),
             ("NE", 1.7),
             ("ISC", 4.0e-13),
@@ -475,6 +476,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("XTF").unwrap(), 2.0);
     assert_close(*bjt_card.parameters.get("ITF").unwrap(), 4.0e-3);
     assert_close(*bjt_card.parameters.get("VTF").unwrap(), 0.6);
+    assert_close(*bjt_card.parameters.get("RE").unwrap(), 12.0);
     assert_close(*bjt_card.parameters.get("ISE").unwrap(), 3.0e-13);
     assert_close(*bjt_card.parameters.get("NE").unwrap(), 1.7);
     assert_close(*bjt_card.parameters.get("ISC").unwrap(), 4.0e-13);
@@ -504,6 +506,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(bjt_model.forward_transit_time_bias_coefficient, 2.0);
     assert_close(bjt_model.forward_transit_time_current, 4.0e-3);
     assert_close(bjt_model.forward_transit_time_voltage, 0.6);
+    assert_close(bjt_model.emitter_resistance, 12.0);
     assert_close(bjt_model.base_emitter_leakage_saturation_current, 3.0e-13);
     assert_close(bjt_model.base_emitter_leakage_emission_coefficient, 1.7);
     assert_close(bjt_model.base_collector_leakage_saturation_current, 4.0e-13);
@@ -1451,6 +1454,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     bjt.forward_transit_time_bias_coefficient = 2.0;
     bjt.forward_transit_time_current = 4.0e-3;
     bjt.forward_transit_time_voltage = 0.6;
+    bjt.emitter_resistance = 12.0;
     let mut circuit = Circuit::new();
     circuit
         .define_subcircuit(SubcircuitDefinition::new(
@@ -1501,6 +1505,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.forward_transit_time_bias_coefficient, 2.0);
     assert_close(expanded.forward_transit_time_current, 4.0e-3);
     assert_close(expanded.forward_transit_time_voltage, 0.6);
+    assert_close(expanded.emitter_resistance, 12.0);
 }
 
 #[test]
@@ -2092,6 +2097,18 @@ fn dc_rejects_invalid_bjt_forward_transit_time_voltage() {
     assert!(error
         .to_string()
         .contains("forward transit-time voltage must be finite and non-negative"));
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_emitter_resistance() {
+    let mut transistor = Bjt::new("Qbad", "c", "b", "0");
+    transistor.emitter_resistance = -1.0;
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Bjt(transistor));
+    let error = dc_op(&circuit).unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("emitter resistance must be finite and non-negative"));
 }
 
 #[test]
@@ -2766,6 +2783,44 @@ fn dc_bjt_solves_npn_emitter_follower_operating_point() {
         "expected emitter current through load, got {out}"
     );
     assert!(out < 0.7, "expected emitter below base bias, got {out}");
+}
+
+#[test]
+fn dc_bjt_emitter_resistance_reduces_fixed_base_collector_current() {
+    fn collector_voltage(emitter_resistance: f64) -> f64 {
+        let mut transistor = Bjt::with_model(
+            "Q1",
+            "collector",
+            "base",
+            "0",
+            BjtPolarity::Npn,
+            1.0e-14,
+            100.0,
+            0.02585,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        );
+        transistor.emitter_resistance = emitter_resistance;
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vcc", "vcc", "0", 5.0,
+        )));
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vbase", "base", "0", 0.7,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rc",
+            "vcc",
+            "collector",
+            1_000.0,
+        )));
+        circuit.add(Element::Bjt(transistor));
+        dc_op(&circuit).unwrap().voltage("collector").unwrap()
+    }
+
+    assert!(collector_voltage(100.0) > collector_voltage(0.0) + 0.5);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -89,6 +89,30 @@ fn bjt_base_collector_leakage_increases_shot_noise() {
 }
 
 #[test]
+fn bjt_emitter_resistance_adds_thermal_noise() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vbase", "base", "0", 0.65,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+    let mut transistor = Bjt::new("Q1", "out", "base", "0");
+    transistor.emitter_resistance = 100.0;
+    circuit.add(Element::Bjt(transistor));
+
+    let result = noise_ac(&circuit, "out", "Vbase", &[1_000.0], 300.0).unwrap();
+    let emitter_resistance = result.points[0]
+        .entries
+        .iter()
+        .find(|entry| entry.element_name == "Q1:RE")
+        .unwrap();
+
+    assert_eq!(emitter_resistance.noise_type, NoiseType::Thermal);
+    assert!(emitter_resistance.source_psd > 0.0);
+}
+
+#[test]
 fn bjt_flicker_noise_uses_kf_with_inverse_frequency_scaling() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add BJT model-card `RE` emitter-resistance support with an intrinsic emitter
+  node in DC, AC, and transient analysis plus thermal noise in noise analysis.
 - Add BJT model-card `VTF` forward transit-time voltage-scale support, applying
   `exp(Vbc / (1.44 * VTF))` to the `XTF` AC and transient storage enhancement.
 

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1736,6 +1736,7 @@ export interface Bjt {
   readonly forwardTransitTimeBiasCoefficient: number;
   readonly forwardTransitTimeCurrent: number;
   readonly forwardTransitTimeVoltage: number;
+  readonly emitterResistance: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -2013,8 +2014,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [33, 50, 13, 4],
-  PNP: [33, 50, 13, 4],
+  NPN: [34, 51, 13, 4],
+  PNP: [34, 51, 13, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3604,7 +3605,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees, element.forwardTransitTimeBiasCoefficient, element.forwardTransitTimeCurrent, element.forwardTransitTimeVoltage);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees, element.forwardTransitTimeBiasCoefficient, element.forwardTransitTimeCurrent, element.forwardTransitTimeVoltage, element.emitterResistance);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7796,6 +7797,7 @@ export function bjt(
   forwardTransitTimeBiasCoefficient = 0.0,
   forwardTransitTimeCurrent = 0.0,
   forwardTransitTimeVoltage = 0.0,
+  emitterResistance = 0.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7837,6 +7839,7 @@ export function bjt(
     forwardTransitTimeBiasCoefficient,
     forwardTransitTimeCurrent,
     forwardTransitTimeVoltage,
+    emitterResistance,
   };
 }
 
@@ -7955,6 +7958,7 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   XTF: "XTF",
   ITF: "ITF",
   VTF: "VTF",
+  RE: "RE",
   ISE: "ISE",
   NE: "NE",
   ISC: "ISC",
@@ -8495,6 +8499,7 @@ export function bjtFromModelCard(
     p.XTF ?? 0.0,
     p.ITF ?? 0.0,
     p.VTF ?? 0.0,
+    p.RE ?? 0.0,
   );
 }
 
@@ -18267,6 +18272,9 @@ function collectNodeIndices(circuit: Circuit): Map<string, number> {
         insertNode(names, element.collector);
         insertNode(names, element.base);
         insertNode(names, element.emitter);
+        if (element.emitterResistance > 0.0) {
+          insertNode(names, bjtIntrinsicEmitterNode(element));
+        }
         break;
       case "mosfet":
         insertNode(names, element.drain);
@@ -18422,8 +18430,20 @@ function collectNoiseSources(
       });
     } else if (element.kind === "bjt") {
       validateBjt(element);
+      const emitterNode = bjtIntrinsicEmitterNode(element);
+      if (element.emitterResistance > 0.0) {
+        sources.push({
+          elementName: `${element.name}:RE`,
+          noiseType: "thermal",
+          positive: nodeIndex(nodeIndices, element.emitter),
+          negative: nodeIndex(nodeIndices, emitterNode),
+          sourcePsd:
+            4.0 * BOLTZMANN * temperatureKelvin / element.emitterResistance,
+          frequencyExponent: 0.0,
+        });
+      }
       const base = nodeIndex(nodeIndices, element.base);
-      const emitter = nodeIndex(nodeIndices, element.emitter);
+      const emitter = nodeIndex(nodeIndices, emitterNode);
       const collector = nodeIndex(nodeIndices, element.collector);
       const baseVoltage = vectorVoltage(operatingPoint, base);
       const emitterVoltage = vectorVoltage(operatingPoint, emitter);
@@ -19064,6 +19084,16 @@ function stampBjt(
   operatingPoint: readonly number[],
 ): void {
   validateBjt(element);
+  if (element.emitterResistance > 0.0) {
+    const intrinsicEmitter = bjtIntrinsicEmitterNode(element);
+    stampConductance(
+      matrix,
+      nodeIndex(nodeIndices, element.emitter),
+      nodeIndex(nodeIndices, intrinsicEmitter),
+      1.0 / element.emitterResistance,
+    );
+    element = { ...element, emitter: intrinsicEmitter, emitterResistance: 0.0 };
+  }
   const collector = nodeIndex(nodeIndices, element.collector);
   const base = nodeIndex(nodeIndices, element.base);
   const emitter = nodeIndex(nodeIndices, element.emitter);
@@ -19667,6 +19697,12 @@ function bjtBaseCollectorChargeStateName(element: Bjt): string {
   return `_Q_${element.name}_bc_charge`;
 }
 
+function bjtIntrinsicEmitterNode(element: Bjt): string {
+  return element.emitterResistance === 0.0
+    ? element.emitter
+    : `__spice_${element.name}_emitter`;
+}
+
 function bjtJunctionTransconductance(
   element: Bjt,
   voltage: number,
@@ -19766,11 +19802,12 @@ function bjtBaseCollectorDepletionCapacitance(element: Bjt, voltage: number): nu
 
 function bjtChargeStateSpecs(element: Bjt): BjtChargeStateSpec[] {
   const specs: BjtChargeStateSpec[] = [];
+  const emitter = bjtIntrinsicEmitterNode(element);
   if (element.baseEmitterCapacitance > 0.0 || element.forwardTransitTime > 0.0) {
     const [positive, negative] =
       element.polarity === "NPN"
-        ? [element.base, element.emitter]
-        : [element.emitter, element.base];
+        ? [element.base, emitter]
+        : [emitter, element.base];
     specs.push({
       name: bjtBaseEmitterChargeStateName(element),
       positive,
@@ -20028,6 +20065,9 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.forwardTransitTimeVoltage) || element.forwardTransitTimeVoltage < 0.0) {
     throw invalidElement(element.name, "forward transit-time voltage must be finite and non-negative");
+  }
+  if (!Number.isFinite(element.emitterResistance) || element.emitterResistance < 0.0) {
+    throw invalidElement(element.name, "emitter resistance must be finite and non-negative");
   }
   if (!Number.isFinite(element.baseEmitterLeakageSaturationCurrent) || element.baseEmitterLeakageSaturationCurrent < 0.0) {
     throw invalidElement(element.name, "base-emitter leakage saturation current must be finite and non-negative");
@@ -21375,6 +21415,16 @@ function stampBjtSmallSignal(
   operatingPoint: readonly number[],
 ): void {
   validateBjt(element);
+  if (element.emitterResistance > 0.0) {
+    const intrinsicEmitter = bjtIntrinsicEmitterNode(element);
+    stampConductance(
+      matrix,
+      nodeIndex(nodeIndices, element.emitter),
+      nodeIndex(nodeIndices, intrinsicEmitter),
+      1.0 / element.emitterResistance,
+    );
+    element = { ...element, emitter: intrinsicEmitter, emitterResistance: 0.0 };
+  }
   const collector = nodeIndex(nodeIndices, element.collector);
   const base = nodeIndex(nodeIndices, element.base);
   const emitter = nodeIndex(nodeIndices, element.emitter);
@@ -21970,6 +22020,16 @@ function stampAcBjtSmallSignal(
   omega: number,
 ): void {
   validateBjt(element);
+  if (element.emitterResistance > 0.0) {
+    const intrinsicEmitter = bjtIntrinsicEmitterNode(element);
+    stampComplexConductance(
+      matrix,
+      nodeIndex(nodeIndices, element.emitter),
+      nodeIndex(nodeIndices, intrinsicEmitter),
+      complex(1.0 / element.emitterResistance, 0.0),
+    );
+    element = { ...element, emitter: intrinsicEmitter, emitterResistance: 0.0 };
+  }
   const collector = nodeIndex(nodeIndices, element.collector);
   const base = nodeIndex(nodeIndices, element.base);
   const emitter = nodeIndex(nodeIndices, element.emitter);

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(124);
+    expect(coverage).toHaveLength(126);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(124);
+    expect(records).toHaveLength(126);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 124,
-      expectedCanonicalParameterCount: 124,
-      acceptedNameCount: 190,
+      canonicalParameterCount: 126,
+      expectedCanonicalParameterCount: 126,
+      acceptedNameCount: 192,
       aliasedParameterCount: 53,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t124\t124\t190\t53\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t126\t126\t192\t53\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,8 +241,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(123);
-    expect(report.acceptedNameCount).toBe(187);
+    expect(report.canonicalParameterCount).toBe(125);
+    expect(report.acceptedNameCount).toBe(189);
     expect(report.aliasedParameterCount).toBe(52);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t123\t124\t187\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t125\t126\t189\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -349,6 +349,7 @@ describe("dcOp", () => {
       XTF: 2.0,
       ITF: 4.0e-3,
       VTF: 0.6,
+      RE: 12.0,
       ISE: 3.0e-13,
       NE: 1.7,
       ISC: 4.0e-13,
@@ -362,7 +363,7 @@ describe("dcOp", () => {
       FC: 0.4,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, TNOM: 50.0, KF: 1.0e-12, AF: 1.3, PTF: 30.0, XTF: 2.0, ITF: 4.0e-3, VTF: 0.6, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, TNOM: 50.0, KF: 1.0e-12, AF: 1.3, PTF: 30.0, XTF: 2.0, ITF: 4.0e-3, VTF: 0.6, RE: 12.0, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.reverseBeta, 0.25);
@@ -381,6 +382,7 @@ describe("dcOp", () => {
     expectClose(bjtModel.forwardTransitTimeBiasCoefficient, 2.0);
     expectClose(bjtModel.forwardTransitTimeCurrent, 4.0e-3);
     expectClose(bjtModel.forwardTransitTimeVoltage, 0.6);
+    expectClose(bjtModel.emitterResistance, 12.0);
     expectClose(bjtModel.baseEmitterLeakageSaturationCurrent, 3.0e-13);
     expectClose(bjtModel.baseEmitterLeakageEmissionCoefficient, 1.7);
     expectClose(bjtModel.baseCollectorLeakageSaturationCurrent, 4.0e-13);
@@ -1024,7 +1026,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3, 323.15, 1.0e-12, 1.3, 30.0, 2.0, 4.0e-3, 0.6),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3, 323.15, 1.0e-12, 1.3, 30.0, 2.0, 4.0e-3, 0.6, 12.0),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -1058,6 +1060,7 @@ describe("dcOp", () => {
       expectClose(expanded.forwardTransitTimeBiasCoefficient, 2.0);
       expectClose(expanded.forwardTransitTimeCurrent, 4.0e-3);
       expectClose(expanded.forwardTransitTimeVoltage, 0.6);
+      expectClose(expanded.emitterResistance, 12.0);
     }
   });
 
@@ -1464,6 +1467,17 @@ describe("dcOp", () => {
     );
   });
 
+  it("rejects invalid BJT emitter resistances", () => {
+    const circuit = new Circuit();
+    circuit.add({
+      ...bjt("Qbad", "c", "b", "0"),
+      emitterResistance: -1.0,
+    });
+    expect(() => dcOp(circuit)).toThrowError(
+      "emitter resistance must be finite and non-negative",
+    );
+  });
+
   it("rejects non-finite BJT beta temperature exponents", () => {
     const circuit = new Circuit();
     circuit.add({
@@ -1775,6 +1789,22 @@ describe("dcOp", () => {
 
     expect(result.voltage("collector")).toBeGreaterThan(0.0);
     expect(result.voltage("collector")).toBeLessThan(5.0);
+  });
+
+  it("uses BJT emitter resistance to reduce fixed-base collector current", () => {
+    const collectorVoltage = (emitterResistance: number): number => {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vcc", "vcc", "0", 5.0));
+      circuit.add(voltageSource("Vbase", "base", "0", 0.7));
+      circuit.add(resistor("Rc", "vcc", "collector", 1_000.0));
+      circuit.add({
+        ...bjt("Q1", "collector", "base", "0"),
+        emitterResistance,
+      });
+      return dcOp(circuit).voltage("collector") ?? 0.0;
+    };
+
+    expect(collectorVoltage(100.0)).toBeGreaterThan(collectorVoltage(0.0) + 0.5);
   });
 
   it("solves an NMOS operating point", () => {

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -67,6 +67,18 @@ describe("noiseAc", () => {
 
     expect(sourcePsd(1.0e-10)).toBeGreaterThan(sourcePsd(0.0));
   });
+  it("adds thermal noise for BJT emitter resistance", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vbase", "base", "0", 0.65));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+    circuit.add({ ...bjt("Q1", "out", "base", "0"), emitterResistance: 100.0 });
+
+    const entry = noiseAc(circuit, "out", "Vbase", [1_000.0], 300.0).points[0]!.entries
+      .find((candidate) => candidate.elementName === "Q1:RE")!;
+
+    expect(entry.noiseType).toBe("thermal");
+    expect(entry.sourcePsd).toBeGreaterThan(0.0);
+  });
   it("uses BJT KF for inverse-frequency flicker noise", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vcc", "vcc", "0", 5.0));

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,17 +33,17 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT forward transit-time voltage scale.
+1. Cross-language BJT emitter resistance.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `VTF` model-card support in Rust, Python, and TypeScript,
-     defaulting to zero so existing AC and transient results remain unchanged.
-   - Apply the Berkeley base-collector voltage factor
-     `exp(Vbc / (1.44 * VTF))` to the `XTF` diffusion-capacitance and transient
-     stored-charge enhancement while preserving the complete BJT model through
-     subcircuits and tracking the control voltage in transient state.
-   - Extend the supported-parameter coverage gate from 122 to 124 canonical
-     rows and lock model-card behavior, validation, hierarchy, AC loading, and
-     transient stored-charge behavior in all engines.
+   - Add Berkeley BJT `RE` model-card support in Rust, Python, and TypeScript,
+     defaulting to zero so existing operating-point, AC, transient, and noise
+     results remain unchanged.
+   - Insert an intrinsic emitter node behind the configured series resistance,
+     use that node for nonlinear and stored-charge behavior, and include the
+     resistor's thermal-noise contribution.
+   - Extend the supported-parameter coverage gate from 124 to 126 canonical
+     rows and lock model-card behavior, validation, hierarchy, operating-point
+     loading, and noise behavior in all engines.
 
 ## Completed Slices
 
@@ -3159,6 +3159,15 @@ the Rust, Python, and TypeScript surfaces together.
      storage enhancement.
    - Hierarchical subcircuit expansion preserves the complete BJT model, and
      the supported-parameter release gate now covers 122 canonical rows.
+
+239. Cross-language BJT forward transit-time voltage scale.
+   - Status: completed in PR 8851.
+   - Rust, Python, and TypeScript BJT model cards now accept `VTF`, default it
+     to zero, and apply `exp(Vbc / (1.44 * VTF))` to the `XTF` AC and transient
+     storage enhancement.
+   - Hierarchical subcircuit expansion preserves the complete BJT model and
+     transient state tracks the controlling base-collector voltage; the
+     supported-parameter release gate now covers 124 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley BJT `RE` model-card support across Rust, Python, and TypeScript
- model the external-to-intrinsic emitter series resistance in DC, transient, AC, and transfer-function paths
- include emitter-resistance thermal noise and raise supported model-card coverage from 124 to 126 canonical rows
- reconcile the SPICE completion plan after merged PR #8851

## Verification
- `cargo test -p spice-engine`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- Python: `567 passed`, 88.85% coverage
- touched Python files: `ruff check`
- TypeScript: `325 passed`
- `npm run build`