### PR TITLE
feat(hl03): Learn mode — the curriculum teaching session (phase 6, slice 6b-1)

### DIFF
--- a/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
+++ b/code/programs/typescript/script-writing-visualizer/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.9.5 — the Learn session, teaching view (HL03 phase 6, slice 6b-1)
+
+- **New "Learn" mode, now the default** — the curriculum walked the way the book
+  does: one concept at a time, forward along the language chain. It renders the
+  engine's *teaching pass* (`planSession(...).teaching`) as a numbered sweep of
+  cards, one per active language that teaches the concept, in chain order.
+- Each card shows the word in its own script, its gloss/romanization, its
+  etymology hook, and — the point of the whole app — the **connections back** to
+  earlier languages that share a root (e.g. Telugu *ధన్యవాదములు* → Hindi and
+  Kannada via `dhanya, vada`). Connections are grounded and backward-only; the
+  first stop, where the concept enters, wears an "introduced here" badge.
+- Prev / Next walk the **concept spine** (`sweepableConcepts`) — the concepts in
+  book order (earliest chapter first). Consolidation lessons (`practice`,
+  `practice-mix`, `review` — placeholder headwords, no roots, `reviews_of`
+  links) are filtered OUT of the spine: that kind of revisiting is what the
+  review quiz is for, so the learner walks real words, not "(practice)". 205 →
+  186 concepts.
+- DOM-only shell; all sequencing stays in the tested engine. Verified in a real
+  browser: every script renders (no tofu), the ten-language THANKS sweep shows
+  its `dhanya`/`nal` threads. The review quiz (`pickNext`/`applyAnswer`) is the
+  next slice (6b-2).
+
 ## 0.9.4 — the session view-model (HL03 phase 6, slice 6a)
 
 - `src/sessionplan.ts` — the seam that assembles the four engine modules into

--- a/code/programs/typescript/script-writing-visualizer/README.md
+++ b/code/programs/typescript/script-writing-visualizer/README.md
@@ -1,9 +1,26 @@
 # Script Writing Visualizer
 
-**The HL02 companion app.** Four modes: **Browse** and **Practice** work on
-*script letters*; **Lessons** drills the *written curriculum* — every lesson in
-every track — on a spaced-repetition schedule that persists between visits; and
-**Concepts** shows one idea in every language that has it, side by side.
+**The HL02 companion app, growing into the HL03 unified learning app.** Five
+modes. **Learn** (the default) walks the curriculum the way the book does — one
+concept at a time, forward along the language chain, each new language showing
+its threads back to the ones already learned. **Browse** and **Practice** work
+on *script letters*; **Lessons** drills the *written curriculum* — every lesson
+in every track — on a spaced-repetition schedule that persists between visits;
+and **Concepts** shows one idea in every language that has it, side by side.
+
+## Learn mode (the curriculum session)
+
+The spine of the app: [HL03](../../../specs/HL03-unified-language-learning-app.md)
+in one screen. For each concept in book order (`sweepableConcepts`), the
+engine's *teaching pass* (`sessionplan.ts` → `planSession`) is rendered as a
+numbered sweep — one card per language that teaches it, in chain order
+(Spanish → Latin → French → … → Malayalam). Each card carries the word in its
+own script, its etymology hook, and the **connections back** to earlier
+languages that share a root, so the cross-language memory the interleaving is
+meant to build is made visible rather than left implicit. Prev / Next walk the
+spine; consolidation lessons (`practice`/`review`) are left to the review quiz,
+not the teaching sweep. The review pass (`pickNext`/`applyAnswer`) is the next
+slice.
 
 ## Concepts mode
 

--- a/code/programs/typescript/script-writing-visualizer/package.json
+++ b/code/programs/typescript/script-writing-visualizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "script-writing-visualizer",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "private": true,
   "description": "Companion study app (HL02): break a non-Latin script apart and learn to write it — and drill the whole written curriculum with a spaced-repetition schedule that remembers you",
   "type": "module",

