### PR TITLE
feat(semantic-ir-to-javascript,q-to-semantic-ir): Q's own ASCII-minus display convention (task #109)

### DIFF
--- a/code/packages/rust/q-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/q-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## [0.1.1] - 2026-07-23
+
+### Fixed (in the shared `semantic-ir-to-javascript` crate — task #109)
+
+`tests/oracle.rs`'s own module doc comment ("A pre-existing shared-crate
+display gap") disclosed 5 `known_bug` cases whose only remaining
+disagreement was `semantic-ir-to-javascript` having no Q-specific display
+convention: a genuine SIR22 `NDArray` result's negative values rendered
+with APL's high-minus glyph `¯` instead of Q's own plain ASCII `-`,
+regardless of source language, whenever `SIR_DISPLAY_J_UNDERSCORE` was
+unset. This was the exact same shared-crate gap `j-to-semantic-ir/tests/
+oracle.rs`'s own "Bug A" already found and left unfixed, per this repo's
+"found, NOT fixed here" discipline for a bug in a crate consumed by many
+frontends — not specific to this crate's own lowering, and not something
+this crate could route around on its own.
+
+Fixed directly in `semantic-ir-to-javascript` 0.51.4: a fifth,
+mutually-exclusive `SIR_DISPLAY_Q_ASCII_MINUS` display flag, following the
+exact pattern `SIR_DISPLAY_J_UNDERSCORE` established for J (see that
+crate's own `CHANGELOG.md` for the full writeup). No change was needed in
+this crate's own `src/lower.rs` — the gap was purely a shared-runtime
+display-convention omission, not a lowering bug.
+
+### Changed
+
+- **`tests/oracle.rs`**: flips all 5 `known_bug: Some(DISPLAY_GAP)` cases
+  to `known_bug: None`, confirmed by actually running the oracle test (not
+  just inferred from source reading) — every one now agrees end-to-end
+  with `q-runtime`: `whitespace_sensitive_strand_vs_subtraction_strand`
+  (`2 -1`), `dyadic_sub_negative_result` (`3-4` → `-1`),
+  `monadic_minus_negates_a_vector` (`-(1 2 3)` → `-1 -2 -3`),
+  `each_on_an_elementwise_primitive_matches_direct_application` (`-'1 2 3`
+  → `-1 -2 -3`), and `scan_then_reduce_negative` (`-/+\1 2 3` → `-8`). The
+  now-unused `DISPLAY_GAP` constant is removed and the module doc comment
+  updated to record the fix; the `known_bug` field itself stays on `Case`
+  (unused by any entry today) for a future genuine bug to reuse.
+- Verified via a genuine revert-and-confirm: temporarily forcing
+  `semantic-ir-to-javascript`'s new `SIR_DISPLAY_Q_ASCII_MINUS` flag back
+  to `false` reproduced the exact pre-fix failure (`¯1` instead of `-1`,
+  etc.) for all 5 cases; restoring the flag made them pass again.
+
 ## [0.1.0] - 2026-07-22
 
 ### Added

--- a/code/packages/rust/q-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/q-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "q-to-semantic-ir"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Q (kdb+) CST → narrow-waist Semantic IR (SIR22 array/matrix domain, reusing APL/J's addendum). MA-11e, front2 Wave 5."
 

--- a/code/packages/rust/q-to-semantic-ir/tests/oracle.rs
+++ b/code/packages/rust/q-to-semantic-ir/tests/oracle.rs
@@ -22,42 +22,43 @@
 //! is just `name` + `source` (one full program, byte-identical on both
 //! sides) + `expected`, plus `known_bug` (see below).
 //!
-//! ## A pre-existing shared-crate display gap, confirmed here too (matches
-//! `j-to-semantic-ir/tests/oracle.rs`'s own "Bug A")
+//! ## A pre-existing shared-crate display gap (matches `j-to-semantic-ir/
+//! tests/oracle.rs`'s own "Bug A"), FIXED as of task #109
 //!
-//! `semantic-ir-to-javascript` has exactly two per-source-language display
-//! flags (`SIR_DISPLAY_APL_HIGH_MINUS`, `SIR_DISPLAY_J_UNDERSCORE`) and no
-//! third one for Q. Empirically confirmed directly (a throwaway probe that
-//! ran each shape through `node` before this file was finalized, mirroring
-//! `j-to-semantic-ir/tests/oracle.rs`'s own verification discipline):
+//! `semantic-ir-to-javascript` originally had exactly two per-source-
+//! language display flags (`SIR_DISPLAY_APL_HIGH_MINUS`,
+//! `SIR_DISPLAY_J_UNDERSCORE`) and no third one for Q. Empirically
+//! confirmed directly (a throwaway probe that ran each shape through
+//! `node` before this file was finalized, mirroring `j-to-semantic-ir/
+//! tests/oracle.rs`'s own verification discipline):
 //!
 //! - A **bare/boxed scalar** negative result (`formatSeen`'s `typeof v ===
-//!   "number"` branch) renders via plain `String(v)` when neither flag is
+//!   "number"` branch) renders via plain `String(v)` when no display flag is
 //!   set — which happens to be Q's OWN convention already (`-5`, ASCII, no
-//!   high-minus) — so this path has **no bug for Q at all**, unlike J
-//!   (which needs a leading underscore neither flag produces).
+//!   high-minus) — so this path had **no bug for Q at all**, unlike J
+//!   (which needs a leading underscore no pre-existing flag produced).
 //! - A **genuine NDArray** result (any [`semantic_ir::Expr::ElementwiseOp`]/
 //!   `Reduce`/`Scan`/`Ravel`/`Catenate`, or `mapNDArrayRank1Plus`'s rank≥1
-//!   branch inside `neg`/`q_reverse`/etc.) reaches `ArrayRt.display` →
-//!   `ArrayRt.fmtNum`, which renders APL's own high-minus `¯` for ANY
-//!   negative value whenever `SIR_DISPLAY_J_UNDERSCORE` is unset —
+//!   branch inside `neg`/`q_reverse`/etc.) reached `ArrayRt.display` →
+//!   `ArrayRt.fmtNum`, which rendered APL's own high-minus `¯` for ANY
+//!   negative value whenever `SIR_DISPLAY_J_UNDERSCORE` was unset —
 //!   *unconditionally*, with no flag gating it for Q either. Confirmed
-//!   directly: `3-4` (a dyadic `ElementwiseOp`) prints `¯1`, not Q's own
-//!   `-1`; `-/1 2 10` (`Reduce`) prints `¯11`.
+//!   directly: `3-4` (a dyadic `ElementwiseOp`) printed `¯1`, not Q's own
+//!   `-1`; `-/1 2 10` (`Reduce`) printed `¯11`.
 //!
-//! This is the exact same shared-crate gap `j-to-semantic-ir`'s own oracle
-//! file already found and left unfixed (per this task's own "found, NOT
-//! fixed here" discipline for a bug in a crate consumed by many other
-//! frontends) — not a new, Q-specific bug, and not something this crate's
-//! own lowering can route around (same conclusion `j-to-semantic-ir`
-//! reached: fixing it needs a third `SIR_DISPLAY_Q_ASCII`-shaped flag, or
-//! simply making the "no flag set" default apply inside `ArrayRt.fmtNum`
-//! too, in `semantic-ir-to-javascript` itself, out of scope here). Every
-//! `CORPUS` entry below whose `expected` value is a negative number reached
-//! through a genuine-NDArray-producing path carries a `known_bug` note
-//! citing this section; a negative result reached through a BARE-number
-//! path (a literal, or `neg`'s own rank-0 fallback unwrap) is a clean,
-//! both-sides-pass case, confirmed by direct empirical check.
+//! This was the exact same shared-crate gap `j-to-semantic-ir`'s own oracle
+//! file already found and left unfixed (per this repo's "found, NOT fixed
+//! here" discipline for a bug in a crate consumed by many other frontends)
+//! — not a Q-specific bug, and not something this crate's own lowering could
+//! route around. Task #109 closed it directly in `semantic-ir-to-javascript`
+//! (a third, mutually-exclusive `SIR_DISPLAY_Q_ASCII_MINUS` display flag,
+//! following the same pattern `SIR_DISPLAY_J_UNDERSCORE` established for
+//! J — see that crate's own `src/emit.rs`/`src/runtime.rs` and
+//! `CHANGELOG.md` for the full writeup), so every `CORPUS` entry below now
+//! has `known_bug: None` and is checked end-to-end on both sides. The
+//! `known_bug` field itself is kept on [`Case`] (unused by any entry today)
+//! so a future frontier bug can be recorded the same way without a struct
+//! change.
 
 use std::fs::OpenOptions;
 use std::io::Write as _;
@@ -83,16 +84,12 @@ struct Case {
     /// `None`: both `ground_truth` and `compiled` must equal `expected`.
     /// `Some(reason)`: only `ground_truth` is checked against `expected`;
     /// the `compiled`-side call is skipped entirely -- see this file's
-    /// module doc comment's "shared-crate display gap" section.
+    /// module doc comment's "shared-crate display gap" section. No
+    /// `CORPUS` entry uses `Some` today (task #109 fixed the one
+    /// pre-existing gap directly in `semantic-ir-to-javascript`) -- the
+    /// field stays available for a future genuine bug.
     known_bug: Option<&'static str>,
 }
-
-const DISPLAY_GAP: &str =
-    "shared-crate display gap (semantic-ir-to-javascript has no Q-specific ASCII-minus display \
-     flag -- see this file's module doc comment): a genuine NDArray result's negative values \
-     render with APL's high-minus glyph (\u{af}) instead of Q's own ASCII '-', regardless of \
-     source language, whenever SIR_DISPLAY_J_UNDERSCORE is unset. Confirmed by directly running \
-     the generated JavaScript; not a bug in this crate's own lowering.";
 
 const CORPUS: &[Case] = &[
     // --- Base breadth: right-to-left, no precedence, grouping ---
@@ -118,7 +115,7 @@ const CORPUS: &[Case] = &[
         name: "whitespace_sensitive_strand_vs_subtraction_strand",
         source: "2 -1\n",
         expected: "2 -1",
-        known_bug: Some(DISPLAY_GAP),
+        known_bug: None,
     },
     Case {
         name: "whitespace_sensitive_strand_vs_subtraction_subtract",
@@ -149,12 +146,13 @@ const CORPUS: &[Case] = &[
         expected: "3 7",
         known_bug: None,
     },
-    // Dyadic subtraction with a NEGATIVE result -- hits the display gap.
+    // Dyadic subtraction with a NEGATIVE result -- used to hit the display
+    // gap (fixed by task #109; see this file's module doc comment).
     Case {
         name: "dyadic_sub_negative_result",
         source: "3-4\n",
         expected: "-1",
-        known_bug: Some(DISPLAY_GAP),
+        known_bug: None,
     },
 
     // --- Monadic primitives ---
@@ -169,14 +167,14 @@ const CORPUS: &[Case] = &[
         expected: "-7",
         known_bug: None,
     },
-    // Monadic `-` on a genuine VECTOR operand DOES hit the display gap
+    // Monadic `-` on a genuine VECTOR operand used to hit the display gap
     // (`mapNDArrayRank1Plus`'s rank>=1 branch always re-wraps in an
-    // NDArray).
+    // NDArray) -- fixed by task #109; see this file's module doc comment.
     Case {
         name: "monadic_minus_negates_a_vector",
         source: "-(1 2 3)\n",
         expected: "-1 -2 -3",
-        known_bug: Some(DISPLAY_GAP),
+        known_bug: None,
     },
     Case { name: "monadic_star_is_first_not_sign", source: "*1 2 3\n", expected: "1", known_bug: None },
     Case { name: "monadic_percent_is_reciprocal", source: "%4\n", expected: "0.25", known_bug: None },
@@ -242,15 +240,16 @@ const CORPUS: &[Case] = &[
         name: "each_on_an_elementwise_primitive_matches_direct_application",
         source: "-'1 2 3\n",
         expected: "-1 -2 -3",
-        known_bug: Some(DISPLAY_GAP),
+        known_bug: None,
     },
     // Reduce-of-scan with a negative result -- Reduce's own NDArray output
-    // hits the display gap.
+    // used to hit the display gap (fixed by task #109; see this file's
+    // module doc comment).
     Case {
         name: "scan_then_reduce_negative",
         source: "-/+\\1 2 3\n",
         expected: "-8",
-        known_bug: Some(DISPLAY_GAP),
+        known_bug: None,
     },
 
     // --- Assignment: silent, chained, later reference ---

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,70 @@
 # Changelog
 
+## 0.51.4 — Q's own display convention (task #109, the direct Q sibling of J's `SIR_DISPLAY_J_UNDERSCORE` fix)
+
+`q-to-semantic-ir/tests/oracle.rs` (built alongside the runtime in the same
+wave as 0.51.0's five new Q primitives) confirmed the exact same shared-crate
+display-glyph gap `j-to-semantic-ir/tests/oracle.rs`'s own "Bug A" already
+found for J now affected Q too: no per-source-language ASCII-minus flag
+existed for a non-APL/non-J language's genuine-`NDArray` results, so a
+Q-sourced module's negative array values rendered with APL's high-minus
+glyph `¯` instead of Q's own plain ASCII `-`. Fixed here, mirroring
+`SIR_DISPLAY_J_UNDERSCORE`'s own 0.46.0 fix file-for-file.
+
+### Added
+
+- **`emit.rs`/`runtime.rs`: a fifth `SIR_DISPLAY_*` flag,
+  `SIR_DISPLAY_Q_ASCII_MINUS`** — extends the existing, already-proven
+  `SIR_DISPLAY_RUBY`/`SIR_DISPLAY_APL_HIGH_MINUS`/`SIR_DISPLAY_J_UNDERSCORE`/
+  `SIR_DISPLAY_DERIVE` mechanism exactly (a mutually-exclusive boolean
+  computed from `m.metadata.source_language`, substituted into the inlined
+  `RUNTIME` blob as a hardcoded literal — never source-derived text,
+  preserving the existing SECURITY invariant), rather than inventing a new
+  one. `true` when `source_language` is `"q"`, else `false`.
+- **`runtime.rs`: `fmtNum`** gains a third glyph branch, gated on
+  `SIR_DISPLAY_Q_ASCII_MINUS`, ported 1:1 from `q_runtime::value::fmt_num`:
+  a negative finite number prefixes with plain ASCII `-` (never `¯`, never
+  `_`); a non-finite value spells `"-inf"`/`"inf"` — lowercase, and with an
+  ASCII minus PREFIX on negative infinity, deliberately DIFFERENT from J's
+  own `"_inf"` spelling (a leading underscore, not a prefix minus). `x < 0`
+  (a numeric comparison) already excludes `-0` from the negative branch on
+  its own, matching the existing APL/J branches' identical reasoning — no
+  separate `-0` guard needed, even though `q_runtime::value::fmt_num`'s own
+  Rust source needs one (`is_sign_negative()` is a bit-level check that
+  says `true` for `-0`, unlike JS's `x < 0`).
+- **`runtime.rs`: `formatSeen`'s two `SirFloat`/bare-number branches** now
+  also check `SIR_DISPLAY_Q_ASCII_MINUS` in their `ArrayRt.fmtNum`-vs-
+  fallback OR-condition (alongside the existing `SIR_DISPLAY_APL_HIGH_MINUS`/
+  `SIR_DISPLAY_J_UNDERSCORE` checks). A Q-sourced module's bare/boxed scalar
+  negative INTEGER already happened to print correctly through the generic
+  `String(v)` fallback (Q's own convention IS plain ASCII `-`), but a
+  non-finite bare scalar printed JS's native `"Infinity"`/`"-Infinity"`
+  instead of Q's own `"inf"`/`"-inf"`, and a boxed whole-valued `SirFloat`
+  fell through to `floatToRubyString`'s Ruby-style trailing `.0` (`"5.0"`,
+  not Q's own `"5"`) — both now route through the now-Q-aware `fmtNum`
+  instead.
+- Two new `runtime.rs` regression tests,
+  `fmtnum_gates_the_negative_glyph_and_infinity_spelling_on_the_q_ascii_minus_flag`
+  and an update to the pre-existing
+  `formatseen_gates_bare_number_and_boxed_float_glyph_on_apl_high_minus_flag`
+  (its two exact-string OR-condition assertions now include the third
+  flag), mirroring the J-underscore flag's own test-shape exactly.
+
+### Verification
+
+Reverted `display_q_ascii_minus` to a hardcoded `false` in `emit.rs` and
+re-ran `q-to-semantic-ir/tests/oracle.rs`: all 5 previously-`known_bug`
+cases failed exactly as before (`¯1` instead of `-1`, etc.) — confirming
+the fix, not a coincidence, is what makes them pass. Restored and
+re-confirmed green. Full suite of every SIR22-array-domain consumer crate
+(`q-to-semantic-ir`, `matlab-to-semantic-ir`, `octave-to-semantic-ir`,
+`apl-to-semantic-ir`, `j-to-semantic-ir`, `scilab-to-semantic-ir`) passes
+unchanged.
+
+### Flips 5 of `q-to-semantic-ir`'s `known_bug` oracle cases to `known_bug: None`
+
+See that crate's own `CHANGELOG.md` for the full per-case accounting.
+
 ## 0.51.3 — calculus / elementary-function handlers: `Sin`/`Cos`/`Sqrt`/`D`/`Integrate` (SIR23 addendum, item 3 of 4)
 
 Item 3 of the 4-item rollout described by `SIR23-symbolic-pattern-

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.51.3"
+version = "0.51.4"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -148,7 +148,30 @@ pub fn emit_module(m: &Module) -> String {
     // generic, source-language-agnostic `head(args, …)` form every other
     // language (and Derive, before this item) still gets.
     //
-    // SECURITY: all four replacement values MUST remain a hardcoded literal
+    // A FIFTH, independent placeholder (task #109, the direct Q sibling of
+    // J's own "A THIRD" entry above, found by `q-to-semantic-ir/tests/
+    // oracle.rs`'s own `DISPLAY_GAP` cases): `true` when the module's
+    // `source_language` is Q, else `false`. Q's own console convention
+    // renders a negative number with a plain ASCII `-` (never APL's
+    // high-minus `¯`, never J's leading underscore `_`) and a non-finite
+    // value as lowercase `-inf`/`inf` — note the ASCII minus prefix on
+    // infinity, DIFFERENT from J's own `_inf` spelling
+    // (`q_runtime::value::fmt_num`, ported 1:1 in `ArrayRt.fmtNum` below).
+    // Q's bare/boxed-scalar path already happens to print ASCII `-` today
+    // (the generic `String(v)`/`floatToRubyString` fallback ends up
+    // matching Q's own convention for a plain negative integer by
+    // coincidence), but NOT for non-finite values or whole-valued floats
+    // (see `runtime.rs`'s `formatSeen` gate for the exact divergence), and
+    // a genuine SIR22 `NDArray` result reaches `ArrayRt.fmtNum`, which
+    // renders APL's own high-minus glyph unconditionally whenever neither
+    // of the other two `fmtNum`-gating flags is set — this flag closes
+    // both gaps in one place. Mutually exclusive with the four flags above
+    // by construction (all five are computed from the same single
+    // `source_language` field in `emit.rs`), so `fmtNum`/`formatSeen`
+    // below never need to arbitrate between them — only one can ever be
+    // `true` for a given module.
+    //
+    // SECURITY: all five replacement values MUST remain a hardcoded literal
     // selected by a boolean — never text derived from `source_language` or
     // any other source-controlled field — so this substitution can never
     // inject into the emitted JavaScript.
@@ -156,6 +179,7 @@ pub fn emit_module(m: &Module) -> String {
     let display_apl_high_minus = m.metadata.source_language.as_deref() == Some("apl");
     let display_j_underscore = m.metadata.source_language.as_deref() == Some("j");
     let display_derive = m.metadata.source_language.as_deref() == Some("derive");
+    let display_q_ascii_minus = m.metadata.source_language.as_deref() == Some("q");
     out.push_str(
         &RUNTIME
             .replace(
@@ -173,6 +197,10 @@ pub fn emit_module(m: &Module) -> String {
             .replace(
                 "__SIR_DISPLAY_DERIVE__",
                 if display_derive { "true" } else { "false" },
+            )
+            .replace(
+                "__SIR_DISPLAY_Q_ASCII_MINUS__",
+                if display_q_ascii_minus { "true" } else { "false" },
             ),
     );
     emit_ancestry_registration(&mut out, m);

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -135,6 +135,21 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
   // semantic-ir` frontend that sets one of the first three (Ruby/APL/J)
   // emits any SIR23 `SymApply`/`SymSymbol` node at all today.
   const SIR_DISPLAY_DERIVE = __SIR_DISPLAY_DERIVE__;
+  // A FIFTH, independent display-convention flag (task #109, the direct Q
+  // sibling of J's own flag immediately above, found by `q-to-semantic-ir/
+  // tests/oracle.rs`'s own `DISPLAY_GAP` cases): `true` when the module's
+  // `source_language` is Q, else `false`. Q's own console convention
+  // renders a negative number with a plain ASCII `-` (never APL's
+  // high-minus `¯`, never J's leading underscore `_`) and a non-finite
+  // value as lowercase `-inf`/`inf` (note the ASCII minus PREFIX on
+  // infinity -- DIFFERENT from J's own `_inf` spelling immediately above),
+  // matching `q_runtime::value::fmt_num` exactly (`fmtNum` below is ported
+  // 1:1 from it). Mutually exclusive with the four flags above by
+  // construction (all five are computed from the same single
+  // `source_language` field in `emit.rs`), so `fmtNum`/`formatSeen` below
+  // never need to arbitrate between them -- only one can ever be `true`
+  // for a given module.
+  const SIR_DISPLAY_Q_ASCII_MINUS = __SIR_DISPLAY_Q_ASCII_MINUS__;
   // ── value model ────────────────────────────────────────────────
   // A symbol is an interned name; `===` on two interned symbols with
   // the same name is therefore identity-equal.
@@ -414,10 +429,10 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     // (MATLAB's `2 ^ 2` reaches the identical shape), so only the source
     // language, not the value's own shape, can decide the glyph.
     if (v instanceof SirFloat) {
-      return (SIR_DISPLAY_APL_HIGH_MINUS || SIR_DISPLAY_J_UNDERSCORE) ? ArrayRt.fmtNum(v.f) : floatToRubyString(v.f);
+      return (SIR_DISPLAY_APL_HIGH_MINUS || SIR_DISPLAY_J_UNDERSCORE || SIR_DISPLAY_Q_ASCII_MINUS) ? ArrayRt.fmtNum(v.f) : floatToRubyString(v.f);
     }
     if (typeof v === "number") {
-      return (SIR_DISPLAY_APL_HIGH_MINUS || SIR_DISPLAY_J_UNDERSCORE) ? ArrayRt.fmtNum(v) : String(v);
+      return (SIR_DISPLAY_APL_HIGH_MINUS || SIR_DISPLAY_J_UNDERSCORE || SIR_DISPLAY_Q_ASCII_MINUS) ? ArrayRt.fmtNum(v) : String(v);
     }
     if (v instanceof Sym) { return v.name; }
     if (v instanceof Pair) {
@@ -5864,21 +5879,27 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     }
 
     /**
-     * Format one number the way `apl_runtime::value::fmt_num` (APL) or
+     * Format one number the way `apl_runtime::value::fmt_num` (APL),
      * `j_runtime::value::fmt_num` (J, when `SIR_DISPLAY_J_UNDERSCORE` is
-     * set — added alongside `j-to-semantic-ir/tests/oracle.rs`'s "Bug A")
+     * set — added alongside `j-to-semantic-ir/tests/oracle.rs`'s "Bug A"),
+     * or `q_runtime::value::fmt_num` (Q, when `SIR_DISPLAY_Q_ASCII_MINUS`
+     * is set — task #109, the direct Q sibling of J's own fix, added
+     * alongside `q-to-semantic-ir/tests/oracle.rs`'s `DISPLAY_GAP` cases)
      * does, ported 1:1 from whichever is active: APL's high-minus glyph
-     * `¯` (never ASCII `-`), or J's leading underscore `_` (never `¯`,
-     * never `-`), prefixes a negative number; a whole-valued float prints
-     * without a trailing `.0`. Unlike the Rust source, no separate
-     * integer-vs-float branch is needed for the whole-value case —
-     * `String(5)` and `String(5.0)` are both `"5"` in JS, where Rust needs
-     * `format!("{}", mag as i64)` specifically to avoid `5.0`'s `Display`
-     * impl printing a trailing `.0`. `x < 0` (a numeric comparison) already
-     * excludes `-0` from either negative-glyph branch on its own — `-0 < 0`
-     * is `false` in JS — so, unlike Rust's `is_sign_negative()` (a
-     * bit-level check that says `true` for `-0`), no separate
-     * `-0`-is-plain-`0` guard is needed here either.
+     * `¯` (never ASCII `-`), J's leading underscore `_` (never `¯`, never
+     * `-`), or Q's own plain ASCII `-` (never `¯`, never `_`) prefixes a
+     * negative number; a whole-valued float prints without a trailing
+     * `.0`. Unlike the Rust source, no separate integer-vs-float branch is
+     * needed for the whole-value case — `String(5)` and `String(5.0)` are
+     * both `"5"` in JS, where Rust needs `format!("{}", mag as i64)`
+     * specifically to avoid `5.0`'s `Display` impl printing a trailing
+     * `.0`. `x < 0` (a numeric comparison) already excludes `-0` from any
+     * of the three negative-glyph branches on its own — `-0 < 0` is
+     * `false` in JS — so, unlike Rust's `is_sign_negative()` (a bit-level
+     * check that says `true` for `-0`), no separate `-0`-is-plain-`0`
+     * guard is needed here either (matching `q_runtime::value::fmt_num`'s
+     * own explicit `mag != 0.0` guard against exactly this, via a
+     * different mechanism that reaches the identical result).
      */
     function fmtNum(x) {
       if (Number.isNaN(x)) {
@@ -5886,10 +5907,12 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
       }
       if (!Number.isFinite(x)) {
         if (SIR_DISPLAY_J_UNDERSCORE) { return x < 0 ? "_inf" : "inf"; }
+        if (SIR_DISPLAY_Q_ASCII_MINUS) { return x < 0 ? "-inf" : "inf"; }
         return x < 0 ? "¯∞" : "∞";
       }
       const body = String(Math.abs(x));
       if (SIR_DISPLAY_J_UNDERSCORE) { return x < 0 ? "_" + body : body; }
+      if (SIR_DISPLAY_Q_ASCII_MINUS) { return x < 0 ? "-" + body : body; }
       return x < 0 ? "¯" + body : body;
     }
 
@@ -6534,10 +6557,10 @@ mod tests {
         // shape the way `neg`'s array branch is.
         assert!(RUNTIME.contains("const SIR_DISPLAY_APL_HIGH_MINUS = __SIR_DISPLAY_APL_HIGH_MINUS__;"));
         assert!(RUNTIME.contains(
-            "return (SIR_DISPLAY_APL_HIGH_MINUS || SIR_DISPLAY_J_UNDERSCORE) ? ArrayRt.fmtNum(v.f) : floatToRubyString(v.f);"
+            "return (SIR_DISPLAY_APL_HIGH_MINUS || SIR_DISPLAY_J_UNDERSCORE || SIR_DISPLAY_Q_ASCII_MINUS) ? ArrayRt.fmtNum(v.f) : floatToRubyString(v.f);"
         ));
         assert!(RUNTIME.contains(
-            "return (SIR_DISPLAY_APL_HIGH_MINUS || SIR_DISPLAY_J_UNDERSCORE) ? ArrayRt.fmtNum(v) : String(v);"
+            "return (SIR_DISPLAY_APL_HIGH_MINUS || SIR_DISPLAY_J_UNDERSCORE || SIR_DISPLAY_Q_ASCII_MINUS) ? ArrayRt.fmtNum(v) : String(v);"
         ));
         // `fmtNum` must be reachable from OUTSIDE the `ArrayRt` IIFE (where
         // `formatSeen` lives) for the branches above to compile at all.
@@ -6561,6 +6584,30 @@ mod tests {
         // The APL branch must still be the DEFAULT (reached when the J flag
         // is false) -- these two lines are unchanged from before this fix,
         // confirming APL's own display is untouched by adding J's.
+        assert!(RUNTIME.contains("return x < 0 ? \"¯∞\" : \"∞\";"));
+        assert!(RUNTIME.contains("return x < 0 ? \"¯\" + body : body;"));
+    }
+
+    // ── Q's own display convention (task #109, the direct Q sibling of
+    // J's "Bug A" above, `q-to-semantic-ir/tests/oracle.rs`'s `DISPLAY_GAP`
+    // cases) ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn fmtnum_gates_the_negative_glyph_and_infinity_spelling_on_the_q_ascii_minus_flag() {
+        // Regression guard for task #109: `semantic-ir-to-javascript` had
+        // no Q-specific counterpart to `SIR_DISPLAY_APL_HIGH_MINUS`/
+        // `SIR_DISPLAY_J_UNDERSCORE` at all, so a Q-sourced module's
+        // genuine-NDArray negative numbers/infinity fell through to APL's
+        // own high-minus glyph (`ArrayRt.fmtNum`'s previously-unconditional
+        // branch) instead of Q's own plain ASCII `-`/lowercase `-inf`.
+        assert!(RUNTIME.contains("const SIR_DISPLAY_Q_ASCII_MINUS = __SIR_DISPLAY_Q_ASCII_MINUS__;"));
+        assert!(RUNTIME.contains("if (SIR_DISPLAY_Q_ASCII_MINUS) { return x < 0 ? \"-inf\" : \"inf\"; }"));
+        assert!(RUNTIME.contains("if (SIR_DISPLAY_Q_ASCII_MINUS) { return x < 0 ? \"-\" + body : body; }"));
+        // J's and APL's own branches must still be reachable (both unchanged
+        // by adding Q's) -- confirming Q's flag is a pure addition, not a
+        // replacement.
+        assert!(RUNTIME.contains("if (SIR_DISPLAY_J_UNDERSCORE) { return x < 0 ? \"_inf\" : \"inf\"; }"));
+        assert!(RUNTIME.contains("if (SIR_DISPLAY_J_UNDERSCORE) { return x < 0 ? \"_\" + body : body; }"));
         assert!(RUNTIME.contains("return x < 0 ? \"¯∞\" : \"∞\";"));
         assert!(RUNTIME.contains("return x < 0 ? \"¯\" + body : body;"));
     }


### PR DESCRIPTION
## Summary
- Adds a fifth per-source-language display flag, `SIR_DISPLAY_Q_ASCII_MINUS`, mirroring the already-shipped `SIR_DISPLAY_J_UNDERSCORE` (task #98) exactly — same `emit.rs` wiring, same `fmtNum` extension pattern.
- Root cause: Q lowers to the shared SIR22 array domain (like APL/J), so a Q program's negative-number results went through the same `ArrayRt.fmtNum`, which had no Q-specific branch and fell through to APL's high-minus glyph `¯` by default. Q's own convention is a plain ASCII `-` (never `¯`, never J's `_`), and non-finite values print as `-inf`/`inf` (note: ASCII minus prefix, distinct from J's own `_inf` spelling) — ported 1:1 from `q_runtime::value::fmt_num`.
- Flips all 5 `known_bug: Some(DISPLAY_GAP)` cases in `q-to-semantic-ir/tests/oracle.rs` to `known_bug: None`: `whitespace_sensitive_strand_vs_subtraction_strand`, `dyadic_sub_negative_result`, `monadic_minus_negates_a_vector`, `each_on_an_elementwise_primitive_matches_direct_application`, `scan_then_reduce_negative`.
- Version bumps: `semantic-ir-to-javascript` 0.51.3 → 0.51.4, `q-to-semantic-ir` 0.1.0 → 0.1.1.

## Test plan
- [x] Independently reverted the new flag (forced `display_q_ascii_minus = false`), confirmed the Q oracle test fails exactly as predicted for all 5 cases (`got "¯1", expected "-1"`, etc.), then restored and confirmed it passes again
- [x] `cargo test -p semantic-ir-to-javascript --lib` — 144/144 pass
- [x] `cargo test -p q-to-semantic-ir --test oracle -- --nocapture` — passes clean, no skip lines
- [x] Zero regressions confirmed across every other SIR22-array-domain consumer: `matlab-to-semantic-ir`, `octave-to-semantic-ir`, `apl-to-semantic-ir`, `j-to-semantic-ir`, `scilab-to-semantic-ir` (all full suites pass)
- [x] Security review passed clean — confirmed the new flag's replacement value is always a hardcoded `"true"`/`"false"` literal gated by a `bool`, never text derived from `source_language` (the same injection-safety invariant already established for the four pre-existing display flags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)