### PR TITLE
feat(semantic-ir-to-ruby): keyword parameters — native x: (SIR19)

### DIFF
--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.9.0 — keyword parameters (SIR19)
+
+Accepts `Feature::KeywordParams`. Ruby has native keyword arguments, so this is
+a direct emission — no positional resolution like the Go/C backends' KW6:
+
+- A **keyword parameter** renders `def f(x:)` (required) or `def f(x: <default>)`
+  (optional — a keyword default is an optional keyword, riding on
+  `KeywordParams`, not `DefaultParams`).
+- A **keyword argument** (`Expr::KeywordArg`) renders `x: <value>` in the call's
+  argument list; Ruby binds it to the parameter by **name**, so keyword
+  arguments are order-independent (`f(b: 2, a: 10)` binds `a`/`b` correctly). The
+  label is sanitised identically to the parameter it binds, so the two agree.
+- The unsupported-builtin pre-check (`scan_expr`) recurses into a keyword
+  argument's value.
+
+While restructuring the parameter loop, made it **total** over every
+`ParamKind`: a `Rest` parameter now renders `*rest` and a `KwRest` renders
+`**opts` (native Ruby), where both were previously mis-emitted as bare names.
+This matters because a `**opts` co-occurs with keyword parameters, so accepting
+`KeywordParams` must not leave it broken. (These kinds carry no feature of their
+own — a validator matter — but the emitter now spells all four kinds correctly.)
+
+First of the KeywordParams parity arc: Go/Python/JS already accept it; this
+brings the Ruby backend up (C is tracked next; the Rust backend is a separate
+gap). Verified through a real `ruby` with hand-built modules: a keyword argument
+binding by name, order-independent resolution (`f(b: 2, a: 10)` → `8` for `f(a:,
+b:) = a - b`), an optional keyword using its default when omitted (`f()` → `7`
+for `f(x: 7)`) and overridden when supplied, native `x:` / `x: 5` syntax, and
+the `*rest` / `**opts` splat emission. Bumps semantic-ir-to-ruby 0.8.0 → 0.9.0.
+
 ## 0.8.0 — default parameters (SIR19)
 
 Accepts `Feature::DefaultParams`. A positional parameter carrying a default

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/README.md
+++ b/code/packages/rust/semantic-ir-to-ruby/README.md
@@ -57,9 +57,12 @@ so `7.0` stays a Float, not the Integer `7`; `Infinity`/`NaN` are named), with
 native float arithmetic and division; SIR16 `ShortCircuit` — `LogicalAnd`
 (`&&`) and `LogicalOr` (`||`) rendered as Ruby's native short-circuit
 operators, which yield the deciding operand and skip the dead branch exactly as
-SIR requires; and SIR19 `DefaultParams` — a positional parameter with a default
+SIR requires; SIR19 `DefaultParams` — a positional parameter with a default
 renders as native `def f(a, b = <default>)` (evaluated at call time when the
-argument is omitted; may reference an earlier parameter).
+argument is omitted; may reference an earlier parameter); and SIR19
+`KeywordParams` — a keyword parameter (`def f(x:)` / `def f(x: 1)`) and keyword
+argument (`f(x: 5)`) render as Ruby's native keyword forms, matched by name (so
+order-independent).
 Rejects `TailCalls`, `Intrinsics`, and every not-yet-wired feature (array
 indexing / slicing via `IndexGet` — `NDArrays`; array-pattern destructuring;
 collection methods, exceptions, OOP) until its cascade batch

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -10,7 +10,7 @@
 use std::fmt::Write;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use semantic_ir::{Block, Expr, Function, Global, IntWidth, Module, Scope, Stmt};
+use semantic_ir::{Block, Expr, Function, Global, IntWidth, Module, ParamKind, Scope, Stmt};
 
 use crate::runtime::RUNTIME;
 
@@ -216,6 +216,9 @@ fn scan_expr(e: &Expr) -> Option<(String, semantic_ir::Span)> {
         Expr::LogicalAnd { lhs, rhs, .. } | Expr::LogicalOr { lhs, rhs, .. } => {
             scan_expr(lhs).or_else(|| scan_expr(rhs))
         }
+        // A keyword argument carries its value as a sub-expression — scan it so
+        // an unsupported builtin in `f(x: foo())` is reported cleanly.
+        Expr::KeywordArg { value, .. } => scan_expr(value),
         _ => None,
     }
 }
