### PR TITLE
fix(semantic-ir-to-javascript): add eval/arguments to is_js_reserved (strict-mode contextual reserved words)

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.51.5 — `is_js_reserved` was missing `eval`/`arguments` (task #110)
+
+**Not a syntactic-keyword gap — a strict-mode contextual-reserved-word
+gap.** `is_js_reserved` (`emit.rs`) is the shared identifier-safety check
+every frontend that lowers to this backend (MATLAB, Octave, Wolfram,
+Macsyma, Maxima, APL, J, Derive, Reduce, Maple, Scilab, Q, Python, Ruby,
+JS, Twig, and more) goes through via `sanitize_ident`/`is_valid_js_ident`
+before emitting a user-level identifier as a JS binding. It already listed
+every syntactic keyword (`if`, `for`, `class`, …) plus a handful of
+contextual ones unsafe as bindings (`let`, `static`, `await`, `async`,
+and the "future reserved in strict mode" set) — but not `eval` or
+`arguments`.
+
+Neither is a syntactic keyword; both are ordinary identifiers lexically.
+But every module this backend emits runs under strict-mode semantics
+(`"use strict";` / ES-module code), and strict mode specifically forbids
+binding, assigning to, or otherwise declaring a variable, parameter,
+function, or class named `eval` or `arguments` — a `SyntaxError` at
+parse time. Even in the (non-existent, for this backend) sloppy-mode
+case, shadowing either name silently breaks the special semantics it
+normally carries (`arguments` inside a non-arrow function). A SIR module
+with a user-level name `eval` or `arguments` would previously have been
+emitted verbatim by `sanitize_ident` (since `is_js_reserved` returned
+`false`), producing invalid/miscompiled JavaScript.
+
+Fixed by adding both to the existing contextual-reserved-word group in
+`is_js_reserved`'s `matches!` list (same style as the existing entries;
+no restructuring). New unit test
+`is_js_reserved_flags_strict_mode_contextual_words` pins both as reserved
+and confirms ordinary look-alike identifiers (`value`, `evaluate`,
+`argument`) are untouched.
+
 ## 0.51.4 — Q's own display convention (task #109, the direct Q sibling of J's `SIR_DISPLAY_J_UNDERSCORE` fix)
 
 `q-to-semantic-ir/tests/oracle.rs` (built alongside the runtime in the same

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.51.4"
+version = "0.51.5"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -1996,6 +1996,8 @@ fn is_js_reserved(s: &str) -> bool {
             | "private"
             | "protected"
             | "public"
+            | "arguments"
+            | "eval"
     )
 }
 
@@ -2077,6 +2079,25 @@ mod tests {
         assert_eq!(sanitize_ident("class"), "_$class");
         assert!(sanitize_ident("function").starts_with("_$"));
         assert!(sanitize_ident("await").starts_with("_$"));
+    }
+
+    #[test]
+    fn is_js_reserved_flags_strict_mode_contextual_words() {
+        // `eval` and `arguments` are not syntactic keywords, but this
+        // backend always emits strict-mode code (`"use strict";` / ES
+        // modules), and strict mode forbids binding, assigning to, or
+        // otherwise shadowing either name — so they must be treated as
+        // reserved here too, exactly like the syntactic keywords above.
+        assert!(is_js_reserved("eval"));
+        assert!(is_js_reserved("arguments"));
+        assert!(sanitize_ident("eval").starts_with("_$"));
+        assert!(sanitize_ident("arguments").starts_with("_$"));
+
+        // Ordinary identifiers — including close look-alikes — are
+        // unaffected by the addition.
+        assert!(!is_js_reserved("value"));
+        assert!(!is_js_reserved("evaluate"));
+        assert!(!is_js_reserved("argument"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `is_js_reserved` (shared identifier-safety check in `semantic-ir-to-javascript`, used by every frontend that lowers to this backend — MATLAB, Octave, Wolfram, Macsyma, Maxima, APL, J, Derive, Reduce, Maple, Scilab, Q, Python, Ruby, JS, Twig, etc.) was missing `eval` and `arguments`.
- Neither is a JS syntactic keyword, but this backend always emits strict-mode code (`"use strict";` / ES modules), and strict mode forbids binding/assigning/shadowing either name as a variable, parameter, function, or class name — a `SyntaxError`. A SIR module using either name as a user-level identifier was previously emitted verbatim into invalid JavaScript.
- Fixed by adding both to the existing contextual-reserved-word group in the `matches!` list, same style as existing entries, no restructuring.
- New regression test `is_js_reserved_flags_strict_mode_contextual_words` pins both as reserved and confirms look-alike identifiers (`value`, `evaluate`, `argument`) are unaffected.
- Version bump 0.51.4 → 0.51.5 + CHANGELOG entry.

Task #110 in the ongoing HML01/SIR hardening track.

## Test plan
- [x] `cargo test -p semantic-ir-to-javascript` — 145 unit tests + all integration suites pass, including the new test
- [x] Revert-and-confirm: temporarily removed the two new match arms, confirmed the new test fails with the exact predicted assertion failure, restored the fix, confirmed it passes again
- [x] `cargo check --workspace` (excluding a pre-existing, unrelated `os-kernel`/UEFI `panic_impl` failure and two Windows-only crates) — clean
- [x] `/security-review` — passed clean (one INFO follow-up noted: `semantic-ir-to-typescript`'s `is_ts_reserved` has the identical gap — tracked separately as task #112)

🤖 Generated with [Claude Code](https://claude.com/claude-code)