### PR TITLE
feat(c-to-semantic-ir): early return via return-lifting (SIR27 milestone 3)

### DIFF
--- a/code/packages/rust/c-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/c-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 ## Unreleased
 
+### Milestone 3 — early `return` (return lifting)
+
+- A returning `if` is now **lifted** into a value-producing `Expr::If`, with the
+  rest of the function becoming the continuation of the branch that does not
+  return.  SIR functions yield a block value with no early-exit statement, so
+  this is what makes C's guard-clause idiom — and therefore idiomatic recursion
+  like `fib` — translatable at all.
+- The continuation attaches only to a branch that can fall through, so the
+  common guard-clause shape **never duplicates code**.
+- `lower_seq` replaces the old "return must be the last statement" body walk;
+  nested `{ }` blocks splice into the enclosing sequence, and `always_returns`
+  drives the branch analysis (conservative: an `if` with no `else` never
+  qualifies, loops are not analysed).  The walk is **iterative in two
+  dimensions** — per statement *and* per sibling guard clause, both of which are
+  flat sequences the parser does not bound.  (Recursing per statement overflowed
+  at ~350; recursing per guard overflowed the `sign()` idiom at ~150.)  A lifted
+  `if` pushes its condition and returning branch on a stack, splices the
+  falling-through branch onto the work queue, and the nested `If` is folded
+  bottom-up at the end.
+- Four shapes are **refused** rather than mis-handled, each a positioned error:
+  - `return` inside a loop (needs a break-with-value, which SIR lacks);
+  - an `if` where neither branch returns on all paths but one contains a
+    `return` — lifting would duplicate the continuation into both branches, and
+    chained that is **4^N** IR nodes (<1 KB of C emitted ~185 MB before this
+    was caught);
+  - a declaration that **re-uses a name already in scope** — the symbol table is
+    flat and nested blocks are spliced into the enclosing sequence, so two
+    bindings collapse into one, silently taking the wrong type *and* emitting C
+    that fails with `redefinition of 'v'`.  Early return sharpens the same
+    hazard (the continuation is lowered inside the falling-through branch), so
+    the check lives on the declaration itself and covers every binding path —
+    blocks, branches, loop bodies, `for`-inits, and the lifted continuation.
+    Two sequential `for (int i = …)` loops are the everyday form of this;
+  - an **emitted tree deeper than the budget** — every IR consumer walks it
+    recursively, and depth accumulates from three sources that all add in the
+    same tree: flat operator chains (`x + 1 + 1 + …` folds left into a tree as
+    deep as it is wide, and nothing else bounds it), expression nesting, and
+    statement nesting (weighted 3× to match its measured stack cost).  All three
+    share **one** budget.  A chain's width is *held* while its operands are
+    lowered — merely checking it let widths at different nesting levels multiply
+    (~14× the cap, crashing on 369 bytes) — and budgeting the sources separately
+    also failed (64 guards each returning a 50-term chain passed two independent
+    caps and still overflowed).  The cap is calibrated against a **debug** build
+    on a **1 MiB** stack, not a roomier test-harness thread;
+  - **more than that many lifted early returns in one function** — each one nests the
+    emitted IR a level deeper and every IR consumer walks it recursively, so 250
+    chained guards aborted the process inside the validator.  The cap makes that
+    a clean error; raising it means making the validator and backends iterative.
+- Corpus grows with 8 early-return programs: **recursive `fib(20)` → 6765**,
+  chained guards, unbraced guards, both-branches-return, statements before a
+  return, a nested `if` in an `else`, an early return of a wrapped `uint8`, and
+  early return combined with a loop result — all byte-identical across reference
+  `clang -fwrapv`, emitted Ruby, and emitted C (and clang+gcc+MSVC).
+
 ### Milestone 2 — control flow & comparisons
 
 - Comparisons `< > <= >= == !=` (with the usual arithmetic conversions on their

--- a/code/packages/rust/c-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/c-to-semantic-ir/src/lib.rs
@@ -8,9 +8,14 @@
 //! width/wrap/truncate semantics survive the narrow waist and every backend
 //! reproduces the program's results.
 //!
-//! Implements [SIR27](../../../specs/SIR27-c-to-semantic-ir.md).  Milestone 1:
-//! functions, typed `+`/`-`/`*` arithmetic (with `Convert` insertion), casts,
-//! declarations & assignments, `printf`, and `return`.
+//! Implements [SIR27](../../../specs/SIR27-c-to-semantic-ir.md):
+//!
+//! - **Milestone 1** — functions, typed `+`/`-`/`*` arithmetic (with `Convert`
+//!   insertion), casts, declarations & assignments, `printf`, `return`.
+//! - **Milestone 2** — comparisons and control flow (`if`/`else`, `while`,
+//!   `for`, re-assignment), bridging the C-vs-SIR truthiness mismatch.
+//! - **Milestone 3** — early `return`, lifted into value-producing `If`s, which
+//!   is what makes guard clauses and idiomatic recursion translatable.
 
 mod lower;
 
@@ -119,17 +124,241 @@ mod tests {
         assert!(text.contains("(if (builtin-call >"), "no if-int:\n{text}");
     }
 
+    // ── milestone 3: early return ───────────────────────────────────────────
+
     #[test]
-    fn early_return_is_a_clean_error() {
-        // A `return` that is not the function's last statement has no SIR
-        // representation (no early exit) and must error, not miscompile.
+    fn guard_clause_lifts_into_a_value_producing_if() {
+        // `if (x == 0) { return 1; } return 0;` has no early-exit form in SIR,
+        // so it becomes the block's *value*: If(x==0, {1}, {0}).
+        let m = lower("int f(int x) { if (x == 0) { return 1; } return 0; }");
+        let text = semantic_ir::print_module(&m);
+        assert!(
+            text.contains("(block (if (builtin-call =="),
+            "guard clause not lifted into the block value:\n{text}"
+        );
+    }
+
+    #[test]
+    fn guard_clause_does_not_duplicate_the_continuation() {
+        // The tail attaches only to the branch that falls through, so it must
+        // appear exactly once — this is what keeps the transformation linear.
+        let m = lower("int f(int x) { if (x == 0) { return 1; } return 12345; }");
+        let text = semantic_ir::print_module(&m);
+        assert_eq!(
+            text.matches("12345").count(),
+            1,
+            "continuation duplicated:\n{text}"
+        );
+    }
+
+    #[test]
+    fn recursive_function_with_a_guard_clause_lowers() {
+        // The canonical shape that early return unlocks.
+        let m =
+            lower("int fib(int n) { if (n < 2) { return n; } return fib(n - 1) + fib(n - 2); }");
+        assert!(semantic_ir::validate(&m).is_ok());
+        let text = semantic_ir::print_module(&m);
+        assert!(text.contains("(direct-call fib"), "no recursion:\n{text}");
+    }
+
+    #[test]
+    fn long_statement_sequence_does_not_overflow_the_stack() {
+        // Regression: the sequence walk must be ITERATIVE.  Recursing once per
+        // statement overflowed the stack at ~350 statements — an ordinary
+        // function size, so this was a plain functionality bug as well as a
+        // DoS on untrusted input.
+        let mut src = String::from("int main(void) { int x = 0;");
+        for _ in 0..5000 {
+            src.push_str(" x = x + 1;");
+        }
+        src.push_str(" return x; }");
+        let m = lower(&src);
+        assert!(semantic_ir::validate(&m).is_ok());
+    }
+
+    #[test]
+    fn continuation_duplicating_if_is_rejected() {
+        // `if (c) { if (d) { return 1; } }` — neither branch returns on all
+        // paths, so lifting would copy the tail into BOTH.  Chained, that is
+        // 4^N IR nodes: <1 KB of C emitted hundreds of MB.  Refuse it.
         let err = compile_source(
-            "int f(int x) { if (x == 0) { return 1; } return 0; }",
+            "int f(int x) { if (x > 0) { if (x > 5) { return 1; } } return 0; }",
             "test",
         )
         .unwrap_err();
         assert!(
-            err.message.contains("early `return`"),
+            err.message.contains("duplicate the rest"),
+            "wrong error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn shadowing_a_live_name_is_rejected_everywhere() {
+        // The symbol table is flat (no per-block scopes) and nested `{ }` blocks
+        // are spliced into the enclosing sequence, so a re-used name collapses
+        // two bindings into one — silently taking the wrong type, and making the
+        // emitted C a `redefinition of 'v'` error.  One central check in
+        // `lower_init_declarator` covers every path that can bind a name.
+        for src in [
+            // A plain nested block: C scopes the inner `v` and returns 1001.
+            "int f(int x) { int v = 1; { uint8_t v = 250; v = v + 6; } return v + 1000; }",
+            // The falling-through branch of a lifted early return.
+            "int f(int x) { int v = 1; if (x > 0) { return 5; } \
+             else { uint8_t v = 250; } return v + 1000; }",
+            // Loops bind into the same flat table — `for`-init and `while` body.
+            "int f(int x){ int v=1; if(x>0){return 5;} \
+             else { for(uint8_t v=250; v>249; v=v+1){ x=x+1; } } return v+1000; }",
+            "int g(int x){ int v=1; if(x>0){return 5;} \
+             else { while(x<0){ uint8_t v=250; x=x+1; } } return v+1000; }",
+            // A branch that always returns: harmless in C, but the flat table
+            // still cannot represent it, and refusing is consistent.
+            "int f(int x) { int v = 1; if (x > 0) { uint8_t v = 250; return v; } \
+             return v + 1000; }",
+            // Two sequential `for (int i = …)` loops — the everyday form of the
+            // same limitation, which would otherwise emit non-compiling C.
+            "int f(int x) { for (int i = 0; i < 3; i = i + 1) { x = x + 1; } \
+             for (int i = 0; i < 3; i = i + 1) { x = x + 1; } return x; }",
+            // Shadowing a parameter.
+            "int f(int v) { if (v > 0) { return 5; } else { uint8_t v = 250; } return v; }",
+        ] {
+            let err = compile_source(src, "test")
+                .err()
+                .unwrap_or_else(|| panic!("should have been rejected: {src}"));
+            assert!(
+                err.message
+                    .contains("re-uses a name that is already in scope"),
+                "wrong error for {src}: {}",
+                err.message
+            );
+        }
+    }
+
+    #[test]
+    fn distinct_names_in_sibling_branches_still_compile() {
+        // The check must not fire across *sibling* branches: only one runs, and
+        // the symbol table is restored between them.
+        let m = lower(
+            "int f(int x) { if (x > 0) { int a = 1; return a; } \
+             else { int a = 2; return a; } }",
+        );
+        assert!(semantic_ir::validate(&m).is_ok());
+    }
+
+    /// `if (x > 0) return 0; if (x > 1) return 1; …` — the `sign()` idiom, a
+    /// *flat* sequence of sibling guards.  Recursing once per guard overflowed
+    /// the stack at ~150, so this shape must stay iterative.
+    fn chained_guards(n: usize) -> String {
+        let mut s = String::from("int f(int x) {");
+        for i in 0..n {
+            s.push_str(&format!(" if (x > {i}) return {i};"));
+        }
+        s.push_str(" return 0; }");
+        s
+    }
+
+    #[test]
+    fn many_sibling_guard_clauses_lower_without_recursing_per_guard() {
+        let m = lower(&chained_guards(40));
+        assert!(semantic_ir::validate(&m).is_ok());
+    }
+
+    #[test]
+    fn too_many_chained_guards_is_a_clean_error_not_a_crash() {
+        // Each lifted guard nests the emitted IR one level deeper, and every
+        // consumer of that IR (validator, backends, printer, Drop) walks it
+        // recursively — 250 aborted the process inside the validator.  Past the
+        // cap it must be a positioned error instead.
+        // Guards and expression nesting share one budget (they add in the
+        // emitted tree), so either cap may fire first — both are the point.
+        let err = compile_source(&chained_guards(250), "test").unwrap_err();
+        assert!(
+            err.message.contains("too many early returns") || err.message.contains("limit"),
+            "wrong error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn guards_plus_deep_expressions_share_one_budget() {
+        // Lifted guards and expression depth ADD in the emitted tree.  64 guards
+        // each returning a 50-term chain passed both caps independently and
+        // still overflowed the stack, so the budget must be joint.
+        let mut src = String::from("int f(int x) {");
+        for i in 0..64 {
+            src.push_str(&format!(" if (x > {i}) return x"));
+            for _ in 0..50 {
+                src.push_str(" + 1");
+            }
+            src.push(';');
+        }
+        src.push_str(" return 0; }");
+        let err = compile_source(&src, "test").unwrap_err();
+        assert!(
+            err.message.contains("limit"),
+            "wrong error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn nested_chains_do_not_multiply_past_the_cap() {
+        // `((((x + 1 ×22) + 1 ×22) …)` — checking a chain's width without
+        // *spending* it let each nesting level restart from the same low base,
+        // reaching ~14× the cap and aborting the process on a 369-byte input.
+        let mut e = String::from("x");
+        for _ in 0..4 {
+            let mut inner = format!("({e}");
+            for _ in 0..22 {
+                inner.push_str(" + 1");
+            }
+            inner.push(')');
+            e = inner;
+        }
+        let err = compile_source(&format!("int f(int x){{ return {e}; }}"), "test").unwrap_err();
+        assert!(
+            err.message.contains("limit"),
+            "wrong error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn deep_operator_chain_is_a_clean_error_not_a_crash() {
+        // A *flat* operator chain folds left into a tree as deep as it is wide,
+        // and the validator recurses over it — a 428-byte file of `x + 1 + 1 …`
+        // aborted the process (debug builds die around 80 terms).  Chain width
+        // is charged against the expression-depth budget, so this errors.
+        let mut src = String::from("int f(int x) { return x");
+        for _ in 0..200 {
+            src.push_str(" + 1");
+        }
+        src.push_str("; }");
+        let err = compile_source(&src, "test").unwrap_err();
+        assert!(
+            err.message.contains("limit"),
+            "wrong error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn ordinary_operator_chains_still_lower() {
+        let m = lower("int f(int x) { return x + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8; }");
+        assert!(semantic_ir::validate(&m).is_ok());
+    }
+
+    #[test]
+    fn return_inside_a_loop_is_a_clean_error() {
+        // Leaving a loop early needs a break-with-value, which SIR has no node
+        // for — so this must be a positioned error, not a miscompile.
+        let err = compile_source(
+            "int f(int x) { while (x > 0) { return 1; } return 0; }",
+            "test",
+        )
+        .unwrap_err();
+        assert!(
+            err.message.contains("`return` inside a loop"),
             "wrong error: {}",
             err.message
         );

--- a/code/packages/rust/c-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/c-to-semantic-ir/src/lower.rs
@@ -11,14 +11,20 @@
 //! Milestone 1: functions, typed integer `+`/`-`/`*`, casts, declarations,
 //! `printf`, and a trailing `return`.
 //!
-//! Milestone 2 (this revision) adds **comparisons and control flow** —
+//! Milestone 2 adds **comparisons and control flow** —
 //! `< > <= >= == !=`, `if`/`else`, `while`, `for`, and re-assignment — bridging
 //! the C-vs-SIR *truthiness mismatch* (C: `0` is false and a comparison yields
 //! `int` `0`/`1`; SIR: only nil/false are falsy and comparisons yield `bool`).
 //! A C condition lowers to a SIR bool (`!=(e, 0)`, or the comparison builtin
 //! directly), and a comparison used as a value lowers back to an int via
-//! `If(cmp, 1, 0)`.  Early `return` (anywhere but the function's last statement)
-//! stays deferred: SIR functions yield their block value, with no early exit.
+//! `If(cmp, 1, 0)`.
+//!
+//! Milestone 3 (this revision) adds **early `return`**.  SIR functions have no
+//! early-exit statement — they yield their block's value — so a returning `if`
+//! is *lifted* into a value-producing `Expr::If` whose non-returning branch
+//! continues with the rest of the function (see `lower_seq`).  That makes the
+//! guard-clause shape, and hence idiomatic recursion like `fib`, translatable.
+//! A `return` inside a loop still errors: it would need a break-with-value.
 
 use std::collections::HashMap;
 
@@ -257,18 +263,64 @@ fn if_int(cond: Expr) -> Expr {
 
 // ── The lowerer ──────────────────────────────────────────────────────────────
 
+/// The deepest tree one function may emit, counting lifted guards *and*
+/// expression nesting together — they add in the output, so they share a budget
+/// (`budget_used`).
+///
+/// Same output-depth argument as [`MAX_LIFTED_GUARDS`]: every consumer of the IR
+/// walks it recursively.  Expression depth comes from CST nesting (`((((x))))`)
+/// *and* from a **flat operator chain**, which the parser does not bound at all:
+/// `x + 1 + 1 + …` is one `additive` node with N operands that folds left into
+/// an N-deep tree.  Both are charged here, and a chain's width is *held* while
+/// its operands are lowered — checking without spending let widths at different
+/// nesting levels multiply rather than add, which reached ~14× this cap and
+/// aborted the process on a 369-byte input.
+///
+/// The value is empirical, calibrated against the most hostile realistic
+/// configuration: a **debug** build on a **1 MiB** stack (the Windows
+/// main-thread default — `cargo test` threads are larger, which is exactly how
+/// earlier versions of this bound looked safe while crashing in the wild).
+/// Ordinary C is far below it: an 8-term chain costs 8, a 3-deep `if` costs 9,
+/// 20 guards with small conditions cost ~23.
+const MAX_EXPR_DEPTH: usize = 48;
+
+/// The most early-return `if`s one function may have lifted.
+///
+/// Each lifted guard adds a level of `Expr::If` nesting to the emitted IR, and
+/// every consumer of that IR walks it **recursively** — the validator, all five
+/// backends, the text printer, even `Drop`.  So the bound that matters is on the
+/// *output* depth, not on the lowering (which is iterative).  Measured: a
+/// 150-guard function lowers, validates and emits fine, while 250 aborts the
+/// process inside the validator.  64 is comfortably clear of that and far beyond
+/// any real C function, and exceeding it is a clean positioned error instead of
+/// a stack-overflow crash on untrusted input.
+/// Kept equal to [`MAX_EXPR_DEPTH`] — guards are charged into that joint budget
+/// too, so this only adds a friendlier message for a pure guard chain.
+const MAX_LIFTED_GUARDS: usize = MAX_EXPR_DEPTH;
+
 struct Lowerer {
     /// Function signatures for call-site type resolution.
     fns: HashMap<String, (Vec<IntSpec>, Option<IntSpec>)>,
     /// Current function's in-scope names → (type, SIR scope).  Parameters bind
     /// as `Scope::Param`, local declarations as `Scope::Local`.
     vars: HashMap<String, (IntSpec, Scope)>,
+    /// Early-return `if`s lifted in the function currently being lowered — see
+    /// [`MAX_LIFTED_GUARDS`].  Reset per function.
+    lifted: usize,
+    /// Current expression nesting — see [`MAX_EXPR_DEPTH`].
+    expr_depth: usize,
+    /// Current *statement* nesting (`if`/`while`/`for` bodies and nested
+    /// blocks) — the third dimension of the same budget.
+    stmt_depth: usize,
 }
 
 pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, CLowerError> {
     let mut lo = Lowerer {
         fns: HashMap::new(),
         vars: HashMap::new(),
+        lifted: 0,
+        expr_depth: 0,
+        stmt_depth: 0,
     };
 
     // Pre-pass: collect function signatures.
@@ -388,6 +440,7 @@ impl Lowerer {
     fn lower_function(&mut self, f: &GrammarASTNode) -> Result<Function, CLowerError> {
         let (name, params, ret) = self.function_header(f)?;
         self.vars.clear();
+        self.lifted = 0;
         let mut sir_params = Vec::new();
         for (pname, ty) in &params {
             self.vars.insert(pname.clone(), (*ty, Scope::Param));
@@ -417,49 +470,212 @@ impl Lowerer {
         })
     }
 
-    /// Lower a `compound_stmt` as a function body: statements, then the value of
-    /// a trailing `return` (SIR functions return their block's value).  A
-    /// `return` anywhere but the last position has no SIR representation (no
-    /// early exit) and is a positioned error.
+    /// Lower a `compound_stmt` as a function body.
     fn lower_body(
         &mut self,
         body: &GrammarASTNode,
         ret: Option<IntSpec>,
     ) -> Result<Block, CLowerError> {
-        let items: Vec<&GrammarASTNode> = child_nodes(body)
-            .into_iter()
-            .filter(|x| x.rule_name == "block_item")
-            .collect();
-        let mut stmts = Vec::new();
+        let items = block_items_of(body);
+        self.lower_seq(&items, ret)
+    }
+
+    /// **The early-return transformation (milestone 3).**
+    ///
+    /// SIR functions have no early-exit statement — a function yields its
+    /// block's *value*.  C exits early all the time (guard clauses).  So we
+    /// lower a statement sequence to the block whose value *is* the function's
+    /// result, and when an `if` returns we make the **rest of the sequence the
+    /// continuation of the branch that doesn't return**:
+    ///
+    /// ```text
+    /// if (n < 2) return n;          If( n<2,
+    /// return fib(n-1)+fib(n-2);  →      {n},                    // then: returns
+    ///                                   {fib(n-1)+fib(n-2)} )   // else: the rest
+    /// ```
+    ///
+    /// Because the continuation attaches only to a branch that does *not*
+    /// already return, the common guard-clause shape never duplicates code.
+    /// (When *neither* branch returns on all paths yet one contains a return,
+    /// the tail is lowered into both branches — correct, since exactly one runs,
+    /// just larger.)
+    fn lower_seq(
+        &mut self,
+        items: &[&GrammarASTNode],
+        ret: Option<IntSpec>,
+    ) -> Result<Block, CLowerError> {
+        // This walk is **iterative in two dimensions**, and both matter:
+        //
+        //  * per *statement* — a function body is an unbounded statement list,
+        //    and recursing per statement overflowed the stack at a few hundred;
+        //  * per *sibling guard clause* — `if (a) return 1; if (b) return 2; …`
+        //    is the `sign()` idiom, and it is a flat sequence too.  Recursing
+        //    once per guard (lower_seq → lift_if → lower_branch → lower_seq)
+        //    overflowed at ~200 guards.
+        //
+        // So a returning `if` does not recurse into the continuation.  Instead
+        // its condition and its *returning* branch are pushed on a `frames`
+        // stack, the falling-through branch is spliced onto the work queue, and
+        // the nested `Expr::If` is folded bottom-up after the loop.  The only
+        // recursion left is into a *nested* sub-sequence (a returning branch),
+        // whose depth is bounded only incidentally — the C parser is itself
+        // recursive and dies on deeply nested statements before the lowering
+        // would, so this is not a guarantee to lean on.  Giving the parser a
+        // rule-depth counter (and this walk an explicit cap) is a follow-up.
+        struct Frame {
+            cond: Expr,
+            /// The branch that returns — already lowered.
+            branch: Block,
+            /// Is `branch` the `then` side (else the `else` side)?
+            branch_is_then: bool,
+            /// Statements that preceded this `if` at its own level.
+            before: Vec<Stmt>,
+        }
+
+        let mut work: std::collections::VecDeque<&GrammarASTNode> = items.iter().copied().collect();
+        let mut stmts: Vec<Stmt> = Vec::new();
+        let mut frames: Vec<Frame> = Vec::new();
+        // The value of the innermost block, once the walk finishes.  Falling off
+        // the end of a function yields nil.
         let mut value = Expr::NilLit { span: sp() };
-        let last = items.len().saturating_sub(1);
-        for (i, item) in items.iter().enumerate() {
-            let inner = peel_block_item(item);
-            match inner.rule_name.as_str() {
-                "declaration" => stmts.push(self.lower_declaration(inner)?),
-                "statement" => {
-                    let s = peel(inner);
-                    if s.rule_name == "return_stmt" {
-                        if i != last {
-                            return err(
-                                "early `return` is not supported yet (a `return` may appear \
-                                 only as the function's last statement)",
-                                s,
-                            );
-                        }
-                        value = self.lower_return(s, ret)?;
-                    } else {
-                        self.lower_stmt(s, &mut stmts)?;
+
+        while let Some(head) = work.pop_front() {
+            let e = seq_elem(head);
+            match e.rule_name.as_str() {
+                // `return e;` supplies the value — anything after it is dead.
+                "return_stmt" => {
+                    value = self.lower_return(e, ret)?;
+                    break;
+                }
+                // A nested `{ … }` splices into this sequence, in order (v1 has
+                // flat scoping).  Spliced in place rather than by recursing.
+                "compound_stmt" => {
+                    for it in block_items_of(e).into_iter().rev() {
+                        work.push_front(it);
                     }
                 }
-                other => return err(format!("block item `{other}` unsupported"), inner),
+                // An `if` that returns becomes a value-producing `If`.
+                "if_stmt" if if_returns(e) => {
+                    let cond_node = first_node(e, "expr").ok_or_else(|| CLowerError {
+                        message: "`if` without a condition".into(),
+                        line: e.start_line.unwrap_or(0),
+                        column: e.start_column.unwrap_or(0),
+                    })?;
+                    let cond = self.lower_cond(cond_node)?;
+                    let branches = if_branches(e);
+                    let then_items = branches
+                        .first()
+                        .map(|b| branch_items(b))
+                        .unwrap_or_default();
+                    let else_items = branches.get(1).map(|b| branch_items(b)).unwrap_or_default();
+                    let then_ret = always_returns(&then_items);
+                    let else_ret = always_returns(&else_items);
+
+                    // Bound the *emitted* nesting — see `MAX_LIFTED_GUARDS`.
+                    self.lifted += 1;
+                    if self.lifted > MAX_LIFTED_GUARDS {
+                        return err(
+                            format!(
+                                "too many early returns in one function (limit \
+                                 {MAX_LIFTED_GUARDS}); each one nests the emitted IR one \
+                                 level deeper, and every consumer of that IR walks it \
+                                 recursively"
+                            ),
+                            e,
+                        );
+                    }
+
+                    // Nothing left to thread (or both branches exit): lower both
+                    // branches directly.  Any queued statements are unreachable.
+                    if work.is_empty() || (then_ret && else_ret) {
+                        let saved = self.vars.clone();
+                        let tb = self.lower_seq(&then_items, ret)?;
+                        self.vars = saved.clone();
+                        let eb = self.lower_seq(&else_items, ret)?;
+                        self.vars = saved;
+                        value = Expr::If {
+                            cond: Box::new(cond),
+                            then_branch: Box::new(tb),
+                            else_branch: Box::new(eb),
+                            span: sp(),
+                        };
+                        break;
+                    }
+
+                    // Neither branch exits on every path, so the continuation
+                    // would have to be copied into *both*.  Correct but the
+                    // duplication compounds through nesting (4^N nodes), so it
+                    // is refused, like the `return`-inside-a-loop rule.
+                    if !then_ret && !else_ret {
+                        return err(
+                            "an `if` where neither branch returns on all paths but one \
+                             contains a `return` is not supported yet (lifting it would \
+                             duplicate the rest of the function into both branches)",
+                            e,
+                        );
+                    }
+
+                    // Exactly one branch exits; the other receives the
+                    // continuation and is spliced onto the work queue.
+                    let (ret_items, fall_items) = if then_ret {
+                        (then_items, else_items)
+                    } else {
+                        (else_items, then_items)
+                    };
+
+                    // (A declaration in the falling-through branch that shadows
+                    // an outer name would silently re-bind it for the
+                    // continuation, which is lowered inside that branch.  That
+                    // is caught centrally by `lower_init_declarator`, which
+                    // refuses any re-use of a live name.)
+
+                    // Lower the exiting branch now (recursion here is per
+                    // *nesting* level; see the note in `lower_seq`).
+                    let saved = self.vars.clone();
+                    let branch = self.lower_seq(&ret_items, ret)?;
+                    self.vars = saved;
+
+                    frames.push(Frame {
+                        cond,
+                        branch,
+                        branch_is_then: then_ret,
+                        before: std::mem::take(&mut stmts),
+                    });
+                    for it in fall_items.into_iter().rev() {
+                        work.push_front(it);
+                    }
+                }
+                // Anything else is an ordinary statement; lower it and continue.
+                "declaration" => stmts.push(self.lower_declaration(e)?),
+                _ => self.lower_stmt(e, &mut stmts)?,
             }
         }
-        Ok(Block {
+
+        // Fold the guards bottom-up: each frame wraps everything accumulated so
+        // far as the continuation of its non-returning side.
+        let mut cur = Block {
             stmts,
             value,
             span: sp(),
-        })
+        };
+        for f in frames.into_iter().rev() {
+            let (then_branch, else_branch) = if f.branch_is_then {
+                (f.branch, cur)
+            } else {
+                (cur, f.branch)
+            };
+            cur = Block {
+                stmts: f.before,
+                value: Expr::If {
+                    cond: Box::new(f.cond),
+                    then_branch: Box::new(then_branch),
+                    else_branch: Box::new(else_branch),
+                    span: sp(),
+                },
+                span: sp(),
+            };
+        }
+        Ok(cur)
     }
 
     /// The value a trailing `return e;` (or bare `return;`) supplies, converted
@@ -489,8 +705,10 @@ impl Lowerer {
         match s.rule_name.as_str() {
             "compound_stmt" => {
                 // A nested `{ … }` block: splice its statements in (v1 shares one
-                // flat symbol table — no per-block scoping).
-                let inner = self.lower_block_items(s)?;
+                // flat symbol table — no per-block scoping).  Charged for depth
+                // like any other nested body, so this recursion shares the
+                // budget too (see `charge_stmt_nesting`).
+                let inner = self.charge_stmt_nesting(s, |lo| lo.lower_block_items(s))?;
                 out.extend(inner);
             }
             "expr_stmt" => {
@@ -501,10 +719,15 @@ impl Lowerer {
             "if_stmt" => self.lower_if(s, out)?,
             "while_stmt" => self.lower_while(s, out)?,
             "for_stmt" => self.lower_for(s, out)?,
+            // `return` in a *statement* position that the early-return lifting
+            // could not turn into a value — in practice, inside a loop body.
+            // Exiting a loop early needs a break-with-value, which SIR has no
+            // node for, so this is a clear error rather than a miscompile.
             "return_stmt" => {
                 return err(
-                    "early `return` is not supported yet (a `return` may appear \
-                     only as the function's last statement)",
+                    "`return` inside a loop is not supported yet (early return is lifted \
+                     through `if`/`else`, but leaving a `while`/`for` early needs a \
+                     break-with-value)",
                     s,
                 )
             }
@@ -536,7 +759,34 @@ impl Lowerer {
     /// Lower a loop/branch body (`statement`, possibly a `compound_stmt`) to a
     /// SIR `Block` with a nil value — control-flow bodies are evaluated for
     /// their effects, not a value.
+    /// Run `f` one level deeper in statement nesting, charged against the joint
+    /// depth budget (see [`Self::budget_used`]) and restored on every path.
+    /// Both recursion sites for nested statements — loop/branch bodies via
+    /// [`Self::lower_void_block`] and bare `{ }` blocks via [`Self::lower_stmt`]
+    /// — go through here, so neither can grow the emitted tree without paying.
+    fn charge_stmt_nesting<T>(
+        &mut self,
+        at: &GrammarASTNode,
+        f: impl FnOnce(&mut Self) -> Result<T, CLowerError>,
+    ) -> Result<T, CLowerError> {
+        self.stmt_depth += 1;
+        if self.budget_used() > MAX_EXPR_DEPTH {
+            self.stmt_depth -= 1;
+            return err(
+                format!("statement nesting exceeds the limit of {MAX_EXPR_DEPTH}"),
+                at,
+            );
+        }
+        let result = f(self);
+        self.stmt_depth -= 1;
+        result
+    }
+
     fn lower_void_block(&mut self, stmt: &GrammarASTNode) -> Result<Block, CLowerError> {
+        self.charge_stmt_nesting(stmt, |lo| lo.lower_void_block_inner(stmt))
+    }
+
+    fn lower_void_block_inner(&mut self, stmt: &GrammarASTNode) -> Result<Block, CLowerError> {
         let s = peel(stmt);
         let stmts = if s.rule_name == "compound_stmt" {
             self.lower_block_items(s)?
@@ -752,7 +1002,45 @@ impl Lowerer {
     /// an intermediate comparison result feeds the next as an `int` `0`/`1`
     /// (matching C's chained-comparison semantics), and the final step is the
     /// bool we return.
+    /// Charge a flat operator chain's width against the expression-depth
+    /// budget: folding N operands left produces an N-deep tree.  Returns the
+    /// width, which the caller must **hold** (add to `expr_depth`) for as long
+    /// as it lowers the chain's operands — otherwise widths at different
+    /// nesting levels each restart from the same low base and multiply instead
+    /// of adding, which is how `((x+1…) +1…) +1…` reached ~14× the cap.
+    fn charge_chain(&mut self, n: &GrammarASTNode) -> Result<usize, CLowerError> {
+        let operands = child_nodes(n).len();
+        if self.budget_used() + operands > MAX_EXPR_DEPTH {
+            return err(
+                format!(
+                    "operator chain of {operands} operands nests the emitted expression \
+                     deeper than the limit of {MAX_EXPR_DEPTH}"
+                ),
+                n,
+            );
+        }
+        Ok(operands)
+    }
+
+    /// Depth already committed in the emitted tree.  Lifted guards, expression
+    /// nesting and **statement** nesting all add in the same output tree and in
+    /// the same recursive walk, so they share one budget.  Statement nesting is
+    /// weighted 3× because a level of it costs roughly three times the lowering
+    /// stack of one expression level (measured ~23 KB vs ~8 KB in a debug
+    /// build).
+    fn budget_used(&self) -> usize {
+        self.lifted + self.expr_depth + 3 * self.stmt_depth
+    }
+
     fn lower_compare_bool(&mut self, n: &GrammarASTNode) -> Result<Expr, CLowerError> {
+        let width = self.charge_chain(n)?;
+        self.expr_depth += width;
+        let result = self.lower_compare_bool_inner(n);
+        self.expr_depth -= width;
+        result
+    }
+
+    fn lower_compare_bool_inner(&mut self, n: &GrammarASTNode) -> Result<Expr, CLowerError> {
         let mut acc: Option<(Expr, IntSpec)> = None;
         let mut pending_op: Option<String> = None;
         let mut last_bool: Option<Expr> = None;
@@ -838,6 +1126,25 @@ impl Lowerer {
             .find(|t| t.effective_type_name() == "NAME")
             .map(|t| t.value.clone())
             .unwrap_or_default();
+        // v1's symbol table is **flat** — it has no per-block scopes — and the
+        // lowering splices nested `{ }` blocks into the enclosing sequence.  So
+        // a declaration that re-uses a live name cannot be modelled: the two
+        // bindings collapse into one SIR block, which silently takes the wrong
+        // type (a wrong-value miscompile) and makes the emitted C a
+        // `redefinition of 'x'` error.  Refuse it here — one check covering
+        // every path that can bind a name (plain blocks, `if`/`else` branches,
+        // loop bodies, `for`-inits, and the lifted early-return continuation).
+        if self.vars.contains_key(&name) {
+            return err(
+                format!(
+                    "declaration of `{name}` re-uses a name that is already in scope; \
+                     shadowing is not supported yet, because the symbol table has no \
+                     per-block scopes (two sequential `for (int i = …)` loops hit this \
+                     too)"
+                ),
+                init,
+            );
+        }
         let value = match first_node(init, "expr") {
             Some(e) => {
                 let (ex, ety) = self.lower_expr(e)?;
@@ -856,6 +1163,23 @@ impl Lowerer {
 
     /// Lower an expression, returning both the SIR node and its C type.
     fn lower_expr(&mut self, node: &GrammarASTNode) -> Result<(Expr, IntSpec), CLowerError> {
+        // Bound the depth of the tree we emit — see `MAX_EXPR_DEPTH`.  The
+        // counter is restored on every path so a rejected sub-expression does
+        // not poison the rest of the function.
+        self.expr_depth += 1;
+        if self.budget_used() > MAX_EXPR_DEPTH {
+            self.expr_depth -= 1;
+            return err(
+                format!("expression nests deeper than the limit of {MAX_EXPR_DEPTH}"),
+                node,
+            );
+        }
+        let result = self.lower_expr_inner(node);
+        self.expr_depth -= 1;
+        result
+    }
+
+    fn lower_expr_inner(&mut self, node: &GrammarASTNode) -> Result<(Expr, IntSpec), CLowerError> {
         let n = peel(node);
         match n.rule_name.as_str() {
             // Binary arithmetic / bitwise / shift — left-associative fold.
@@ -879,6 +1203,17 @@ impl Lowerer {
     }
 
     fn lower_binary(&mut self, n: &GrammarASTNode) -> Result<(Expr, IntSpec), CLowerError> {
+        // A chain is flat in the CST but folds left into a tree as deep as it is
+        // wide, so its width is charged against the same budget as nesting — and
+        // *held* while its operands are lowered.
+        let width = self.charge_chain(n)?;
+        self.expr_depth += width;
+        let result = self.lower_binary_inner(n);
+        self.expr_depth -= width;
+        result
+    }
+
+    fn lower_binary_inner(&mut self, n: &GrammarASTNode) -> Result<(Expr, IntSpec), CLowerError> {
         // children: operand (op operand)+   — fold left.
         let mut acc: Option<(Expr, IntSpec)> = None;
         let mut pending_op: Option<String> = None;
@@ -1094,6 +1429,101 @@ impl Lowerer {
 
 fn peel_block_item(item: &GrammarASTNode) -> &GrammarASTNode {
     child_nodes(item).into_iter().next().unwrap_or(item)
+}
+
+// ── sequence / control-flow shape analysis (milestone 3) ────────────────────
+//
+// The early-return transformation reasons about *sequences* of statements that
+// may come from a `compound_stmt` (a list of `block_item`s) or from a single
+// unbraced branch (`if (c) return 1;`).  These helpers normalise both shapes so
+// `lower_seq` can walk them uniformly.
+
+/// Reduce a `block_item` (or a bare `statement`) to the node carrying its kind:
+/// a `declaration`, or the peeled statement kind (`return_stmt`, `if_stmt`, …).
+fn seq_elem(n: &GrammarASTNode) -> &GrammarASTNode {
+    let inner = if n.rule_name == "block_item" {
+        peel_block_item(n)
+    } else {
+        n
+    };
+    if inner.rule_name == "declaration" {
+        inner
+    } else {
+        peel(inner)
+    }
+}
+
+/// The `block_item` children of a `compound_stmt`.
+fn block_items_of(compound: &GrammarASTNode) -> Vec<&GrammarASTNode> {
+    child_nodes(compound)
+        .into_iter()
+        .filter(|x| x.rule_name == "block_item")
+        .collect()
+}
+
+/// The `statement` children of an `if_stmt`: `[then]` or `[then, else]`.
+fn if_branches(s: &GrammarASTNode) -> Vec<&GrammarASTNode> {
+    child_nodes(s)
+        .into_iter()
+        .filter(|x| x.rule_name == "statement")
+        .collect()
+}
+
+/// A branch as a statement sequence: a braced branch contributes its
+/// `block_item`s, an unbraced one contributes itself as a single element.
+fn branch_items(branch: &GrammarASTNode) -> Vec<&GrammarASTNode> {
+    let s = peel(branch);
+    if s.rule_name == "compound_stmt" {
+        block_items_of(s)
+    } else {
+        vec![branch]
+    }
+}
+
+/// Does this sequence return on **every** path?  Used to decide whether a
+/// branch needs the continuation appended.  Conservative: an `if` without an
+/// `else` never qualifies, and loops are not analysed (a `while` may run zero
+/// times, so it can never guarantee a return).
+fn always_returns(items: &[&GrammarASTNode]) -> bool {
+    items.iter().any(|it| {
+        let e = seq_elem(it);
+        match e.rule_name.as_str() {
+            "return_stmt" => true,
+            "compound_stmt" => always_returns(&block_items_of(e)),
+            "if_stmt" => {
+                let br = if_branches(e);
+                match (br.first(), br.get(1)) {
+                    (Some(t), Some(f)) => {
+                        always_returns(&branch_items(t)) && always_returns(&branch_items(f))
+                    }
+                    _ => false, // no `else` — the fall-through path doesn't return
+                }
+            }
+            _ => false,
+        }
+    })
+}
+
+/// Does either branch of this `if` contain a `return` in a *liftable* position?
+/// Deliberately does not descend into loops: a `return` inside a `while`/`for`
+/// cannot be turned into a value (it needs a break-with-value), so it is left
+/// for `lower_stmt` to reject with a clear, positioned error.
+fn if_returns(s: &GrammarASTNode) -> bool {
+    if_branches(s)
+        .iter()
+        .any(|b| contains_return(&branch_items(b)))
+}
+
+fn contains_return(items: &[&GrammarASTNode]) -> bool {
+    items.iter().any(|it| {
+        let e = seq_elem(it);
+        match e.rule_name.as_str() {
+            "return_stmt" => true,
+            "compound_stmt" => contains_return(&block_items_of(e)),
+            "if_stmt" => if_returns(e),
+            _ => false,
+        }
+    })
 }
 
 /// The string-literal value inside a call's arg_list (the printf format), with

--- a/code/packages/rust/c-to-semantic-ir/tests/three_way_conformance.rs
+++ b/code/packages/rust/c-to-semantic-ir/tests/three_way_conformance.rs
@@ -305,6 +305,63 @@ fn corpus() -> Vec<Case> {
                    if (x == 0) { r = 100; } else { r = 200; } return r; }\n\
                    int main(void) { printf(\"%d\\n\", classify(0)); return 0; }",
         },
+        // ── milestone 3: early return ────────────────────────────────────────
+        Case {
+            // The headline: idiomatic recursion with a guard clause — impossible
+            // before early-return lifting.
+            label: "recursive fib(20) with a guard clause → 6765",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int fib(int n) { if (n < 2) { return n; } \
+                   return fib(n - 1) + fib(n - 2); }\n\
+                   int main(void) { printf(\"%d\\n\", fib(20)); return 0; }",
+        },
+        Case {
+            label: "chained guard clauses sign(-5) → -1",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int sign(int x) { if (x > 0) { return 1; } \
+                   if (x < 0) { return -1; } return 0; }\n\
+                   int main(void) { printf(\"%d\\n\", sign(-5)); return 0; }",
+        },
+        Case {
+            label: "unbraced guard clause (no block) sign2(0) → 0",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int sign2(int x) { if (x > 0) return 1; if (x < 0) return -1; return 0; }\n\
+                   int main(void) { printf(\"%d\\n\", sign2(0)); return 0; }",
+        },
+        Case {
+            label: "if/else where both branches return, larger(7,3) → 7",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int larger(int a, int b) { if (a > b) { return a; } else { return b; } }\n\
+                   int main(void) { printf(\"%d\\n\", larger(7, 3)); return 0; }",
+        },
+        Case {
+            label: "statements before an early return, f(6) → 12",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int f(int x) { int y = x * 2; if (y > 10) { return y; } return 0; }\n\
+                   int main(void) { printf(\"%d\\n\", f(6)); return 0; }",
+        },
+        Case {
+            label: "nested if inside an else, deep(-5) → 300",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int deep(int x) { if (x == 0) { return 100; } \
+                   else { if (x > 0) { return 200; } return 300; } }\n\
+                   int main(void) { printf(\"%d\\n\", deep(-5)); return 0; }",
+        },
+        Case {
+            // Early return still carries the width semantics through.
+            label: "early return of a wrapped uint8 → 44",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int wrap8(int go) { uint8_t c = 200 + 100; if (go > 0) { return c; } return 0; }\n\
+                   int main(void) { printf(\"%d\\n\", wrap8(1)); return 0; }",
+        },
+        Case {
+            label: "early return combined with a loop result → 5050",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   uint32_t total(int go) { uint32_t s = 0; \
+                   for (int i = 1; i <= 100; i = i + 1) { s = s + i; } \
+                   if (go > 0) { return s; } return 0; }\n\
+                   int main(void) { printf(\"%u\\n\", total(1)); return 0; }",
+        },
     ]
 }
 

--- a/code/specs/SIR27-c-to-semantic-ir.md
+++ b/code/specs/SIR27-c-to-semantic-ir.md
@@ -166,12 +166,111 @@ end of the loop body, and an absent condition becomes `true`.  A nested `{ … }
 block is spliced into the enclosing statement list (v1 does not model per-block
 scopes; the flat symbol table is shared).
 
-**Early `return` is still out of scope.**  SIR functions yield their block's
-*value* — there is no early-return statement — so `return` is accepted **only as
-the function's last statement** (where it supplies that value).  A `return`
-inside an `if`/`while`/`for` body is a clear, positioned error rather than a
-silent miscompile; lifting it into nested `If` values is a later milestone.
-Logical `&& ||`, unary `!`, bitwise, and `/`/`%` also remain deferred.
+Logical `&& ||`, unary `!`, bitwise, and `/`/`%` remain deferred.
+
+## Early `return` — return lifting (milestone 3)
+
+SIR functions yield their block's **value**; there is no early-exit statement.
+C exits early constantly (guard clauses), so milestone 3 **lifts** a returning
+`if` into a value-producing `Expr::If`, making **the rest of the function the
+continuation of the branch that does not return**:
+
+```text
+int fib(int n) {                     (function fib (n)
+  if (n < 2) return n;                 (block
+  return fib(n-1) + fib(n-2);            (if (< n 2)
+}                                            (block n)
+                                             (block (+ (fib (- n 1)) (fib (- n 2)))))))
+```
+
+The lowering walks a statement sequence (`lower_seq`) and, for each head:
+
+| head | result |
+|---|---|
+| `return e;` | the block's value is `Convert{ret}(e)`; the rest is unreachable |
+| `{ … }` | its items are spliced into this sequence (v1 has flat scoping) |
+| `if` containing a `return` | `If(cond, then′, else′)` — see below |
+| anything else | lower it as a statement, then continue with the tail |
+
+For a lifted `if`, each branch is lowered with the continuation appended **only
+if that branch can fall through** (`always_returns` is false).  So the
+guard-clause shape — where the `then` always returns — attaches the tail to the
+`else` alone and **never duplicates code**.
+
+`always_returns` is deliberately conservative: an `if` without an `else` never
+qualifies, and loops are not analysed (a `while` may iterate zero times).
+
+The sequence walk is **iterative in two dimensions**, and both matter because
+both are *flat* sequences the parser does not bound:
+
+- per **statement** — a function body is an unbounded statement list;
+- per **sibling guard clause** — `if (a) return 1; if (b) return 2; …` (the
+  `sign()` idiom) is equally flat.
+
+So a lifted `if` does not recurse into its continuation.  Its condition and its
+*returning* branch are pushed on a stack, the falling-through branch is spliced
+onto the work queue, and the nested `If` is folded bottom-up once the walk ends.
+Recursion remains only for a *nested* sub-sequence, which the parser's rule-depth
+guard bounds.
+
+### Five shapes that are refused (rather than mis-handled)
+
+1. **`return` inside a loop.**  Leaving a `while`/`for` early needs a
+   break-with-value, which SIR has no node for.
+2. **An `if` where neither branch returns on all paths but one contains a
+   `return`.**  Lifting it would place the continuation in *both* branches.
+   That is semantically fine (exactly one runs) but the duplication compounds
+   through nesting — N chained guards of this shape produce **4^N** IR nodes, so
+   well under 1 KB of C can emit hundreds of megabytes.  A future version can
+   hoist the continuation into a synthesized function called from both branches,
+   making the transform linear; until then it is a positioned error.
+3. **A declaration that re-uses a name already in scope.**  v1's symbol table is
+   **flat** — it has no per-block scopes — and nested `{ }` blocks are spliced
+   into the enclosing sequence, so two bindings of one name collapse into a
+   single SIR block.  That silently takes the wrong type *and* makes the emitted
+   C a `redefinition of 'v'` error:
+
+   ```c
+   int f(int x) { int v = 1; { uint8_t v = 250; v = v + 6; } return v + 1000; }
+   ```
+
+   C scopes the inner `v` and yields **1001**; lowering it flat yields **1000**.
+   Early return sharpens the same hazard, because the continuation is lowered
+   *inside* the branch that falls through.  So the check lives in one place —
+   the declaration itself — covering every path that can bind a name: plain
+   blocks, `if`/`else` branches, loop bodies, `for`-inits, and the lifted
+   continuation.  Sibling branches are unaffected (only one runs, and the table
+   is restored between them).  Two sequential `for (int i = …)` loops are the
+   everyday form of this limitation.
+4. **An emitted tree deeper than the budget.**  Every consumer of the IR walks
+   it recursively, so the frontend caps how deep a tree it will build.  Depth
+   accumulates from **three** independent sources that all add in the same tree
+   and the same recursion, so they share **one** budget:
+   - **flat operator chains** — `x + 1 + 1 + …` is one node with N operands that
+     folds left into an N-deep tree, and nothing else bounds N;
+   - **expression nesting** — `((((x))))`;
+   - **statement nesting** — nested `if`/`while`/`for` bodies and blocks
+     (weighted 3×, matching its measured ~3× lowering-stack cost per level).
+
+   Two subtleties, both found the hard way: a chain's width must be **held**
+   while its operands are lowered, not merely checked on entry (otherwise widths
+   at different nesting levels each restart from the same base and *multiply* —
+   ~14× the cap, aborting on a 369-byte input); and the sources must be budgeted
+   *jointly* (64 guards each returning a 50-term chain passed two independent
+   caps and still overflowed).
+
+   The cap is calibrated empirically against the most hostile realistic
+   configuration — a **debug** build on a **1 MiB** stack.  Calibrating against
+   a test-harness thread instead is exactly how earlier versions looked safe
+   while crashing in the wild.
+5. **More than that many lifted early returns in one function.**  Each lifted guard
+   nests the emitted IR one level deeper, and every consumer of that IR walks it
+   *recursively* — the validator, all five backends, the text printer, even
+   `Drop`.  Measured: 150 chained guards lower, validate and emit fine while 250
+   abort the process inside the validator.  The bound that matters is therefore
+   on the **output** depth, not the lowering, so the frontend caps it and reports
+   a positioned error.  Lifting the cap means making those consumers iterative —
+   a cross-cutting change well beyond this frontend.
 
 ## Pipeline
 


### PR DESCRIPTION
## Milestone 3 of the C → SIR → Ruby initiative — early `return`

SIR functions have no early-exit statement (they yield their block's *value*), so C's guard-clause idiom — and therefore idiomatic recursion — could not be translated at all. This **lifts** a returning `if` into a value-producing `Expr::If` whose non-returning branch becomes the continuation of the rest of the function:

```c
int fib(int n) { if (n < 2) return n; return fib(n-1) + fib(n-2); }
```
→ `(if (< n 2) (block n) (block (+ (fib (- n 1)) (fib (- n 2)))))`

The continuation attaches only to a branch that can fall through, so the common guard-clause shape **never duplicates code**. The statement-sequence walk is a **trampoline** — iterative in both the per-statement and per-sibling-guard dimensions — and the nested `If` is folded bottom-up.

### Five shapes refused with positioned errors (rather than mis-handled)
- `return` inside a loop (needs a break-with-value SIR lacks);
- an `if` where neither branch returns on all paths but one contains a `return` (lifting would duplicate the continuation into both → 4^N nodes);
- a declaration re-using a live name (the flat symbol table has no per-block scopes; would miscompile and emit `redefinition of 'v'` C);
- an emitted tree past a **joint depth budget** shared by flat operator-chain width, expression nesting, and statement nesting (all add in the output and in the recursive IR walk);
- more than that many lifted early returns in one function.

### Verified locally
- **27-program three-way conformance corpus** byte-identical across reference `clang -fwrapv`, emitted Ruby (`ruby` 3.4), and emitted C.
- Nine early-return programs — **`fib(20)=6765`**, `sign`, unbraced guards, both-branches-return, statements-before-return, nested-if-in-else, uint8 wrap through a guard, loop result behind a guard, banded guards — also compile+run identically on **clang + gcc + MSVC**.

### Security
Hardened across **six adversarial review rounds**. Found and fixed: a per-statement stack overflow, a per-sibling-guard stack overflow, 4^N IR blowup, a silent shadowing miscompile (`f(3)` → 1250 where C gives 1001), a validator-depth crash, a `charge_chain` check-but-don't-spend multiply bypass (~14×, 369-byte crash), and a third (statement-nesting) uncharged depth dimension. All DoS shapes now reject cleanly on a 1 MiB debug stack; final review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)