--- a/code/programs/typescript/script-writing-visualizer/src/main.ts
+++ b/code/programs/typescript/script-writing-visualizer/src/main.ts
@@ -32,6 +32,13 @@ import {
 } from "./scheduler.ts";
 import { buildPool, type PoolEntry } from "./interleave.ts";
 import { loadLessons, indicesByLanguage, nextDue } from "./lessons.ts";
+import { planSession } from "./sessionplan.ts";
+import {
+  sweepableConcepts,
+  activeChain,
+  LANGUAGE_CHAIN,
+} from "./sequence.ts";
+import type { SessionStep } from "./session.ts";
 import {
   crossLanguageConcepts,
   datasetFromLessons,
@@ -53,8 +60,26 @@ import "./styles.css";
 const app = document.getElementById("app");
 if (!app) throw new Error("missing #app root");
 
-type Mode = "browse" | "practice" | "lessons" | "concepts";
-let mode: Mode = "browse";
+type Mode = "learn" | "browse" | "practice" | "lessons" | "concepts";
+let mode: Mode = "learn";
+
+// --- the curriculum session (HL03 phase 6) ----------------------------------
+//
+// The whole app is really ONE thing: walk the curriculum the way the book does —
+// concept by concept, forward along the language chain — and let every new
+// language connect back to the ones already learned. `sequence.ts` gives the
+// book-ordered spine of concepts; `sessionplan.ts` assembles one concept into a
+// teaching sweep across the active chain, each stop carrying its connections
+// back to earlier languages that share a root.
+//
+// The whole chain is active: a concept simply appears in whichever of the ten
+// languages actually teach it (a sweep is "the languages that CAN show it").
+const ACTIVE_COUNT = LANGUAGE_CHAIN.length;
+// How far along the spine the learner has walked. Everything up to and including
+// this concept is "covered" (what the review quiz will later draw from); this
+// concept is the one currently being taught. The spine itself (CONCEPT_SPINE) is
+// built just below, once LESSONS is loaded.
+let conceptCursor = 0;
 
 // --- lesson review state ----------------------------------------------------
 //
@@ -65,6 +90,18 @@ let mode: Mode = "browse";
 // written to localStorage (see progress.ts), so the app finally remembers you.
 const LESSONS = loadLessons();
 const LESSON_IDS = LESSONS.map((l) => l.id);
+// Consolidation lessons — chapter practice, mixed drills, dialogues, reviews —
+// are not atomic concepts: their headword is a placeholder ("(practice)"), they
+// carry no roots, and they exist to REVISIT earlier lessons (`reviews_of`).
+// That kind of consolidation is exactly what the review quiz is for, so keep
+// these out of the teaching spine — the learner should walk real words and
+// grammar, one concept at a time, not land on "(practice)".
+const CONSOLIDATION_TYPES = new Set(["practice", "practice-mix", "review"]);
+const CONCEPT_LESSONS = LESSONS.filter((l) => !CONSOLIDATION_TYPES.has(l.type));
+// The book-ordered concept spine the Learn session walks — the concepts taught
+// by any active language, in the order the book first introduces them. Constant
+// for the page's lifetime (the curriculum does not change while it is open).
+const CONCEPT_SPINE = sweepableConcepts(CONCEPT_LESSONS, activeChain(ACTIVE_COUNT));
 // Constant for the page's lifetime: lesson indices grouped by language, and the
 // round-robin pool over those groups. Computing them once is why consecutive
 // reviews can walk across languages cheaply.
@@ -125,15 +162,23 @@ function resolve(idx: number): PoolEntry {
 
 // --- shared chrome ----------------------------------------------------------
 
+const SUBTITLES: Record<Mode, string> = {
+  learn:
+    "Walk the curriculum the way the book does — one concept at a time, across every language that teaches it, with the threads back to what you already know.",
+  browse:
+    "Pick a script and a letter to see its pieces and stroke order — for pen-and-paper practice.",
+  practice:
+    "Recall drill: read the sound, pick the matching letter. Wrong answers are the confusable ones.",
+  lessons: "Spaced review across the whole curriculum, interleaved by language.",
+  concepts: "One idea, side by side, in every language that has it.",
+};
+
 function renderHeader(): HTMLElement {
   const header = el("header", "header");
   const h1 = el("h1", "");
   h1.textContent = "Script writing — learn it, then write it";
   const sub = el("p", "sub");
-  sub.textContent =
-    mode === "browse"
-      ? "Pick a script and a letter to see its pieces and stroke order — for pen-and-paper practice."
-      : "Recall drill: read the sound, pick the matching letter. Wrong answers are the confusable ones.";
+  sub.textContent = SUBTITLES[mode];
   header.append(h1, sub, renderModeToggle());
   return header;
 }
@@ -141,12 +186,13 @@ function renderHeader(): HTMLElement {
 function renderModeToggle(): HTMLElement {
   const wrap = el("div", "modes");
   const LABELS: Record<Mode, string> = {
+    learn: "Learn",
     browse: "Browse",
     practice: "Practice",
     lessons: "Lessons",
     concepts: "Concepts",
   };
-  (["browse", "practice", "lessons", "concepts"] as Mode[]).forEach((m) => {
+  (["learn", "browse", "practice", "lessons", "concepts"] as Mode[]).forEach((m) => {
     const b = el("button", "mode" + (m === mode ? " mode--active" : ""));
     b.textContent = LABELS[m];
     b.setAttribute("aria-pressed", String(m === mode));
@@ -469,6 +515,158 @@ function gradeLesson(wasCorrect: boolean): void {
   render();
 }
 
+// --- learn mode — the curriculum session -----------------------------------
+//
+// This is the app's spine made visible: a single concept, taught across every
+// active language that has it, in chain order, each stop showing the word and —
+// the whole point — the threads back to the languages already learned. The
+// learner walks the concept spine forward one step at a time; "covered" grows
+// with the cursor, which is what the review quiz (a later slice) will draw from.
+//
+// All the sequencing is in the engine (`planSession` → teaching sweep with
+// connections); this function only lays it out. Everything goes in via
+// textContent — the corpus is repo-authored, but it is still data.
+
+/** Humanize a concept tag ("COURTESY-THANKS") for a heading ("courtesy · thanks"). */
+function conceptTitle(tag: string): string {
+  return tag.toLowerCase().replace(/_/g, " ").replace(/-/g, " · ");
+}
+
+/** The gloss of the first lesson taught in the sweep, for the concept subhead. */
+function firstGloss(teaching: SessionStep[]): string {
+  return teaching[0]?.lessons[0]?.gloss ?? "";
+}
+
+/** One stop of the sweep: a language, its word(s) for the concept, its threads back. */
+function renderTeachingStep(step: SessionStep, ordinal: number): HTMLElement {
+  const card = el("div", "step");
+
+  const head = el("div", "step__head");
+  const num = el("span", "step__num");
+  num.textContent = String(ordinal + 1);
+  const lang = el("span", "step__lang");
+  lang.textContent = step.language;
+  head.append(num, lang);
+  if (ordinal === 0) {
+    // The first stop has no connections — it is where the concept enters.
+    const badge = el("span", "step__badge");
+    badge.textContent = "introduced here";
+    head.appendChild(badge);
+  }
+  card.appendChild(head);
+
+  for (const lesson of step.lessons) {
+    const row = el("div", "step__word");
+    const glyph = el("span", "step__glyph");
+    glyph.textContent = lesson.headword; // in its own script
+    row.appendChild(glyph);
+
+    const meta = el("div", "step__meta");
+    // Only show romanization when it adds something the headword doesn't.
+    if (lesson.romanization && lesson.romanization !== lesson.headword) {
+      const rom = el("span", "step__rom");
+      rom.textContent = lesson.romanization;
+      meta.appendChild(rom);
+    }
+    const gl = el("span", "step__gloss");
+    gl.textContent = lesson.gloss;
+    meta.appendChild(gl);
+    row.appendChild(meta);
+    card.appendChild(row);
+
+    if (lesson.etymologyHook) {
+      const hook = el("p", "step__hook");
+      hook.textContent = lesson.etymologyHook;
+      card.appendChild(hook);
+    }
+  }
+
+  // The threads back to earlier languages — the spiral, made literal. Each is a
+  // grounded link: the two words genuinely share the named root.
+  for (const c of step.connections) {
+    const conn = el("p", "step__conn");
+    conn.textContent = `↩ connects to ${c.to} — shared root ${c.sharedRoots.join(", ")}`;
+    card.appendChild(conn);
+  }
+  return card;
+}
+
+/** Prev / Next along the concept spine — walking the curriculum forward. */
+function renderLearnNav(): HTMLElement {
+  const nav = el("div", "learn__nav");
+  const prev = el("button", "opt") as HTMLButtonElement;
+  prev.textContent = "← Previous concept";
+  prev.disabled = conceptCursor === 0;
+  prev.onclick = () => {
+    if (conceptCursor > 0) {
+      conceptCursor -= 1;
+      render();
+    }
+  };
+  const next = el("button", "opt") as HTMLButtonElement;
+  next.textContent = "Next concept →";
+  next.disabled = conceptCursor >= CONCEPT_SPINE.length - 1;
+  next.onclick = () => {
+    if (conceptCursor < CONCEPT_SPINE.length - 1) {
+      conceptCursor += 1;
+      render();
+    }
+  };
+  nav.append(prev, next);
+  return nav;
+}
+
+function renderLearn(): HTMLElement {
+  const wrap = el("div", "learn");
+
+  if (CONCEPT_SPINE.length === 0) {
+    const empty = el("p", "muted");
+    empty.textContent = "No concepts to walk yet.";
+    wrap.appendChild(empty);
+    return wrap;
+  }
+
+  // The cursor only moves via the nav buttons, but clamp defensively so a stray
+  // value can never index off the end of the spine.
+  conceptCursor = Math.max(0, Math.min(conceptCursor, CONCEPT_SPINE.length - 1));
+
+  const concept = CONCEPT_SPINE[conceptCursor]!;
+  // Everything up to and including the current concept is "covered" — the review
+  // quiz (a later slice) draws from exactly this. Here we render the teaching
+  // pass: the current concept alone, swept across the chain.
+  const covered = CONCEPT_SPINE.slice(0, conceptCursor + 1);
+  const plan = planSession(concept, covered, CONCEPT_LESSONS, ACTIVE_COUNT);
+
+  const progress = el("p", "score");
+  progress.textContent =
+    `Concept ${conceptCursor + 1} of ${CONCEPT_SPINE.length}` +
+    ` · taught in ${plan.teaching.length} language${plan.teaching.length === 1 ? "" : "s"}`;
+  wrap.appendChild(progress);
+
+  const heading = el("h2", "learn__concept");
+  heading.textContent = conceptTitle(concept);
+  wrap.appendChild(heading);
+  const gloss = firstGloss(plan.teaching);
+  if (gloss) {
+    const g = el("p", "muted learn__gloss");
+    g.textContent = gloss;
+    wrap.appendChild(g);
+  }
+
+  if (plan.teaching.length === 0) {
+    const none = el("p", "muted");
+    none.textContent = "No active language teaches this concept yet.";
+    wrap.appendChild(none);
+  } else {
+    const sweep = el("div", "sweep");
+    plan.teaching.forEach((step, i) => sweep.appendChild(renderTeachingStep(step, i)));
+    wrap.appendChild(sweep);
+  }
+
+  wrap.appendChild(renderLearnNav());
+  return wrap;
+}
+
 /**
  * Concepts mode — the same idea, side by side, in every language that has it.
  *
@@ -641,12 +839,15 @@ function render(): void {
   // The script tabs steer per-script work; hide them during a mixed session,
   // and in Lessons/Concepts modes, which span every language rather than one
   // script.
-  const spansAllLanguages = mode === "lessons" || mode === "concepts";
+  const spansAllLanguages =
+    mode === "learn" || mode === "lessons" || mode === "concepts";
   if (!spansAllLanguages && !(mode === "practice" && scope === "mixed")) {
     app!.appendChild(renderTabs());
   }
 
-  if (mode === "concepts") {
+  if (mode === "learn") {
+    app!.appendChild(renderLearn());
+  } else if (mode === "concepts") {
     app!.appendChild(renderConcepts());
   } else if (mode === "lessons") {
     app!.appendChild(renderLessons());

--- a/code/programs/typescript/script-writing-visualizer/src/styles.css
+++ b/code/programs/typescript/script-writing-visualizer/src/styles.css
@@ -233,3 +233,80 @@ body {
 @media (max-width: 560px) {
   .concept__row { grid-template-columns: 1fr; gap: 2px; }
 }
+
+/* --- learn mode — the curriculum session -------------------------------- */
+.learn { max-width: 640px; }
+.learn__concept {
+  font-size: 1.5rem;
+  margin: 2px 0 2px;
+  text-transform: capitalize;
+}
+.learn__gloss { margin: 0 0 18px; font-size: 1rem; font-style: normal; }
+
+/* The sweep: one card per language stop, read top-to-bottom in chain order. */
+.sweep { display: flex; flex-direction: column; gap: 12px; }
+.step {
+  border: 1px solid var(--line);
+  background: var(--card);
+  border-radius: 8px;
+  padding: 12px 14px;
+}
+.step__head { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }
+.step__num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  background: var(--ink);
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 700;
+  flex: none;
+}
+.step__lang {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  font-weight: 600;
+}
+.step__badge {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  padding: 1px 8px;
+}
+.step__word { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; }
+.step__glyph { font-size: 1.9rem; line-height: 1.2; }
+.step__meta { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
+.step__rom { color: var(--muted); font-style: italic; font-size: 0.95rem; }
+.step__gloss { font-size: 0.95rem; }
+.step__hook { margin: 8px 0 0; font-size: 0.85rem; line-height: 1.5; color: var(--muted); }
+/* The threads back to earlier languages — the reason the whole app exists. */
+.step__conn {
+  margin: 8px 0 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--accent);
+  background: #eef1fd;
+  border-left: 3px solid var(--accent);
+  padding: 5px 10px;
+  border-radius: 0 4px 4px 0;
+}
+.learn__nav { display: flex; justify-content: space-between; gap: 10px; margin-top: 20px; }
+.learn__nav .opt {
+  border: 1px solid var(--line);
+  background: var(--card);
+  color: var(--ink);
+  border-radius: 6px;
+  padding: 8px 16px;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+.learn__nav .opt:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
+.learn__nav .opt:disabled { opacity: 0.4; cursor: default; }


### PR DESCRIPTION
## What

The first visible slice of the HL03 unified app: a new **Learn** mode (now the default) that walks the curriculum the way the book does — **one concept at a time, forward along the language chain** — rendering the already-merged engine's *teaching pass* (`sessionplan.ts` → `planSession`) as a numbered sweep of cards, one per active language that teaches the concept, in chain order (Spanish → Latin → French → … → Malayalam).

Each card shows:
- the word **in its own script**, with gloss / romanization,
- its **etymology hook**, and
- the **connections back** to earlier languages that share a root — the spiral made visible.

Prev / Next walk the **concept spine** (`sweepableConcepts`, book order). The first stop of each sweep wears an "introduced here" badge.

## Consolidation filter

`practice` / `practice-mix` / `review` lessons (placeholder headwords like `(practice)`, no roots, `reviews_of` links) are filtered out of the teaching spine — that kind of revisiting is what the **review quiz** is for. Spine goes **205 → 186** concepts, so concept #1 is now `COURTESY-THANKS`, not `(practice)`.

## Verification

- All **185** engine tests still pass (this slice is a DOM-only shell over the tested engine; no engine changes).
- Verified in a **real browser** (headless Chrome screenshot, read back): every script renders with **no tofu/mojibake** — gracias · grātiās agō · merci · danke · شكرا · धन्यवाद · நன்றி · ಧನ್ಯವಾದ · ధన్యవాదములు · നന്ദി — and the ten-language THANKS sweep shows its grounded `dhanya` / `nal` threads (Kannada→Hindi, Telugu→Hindi+Kannada, Malayalam→Tamil).
- Correctness/security review (subagent): clean — no `innerHTML`, no OOB/TDZ, no leftover debug code.

## Scope

Teaching view only. The **review quiz** (`pickNext` / `applyAnswer` over the covered grid, plus "what I keep confusing" from `confusions(log)`) is the next slice (**6b-2**). Renaming the app away from `script-writing-visualizer` is **6c**.

Builds on #8862 (slice 6a, merged).