### PR TITLE
feat(app): session view-model — HL03 phase 6 slice 6a

### DIFF
--- a/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.9.4 — the session view-model (HL03 phase 6, slice 6a)
+
+- `src/sessionplan.ts` — the seam that assembles the four engine modules into
+  one session, with no DOM (the UI slice renders what this returns):
+  `planSession(current, covered, lessons, activeCount)` returns the **teaching
+  pass** (the current concept swept across the active chain, with connections)
+  and the **review pass** (the covered grid the quiz draws from).
+- `applyAnswer(progress, cell, correct, session, chosenKey?)` threads the state
+  that makes review adaptive: a hit **promotes** the cell (comes back later), a
+  miss **demotes** it (box 0, due now) and logs the confusion — so the next
+  `pickNext` leans on what was just missed. Immutable; `initProgress` seeds it.
+- Controls bite (fault-injected): a review pass that only covered the current
+  concept fails the "spans every covered concept" test; a no-op `applyAnswer`
+  fails the "missed cell outweighs a mastered one" test. Verified against the
+  real curriculum (COURTESY-THANKS teaches across all ten, reviews alongside
+  GREETING-HELLO). Pure, deterministic. Next: slice 6b renders it.
+
 ## 0.9.3 — the mistakes store (HL03 phase 5)
 
 - `src/mistakes.ts` — records each quiz answer and, crucially, WHAT THE LEARNER

--- a/code/programs/typescript/script-writing-visualizer/package.json
+++ b/code/programs/typescript/script-writing-visualizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "script-writing-visualizer",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "private": true,
   "description": "Companion study app (HL02): break a non-Latin script apart and learn to write it — and drill the whole written curriculum with a spaced-repetition schedule that remembers you",
   "type": "module",

--- a/code/programs/typescript/script-writing-visualizer/src/sessionplan.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/sessionplan.ts
@@ -1,0 +1,104 @@
+// ---------------------------------------------------------------------------
+// sessionplan.ts — the session view-model (HL03 phase 6, slice 6a)
+// ---------------------------------------------------------------------------
+//
+// The engine is complete but scattered across four pure modules — the sweep
+// (session.ts), the connections it carries, the covered grid and the weighted
+// draw (quiz.ts), and the mistakes store (mistakes.ts). This file is the thin
+// seam that assembles them into the shape a single study session actually has,
+// with no DOM in sight: the UI layer (slice 6b) renders what this returns and
+// hands answers back to it.
+//
+// A session is two passes:
+//   • the TEACHING pass — the current concept walked forward across the active
+//     chain, each stop annotated with its connections back to earlier languages;
+//   • the REVIEW pass — a weighted draw over everything covered so far.
+//
+// And it threads the state that makes the review adaptive: each answer updates
+// the per-cell Leitner state (promote on a hit, demote on a miss) and appends to
+// the mistakes log, so the next `pickNext` leans on what was just missed. All of
+// that is done here as pure functions over immutable inputs.
+// ---------------------------------------------------------------------------
+
+import type { Lesson } from "./lessons";
+import { buildSession, type SessionStep } from "./session";
+import { coveredGrid, cellKey, type GridCell, type QuizState } from "./quiz";
+import { recordAnswer, demote, type AnswerRecord } from "./mistakes";
+import { intervalFor, MAX_BOX } from "./scheduler";
+
+/** Everything the UI needs to run one session, assembled from the engine. */
+export interface SessionPlan {
+  concept: string;
+  /** The teaching sweep: the concept across the active chain, with connections. */
+  teaching: SessionStep[];
+  /** The pool the review quiz draws from — everything covered so far. */
+  reviewGrid: GridCell[];
+}
+
+/**
+ * Assemble a session for the current concept.
+ *
+ * `covered` is every concept studied so far (it should include `current`); the
+ * teaching pass is `current` alone, the review pass is the whole covered grid.
+ */
+export function planSession(
+  current: string,
+  covered: Iterable<string>,
+  lessons: Lesson[],
+  activeCount: number,
+): SessionPlan {
+  return {
+    concept: current,
+    teaching: buildSession(current, lessons, activeCount),
+    reviewGrid: coveredGrid(covered, lessons, activeCount),
+  };
+}
+
+/** The mutable progress a session accumulates: per-cell SRS state + the log. */
+export interface Progress {
+  states: Map<string, QuizState>;
+  log: AnswerRecord[];
+}
+
+/** A fresh, empty progress. */
+export function initProgress(): Progress {
+  return { states: new Map(), log: [] };
+}
+
+/** Promote a cell after a HIT: up a box (capped), due after the new interval. */
+function promote(state: QuizState, session: number): QuizState {
+  const box = Math.min(MAX_BOX, state.box + 1);
+  return { box, dueAtSession: session + intervalFor(box), lapses: state.lapses, reps: state.reps + 1 };
+}
+
+/** The state a cell starts from the first time it is answered. */
+function seed(session: number): QuizState {
+  return { box: 0, dueAtSession: session, lapses: 0, reps: 0 };
+}
+
+/**
+ * Apply one quiz answer, returning fresh progress (inputs untouched).
+ *
+ * A correct answer promotes the cell (it comes back later); a wrong answer
+ * demotes it (box 0, due now, lapse) so it resurfaces soon, and records the
+ * confusion (`chosenKey`, what was picked instead). Either way the answer is
+ * logged.
+ */
+export function applyAnswer(
+  progress: Progress,
+  cell: GridCell,
+  correct: boolean,
+  session: number,
+  chosenKey?: string,
+): Progress {
+  const key = cellKey(cell);
+  const prev = progress.states.get(key) ?? seed(session);
+  const next = correct ? promote(prev, session) : demote(prev, session);
+
+  const states = new Map(progress.states);
+  states.set(key, next);
+  return {
+    states,
+    log: recordAnswer(progress.log, key, correct, chosenKey),
+  };
+}