@@ -250,15 +253,42 @@ fn emit_function(out: &mut String, f: &Function) {
             out.push_str(", ");
         }
         first = false;
-        out.push_str(&sanitize_ident(&p.name));
-        // SIR19 default parameter (`Feature::DefaultParams`): render Ruby's
-        // native `name = <default>`.  Ruby evaluates the default at call time
-        // when the argument is omitted — exactly the SIR semantics — and left to
-        // right, so a default may reference an earlier parameter (`def f(a, b =
-        // a)`).  Only a positional default reaches here; a keyword default is
-        // the separate (unaccepted) `KeywordParams` feature.
-        if let Some(default) = &p.default {
-            let _ = write!(out, " = {}", emit_expr(default));
+        let name = sanitize_ident(&p.name);
+        // Every `ParamKind` has a native Ruby spelling — the canonical order the
+        // validator enforces (`Required* Rest? Keyword* KwRest?`) is exactly
+        // Ruby's, so emitting each in place yields a valid signature.
+        match p.kind {
+            // `x` / `x = <default>` — a positional parameter, optionally with a
+            // SIR19 default (`Feature::DefaultParams`).  Ruby evaluates the
+            // default at call time when the argument is omitted, left to right,
+            // so it may reference an earlier parameter (`def f(a, b = a)`).
+            ParamKind::Required => {
+                out.push_str(&name);
+                if let Some(default) = &p.default {
+                    let _ = write!(out, " = {}", emit_expr(default));
+                }
+            }
+            // `x:` / `x: <default>` — a native keyword parameter
+            // (`Feature::KeywordParams`): required when it has no default, an
+            // optional keyword when it does (a keyword default rides on
+            // `KeywordParams`, not `DefaultParams`).  Matched by NAME at the
+            // call site, which Ruby handles natively.
+            ParamKind::Keyword => {
+                let _ = write!(out, "{name}:");
+                if let Some(default) = &p.default {
+                    let _ = write!(out, " {}", emit_expr(default));
+                }
+            }
+            // `*rest` — a native rest parameter collecting trailing positionals
+            // into an `Array`.  (Rest/KwRest carry no default.)
+            ParamKind::Rest => {
+                let _ = write!(out, "*{name}");
+            }
+            // `**opts` — a native keyword-rest parameter collecting unmatched
+            // keywords into a `Hash`.
+            ParamKind::KwRest => {
+                let _ = write!(out, "**{name}");
+            }
         }
     }
     out.push_str(")\n");
@@ -556,6 +586,14 @@ fn emit_expr(e: &Expr) -> String {
         }
         Expr::LogicalOr { lhs, rhs, .. } => {
             format!("({} || {})", emit_expr(lhs), emit_expr(rhs))
+        }
+        // A SIR19 keyword argument (`Feature::KeywordParams`): `name: <value>`
+        // in a call's argument list.  Ruby matches it to the callee's keyword
+        // parameter by name natively, so no positional resolution is needed
+        // (unlike the Go/C backends).  The label is sanitised identically to the
+        // keyword parameter it binds, so the two always agree.
+        Expr::KeywordArg { name, value, .. } => {
+            format!("{}: {}", sanitize_ident(name), emit_expr(value))
         }
         other => unreachable!("Ruby backend reached unsupported expr: {other:?}"),
     }

--- a/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
@@ -125,6 +125,13 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // unsupported-builtin pre-check now scans each parameter default too, so the
     // emitter stays total.
     Feature::DefaultParams,
+    // ── SIR19 keyword parameters ─────────────────────────────────────
+    // A keyword parameter (`def f(x:)` / `def f(x: 1)`) and a keyword argument
+    // (`f(x: 5)`) render as Ruby's NATIVE keyword forms — Ruby matches a keyword
+    // argument to its parameter by name, so no positional resolution is needed
+    // (unlike the Go/C backends' KW6 lowering).  A keyword default rides on this
+    // feature (an optional keyword), not `DefaultParams`.
+    Feature::KeywordParams,
 ];
 
 impl Backend for RubyBackend {

--- a/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
@@ -1093,3 +1093,127 @@ fn unsupported_builtin_in_an_indirect_call_target_is_rejected_cleanly() {
         "a bad builtin in an IndirectCall target must be rejected, not panic"
     );
 }
