### PR TITLE
feat(semantic-ir-to-c): default parameters — _sir_missing sentinel (SIR19)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## 0.10.0 — default parameters (SIR19)
+
+Accepts `Feature::DefaultParams`. C has no native default parameters, so — like
+the Go backend — this uses a `_sir_missing` sentinel with call-site padding and
+a per-function prologue:
+
+- **Runtime**: a new `SIR_MISSING` tag with `_sir_missing()` / `_sir_is_missing`.
+  It is an INTERNAL "argument omitted" sentinel — a `SIR_MISSING` value is
+  replaced by its default before the body runs, so user code never observes it.
+- **Call site**: a `DirectCall` that leaves trailing defaulted arguments off
+  pads the call with `_sir_missing()` up to the callee's declared arity. The
+  arity is looked up in a thread-local map (`ARITY`) snapshotted at the top of
+  `emit_module` — the same mechanism as the `TEMP_ID` counter, so the deep
+  `emit_expr`/`emit_assign` call tree reads it without threading a context.
+  (The map is only read by key, so emission stays deterministic.)
+- **Prologue**: each function opens with `if (_sir_is_missing(p)) { p =
+  <default>; }` for every defaulted parameter, in declaration order — so a later
+  default may reference an earlier parameter (whose own default is already
+  filled), matching the validator and the Go/Ruby backends. A C parameter is a
+  mutable lvalue, so it is reassigned in place; a compound default hoists
+  through `emit_assign`.
+
+Only the positional case is `DefaultParams`; a keyword default is the separate
+(still-unaccepted) `KeywordParams` feature. An `IndirectCall` (a closure with no
+statically-known signature) is not padded — the closure's own arity handling
+applies; the DirectCall path is the default-parameter path.
+
+Also extends `first_unsupported_builtin` to scan each parameter default, not
+just the body — a default is evaluated (in the prologue) at call time, so a
+deferred builtin hidden in one must be rejected cleanly rather than reach the
+emitter's `unreachable!`. (The C `scan_expr_for_builtin` already scanned an
+`IndirectCall`'s target, so — unlike the Ruby backend — no target-scan fix was
+needed here.)
+
+This closes the DefaultParams parity arc: with the Ruby backend's default
+parameters (0.8.0), `Feature::DefaultParams` is now accepted on all six
+backends. Verified with hand-built modules compiled and run through a real `cc`:
+a single default used when omitted (`f(1)` → `6` for `f(a, b = 5) = a + b`) and
+overridden when supplied (`f(1, 2)` → `3`), two trailing defaults each filling
+independently, a default referencing an earlier parameter, and the prologue /
+call-site sentinel shape. Bumps semantic-ir-to-c 0.9.0 → 0.10.0.
+
 ## 0.9.0 — short-circuit (SIR16)
 
 Accepts `Feature::ShortCircuit`. `Expr::LogicalAnd` / `Expr::LogicalOr`

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -88,13 +88,16 @@ composite keys, positional structural equality, and `{k: v}` display (matching
 the Go/Rust backends); SIR16 `Floats` — a `SIR_FLOAT` `FloatLit` (`7.0`
 stays a Float, not the Integer `7`; `Infinity`/`NaN` via `<math.h>`), with
 native float arithmetic, the division frontier (Float promotes, two Integers
-floor), and IEEE non-finite results; and SIR16 `ShortCircuit` — `LogicalAnd`
+floor), and IEEE non-finite results; SIR16 `ShortCircuit` — `LogicalAnd`
 (`&&`) and `LogicalOr` (`||`) lowered to an `if (_sir_truthy(...))` overwrite
 that short-circuits the dead operand and yields the deciding operand (not a
-bool).
+bool); and SIR19 `DefaultParams` — a positional default via a `_sir_missing`
+sentinel: a `DirectCall` pads omitted trailing arguments and each function opens
+with an `if (_sir_is_missing(p)) { p = <default>; }` prologue (a later default
+may reference an earlier parameter).
 
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
-`Intrinsics`, `NDArrays`, exceptions/OOP, and every
+`Intrinsics`, `NDArrays`, `KeywordParams`, exceptions/OOP, and every
 other not-yet-wired feature until its batch lands.  `Bignum` stays rejected
 until a bignum runtime ships — a module needing arbitrary precision is refused,
 never silently truncated.

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -10,7 +10,8 @@
 //!
 //! See [SIR24](../../../specs/SIR24-semantic-ir-to-c.md) for the design.
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
 use std::fmt::Write;
 
 use semantic_ir::{Block, Expr, Function, Global, IntSpec, IntWidth, Module, Scope, Span, Stmt};
