### PR TITLE
feat(semantic-ir-to-c): keyword parameters — KW6 name resolution (SIR19)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 0.11.0 — keyword parameters (SIR19)
+
+Accepts `Feature::KeywordParams`, building directly on the `_sir_missing`
+default-parameter machinery (0.10.0). C has no native keyword calls, so — like
+the Go backend's KW6 — a keyword argument is resolved to its callee's parameter
+**slot by name at emit time**, producing a plain positional C call:
+
+- A **keyword parameter** needs NO special signature — it is a positional
+  `SirValue` C parameter like any other. Only the call site resolves by name.
+- A `DirectCall` carrying any `KeywordArg` routes to a dedicated resolver
+  (`emit_keyword_call`) instead of the generic left-to-right hoist. For each
+  callee slot, in declared order, the filler is: the leading positional argument
+  at that index; else the `KeywordArg` naming that parameter; else
+  `_sir_missing()` (an omitted optional — the validator guarantees a required
+  keyword is never left out, and the same default prologue as `DefaultParams`
+  substitutes the default).
+- The thread-local signature map — previously just a per-callee arity for
+  default padding — now stores each callee's **parameter names** in order, so
+  the resolver can place a keyword argument at its slot. (Renamed `ARITY` →
+  `SIGNATURES`; `callee_arity` derives the length, `callee_param_names` the
+  names. Still read only by key, so emission stays deterministic.)
+- Each filler is hoisted into a temp first (matching the statement-oriented
+  emitter), so a compound keyword value (`f(b: g(), a: 10)`) is evaluated
+  exactly once; the temps are computed in slot order, matching Go's
+  declared-order evaluation. The unsupported-builtin pre-check scans a keyword
+  argument's value.
+
+Because a `KeywordArg` argument is non-`is_simple`, a keyword-bearing call is
+always compound → routed through `emit_keyword_call`, so a `KeywordArg` node
+never reaches the generic arg emit or `emit_expr` (where it has no arm). A
+`KeywordArg` outside a call is rejected by the validator before emit.
+
+First of the KeywordParams parity arc's C half: with the Ruby backend (0.9.0),
+`KeywordParams` is now accepted on five of six backends (the Rust backend is a
+separate gap). Verified with hand-built modules compiled and run through a real
+`cc`: a keyword argument binding by name, order-independent resolution (`f(b: 2,
+a: 10)` → `8` for `f(a:, b:) = a - b`), an optional keyword using its default
+when omitted (`f()` → `7` for `f(x: 7)`) and overridden when supplied, a mixed
+positional + keyword call, and a compound keyword value hoisted once. Bumps
+semantic-ir-to-c 0.10.0 → 0.11.0.
+
 ## 0.10.0 — default parameters (SIR19)
 
 Accepts `Feature::DefaultParams`. C has no native default parameters, so — like

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -91,13 +91,16 @@ native float arithmetic, the division frontier (Float promotes, two Integers
 floor), and IEEE non-finite results; SIR16 `ShortCircuit` — `LogicalAnd`
 (`&&`) and `LogicalOr` (`||`) lowered to an `if (_sir_truthy(...))` overwrite
 that short-circuits the dead operand and yields the deciding operand (not a
-bool); and SIR19 `DefaultParams` — a positional default via a `_sir_missing`
+bool); SIR19 `DefaultParams` — a positional default via a `_sir_missing`
 sentinel: a `DirectCall` pads omitted trailing arguments and each function opens
 with an `if (_sir_is_missing(p)) { p = <default>; }` prologue (a later default
-may reference an earlier parameter).
+may reference an earlier parameter); and SIR19 `KeywordParams` — a keyword
+argument resolved to its callee's parameter slot **by name** at emit time (KW6),
+producing a plain positional C call (omitted optional keywords filled with
+`_sir_missing()` and substituted by the same default prologue).
 
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
-`Intrinsics`, `NDArrays`, `KeywordParams`, exceptions/OOP, and every
+`Intrinsics`, `NDArrays`, exceptions/OOP, and every
 other not-yet-wired feature until its batch lands.  `Bignum` stays rejected
 until a bignum runtime ships — a module needing arbitrary precision is refused,
 never silently truncated.

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -25,12 +25,13 @@ thread_local! {
     static TEMP_ID: Cell<u64> = const { Cell::new(0) };
 
     /// Per-module map from a user function's RAW name to its declared parameter
-    /// count, snapshotted at the top of [`emit_module`].  A `DirectCall` that
-    /// omits trailing SIR19-defaulted arguments pads the call up to this arity
-    /// with `_sir_missing()`; the callee's prologue then substitutes each
-    /// default.  Thread-local (like `TEMP_ID`) so the deep `emit_expr` /
-    /// `emit_assign` call tree can read it without threading a context.
-    static ARITY: RefCell<HashMap<String, usize>> = RefCell::new(HashMap::new());
+    /// NAMES in order, snapshotted at the top of [`emit_module`].  Used at a
+    /// `DirectCall` for two SIR19 jobs: default-argument padding needs the arity
+    /// (the length), and keyword resolution needs the names (to place a
+    /// `KeywordArg` at its callee slot by name).  Thread-local (like `TEMP_ID`)
+    /// so the deep `emit_expr` / `emit_assign` call tree can read it without
+    /// threading a context.
+    static SIGNATURES: RefCell<HashMap<String, Vec<String>>> = RefCell::new(HashMap::new());
 }
 
 fn fresh_id() -> u64 {
@@ -44,7 +45,14 @@ fn fresh_id() -> u64 {
 /// The declared parameter count of a known user function (by raw name), for
 /// call-site default-argument padding.  `None` for an unknown callee.
 fn callee_arity(fn_name: &str) -> Option<usize> {
-    ARITY.with(|a| a.borrow().get(fn_name).copied())
+    SIGNATURES.with(|a| a.borrow().get(fn_name).map(|p| p.len()))
+}
+
+/// The declared parameter NAMES of a known user function (by raw name), for
+/// resolving a `KeywordArg` to its callee slot.  `None` for an unknown callee
+/// (which the validator guarantees never receives keyword arguments).
+fn callee_param_names(fn_name: &str) -> Option<Vec<String>> {
+    SIGNATURES.with(|a| a.borrow().get(fn_name).cloned())
 }
 
 /// Append `_sir_missing()` arguments to bring a `DirectCall`'s `provided`
@@ -67,13 +75,17 @@ fn emit_default_padding(out: &mut String, fn_name: &str, provided: usize) {
 /// Emit a complete self-contained C source file for `m`.
 pub fn emit_module(m: &Module) -> String {
     TEMP_ID.with(|c| c.set(0));
-    // Snapshot each user function's declared arity for `DirectCall` default
-    // padding (SIR19).  Cleared first so a reused thread starts empty.
-    ARITY.with(|a| {
+    // Snapshot each user function's declared parameter names for `DirectCall`
+    // default padding (needs the count) and keyword resolution (needs the
+    // names).  Cleared first so a reused thread starts empty.
+    SIGNATURES.with(|a| {
         let mut map = a.borrow_mut();
         map.clear();
         for f in &m.functions {
-            map.insert(f.name.clone(), f.params.len());
+            map.insert(
+                f.name.clone(),
+                f.params.iter().map(|p| p.name.clone()).collect(),
+            );
         }
     });
 
@@ -760,6 +772,15 @@ fn hoist_operands(out: &mut String, ops: &[&Expr], indent: usize) -> Vec<String>
 fn emit_compound_call(out: &mut String, dst: &str, e: &Expr, indent: usize) {
     let pad = indent_str(indent);
     let args = call_args(e).expect("emit_compound_call on a non-call expr");
+    // SIR19 keyword call: a `DirectCall` carrying any `KeywordArg` needs by-name
+    // resolution to the callee's declared slots (not the generic left-to-right
+    // hoist below), so route it to the dedicated resolver.
+    if let Expr::DirectCall { fn_name, .. } = e {
+        if args.iter().any(|a| matches!(a, Expr::KeywordArg { .. })) {
+            emit_keyword_call(out, dst, fn_name, args, indent);
+            return;
+        }
+    }
     let _ = writeln!(out, "{pad}{{");
     let inner = indent + 1;
     let ipad = indent_str(inner);
@@ -779,6 +800,86 @@ fn emit_compound_call(out: &mut String, dst: &str, e: &Expr, indent: usize) {
     let _ = write!(out, "{ipad}{dst} = ");
     emit_call_with_arg_names(out, e, &names);
     out.push_str(";\n");
+    let _ = writeln!(out, "{pad}}}");
+}
+
+/// Emit a `DirectCall` that carries keyword arguments (SIR19 `KeywordParams`).
+///
+/// C has no native keyword calls, so — like the Go backend's KW6 — a keyword
+/// argument is resolved to the callee's declared parameter SLOT BY NAME at emit
+/// time, producing a plain positional C call.  For each callee slot, in
+/// declared order, the filler is: the leading positional argument at that index;
+/// else the `KeywordArg` naming that parameter; else `_sir_missing()` (an
+/// omitted optional slot — the validator guarantees a required parameter is
+/// never left out, and the callee's prologue substitutes the default).  Each
+/// filler expression is hoisted into a temp first (matching the statement-
+/// oriented emitter), so a compound argument is evaluated exactly once; the
+/// temps are computed in slot order (matching Go's declared-order evaluation).
+fn emit_keyword_call(out: &mut String, dst: &str, fn_name: &str, args: &[Expr], indent: usize) {
+    let pad = indent_str(indent);
+    let inner = indent + 1;
+    let ipad = indent_str(inner);
+
+    // The validator guarantees every keyword argument trails all positionals, so
+    // the first `KeywordArg` marks the split.
+    let split = args
+        .iter()
+        .position(|a| matches!(a, Expr::KeywordArg { .. }))
+        .unwrap_or(args.len());
+    let positionals = &args[..split];
+    let keywords: Vec<(&str, &Expr)> = args[split..]
+        .iter()
+        .map(|a| match a {
+            Expr::KeywordArg { name, value, .. } => (name.as_str(), value.as_ref()),
+            // Guaranteed by the validator (keywords trail positionals).
+            other => unreachable!("keyword-call tail held a non-KeywordArg: {other:?}"),
+        })
+        .collect();
+
+    // The callee's declared parameter names — present for any function that can
+    // receive keywords (the validator rejects keyword calls to unknown callees).
+    let param_names = callee_param_names(fn_name).unwrap_or_default();
+
+    let _ = writeln!(out, "{pad}{{");
+    // One entry per callee slot: `Some(temp)` for a filled slot, `None` for an
+    // omitted optional (rendered as `_sir_missing()`).
+    let mut slots: Vec<Option<String>> = Vec::with_capacity(param_names.len());
+    for (i, pname) in param_names.iter().enumerate() {
+        let fill: Option<&Expr> = if i < positionals.len() {
+            Some(&positionals[i])
+        } else {
+            keywords
+                .iter()
+                .find(|(kw, _)| *kw == pname)
+                .map(|(_, v)| *v)
+        };
+        match fill {
+            Some(expr) => {
+                let t = format!("_sir_k{}", fresh_id());
+                if is_simple(expr) {
+                    let _ = write!(out, "{ipad}SirValue {t} = ");
+                    emit_expr(out, expr, inner);
+                    out.push_str(";\n");
+                } else {
+                    let _ = writeln!(out, "{ipad}SirValue {t};");
+                    emit_assign(out, &t, expr, inner);
+                }
+                slots.push(Some(t));
+            }
+            None => slots.push(None),
+        }
+    }
+    let _ = write!(out, "{ipad}{dst} = {}(", function_emit_name(fn_name));
+    for (i, slot) in slots.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        match slot {
+            Some(t) => out.push_str(t),
+            None => out.push_str("_sir_missing()"),
+        }
+    }
+    out.push_str(");\n");
     let _ = writeln!(out, "{pad}}}");
 }
 
@@ -1192,6 +1293,10 @@ fn scan_expr_for_builtin(e: &Expr) -> Option<(String, Span)> {
         Expr::IndirectCall { target, args, .. } => {
             scan_expr_for_builtin(target).or_else(|| args.iter().find_map(scan_expr_for_builtin))
         }
+        // A keyword argument (in a `DirectCall`'s arg list) carries its value as
+        // a sub-expression — scan it so a deferred builtin in `f(x: foo())` is
+        // reported cleanly.
+        Expr::KeywordArg { value, .. } => scan_expr_for_builtin(value),
         Expr::If {
             cond,
             then_branch,

--- a/code/packages/rust/semantic-ir-to-c/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/lib.rs
@@ -124,9 +124,19 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // and each function opens with a prologue `if (_sir_is_missing(p)) { p =
     // <default>; }` in declaration order (so a later default may reference an
     // earlier parameter).  The unsupported-builtin pre-check also scans each
-    // default, so the emitter stays total.  Keyword defaults are the separate
-    // (still-unaccepted) `KeywordParams` feature.
+    // default, so the emitter stays total.
     Feature::DefaultParams,
+    // ── SIR19 keyword parameters ─────────────────────────────────────
+    // A keyword parameter (`def f(x:)`) and keyword argument (`f(x: 5)`).  C has
+    // no native keywords, so — like the Go backend's KW6 — a `KeywordArg` is
+    // resolved to its callee's parameter SLOT BY NAME at emit time (using the
+    // thread-local signature map's parameter names), producing a plain
+    // positional C call; an omitted optional keyword is filled with
+    // `_sir_missing()` and substituted by the same default prologue as
+    // `DefaultParams`.  A keyword parameter needs NO special signature — it is a
+    // positional `SirValue` C parameter like any other; only the call site
+    // resolves by name.
+    Feature::KeywordParams,
 ];
 
 impl Backend for CBackend {

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_keywordparams.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_keywordparams.rs
@@ -1,0 +1,224 @@
+//! Execution proof for SIR19 keyword parameters on the C backend — hand-build
+//! modules (producer-agnostic), emit C, compile with a real gcc/clang-style
+//! compiler, run, assert stdout. Skips gracefully when no `cc` is present.
+//!
+//! C has no native keyword calls, so — like the Go backend's KW6 — a
+//! `KeywordArg` is resolved to its callee's parameter SLOT BY NAME at emit time,
+//! producing a plain positional C call (omitted optional keywords filled with
+//! `_sir_missing()` and substituted by the default prologue). Hand-built to
+//! bypass the frontend and prove the resolution end to end.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Param, ParamKind,
+    Scope, Span, Stmt, CURRENT_SIR_VERSION,
+};
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    for cand in ["cc", "clang", "gcc"] {
+        if Command::new(cand)
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+        {
+            return Some(cand.to_string());
+        }
+    }
+    None
+}
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn run(module: &Module) -> Option<String> {
+    let cc = find_cc()?;
+    let artifact = semantic_ir_to_c::compile(module).expect("C backend compile (no panic)");
+    let dir = std::env::temp_dir();
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let stem = format!("sirc_kw_{}_{}", std::process::id(), n);
+    let cpath: PathBuf = dir.join(format!("{stem}.c"));
+    let exe: PathBuf = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::File::create(&cpath)
+        .and_then(|mut f| f.write_all(artifact.source.as_bytes()))
+        .expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-Werror=unused-variable", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        artifact.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "run failed (exit {:?})", r.status.code());
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+fn s() -> Span {
+    Span::synthetic()
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn pref(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Param, span: s() }
+}
+fn bc(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+fn puts(arg: Expr) -> Stmt {
+    Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: s() }
+}
+fn directcall(fn_name: &str, args: Vec<Expr>) -> Expr {
+    Expr::DirectCall { fn_name: fn_name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+fn param(name: &str, kind: ParamKind, default: Option<Expr>) -> Param {
+    Param {
+        name: name.into(),
+        sir_type: None,
+        kind,
+        default: default.map(Box::new),
+        span: s(),
+    }
+}
+fn kwparam(name: &str, default: Option<Expr>) -> Param {
+    param(name, ParamKind::Keyword, default)
+}
+fn kwarg(name: &str, value: Expr) -> Expr {
+    Expr::KeywordArg { name: name.into(), value: Box::new(value), span: s() }
+}
+/// A module with a helper function `f(<params>) = <body_value>` and a `main`
+/// running `main_stmts`, declaring `KeywordParams` (+ `DynamicTyping`).
+fn kw_module(params: Vec<Param>, body_value: Expr, main_stmts: Vec<Stmt>) -> Module {
+    let f = Function {
+        name: "f".into(),
+        params,
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: vec![], value: body_value, span: s() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: s(),
+    };
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: main_stmts, value: Expr::NilLit { span: s() }, span: s() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: s(),
+    };
+    Module {
+        name: "kwprog".into(),
+        manifest: FeatureManifest::from_features(&[Feature::KeywordParams, Feature::DynamicTyping]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![f, main],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+#[test]
+fn keyword_argument_binds_to_the_keyword_parameter() {
+    // `def f(x:); x; end` called `f(x: 5)` → `5`.
+    match run(&kw_module(
+        vec![kwparam("x", None)],
+        pref("x"),
+        vec![puts(directcall("f", vec![kwarg("x", ilit(5))]))],
+    )) {
+        Some(out) => assert_eq!(out, "5\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn keyword_arguments_resolve_by_name_regardless_of_order() {
+    // `f(a:, b:) = a - b` called `f(b: 2, a: 10)` → `8` — resolved BY NAME, so
+    // the reversed call order still binds `a`/`b` to their slots.
+    match run(&kw_module(
+        vec![kwparam("a", None), kwparam("b", None)],
+        bc("-", vec![pref("a"), pref("b")]),
+        vec![puts(directcall("f", vec![kwarg("b", ilit(2)), kwarg("a", ilit(10))]))],
+    )) {
+        Some(out) => assert_eq!(out, "8\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn optional_keyword_uses_its_default_when_omitted() {
+    // `f(x: 7) = x` — `f()` fills the default `7` (via `_sir_missing()` + the
+    // prologue), `f(x: 9)` overrides it.
+    match run(&kw_module(
+        vec![kwparam("x", Some(ilit(7)))],
+        pref("x"),
+        vec![
+            puts(directcall("f", vec![])),                    // 7
+            puts(directcall("f", vec![kwarg("x", ilit(9))])), // 9
+        ],
+    )) {
+        Some(out) => assert_eq!(out, "7\n9\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn positional_and_keyword_arguments_mix() {
+    // `f(a, b:) = a - b` called `f(10, b: 2)` → `8` — the leading positional
+    // fills slot 0, the keyword fills slot 1 by name.
+    match run(&kw_module(
+        vec![param("a", ParamKind::Required, None), kwparam("b", None)],
+        bc("-", vec![pref("a"), pref("b")]),
+        vec![puts(directcall("f", vec![ilit(10), kwarg("b", ilit(2))]))],
+    )) {
+        Some(out) => assert_eq!(out, "8\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn compound_keyword_value_is_evaluated_once() {
+    // A keyword argument whose value is a compound expression (a nested call)
+    // hoists into a temp — resolved by name into the right slot. `f(a:, b:) =
+    // a - b` called `f(b: g(), a: 10)` where `g() = 2` → `8`.
+    let g = Function {
+        name: "g".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: vec![], value: ilit(2), span: s() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: s(),
+    };
+    let mut m = kw_module(
+        vec![kwparam("a", None), kwparam("b", None)],
+        bc("-", vec![pref("a"), pref("b")]),
+        vec![puts(directcall(
+            "f",
+            vec![kwarg("b", directcall("g", vec![])), kwarg("a", ilit(10))],
+        ))],
+    );
+    m.functions.push(g);
+    match run(&m) {
+        Some(out) => assert_eq!(out, "8\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}

--- a/code/specs/SIR24-semantic-ir-to-c.md
+++ b/code/specs/SIR24-semantic-ir-to-c.md
@@ -82,14 +82,17 @@ time — see the roadmap): the SIR26 integer conversions (`Conversions`,
 (0.8.0 — `FloatLit` on the v0 `SIR_FLOAT` tag; emitter-only, the runtime
 already carried the float path), `ShortCircuit` (0.9.0 — `LogicalAnd`/
 `LogicalOr` lowered to a truthiness-branch overwrite, reusing the eager
-`and`/`or` builtin lowering; yields the deciding operand), and `DefaultParams`
+`and`/`or` builtin lowering; yields the deciding operand), `DefaultParams`
 (SIR19, 0.10.0 — the `SIR_MISSING` sentinel now exists in the runtime; a
 `DirectCall` pads omitted trailing defaults with `_sir_missing()` and each
-function opens with an `if (_sir_is_missing(p)) { p = <default>; }` prologue).
+function opens with an `if (_sir_is_missing(p)) { p = <default>; }` prologue),
+and `KeywordParams` (SIR19, 0.11.0 — KW6: a `KeywordArg` is resolved to its
+callee's parameter slot BY NAME at emit time, using the thread-local signature
+map's parameter names, producing a plain positional call).
 
 **Still rejects** (clean, source-positioned `UnsupportedFeature`):
 `TailCalls` (C does not guarantee TCO), `Intrinsics` (empty whitelist), and
-every not-yet-landed feature (`KeywordParams`, `NDArrays`,
+every not-yet-landed feature (`NDArrays`,
 `Exceptions`, `Classes`, … — see the roadmap).  `Bignum` stays
 rejected until a bignum runtime ships, so a module that *needs* arbitrary
 precision is refused rather than silently truncated.


### PR DESCRIPTION
## What

Adds SIR19 **keyword parameters** to the C backend (`semantic-ir-to-c` 0.10.0 → 0.11.0), building on the `_sir_missing` default-parameter machinery. With the Ruby backend (#8869), `Feature::KeywordParams` is now accepted on **five of six** backends (the Rust backend is a separate gap).

C has no native keyword calls, so — like the Go backend's KW6 — a keyword argument is resolved to its callee's parameter **slot by name at emit time**, producing a plain positional C call:

- A **keyword parameter** needs no special signature — it's a positional `SirValue` C param; only the call site resolves by name.
- A `DirectCall` carrying any `KeywordArg` routes to a dedicated resolver (`emit_keyword_call`). For each callee slot, in declared order, the filler is: the leading positional at that index; else the `KeywordArg` naming that param; else `_sir_missing()` (an omitted optional — the same default prologue as `DefaultParams` substitutes the default).
- The thread-local signature map (`ARITY` count → `SIGNATURES` param **names**) now lets the resolver place a keyword at its slot; `callee_arity` derives the length for the existing default padding.
- Each filler hoists into a temp, so a compound keyword value (`f(b: g(), a: 10)`) is evaluated once, in slot order (matching Go).

A `KeywordArg` is non-`is_simple`, so a keyword-bearing call is always compound → routed through `emit_keyword_call`; a `KeywordArg` never reaches `emit_expr` (no arm), and one outside a call is rejected by the validator before emit.

## Verification

- `cargo test -p semantic-ir-to-c` — **54 tests green** (5 new), compiled and run through a real `cc`: binding by name, order-independent resolution (`f(b: 2, a: 10)` → `8` for `f(a:, b:) = a - b`), an optional keyword using its default when omitted (`f()` → `7`) and overridden, a mixed positional + keyword call, and a compound keyword value hoisted once.
- `cargo clippy -p semantic-ir-to-c --all-targets` clean.
- Security review: **no memory-safety issues** — the resolver emits exactly the callee arity, so no arg-count UB. Two documented **LOW** notes (validator-gated compile-time panics / a wrong-value miscompile on a malformed module) are unreachable via the public `compile` API (which validates first) and consistent with the crate's infallible-post-validation `unreachable!` pattern.
- SIR24 spec updated (KeywordParams → landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)