--- a/code/programs/typescript/script-writing-visualizer/tests/sessionplan.test.ts
+++ b/code/programs/typescript/script-writing-visualizer/tests/sessionplan.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import type { Lesson } from "../src/lessons";
+import { loadLessons } from "../src/lessons";
+import { planSession, initProgress, applyAnswer } from "../src/sessionplan";
+import { cellKey, cellWeight, type GridCell } from "../src/quiz";
+
+function L(language: string, concept: string, id: string, roots: string[] = []): Lesson {
+  return {
+    id, language, headword: `${language}:${concept}`, gloss: concept, type: "word",
+    chapter: 1, concept, prerequisites: [], reviewsOf: [], roots,
+    romanization: "x", script: language, etymologyHook: "",
+  };
+}
+
+describe("planSession — assembling the two passes", () => {
+  const lessons = [
+    L("spanish", "THANKS", "es-t", ["gratia"]),
+    L("french", "THANKS", "fr-t", ["gratia"]),
+    L("spanish", "HELLO", "es-h"),
+    L("french", "HELLO", "fr-h"),
+  ];
+
+  it("teaching pass is the current concept swept across the active chain, with connections", () => {
+    const plan = planSession("THANKS", ["THANKS", "HELLO"], lessons, 10);
+    expect(plan.concept).toBe("THANKS");
+    expect(plan.teaching.map((s) => s.language)).toEqual(["spanish", "french"]);
+    // french links back to spanish via the shared root
+    expect(plan.teaching[1].connections).toEqual([{ to: "spanish", sharedRoots: ["gratia"] }]);
+  });
+
+  it("review pass spans EVERY covered concept, not just the current one", () => {
+    const plan = planSession("THANKS", ["THANKS", "HELLO"], lessons, 10);
+    const concepts = new Set(plan.reviewGrid.map((c) => c.concept));
+    expect(concepts).toEqual(new Set(["THANKS", "HELLO"])); // CONTROL: a plan that only reviewed the current concept fails
+  });
+
+  it("an un-covered concept never enters the review grid", () => {
+    const plan = planSession("THANKS", ["THANKS"], lessons, 10); // HELLO not covered
+    expect(new Set(plan.reviewGrid.map((c) => c.concept))).toEqual(new Set(["THANKS"]));
+  });
+});
+
+describe("applyAnswer — threading SRS state + the mistakes log", () => {
+  const grid: GridCell[] = [{ concept: "C", language: "spanish", lesson: L("spanish", "C", "sc") }];
+  const cell = grid[0];
+  const key = cellKey(cell);
+
+  it("a wrong answer demotes the cell and logs the confusion", () => {
+    const p = applyAnswer(initProgress(), cell, false, 5, "fr:wrong");
+    const st = p.states.get(key)!;
+    expect(st.box).toBe(0);
+    expect(st.dueAtSession).toBe(5); // due now → resurfaces
+    expect(st.lapses).toBe(1);
+    expect(p.log).toEqual([{ cellKey: key, correct: false, chosenKey: "fr:wrong" }]);
+  });
+
+  it("a correct answer promotes the cell so it comes back LATER, not now", () => {
+    const p = applyAnswer(initProgress(), cell, true, 5);
+    const st = p.states.get(key)!;
+    expect(st.box).toBe(1);
+    expect(st.dueAtSession).toBeGreaterThan(5); // scheduled out, not due now
+    expect(p.log).toEqual([{ cellKey: key, correct: true }]); // no chosenKey on a hit
+  });
+
+  it("a missed-then-reviewed cell outweighs a mastered one in the draw", () => {
+    // miss it (session 5) → demoted, due at 5. cellWeight at session 5 is high.
+    const missed = applyAnswer(initProgress(), cell, false, 5);
+    const wMissed = cellWeight(missed.states.get(key), 5);
+    // a mastered cell (several correct answers) is scheduled far out → floor weight.
+    let mastered = initProgress();
+    for (let s = 0; s < 4; s++) mastered = applyAnswer(mastered, cell, true, s);
+    const wMastered = cellWeight(mastered.states.get(key), 5);
+    expect(wMissed).toBeGreaterThan(wMastered); // CONTROL: no promote/demote effect → equal → fails
+  });
+
+  it("does not mutate the input progress", () => {
+    const p0 = initProgress();
+    applyAnswer(p0, cell, false, 5, "x");
+    expect(p0.states.size).toBe(0);
+    expect(p0.log).toEqual([]);
+  });
+});
+
+describe("planSession against the real curriculum", () => {
+  it("teaches COURTESY-THANKS across the whole chain and reviews it alongside GREETING-HELLO", () => {
+    const lessons = loadLessons();
+    const plan = planSession("COURTESY-THANKS", ["COURTESY-THANKS", "GREETING-HELLO"], lessons, 10);
+    expect(plan.teaching.length).toBe(10); // all ten chain languages teach thanks
+    const reviewConcepts = new Set(plan.reviewGrid.map((c) => c.concept));
+    expect(reviewConcepts).toEqual(new Set(["COURTESY-THANKS", "GREETING-HELLO"]));
+  });
+});