@@ -22,6 +23,14 @@ thread_local! {
     /// the top of [`emit_module`] so emission is byte-stable (the determinism
     /// test relies on this).
     static TEMP_ID: Cell<u64> = const { Cell::new(0) };
+
+    /// Per-module map from a user function's RAW name to its declared parameter
+    /// count, snapshotted at the top of [`emit_module`].  A `DirectCall` that
+    /// omits trailing SIR19-defaulted arguments pads the call up to this arity
+    /// with `_sir_missing()`; the callee's prologue then substitutes each
+    /// default.  Thread-local (like `TEMP_ID`) so the deep `emit_expr` /
+    /// `emit_assign` call tree can read it without threading a context.
+    static ARITY: RefCell<HashMap<String, usize>> = RefCell::new(HashMap::new());
 }
 
 fn fresh_id() -> u64 {
@@ -32,9 +41,41 @@ fn fresh_id() -> u64 {
     })
 }
 
+/// The declared parameter count of a known user function (by raw name), for
+/// call-site default-argument padding.  `None` for an unknown callee.
+fn callee_arity(fn_name: &str) -> Option<usize> {
+    ARITY.with(|a| a.borrow().get(fn_name).copied())
+}
+
+/// Append `_sir_missing()` arguments to bring a `DirectCall`'s `provided`
+/// argument count up to the callee's declared arity — the SIR19 default-param
+/// call-site padding.  A leading comma is written before each pad when the call
+/// already has `provided > 0` arguments (or a previous pad) so the argument
+/// list stays well-formed.  No-op for an unknown callee or an exact/over-full
+/// call.
+fn emit_default_padding(out: &mut String, fn_name: &str, provided: usize) {
+    if let Some(arity) = callee_arity(fn_name) {
+        for i in provided..arity {
+            if i > 0 {
+                out.push_str(", ");
+            }
+            out.push_str("_sir_missing()");
+        }
+    }
+}
+
 /// Emit a complete self-contained C source file for `m`.
 pub fn emit_module(m: &Module) -> String {
     TEMP_ID.with(|c| c.set(0));
+    // Snapshot each user function's declared arity for `DirectCall` default
+    // padding (SIR19).  Cleared first so a reused thread starts empty.
+    ARITY.with(|a| {
+        let mut map = a.borrow_mut();
+        map.clear();
+        for f in &m.functions {
+            map.insert(f.name.clone(), f.params.len());
+        }
+    });
 
     let mut out = String::new();
     emit_banner(&mut out, m);
@@ -168,8 +209,30 @@ fn emit_function(out: &mut String, f: &Function) {
     let _ = write!(out, "SirValue {}(", function_emit_name(&f.name));
     emit_param_list(out, f);
     out.push_str(") {\n");
+    emit_default_prologue(out, f, 1);
     emit_block_body(out, &f.body, 1);
     out.push_str("}\n");
+}
+
+/// Emit the SIR19 default-parameter prologue: for each parameter carrying a
+/// default, in declaration order, guard `if (_sir_is_missing(name)) { name =
+/// <default>; }`.  A call site pads an omitted trailing defaulted argument with
+/// `_sir_missing()` (see [`emit_default_padding`]); this replaces it with the
+/// default value BEFORE the body runs, so the body never sees a `SIR_MISSING`.
+/// Declaration order lets a later default reference an earlier parameter (whose
+/// own default, if any, is already filled) — matching the validator and the
+/// Go/Ruby backends.  The parameter is a C function parameter (a mutable
+/// lvalue), so it is reassigned in place; a compound default hoists through
+/// `emit_assign`.
+fn emit_default_prologue(out: &mut String, f: &Function, indent: usize) {
+    let pad = indent_str(indent);
+    for p in &f.params {
+        let Some(default) = &p.default else { continue };
+        let name = sanitize_ident(&p.name);
+        let _ = writeln!(out, "{pad}if (_sir_is_missing({name})) {{");
+        emit_assign(out, &name, default, indent + 1);
+        let _ = writeln!(out, "{pad}}}");
+    }
 }
 
 /// Emit a block in **statement/return** position — its `stmts` run for effect,
@@ -735,6 +798,8 @@ fn emit_call_with_arg_names(out: &mut String, e: &Expr, names: &[String]) {
         Expr::DirectCall { fn_name, .. } => {
             let _ = write!(out, "{}(", function_emit_name(fn_name));
             push_joined(out, names);
+            // SIR19: pad a call that omits trailing defaulted arguments.
+            emit_default_padding(out, fn_name, names.len());
             out.push(')');
         }
         Expr::IndirectCall { target, .. } => {
@@ -830,6 +895,8 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         Expr::DirectCall { fn_name, args, .. } => {
             let _ = write!(out, "{}(", function_emit_name(fn_name));
             emit_simple_args(out, args, indent);
+            // SIR19: pad a call that omits trailing defaulted arguments.
+            emit_default_padding(out, fn_name, args.len());
             out.push(')');
         }
         Expr::IndirectCall { target, args, .. } => {
@@ -1047,6 +1114,17 @@ fn is_supported_builtin(name: &str) -> bool {
 /// cleanly.
 pub fn first_unsupported_builtin(m: &Module) -> Option<(String, Span)> {
     for f in &m.functions {
+        // A SIR19 parameter default is an expression the prologue evaluates at
+        // call time, so a deferred builtin nested in one must be pre-checked
+        // too — otherwise it would slip past the body scan and reach the
+        // emitter's `unreachable!`.
+        for p in &f.params {
+            if let Some(default) = &p.default {
+                if let Some(hit) = scan_expr_for_builtin(default) {
+                    return Some(hit);
+                }
+            }
+        }
         if let Some(hit) = scan_block_for_builtin(&f.body) {
             return Some(hit);
         }

--- a/code/packages/rust/semantic-ir-to-c/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/lib.rs
@@ -116,6 +116,17 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // `_sir_seq_iter` panics on it); C's lenient `_sir_seq_iter` else-branch
     // (empty iteration) already covers it without an emitter `unreachable!`.
     Feature::Maps,
+    // ── SIR19 default parameters ─────────────────────────────────────
+    // A positional parameter carrying a default value.  C has no native
+    // defaults, so — like the Go backend — this uses a `_sir_missing` sentinel:
+    // a `DirectCall` that omits trailing defaulted arguments pads the call with
+    // `_sir_missing()` (call-site padding, keyed off a thread-local arity map),
+    // and each function opens with a prologue `if (_sir_is_missing(p)) { p =
+    // <default>; }` in declaration order (so a later default may reference an
+    // earlier parameter).  The unsupported-builtin pre-check also scans each
+    // default, so the emitter stays total.  Keyword defaults are the separate
+    // (still-unaccepted) `KeywordParams` feature.
+    Feature::DefaultParams,
 ];
 
 impl Backend for CBackend {

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -42,7 +42,13 @@ pub const RUNTIME: &str = r####"/* =============================================
 
 typedef enum {
     SIR_NIL, SIR_BOOL, SIR_INT, SIR_FLOAT,
-    SIR_STR, SIR_SYM, SIR_PAIR, SIR_CLOSURE, SIR_SEQ, SIR_MAP
+    SIR_STR, SIR_SYM, SIR_PAIR, SIR_CLOSURE, SIR_SEQ, SIR_MAP,
+    /* An INTERNAL "argument was omitted" sentinel for SIR19 default parameters.
+     * A `DirectCall` that leaves a trailing defaulted argument off pads the call
+     * with `_sir_missing()`; the callee's prologue replaces each such parameter
+     * with its default expression BEFORE the body runs, so a `SIR_MISSING` value
+     * is never observed by user code (never printed, compared, or stored). */
+    SIR_MISSING
 } SirTag;
 
 typedef struct SirValue SirValue;
@@ -138,6 +144,12 @@ SirValue _sir_int(int64_t i)   { SirValue v; v.tag = SIR_INT;  v.as.i = i;   ret
 SirValue _sir_float(double f)  { SirValue v; v.tag = SIR_FLOAT; v.as.f = f;  return v; }
 SirValue _sir_str(const char *s) { SirValue v; v.tag = SIR_STR; v.as.s = s;  return v; }
 SirValue _sir_sym(const char *s) { SirValue v; v.tag = SIR_SYM; v.as.s = _sir_intern(s); return v; }
+
+/* The SIR19 "argument omitted" sentinel (see `SIR_MISSING`).  `_sir_missing()`
+ * is passed at a call site for each trailing defaulted parameter left off; the
+ * callee's prologue tests `_sir_is_missing` and substitutes the default. */
+SirValue _sir_missing(void)      { SirValue v; v.tag = SIR_MISSING; v.as.i = 0; return v; }
+int _sir_is_missing(SirValue v)  { return v.tag == SIR_MISSING; }
 
 /* ---- truthiness --------------------------------------------- */
 

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_defaultparams.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_defaultparams.rs
@@ -1,0 +1,202 @@
+//! Execution proof for SIR19 default parameters on the C backend — hand-build
+//! modules (producer-agnostic), emit C, compile with a real gcc/clang-style
+//! compiler, run, assert stdout. Skips gracefully when no `cc` is present.
+//!
+//! C has no native default parameters, so this uses the `_sir_missing` sentinel:
+//! a `DirectCall` that omits a trailing defaulted argument pads the call with
+//! `_sir_missing()`, and each function opens with a prologue `if
+//! (_sir_is_missing(p)) { p = <default>; }` in declaration order. Hand-built to
+//! bypass the frontend and prove the whole path (padding + prologue) end to end.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Param, ParamKind,
+    Scope, Span, Stmt, CURRENT_SIR_VERSION,
+};
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    for cand in ["cc", "clang", "gcc"] {
+        if Command::new(cand)
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+        {
+            return Some(cand.to_string());
+        }
+    }
+    None
+}
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn run(module: &Module) -> Option<String> {
+    let cc = find_cc()?;
+    let artifact = semantic_ir_to_c::compile(module).expect("C backend compile (no panic)");
+    let dir = std::env::temp_dir();
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let stem = format!("sirc_def_{}_{}", std::process::id(), n);
+    let cpath: PathBuf = dir.join(format!("{stem}.c"));
+    let exe: PathBuf = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::File::create(&cpath)
+        .and_then(|mut f| f.write_all(artifact.source.as_bytes()))
+        .expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-Werror=unused-variable", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        artifact.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "run failed (exit {:?})", r.status.code());
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+fn s() -> Span {
+    Span::synthetic()
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn pref(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Param, span: s() }
+}
+fn bc(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+fn puts(arg: Expr) -> Stmt {
+    Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: s() }
+}
+fn directcall(fn_name: &str, args: Vec<Expr>) -> Expr {
+    Expr::DirectCall { fn_name: fn_name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+fn param(name: &str, default: Option<Expr>) -> Param {
+    Param {
+        name: name.into(),
+        sir_type: None,
+        kind: ParamKind::Required,
+        default: default.map(Box::new),
+        span: s(),
+    }
+}
+/// A module with a helper function `f(<params>) = <body_value>` and a `main`
+/// running `main_stmts`, declaring `DefaultParams` (+ `DynamicTyping`, which an
+/// untyped parameter makes the validator observe).
+fn defparam_module(params: Vec<Param>, body_value: Expr, main_stmts: Vec<Stmt>) -> Module {
+    let f = Function {
+        name: "f".into(),
+        params,
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: vec![], value: body_value, span: s() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: s(),
+    };
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: main_stmts, value: Expr::NilLit { span: s() }, span: s() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: s(),
+    };
+    Module {
+        name: "defprog".into(),
+        manifest: FeatureManifest::from_features(&[Feature::DefaultParams, Feature::DynamicTyping]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![f, main],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+#[test]
+fn default_param_is_used_when_the_argument_is_omitted() {
+    // `f(a, b = 5) = a + b` — `f(1)` pads the missing `b` and the prologue fills
+    // `5` (`1 + 5 = 6`); `f(1, 2)` supplies `b` (`1 + 2 = 3`).
+    let body = bc("+", vec![pref("a"), pref("b")]);
+    match run(&defparam_module(
+        vec![param("a", None), param("b", Some(ilit(5)))],
+        body,
+        vec![
+            puts(directcall("f", vec![ilit(1)])),          // 6
+            puts(directcall("f", vec![ilit(1), ilit(2)])), // 3
+        ],
+    )) {
+        Some(out) => assert_eq!(out, "6\n3\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn default_may_reference_an_earlier_parameter() {
+    // `f(a, b = a) = b` — a default sees the parameters declared before it (the
+    // prologue runs in declaration order), so `f(7)` yields `7`.
+    match run(&defparam_module(
+        vec![param("a", None), param("b", Some(pref("a")))],
+        pref("b"),
+        vec![puts(directcall("f", vec![ilit(7)]))], // 7
+    )) {
+        Some(out) => assert_eq!(out, "7\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn two_defaults_both_fill_when_omitted() {
+    // `f(a, b = 10, c = 20) = a + b + c` — `f(1)` fills both (`31`), `f(1, 2)`
+    // fills only `c` (`23`), `f(1, 2, 3)` supplies all (`6`). Proves multiple
+    // trailing defaults pad and fill correctly.
+    let body = bc("+", vec![bc("+", vec![pref("a"), pref("b")]), pref("c")]);
+    match run(&defparam_module(
+        vec![
+            param("a", None),
+            param("b", Some(ilit(10))),
+            param("c", Some(ilit(20))),
+        ],
+        body,
+        vec![
+            puts(directcall("f", vec![ilit(1)])),                    // 31
+            puts(directcall("f", vec![ilit(1), ilit(2)])),           // 23
+            puts(directcall("f", vec![ilit(1), ilit(2), ilit(3)])),  // 6
+        ],
+    )) {
+        Some(out) => assert_eq!(out, "31\n23\n6\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn prologue_and_padding_emit_the_sentinel() {
+    // Emit-shape: the callee opens with a `_sir_is_missing` guard, and a call
+    // that omits the defaulted argument pads with `_sir_missing()`.
+    let src = semantic_ir_to_c::compile(&defparam_module(
+        vec![param("a", None), param("b", Some(ilit(5)))],
+        bc("+", vec![pref("a"), pref("b")]),
+        vec![puts(directcall("f", vec![ilit(1)]))],
+    ))
+    .expect("compile")
+    .source;
+    assert!(src.contains("if (_sir_is_missing(b))"), "prologue guard:\n{src}");
+    assert!(src.contains("_sir_missing()"), "call-site padding:\n{src}");
+}

--- a/code/specs/SIR24-semantic-ir-to-c.md
+++ b/code/specs/SIR24-semantic-ir-to-c.md
@@ -80,13 +80,16 @@ time — see the roadmap): the SIR26 integer conversions (`Conversions`,
 `Loops` + `MutableBindings` (0.3.0–0.5.0), `Sequences` (0.6.0), `Maps`
 (0.7.0 — the `SIR_MAP` assoc-array with `MapLit`/`MapGet`/`MapSet`), `Floats`
 (0.8.0 — `FloatLit` on the v0 `SIR_FLOAT` tag; emitter-only, the runtime
-already carried the float path), and `ShortCircuit` (0.9.0 — `LogicalAnd`/
+already carried the float path), `ShortCircuit` (0.9.0 — `LogicalAnd`/
 `LogicalOr` lowered to a truthiness-branch overwrite, reusing the eager
-`and`/`or` builtin lowering; yields the deciding operand).
+`and`/`or` builtin lowering; yields the deciding operand), and `DefaultParams`
+(SIR19, 0.10.0 — the `SIR_MISSING` sentinel now exists in the runtime; a
+`DirectCall` pads omitted trailing defaults with `_sir_missing()` and each
+function opens with an `if (_sir_is_missing(p)) { p = <default>; }` prologue).
 
 **Still rejects** (clean, source-positioned `UnsupportedFeature`):
 `TailCalls` (C does not guarantee TCO), `Intrinsics` (empty whitelist), and
-every not-yet-landed feature (`NDArrays`,
+every not-yet-landed feature (`KeywordParams`, `NDArrays`,
 `Exceptions`, `Classes`, … — see the roadmap).  `Bignum` stays
 rejected until a bignum runtime ships, so a module that *needs* arbitrary
 precision is refused rather than silently truncated.


### PR DESCRIPTION
## What

Adds SIR19 **default parameters** to the C backend (`semantic-ir-to-c` 0.9.0 → 0.10.0) — the **last** of the DefaultParams parity arc. With the Ruby backend's default parameters (#8859), `Feature::DefaultParams` is now accepted on **all six** backends.

C has no native default parameters, so — like the Go backend — this uses a `_sir_missing` sentinel with call-site padding and a per-function prologue:

- **Runtime**: a new `SIR_MISSING` tag with `_sir_missing()` / `_sir_is_missing()`. An **internal** "argument omitted" sentinel — replaced by its default before the body runs, so user code never observes it.
- **Call site**: a `DirectCall` that leaves trailing defaulted arguments off pads the call with `_sir_missing()` up to the callee's declared arity, looked up in a **thread-local** arity map snapshotted at the top of `emit_module` (the same mechanism as the `TEMP_ID` counter — so the deep `emit_expr`/`emit_assign` call tree reads it without threading a context; read only by key, so emission stays deterministic).
- **Prologue**: each function opens with `if (_sir_is_missing(p)) { p = <default>; }` per defaulted param, **in declaration order** — so a later default may reference an earlier parameter (whose own default is already filled). A C parameter is a mutable lvalue; a compound default hoists through `emit_assign`.

Only the positional case is `DefaultParams`; a keyword default is the separate (still-unaccepted) `KeywordParams`. An `IndirectCall` (closure, no static signature) is not padded — the DirectCall path is the default-parameter path.

Also extends `first_unsupported_builtin` to scan each parameter default (a deferred builtin in a default must be rejected cleanly, not reach `unreachable!`). C's `scan_expr_for_builtin` already scanned an `IndirectCall` target, so — unlike the Ruby backend — no target-scan fix was needed.

## Verification

- `cargo test -p semantic-ir-to-c` — **49 tests green** (4 new), hand-built modules compiled and run through a real `cc`: a single default used when omitted (`f(1)` → `6` for `f(a, b = 5) = a + b`) and overridden when supplied (`f(1, 2)` → `3`), two trailing defaults each filling independently, a default referencing an earlier parameter, and the prologue / call-site sentinel shape.
- `cargo clippy -p semantic-ir-to-c --all-targets` clean.
- Security review passed — padding arg-count is memory-safe (empty range on over-full, no underflow), the comma logic is well-formed across all call shapes and both call sites, `SIR_MISSING` never leaks unsafely (every runtime consumer tag-guards), and the thread-local `ARITY` map is deterministic and cleared per compile.
- SIR24 spec capability section updated (DefaultParams → landed; `SIR_MISSING` now in the runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)