+
+// ── SIR19 keyword parameters ────────────────────────────────────────────────
+// `Feature::KeywordParams` — a keyword parameter (`def f(x:)` / `def f(x: 1)`)
+// and a keyword argument (`f(x: 5)`) render as Ruby's NATIVE keyword forms;
+// Ruby matches by name, so no positional resolution is needed (unlike Go/C).
+
+fn kwparam(name: &str, default: Option<Expr>) -> Param {
+    Param {
+        name: name.into(),
+        sir_type: None,
+        kind: ParamKind::Keyword,
+        default: default.map(Box::new),
+        span: s2(),
+    }
+}
+fn kwarg(name: &str, value: Expr) -> Expr {
+    Expr::KeywordArg { name: name.into(), value: Box::new(value), span: s2() }
+}
+/// Like `defparam_module` but declaring `KeywordParams` (+ `DynamicTyping`).
+fn kwparam_module(params: Vec<Param>, body_value: Expr, main_stmts: Vec<Stmt>) -> Module {
+    let mut m = defparam_module(params, body_value, main_stmts);
+    m.manifest = FeatureManifest::from_features(&[
+        Feature::KeywordParams,
+        Feature::DynamicTyping,
+    ]);
+    m
+}
+fn run_kwparam(params: Vec<Param>, body_value: Expr, main_stmts: Vec<Stmt>) -> Option<String> {
+    let m = kwparam_module(params, body_value, main_stmts);
+    run_ruby(&compile(&m).expect("keyword-param module must compile, not panic").source)
+}
+
+#[test]
+fn keyword_argument_binds_to_the_keyword_parameter() {
+    // `def f(x:); x; end` called `f(x: 5)` → `5`.
+    let out = run_kwparam(
+        vec![kwparam("x", None)],
+        pref("x"),
+        vec![puts(directcall("f", vec![kwarg("x", ilit(5))]))],
+    );
+    match out {
+        Some(o) => assert_eq!(o, "5"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn keyword_arguments_resolve_by_name_regardless_of_order() {
+    // `def f(a:, b:); a - b; end` called `f(b: 2, a: 10)` → `8` — a keyword
+    // argument binds by NAME, so the call order does not matter (Ruby native).
+    let out = run_kwparam(
+        vec![kwparam("a", None), kwparam("b", None)],
+        bin("-", pref("a"), pref("b")),
+        vec![puts(directcall("f", vec![kwarg("b", ilit(2)), kwarg("a", ilit(10))]))],
+    );
+    match out {
+        Some(o) => assert_eq!(o, "8"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn optional_keyword_uses_its_default_when_omitted() {
+    // `def f(x: 7); x; end` — `f()` uses the default (`7`), `f(x: 9)` overrides
+    // it (`9`). A keyword default is an OPTIONAL keyword (rides on
+    // `KeywordParams`, not `DefaultParams`).
+    let out = run_kwparam(
+        vec![kwparam("x", Some(ilit(7)))],
+        pref("x"),
+        vec![
+            puts(directcall("f", vec![])),                 // 7
+            puts(directcall("f", vec![kwarg("x", ilit(9))])), // 9
+        ],
+    );
+    match out {
+        Some(o) => assert_eq!(o, "7\n9"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn keyword_param_and_arg_emit_native_ruby_syntax() {
+    // Emit-shape: the signature carries `x:` and the call carries `x: 5`.
+    let rb = compile(&kwparam_module(
+        vec![kwparam("x", None)],
+        pref("x"),
+        vec![puts(directcall("f", vec![kwarg("x", ilit(5))]))],
+    ))
+    .expect("compile")
+    .source;
+    assert!(rb.contains("def f(x:)"), "keyword parameter syntax:\n{rb}");
+    assert!(rb.contains("x: 5"), "keyword argument syntax:\n{rb}");
+}
+
+#[test]
+fn rest_and_keyword_rest_params_emit_splat_syntax() {
+    // Making the parameter emitter TOTAL: a `Rest` parameter renders `*rest`
+    // and a `KwRest` renders `**opts` — native Ruby.  A `**opts` in particular
+    // co-occurs with keyword parameters, so accepting `KeywordParams` must not
+    // leave it mis-emitted as a bare name. (These kinds carry no feature of
+    // their own, so the untyped-param `DynamicTyping` is the only manifest
+    // requirement.)
+    let splat = |kind: ParamKind, name: &str| Param {
+        name: name.into(),
+        sir_type: None,
+        kind,
+        default: None,
+        span: s2(),
+    };
+    // `def f(a, *rest, x:, **opts)` — canonical order the validator enforces.
+    let rb = compile(&kwparam_module(
+        vec![
+            param("a", None),
+            splat(ParamKind::Rest, "rest"),
+            kwparam("x", None),
+            splat(ParamKind::KwRest, "opts"),
+        ],
+        pref("a"),
+        vec![],
+    ))
+    .expect("compile")
+    .source;
+    assert!(rb.contains("def f(a, *rest, x:, **opts)"), "splat syntax:\n{rb}");
+}

--- a/code/specs/SIR25-semantic-ir-to-ruby.md
+++ b/code/specs/SIR25-semantic-ir-to-ruby.md
@@ -74,9 +74,11 @@ SIR26 integer conversions (`Conversions`, `SizedIntegers`, `Unsigned`,
 `WrappingArithmetic`); and the SIR16 batches `Loops` + `MutableBindings`
 (0.3.0), `Sequences` (native `Array`, 0.4.0), `Maps` (native `Hash`, 0.5.0),
 `Floats` (native `Float`, 0.6.0), and `ShortCircuit` (native `&&`/`||`, 0.7.0);
-and SIR19 `DefaultParams` (native `def f(a, b = <default>)`, 0.8.0).
+and the SIR19 parameter batches `DefaultParams` (native `def f(a, b =
+<default>)`, 0.8.0) and `KeywordParams` (native `def f(x:)` / `f(x: 5)`, matched
+by name, 0.9.0).
 
-**Still rejects** `TailCalls`, `Intrinsics`, `NDArrays`, `KeywordParams`,
+**Still rejects** `TailCalls`, `Intrinsics`, `NDArrays`,
 exceptions/OOP, and every not-yet-landed feature (each rejection is a clean,
 source-positioned `UnsupportedFeature`).
 


### PR DESCRIPTION
## What

Adds SIR19 **keyword parameters** to the Ruby backend (`semantic-ir-to-ruby` 0.8.0 → 0.9.0) — the first of the KeywordParams parity arc (Go/Python/JS already accept `Feature::KeywordParams`; the C backend is tracked next; the Rust backend is a separate gap).

Ruby has native keyword arguments, so this is a **direct emission** — no positional resolution like the Go/C backends' KW6:

- A **keyword parameter** renders `def f(x:)` (required) or `def f(x: <default>)` (optional — a keyword default is an optional keyword, riding on `KeywordParams`, not `DefaultParams`).
- A **keyword argument** (`Expr::KeywordArg`) renders `x: <value>` in the call's argument list; Ruby binds by **name**, so keyword arguments are order-independent (`f(b: 2, a: 10)` binds `a`/`b` correctly). The label is sanitised identically to the parameter it binds, so the two always agree (no misbinding).

While restructuring the parameter loop, made it **total** over every `ParamKind`: a `Rest` param now renders `*rest` and a `KwRest` renders `**opts` (native Ruby), where both were previously mis-emitted as bare names — this matters because a `**opts` co-occurs with keyword parameters.

## Verification

- `cargo test -p semantic-ir-to-ruby` — **54 tests green** (5 new), through a real `ruby` with hand-built modules: a keyword argument binding by name, order-independent resolution (`f(b: 2, a: 10)` → `8` for `f(a:, b:) = a - b`), an optional keyword using its default when omitted (`f()` → `7` for `f(x: 7)`) and overridden when supplied, native `x:` / `x: 5` syntax, and the `*rest`/`**opts` splat emission.
- `cargo clippy -p semantic-ir-to-ruby --all-targets` clean.
- Security review passed — param and arg use *identical* `sanitize_ident` (no injection/misbinding); a `KeywordArg` outside a call is a clean validator rejection (not a panic, unlike Go/C). (One out-of-threat-model robustness nit noted: a `sanitize_ident` collision between two exotic distinct names would produce a Ruby parse-time `SyntaxError` locally — a validator-wide dedup follow-up, not a blocker.)
- SIR25 spec capability section synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)