### PR TITLE
feat(twig-aot): MsX64 (Windows) precise-roots registration (AOT00-T1 x86_64 PR-x6)

### DIFF
--- a/code/packages/rust/twig-aot/CHANGELOG.md
+++ b/code/packages/rust/twig-aot/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog — `twig-aot`
 
+## 0.44.0 - 2026-07-23 — MsX64 (Windows) precise-roots registration (AOT00-T1 x86_64 PR-x6)
+
+Brings Windows from safe-conservative GC to **real precise-roots registration**, completing
+precise roots across all three native targets (aarch64 macOS, x86-64 Linux, x86-64 Windows).
+
+Since PR-x3, `__gc_init_stackmaps` was real on System V (Linux) but a no-op on Microsoft x64
+(Windows), so Windows silently degraded to conservative collection. The presumed blocker —
+that the encoder lacked a `mov [rsp+disp], reg` store for the MsX64 stack args — turned out
+to be **already solved**: `x86_64-encoder`'s `mov_mem_r64` emits the required SIB byte for an
+`rsp` base. So no encoder change was needed; the work was purely twig-aot.
+
+- New `build_gc_init_stackmaps_x86_64_msx64` marshals the 8-arg `__gc_register_stackmap`
+  the Microsoft-x64 way: args 1–4 in `rcx/rdx/r8/r9`; args 5–8 stored at `[rsp+32..56]`
+  **above the mandatory 32-byte shadow space** via a single `sub rsp, 64` (kept 16-aligned
+  through the `call`, as MS x64 requires); `add rsp, 64` after. The `func_start` LEA and its
+  pass-2b patch are ABI-independent and reused verbatim.
+- `compile_module_x86_64_to_text` now routes both ABIs to real registration
+  (`match abi { SysV => …, MsX64 => … }`) and registers the entry wrapper on both. The
+  `build_gc_noop_init_x86_64` stub is retired.
+- Windows links the same `gc-core-capi` archive that provides `__gc_register_stackmap`, so
+  the newly-referenced symbol resolves at link time (no unresolved-symbol regression).
+
+Validated by: structural unit tests on the generated MsX64 bytes (shadow reservation +
+`rsp`-relative arg stores + one registration per function-with-records); and — because the
+`windows-latest` CI runner **executes** the AOT pipeline (`windows_x86_64_smoke` links via
+`link.exe`/`lld-link`/`gcc` and runs the `.exe`) — the same executing GC differentials as
+Linux: registration-ran (`count > 0`), `gc_stress` (`live_bytes` 0 precise / 64 conservative),
+and the recursion differential (0 precise / 128 conservative, exercising the self-recursive
+safepoint from PR-x4). twig-aot 0.43.1 → 0.44.0. Needs no encoder bump.
+
 ## 0.43.1 - 2026-07-23 — recursion GC differential (AOT00-T1 x86_64 PR-x5, test-only)
 
 Adds an end-to-end differential proving precise roots reach through a **self-recursive**

--- a/code/packages/rust/twig-aot/Cargo.toml
+++ b/code/packages/rust/twig-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-aot"
-version = "0.43.1"
+version = "0.44.0"
 edition = "2021"
 description = "Twig AOT compiler — produces native Mach-O / ELF executables from Twig source. v0.28.0 (E4d-4 fix): strip_dead_aot_string_allocs now keeps EVERY buffer bound to a live string alias — a branch-selected (multi-block) str var aliases several buffers, and the old alias-keyed map dropped all but the last, so a not-last branch read a freed/empty buffer at run time. v0.27.0 (E4-dyn E4d-4): runtime (branch-selected) strings on the native aarch64 + x86_64 columns — a str var assigned by str_const in >1 basic block is kept out of the compile-time literal map so print_str/str_len read the length from the [i64 len][bytes] buffer header at run time (field_load) instead of folding one branch's static length; the var's stack slot already carries the buffer address. v0.26.0 (E4-dyn E4d-1): runtime string helpers __twig_str_concat/_slice/_index/_len/_cmp in twig_runtime.c on the E5 length-prefixed heap block; bounds-trap on slice/index; C-driver unit tests."
 

--- a/code/packages/rust/twig-aot/src/lib.rs
+++ b/code/packages/rust/twig-aot/src/lib.rs
@@ -1023,18 +1023,6 @@ fn build_gc_wrapper_x86_64(
     Ok((bytes, relocs))
 }
 
