### PR TITLE
feat(spice): partition BJT collector capacitance

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add BJT model-card `XCJC` support to partition base-collector depletion
+  capacitance between intrinsic and external base nodes in AC and transient
+  analysis.
 - Add BJT model-card `RBM` and `IRB` support for Berkeley bias-dependent base
   resistance across DC, AC, transient, transfer-function, and noise analysis.
 - Add BJT model-card `RB` base-resistance support with an intrinsic base node

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -632,6 +632,9 @@ class BJT:
     Irb:
         Base current where the resistance is halfway between ``Rb`` and
         ``Rbm`` (default 0.0, disabled).
+    Xcjc:
+        Fraction of ``Cjc`` connected to the intrinsic base (default 1.0).
+        The remainder is connected between the external base and collector.
     """
 
     name: str
@@ -677,6 +680,7 @@ class BJT:
     Rb: float = 0.0            # base resistance (ohms)
     Rbm: float | None = None   # minimum base resistance (ohms)
     Irb: float = 0.0           # base-resistance half-current (A)
+    Xcjc: float = 1.0          # intrinsic-base fraction of Cjc
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -605,7 +605,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
-        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr, element.Tnom, element.Kf, element.Af, element.Ptf, element.Xtf, element.Itf, element.Vtf, element.Re, element.Rc, element.Rb, element.Rbm, element.Irb)
+        return BJT(name, _map_subckt_node(element.collector, instance_name, node_map), _map_subckt_node(element.base, instance_name, node_map), _map_subckt_node(element.emitter, instance_name, node_map), element.polarity, element.Is, element.beta_f, element.Vt, element.Cje, element.Cjc, element.Tf, element.Tr, element.Xti, element.Eg, element.Vaf, element.Nf, element.Nr, element.Vje, element.Mje, element.Vjc, element.Mjc, element.Fc, element.Var, element.Ikf, element.Ise, element.Ne, element.Isc, element.Nc, element.Xtb, element.beta_r, element.Ikr, element.Tnom, element.Kf, element.Af, element.Ptf, element.Xtf, element.Itf, element.Vtf, element.Re, element.Rc, element.Rb, element.Rbm, element.Irb, element.Xcjc)
     if isinstance(element, VCVS):
         return VCVS(name, _map_subckt_node(element.n_plus, instance_name, node_map), _map_subckt_node(element.n_minus, instance_name, node_map), _map_subckt_node(element.ctrl_plus, instance_name, node_map), _map_subckt_node(element.ctrl_minus, instance_name, node_map), element.gain)
     if isinstance(element, VCCS):
@@ -8744,6 +8744,10 @@ def _bjt_base_collector_charge_state_name(el: BJT) -> str:
     return f"_Q_{el.name}_bc_charge"
 
 
+def _bjt_external_base_collector_charge_state_name(el: BJT) -> str:
+    return f"_Q_{el.name}_bx_charge"
+
+
 def _bjt_intrinsic_emitter_node(el: BJT) -> str:
     return el.emitter if el.Re == 0.0 else f"__spice_{el.name}_emitter"
 
@@ -8797,8 +8801,11 @@ def _bjt_charge_dynamic_capacitance(
             * _bjt_forward_transit_time_scale(el, voltage, reverse_junction_voltage)
             * conductance
         )
+    depletion_capacitance = _bjt_base_collector_depletion_capacitance(el, voltage)
+    if state_kind == "bx":
+        return (1.0 - el.Xcjc) * depletion_capacitance
     conductance = _bjt_junction_transconductance(el, voltage, el.Nr)
-    return _bjt_base_collector_depletion_capacitance(el, voltage) + el.Tr * conductance
+    return el.Xcjc * depletion_capacitance + el.Tr * conductance
 
 
 def _bjt_base_emitter_depletion_capacitance(el: BJT, voltage: float) -> float:
@@ -8840,6 +8847,25 @@ def _bjt_charge_state_specs(el: BJT) -> list[tuple[str, str, str, str]]:
             specs.append((_bjt_base_collector_charge_state_name(el), base, collector, "bc"))
         else:
             specs.append((_bjt_base_collector_charge_state_name(el), collector, base, "bc"))
+    if el.Cjc > 0.0 and el.Xcjc < 1.0:
+        if el.polarity == "NPN":
+            specs.append(
+                (
+                    _bjt_external_base_collector_charge_state_name(el),
+                    el.base,
+                    collector,
+                    "bx",
+                )
+            )
+        else:
+            specs.append(
+                (
+                    _bjt_external_base_collector_charge_state_name(el),
+                    collector,
+                    el.base,
+                    "bx",
+                )
+            )
     return specs
 
 
@@ -9467,6 +9493,10 @@ def _validate_bjt(el: BJT) -> None:
     if not math.isfinite(el.Irb) or el.Irb < 0.0:
         raise ValueError(
             f"{el.name}: BJT base-resistance half-current must be finite and non-negative"
+        )
+    if not math.isfinite(el.Xcjc) or not 0.0 <= el.Xcjc <= 1.0:
+        raise ValueError(
+            f"{el.name}: BJT base-collector capacitance fraction must be between zero and one"
         )
     if not math.isfinite(el.Ise) or el.Ise < 0.0:
         raise ValueError(
@@ -12723,6 +12753,7 @@ def _stamp_ac(
         # VCCS).  Mirror the DC _stamp_bjt stamps but in the complex domain and
         # without the Norton offsets (which are DC bias terms, zero in AC).
         _validate_bjt(el)
+        external_base = el.base
         if el.Re > 0.0:
             intrinsic_emitter = _bjt_intrinsic_emitter_node(el)
             _stamp_g_c(
@@ -12817,11 +12848,16 @@ def _stamp_ac(
         y_be = g_pi + 1j * omega * (
             _bjt_base_emitter_depletion_capacitance(el, Vjunc) + diffusion_capacitance
         )
-        y_bc = collector_leakage_conductance + reverse_base_conductance + 1j * omega * (
-            _bjt_base_collector_depletion_capacitance(el, Vreverse)
-            + reverse_diffusion_capacitance
+        base_collector_depletion = _bjt_base_collector_depletion_capacitance(
+            el, Vreverse
         )
+        y_bc = collector_leakage_conductance + reverse_base_conductance + 1j * omega * (
+            el.Xcjc * base_collector_depletion + reverse_diffusion_capacitance
+        )
+        y_bx = 1j * omega * (1.0 - el.Xcjc) * base_collector_depletion
         _stamp_g_c(G, node_to_idx, el.collector, el.emitter, output_conductance + 0j)
+        if y_bx != 0j:
+            _stamp_g_c(G, node_to_idx, external_base, el.collector, y_bx)
 
         if el.polarity == "NPN":
             _stamp_g_c(G, node_to_idx, el.base, el.emitter, y_be)
@@ -14390,6 +14426,7 @@ def sens_dc(
                     Rb=el.Rb,
                     Rbm=el.Rbm,
                     Irb=el.Irb,
+                    Xcjc=el.Xcjc,
                 ),
             )
             delta_beta = max(abs(el.beta_f) * perturbation, abs_floor)
@@ -14430,6 +14467,7 @@ def sens_dc(
                     Rb=el.Rb,
                     Rbm=el.Rbm,
                     Irb=el.Irb,
+                    Xcjc=el.Xcjc,
                 ),
             )
 
@@ -14680,6 +14718,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             Rb=el.Rb,
             Rbm=el.Rbm,
             Irb=el.Irb,
+            Xcjc=el.Xcjc,
         )
 
     # Capacitor, Inductor, Mosfet — no tunable DC parameter; return unchanged.

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (38, 55, 13, 4),
-    "PNP": (38, 55, 13, 4),
+    "NPN": (39, 56, 13, 4),
+    "PNP": (39, 56, 13, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -368,6 +368,7 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "CJC": "CJC",
     "CJC0": "CJC",
     "CBC": "CJC",
+    "XCJC": "XCJC",
     "TF": "TF",
     "TR": "TR",
     "XTI": "XTI",
@@ -965,6 +966,7 @@ def bjt_from_model_card(
         Rb=p.get("RB", 0.0),
         Rbm=p.get("RBM"),
         Irb=p.get("IRB", 0.0),
+        Xcjc=p.get("XCJC", 1.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 134
+    assert len(coverage) == 136
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 134
+    assert len(records) == 136
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,9 +501,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 134
-    assert report.expected_canonical_parameter_count == 134
-    assert report.accepted_name_count == 200
+    assert report.canonical_parameter_count == 136
+    assert report.expected_canonical_parameter_count == 136
+    assert report.accepted_name_count == 202
     assert report.aliased_parameter_count == 53
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -511,7 +511,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t134\t134\t200\t53\t4\t0"
+        "true\t7\t7\t136\t136\t202\t53\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,8 +539,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 133
-    assert report.accepted_name_count == 197
+    assert report.canonical_parameter_count == 135
+    assert report.accepted_name_count == 199
     assert report.aliased_parameter_count == 52
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t133\t134\t197\t52\t4\t4\n"
+        "false\t7\t7\t135\t136\t199\t52\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -647,10 +647,10 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
 
     bjt_card = normalize_model_card(
-        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "VTF": 0.6, "RE": 12.0, "RC": 13.0, "RB": 14.0, "RBM": 2.0, "IRB": 5.0e-6, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
+        "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "VTF": 0.6, "RE": 12.0, "RC": 13.0, "RB": 14.0, "RBM": 2.0, "IRB": 5.0e-6, "XCJC": 0.4, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
     )
     bjt_model = bjt_from_model_card("Q1", "c", "b", "e", bjt_card)
-    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "TNOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "VTF": 0.6, "RE": 12.0, "RC": 13.0, "RB": 14.0, "RBM": 2.0, "IRB": 5.0e-6, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
+    assert bjt_card.parameters == {"BF": 125.0, "BR": 0.25, "CJE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VAF": 80.0, "VAR": 120.0, "IKF": 2.0e-3, "IKR": 3.0e-3, "TNOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "VTF": 0.6, "RE": 12.0, "RC": 13.0, "RB": 14.0, "RBM": 2.0, "IRB": 5.0e-6, "XCJC": 0.4, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "VJE": 0.8, "MJE": 0.4, "VJC": 0.7, "MJC": 0.45, "FC": 0.4}
     assert bjt_model.polarity == "NPN"
     assert bjt_model.beta_f == pytest.approx(125.0)
     assert bjt_model.beta_r == pytest.approx(0.25)
@@ -674,6 +674,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert bjt_model.Rb == pytest.approx(14.0)
     assert bjt_model.Rbm == pytest.approx(2.0)
     assert bjt_model.Irb == pytest.approx(5.0e-6)
+    assert bjt_model.Xcjc == pytest.approx(0.4)
     assert bjt_model.Ise == pytest.approx(3.0e-13)
     assert bjt_model.Ne == pytest.approx(1.7)
     assert bjt_model.Isc == pytest.approx(4.0e-13)
@@ -1576,6 +1577,40 @@ def test_transient_bjt_base_collector_depletion_capacitance_falls_with_reverse_b
     assert stepped_collector_voltage(0.5) < stepped_collector_voltage(0.0)
 
 
+def test_transient_bjt_xcjc_partitions_depletion_charge_to_external_base() -> None:
+    def stepped_base_voltage(fraction: float) -> float:
+        circuit = Circuit()
+        circuit.add(
+            VoltageSource(
+                "Vdrive",
+                "in",
+                "0",
+                0.0,
+                waveform=PwlWaveform(
+                    ((0.0, 0.0), (1.0e-9, 0.0), (2.0e-9, 1.0), (5.0e-9, 1.0))
+                ),
+            )
+        )
+        circuit.add(Resistor("Rin", "in", "base", 1_000.0))
+        circuit.add(
+            BJT(
+                "Q1",
+                collector="0",
+                base="base",
+                emitter="0",
+                Is=1.0e-30,
+                Cjc=1.0e-12,
+                Rb=10_000.0,
+                Xcjc=fraction,
+            )
+        )
+        return transient(
+            circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler"
+        ).points[2].node_voltages["base"]
+
+    assert stepped_base_voltage(1.0) > stepped_base_voltage(0.0)
+
+
 def test_transient_bjt_forward_bias_depletion_coefficient_shapes_both_junctions() -> None:
     def held_voltage(coefficient: float, base_emitter: bool) -> float:
         circuit = Circuit()
@@ -2345,7 +2380,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     cell = SubcircuitDefinition(
         "bjt-cell",
         ("c", "b", "e"),
-        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3, Tnom=323.15, Kf=1.0e-12, Af=1.3, Ptf=30.0, Xtf=2.0, Itf=4.0e-3, Vtf=0.6, Re=12.0, Rc=13.0, Rb=14.0, Rbm=2.0, Irb=5.0e-6),),
+        (BJT("Qcell", "c", "b", "e", Xti=2.4, Eg=1.05, Vaf=80.0, Nf=1.2, Nr=1.3, Vje=0.8, Mje=0.4, Vjc=0.7, Mjc=0.45, Fc=0.4, Var=120.0, Ikf=2.0e-3, Ise=3.0e-13, Ne=1.7, Isc=4.0e-13, Nc=1.8, Xtb=1.5, beta_r=0.25, Ikr=3.0e-3, Tnom=323.15, Kf=1.0e-12, Af=1.3, Ptf=30.0, Xtf=2.0, Itf=4.0e-3, Vtf=0.6, Re=12.0, Rc=13.0, Rb=14.0, Rbm=2.0, Irb=5.0e-6, Xcjc=0.4),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2383,6 +2418,7 @@ def test_subcircuit_expansion_preserves_complete_bjt_model():
     assert expanded.Rb == pytest.approx(14.0)
     assert expanded.Rbm == pytest.approx(2.0)
     assert expanded.Irb == pytest.approx(5.0e-6)
+    assert expanded.Xcjc == pytest.approx(0.4)
 
 
 def test_branch_current_in_voltage_source():
@@ -2700,6 +2736,16 @@ def test_dc_rejects_invalid_bjt_base_resistance():
     with pytest.raises(
         ValueError,
         match="base resistance must be finite and non-negative",
+    ):
+        dc_op(circuit)
+
+
+def test_dc_rejects_invalid_bjt_base_collector_capacitance_fraction():
+    circuit = Circuit()
+    circuit.add(BJT("Qbad", "c", "b", "0", Xcjc=1.1))
+    with pytest.raises(
+        ValueError,
+        match="base-collector capacitance fraction must be between zero and one",
     ):
         dc_op(circuit)
 
@@ -4754,6 +4800,31 @@ def test_ac_bjt_base_collector_depletion_capacitance_falls_with_reverse_bias():
         return abs(result.points[0].node_voltages["collector"])
 
     assert collector_amplitude(0.5) > collector_amplitude(0.0)
+
+
+def test_ac_bjt_xcjc_partitions_depletion_capacitance_to_external_base():
+    def base_amplitude(fraction: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vac", "in", "0", 0.0, ac=AcSource(1.0)))
+        circuit.add(Resistor("Rin", "in", "base", 1_000.0))
+        circuit.add(
+            BJT(
+                "Q1",
+                collector="0",
+                base="base",
+                emitter="0",
+                Is=1.0e-30,
+                Cjc=1.0e-9,
+                Rb=10_000.0,
+                Xcjc=fraction,
+            )
+        )
+        point = ac_sweep(
+            circuit, f_start=1.0e6, f_stop=1.0e6, n_points=1
+        ).points[0]
+        return abs(point.node_voltages["base"])
+
+    assert base_amplitude(1.0) > base_amplitude(0.0)
 
 
 def test_ac_bjt_forward_bias_depletion_coefficient_shapes_both_junctions():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add BJT model-card `XCJC` support to partition base-collector depletion
+  capacitance between intrinsic and external base nodes in AC and transient
+  analysis.
 - Add BJT model-card `RBM` and `IRB` support for Berkeley bias-dependent base
   resistance across DC, AC, transient, transfer-function, and noise analysis.
 - Add BJT model-card `RB` base-resistance support with an intrinsic base node

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -466,6 +466,8 @@ fn clone_subckt_element(
             expanded.base_resistance = element.base_resistance;
             expanded.minimum_base_resistance = element.minimum_base_resistance;
             expanded.base_resistance_half_current = element.base_resistance_half_current;
+            expanded.base_collector_capacitance_fraction =
+                element.base_collector_capacitance_fraction;
             Element::Bjt(expanded)
         }
         Element::Mosfet(element) => Element::Mosfet(Mosfet::with_model(
@@ -2919,6 +2921,7 @@ pub struct Bjt {
     pub base_resistance: f64,
     pub minimum_base_resistance: Option<f64>,
     pub base_resistance_half_current: f64,
+    pub base_collector_capacitance_fraction: f64,
 }
 
 impl Bjt {
@@ -3393,6 +3396,7 @@ impl Bjt {
             base_resistance: 0.0,
             minimum_base_resistance: None,
             base_resistance_half_current: 0.0,
+            base_collector_capacitance_fraction: 1.0,
         }
     }
 }
@@ -3783,8 +3787,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 38, 55, 13, 4),
-    (ModelCardKind::Pnp, 38, 55, 13, 4),
+    (ModelCardKind::Npn, 39, 56, 13, 4),
+    (ModelCardKind::Pnp, 39, 56, 13, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3848,6 +3852,7 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("RB", "RB"),
     ("RBM", "RBM"),
     ("IRB", "IRB"),
+    ("XCJC", "XCJC"),
     ("ISE", "ISE"),
     ("NE", "NE"),
     ("ISC", "ISC"),
@@ -4553,6 +4558,7 @@ pub fn bjt_from_model_card(
     bjt.base_resistance = model_card_value(model, "RB", 0.0);
     bjt.minimum_base_resistance = model.parameters.get("RBM").copied();
     bjt.base_resistance_half_current = model_card_value(model, "IRB", 0.0);
+    bjt.base_collector_capacitance_fraction = model_card_value(model, "XCJC", 1.0);
     Ok(bjt)
 }
 
@@ -22928,6 +22934,7 @@ fn stamp_bjt(
     operating_point: &[f64],
 ) -> Result<(), SpiceError> {
     validate_bjt(bjt)?;
+    let charge_bjt = bjt.clone();
     let intrinsic_bjt = if bjt.emitter_resistance > 0.0
         || bjt.collector_resistance > 0.0
         || bjt.base_resistance > 0.0
@@ -23064,7 +23071,7 @@ fn stamp_bjt(
             );
         }
     }
-    stamp_bjt_charge(bjt, capacitor_states, node_indices, matrix, rhs)?;
+    stamp_bjt_charge(&charge_bjt, capacitor_states, node_indices, matrix, rhs)?;
     Ok(())
 }
 
@@ -23268,6 +23275,7 @@ fn stamp_ac_bjt_small_signal(
     omega: f64,
 ) -> Result<(), SpiceError> {
     validate_bjt(bjt)?;
+    let external_base = node_index(node_indices, &bjt.base);
     let intrinsic_bjt = if bjt.emitter_resistance > 0.0
         || bjt.collector_resistance > 0.0
         || bjt.base_resistance > 0.0
@@ -23384,11 +23392,17 @@ fn stamp_ac_bjt_small_signal(
             * (bjt_base_emitter_depletion_capacitance(bjt, junction_voltage)
                 + diffusion_capacitance),
     );
+    let base_collector_depletion =
+        bjt_base_collector_depletion_capacitance(bjt, reverse_junction_voltage);
     let ybc = Complex::new(
         collector_leakage_conductance + reverse_base_conductance,
         omega
-            * (bjt_base_collector_depletion_capacitance(bjt, reverse_junction_voltage)
+            * (bjt.base_collector_capacitance_fraction * base_collector_depletion
                 + reverse_diffusion_capacitance),
+    );
+    let ybx = Complex::new(
+        0.0,
+        omega * (1.0 - bjt.base_collector_capacitance_fraction) * base_collector_depletion,
     );
     stamp_complex_conductance(
         matrix,
@@ -23396,6 +23410,9 @@ fn stamp_ac_bjt_small_signal(
         emitter,
         Complex::new(output_conductance, 0.0),
     );
+    if ybx != Complex::new(0.0, 0.0) {
+        stamp_complex_conductance(matrix, external_base, collector, ybx);
+    }
     match bjt.polarity {
         BjtPolarity::Npn => {
             stamp_complex_conductance(matrix, base, emitter, gpi);
@@ -23962,6 +23979,7 @@ fn diode_charge_voltage(diode: &Diode, node_voltages: &BTreeMap<String, f64>) ->
 enum BjtChargeStateKind {
     BaseEmitter,
     BaseCollector,
+    ExternalBaseCollector,
 }
 
 struct BjtChargeStateSpec {
@@ -23977,6 +23995,10 @@ fn bjt_base_emitter_charge_state_name(bjt: &Bjt) -> String {
 
 fn bjt_base_collector_charge_state_name(bjt: &Bjt) -> String {
     format!("_Q_{}_bc_charge", bjt.name)
+}
+
+fn bjt_external_base_collector_charge_state_name(bjt: &Bjt) -> String {
+    format!("_Q_{}_bx_charge", bjt.name)
 }
 
 fn bjt_intrinsic_emitter_node(bjt: &Bjt) -> String {
@@ -24053,8 +24075,13 @@ fn bjt_charge_dynamic_capacitance(
         BjtChargeStateKind::BaseCollector => {
             let conductance =
                 bjt_junction_transconductance(bjt, voltage, bjt.reverse_emission_coefficient);
-            bjt_base_collector_depletion_capacitance(bjt, voltage)
+            bjt.base_collector_capacitance_fraction
+                * bjt_base_collector_depletion_capacitance(bjt, voltage)
                 + bjt.reverse_transit_time * conductance
+        }
+        BjtChargeStateKind::ExternalBaseCollector => {
+            (1.0 - bjt.base_collector_capacitance_fraction)
+                * bjt_base_collector_depletion_capacitance(bjt, voltage)
         }
     }
 }
@@ -24124,6 +24151,19 @@ fn bjt_charge_state_specs(bjt: &Bjt) -> Vec<BjtChargeStateSpec> {
             positive,
             negative,
             kind: BjtChargeStateKind::BaseCollector,
+        });
+    }
+    if bjt.base_collector_capacitance > 0.0 && bjt.base_collector_capacitance_fraction < 1.0 {
+        let collector = bjt_intrinsic_collector_node(bjt);
+        let (positive, negative) = match bjt.polarity {
+            BjtPolarity::Npn => (bjt.base.clone(), collector),
+            BjtPolarity::Pnp => (collector, bjt.base.clone()),
+        };
+        specs.push(BjtChargeStateSpec {
+            name: bjt_external_base_collector_charge_state_name(bjt),
+            positive,
+            negative,
+            kind: BjtChargeStateKind::ExternalBaseCollector,
         });
     }
     specs
@@ -24550,6 +24590,14 @@ fn validate_bjt(bjt: &Bjt) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: bjt.name.clone(),
             reason: "base-resistance half-current must be finite and non-negative".to_string(),
+        });
+    }
+    if !bjt.base_collector_capacitance_fraction.is_finite()
+        || !(0.0..=1.0).contains(&bjt.base_collector_capacitance_fraction)
+    {
+        return Err(SpiceError::InvalidElement {
+            name: bjt.name.clone(),
+            reason: "base-collector capacitance fraction must be between zero and one".to_string(),
         });
     }
     if !bjt.base_emitter_leakage_saturation_current.is_finite()

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -1192,6 +1192,32 @@ fn ac_bjt_base_collector_depletion_capacitance_falls_with_reverse_bias() {
 }
 
 #[test]
+fn ac_bjt_xcjc_partitions_depletion_capacitance_to_external_base() {
+    fn base_amplitude(fraction: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "in", "0", 0.0, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "base", 1_000.0,
+        )));
+        let mut transistor = Bjt::new("Q1", "0", "base", "0");
+        transistor.saturation_current = 1.0e-30;
+        transistor.base_collector_capacitance = 1.0e-9;
+        transistor.base_resistance = 10_000.0;
+        transistor.base_collector_capacitance_fraction = fraction;
+        circuit.add(Element::Bjt(transistor));
+
+        ac_sweep(&circuit, 1.0e6, 1.0e6, 1).unwrap()[0]
+            .voltage("base")
+            .unwrap()
+            .abs()
+    }
+
+    assert!(base_amplitude(1.0) > base_amplitude(0.0));
+}
+
+#[test]
 fn ac_bjt_forward_bias_depletion_coefficient_shapes_both_junctions() {
     fn junction_amplitude(coefficient: f64, base_emitter: bool) -> f64 {
         let mut circuit = Circuit::new();

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 134);
+    assert_eq!(coverage.len(), 136);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 134);
+    assert_eq!(records.len(), 136);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 134);
-    assert_eq!(report.expected_canonical_parameter_count, 134);
-    assert_eq!(report.accepted_name_count, 200);
+    assert_eq!(report.canonical_parameter_count, 136);
+    assert_eq!(report.expected_canonical_parameter_count, 136);
+    assert_eq!(report.accepted_name_count, 202);
     assert_eq!(report.aliased_parameter_count, 53);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t134\t134\t200\t53\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t136\t136\t202\t53\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,8 +235,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 133);
-    assert_eq!(report.accepted_name_count, 197);
+    assert_eq!(report.canonical_parameter_count, 135);
+    assert_eq!(report.accepted_name_count, 199);
     assert_eq!(report.aliased_parameter_count, 52);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t133\t134\t197\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t135\t136\t199\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -459,6 +459,7 @@ fn model_card_aliases_build_device_instances() {
             ("RB", 14.0),
             ("RBM", 2.0),
             ("IRB", 5.0e-6),
+            ("XCJC", 0.4),
         ],
     )
     .unwrap();
@@ -519,6 +520,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(bjt_model.base_resistance, 14.0);
     assert_close(bjt_model.minimum_base_resistance.unwrap(), 2.0);
     assert_close(bjt_model.base_resistance_half_current, 5.0e-6);
+    assert_close(bjt_model.base_collector_capacitance_fraction, 0.4);
     assert_close(bjt_model.base_emitter_leakage_saturation_current, 3.0e-13);
     assert_close(bjt_model.base_emitter_leakage_emission_coefficient, 1.7);
     assert_close(bjt_model.base_collector_leakage_saturation_current, 4.0e-13);
@@ -1471,6 +1473,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     bjt.base_resistance = 14.0;
     bjt.minimum_base_resistance = Some(2.0);
     bjt.base_resistance_half_current = 5.0e-6;
+    bjt.base_collector_capacitance_fraction = 0.4;
     let mut circuit = Circuit::new();
     circuit
         .define_subcircuit(SubcircuitDefinition::new(
@@ -1526,6 +1529,7 @@ fn subcircuit_expansion_preserves_complete_bjt_model() {
     assert_close(expanded.base_resistance, 14.0);
     assert_close(expanded.minimum_base_resistance.unwrap(), 2.0);
     assert_close(expanded.base_resistance_half_current, 5.0e-6);
+    assert_close(expanded.base_collector_capacitance_fraction, 0.4);
 }
 
 #[test]
@@ -2153,6 +2157,18 @@ fn dc_rejects_invalid_bjt_base_resistance() {
     assert!(error
         .to_string()
         .contains("base resistance must be finite and non-negative"));
+}
+
+#[test]
+fn dc_rejects_invalid_bjt_base_collector_capacitance_fraction() {
+    let mut transistor = Bjt::new("Qbad", "c", "b", "0");
+    transistor.base_collector_capacitance_fraction = 1.1;
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Bjt(transistor));
+    let error = dc_op(&circuit).unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("base-collector capacitance fraction must be between zero and one"));
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -633,6 +633,45 @@ fn transient_bjt_base_collector_depletion_capacitance_falls_with_reverse_bias() 
 }
 
 #[test]
+fn transient_bjt_xcjc_partitions_depletion_charge_to_external_base() {
+    fn stepped_base_voltage(fraction: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
+            "Vdrive",
+            "in",
+            "0",
+            0.0,
+            Waveform::Pwl(PwlWaveform::new(vec![
+                (0.0, 0.0),
+                (1.0e-9, 0.0),
+                (2.0e-9, 1.0),
+                (5.0e-9, 1.0),
+            ])),
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "base", 1_000.0,
+        )));
+        let mut transistor = Bjt::new("Q1", "0", "base", "0");
+        transistor.saturation_current = 1.0e-30;
+        transistor.base_collector_capacitance = 1.0e-12;
+        transistor.base_resistance = 10_000.0;
+        transistor.base_collector_capacitance_fraction = fraction;
+        circuit.add(Element::Bjt(transistor));
+
+        transient(&circuit, 1.0e-9, 5.0e-9).unwrap()[1]
+            .voltage("base")
+            .unwrap()
+    }
+
+    let intrinsic = stepped_base_voltage(1.0);
+    let external = stepped_base_voltage(0.0);
+    assert!(
+        intrinsic > external,
+        "intrinsic={intrinsic}, external={external}"
+    );
+}
+
+#[test]
 fn transient_bjt_forward_bias_depletion_coefficient_shapes_both_junctions() {
     fn held_voltage(coefficient: f64, base_emitter: bool) -> f64 {
         let mut circuit = Circuit::new();

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add BJT model-card `XCJC` support to partition base-collector depletion
+  capacitance between intrinsic and external base nodes in AC and transient
+  analysis.
 - Add BJT model-card `RBM` and `IRB` support for Berkeley bias-dependent base
   resistance across DC, AC, transient, transfer-function, and noise analysis.
 - Add BJT model-card `RB` base-resistance support with an intrinsic base node

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1741,6 +1741,7 @@ export interface Bjt {
   readonly baseResistance: number;
   readonly minimumBaseResistance: number | undefined;
   readonly baseResistanceHalfCurrent: number;
+  readonly baseCollectorCapacitanceFraction: number;
 }
 
 export type MosfetType = "NMOS" | "PMOS";
@@ -2018,8 +2019,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [38, 55, 13, 4],
-  PNP: [38, 55, 13, 4],
+  NPN: [39, 56, 13, 4],
+  PNP: [39, 56, 13, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -3609,7 +3610,7 @@ function cloneSubcktElement(
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
-      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees, element.forwardTransitTimeBiasCoefficient, element.forwardTransitTimeCurrent, element.forwardTransitTimeVoltage, element.emitterResistance, element.collectorResistance, element.baseResistance, element.minimumBaseResistance, element.baseResistanceHalfCurrent);
+      return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees, element.forwardTransitTimeBiasCoefficient, element.forwardTransitTimeCurrent, element.forwardTransitTimeVoltage, element.emitterResistance, element.collectorResistance, element.baseResistance, element.minimumBaseResistance, element.baseResistanceHalfCurrent, element.baseCollectorCapacitanceFraction);
     case "mosfet":
       return mosfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), mapSubcktNode(element.body, instanceName, nodeMap), element.type, element.params);
     case "vccs":
@@ -7806,6 +7807,7 @@ export function bjt(
   baseResistance = 0.0,
   minimumBaseResistance: number | undefined = undefined,
   baseResistanceHalfCurrent = 0.0,
+  baseCollectorCapacitanceFraction = 1.0,
 ): Bjt {
   return {
     kind: "bjt",
@@ -7852,6 +7854,7 @@ export function bjt(
     baseResistance,
     minimumBaseResistance,
     baseResistanceHalfCurrent,
+    baseCollectorCapacitanceFraction,
   };
 }
 
@@ -7975,6 +7978,7 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   RB: "RB",
   RBM: "RBM",
   IRB: "IRB",
+  XCJC: "XCJC",
   ISE: "ISE",
   NE: "NE",
   ISC: "ISC",
@@ -8520,6 +8524,7 @@ export function bjtFromModelCard(
     p.RB ?? 0.0,
     p.RBM,
     p.IRB ?? 0.0,
+    p.XCJC ?? 1.0,
   );
 }
 
@@ -19197,6 +19202,7 @@ function stampBjt(
   operatingPoint: readonly number[],
 ): void {
   validateBjt(element);
+  const chargeElement = element;
   if (element.emitterResistance > 0.0) {
     const intrinsicEmitter = bjtIntrinsicEmitterNode(element);
     stampConductance(
@@ -19313,7 +19319,7 @@ function stampBjt(
     stampCurrentSourceEquivalent(rhs, emitter, collector, equivalentCollectorCurrent);
     stampCurrentSourceEquivalent(rhs, collector, base, equivalentCollectorLeakageCurrent);
   }
-  stampBjtCharge(element, capacitorStates, nodeIndices, matrix, rhs);
+  stampBjtCharge(chargeElement, capacitorStates, nodeIndices, matrix, rhs);
 }
 
 function stampBjtCharge(
@@ -19835,7 +19841,10 @@ function diodeChargeVoltage(element: Diode, nodeVoltages: ReadonlyMap<string, nu
   return voltageAt(nodeVoltages, element.anode) - voltageAt(nodeVoltages, element.cathode);
 }
 
-type BjtChargeStateKind = "base-emitter" | "base-collector";
+type BjtChargeStateKind =
+  | "base-emitter"
+  | "base-collector"
+  | "external-base-collector";
 
 interface BjtChargeStateSpec {
   readonly name: string;
@@ -19850,6 +19859,10 @@ function bjtBaseEmitterChargeStateName(element: Bjt): string {
 
 function bjtBaseCollectorChargeStateName(element: Bjt): string {
   return `_Q_${element.name}_bc_charge`;
+}
+
+function bjtExternalBaseCollectorChargeStateName(element: Bjt): string {
+  return `_Q_${element.name}_bx_charge`;
 }
 
 function bjtIntrinsicEmitterNode(element: Bjt): string {
@@ -19924,12 +19937,16 @@ function bjtChargeDynamicCapacitance(
         bjtForwardTransitTimeScale(element, voltage, reverseJunctionVoltage) *
         conductance;
   }
+  const depletionCapacitance = bjtBaseCollectorDepletionCapacitance(element, voltage);
+  if (kind === "external-base-collector") {
+    return (1.0 - element.baseCollectorCapacitanceFraction) * depletionCapacitance;
+  }
   const conductance = bjtJunctionTransconductance(
     element,
     voltage,
     element.reverseEmissionCoefficient,
   );
-  return bjtBaseCollectorDepletionCapacitance(element, voltage) +
+  return element.baseCollectorCapacitanceFraction * depletionCapacitance +
     element.reverseTransitTime * conductance;
 }
 
@@ -20002,6 +20019,21 @@ function bjtChargeStateSpecs(element: Bjt): BjtChargeStateSpec[] {
       positive,
       negative,
       kind: "base-collector",
+    });
+  }
+  if (
+    element.baseCollectorCapacitance > 0.0 &&
+    element.baseCollectorCapacitanceFraction < 1.0
+  ) {
+    const [positive, negative] =
+      element.polarity === "NPN"
+        ? [element.base, collector]
+        : [collector, element.base];
+    specs.push({
+      name: bjtExternalBaseCollectorChargeStateName(element),
+      positive,
+      negative,
+      kind: "external-base-collector",
     });
   }
   return specs;
@@ -20256,6 +20288,14 @@ function validateBjt(element: Bjt): void {
     throw invalidElement(
       element.name,
       "base-resistance half-current must be finite and non-negative",
+    );
+  }
+  if (!Number.isFinite(element.baseCollectorCapacitanceFraction) ||
+      element.baseCollectorCapacitanceFraction < 0.0 ||
+      element.baseCollectorCapacitanceFraction > 1.0) {
+    throw invalidElement(
+      element.name,
+      "base-collector capacitance fraction must be between zero and one",
     );
   }
   if (!Number.isFinite(element.baseEmitterLeakageSaturationCurrent) || element.baseEmitterLeakageSaturationCurrent < 0.0) {
@@ -22251,6 +22291,7 @@ function stampAcBjtSmallSignal(
   omega: number,
 ): void {
   validateBjt(element);
+  const externalBase = nodeIndex(nodeIndices, element.base);
   if (element.emitterResistance > 0.0) {
     const intrinsicEmitter = bjtIntrinsicEmitterNode(element);
     stampComplexConductance(
@@ -22365,14 +22406,29 @@ function stampAcBjtSmallSignal(
       bjtBaseEmitterDepletionCapacitance(element, junctionVoltage) + diffusionCapacitance
     ),
   );
+  const baseCollectorDepletion =
+    bjtBaseCollectorDepletionCapacitance(element, reverseJunctionVoltage);
   const baseCollectorAdmittance = complex(
     collectorLeakage.conductance + reverseBase.conductance,
     omega * (
-      bjtBaseCollectorDepletionCapacitance(element, reverseJunctionVoltage) +
+      element.baseCollectorCapacitanceFraction * baseCollectorDepletion +
       reverseDiffusionCapacitance
     ),
   );
+  const externalBaseCollectorAdmittance = complex(
+    0.0,
+    omega * (1.0 - element.baseCollectorCapacitanceFraction) *
+      baseCollectorDepletion,
+  );
   stampComplexConductance(matrix, collector, emitter, complex(outputConductance, 0.0));
+  if (externalBaseCollectorAdmittance.imag !== 0.0) {
+    stampComplexConductance(
+      matrix,
+      externalBase,
+      collector,
+      externalBaseCollectorAdmittance,
+    );
+  }
   if (element.polarity === "NPN") {
     stampComplexConductance(
       matrix,

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -739,6 +739,24 @@ describe("acSweep", () => {
     expect(collectorAmplitude(0.5)).toBeGreaterThan(collectorAmplitude(0.0));
   });
 
+  it("uses BJT XCJC to partition depletion capacitance to the external base", () => {
+    function baseAmplitude(baseCollectorCapacitanceFraction: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "in", "0", 0.0, 1.0));
+      circuit.add(resistor("Rin", "in", "base", 1_000.0));
+      circuit.add({
+        ...bjt("Q1", "0", "base", "0"),
+        saturationCurrent: 1.0e-30,
+        baseCollectorCapacitance: 1.0e-9,
+        baseResistance: 10_000.0,
+        baseCollectorCapacitanceFraction,
+      });
+      return complexAbs(acSweep(circuit, 1.0e6, 1.0e6, 1)[0].voltage("base")!);
+    }
+
+    expect(baseAmplitude(1.0)).toBeGreaterThan(baseAmplitude(0.0));
+  });
+
   it("uses BJT FC to shape both forward-biased depletion junctions", () => {
     function junctionAmplitude(coefficient: number, baseEmitter: boolean): number {
       const circuit = new Circuit();

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(134);
+    expect(coverage).toHaveLength(136);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(134);
+    expect(records).toHaveLength(136);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 134,
-      expectedCanonicalParameterCount: 134,
-      acceptedNameCount: 200,
+      canonicalParameterCount: 136,
+      expectedCanonicalParameterCount: 136,
+      acceptedNameCount: 202,
       aliasedParameterCount: 53,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t134\t134\t200\t53\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t136\t136\t202\t53\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,8 +241,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(133);
-    expect(report.acceptedNameCount).toBe(197);
+    expect(report.canonicalParameterCount).toBe(135);
+    expect(report.acceptedNameCount).toBe(199);
     expect(report.aliasedParameterCount).toBe(52);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t133\t134\t197\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t135\t136\t199\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -354,6 +354,7 @@ describe("dcOp", () => {
       RB: 14.0,
       RBM: 2.0,
       IRB: 5.0e-6,
+      XCJC: 0.4,
       ISE: 3.0e-13,
       NE: 1.7,
       ISC: 4.0e-13,
@@ -367,7 +368,7 @@ describe("dcOp", () => {
       FC: 0.4,
     });
     const bjtModel = bjtFromModelCard("Q1", "c", "b", "e", bjtCard);
-    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, TNOM: 50.0, KF: 1.0e-12, AF: 1.3, PTF: 30.0, XTF: 2.0, ITF: 4.0e-3, VTF: 0.6, RE: 12.0, RC: 13.0, RB: 14.0, RBM: 2.0, IRB: 5.0e-6, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
+    expect(bjtCard.parameters).toStrictEqual({ BF: 125.0, BR: 0.25, CJE: 2.0e-12, XTI: 2.4, XTB: 1.5, EG: 1.05, VAF: 80.0, VAR: 120.0, IKF: 2.0e-3, IKR: 3.0e-3, TNOM: 50.0, KF: 1.0e-12, AF: 1.3, PTF: 30.0, XTF: 2.0, ITF: 4.0e-3, VTF: 0.6, RE: 12.0, RC: 13.0, RB: 14.0, RBM: 2.0, IRB: 5.0e-6, XCJC: 0.4, ISE: 3.0e-13, NE: 1.7, ISC: 4.0e-13, NC: 1.8, NF: 1.2, NR: 1.3, VJE: 0.8, MJE: 0.4, VJC: 0.7, MJC: 0.45, FC: 0.4 });
     expect(bjtModel.polarity).toBe("NPN");
     expectClose(bjtModel.forwardBeta, 125.0);
     expectClose(bjtModel.reverseBeta, 0.25);
@@ -391,6 +392,7 @@ describe("dcOp", () => {
     expectClose(bjtModel.baseResistance, 14.0);
     expectClose(bjtModel.minimumBaseResistance, 2.0);
     expectClose(bjtModel.baseResistanceHalfCurrent, 5.0e-6);
+    expectClose(bjtModel.baseCollectorCapacitanceFraction, 0.4);
     expectClose(bjtModel.baseEmitterLeakageSaturationCurrent, 3.0e-13);
     expectClose(bjtModel.baseEmitterLeakageEmissionCoefficient, 1.7);
     expectClose(bjtModel.baseCollectorLeakageSaturationCurrent, 4.0e-13);
@@ -1034,7 +1036,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("bjt-cell", ["c", "b", "e"], [
-        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3, 323.15, 1.0e-12, 1.3, 30.0, 2.0, 4.0e-3, 0.6, 12.0, 13.0, 14.0, 2.0, 5.0e-6),
+        bjt("Qcell", "c", "b", "e", "NPN", 1e-14, 100, 0.02585, 0, 0, 0, 0, 2.4, 1.05, 80.0, 1.2, 1.3, 0.8, 0.4, 0.7, 0.45, 0.4, 120.0, 2.0e-3, 3.0e-13, 1.7, 4.0e-13, 1.8, 1.5, 0.25, 3.0e-3, 323.15, 1.0e-12, 1.3, 30.0, 2.0, 4.0e-3, 0.6, 12.0, 13.0, 14.0, 2.0, 5.0e-6, 0.4),
       ]),
     );
     circuit.add(xInstance("X1", ["c1", "b1", "0"], "bjt-cell"));
@@ -1073,6 +1075,7 @@ describe("dcOp", () => {
       expectClose(expanded.baseResistance, 14.0);
       expectClose(expanded.minimumBaseResistance, 2.0);
       expectClose(expanded.baseResistanceHalfCurrent, 5.0e-6);
+      expectClose(expanded.baseCollectorCapacitanceFraction, 0.4);
     }
   });
 
@@ -1509,6 +1512,17 @@ describe("dcOp", () => {
     });
     expect(() => dcOp(circuit)).toThrow(
       "base resistance must be finite and non-negative",
+    );
+  });
+
+  it("rejects invalid BJT base-collector capacitance fractions", () => {
+    const circuit = new Circuit();
+    circuit.add({
+      ...bjt("Qbad", "c", "b", "0"),
+      baseCollectorCapacitanceFraction: 1.1,
+    });
+    expect(() => dcOp(circuit)).toThrow(
+      "base-collector capacitance fraction must be between zero and one",
     );
   });
 

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -493,6 +493,30 @@ describe("transient", () => {
     expect(steppedCollectorVoltage(0.5)).toBeLessThan(steppedCollectorVoltage(0.0));
   });
 
+  it("uses BJT XCJC to partition depletion charge to the external base", () => {
+    function steppedBaseVoltage(baseCollectorCapacitanceFraction: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithWaveform(
+        "Vdrive",
+        "in",
+        "0",
+        0.0,
+        new PwlWaveform([[0.0, 0.0], [1.0e-9, 0.0], [2.0e-9, 1.0], [5.0e-9, 1.0]]),
+      ));
+      circuit.add(resistor("Rin", "in", "base", 1_000.0));
+      circuit.add({
+        ...bjt("Q1", "0", "base", "0"),
+        saturationCurrent: 1.0e-30,
+        baseCollectorCapacitance: 1.0e-12,
+        baseResistance: 10_000.0,
+        baseCollectorCapacitanceFraction,
+      });
+      return transient(circuit, 1.0e-9, 5.0e-9)[1].voltage("base")!;
+    }
+
+    expect(steppedBaseVoltage(1.0)).toBeGreaterThan(steppedBaseVoltage(0.0));
+  });
+
   it("uses BJT FC to shape both forward-biased transient charge companions", () => {
     function heldVoltage(coefficient: number, baseEmitter: boolean): number {
       const circuit = new Circuit();

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,18 +33,17 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT bias-dependent base resistance.
+1. Cross-language BJT base-collector capacitance partitioning.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `RBM` minimum-base-resistance and `IRB`
-     half-resistance-current model-card support in Rust, Python, and
-     TypeScript.
-   - Reuse the intrinsic base topology for Berkeley base-charge and
-     current-dependent resistance reduction in DC, transient, AC,
-     transfer-function, and thermal-noise behavior.
-   - Preserve constant `RB` behavior when `RBM` is omitted, extend the
-     supported-parameter coverage gate from 130 to 134 canonical rows, and
-     lock model-card behavior, validation, hierarchy, operating-point loading,
-     and noise behavior in all engines.
+   - Add Berkeley BJT `XCJC` model-card support in Rust, Python, and
+     TypeScript, defaulting to one.
+   - Partition `CJC` depletion capacitance between the intrinsic
+     base-collector branch and a new external-base/collector charge branch in
+     AC and transient analysis while keeping reverse transit-time diffusion
+     capacitance intrinsic.
+   - Preserve existing behavior by default, extend the supported-parameter
+     coverage gate from 134 to 136 canonical rows, and lock model-card,
+     validation, hierarchy, AC, and transient behavior in all engines.
 
 ## Completed Slices
 
@@ -3196,6 +3195,15 @@ the Rust, Python, and TypeScript surfaces together.
    - DC, transient, AC, transfer-function, and noise paths share the intrinsic
      base topology, including resistor thermal noise; the supported-parameter
      release gate now covers 130 canonical rows.
+
+243. Cross-language BJT bias-dependent base resistance.
+   - Status: completed in PR 8872.
+   - Rust, Python, and TypeScript BJT model cards now accept `RBM` and `IRB`
+     and apply Berkeley base-charge and base-current-dependent resistance
+     reduction.
+   - DC, transient, AC, transfer-function, and noise paths share the
+     bias-dependent intrinsic-base topology; the supported-parameter release
+     gate now covers 134 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley BJT `XCJC` model-card support across Rust, Python, and TypeScript with the standard default of one
- partition `CJC` depletion capacitance between intrinsic base-collector and external-base/collector branches in AC and transient analysis while keeping `TR` diffusion capacitance intrinsic
- preserve charge topology through intrinsic-node stamping and extend validation, hierarchy parity, coverage gates, behavioral tests, changelogs, and the SPICE plan

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo check -p spice-engine`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python Ruff on touched source and tests
- Python spice-engine: 578 passed, 88.83% coverage
- TypeScript `npm run build`
- TypeScript spice-engine: 336 passed