### PR TITLE
fix(semantic-ir-to-typescript): add eval/arguments to is_ts_reserved (strict-mode contextual reserved words)

### DIFF
--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 0.11.1 — `is_ts_reserved` was missing `eval`/`arguments` (task #112, the direct TS sibling of task #110's JS fix)
+
+**Not a syntactic-keyword gap — a strict-mode contextual-reserved-word
+gap**, identical to the one just fixed in `semantic-ir-to-javascript`
+(task #110). `is_ts_reserved` (`emit.rs`) is the shared identifier-safety
+check every frontend that lowers to this backend (MATLAB, Octave, Wolfram,
+Macsyma, Maxima, APL, J, Derive, Reduce, Maple, Scilab, Q, Python, Ruby,
+JS, Twig, and more) goes through via `sanitize_ident`/`is_valid_ts_ident`
+before emitting a user-level identifier as a TypeScript binding. It
+already listed every syntactic keyword (`if`, `for`, `class`, …) plus a
+handful of contextual/type-level ones unsafe as bindings (`let`, `static`,
+`any`, `boolean`, `number`, `string`, `symbol`, `type`, `namespace`,
+`interface`, and the rest of the future-reserved-in-strict-mode set) —
+but not `eval` or `arguments`.
+
+Neither is a syntactic keyword; both are ordinary identifiers lexically.
+But TypeScript is a superset of JavaScript that compiles to (and, in
+ES-module contexts, is itself parsed under) strict-mode-equivalent
+semantics, and strict mode specifically forbids binding, assigning to, or
+otherwise declaring a variable, parameter, function, or class named
+`eval` or `arguments` — a compile-time error. A SIR module with a
+user-level name `eval` or `arguments` would previously have been emitted
+verbatim by `sanitize_ident` (since `is_ts_reserved` returned `false`),
+producing invalid/broken TypeScript output.
+
+Fixed by adding both to the existing `matches!` list in `is_ts_reserved`
+(same style and position as the JS sibling fix — appended after
+`"public"`; no restructuring). New unit test
+`is_ts_reserved_flags_strict_mode_contextual_words` (modeled directly on
+the JS sibling's `is_js_reserved_flags_strict_mode_contextual_words`)
+pins both as reserved, confirms `sanitize_ident` prefixes both with
+`_$`, and confirms ordinary look-alike identifiers (`value`, `evaluate`,
+`argument`) are untouched.
+
 ## 0.11.0 — SIR22 "APL addendum" codegen: `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`
 
 Closes the gap 0.10.0's own CHANGELOG entry (below) flagged as a "scope

--- a/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-typescript"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 description = "Semantic IR → self-contained TypeScript source code (SIR12). First backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -2601,6 +2601,8 @@ fn is_ts_reserved(s: &str) -> bool {
             | "private"
             | "protected"
             | "public"
+            | "arguments"
+            | "eval"
     )
 }
 
@@ -2728,6 +2730,27 @@ mod tests {
     fn sanitize_avoids_reserved_words() {
         assert_ne!(sanitize_ident("class"), "class");
         assert!(sanitize_ident("class").starts_with("_$"));
+    }
+
+    #[test]
+    fn is_ts_reserved_flags_strict_mode_contextual_words() {
+        // `eval` and `arguments` are not syntactic keywords, but this
+        // backend emits TypeScript that is a strict-mode-equivalent
+        // superset of JavaScript (compiled/parsed under the same
+        // strict-mode identifier restrictions), and strict mode forbids
+        // binding, assigning to, or otherwise shadowing either name — so
+        // they must be treated as reserved here too, exactly like the
+        // syntactic keywords above.
+        assert!(is_ts_reserved("eval"));
+        assert!(is_ts_reserved("arguments"));
+        assert!(sanitize_ident("eval").starts_with("_$"));
+        assert!(sanitize_ident("arguments").starts_with("_$"));
+
+        // Ordinary identifiers — including close look-alikes — are
+        // unaffected by the addition.
+        assert!(!is_ts_reserved("value"));
+        assert!(!is_ts_reserved("evaluate"));
+        assert!(!is_ts_reserved("argument"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `is_ts_reserved` (shared identifier-safety check in `semantic-ir-to-typescript`, used by every frontend that lowers to this backend — MATLAB, Octave, Wolfram, Macsyma, Maxima, APL, J, Derive, Reduce, Maple, Scilab, Q, Python, Ruby, JS, Twig, etc.) was missing `eval` and `arguments`.
- This is the direct TS sibling of PR #8870 (`semantic-ir-to-javascript`'s `is_js_reserved` fix, task #110), flagged as a follow-up by that PR's security review. Same root cause: neither is a syntactic keyword, but TypeScript compiles to (and, in ES-module contexts, is parsed under) strict-mode-equivalent semantics, which forbid binding/assigning/shadowing either name as a variable, parameter, function, or class name.
- Fixed by adding both to the existing `matches!` list, same style/position as the JS sibling fix.
- New regression test `is_ts_reserved_flags_strict_mode_contextual_words`, modeled directly on the JS sibling's test.
- Version bump 0.11.0 → 0.11.1 + CHANGELOG entry.

Task #112 in the ongoing HML01/SIR hardening track.

## Test plan
- [x] `cargo test -p semantic-ir-to-typescript` — 119 unit tests + all integration suites pass, including the new test
- [x] Revert-and-confirm: temporarily removed the two new match arms, confirmed the new test fails with the exact predicted assertion failure, restored the fix, confirmed it passes again
- [x] `cargo check --workspace` (excluding a pre-existing, unrelated `os-kernel`/UEFI `panic_impl` failure and two Windows-only crates) — clean
- [x] `/security-review` — passed clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)