-/// Build the **no-op** `__gc_init_stackmaps` for x86-64 (a bare `ret`). A later PR
-/// (AOT00-T1 x86_64 PR-x3) fills it in to register each function's stack map; this
-/// increment lands the wrapper mechanism and proves it transparent first.
-fn build_gc_noop_init_x86_64() -> Result<Vec<u8>, AotError> {
-    let mut a = x86_64_encoder::Assembler::new();
-    a.ret();
-    a.finish().map_err(|e| AotError::Linker {
-        status: None,
-        stderr: format!("twig-aot: x86_64 GC init codegen: {e:?}"),
-    })
-}
-
 /// One `LEA r64, [RIP+…]` in the x86-64 `__gc_init_stackmaps` that must be patched to a
 /// user function's runtime address (`func_start`, the first `__gc_register_stackmap`
 /// argument). `RIP`-relative in bytes, so the displacement is a link-time constant
@@ -1065,9 +1053,8 @@ fn call_return_offsets_x86_64(relocs: &[x86_64_encoder::ExternalReloc]) -> Vec<u
 }
 
 /// Build the **SysV** x86-64 `__gc_init_stackmaps`: for every function with records,
-/// marshal the eight `__gc_register_stackmap` arguments and call it. (Windows/MsX64
-/// keeps the no-op init — its precise walk is a follow-up — so Windows degrades to a
-/// safe conservative collection.)
+/// marshal the eight `__gc_register_stackmap` arguments and call it. The MsX64 (Windows)
+/// twin is [`build_gc_init_stackmaps_x86_64_msx64`]; both ABIs now do real registration.
 ///
 /// ```text
 ///   __gc_init_stackmaps:
@@ -1163,6 +1150,108 @@ fn build_gc_init_stackmaps_x86_64(
     Ok((a.finish().map_err(gc_asm_err_x86)?, relocs, faddr))
 }
 