### PR DESCRIPTION
First slice of phase 6 (unify the UI). This is the **pure half** — the seam that assembles the four engine modules into one session, with no DOM. Slice 6b renders it.

## What it adds — `src/sessionplan.ts`

The engine is complete but scattered (the sweep, the connections, the covered grid + weighted draw, the mistakes store). This assembles them into the shape a study session actually has:

- **`planSession(current, covered, lessons, activeCount)`** → the **teaching pass** (the current concept swept across the active chain, with its connections) and the **review pass** (the covered grid the quiz draws from).
- **`applyAnswer(progress, cell, correct, session, chosenKey?)`** threads the adaptive state: a **hit** promotes the cell (box+1, scheduled out — comes back later); a **miss** demotes it (box 0, due now) and logs the confusion — so the next `pickNext` leans on what was just missed. Immutable; `initProgress` seeds it.

## Controls that bite (fault-injected)

- A review pass covering only the *current* concept fails "spans every covered concept" (`Set{THANKS}` vs `{THANKS, HELLO}`).
- A no-op `applyAnswer` fails "missed cell outweighs a mastered one" (6 not > 6).

Verified against the real curriculum: COURTESY-THANKS teaches across all ten chain languages and reviews alongside GREETING-HELLO.

Independently reviewed (SRS math traced): composition correct, `applyAnswer` immutable, promote schedules into the future with no off-by-one, demote resurfaces, no security surface, no NUL bytes.

App CHANGELOG + version 0.9.3 → 0.9.4. **185 tests.**

Next slices: 6b renders one session flow (folding the four mode tabs, verified in-browser), 6c renames the app, 6d retires the standalone artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)