### PR TITLE
feat(spice): add BJT collector resistance

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add BJT model-card `RC` collector-resistance support with an intrinsic
+  collector node in DC, AC, and transient analysis plus thermal noise in noise
+  analysis.
 - Add BJT model-card `RE` emitter-resistance support with an intrinsic emitter
   node in DC, AC, and transient analysis plus thermal noise in noise analysis.
 - Add BJT model-card `VTF` forward transit-time voltage-scale support, applying

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -622,6 +622,8 @@ class BJT:
         Base-collector voltage scale for transit-time bias dependence (default 0.0).
     Re:
         Constant external-to-intrinsic emitter resistance in Ohms (default 0.0).
+    Rc:
+        Constant external-to-intrinsic collector resistance in Ohms (default 0.0).
     """
 
     name: str
@@ -663,6 +665,7 @@ class BJT:
     Itf: float = 0.0           # forward transit-time current scale (A)
     Vtf: float = 0.0           # forward transit-time voltage scale (V)
     Re: float = 0.0            # emitter resistance (ohms)
+    Rc: float = 0.0            # collector resistance (ohms)
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -605,7 +605,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr, element.Tnom, element.Kf, element.Af, element.Ptf, element.Xtf, element.Itf, element.Vtf, element.Re)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr, element.Tnom, element.Kf, element.Af, element.Ptf, element.Xtf, element.Itf, element.Vtf, element.Re, element.Rc)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -7263,6 +7263,8 @@ def _element_nodes(el: Element) -> list[str]:
         nodes = [el.collector, el.base, el.emitter]
         if el.Re > 0.0:
             nodes.append(_bjt_intrinsic_emitter_node(el))
+        if el.Rc > 0.0:
+            nodes.append(_bjt_intrinsic_collector_node(el))
         return nodes
     if isinstance(el, TransmissionLine):
         return [el.n1, el.n2, el.n3, el.n4]
@@ -8744,6 +8746,10 @@ def _bjt_intrinsic_emitter_node(el: BJT) -> str:
     return el.emitter if el.Re == 0.0 else f"__spice_{el.name}_emitter"
 
 
+def _bjt_intrinsic_collector_node(el: BJT) -> str:
+    return el.collector if el.Rc == 0.0 else f"__spice_{el.name}_collector"
+
+
 def _bjt_junction_transconductance(el: BJT, voltage: float, emission_coefficient: float) -> float:
     effective_thermal_voltage = el.Vt * emission_coefficient
     exponent = max(-40.0, min(40.0, voltage / effective_thermal_voltage))
@@ -8816,6 +8822,7 @@ def _bjt_base_collector_depletion_capacitance(el: BJT, voltage: float) -> float:
 def _bjt_charge_state_specs(el: BJT) -> list[tuple[str, str, str, str]]:
     specs: list[tuple[str, str, str, str]] = []
     emitter = _bjt_intrinsic_emitter_node(el)
+    collector = _bjt_intrinsic_collector_node(el)
     if el.Cje > 0.0 or el.Tf > 0.0:
         if el.polarity == "NPN":
             specs.append((_bjt_base_emitter_charge_state_name(el), el.base, emitter, "be"))
@@ -8823,9 +8830,9 @@ def _bjt_charge_state_specs(el: BJT) -> list[tuple[str, str, str, str]]:
             specs.append((_bjt_base_emitter_charge_state_name(el), emitter, el.base, "be"))
     if el.Cjc > 0.0 or el.Tr > 0.0 or (el.Tf > 0.0 and el.Xtf > 0.0 and el.Vtf > 0.0):
         if el.polarity == "NPN":
-            specs.append((_bjt_base_collector_charge_state_name(el), el.base, el.collector, "bc"))
+            specs.append((_bjt_base_collector_charge_state_name(el), el.base, collector, "bc"))
         else:
-            specs.append((_bjt_base_collector_charge_state_name(el), el.collector, el.base, "bc"))
+            specs.append((_bjt_base_collector_charge_state_name(el), collector, el.base, "bc"))
     return specs
 
 
@@ -9199,6 +9206,10 @@ def _stamp_bjt(
         intrinsic_emitter = _bjt_intrinsic_emitter_node(el)
         _stamp_g(G, node_to_idx, el.emitter, intrinsic_emitter, 1.0 / el.Re)
         el = replace(el, emitter=intrinsic_emitter, Re=0.0)
+    if el.Rc > 0.0:
+        intrinsic_collector = _bjt_intrinsic_collector_node(el)
+        _stamp_g(G, node_to_idx, el.collector, intrinsic_collector, 1.0 / el.Rc)
+        el = replace(el, collector=intrinsic_collector, Rc=0.0)
     # --- Resolve node voltages at the current Newton iterate -----------------
     Vb = 0.0 if _is_ground(el.base) else x[node_to_idx[el.base]]
     Ve = 0.0 if _is_ground(el.emitter) else x[node_to_idx[el.emitter]]
@@ -9369,6 +9380,10 @@ def _validate_bjt(el: BJT) -> None:
     if not math.isfinite(el.Re) or el.Re < 0.0:
         raise ValueError(
             f"{el.name}: BJT emitter resistance must be finite and non-negative"
+        )
+    if not math.isfinite(el.Rc) or el.Rc < 0.0:
+        raise ValueError(
+            f"{el.name}: BJT collector resistance must be finite and non-negative"
         )
     if not math.isfinite(el.Ise) or el.Ise < 0.0:
         raise ValueError(
@@ -12635,6 +12650,16 @@ def _stamp_ac(
                 complex(1.0 / el.Re),
             )
             el = replace(el, emitter=intrinsic_emitter, Re=0.0)
+        if el.Rc > 0.0:
+            intrinsic_collector = _bjt_intrinsic_collector_node(el)
+            _stamp_g_c(
+                G,
+                node_to_idx,
+                el.collector,
+                intrinsic_collector,
+                complex(1.0 / el.Rc),
+            )
+            el = replace(el, collector=intrinsic_collector, Rc=0.0)
         Vc_dc = 0.0 if _is_ground(el.collector) else dc_x[node_to_idx[el.collector]]
         Vb_dc = 0.0 if _is_ground(el.base) else dc_x[node_to_idx[el.base]]
         Ve_dc = 0.0 if _is_ground(el.emitter) else dc_x[node_to_idx[el.emitter]]
@@ -13291,6 +13316,16 @@ def _build_ss_matrix(
                     1.0 / el.Re,
                 )
                 el = replace(el, emitter=intrinsic_emitter, Re=0.0)
+            if el.Rc > 0.0:
+                intrinsic_collector = _bjt_intrinsic_collector_node(el)
+                _stamp_g(
+                    G,
+                    node_to_idx,
+                    el.collector,
+                    intrinsic_collector,
+                    1.0 / el.Rc,
+                )
+                el = replace(el, collector=intrinsic_collector, Rc=0.0)
             Vc_dc = 0.0 if _is_ground(el.collector) else dc_x[node_to_idx[el.collector]]
             Vb_dc = 0.0 if _is_ground(el.base) else dc_x[node_to_idx[el.base]]
             Ve_dc = 0.0 if _is_ground(el.emitter) else dc_x[node_to_idx[el.emitter]]
@@ -14218,6 +14253,7 @@ def sens_dc(
                     beta_r=el.beta_r,
                     Ikr=el.Ikr,
                     Re=el.Re,
+                    Rc=el.Rc,
                 ),
             )
             delta_beta = max(abs(el.beta_f) * perturbation, abs_floor)
@@ -14254,6 +14290,7 @@ def sens_dc(
                     beta_r=el.beta_r,
                     Ikr=el.Ikr,
                     Re=el.Re,
+                    Rc=el.Rc,
                 ),
             )
 
@@ -14500,6 +14537,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             beta_r=el.beta_r,
             Ikr=el.Ikr,
             Re=el.Re,
+            Rc=el.Rc,
         )
 
     # Capacitor, Inductor, Mosfet — no tunable DC parameter; return unchanged.
@@ -14947,6 +14985,17 @@ def _collect_noise_sources(
                     0.0,
                 ))
                 el = replace(el, emitter=intrinsic_emitter, Re=0.0)
+            if el.Rc > 0.0:
+                intrinsic_collector = _bjt_intrinsic_collector_node(el)
+                sources.append((
+                    f"{el.name}:RC",
+                    "thermal",
+                    node_to_idx.get(el.collector),
+                    node_to_idx.get(intrinsic_collector),
+                    kT4 / el.Rc,
+                    0.0,
+                ))
+                el = replace(el, collector=intrinsic_collector, Rc=0.0)
             Vb = 0.0 if _is_ground(el.base) else dc_x[node_to_idx[el.base]]
             Ve = 0.0 if _is_ground(el.emitter) else dc_x[node_to_idx[el.emitter]]
             Vc = 0.0 if _is_ground(el.collector) else dc_x[node_to_idx[el.collector]]

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (34, 51, 13, 4),
-    "PNP": (34, 51, 13, 4),
+    "NPN": (35, 52, 13, 4),
+    "PNP": (35, 52, 13, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -388,6 +388,7 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "ITF": "ITF",
     "VTF": "VTF",
     "RE": "RE",
+    "RC": "RC",
     "ISE": "ISE",
     "NE": "NE",
     "ISC": "ISC",
@@ -957,6 +958,7 @@ def bjt_from_model_card(
         Itf=p.get("ITF", 0.0),
         Vtf=p.get("VTF", 0.0),
         Re=p.get("RE", 0.0),
+        Rc=p.get("RC", 0.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 126
+    assert len(coverage) == 128
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 126
+    assert len(records) == 128
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,9 +501,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 126
-    assert report.expected_canonical_parameter_count == 126
-    assert report.accepted_name_count == 192
+    assert report.canonical_parameter_count == 128
+    assert report.expected_canonical_parameter_count == 128
+    assert report.accepted_name_count == 194
     assert report.aliased_parameter_count == 53
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -511,7 +511,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t126\t126\t192\t53\t4\t0"
+        "true\t7\t7\t128\t128\t194\t53\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,8 +539,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 125
-    assert report.accepted_name_count == 189
+    assert report.canonical_parameter_count == 127
+    assert report.accepted_name_count == 191
     assert report.aliased_parameter_count == 52
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t125\t126\t189\t52\t4\t4\n"
+        "false\t7\t7\t127\t128\t191\t52\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,10 +647,10 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "VTF": 0.6, "RE": 12.0, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
+        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "VTF": 0.6, "RE": 12.0, "RC": 13.0, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "TNOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "VTF": 0.6, "RE": 12.0, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
+    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "TNOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "VTF": 0.6, "RE": 12.0, "RC": 13.0, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.beta_r == pytest.approx(0.25)
@@ -670,6 +670,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert bjt_model.Itf == pytest.approx(4.0e-3)
     assert bjt_model.Vtf == pytest.approx(0.6)
     assert bjt_model.Re == pytest.approx(12.0)
+    assert bjt_model.Rc == pytest.approx(13.0)
     assert bjt_model.Ise == pytest.approx(3.0e-13)
     assert bjt_model.Ne == pytest.approx(1.7)
     assert bjt_model.Isc == pytest.approx(4.0e-13)
@@ -2341,7 +2342,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3, Tnom=323.15, Kf=1.0e-12, Af=1.3, Ptf=30.0, Xtf=2.0, Itf=4.0e-3, Vtf=0.6, Re=12.0),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3, Tnom=323.15, Kf=1.0e-12, Af=1.3, Ptf=30.0, Xtf=2.0, Itf=4.0e-3, Vtf=0.6, Re=12.0, Rc=13.0),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2375,6 +2376,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.Itf == pytest.approx(4.0e-3)
     assert expanded.Vtf == pytest.approx(0.6)
     assert expanded.Re == pytest.approx(12.0)
+    assert expanded.Rc == pytest.approx(13.0)
 
 
 def test_branch_current_in_voltage_source():
@@ -2672,6 +2674,16 @@ def test_dc_rejects_invalid_bjt_emitter_resistance():
     with pytest.raises(
         ValueError,
         match="emitter resistance must be finite and non-negative",
+    ):
+        dc_op(circuit)
+
+
+def test_dc_rejects_invalid_bjt_collector_resistance():
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", Rc=-1.0))
+    with pytest.raises(
+        ValueError,
+        match="collector resistance must be finite and non-negative",
     ):
         dc_op(circuit)
 
@@ -3575,6 +3587,16 @@ def test_bjt_emitter_resistance_reduces_fixed_base_collector_current():
         return dc_op(circuit).node_voltages["collector"]
 
     assert collector_voltage(100.0) > collector_voltage(0.0) + 0.5
+
+
+def test_bjt_collector_resistance_drops_intrinsic_collector_voltage():
+    circuit = Circuit()
+    circuit.add(VoltageSource("Vcollector", "collector", "0", voltage=5.0))
+    circuit.add(VoltageSource("Vbase", "base", "0", voltage=0.65))
+    circuit.add(BJT("Q1", "collector", "base", "0", Rc=100.0))
+
+    intrinsic = dc_op(circuit).node_voltages["__spice_Q1_collector"]
+    assert 0.0 < intrinsic < 5.0
 
 
 def test_bjt_npn_beta_ratio():
@@ -7115,6 +7137,21 @@ def test_noise_bjt_emitter_resistance_adds_thermal_noise() -> None:
 
     assert emitter_resistance.noise_type == "thermal"
     assert emitter_resistance.source_psd > 0.0
+
+
+def test_noise_bjt_collector_resistance_adds_thermal_noise() -> None:
+    circuit = Circuit()
+    circuit.add(VoltageSource("Vbase", "base", "0", 0.65))
+    circuit.add(Resistor("Rload", "out", "0", 1_000.0))
+    circuit.add(BJT("Q1", "out", "base", "0", Rc=100.0))
+
+    result = noise_ac(circuit, "out", "Vbase", freqs=[1_000.0])
+    collector_resistance = next(
+        entry for entry in result.points[0].entries if entry.element_name == "Q1:RC"
+    )
+
+    assert collector_resistance.noise_type == "thermal"
+    assert collector_resistance.source_psd > 0.0
 
 
 def test_noise_bjt_kf_adds_inverse_frequency_flicker_noise() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add BJT model-card `RC` collector-resistance support with an intrinsic
+  collector node in DC, AC, and transient analysis plus thermal noise in noise
+  analysis.
 - Add BJT model-card `RE` emitter-resistance support with an intrinsic emitter
   node in DC, AC, and transient analysis plus thermal noise in noise analysis.
 - Add BJT model-card `VTF` forward transit-time voltage-scale support, applying

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -462,6 +462,7 @@ fn clone_subckt_element(
             expanded.forward_transit_time_current = element.forward_transit_time_current;
             expanded.forward_transit_time_voltage = element.forward_transit_time_voltage;
             expanded.emitter_resistance = element.emitter_resistance;
+            expanded.collector_resistance = element.collector_resistance;
             Element::Bjt(expanded)
         }
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
@@ -2911,6 +2912,7 @@ pub struct Bjt {
     pub forward_transit_time_current: f64,
     pub forward_transit_time_voltage: f64,
     pub emitter_resistance: f64,
+    pub collector_resistance: f64,
 }
 
 impl Bjt {
@@ -3381,6 +3383,7 @@ impl Bjt {
             forward_transit_time_current: 0.0,
             forward_transit_time_voltage: 0.0,
             emitter_resistance: 0.0,
+            collector_resistance: 0.0,
         }
     }
 }
@@ -3771,8 +3774,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 34, 51, 13, 4),
-    (ModelCardKind::Pnp, 34, 51, 13, 4),
+    (ModelCardKind::Npn, 35, 52, 13, 4),
+    (ModelCardKind::Pnp, 35, 52, 13, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3832,6 +3835,7 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("ITF", "ITF"),
     ("VTF", "VTF"),
     ("RE", "RE"),
+    ("RC", "RC"),
     ("ISE", "ISE"),
     ("NE", "NE"),
     ("ISC", "ISC"),
@@ -4533,6 +4537,7 @@ pub fn bjt_from_model_card(
     bjt.forward_transit_time_current = model_card_value(model, "ITF", 0.0);
     bjt.forward_transit_time_voltage = model_card_value(model, "VTF", 0.0);
     bjt.emitter_resistance = model_card_value(model, "RE", 0.0);
+    bjt.collector_resistance = model_card_value(model, "RC", 0.0);
     Ok(bjt)
 }
 
@@ -21973,6 +21978,9 @@ fn collect_node_indices(circuit: &Circuit) -> HashMap<String, usize> {
                 if bjt.emitter_resistance > 0.0 {
                     insert_node(&mut names, &bjt_intrinsic_emitter_node(bjt));
                 }
+                if bjt.collector_resistance > 0.0 {
+                    insert_node(&mut names, &bjt_intrinsic_collector_node(bjt));
+                }
             }
             Element::Mosfet(mosfet) => {
                 insert_node(&mut names, &mosfet.drain);
@@ -22180,23 +22188,41 @@ fn collect_noise_sources(
             }
             Element::Bjt(bjt) => {
                 validate_bjt(bjt)?;
-                let intrinsic_bjt = if bjt.emitter_resistance > 0.0 {
-                    let intrinsic_emitter = bjt_intrinsic_emitter_node(bjt);
-                    sources.push(NoiseSource {
-                        element_name: format!("{}:RE", bjt.name),
-                        noise_type: NoiseType::Thermal,
-                        positive: node_index(node_indices, &bjt.emitter),
-                        negative: node_index(node_indices, &intrinsic_emitter),
-                        source_psd: 4.0 * BOLTZMANN * temperature_kelvin / bjt.emitter_resistance,
-                        frequency_exponent: 0.0,
-                    });
-                    let mut intrinsic = bjt.clone();
-                    intrinsic.emitter = intrinsic_emitter;
-                    intrinsic.emitter_resistance = 0.0;
-                    Some(intrinsic)
-                } else {
-                    None
-                };
+                let intrinsic_bjt =
+                    if bjt.emitter_resistance > 0.0 || bjt.collector_resistance > 0.0 {
+                        let mut intrinsic = bjt.clone();
+                        if bjt.emitter_resistance > 0.0 {
+                            let intrinsic_emitter = bjt_intrinsic_emitter_node(bjt);
+                            sources.push(NoiseSource {
+                                element_name: format!("{}:RE", bjt.name),
+                                noise_type: NoiseType::Thermal,
+                                positive: node_index(node_indices, &bjt.emitter),
+                                negative: node_index(node_indices, &intrinsic_emitter),
+                                source_psd: 4.0 * BOLTZMANN * temperature_kelvin
+                                    / bjt.emitter_resistance,
+                                frequency_exponent: 0.0,
+                            });
+                            intrinsic.emitter = intrinsic_emitter;
+                            intrinsic.emitter_resistance = 0.0;
+                        }
+                        if bjt.collector_resistance > 0.0 {
+                            let intrinsic_collector = bjt_intrinsic_collector_node(bjt);
+                            sources.push(NoiseSource {
+                                element_name: format!("{}:RC", bjt.name),
+                                noise_type: NoiseType::Thermal,
+                                positive: node_index(node_indices, &bjt.collector),
+                                negative: node_index(node_indices, &intrinsic_collector),
+                                source_psd: 4.0 * BOLTZMANN * temperature_kelvin
+                                    / bjt.collector_resistance,
+                                frequency_exponent: 0.0,
+                            });
+                            intrinsic.collector = intrinsic_collector;
+                            intrinsic.collector_resistance = 0.0;
+                        }
+                        Some(intrinsic)
+                    } else {
+                        None
+                    };
                 let bjt = intrinsic_bjt.as_ref().unwrap_or(bjt);
                 let base = node_index(node_indices, &bjt.base);
                 let emitter = node_index(node_indices, &bjt.emitter);
@@ -22802,17 +22828,30 @@ fn stamp_bjt(
     operating_point: &[f64],
 ) -> Result<(), SpiceError> {
     validate_bjt(bjt)?;
-    let intrinsic_bjt = if bjt.emitter_resistance > 0.0 {
-        let intrinsic_emitter = bjt_intrinsic_emitter_node(bjt);
-        stamp_conductance(
-            matrix,
-            node_index(node_indices, &bjt.emitter),
-            node_index(node_indices, &intrinsic_emitter),
-            1.0 / bjt.emitter_resistance,
-        );
+    let intrinsic_bjt = if bjt.emitter_resistance > 0.0 || bjt.collector_resistance > 0.0 {
         let mut intrinsic = bjt.clone();
-        intrinsic.emitter = intrinsic_emitter;
-        intrinsic.emitter_resistance = 0.0;
+        if bjt.emitter_resistance > 0.0 {
+            let intrinsic_emitter = bjt_intrinsic_emitter_node(bjt);
+            stamp_conductance(
+                matrix,
+                node_index(node_indices, &bjt.emitter),
+                node_index(node_indices, &intrinsic_emitter),
+                1.0 / bjt.emitter_resistance,
+            );
+            intrinsic.emitter = intrinsic_emitter;
+            intrinsic.emitter_resistance = 0.0;
+        }
+        if bjt.collector_resistance > 0.0 {
+            let intrinsic_collector = bjt_intrinsic_collector_node(bjt);
+            stamp_conductance(
+                matrix,
+                node_index(node_indices, &bjt.collector),
+                node_index(node_indices, &intrinsic_collector),
+                1.0 / bjt.collector_resistance,
+            );
+            intrinsic.collector = intrinsic_collector;
+            intrinsic.collector_resistance = 0.0;
+        }
         Some(intrinsic)
     } else {
         None
@@ -22972,17 +23011,30 @@ fn stamp_bjt_small_signal(
     operating_point: &[f64],
 ) -> Result<(), SpiceError> {
     validate_bjt(bjt)?;
-    let intrinsic_bjt = if bjt.emitter_resistance > 0.0 {
-        let intrinsic_emitter = bjt_intrinsic_emitter_node(bjt);
-        stamp_conductance(
-            matrix,
-            node_index(node_indices, &bjt.emitter),
-            node_index(node_indices, &intrinsic_emitter),
-            1.0 / bjt.emitter_resistance,
-        );
+    let intrinsic_bjt = if bjt.emitter_resistance > 0.0 || bjt.collector_resistance > 0.0 {
         let mut intrinsic = bjt.clone();
-        intrinsic.emitter = intrinsic_emitter;
-        intrinsic.emitter_resistance = 0.0;
+        if bjt.emitter_resistance > 0.0 {
+            let intrinsic_emitter = bjt_intrinsic_emitter_node(bjt);
+            stamp_conductance(
+                matrix,
+                node_index(node_indices, &bjt.emitter),
+                node_index(node_indices, &intrinsic_emitter),
+                1.0 / bjt.emitter_resistance,
+            );
+            intrinsic.emitter = intrinsic_emitter;
+            intrinsic.emitter_resistance = 0.0;
+        }
+        if bjt.collector_resistance > 0.0 {
+            let intrinsic_collector = bjt_intrinsic_collector_node(bjt);
+            stamp_conductance(
+                matrix,
+                node_index(node_indices, &bjt.collector),
+                node_index(node_indices, &intrinsic_collector),
+                1.0 / bjt.collector_resistance,
+            );
+            intrinsic.collector = intrinsic_collector;
+            intrinsic.collector_resistance = 0.0;
+        }
         Some(intrinsic)
     } else {
         None
@@ -23052,17 +23104,30 @@ fn stamp_ac_bjt_small_signal(
     omega: f64,
 ) -> Result<(), SpiceError> {
     validate_bjt(bjt)?;
-    let intrinsic_bjt = if bjt.emitter_resistance > 0.0 {
-        let intrinsic_emitter = bjt_intrinsic_emitter_node(bjt);
-        stamp_complex_conductance(
-            matrix,
-            node_index(node_indices, &bjt.emitter),
-            node_index(node_indices, &intrinsic_emitter),
-            Complex::new(1.0 / bjt.emitter_resistance, 0.0),
-        );
+    let intrinsic_bjt = if bjt.emitter_resistance > 0.0 || bjt.collector_resistance > 0.0 {
         let mut intrinsic = bjt.clone();
-        intrinsic.emitter = intrinsic_emitter;
-        intrinsic.emitter_resistance = 0.0;
+        if bjt.emitter_resistance > 0.0 {
+            let intrinsic_emitter = bjt_intrinsic_emitter_node(bjt);
+            stamp_complex_conductance(
+                matrix,
+                node_index(node_indices, &bjt.emitter),
+                node_index(node_indices, &intrinsic_emitter),
+                Complex::new(1.0 / bjt.emitter_resistance, 0.0),
+            );
+            intrinsic.emitter = intrinsic_emitter;
+            intrinsic.emitter_resistance = 0.0;
+        }
+        if bjt.collector_resistance > 0.0 {
+            let intrinsic_collector = bjt_intrinsic_collector_node(bjt);
+            stamp_complex_conductance(
+                matrix,
+                node_index(node_indices, &bjt.collector),
+                node_index(node_indices, &intrinsic_collector),
+                Complex::new(1.0 / bjt.collector_resistance, 0.0),
+            );
+            intrinsic.collector = intrinsic_collector;
+            intrinsic.collector_resistance = 0.0;
+        }
         Some(intrinsic)
     } else {
         None
@@ -23726,6 +23791,14 @@ fn bjt_intrinsic_emitter_node(bjt: &Bjt) -> String {
     }
 }
 
+fn bjt_intrinsic_collector_node(bjt: &Bjt) -> String {
+    if bjt.collector_resistance == 0.0 {
+        bjt.collector.clone()
+    } else {
+        format!("__spice_{}_collector", bjt.name)
+    }
+}
+
 fn bjt_junction_transconductance(bjt: &Bjt, voltage: f64, emission_coefficient: f64) -> f64 {
     let effective_thermal_voltage = bjt.thermal_voltage * emission_coefficient;
     bjt.saturation_current / effective_thermal_voltage
@@ -23836,9 +23909,10 @@ fn bjt_charge_state_specs(bjt: &Bjt) -> Vec<BjtChargeStateSpec> {
             && bjt.forward_transit_time_bias_coefficient > 0.0
             && bjt.forward_transit_time_voltage > 0.0)
     {
+        let collector = bjt_intrinsic_collector_node(bjt);
         let (positive, negative) = match bjt.polarity {
-            BjtPolarity::Npn => (bjt.base.clone(), bjt.collector.clone()),
-            BjtPolarity::Pnp => (bjt.collector.clone(), bjt.base.clone()),
+            BjtPolarity::Npn => (bjt.base.clone(), collector),
+            BjtPolarity::Pnp => (collector, bjt.base.clone()),
         };
         specs.push(BjtChargeStateSpec {
             name: bjt_base_collector_charge_state_name(bjt),
@@ -24244,6 +24318,12 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "emitter resistance must be finite and non-negative".to_string(),
+        });
+    }
+    if !bjt.collector_resistance.is_finite() || bjt.collector_resistance < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "collector resistance must be finite and non-negative".to_string(),
         });
     }
     if !bjt.base_emitter_leakage_saturation_current.is_finite()

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 126);
+    assert_eq!(coverage.len(), 128);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 126);
+    assert_eq!(records.len(), 128);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 126);
-    assert_eq!(report.expected_canonical_parameter_count, 126);
-    assert_eq!(report.accepted_name_count, 192);
+    assert_eq!(report.canonical_parameter_count, 128);
+    assert_eq!(report.expected_canonical_parameter_count, 128);
+    assert_eq!(report.accepted_name_count, 194);
     assert_eq!(report.aliased_parameter_count, 53);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t126\t126\t192\t53\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t128\t128\t194\t53\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,8 +235,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 125);
-    assert_eq!(report.accepted_name_count, 189);
+    assert_eq!(report.canonical_parameter_count, 127);
+    assert_eq!(report.accepted_name_count, 191);
     assert_eq!(report.aliased_parameter_count, 52);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t125\t126\t189\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t127\t128\t191\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -444,6 +444,7 @@ fn model_card_aliases_build_device_instances() {
             ("ITF", 4.0e-3),
             ("VTF", 0.6),
             ("RE", 12.0),
+            ("RC", 13.0),
             ("ISE", 3.0e-13),
             ("NE", 1.7),
             ("ISC", 4.0e-13),
@@ -477,6 +478,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("ITF").unwrap(), 4.0e-3);
     assert_close(*bjt_card.parameters.get("VTF").unwrap(), 0.6);
     assert_close(*bjt_card.parameters.get("RE").unwrap(), 12.0);
+    assert_close(*bjt_card.parameters.get("RC").unwrap(), 13.0);
     assert_close(*bjt_card.parameters.get("ISE").unwrap(), 3.0e-13);
     assert_close(*bjt_card.parameters.get("NE").unwrap(), 1.7);
     assert_close(*bjt_card.parameters.get("ISC").unwrap(), 4.0e-13);
@@ -507,6 +509,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(bjt_model.forward_transit_time_current, 4.0e-3);
     assert_close(bjt_model.forward_transit_time_voltage, 0.6);
     assert_close(bjt_model.emitter_resistance, 12.0);
+    assert_close(bjt_model.collector_resistance, 13.0);
     assert_close(bjt_model.base_emitter_leakage_saturation_current, 3.0e-13);
     assert_close(bjt_model.base_emitter_leakage_emission_coefficient, 1.7);
     assert_close(bjt_model.base_collector_leakage_saturation_current, 4.0e-13);
@@ -1455,6 +1458,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     bjt.forward_transit_time_current = 4.0e-3;
     bjt.forward_transit_time_voltage = 0.6;
     bjt.emitter_resistance = 12.0;
+    bjt.collector_resistance = 13.0;
     let mut circuit = Circuit::new();
     circuit
         .define_subcircuit(SubcircuitDefinition::new(
@@ -1506,6 +1510,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.forward_transit_time_current, 4.0e-3);
     assert_close(expanded.forward_transit_time_voltage, 0.6);
     assert_close(expanded.emitter_resistance, 12.0);
+    assert_close(expanded.collector_resistance, 13.0);
 }
 
 #[test]
@@ -2109,6 +2114,18 @@ fn dc_rejects_invalid_bjt_emitter_resistance() {
     assert!(error
         .to_string()
         .contains("emitter resistance must be finite and non-negative"));
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_collector_resistance() {
+    let mut transistor = Bjt::new("Qbad", "c", "b", "0");
+    transistor.collector_resistance = -1.0;
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Bjt(transistor));
+    let error = dc_op(&circuit).unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("collector resistance must be finite and non-negative"));
 }
 
 #[test]
@@ -2821,6 +2838,30 @@ fn dc_bjt_emitter_resistance_reduces_fixed_base_collector_current() {
     }
 
     assert!(collector_voltage(100.0) > collector_voltage(0.0) + 0.5);
+}
+
+#[test]
+fn dc_bjt_collector_resistance_drops_intrinsic_collector_voltage() {
+    let mut transistor = Bjt::new("Q1", "collector", "base", "0");
+    transistor.collector_resistance = 100.0;
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vcollector",
+        "collector",
+        "0",
+        5.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vbase", "base", "0", 0.65,
+    )));
+    circuit.add(Element::Bjt(transistor));
+
+    let intrinsic = dc_op(&circuit)
+        .unwrap()
+        .voltage("__spice_Q1_collector")
+        .unwrap();
+    assert!(intrinsic < 5.0);
+    assert!(intrinsic > 0.0);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -113,6 +113,30 @@ fn bjt_emitter_resistance_adds_thermal_noise() {
 }
 
 #[test]
+fn bjt_collector_resistance_adds_thermal_noise() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vbase", "base", "0", 0.65,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "out", "0", 1_000.0,
+    )));
+    let mut transistor = Bjt::new("Q1", "out", "base", "0");
+    transistor.collector_resistance = 100.0;
+    circuit.add(Element::Bjt(transistor));
+
+    let result = noise_ac(&circuit, "out", "Vbase", &[1_000.0], 300.0).unwrap();
+    let collector_resistance = result.points[0]
+        .entries
+        .iter()
+        .find(|entry| entry.element_name == "Q1:RC")
+        .unwrap();
+
+    assert_eq!(collector_resistance.noise_type, NoiseType::Thermal);
+    assert!(collector_resistance.source_psd > 0.0);
+}
+
+#[test]
 fn bjt_flicker_noise_uses_kf_with_inverse_frequency_scaling() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add BJT model-card `RC` collector-resistance support with an intrinsic
+  collector node in DC, AC, and transient analysis plus thermal noise in noise
+  analysis.
 - Add BJT model-card `RE` emitter-resistance support with an intrinsic emitter
   node in DC, AC, and transient analysis plus thermal noise in noise analysis.
 - Add BJT model-card `VTF` forward transit-time voltage-scale support, applying

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1737,6 +1737,7 @@ export interface Bjt {
   readonly forwardTransitTimeCurrent: number;
   readonly forwardTransitTimeVoltage: number;
   readonly emitterResistance: number;
+  readonly collectorResistance: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -2014,8 +2015,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [34, 51, 13, 4],
-  PNP: [34, 51, 13, 4],
+  NPN: [35, 52, 13, 4],
+  PNP: [35, 52, 13, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3605,7 +3606,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees, element.forwardTransitTimeBiasCoefficient, element.forwardTransitTimeCurrent, element.forwardTransitTimeVoltage, element.emitterResistance);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees, element.forwardTransitTimeBiasCoefficient, element.forwardTransitTimeCurrent, element.forwardTransitTimeVoltage, element.emitterResistance, element.collectorResistance);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7798,6 +7799,7 @@ export function bjt(
   forwardTransitTimeCurrent = 0.0,
   forwardTransitTimeVoltage = 0.0,
   emitterResistance = 0.0,
+  collectorResistance = 0.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7840,6 +7842,7 @@ export function bjt(
     forwardTransitTimeCurrent,
     forwardTransitTimeVoltage,
     emitterResistance,
+    collectorResistance,
   };
 }
 
@@ -7959,6 +7962,7 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   ITF: "ITF",
   VTF: "VTF",
   RE: "RE",
+  RC: "RC",
   ISE: "ISE",
   NE: "NE",
   ISC: "ISC",
@@ -8500,6 +8504,7 @@ export function bjtFromModelCard(
     p.ITF ?? 0.0,
     p.VTF ?? 0.0,
     p.RE ?? 0.0,
+    p.RC ?? 0.0,
   );
 }
 
@@ -18275,6 +18280,9 @@ function collectNodeIndices(circuit: Circuit): Map<string, number> {
         if (element.emitterResistance > 0.0) {
           insertNode(names, bjtIntrinsicEmitterNode(element));
         }
+        if (element.collectorResistance > 0.0) {
+          insertNode(names, bjtIntrinsicCollectorNode(element));
+        }
         break;
       case "mosfet":
         insertNode(names, element.drain);
@@ -18431,6 +18439,7 @@ function collectNoiseSources(
     } else if (element.kind === "bjt") {
       validateBjt(element);
       const emitterNode = bjtIntrinsicEmitterNode(element);
+      const collectorNode = bjtIntrinsicCollectorNode(element);
       if (element.emitterResistance > 0.0) {
         sources.push({
           elementName: `${element.name}:RE`,
@@ -18442,9 +18451,20 @@ function collectNoiseSources(
           frequencyExponent: 0.0,
         });
       }
+      if (element.collectorResistance > 0.0) {
+        sources.push({
+          elementName: `${element.name}:RC`,
+          noiseType: "thermal",
+          positive: nodeIndex(nodeIndices, element.collector),
+          negative: nodeIndex(nodeIndices, collectorNode),
+          sourcePsd:
+            4.0 * BOLTZMANN * temperatureKelvin / element.collectorResistance,
+          frequencyExponent: 0.0,
+        });
+      }
       const base = nodeIndex(nodeIndices, element.base);
       const emitter = nodeIndex(nodeIndices, emitterNode);
-      const collector = nodeIndex(nodeIndices, element.collector);
+      const collector = nodeIndex(nodeIndices, collectorNode);
       const baseVoltage = vectorVoltage(operatingPoint, base);
       const emitterVoltage = vectorVoltage(operatingPoint, emitter);
       const collectorVoltage = vectorVoltage(operatingPoint, collector);
@@ -19094,6 +19114,16 @@ function stampBjt(
     );
     element = { ...element, emitter: intrinsicEmitter, emitterResistance: 0.0 };
   }
+  if (element.collectorResistance > 0.0) {
+    const intrinsicCollector = bjtIntrinsicCollectorNode(element);
+    stampConductance(
+      matrix,
+      nodeIndex(nodeIndices, element.collector),
+      nodeIndex(nodeIndices, intrinsicCollector),
+      1.0 / element.collectorResistance,
+    );
+    element = { ...element, collector: intrinsicCollector, collectorResistance: 0.0 };
+  }
   const collector = nodeIndex(nodeIndices, element.collector);
   const base = nodeIndex(nodeIndices, element.base);
   const emitter = nodeIndex(nodeIndices, element.emitter);
@@ -19703,6 +19733,12 @@ function bjtIntrinsicEmitterNode(element: Bjt): string {
     : `__spice_${element.name}_emitter`;
 }
 
+function bjtIntrinsicCollectorNode(element: Bjt): string {
+  return element.collectorResistance === 0.0
+    ? element.collector
+    : `__spice_${element.name}_collector`;
+}
+
 function bjtJunctionTransconductance(
   element: Bjt,
   voltage: number,
@@ -19803,6 +19839,7 @@ function bjtBaseCollectorDepletionCapacitance(element: Bjt, voltage: number): nu
 function bjtChargeStateSpecs(element: Bjt): BjtChargeStateSpec[] {
   const specs: BjtChargeStateSpec[] = [];
   const emitter = bjtIntrinsicEmitterNode(element);
+  const collector = bjtIntrinsicCollectorNode(element);
   if (element.baseEmitterCapacitance > 0.0 || element.forwardTransitTime > 0.0) {
     const [positive, negative] =
       element.polarity === "NPN"
@@ -19826,8 +19863,8 @@ function bjtChargeStateSpecs(element: Bjt): BjtChargeStateSpec[] {
   ) {
     const [positive, negative] =
       element.polarity === "NPN"
-        ? [element.base, element.collector]
-        : [element.collector, element.base];
+        ? [element.base, collector]
+        : [collector, element.base];
     specs.push({
       name: bjtBaseCollectorChargeStateName(element),
       positive,
@@ -20068,6 +20105,9 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.emitterResistance) || element.emitterResistance < 0.0) {
     throw invalidElement(element.name, "emitter resistance must be finite and non-negative");
+  }
+  if (!Number.isFinite(element.collectorResistance) || element.collectorResistance < 0.0) {
+    throw invalidElement(element.name, "collector resistance must be finite and non-negative");
   }
   if (!Number.isFinite(element.baseEmitterLeakageSaturationCurrent) || element.baseEmitterLeakageSaturationCurrent < 0.0) {
     throw invalidElement(element.name, "base-emitter leakage saturation current must be finite and non-negative");
@@ -21425,6 +21465,16 @@ function stampBjtSmallSignal(
     );
     element = { ...element, emitter: intrinsicEmitter, emitterResistance: 0.0 };
   }
+  if (element.collectorResistance > 0.0) {
+    const intrinsicCollector = bjtIntrinsicCollectorNode(element);
+    stampConductance(
+      matrix,
+      nodeIndex(nodeIndices, element.collector),
+      nodeIndex(nodeIndices, intrinsicCollector),
+      1.0 / element.collectorResistance,
+    );
+    element = { ...element, collector: intrinsicCollector, collectorResistance: 0.0 };
+  }
   const collector = nodeIndex(nodeIndices, element.collector);
   const base = nodeIndex(nodeIndices, element.base);
   const emitter = nodeIndex(nodeIndices, element.emitter);
@@ -22029,6 +22079,16 @@ function stampAcBjtSmallSignal(
       complex(1.0 / element.emitterResistance, 0.0),
     );
     element = { ...element, emitter: intrinsicEmitter, emitterResistance: 0.0 };
+  }
+  if (element.collectorResistance > 0.0) {
+    const intrinsicCollector = bjtIntrinsicCollectorNode(element);
+    stampComplexConductance(
+      matrix,
+      nodeIndex(nodeIndices, element.collector),
+      nodeIndex(nodeIndices, intrinsicCollector),
+      complex(1.0 / element.collectorResistance, 0.0),
+    );
+    element = { ...element, collector: intrinsicCollector, collectorResistance: 0.0 };
   }
   const collector = nodeIndex(nodeIndices, element.collector);
   const base = nodeIndex(nodeIndices, element.base);

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(126);
+    expect(coverage).toHaveLength(128);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(126);
+    expect(records).toHaveLength(128);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 126,
-      expectedCanonicalParameterCount: 126,
-      acceptedNameCount: 192,
+      canonicalParameterCount: 128,
+      expectedCanonicalParameterCount: 128,
+      acceptedNameCount: 194,
       aliasedParameterCount: 53,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t126\t126\t192\t53\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t128\t128\t194\t53\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,8 +241,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(125);
-    expect(report.acceptedNameCount).toBe(189);
+    expect(report.canonicalParameterCount).toBe(127);
+    expect(report.acceptedNameCount).toBe(191);
     expect(report.aliasedParameterCount).toBe(52);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t125\t126\t189\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t127\t128\t191\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -350,6 +350,7 @@ describe("dcOp", () => {
       ITF: 4.0e-3,
       VTF: 0.6,
       RE: 12.0,
+      RC: 13.0,
       ISE: 3.0e-13,
       NE: 1.7,
       ISC: 4.0e-13,
@@ -363,7 +364,7 @@ describe("dcOp", () => {
       FC: 0.4,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, TNOM: 50.0, KF: 1.0e-12, AF: 1.3, PTF: 30.0, XTF: 2.0, ITF: 4.0e-3, VTF: 0.6, RE: 12.0, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, TNOM: 50.0, KF: 1.0e-12, AF: 1.3, PTF: 30.0, XTF: 2.0, ITF: 4.0e-3, VTF: 0.6, RE: 12.0, RC: 13.0, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.reverseBeta, 0.25);
@@ -383,6 +384,7 @@ describe("dcOp", () => {
     expectClose(bjtModel.forwardTransitTimeCurrent, 4.0e-3);
     expectClose(bjtModel.forwardTransitTimeVoltage, 0.6);
     expectClose(bjtModel.emitterResistance, 12.0);
+    expectClose(bjtModel.collectorResistance, 13.0);
     expectClose(bjtModel.baseEmitterLeakageSaturationCurrent, 3.0e-13);
     expectClose(bjtModel.baseEmitterLeakageEmissionCoefficient, 1.7);
     expectClose(bjtModel.baseCollectorLeakageSaturationCurrent, 4.0e-13);
@@ -1026,7 +1028,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3, 323.15, 1.0e-12, 1.3, 30.0, 2.0, 4.0e-3, 0.6, 12.0),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3, 323.15, 1.0e-12, 1.3, 30.0, 2.0, 4.0e-3, 0.6, 12.0, 13.0),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -1061,6 +1063,7 @@ describe("dcOp", () => {
       expectClose(expanded.forwardTransitTimeCurrent, 4.0e-3);
       expectClose(expanded.forwardTransitTimeVoltage, 0.6);
       expectClose(expanded.emitterResistance, 12.0);
+      expectClose(expanded.collectorResistance, 13.0);
     }
   });
 
@@ -1478,6 +1481,17 @@ describe("dcOp", () => {
     );
   });
 
+  it("rejects invalid BJT collector resistances", () => {
+    const circuit = new Circuit();
+    circuit.add({
+      ...bjt("Qbad", "c", "b", "0"),
+      collectorResistance: -1.0,
+    });
+    expect(() => dcOp(circuit)).toThrowError(
+      "collector resistance must be finite and non-negative",
+    );
+  });
+
   it("rejects non-finite BJT beta temperature exponents", () => {
     const circuit = new Circuit();
     circuit.add({
@@ -1805,6 +1819,20 @@ describe("dcOp", () => {
     };
 
     expect(collectorVoltage(100.0)).toBeGreaterThan(collectorVoltage(0.0) + 0.5);
+  });
+
+  it("uses BJT collector resistance to drop intrinsic collector voltage", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vcollector", "collector", "0", 5.0));
+    circuit.add(voltageSource("Vbase", "base", "0", 0.65));
+    circuit.add({
+      ...bjt("Q1", "collector", "base", "0"),
+      collectorResistance: 100.0,
+    });
+
+    const intrinsic = dcOp(circuit).voltage("__spice_Q1_collector") ?? 0.0;
+    expect(intrinsic).toBeGreaterThan(0.0);
+    expect(intrinsic).toBeLessThan(5.0);
   });
 
   it("solves an NMOS operating point", () => {

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -79,6 +79,18 @@ describe("noiseAc", () => {
     expect(entry.noiseType).toBe("thermal");
     expect(entry.sourcePsd).toBeGreaterThan(0.0);
   });
+  it("adds thermal noise for BJT collector resistance", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vbase", "base", "0", 0.65));
+    circuit.add(resistor("Rload", "out", "0", 1_000.0));
+    circuit.add({ ...bjt("Q1", "out", "base", "0"), collectorResistance: 100.0 });
+
+    const entry = noiseAc(circuit, "out", "Vbase", [1_000.0], 300.0).points[0]!.entries
+      .find((candidate) => candidate.elementName === "Q1:RC")!;
+
+    expect(entry.noiseType).toBe("thermal");
+    expect(entry.sourcePsd).toBeGreaterThan(0.0);
+  });
   it("uses BJT KF for inverse-frequency flicker noise", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vcc", "vcc", "0", 5.0));

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT emitter resistance.
+1. Cross-language BJT collector resistance.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `RE` model-card support in Rust, Python, and TypeScript,
+   - Add Berkeley BJT `RC` model-card support in Rust, Python, and TypeScript,
      defaulting to zero so existing operating-point, AC, transient, and noise
      results remain unchanged.
-   - Insert an intrinsic emitter node behind the configured series resistance,
-     use that node for nonlinear and stored-charge behavior, and include the
-     resistor's thermal-noise contribution.
-   - Extend the supported-parameter coverage gate from 124 to 126 canonical
+   - Insert an intrinsic collector node behind the configured series
+     resistance, use that node for nonlinear and base-collector stored-charge
+     behavior, and include the resistor's thermal-noise contribution.
+   - Extend the supported-parameter coverage gate from 126 to 128 canonical
      rows and lock model-card behavior, validation, hierarchy, operating-point
      loading, and noise behavior in all engines.
 
@@ -3168,6 +3168,15 @@ the Rust, Python, and TypeScript surfaces together.
    - Hierarchical subcircuit expansion preserves the complete BJT model and
      transient state tracks the controlling base-collector voltage; the
      supported-parameter release gate now covers 124 canonical rows.
+
+240. Cross-language BJT emitter resistance.
+   - Status: completed in PR 8856.
+   - Rust, Python, and TypeScript BJT model cards now accept `RE`, default it
+     to zero, and insert an intrinsic emitter node behind the configured
+     external series resistance.
+   - DC, transient, AC, transfer-function, and noise paths share the intrinsic
+     emitter topology, including resistor thermal noise; the
+     supported-parameter release gate now covers 126 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley BJT `RC` model-card support across Rust, Python, and TypeScript
- route nonlinear, stored-charge, AC, transient, transfer-function, and noise behavior through an intrinsic collector node
- add collector-resistance thermal noise and raise the synchronized parameter-coverage gate to 128 canonical rows
- reconcile the SPICE completion plan after merged emitter-resistance support

## Verification
- `cargo test -p spice-engine`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo fmt -p spice-engine`
- Python: `570 passed` with `88.85%` coverage
- `ruff check src/spice_engine/elements.py src/spice_engine/engine.py src/spice_engine/model_cards.py tests/test_engine.py`
- TypeScript: `328 passed`
- `npm run build`
- `git diff --check`