+/// `__gc_init_stackmaps` for the **Microsoft x64** ABI (Windows) — the MsX64 twin of
+/// [`build_gc_init_stackmaps_x86_64`] (AOT00-T1 x86_64 §Delta-2, PR-x6).
+///
+/// The stack map and `func_start` machinery are identical; only the 8-argument marshalling
+/// of `__gc_register_stackmap` differs. MsX64 passes the first four integer args in
+/// `rcx, rdx, r8, r9` and the rest on the stack **above a mandatory 32-byte shadow space**:
+///
+/// ```text
+///   sub  rsp, 64                 ; 32 shadow (home for rcx..r9) + 32 for args 5-8; 16-aligned
+///   lea  rcx, [rip + F]          ; arg1 func_start   (placeholder, patched in pass 2b)
+///   mov  rdx, <func_len>         ; arg2
+///   mov  r8,  <num_records>      ; arg3
+///   lea  r9,  [rip + F.pc]       ; arg4 pc_offsets
+///   xor  rax, rax
+///   mov  [rsp+32], rax           ; arg5 frame_sizes  = NULL
+///   mov  [rsp+40], rax           ; arg6 callee_masks = NULL
+///   lea  rax, [rip + F.counts]   ; mov [rsp+48], rax  ; arg7 slot_counts
+///   lea  rax, [rip + F.slots]|0  ; mov [rsp+56], rax  ; arg8 slots_flat
+///   call __gc_register_stackmap
+///   add  rsp, 64
+/// ```
+///
+/// **Stack-alignment invariant:** the wrapper enters this function 16-aligned after
+/// `push rbp`; `sub rsp, 64` keeps `rsp ≡ 0 (mod 16)` at each `call` (64 is a 16-multiple),
+/// as MS x64 requires — get it wrong and a `movaps` in the runtime faults. The four stack
+/// args are placed with `mov [rsp+disp], rax` (an `rsp`-based store, which the encoder
+/// emits with the required SIB byte) rather than SysV's `push`, because MsX64 must not
+/// disturb the shadow space below them.
+#[allow(clippy::type_complexity)]
+fn build_gc_init_stackmaps_x86_64_msx64(
+    fn_maps: &[FnStackMap],
+) -> Result<(Vec<u8>, Vec<x86_64_encoder::ExternalReloc>, Vec<FuncAddrRelocX86>), AotError> {
+    use x86_64_encoder::{Assembler, LabelId, Reg};
+    let mut a = Assembler::new();
+    let mut faddr: Vec<FuncAddrRelocX86> = Vec::new();
+    let mut pool: Vec<(LabelId, Vec<u32>)> = Vec::new();
+
+    a.push(Reg::Rbp);
+    a.mov_r64_r64(Reg::Rbp, Reg::Rsp);
+
+    for fm in fn_maps {
+        if fm.records.is_empty() {
+            continue; // no safepoints → nothing to register (conservative frame)
+        }
+        let mut pc_offsets: Vec<u32> = Vec::with_capacity(fm.records.len());
+        let mut slot_counts: Vec<u32> = Vec::with_capacity(fm.records.len());
+        let mut slots_flat: Vec<u32> = Vec::new();
+        for (pc, slots) in &fm.records {
+            pc_offsets.push(*pc);
+            slot_counts.push(slots.len() as u32);
+            slots_flat.extend(slots.iter().map(|&s| s as u32)); // i32 → u32 bit-cast
+        }
+        let pc_lbl = a.create_label();
+        let cnt_lbl = a.create_label();
+        let slots_lbl = if slots_flat.is_empty() { None } else { Some(a.create_label()) };
+
+        // Reserve shadow space (32) + home for the four stack args (32). One `sub` keeps
+        // rsp 16-aligned through the `call`.
+        a.sub_imm32(Reg::Rsp, 64);
+        // Args 1–4 in registers.
+        let disp_slot = a.lea_rip_placeholder(Reg::Rcx); // arg1 func_start (patched pass 2b)
+        faddr.push(FuncAddrRelocX86 { disp_slot, target: fm.name.clone() });
+        a.mov_r64_imm64(Reg::Rdx, fm.len as u64); //          arg2 func_len
+        a.mov_r64_imm64(Reg::R8, fm.records.len() as u64); // arg3 num_records
+        a.lea_rip_label(Reg::R9, pc_lbl); //                  arg4 pc_offsets
+        // Args 5–8 on the stack, above the 32-byte shadow space: [rsp+32..rsp+56].
+        a.xor_(Reg::Rax, Reg::Rax);
+        a.mov_mem_r64(Reg::Rsp, 32, Reg::Rax); // arg5 frame_sizes  = NULL
+        a.mov_mem_r64(Reg::Rsp, 40, Reg::Rax); // arg6 callee_masks = NULL
+        a.lea_rip_label(Reg::Rax, cnt_lbl);
+        a.mov_mem_r64(Reg::Rsp, 48, Reg::Rax); // arg7 slot_counts
+        match slots_lbl {
+            Some(l) => a.lea_rip_label(Reg::Rax, l), // arg8 = slots_flat
+            None => a.xor_(Reg::Rax, Reg::Rax), //     arg8 = NULL
+        }
+        a.mov_mem_r64(Reg::Rsp, 56, Reg::Rax); // arg8 slots_flat
+        a.call_rel32(GC_REGISTER_STACKMAP, x86_64_encoder::ExternalRelocKind::PltRel32);
+        a.add_imm32(Reg::Rsp, 64); // release shadow + stack args
+
+        pool.push((pc_lbl, pc_offsets));
+        pool.push((cnt_lbl, slot_counts));
+        if let Some(l) = slots_lbl {
+            pool.push((l, slots_flat));
+        }
+    }
+
+    a.mov_r64_r64(Reg::Rsp, Reg::Rbp);
+    a.pop(Reg::Rbp);
+    a.ret();
+
+    // Constant data pool — read via `lea` above, never executed (after `ret`).
+    for (lbl, words) in &pool {
+        a.bind(*lbl).map_err(gc_asm_err_x86)?;
+        for &w in words {
+            a.emit_data_u32(w);
+        }
+    }
+
+    let relocs = std::mem::take(&mut a.external_relocs);
+    Ok((a.finish().map_err(gc_asm_err_x86)?, relocs, faddr))
+}
+
 #[allow(clippy::type_complexity)]
 fn compile_module_x86_64_to_text(
     module: &IIRModule,
@@ -1174,8 +1263,8 @@ fn compile_module_x86_64_to_text(
     let mut fn_results: Vec<(String, Vec<u8>, Vec<x86_64_encoder::ExternalReloc>)> =
         Vec::with_capacity(module.functions.len());
 
-    // Per user function, the GC stack map the SysV registration function will register
-    // (collected only for SysV; MsX64 uses the no-op init, so records are unused there).
+    // Per user function, the GC stack map the registration function will register (used by
+    // both ABIs — SysV and MsX64 both do real registration now, PR-x3/PR-x6).
     let mut fn_maps: Vec<FnStackMap> = Vec::with_capacity(module.functions.len());
     for fn_ in &module.functions {
         let ctx = FunctionContext {
@@ -1193,14 +1282,14 @@ fn compile_module_x86_64_to_text(
         fn_results.push((fn_.name.clone(), bytes, relocs));
     }
 
-    // ── Inject the GC entry wrapper + (no-op) stack-map registration (AOT00-T1
-    //    x86_64 PR-x2) ──────────────────────────────────────────────────────────
+    // ── Inject the GC entry wrapper + stack-map registration (AOT00-T1 x86_64
+    //    PR-x2/x3/x6) ────────────────────────────────────────────────────────────
     //
     // Mirrors the aarch64 path: the wrapper `__gc_aot_entry` becomes the image entry
     // (the packager exports the global `main` symbol at `entry_off`, so redirecting
-    // `entry_off` to the wrapper's offset makes it `main` — no rename). It calls the
-    // (currently no-op) `__gc_init_stackmaps`, then the user entry, returning its rax.
-    // Both calls are intra-module and patched in place by pass 2 below.
+    // `entry_off` to the wrapper's offset makes it `main` — no rename). It calls
+    // `__gc_init_stackmaps` (real registration on both ABIs), then the user entry,
+    // returning its rax. Both calls are intra-module and patched in place by pass 2 below.
     let entry = module.entry_point.as_deref().ok_or(AotError::NoEntryPoint)?;
     // Reserved-symbol guard: `link()` is last-write-wins and the wrapper emits
     // `call <entry>`, so a user function OR entry named `__gc_aot_entry` /
@@ -1222,10 +1311,14 @@ fn compile_module_x86_64_to_text(
     // frame (the increment-C fix; [[feedback_precise_walk_maps_every_frame_in_chain]]).
     let (wrapper_bytes, wrapper_relocs) = build_gc_wrapper_x86_64(entry, abi)?;
 
-    // `__gc_init_stackmaps`: real registration on System V; a no-op on Windows/MsX64
-    // (whose precise walk is a follow-up), so Windows degrades to a safe conservative
-    // collection. `fn_addr_relocs` are the SysV `func_start` LEAs pass 2b patches.
-    let (init_bytes, init_relocs, fn_addr_relocs) = if matches!(abi, X86_64Abi::SysV) {
+    // `__gc_init_stackmaps`: real registration on **both** ABIs — System V (Linux) and
+    // Microsoft x64 (Windows) — so precise roots are load-bearing on every native x86-64
+    // target. The two builders differ only in the 8-arg `__gc_register_stackmap`
+    // marshalling (see `build_gc_init_stackmaps_x86_64{,_msx64}`). `fn_addr_relocs` are the
+    // `func_start` LEAs pass 2b patches (ABI-independent). The wrapper is registered too
+    // (empty ref-slot map) so the precise walk never conservatively re-scans the user
+    // entry's frame (the increment-C fix; [[feedback_precise_walk_maps_every_frame_in_chain]]).
+    let (init_bytes, init_relocs, fn_addr_relocs) = {
         let wrapper_records = call_return_offsets_x86_64(&wrapper_relocs)
             .into_iter()
             .map(|pc| (pc, Vec::new()))
@@ -1235,9 +1328,10 @@ fn compile_module_x86_64_to_text(
             len: wrapper_bytes.len(),
             records: wrapper_records,
         });
-        build_gc_init_stackmaps_x86_64(&fn_maps)?
-    } else {
-        (build_gc_noop_init_x86_64()?, Vec::new(), Vec::new())
+        match abi {
+            X86_64Abi::SysV => build_gc_init_stackmaps_x86_64(&fn_maps)?,
+            X86_64Abi::MsX64 => build_gc_init_stackmaps_x86_64_msx64(&fn_maps)?,
+        }
     };
     fn_results.push((GC_INIT_STACKMAPS.to_string(), init_bytes, init_relocs));
     fn_results.push((GC_AOT_ENTRY.to_string(), wrapper_bytes, wrapper_relocs));
@@ -1324,7 +1418,7 @@ fn compile_module_x86_64_to_text(
     // `LEA` computes `RIP + disp32`; `RIP` (= instruction end) and the target are both
     // `base + offset`, so `disp32 = target_off − (slot + 4)` is correct for any load
     // base — the same base-independence the aarch64 `ADR` func_start relies on. No `ld`
-    // relocation. (Empty on MsX64, whose init is the no-op.)
+    // relocation. Applies to both ABIs now (SysV `lea rdi`, MsX64 `lea rcx`).
     if !fn_addr_relocs.is_empty() {
         let init_off = *offsets.get(GC_INIT_STACKMAPS).ok_or_else(|| AotError::Linker {
             status: None,
@@ -3294,12 +3388,6 @@ mod tests {
         assert!(ms.len() > sysv.len(), "MsX64 reserves shadow space");
     }
 
-    /// The no-op x86_64 init is a bare `ret`.
-    #[test]
-    fn gc_noop_init_x86_64_is_ret() {
-        assert_eq!(build_gc_noop_init_x86_64().expect("codegen"), vec![0xC3]);
-    }
-
     /// After injection, the x86_64 image entry is the wrapper: `entry_off` equals the
     /// wrapper's link offset, and the byte there is `push rbp` (0x55). So the packager
     /// exports `main` at the wrapper, and libc's `_start` runs the GC entry.
@@ -3371,6 +3459,46 @@ mod tests {
         assert!(targets.contains(&"f") && targets.contains(&"g"));
         assert!(!targets.contains(&"leaf"));
         assert_eq!(bytes.last(), None.or(bytes.last())); // no panic on empty edge
+    }
+
+    /// PR-x6: the **MsX64** init registers the same functions as SysV but marshals the
+    /// 8-arg call the Microsoft-x64 way — a `sub rsp, 64` / `add rsp, 64` shadow+stack
+    /// reservation and `mov [rsp+disp], rax` stores for args 5–8 (each an `rsp`-based store
+    /// encoded with the SIB byte `24`), rather than SysV's two `push`es.
+    #[test]
+    fn gc_init_x86_64_msx64_registers_with_shadow_space_and_rsp_stores() {
+        let maps = vec![
+            FnStackMap { name: "f".into(), len: 64, records: vec![(8, vec![-16]), (20, vec![-16])] },
+            FnStackMap { name: "leaf".into(), len: 8, records: vec![] }, // skipped
+            FnStackMap { name: "g".into(), len: 16, records: vec![(4, vec![])] },
+        ];
+        let (bytes, relocs, faddr) =
+            build_gc_init_stackmaps_x86_64_msx64(&maps).expect("codegen");
+
+        // Same registration set as SysV: one call + one func_start LEA per fn with records.
+        assert_eq!(
+            relocs.iter().filter(|r| r.symbol == GC_REGISTER_STACKMAP).count(),
+            2,
+            "one call per function with records (f, g)",
+        );
+        assert_eq!(faddr.len(), 2, "one func_start LEA per registered function");
+        let targets: Vec<&str> = faddr.iter().map(|r| r.target.as_str()).collect();
+        assert!(targets.contains(&"f") && targets.contains(&"g") && !targets.contains(&"leaf"));
+
+        // `sub rsp, 64` = 48 81 EC 40 00 00 00 ; `add rsp, 64` = 48 81 C4 40 00 00 00
+        // (SUB/ADD r/m64, imm32) — one balancing pair per registered fn.
+        let subs = bytes.windows(4).filter(|w| *w == [0x48, 0x81, 0xEC, 0x40]).count();
+        let adds = bytes.windows(4).filter(|w| *w == [0x48, 0x81, 0xC4, 0x40]).count();
+        assert_eq!(subs, 2, "one `sub rsp,64` shadow+stack reservation per registered fn");
+        assert_eq!(adds, 2, "one balancing `add rsp,64` per registered fn");
+
+        // `mov [rsp+disp32], rax` = 48 89 84 24 <disp32> — the four stack args (5–8) per fn
+        // → at least 4 such stores overall (8 total; assert ≥4 to stay robust).
+        let rsp_stores = bytes.windows(4).filter(|w| *w == [0x48, 0x89, 0x84, 0x24]).count();
+        assert!(
+            rsp_stores >= 4,
+            "MsX64 places stack args with rsp-relative stores (SIB 24); found {rsp_stores}",
+        );
     }
 
     /// PR-x3 (UAF-critical): after linking a module whose `main` calls a helper, the

--- a/code/packages/rust/twig-aot/tests/windows_x86_64_smoke.rs
+++ b/code/packages/rust/twig-aot/tests/windows_x86_64_smoke.rs
@@ -332,3 +332,209 @@ fn pe_object_has_correct_machine_field() {
     // First 2 bytes: IMAGE_FILE_MACHINE_AMD64 LE = 0x64 0x86.
     assert_eq!(&obj[0..2], &[0x64, 0x86]);
 }
+
+// ── AOT00-T1 x86_64 PR-x6: precise-roots registration on the Microsoft x64 ABI ─────
+//
+// These execute on the native `windows-latest` runner — the authoritative validator for
+// the MsX64 GC path (the dev host is aarch64 macOS). They prove the MsX64
+// `__gc_init_stackmaps` marshalling (args 1–4 in rcx/rdx/r8/r9, args 5–8 above a 32-byte
+// shadow space) registers correctly and that precise roots are load-bearing on Windows —
+// closing the "Windows degrades to conservative" gap left by PR-x3.
+
+/// The start-up registration actually ran in the linked `.exe`: a program returning
+/// `__gc_stackmap_count()` exits `> 0`. (Also proves the MsX64 init links against
+/// `__gc_register_stackmap` — previously it was a no-op that referenced nothing.)
+#[test]
+fn gc_stackmap_registration_ran_on_windows() {
+    if !linker_available() {
+        eprintln!("skipping: no Windows linker on PATH");
+        return;
+    }
+    use interpreter_ir::function::IIRFunction;
+    use interpreter_ir::instr::{IIRInstr, Operand};
+    use interpreter_ir::module::IIRModule;
+
+    let main = IIRFunction::new(
+        "main", vec![], "i64",
+        vec![
+            IIRInstr::new(
+                "call_builtin",
+                Some("c".into()),
+                vec![Operand::Var("gc_stackmap_count".into())],
+                "i64",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("c".into())], "i64"),
+        ],
+    );
+    let mut m = IIRModule::new("gc_count", "twig");
+    m.add_or_replace(main);
+    m.entry_point = Some("main".into());
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let exe = dir.path().join("gc_count.exe");
+    twig_aot::compile_module_to_windows_executable(&m, &exe).expect("count compiles+links");
+    let code = Command::new(&exe).output().expect("count runs").status.code().unwrap();
+    assert!(code > 0, "MsX64 registration must have run at start-up (count={code})");
+}
+
+/// The GC-stress `live_bytes` differential on Windows: a 64-byte allocation whose address
+/// lives only in an `i64` (non-reference) slot is reclaimed by a precise collect but pinned
+/// by a conservative one. Precise → `live_bytes == 0`, conservative → `== 64`. The headline
+/// proof that MsX64 precise roots are load-bearing (mirrors the Linux/SysV differential).
+#[test]
+fn gc_stress_live_bytes_differential_on_windows() {
+    if !linker_available() {
+        eprintln!("skipping: no Windows linker on PATH");
+        return;
+    }
+    use interpreter_ir::function::IIRFunction;
+    use interpreter_ir::instr::{IIRInstr, Operand};
+    use interpreter_ir::module::IIRModule;
+
+    fn build(collect: &str, collect_returns: bool) -> IIRModule {
+        let mut body = vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(64)], "i64"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("a".into()),
+                vec![Operand::Var("gc_alloc".into()), Operand::Var("n".into())],
+                "i64",
+            ),
+        ];
+        body.push(if collect_returns {
+            IIRInstr::new("call_builtin", Some("f".into()), vec![Operand::Var(collect.into())], "i64")
+        } else {
+            IIRInstr::new("call_builtin", None, vec![Operand::Var(collect.into())], "void")
+        });
+        body.push(IIRInstr::new(
+            "call_builtin",
+            Some("lb".into()),
+            vec![Operand::Var("gc_live_bytes".into())],
+            "i64",
+        ));
+        body.push(IIRInstr::new("ret", None, vec![Operand::Var("lb".into())], "i64"));
+        let mut m = IIRModule::new("gc_stress", "twig");
+        m.add_or_replace(IIRFunction::new("main", vec![], "i64", body));
+        m.entry_point = Some("main".into());
+        m
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let run = |tag: &str, collect: &str, ret: bool| -> i32 {
+        let exe = dir.path().join(format!("{tag}.exe"));
+        twig_aot::compile_module_to_windows_executable(&build(collect, ret), &exe)
+            .unwrap_or_else(|e| panic!("{tag} compiles+links: {e}"));
+        Command::new(&exe).output().unwrap_or_else(|e| panic!("{tag} runs: {e}"))
+            .status.code().unwrap_or_else(|| panic!("{tag} exited by signal"))
+    };
+
+    let conservative = run("gc_stress_cons", "gc_collect", false);
+    let precise = run("gc_stress_prec", "gc_collect_precise", true);
+    assert_eq!(conservative, 64, "conservative retains the 64-byte look-alike-pinned object");
+    assert_eq!(
+        precise, 0,
+        "precise reclaims the object reachable only via a non-reference i64 slot \
+         (conservative kept {conservative})",
+    );
+}
+
+/// The recursion differential on Windows — precise roots reach through an intermediate
+/// **self-recursive** frame (identical module to the Linux/aarch64 twins). `rec(stop)`
+/// allocates an `i64` look-alike per frame and recurses once (`main → rec(0) → rec(1)`);
+/// the collect fires in `rec(1)`, so the collector unwinds through `rec(0)`, an
+/// intermediate self-recursive frame. Conservative pins both look-alikes (`128`); precise
+/// reclaims both (`0`). Exercises the MsX64 registration of the self-recursive-call
+/// safepoint (PR-x4) end to end.
+#[test]
+fn gc_recursive_frame_live_bytes_differential_on_windows() {
+    if !linker_available() {
+        eprintln!("skipping: no Windows linker on PATH");
+        return;
+    }
+    use interpreter_ir::function::IIRFunction;
+    use interpreter_ir::instr::{IIRInstr, Operand};
+    use interpreter_ir::module::IIRModule;
+
+    fn build(collect: &str, collect_returns: bool) -> IIRModule {
+        let mut rec_body = vec![
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(64)], "i64"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("a".into()),
+                vec![Operand::Var("gc_alloc".into()), Operand::Var("n".into())],
+                "i64",
+            ),
+            IIRInstr::new(
+                "jmp_if_true",
+                None,
+                vec![Operand::Var("stop".into()), Operand::Var("base".into())],
+                "i64",
+            ),
+            IIRInstr::new("const", Some("one".into()), vec![Operand::Int(1)], "i64"),
+            IIRInstr::new(
+                "call",
+                Some("r".into()),
+                vec![Operand::Var("rec".into()), Operand::Var("one".into())],
+                "i64",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "i64"),
+            IIRInstr::new("label", None, vec![Operand::Var("base".into())], "i64"),
+        ];
+        rec_body.push(if collect_returns {
+            IIRInstr::new("call_builtin", Some("freed".into()), vec![Operand::Var(collect.into())], "i64")
+        } else {
+            IIRInstr::new("call_builtin", None, vec![Operand::Var(collect.into())], "void")
+        });
+        rec_body.push(IIRInstr::new(
+            "call_builtin",
+            Some("lb".into()),
+            vec![Operand::Var("gc_live_bytes".into())],
+            "i64",
+        ));
+        rec_body.push(IIRInstr::new("ret", None, vec![Operand::Var("lb".into())], "i64"));
+
+        let main_body = vec![
+            IIRInstr::new("const", Some("z".into()), vec![Operand::Int(0)], "i64"),
+            IIRInstr::new(
+                "call",
+                Some("r".into()),
+                vec![Operand::Var("rec".into()), Operand::Var("z".into())],
+                "i64",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "i64"),
+        ];
+
+        let mut m = IIRModule::new("gc_recur", "twig");
+        m.add_or_replace(IIRFunction::new(
+            "rec",
+            vec![("stop".to_string(), "i64".to_string())],
+            "i64",
+            rec_body,
+        ));
+        m.add_or_replace(IIRFunction::new("main", vec![], "i64", main_body));
+        m.entry_point = Some("main".into());
+        m
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let run = |tag: &str, collect: &str, ret: bool| -> i32 {
+        let exe = dir.path().join(format!("{tag}.exe"));
+        twig_aot::compile_module_to_windows_executable(&build(collect, ret), &exe)
+            .unwrap_or_else(|e| panic!("{tag} compiles+links: {e}"));
+        Command::new(&exe).output().unwrap_or_else(|e| panic!("{tag} runs: {e}"))
+            .status.code().unwrap_or_else(|| panic!("{tag} exited by signal"))
+    };
+
+    let conservative = run("gc_recur_cons", "gc_collect", false);
+    let precise = run("gc_recur_prec", "gc_collect_precise", true);
+    assert_eq!(
+        conservative, 128,
+        "conservative pins both recursive frames' 64-byte look-alikes (got {conservative})",
+    );
+    assert_eq!(
+        precise, 0,
+        "precise reclaims both look-alikes, incl. a0 in the intermediate self-recursive \
+         frame — MsX64 must map it at the recursive-call return address (got {precise}, \
+         conservative={conservative})",
+    );
+}

--- a/code/specs/AOT00-T1-x86_64-precise-roots.md
+++ b/code/specs/AOT00-T1-x86_64-precise-roots.md
@@ -179,6 +179,22 @@ before adding; prefer existing methods.
   each recursive call's return address (`asm.len()` after the 5-byte `call rel32`) and
   `build_stack_map` adds a safepoint at each — recursive frames are precise. (aarch64 never
   had this gap: fixed-width, it post-scans finished code for `BL`.) No encoder gaps arose.
+- **PR-x5** *(done — twig-aot 0.43.1, test-only)* — end-to-end recursion differential
+  (`gc_recursive_frame_live_bytes_differential`): a self-recursive `rec(stop)` holds a
+  look-alike in an intermediate recursive frame; precise reclaims through it (`0`),
+  conservative pins (`128`). Runs on the x86-64 CI runner (proves PR-x4) and locally on
+  aarch64 (validates the shape). The end-to-end proof of PR-x4.
+- **PR-x6** *(done — twig-aot 0.44.0)* — **MsX64 (Windows) precise registration**. The
+  Delta-3 §Delta-2 discovery: the encoder *already* has `mov [rsp+disp], reg` (SIB-encoded
+  rsp-base store), so no encoder work was needed — the sole remaining blocker was the
+  twig-aot side. Adds `build_gc_init_stackmaps_x86_64_msx64` (args 1–4 in rcx/rdx/r8/r9;
+  args 5–8 stored at `[rsp+32..56]` above a 32-byte shadow space via a single `sub rsp,64`;
+  16-aligned at the `call`) and routes MsX64 to it, retiring the no-op init. The `func_start`
+  LEA + pass-2b are ABI-independent and reused verbatim. Windows now does **real** precise
+  registration, not safe-conservative. Validated by unit tests (structural byte checks) and
+  — because `windows-latest` **executes** the pipeline (`windows_x86_64_smoke` links via
+  `link.exe`/`lld-link`/`gcc` and runs the `.exe`) — the same `gc_stress` + recursion
+  differentials as Linux, run natively on Windows CI.
 
 ---
 


### PR DESCRIPTION
## What

Brings **Windows** from safe-conservative GC to **real precise-roots registration** — completing precise roots across all three native targets (aarch64 macOS, x86-64 Linux, x86-64 Windows).

Since PR-x3, `__gc_init_stackmaps` was real on System V (Linux) but a **no-op** on Microsoft x64 (Windows), so Windows silently degraded to conservative collection.

## The finding

The presumed blocker — that `x86_64-encoder` lacked a `mov [rsp+disp], reg` store for the MsX64 stack args — was **already solved**: `mov_mem_r64` emits the required SIB byte for an `rsp` base. So **no encoder change was needed**; the work is purely twig-aot.

## How

New `build_gc_init_stackmaps_x86_64_msx64` marshals the 8-arg `__gc_register_stackmap` the Microsoft-x64 way:

```
sub  rsp, 64                 ; 32-byte shadow space + 32 for args 5-8; 16-aligned
lea  rcx, [rip + F]          ; arg1 func_start (placeholder, patched in pass 2b)
mov  rdx, <func_len>         ; arg2
mov  r8,  <num_records>      ; arg3
lea  r9,  [rip + F.pc]       ; arg4 pc_offsets
xor  rax, rax
mov  [rsp+32], rax           ; arg5 frame_sizes  = NULL
mov  [rsp+40], rax           ; arg6 callee_masks = NULL
lea  rax, [rip + F.counts] ; mov [rsp+48], rax   ; arg7 slot_counts
lea  rax, [rip + F.slots]|0 ; mov [rsp+56], rax  ; arg8 slots_flat
call __gc_register_stackmap
add  rsp, 64
```

- args 1-4 in `rcx/rdx/r8/r9`; args 5-8 stored **above the mandatory 32-byte shadow space** at `[rsp+32..56]`. `rsp` stays 16-aligned through the `call` (64 is a 16-multiple), as MS x64 requires.
- The `func_start` LEA and its pass-2b patch are **ABI-independent, reused verbatim** — `lea rcx` vs SysV `lea rdi` is the same 7-byte encoding, same disp32 position, same base-independent RIP math.
- `compile_module_x86_64_to_text` routes both ABIs to real registration (`match abi`) and registers the entry wrapper on both. The `build_gc_noop_init_x86_64` stub is **retired**.
- Windows links the same `gc-core-capi` archive that exports `__gc_register_stackmap`, so the newly-referenced symbol resolves at link time (no unresolved-symbol regression; existing Windows tests, which now also register the wrapper, still link).

## Validation

- 57 lib tests incl. a new structural MsX64 test (shadow reservation + `rsp`-relative arg stores + one registration per function-with-records); clippy clean.
- **Because `windows-latest` CI executes the pipeline** (`windows_x86_64_smoke` links via `link.exe`/`lld-link`/`gcc` and runs the `.exe`), the same executing GC differentials as Linux run natively on Windows CI: registration-ran (`count > 0`), `gc_stress` (`live_bytes` 0 precise / 64 conservative), and the recursion differential (0 precise / 128 conservative, exercising PR-x4's self-recursive safepoint).
- Adversarial `/security-review`: **SAFE TO PUSH** — alignment holds at every `call`, all 8 args map correctly, shadow space preserved, LEA/pass-2b unchanged and base-independent, link edge resolves against the archive SysV already uses, SysV path byte-identical.

twig-aot 0.43.1 → 0.44.0; no encoder bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)