### PR TITLE
feat(spice): add bias-dependent BJT base resistance

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add BJT model-card `RBM` and `IRB` support for Berkeley bias-dependent base
+  resistance across DC, AC, transient, transfer-function, and noise analysis.
 - Add BJT model-card `RB` base-resistance support with an intrinsic base node
   in DC, AC, and transient analysis plus thermal noise in noise analysis.
 - Add BJT model-card `RC` collector-resistance support with an intrinsic

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -625,7 +625,13 @@ class BJT:
     Rc:
         Constant external-to-intrinsic collector resistance in Ohms (default 0.0).
     Rb:
-        Constant external-to-intrinsic base resistance in Ohms (default 0.0).
+        Zero-bias external-to-intrinsic base resistance in Ohms (default 0.0).
+    Rbm:
+        Optional minimum high-current base resistance in Ohms. When omitted,
+        it defaults to ``Rb``.
+    Irb:
+        Base current where the resistance is halfway between ``Rb`` and
+        ``Rbm`` (default 0.0, disabled).
     """
 
     name: str
@@ -669,6 +675,8 @@ class BJT:
     Re: float = 0.0            # emitter resistance (ohms)
     Rc: float = 0.0            # collector resistance (ohms)
     Rb: float = 0.0            # base resistance (ohms)
+    Rbm: float | None = None   # minimum base resistance (ohms)
+    Irb: float = 0.0           # base-resistance half-current (A)
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -605,7 +605,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr, element.Tnom, element.Kf, element.Af, element.Ptf, element.Xtf, element.Itf, element.Vtf, element.Re, element.Rc, element.Rb)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr, element.Tnom, element.Kf, element.Af, element.Ptf, element.Xtf, element.Itf, element.Vtf, element.Re, element.Rc, element.Rb, element.Rbm, element.Irb)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -9142,6 +9142,62 @@ def _bjt_reverse_base_current(el: BJT, junction_voltage: float) -> tuple[float, 
     )
 
 
+def _bjt_effective_base_resistance(
+    el: BJT,
+    base_voltage: float,
+    emitter_voltage: float,
+    collector_voltage: float,
+) -> float:
+    minimum = el.Rb if el.Rbm is None else el.Rbm
+    if minimum == el.Rb:
+        return el.Rb
+    junction_voltage = (
+        base_voltage - emitter_voltage
+        if el.polarity == "NPN"
+        else emitter_voltage - base_voltage
+    )
+    reverse_voltage = (
+        base_voltage - collector_voltage
+        if el.polarity == "NPN"
+        else collector_voltage - base_voltage
+    )
+    forward_thermal_voltage = el.Vt * el.Nf
+    exp_value = math.exp(
+        max(-40.0, min(40.0, junction_voltage / forward_thermal_voltage))
+    )
+    diffusion_current = el.Is * (exp_value - 1.0)
+    diffusion_conductance = el.Is / forward_thermal_voltage * exp_value
+    output_voltage = (
+        collector_voltage - emitter_voltage
+        if el.polarity == "NPN"
+        else emitter_voltage - collector_voltage
+    )
+    early_factor = _bjt_early_factor(el, junction_voltage, output_voltage)
+    _, _, charge_factor = _bjt_forward_transport(
+        el, diffusion_current, diffusion_conductance, early_factor
+    )
+    leakage_current, _ = _bjt_base_emitter_leakage(el, junction_voltage)
+    collector_leakage_current, _ = _bjt_base_collector_leakage(el, reverse_voltage)
+    reverse_base_current, _ = _bjt_reverse_base_current(el, reverse_voltage)
+    base_current = (
+        diffusion_current / el.beta_f
+        + leakage_current
+        + collector_leakage_current
+        + reverse_base_current
+    )
+    variable_resistance = el.Rb - minimum
+    if el.Irb == 0.0:
+        return minimum + variable_resistance / charge_factor
+    ratio = max(base_current / el.Irb, 1.0e-9)
+    angle = (
+        (-1.0 + math.sqrt(1.0 + 14.59025 * ratio))
+        / (2.4317 * math.sqrt(ratio))
+    )
+    tangent = math.tan(angle)
+    transition = 3.0 * (tangent - angle) / (angle * tangent * tangent)
+    return minimum + variable_resistance * transition
+
+
 def _stamp_bjt(
     G: list[list[float]],
     b: list[float],
@@ -9219,8 +9275,12 @@ def _stamp_bjt(
         el = replace(el, collector=intrinsic_collector, Rc=0.0)
     if el.Rb > 0.0:
         intrinsic_base = _bjt_intrinsic_base_node(el)
-        _stamp_g(G, node_to_idx, el.base, intrinsic_base, 1.0 / el.Rb)
-        el = replace(el, base=intrinsic_base, Rb=0.0)
+        Vb_rb = 0.0 if _is_ground(intrinsic_base) else x[node_to_idx[intrinsic_base]]
+        Ve_rb = 0.0 if _is_ground(el.emitter) else x[node_to_idx[el.emitter]]
+        Vc_rb = 0.0 if _is_ground(el.collector) else x[node_to_idx[el.collector]]
+        base_resistance = _bjt_effective_base_resistance(el, Vb_rb, Ve_rb, Vc_rb)
+        _stamp_g(G, node_to_idx, el.base, intrinsic_base, 1.0 / base_resistance)
+        el = replace(el, base=intrinsic_base, Rb=0.0, Rbm=None, Irb=0.0)
     # --- Resolve node voltages at the current Newton iterate -----------------
     Vb = 0.0 if _is_ground(el.base) else x[node_to_idx[el.base]]
     Ve = 0.0 if _is_ground(el.emitter) else x[node_to_idx[el.emitter]]
@@ -9399,6 +9459,14 @@ def _validate_bjt(el: BJT) -> None:
     if not math.isfinite(el.Rb) or el.Rb < 0.0:
         raise ValueError(
             f"{el.name}: BJT base resistance must be finite and non-negative"
+        )
+    if el.Rbm is not None and (not math.isfinite(el.Rbm) or el.Rbm < 0.0):
+        raise ValueError(
+            f"{el.name}: BJT minimum base resistance must be finite and non-negative"
+        )
+    if not math.isfinite(el.Irb) or el.Irb < 0.0:
+        raise ValueError(
+            f"{el.name}: BJT base-resistance half-current must be finite and non-negative"
         )
     if not math.isfinite(el.Ise) or el.Ise < 0.0:
         raise ValueError(
@@ -12677,14 +12745,28 @@ def _stamp_ac(
             el = replace(el, collector=intrinsic_collector, Rc=0.0)
         if el.Rb > 0.0:
             intrinsic_base = _bjt_intrinsic_base_node(el)
+            Vb_rb = (
+                0.0
+                if _is_ground(intrinsic_base)
+                else dc_x[node_to_idx[intrinsic_base]]
+            )
+            Ve_rb = 0.0 if _is_ground(el.emitter) else dc_x[node_to_idx[el.emitter]]
+            Vc_rb = (
+                0.0
+                if _is_ground(el.collector)
+                else dc_x[node_to_idx[el.collector]]
+            )
+            base_resistance = _bjt_effective_base_resistance(
+                el, Vb_rb, Ve_rb, Vc_rb
+            )
             _stamp_g_c(
                 G,
                 node_to_idx,
                 el.base,
                 intrinsic_base,
-                complex(1.0 / el.Rb),
+                complex(1.0 / base_resistance),
             )
-            el = replace(el, base=intrinsic_base, Rb=0.0)
+            el = replace(el, base=intrinsic_base, Rb=0.0, Rbm=None, Irb=0.0)
         Vc_dc = 0.0 if _is_ground(el.collector) else dc_x[node_to_idx[el.collector]]
         Vb_dc = 0.0 if _is_ground(el.base) else dc_x[node_to_idx[el.base]]
         Ve_dc = 0.0 if _is_ground(el.emitter) else dc_x[node_to_idx[el.emitter]]
@@ -13353,14 +13435,30 @@ def _build_ss_matrix(
                 el = replace(el, collector=intrinsic_collector, Rc=0.0)
             if el.Rb > 0.0:
                 intrinsic_base = _bjt_intrinsic_base_node(el)
+                Vb_rb = (
+                    0.0
+                    if _is_ground(intrinsic_base)
+                    else dc_x[node_to_idx[intrinsic_base]]
+                )
+                Ve_rb = (
+                    0.0 if _is_ground(el.emitter) else dc_x[node_to_idx[el.emitter]]
+                )
+                Vc_rb = (
+                    0.0
+                    if _is_ground(el.collector)
+                    else dc_x[node_to_idx[el.collector]]
+                )
+                base_resistance = _bjt_effective_base_resistance(
+                    el, Vb_rb, Ve_rb, Vc_rb
+                )
                 _stamp_g(
                     G,
                     node_to_idx,
                     el.base,
                     intrinsic_base,
-                    1.0 / el.Rb,
+                    1.0 / base_resistance,
                 )
-                el = replace(el, base=intrinsic_base, Rb=0.0)
+                el = replace(el, base=intrinsic_base, Rb=0.0, Rbm=None, Irb=0.0)
             Vc_dc = 0.0 if _is_ground(el.collector) else dc_x[node_to_idx[el.collector]]
             Vb_dc = 0.0 if _is_ground(el.base) else dc_x[node_to_idx[el.base]]
             Ve_dc = 0.0 if _is_ground(el.emitter) else dc_x[node_to_idx[el.emitter]]
@@ -14290,6 +14388,8 @@ def sens_dc(
                     Re=el.Re,
                     Rc=el.Rc,
                     Rb=el.Rb,
+                    Rbm=el.Rbm,
+                    Irb=el.Irb,
                 ),
             )
             delta_beta = max(abs(el.beta_f) * perturbation, abs_floor)
@@ -14328,6 +14428,8 @@ def sens_dc(
                     Re=el.Re,
                     Rc=el.Rc,
                     Rb=el.Rb,
+                    Rbm=el.Rbm,
+                    Irb=el.Irb,
                 ),
             )
 
@@ -14576,6 +14678,8 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             Re=el.Re,
             Rc=el.Rc,
             Rb=el.Rb,
+            Rbm=el.Rbm,
+            Irb=el.Irb,
         )
 
     # Capacitor, Inductor, Mosfet — no tunable DC parameter; return unchanged.
@@ -15036,15 +15140,31 @@ def _collect_noise_sources(
                 el = replace(el, collector=intrinsic_collector, Rc=0.0)
             if el.Rb > 0.0:
                 intrinsic_base = _bjt_intrinsic_base_node(el)
+                Vb_rb = (
+                    0.0
+                    if _is_ground(intrinsic_base)
+                    else dc_x[node_to_idx[intrinsic_base]]
+                )
+                Ve_rb = (
+                    0.0 if _is_ground(el.emitter) else dc_x[node_to_idx[el.emitter]]
+                )
+                Vc_rb = (
+                    0.0
+                    if _is_ground(el.collector)
+                    else dc_x[node_to_idx[el.collector]]
+                )
+                base_resistance = _bjt_effective_base_resistance(
+                    el, Vb_rb, Ve_rb, Vc_rb
+                )
                 sources.append((
                     f"{el.name}:RB",
                     "thermal",
                     node_to_idx.get(el.base),
                     node_to_idx.get(intrinsic_base),
-                    kT4 / el.Rb,
+                    kT4 / base_resistance,
                     0.0,
                 ))
-                el = replace(el, base=intrinsic_base, Rb=0.0)
+                el = replace(el, base=intrinsic_base, Rb=0.0, Rbm=None, Irb=0.0)
             Vb = 0.0 if _is_ground(el.base) else dc_x[node_to_idx[el.base]]
             Ve = 0.0 if _is_ground(el.emitter) else dc_x[node_to_idx[el.emitter]]
             Vc = 0.0 if _is_ground(el.collector) else dc_x[node_to_idx[el.collector]]

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (36, 53, 13, 4),
-    "PNP": (36, 53, 13, 4),
+    "NPN": (38, 55, 13, 4),
+    "PNP": (38, 55, 13, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -390,6 +390,8 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "RE": "RE",
     "RC": "RC",
     "RB": "RB",
+    "RBM": "RBM",
+    "IRB": "IRB",
     "ISE": "ISE",
     "NE": "NE",
     "ISC": "ISC",
@@ -961,6 +963,8 @@ def bjt_from_model_card(
         Re=p.get("RE", 0.0),
         Rc=p.get("RC", 0.0),
         Rb=p.get("RB", 0.0),
+        Rbm=p.get("RBM"),
+        Irb=p.get("IRB", 0.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 130
+    assert len(coverage) == 134
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 130
+    assert len(records) == 134
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,9 +501,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 130
-    assert report.expected_canonical_parameter_count == 130
-    assert report.accepted_name_count == 196
+    assert report.canonical_parameter_count == 134
+    assert report.expected_canonical_parameter_count == 134
+    assert report.accepted_name_count == 200
     assert report.aliased_parameter_count == 53
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -511,7 +511,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t130\t130\t196\t53\t4\t0"
+        "true\t7\t7\t134\t134\t200\t53\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,8 +539,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 129
-    assert report.accepted_name_count == 193
+    assert report.canonical_parameter_count == 133
+    assert report.accepted_name_count == 197
     assert report.aliased_parameter_count == 52
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t129\t130\t193\t52\t4\t4\n"
+        "false\t7\t7\t133\t134\t197\t52\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,10 +647,10 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "VTF": 0.6, "RE": 12.0, "RC": 13.0, "RB": 14.0, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
+        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "VTF": 0.6, "RE": 12.0, "RC": 13.0, "RB": 14.0, "RBM": 2.0, "IRB": 5.0e-6, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "TNOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "VTF": 0.6, "RE": 12.0, "RC": 13.0, "RB": 14.0, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
+    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "TNOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "VTF": 0.6, "RE": 12.0, "RC": 13.0, "RB": 14.0, "RBM": 2.0, "IRB": 5.0e-6, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.beta_r == pytest.approx(0.25)
@@ -672,6 +672,8 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert bjt_model.Re == pytest.approx(12.0)
     assert bjt_model.Rc == pytest.approx(13.0)
     assert bjt_model.Rb == pytest.approx(14.0)
+    assert bjt_model.Rbm == pytest.approx(2.0)
+    assert bjt_model.Irb == pytest.approx(5.0e-6)
     assert bjt_model.Ise == pytest.approx(3.0e-13)
     assert bjt_model.Ne == pytest.approx(1.7)
     assert bjt_model.Isc == pytest.approx(4.0e-13)
@@ -2343,7 +2345,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3, Tnom=323.15, Kf=1.0e-12, Af=1.3, Ptf=30.0, Xtf=2.0, Itf=4.0e-3, Vtf=0.6, Re=12.0, Rc=13.0, Rb=14.0),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3, Tnom=323.15, Kf=1.0e-12, Af=1.3, Ptf=30.0, Xtf=2.0, Itf=4.0e-3, Vtf=0.6, Re=12.0, Rc=13.0, Rb=14.0, Rbm=2.0, Irb=5.0e-6),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2379,6 +2381,8 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.Re == pytest.approx(12.0)
     assert expanded.Rc == pytest.approx(13.0)
     assert expanded.Rb == pytest.approx(14.0)
+    assert expanded.Rbm == pytest.approx(2.0)
+    assert expanded.Irb == pytest.approx(5.0e-6)
 
 
 def test_branch_current_in_voltage_source():
@@ -3619,6 +3623,30 @@ def test_bjt_base_resistance_drops_intrinsic_base_voltage():
 
     intrinsic = dc_op(circuit).node_voltages["__spice_Q1_base"]
     assert 0.0 < intrinsic < 0.65
+
+
+def test_bjt_minimum_base_resistance_reduces_high_current_base_drop():
+    def intrinsic_base(Rbm: float | None, Irb: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vcollector", "collector", "0", voltage=5.0))
+        circuit.add(VoltageSource("Vbase", "base", "0", voltage=0.65))
+        circuit.add(
+            BJT(
+                "Q1",
+                "collector",
+                "base",
+                "0",
+                Rb=1_000.0,
+                Rbm=Rbm,
+                Irb=Irb,
+            )
+        )
+        return dc_op(circuit).node_voltages["__spice_Q1_base"]
+
+    fixed = intrinsic_base(None, 0.0)
+    bias_dependent = intrinsic_base(10.0, 1.0e-6)
+    assert bias_dependent > fixed
+    assert bias_dependent < 0.65
 
 
 def test_bjt_npn_beta_ratio():
@@ -7189,6 +7217,26 @@ def test_noise_bjt_base_resistance_adds_thermal_noise() -> None:
 
     assert base_resistance.noise_type == "thermal"
     assert base_resistance.source_psd > 0.0
+
+
+def test_noise_bjt_minimum_base_resistance_increases_high_current_noise() -> None:
+    def source_psd(*, Rbm: float | None = None, Irb: float = 0.0) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vbase", "base", "0", 0.65))
+        circuit.add(Resistor("Rload", "out", "0", 1_000.0))
+        circuit.add(BJT("Q1", "out", "base", "0", Rb=100.0, Rbm=Rbm, Irb=Irb))
+
+        result = noise_ac(circuit, "out", "Vbase", freqs=[1_000.0])
+        return next(
+            entry.source_psd
+            for entry in result.points[0].entries
+            if entry.element_name == "Q1:RB"
+        )
+
+    fixed = source_psd()
+    bias_dependent = source_psd(Rbm=10.0, Irb=1.0e-9)
+
+    assert bias_dependent > fixed
 
 
 def test_noise_bjt_kf_adds_inverse_frequency_flicker_noise() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add BJT model-card `RBM` and `IRB` support for Berkeley bias-dependent base
+  resistance across DC, AC, transient, transfer-function, and noise analysis.
 - Add BJT model-card `RB` base-resistance support with an intrinsic base node
   in DC, AC, and transient analysis plus thermal noise in noise analysis.
 - Add BJT model-card `RC` collector-resistance support with an intrinsic

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -464,6 +464,8 @@ fn clone_subckt_element(
             expanded.emitter_resistance = element.emitter_resistance;
             expanded.collector_resistance = element.collector_resistance;
             expanded.base_resistance = element.base_resistance;
+            expanded.minimum_base_resistance = element.minimum_base_resistance;
+            expanded.base_resistance_half_current = element.base_resistance_half_current;
             Element::Bjt(expanded)
         }
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
@@ -2915,6 +2917,8 @@ pub struct Bjt {
     pub emitter_resistance: f64,
     pub collector_resistance: f64,
     pub base_resistance: f64,
+    pub minimum_base_resistance: Option<f64>,
+    pub base_resistance_half_current: f64,
 }
 
 impl Bjt {
@@ -3387,6 +3391,8 @@ impl Bjt {
             emitter_resistance: 0.0,
             collector_resistance: 0.0,
             base_resistance: 0.0,
+            minimum_base_resistance: None,
+            base_resistance_half_current: 0.0,
         }
     }
 }
@@ -3777,8 +3783,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 36, 53, 13, 4),
-    (ModelCardKind::Pnp, 36, 53, 13, 4),
+    (ModelCardKind::Npn, 38, 55, 13, 4),
+    (ModelCardKind::Pnp, 38, 55, 13, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3840,6 +3846,8 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("RE", "RE"),
     ("RC", "RC"),
     ("RB", "RB"),
+    ("RBM", "RBM"),
+    ("IRB", "IRB"),
     ("ISE", "ISE"),
     ("NE", "NE"),
     ("ISC", "ISC"),
@@ -4543,6 +4551,8 @@ pub fn bjt_from_model_card(
     bjt.emitter_resistance = model_card_value(model, "RE", 0.0);
     bjt.collector_resistance = model_card_value(model, "RC", 0.0);
     bjt.base_resistance = model_card_value(model, "RB", 0.0);
+    bjt.minimum_base_resistance = model.parameters.get("RBM").copied();
+    bjt.base_resistance_half_current = model_card_value(model, "IRB", 0.0);
     Ok(bjt)
 }
 
@@ -22231,16 +22241,34 @@ fn collect_noise_sources(
                     }
                     if bjt.base_resistance > 0.0 {
                         let intrinsic_base = bjt_intrinsic_base_node(bjt);
+                        let intrinsic_base_index = node_index(node_indices, &intrinsic_base);
+                        let base_voltage = vector_voltage(operating_point, intrinsic_base_index);
+                        let emitter_voltage = vector_voltage(
+                            operating_point,
+                            node_index(node_indices, &intrinsic.emitter),
+                        );
+                        let collector_voltage = vector_voltage(
+                            operating_point,
+                            node_index(node_indices, &intrinsic.collector),
+                        );
+                        let base_resistance = bjt_effective_base_resistance(
+                            &intrinsic,
+                            base_voltage,
+                            emitter_voltage,
+                            collector_voltage,
+                        );
                         sources.push(NoiseSource {
                             element_name: format!("{}:RB", bjt.name),
                             noise_type: NoiseType::Thermal,
                             positive: node_index(node_indices, &bjt.base),
-                            negative: node_index(node_indices, &intrinsic_base),
-                            source_psd: 4.0 * BOLTZMANN * temperature_kelvin / bjt.base_resistance,
+                            negative: intrinsic_base_index,
+                            source_psd: 4.0 * BOLTZMANN * temperature_kelvin / base_resistance,
                             frequency_exponent: 0.0,
                         });
                         intrinsic.base = intrinsic_base;
                         intrinsic.base_resistance = 0.0;
+                        intrinsic.minimum_base_resistance = None;
+                        intrinsic.base_resistance_half_current = 0.0;
                     }
                     Some(intrinsic)
                 } else {
@@ -22842,6 +22870,55 @@ fn bjt_reverse_base_current(bjt: &Bjt, junction_voltage: f64) -> (f64, f64) {
     )
 }
 
+fn bjt_effective_base_resistance(
+    bjt: &Bjt,
+    base_voltage: f64,
+    emitter_voltage: f64,
+    collector_voltage: f64,
+) -> f64 {
+    let minimum = bjt.minimum_base_resistance.unwrap_or(bjt.base_resistance);
+    if minimum == bjt.base_resistance {
+        return bjt.base_resistance;
+    }
+    let (junction_voltage, reverse_voltage, output_voltage) = match bjt.polarity {
+        BjtPolarity::Npn => (
+            base_voltage - emitter_voltage,
+            base_voltage - collector_voltage,
+            collector_voltage - emitter_voltage,
+        ),
+        BjtPolarity::Pnp => (
+            emitter_voltage - base_voltage,
+            collector_voltage - base_voltage,
+            emitter_voltage - collector_voltage,
+        ),
+    };
+    let forward_thermal_voltage = bjt.thermal_voltage * bjt.forward_emission_coefficient;
+    let exp_value = (junction_voltage / forward_thermal_voltage)
+        .clamp(-40.0, 40.0)
+        .exp();
+    let diffusion_current = bjt.saturation_current * (exp_value - 1.0);
+    let diffusion_conductance = bjt.saturation_current / forward_thermal_voltage * exp_value;
+    let early_factor = bjt_early_factor(bjt, junction_voltage, output_voltage);
+    let (_, _, charge_factor) =
+        bjt_forward_transport(bjt, diffusion_current, diffusion_conductance, early_factor);
+    let (leakage_current, _) = bjt_base_emitter_leakage(bjt, junction_voltage);
+    let (collector_leakage_current, _) = bjt_base_collector_leakage(bjt, reverse_voltage);
+    let (reverse_base_current, _) = bjt_reverse_base_current(bjt, reverse_voltage);
+    let base_current = diffusion_current / bjt.forward_beta
+        + leakage_current
+        + collector_leakage_current
+        + reverse_base_current;
+    let variable_resistance = bjt.base_resistance - minimum;
+    if bjt.base_resistance_half_current == 0.0 {
+        return minimum + variable_resistance / charge_factor;
+    }
+    let ratio = (base_current / bjt.base_resistance_half_current).max(1.0e-9);
+    let angle = (-1.0 + (1.0 + 14.59025 * ratio).sqrt()) / (2.4317 * ratio.sqrt());
+    let tangent = angle.tan();
+    let transition = 3.0 * (tangent - angle) / (angle * tangent * tangent);
+    minimum + variable_resistance * transition
+}
+
 fn stamp_bjt(
     bjt: &Bjt,
     capacitor_states: &[CapacitorState],
@@ -22880,14 +22957,32 @@ fn stamp_bjt(
         }
         if bjt.base_resistance > 0.0 {
             let intrinsic_base = bjt_intrinsic_base_node(bjt);
+            let intrinsic_base_index = node_index(node_indices, &intrinsic_base);
+            let base_voltage = vector_voltage(operating_point, intrinsic_base_index);
+            let emitter_voltage = vector_voltage(
+                operating_point,
+                node_index(node_indices, &intrinsic.emitter),
+            );
+            let collector_voltage = vector_voltage(
+                operating_point,
+                node_index(node_indices, &intrinsic.collector),
+            );
+            let base_resistance = bjt_effective_base_resistance(
+                &intrinsic,
+                base_voltage,
+                emitter_voltage,
+                collector_voltage,
+            );
             stamp_conductance(
                 matrix,
                 node_index(node_indices, &bjt.base),
-                node_index(node_indices, &intrinsic_base),
-                1.0 / bjt.base_resistance,
+                intrinsic_base_index,
+                1.0 / base_resistance,
             );
             intrinsic.base = intrinsic_base;
             intrinsic.base_resistance = 0.0;
+            intrinsic.minimum_base_resistance = None;
+            intrinsic.base_resistance_half_current = 0.0;
         }
         Some(intrinsic)
     } else {
@@ -23077,14 +23172,32 @@ fn stamp_bjt_small_signal(
         }
         if bjt.base_resistance > 0.0 {
             let intrinsic_base = bjt_intrinsic_base_node(bjt);
+            let intrinsic_base_index = node_index(node_indices, &intrinsic_base);
+            let base_voltage = vector_voltage(operating_point, intrinsic_base_index);
+            let emitter_voltage = vector_voltage(
+                operating_point,
+                node_index(node_indices, &intrinsic.emitter),
+            );
+            let collector_voltage = vector_voltage(
+                operating_point,
+                node_index(node_indices, &intrinsic.collector),
+            );
+            let base_resistance = bjt_effective_base_resistance(
+                &intrinsic,
+                base_voltage,
+                emitter_voltage,
+                collector_voltage,
+            );
             stamp_conductance(
                 matrix,
                 node_index(node_indices, &bjt.base),
-                node_index(node_indices, &intrinsic_base),
-                1.0 / bjt.base_resistance,
+                intrinsic_base_index,
+                1.0 / base_resistance,
             );
             intrinsic.base = intrinsic_base;
             intrinsic.base_resistance = 0.0;
+            intrinsic.minimum_base_resistance = None;
+            intrinsic.base_resistance_half_current = 0.0;
         }
         Some(intrinsic)
     } else {
@@ -23184,14 +23297,32 @@ fn stamp_ac_bjt_small_signal(
         }
         if bjt.base_resistance > 0.0 {
             let intrinsic_base = bjt_intrinsic_base_node(bjt);
+            let intrinsic_base_index = node_index(node_indices, &intrinsic_base);
+            let base_voltage = vector_voltage(operating_point, intrinsic_base_index);
+            let emitter_voltage = vector_voltage(
+                operating_point,
+                node_index(node_indices, &intrinsic.emitter),
+            );
+            let collector_voltage = vector_voltage(
+                operating_point,
+                node_index(node_indices, &intrinsic.collector),
+            );
+            let base_resistance = bjt_effective_base_resistance(
+                &intrinsic,
+                base_voltage,
+                emitter_voltage,
+                collector_voltage,
+            );
             stamp_complex_conductance(
                 matrix,
                 node_index(node_indices, &bjt.base),
-                node_index(node_indices, &intrinsic_base),
-                Complex::new(1.0 / bjt.base_resistance, 0.0),
+                intrinsic_base_index,
+                Complex::new(1.0 / base_resistance, 0.0),
             );
             intrinsic.base = intrinsic_base;
             intrinsic.base_resistance = 0.0;
+            intrinsic.minimum_base_resistance = None;
+            intrinsic.base_resistance_half_current = 0.0;
         }
         Some(intrinsic)
     } else {
@@ -24404,6 +24535,21 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "base resistance must be finite and non-negative".to_string(),
+        });
+    }
+    if bjt
+        .minimum_base_resistance
+        .is_some_and(|resistance| !resistance.is_finite() || resistance < 0.0)
+    {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "minimum base resistance must be finite and non-negative".to_string(),
+        });
+    }
+    if !bjt.base_resistance_half_current.is_finite() || bjt.base_resistance_half_current < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "base-resistance half-current must be finite and non-negative".to_string(),
         });
     }
     if !bjt.base_emitter_leakage_saturation_current.is_finite()

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 130);
+    assert_eq!(coverage.len(), 134);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 130);
+    assert_eq!(records.len(), 134);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 130);
-    assert_eq!(report.expected_canonical_parameter_count, 130);
-    assert_eq!(report.accepted_name_count, 196);
+    assert_eq!(report.canonical_parameter_count, 134);
+    assert_eq!(report.expected_canonical_parameter_count, 134);
+    assert_eq!(report.accepted_name_count, 200);
     assert_eq!(report.aliased_parameter_count, 53);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t130\t130\t196\t53\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t134\t134\t200\t53\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,8 +235,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 129);
-    assert_eq!(report.accepted_name_count, 193);
+    assert_eq!(report.canonical_parameter_count, 133);
+    assert_eq!(report.accepted_name_count, 197);
     assert_eq!(report.aliased_parameter_count, 52);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t129\t130\t193\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t133\t134\t197\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -457,6 +457,8 @@ fn model_card_aliases_build_device_instances() {
             ("MC", 0.45),
             ("FC", 0.4),
             ("RB", 14.0),
+            ("RBM", 2.0),
+            ("IRB", 5.0e-6),
         ],
     )
     .unwrap();
@@ -481,6 +483,8 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*bjt_card.parameters.get("RE").unwrap(), 12.0);
     assert_close(*bjt_card.parameters.get("RC").unwrap(), 13.0);
     assert_close(*bjt_card.parameters.get("RB").unwrap(), 14.0);
+    assert_close(*bjt_card.parameters.get("RBM").unwrap(), 2.0);
+    assert_close(*bjt_card.parameters.get("IRB").unwrap(), 5.0e-6);
     assert_close(*bjt_card.parameters.get("ISE").unwrap(), 3.0e-13);
     assert_close(*bjt_card.parameters.get("NE").unwrap(), 1.7);
     assert_close(*bjt_card.parameters.get("ISC").unwrap(), 4.0e-13);
@@ -513,6 +517,8 @@ fn model_card_aliases_build_device_instances() {
     assert_close(bjt_model.emitter_resistance, 12.0);
     assert_close(bjt_model.collector_resistance, 13.0);
     assert_close(bjt_model.base_resistance, 14.0);
+    assert_close(bjt_model.minimum_base_resistance.unwrap(), 2.0);
+    assert_close(bjt_model.base_resistance_half_current, 5.0e-6);
     assert_close(bjt_model.base_emitter_leakage_saturation_current, 3.0e-13);
     assert_close(bjt_model.base_emitter_leakage_emission_coefficient, 1.7);
     assert_close(bjt_model.base_collector_leakage_saturation_current, 4.0e-13);
@@ -1463,6 +1469,8 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     bjt.emitter_resistance = 12.0;
     bjt.collector_resistance = 13.0;
     bjt.base_resistance = 14.0;
+    bjt.minimum_base_resistance = Some(2.0);
+    bjt.base_resistance_half_current = 5.0e-6;
     let mut circuit = Circuit::new();
     circuit
         .define_subcircuit(SubcircuitDefinition::new(
@@ -1516,6 +1524,8 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.emitter_resistance, 12.0);
     assert_close(expanded.collector_resistance, 13.0);
     assert_close(expanded.base_resistance, 14.0);
+    assert_close(expanded.minimum_base_resistance.unwrap(), 2.0);
+    assert_close(expanded.base_resistance_half_current, 5.0e-6);
 }
 
 #[test]
@@ -2900,6 +2910,33 @@ fn dc_bjt_base_resistance_drops_intrinsic_base_voltage() {
     let intrinsic = dc_op(&circuit).unwrap().voltage("__spice_Q1_base").unwrap();
     assert!(intrinsic < 0.65);
     assert!(intrinsic > 0.0);
+}
+
+#[test]
+fn dc_bjt_minimum_base_resistance_reduces_high_current_base_drop() {
+    let intrinsic_base = |minimum_base_resistance: Option<f64>, half_current: f64| {
+        let mut transistor = Bjt::new("Q1", "collector", "base", "0");
+        transistor.base_resistance = 1_000.0;
+        transistor.minimum_base_resistance = minimum_base_resistance;
+        transistor.base_resistance_half_current = half_current;
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vcollector",
+            "collector",
+            "0",
+            5.0,
+        )));
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vbase", "base", "0", 0.65,
+        )));
+        circuit.add(Element::Bjt(transistor));
+        dc_op(&circuit).unwrap().voltage("__spice_Q1_base").unwrap()
+    };
+
+    let fixed = intrinsic_base(None, 0.0);
+    let bias_dependent = intrinsic_base(Some(10.0), 1.0e-6);
+    assert!(bias_dependent > fixed);
+    assert!(bias_dependent < 0.65);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -161,6 +161,37 @@ fn bjt_base_resistance_adds_thermal_noise() {
 }
 
 #[test]
+fn bjt_minimum_base_resistance_increases_high_current_thermal_noise() {
+    let source_psd = |minimum_base_resistance, base_resistance_half_current| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vbase", "base", "0", 0.65,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rload", "out", "0", 1_000.0,
+        )));
+        let mut transistor = Bjt::new("Q1", "out", "base", "0");
+        transistor.base_resistance = 100.0;
+        transistor.minimum_base_resistance = minimum_base_resistance;
+        transistor.base_resistance_half_current = base_resistance_half_current;
+        circuit.add(Element::Bjt(transistor));
+
+        let result = noise_ac(&circuit, "out", "Vbase", &[1_000.0], 300.0).unwrap();
+        result.points[0]
+            .entries
+            .iter()
+            .find(|entry| entry.element_name == "Q1:RB")
+            .unwrap()
+            .source_psd
+    };
+
+    let fixed = source_psd(None, 0.0);
+    let bias_dependent = source_psd(Some(10.0), 1.0e-9);
+
+    assert!(bias_dependent > fixed);
+}
+
+#[test]
 fn bjt_flicker_noise_uses_kf_with_inverse_frequency_scaling() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add BJT model-card `RBM` and `IRB` support for Berkeley bias-dependent base
+  resistance across DC, AC, transient, transfer-function, and noise analysis.
 - Add BJT model-card `RB` base-resistance support with an intrinsic base node
   in DC, AC, and transient analysis plus thermal noise in noise analysis.
 - Add BJT model-card `RC` collector-resistance support with an intrinsic

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1739,6 +1739,8 @@ export interface Bjt {
   readonly emitterResistance: number;
   readonly collectorResistance: number;
   readonly baseResistance: number;
+  readonly minimumBaseResistance: number | undefined;
+  readonly baseResistanceHalfCurrent: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -2016,8 +2018,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [36, 53, 13, 4],
-  PNP: [36, 53, 13, 4],
+  NPN: [38, 55, 13, 4],
+  PNP: [38, 55, 13, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3607,7 +3609,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees, element.forwardTransitTimeBiasCoefficient, element.forwardTransitTimeCurrent, element.forwardTransitTimeVoltage, element.emitterResistance, element.collectorResistance, element.baseResistance);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees, element.forwardTransitTimeBiasCoefficient, element.forwardTransitTimeCurrent, element.forwardTransitTimeVoltage, element.emitterResistance, element.collectorResistance, element.baseResistance, element.minimumBaseResistance, element.baseResistanceHalfCurrent);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7802,6 +7804,8 @@ export function bjt(
   emitterResistance = 0.0,
   collectorResistance = 0.0,
   baseResistance = 0.0,
+  minimumBaseResistance: number | undefined = undefined,
+  baseResistanceHalfCurrent = 0.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7846,6 +7850,8 @@ export function bjt(
     emitterResistance,
     collectorResistance,
     baseResistance,
+    minimumBaseResistance,
+    baseResistanceHalfCurrent,
   };
 }
 
@@ -7967,6 +7973,8 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   RE: "RE",
   RC: "RC",
   RB: "RB",
+  RBM: "RBM",
+  IRB: "IRB",
   ISE: "ISE",
   NE: "NE",
   ISC: "ISC",
@@ -8510,6 +8518,8 @@ export function bjtFromModelCard(
     p.RE ?? 0.0,
     p.RC ?? 0.0,
     p.RB ?? 0.0,
+    p.RBM,
+    p.IRB ?? 0.0,
   );
 }
 
@@ -18449,6 +18459,12 @@ function collectNoiseSources(
       const emitterNode = bjtIntrinsicEmitterNode(element);
       const collectorNode = bjtIntrinsicCollectorNode(element);
       const baseNode = bjtIntrinsicBaseNode(element);
+      const base = nodeIndex(nodeIndices, baseNode);
+      const emitter = nodeIndex(nodeIndices, emitterNode);
+      const collector = nodeIndex(nodeIndices, collectorNode);
+      const baseVoltage = vectorVoltage(operatingPoint, base);
+      const emitterVoltage = vectorVoltage(operatingPoint, emitter);
+      const collectorVoltage = vectorVoltage(operatingPoint, collector);
       if (element.emitterResistance > 0.0) {
         sources.push({
           elementName: `${element.name}:RE`,
@@ -18472,22 +18488,22 @@ function collectNoiseSources(
         });
       }
       if (element.baseResistance > 0.0) {
+        const baseResistance = bjtEffectiveBaseResistance(
+          element,
+          baseVoltage,
+          emitterVoltage,
+          collectorVoltage,
+        );
         sources.push({
           elementName: `${element.name}:RB`,
           noiseType: "thermal",
           positive: nodeIndex(nodeIndices, element.base),
           negative: nodeIndex(nodeIndices, baseNode),
           sourcePsd:
-            4.0 * BOLTZMANN * temperatureKelvin / element.baseResistance,
+            4.0 * BOLTZMANN * temperatureKelvin / baseResistance,
           frequencyExponent: 0.0,
         });
       }
-      const base = nodeIndex(nodeIndices, baseNode);
-      const emitter = nodeIndex(nodeIndices, emitterNode);
-      const collector = nodeIndex(nodeIndices, collectorNode);
-      const baseVoltage = vectorVoltage(operatingPoint, base);
-      const emitterVoltage = vectorVoltage(operatingPoint, emitter);
-      const collectorVoltage = vectorVoltage(operatingPoint, collector);
       const junctionVoltage =
         element.polarity === "NPN"
           ? baseVoltage - emitterVoltage
@@ -19115,6 +19131,63 @@ function bjtReverseBaseCurrent(
   };
 }
 
+function bjtEffectiveBaseResistance(
+  element: Bjt,
+  baseVoltage: number,
+  emitterVoltage: number,
+  collectorVoltage: number,
+): number {
+  const minimum = element.minimumBaseResistance ?? element.baseResistance;
+  if (minimum === element.baseResistance) {
+    return element.baseResistance;
+  }
+  const junctionVoltage = element.polarity === "NPN"
+    ? baseVoltage - emitterVoltage
+    : emitterVoltage - baseVoltage;
+  const reverseVoltage = element.polarity === "NPN"
+    ? baseVoltage - collectorVoltage
+    : collectorVoltage - baseVoltage;
+  const outputVoltage = element.polarity === "NPN"
+    ? collectorVoltage - emitterVoltage
+    : emitterVoltage - collectorVoltage;
+  const forwardThermalVoltage =
+    element.thermalVoltage * element.forwardEmissionCoefficient;
+  const exponent = Math.max(
+    -40.0,
+    Math.min(40.0, junctionVoltage / forwardThermalVoltage),
+  );
+  const expValue = Math.exp(exponent);
+  const diffusionCurrent = element.saturationCurrent * (expValue - 1.0);
+  const diffusionConductance =
+    element.saturationCurrent / forwardThermalVoltage * expValue;
+  const earlyFactor = bjtEarlyFactor(element, junctionVoltage, outputVoltage);
+  const transport = bjtForwardTransport(
+    element,
+    diffusionCurrent,
+    diffusionConductance,
+    earlyFactor,
+  );
+  const leakage = bjtBaseEmitterLeakage(element, junctionVoltage);
+  const collectorLeakage = bjtBaseCollectorLeakage(element, reverseVoltage);
+  const reverseBase = bjtReverseBaseCurrent(element, reverseVoltage);
+  const baseCurrent = diffusionCurrent / element.forwardBeta
+    + leakage.current
+    + collectorLeakage.current
+    + reverseBase.current;
+  const variableResistance = element.baseResistance - minimum;
+  if (element.baseResistanceHalfCurrent === 0.0) {
+    return minimum + variableResistance / transport.chargeFactor;
+  }
+  const ratio = Math.max(baseCurrent / element.baseResistanceHalfCurrent, 1.0e-9);
+  const angle =
+    (-1.0 + Math.sqrt(1.0 + 14.59025 * ratio))
+    / (2.4317 * Math.sqrt(ratio));
+  const tangent = Math.tan(angle);
+  const transition =
+    3.0 * (tangent - angle) / (angle * tangent * tangent);
+  return minimum + variableResistance * transition;
+}
+
 function stampBjt(
   element: Bjt,
   capacitorStates: readonly CapacitorState[],
@@ -19146,13 +19219,35 @@ function stampBjt(
   }
   if (element.baseResistance > 0.0) {
     const intrinsicBase = bjtIntrinsicBaseNode(element);
+    const intrinsicBaseIndex = nodeIndex(nodeIndices, intrinsicBase);
+    const baseVoltage = vectorVoltage(operatingPoint, intrinsicBaseIndex);
+    const emitterVoltage = vectorVoltage(
+      operatingPoint,
+      nodeIndex(nodeIndices, element.emitter),
+    );
+    const collectorVoltage = vectorVoltage(
+      operatingPoint,
+      nodeIndex(nodeIndices, element.collector),
+    );
+    const baseResistance = bjtEffectiveBaseResistance(
+      element,
+      baseVoltage,
+      emitterVoltage,
+      collectorVoltage,
+    );
     stampConductance(
       matrix,
       nodeIndex(nodeIndices, element.base),
-      nodeIndex(nodeIndices, intrinsicBase),
-      1.0 / element.baseResistance,
+      intrinsicBaseIndex,
+      1.0 / baseResistance,
     );
-    element = { ...element, base: intrinsicBase, baseResistance: 0.0 };
+    element = {
+      ...element,
+      base: intrinsicBase,
+      baseResistance: 0.0,
+      minimumBaseResistance: undefined,
+      baseResistanceHalfCurrent: 0.0,
+    };
   }
   const collector = nodeIndex(nodeIndices, element.collector);
   const base = nodeIndex(nodeIndices, element.base);
@@ -20148,6 +20243,20 @@ function validateBjt(element: Bjt): void {
   }
   if (!Number.isFinite(element.baseResistance) || element.baseResistance < 0.0) {
     throw invalidElement(element.name, "base resistance must be finite and non-negative");
+  }
+  if (element.minimumBaseResistance !== undefined &&
+      (!Number.isFinite(element.minimumBaseResistance) || element.minimumBaseResistance < 0.0)) {
+    throw invalidElement(
+      element.name,
+      "minimum base resistance must be finite and non-negative",
+    );
+  }
+  if (!Number.isFinite(element.baseResistanceHalfCurrent) ||
+      element.baseResistanceHalfCurrent < 0.0) {
+    throw invalidElement(
+      element.name,
+      "base-resistance half-current must be finite and non-negative",
+    );
   }
   if (!Number.isFinite(element.baseEmitterLeakageSaturationCurrent) || element.baseEmitterLeakageSaturationCurrent < 0.0) {
     throw invalidElement(element.name, "base-emitter leakage saturation current must be finite and non-negative");
@@ -21517,13 +21626,35 @@ function stampBjtSmallSignal(
   }
   if (element.baseResistance > 0.0) {
     const intrinsicBase = bjtIntrinsicBaseNode(element);
+    const intrinsicBaseIndex = nodeIndex(nodeIndices, intrinsicBase);
+    const baseVoltage = vectorVoltage(operatingPoint, intrinsicBaseIndex);
+    const emitterVoltage = vectorVoltage(
+      operatingPoint,
+      nodeIndex(nodeIndices, element.emitter),
+    );
+    const collectorVoltage = vectorVoltage(
+      operatingPoint,
+      nodeIndex(nodeIndices, element.collector),
+    );
+    const baseResistance = bjtEffectiveBaseResistance(
+      element,
+      baseVoltage,
+      emitterVoltage,
+      collectorVoltage,
+    );
     stampConductance(
       matrix,
       nodeIndex(nodeIndices, element.base),
-      nodeIndex(nodeIndices, intrinsicBase),
-      1.0 / element.baseResistance,
+      intrinsicBaseIndex,
+      1.0 / baseResistance,
     );
-    element = { ...element, base: intrinsicBase, baseResistance: 0.0 };
+    element = {
+      ...element,
+      base: intrinsicBase,
+      baseResistance: 0.0,
+      minimumBaseResistance: undefined,
+      baseResistanceHalfCurrent: 0.0,
+    };
   }
   const collector = nodeIndex(nodeIndices, element.collector);
   const base = nodeIndex(nodeIndices, element.base);
@@ -22142,13 +22273,35 @@ function stampAcBjtSmallSignal(
   }
   if (element.baseResistance > 0.0) {
     const intrinsicBase = bjtIntrinsicBaseNode(element);
+    const intrinsicBaseIndex = nodeIndex(nodeIndices, intrinsicBase);
+    const baseVoltage = vectorVoltage(operatingPoint, intrinsicBaseIndex);
+    const emitterVoltage = vectorVoltage(
+      operatingPoint,
+      nodeIndex(nodeIndices, element.emitter),
+    );
+    const collectorVoltage = vectorVoltage(
+      operatingPoint,
+      nodeIndex(nodeIndices, element.collector),
+    );
+    const baseResistance = bjtEffectiveBaseResistance(
+      element,
+      baseVoltage,
+      emitterVoltage,
+      collectorVoltage,
+    );
     stampComplexConductance(
       matrix,
       nodeIndex(nodeIndices, element.base),
-      nodeIndex(nodeIndices, intrinsicBase),
-      complex(1.0 / element.baseResistance, 0.0),
+      intrinsicBaseIndex,
+      complex(1.0 / baseResistance, 0.0),
     );
-    element = { ...element, base: intrinsicBase, baseResistance: 0.0 };
+    element = {
+      ...element,
+      base: intrinsicBase,
+      baseResistance: 0.0,
+      minimumBaseResistance: undefined,
+      baseResistanceHalfCurrent: 0.0,
+    };
   }
   const collector = nodeIndex(nodeIndices, element.collector);
   const base = nodeIndex(nodeIndices, element.base);

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(130);
+    expect(coverage).toHaveLength(134);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(130);
+    expect(records).toHaveLength(134);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 130,
-      expectedCanonicalParameterCount: 130,
-      acceptedNameCount: 196,
+      canonicalParameterCount: 134,
+      expectedCanonicalParameterCount: 134,
+      acceptedNameCount: 200,
       aliasedParameterCount: 53,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t130\t130\t196\t53\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t134\t134\t200\t53\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,8 +241,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(129);
-    expect(report.acceptedNameCount).toBe(193);
+    expect(report.canonicalParameterCount).toBe(133);
+    expect(report.acceptedNameCount).toBe(197);
     expect(report.aliasedParameterCount).toBe(52);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t129\t130\t193\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t133\t134\t197\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -352,6 +352,8 @@ describe("dcOp", () => {
       RE: 12.0,
       RC: 13.0,
       RB: 14.0,
+      RBM: 2.0,
+      IRB: 5.0e-6,
       ISE: 3.0e-13,
       NE: 1.7,
       ISC: 4.0e-13,
@@ -365,7 +367,7 @@ describe("dcOp", () => {
       FC: 0.4,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, TNOM: 50.0, KF: 1.0e-12, AF: 1.3, PTF: 30.0, XTF: 2.0, ITF: 4.0e-3, VTF: 0.6, RE: 12.0, RC: 13.0, RB: 14.0, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, TNOM: 50.0, KF: 1.0e-12, AF: 1.3, PTF: 30.0, XTF: 2.0, ITF: 4.0e-3, VTF: 0.6, RE: 12.0, RC: 13.0, RB: 14.0, RBM: 2.0, IRB: 5.0e-6, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.reverseBeta, 0.25);
@@ -387,6 +389,8 @@ describe("dcOp", () => {
     expectClose(bjtModel.emitterResistance, 12.0);
     expectClose(bjtModel.collectorResistance, 13.0);
     expectClose(bjtModel.baseResistance, 14.0);
+    expectClose(bjtModel.minimumBaseResistance, 2.0);
+    expectClose(bjtModel.baseResistanceHalfCurrent, 5.0e-6);
     expectClose(bjtModel.baseEmitterLeakageSaturationCurrent, 3.0e-13);
     expectClose(bjtModel.baseEmitterLeakageEmissionCoefficient, 1.7);
     expectClose(bjtModel.baseCollectorLeakageSaturationCurrent, 4.0e-13);
@@ -1030,7 +1034,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3, 323.15, 1.0e-12, 1.3, 30.0, 2.0, 4.0e-3, 0.6, 12.0, 13.0, 14.0),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3, 323.15, 1.0e-12, 1.3, 30.0, 2.0, 4.0e-3, 0.6, 12.0, 13.0, 14.0, 2.0, 5.0e-6),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -1067,6 +1071,8 @@ describe("dcOp", () => {
       expectClose(expanded.emitterResistance, 12.0);
       expectClose(expanded.collectorResistance, 13.0);
       expectClose(expanded.baseResistance, 14.0);
+      expectClose(expanded.minimumBaseResistance, 2.0);
+      expectClose(expanded.baseResistanceHalfCurrent, 5.0e-6);
     }
   });
 
@@ -1861,6 +1867,29 @@ describe("dcOp", () => {
     const intrinsic = dcOp(circuit).voltage("__spice_Q1_base") ?? 0.0;
     expect(intrinsic).toBeGreaterThan(0.0);
     expect(intrinsic).toBeLessThan(0.65);
+  });
+
+  it("uses minimum BJT base resistance to reduce high-current base drop", () => {
+    const intrinsicBase = (
+      minimumBaseResistance: number | undefined,
+      baseResistanceHalfCurrent: number,
+    ): number => {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vcollector", "collector", "0", 5.0));
+      circuit.add(voltageSource("Vbase", "base", "0", 0.65));
+      circuit.add({
+        ...bjt("Q1", "collector", "base", "0"),
+        baseResistance: 1_000.0,
+        minimumBaseResistance,
+        baseResistanceHalfCurrent,
+      });
+      return dcOp(circuit).voltage("__spice_Q1_base") ?? 0.0;
+    };
+
+    const fixed = intrinsicBase(undefined, 0.0);
+    const biasDependent = intrinsicBase(10.0, 1.0e-6);
+    expect(biasDependent).toBeGreaterThan(fixed);
+    expect(biasDependent).toBeLessThan(0.65);
   });
 
   it("solves an NMOS operating point", () => {

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -175,6 +175,31 @@ describe("noiseAc", () => {
     expect(baseResistance.sourcePsd).toBeGreaterThan(0.0);
   });
 
+  it("uses minimum BJT base resistance for high-current thermal noise", () => {
+    const sourcePsd = (
+      minimumBaseResistance: number | undefined,
+      baseResistanceHalfCurrent: number,
+    ): number => {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vbase", "base", "0", 0.65));
+      circuit.add(resistor("Rload", "out", "0", 1_000.0));
+      circuit.add({
+        ...bjt("Q1", "out", "base", "0"),
+        baseResistance: 100.0,
+        minimumBaseResistance,
+        baseResistanceHalfCurrent,
+      });
+      const result = noiseAc(circuit, "out", "Vbase", [1_000.0]);
+      return result.points[0]!.entries
+        .find((candidate) => candidate.elementName === "Q1:RB")!.sourcePsd;
+    };
+
+    const fixed = sourcePsd(undefined, 0.0);
+    const biasDependent = sourcePsd(10.0, 1.0e-9);
+
+    expect(biasDependent).toBeGreaterThan(fixed);
+  });
+
   it("sorts resistor contributions by output noise", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vin", "in", "0", 1.0));

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,17 +33,18 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT base resistance.
+1. Cross-language BJT bias-dependent base resistance.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `RB` model-card support in Rust, Python, and TypeScript,
-     defaulting to zero so existing operating-point, AC, transient, and noise
-     results remain unchanged.
-   - Insert an intrinsic base node behind the configured series resistance,
-     use that node for nonlinear and both junction stored-charge behaviors,
-     and include the resistor's thermal-noise contribution.
-   - Extend the supported-parameter coverage gate from 128 to 130 canonical
-     rows and lock model-card behavior, validation, hierarchy, operating-point
-     loading, and noise behavior in all engines.
+   - Add Berkeley BJT `RBM` minimum-base-resistance and `IRB`
+     half-resistance-current model-card support in Rust, Python, and
+     TypeScript.
+   - Reuse the intrinsic base topology for Berkeley base-charge and
+     current-dependent resistance reduction in DC, transient, AC,
+     transfer-function, and thermal-noise behavior.
+   - Preserve constant `RB` behavior when `RBM` is omitted, extend the
+     supported-parameter coverage gate from 130 to 134 canonical rows, and
+     lock model-card behavior, validation, hierarchy, operating-point loading,
+     and noise behavior in all engines.
 
 ## Completed Slices
 
@@ -3186,6 +3187,15 @@ the Rust, Python, and TypeScript surfaces together.
    - DC, transient, AC, transfer-function, and noise paths share the intrinsic
      collector topology, including resistor thermal noise; the
      supported-parameter release gate now covers 128 canonical rows.
+
+242. Cross-language BJT base resistance.
+   - Status: completed in PR 8866.
+   - Rust, Python, and TypeScript BJT model cards now accept `RB`, default it
+     to zero, and insert an intrinsic base node behind the configured external
+     series resistance.
+   - DC, transient, AC, transfer-function, and noise paths share the intrinsic
+     base topology, including resistor thermal noise; the supported-parameter
+     release gate now covers 130 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley BJT `RBM` and `IRB` model-card parameters across Rust, Python, and TypeScript
- apply base-charge and base-current-dependent resistance in DC, transient, AC, transfer-function, and noise analyses while preserving fixed `RB` behavior when `RBM` is omitted
- extend hierarchy/reconstruction parity, validation, model-card coverage gates, behavioral tests, changelogs, and the SPICE implementation plan

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo test -p spice-engine`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- Python spice-engine: 575 passed, 88.82% coverage
- Python Ruff on touched source and tests
- TypeScript `npm run build`
- TypeScript spice-engine: 333 passed