### PR TITLE
feat(spice): add legacy BJT leakage ratios

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add legacy SPICE2 BJT model-card `C2` and `C4` leakage-ratio support,
+  deriving `ISE` and `ISC` from `IS` when explicit leakage currents are absent.
 - Add BJT model-card `XCJC` support to partition base-collector depletion
   capacitance between intrinsic and external base nodes in AC and transient
   analysis.

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -307,8 +307,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (12, 18, 5, 3),
-    "NPN": (39, 56, 13, 4),
-    "PNP": (39, 56, 13, 4),
+    "NPN": (41, 58, 13, 4),
+    "PNP": (41, 58, 13, 4),
     "NJF": (5, 11, 5, 3),
     "PJF": (5, 11, 5, 3),
     "NMOS": (18, 25, 6, 3),
@@ -394,8 +394,10 @@ _BJT_PARAMETER_ALIASES: dict[str, str] = {
     "RBM": "RBM",
     "IRB": "IRB",
     "ISE": "ISE",
+    "C2": "C2",
     "NE": "NE",
     "ISC": "ISC",
+    "C4": "C4",
     "NC": "NC",
     "XTB": "XTB",
     "BR": "BR",
@@ -922,13 +924,14 @@ def bjt_from_model_card(
     if model.kind not in {"NPN", "PNP"}:
         raise ValueError(f"{name}: expected BJT model card, got {model.kind}")
     p = model.parameters
+    saturation_current = p.get("IS", 1.0e-14)
     return BJT(
         name,
         collector,
         base,
         emitter,
         polarity=model.kind,
-        Is=p.get("IS", 1.0e-14),
+        Is=saturation_current,
         beta_f=p.get("BF", 100.0),
         Vt=p.get("VT", 0.02585),
         Cje=p.get("CJE", 0.0),
@@ -947,9 +950,9 @@ def bjt_from_model_card(
         Fc=p.get("FC", 0.5),
         Var=p.get("VAR", 0.0),
         Ikf=p.get("IKF", 0.0),
-        Ise=p.get("ISE", 0.0),
+        Ise=p.get("ISE", p.get("C2", 0.0) * saturation_current),
         Ne=p.get("NE", 1.0),
-        Isc=p.get("ISC", 0.0),
+        Isc=p.get("ISC", p.get("C4", 0.0) * saturation_current),
         Nc=p.get("NC", 2.0),
         Xtb=p.get("XTB", 0.0),
         beta_r=p.get("BR", 1.0),

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -412,7 +412,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 136
+    assert len(coverage) == 140
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +427,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 136
+    assert len(records) == 140
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -501,9 +501,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 136
-    assert report.expected_canonical_parameter_count == 136
-    assert report.accepted_name_count == 202
+    assert report.canonical_parameter_count == 140
+    assert report.expected_canonical_parameter_count == 140
+    assert report.accepted_name_count == 206
     assert report.aliased_parameter_count == 53
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -511,7 +511,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t136\t136\t202\t53\t4\t0"
+        "true\t7\t7\t140\t140\t206\t53\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,8 +539,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 135
-    assert report.accepted_name_count == 199
+    assert report.canonical_parameter_count == 139
+    assert report.accepted_name_count == 203
     assert report.aliased_parameter_count == 52
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -555,7 +555,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t135\t136\t199\t52\t4\t4\n"
+        "false\t7\t7\t139\t140\t203\t52\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -727,6 +727,38 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(3.0e-13) == mos_model.model.model.params.CBD
     assert pytest.approx(0.9) == mos_model.model.model.params.PB
     assert pytest.approx(0.45) == mos_model.model.model.params.MJ
+
+
+def test_bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() -> None:
+    legacy_card = normalize_model_card(
+        "Qlegacy",
+        "npn",
+        {"IS": 2.0e-14, "C2": 15.0, "C4": 20.0},
+    )
+    legacy = bjt_from_model_card("Q1", "c", "b", "e", legacy_card)
+
+    assert legacy_card.parameters == {
+        "IS": 2.0e-14,
+        "C2": 15.0,
+        "C4": 20.0,
+    }
+    assert legacy.Ise == pytest.approx(3.0e-13)
+    assert legacy.Isc == pytest.approx(4.0e-13)
+
+    explicit_card = normalize_model_card(
+        "Qexplicit",
+        "pnp",
+        {
+            "IS": 2.0e-14,
+            "C2": 15.0,
+            "ISE": 5.0e-13,
+            "C4": 20.0,
+            "ISC": 6.0e-13,
+        },
+    )
+    explicit = bjt_from_model_card("Q2", "c", "b", "e", explicit_card)
+    assert explicit.Ise == pytest.approx(5.0e-13)
+    assert explicit.Isc == pytest.approx(6.0e-13)
 
 
 def test_model_card_audit_fixtures_cover_supported_device_families() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add legacy SPICE2 BJT model-card `C2` and `C4` leakage-ratio support,
+  deriving `ISE` and `ISC` from `IS` when explicit leakage currents are absent.
 - Add BJT model-card `XCJC` support to partition base-collector depletion
   capacitance between intrinsic and external base nodes in AC and transient
   analysis.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3787,8 +3787,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
 )] = &[
     (ModelCardKind::Diode, 12, 18, 5, 3),
-    (ModelCardKind::Npn, 39, 56, 13, 4),
-    (ModelCardKind::Pnp, 39, 56, 13, 4),
+    (ModelCardKind::Npn, 41, 58, 13, 4),
+    (ModelCardKind::Pnp, 41, 58, 13, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
     (ModelCardKind::Pjf, 5, 11, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
@@ -3854,8 +3854,10 @@ const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IRB", "IRB"),
     ("XCJC", "XCJC"),
     ("ISE", "ISE"),
+    ("C2", "C2"),
     ("NE", "NE"),
     ("ISC", "ISC"),
+    ("C4", "C4"),
     ("NC", "NC"),
     ("XTB", "XTB"),
     ("BR", "BR"),
@@ -4510,13 +4512,24 @@ pub fn bjt_from_model_card(
         ModelCardKind::Pnp => BjtPolarity::Pnp,
         _ => return Err(model_card_kind_error(&name, "BJT", model.kind)),
     };
+    let saturation_current = model_card_value(model, "IS", 1.0e-14);
+    let base_emitter_leakage_saturation_current = model
+        .parameters
+        .get("ISE")
+        .copied()
+        .unwrap_or_else(|| model_card_value(model, "C2", 0.0) * saturation_current);
+    let base_collector_leakage_saturation_current = model
+        .parameters
+        .get("ISC")
+        .copied()
+        .unwrap_or_else(|| model_card_value(model, "C4", 0.0) * saturation_current);
     let mut bjt = Bjt::with_model_temperature_depletion_early_rolloff_junction_leakage_and_reverse_beta_parameters(
             name,
             collector,
             base,
             emitter,
             polarity,
-            model_card_value(model, "IS", 1.0e-14),
+            saturation_current,
             model_card_value(model, "BF", 100.0),
             model_card_value(model, "VT", 0.02585),
             model_card_value(model, "CJE", 0.0),
@@ -4535,9 +4548,9 @@ pub fn bjt_from_model_card(
             model_card_value(model, "FC", 0.5),
             model_card_value(model, "VAR", 0.0),
             model_card_value(model, "IKF", 0.0),
-            model_card_value(model, "ISE", 0.0),
+            base_emitter_leakage_saturation_current,
             model_card_value(model, "NE", 1.0),
-            model_card_value(model, "ISC", 0.0),
+            base_collector_leakage_saturation_current,
             model_card_value(model, "NC", 2.0),
             model_card_value(model, "XTB", 0.0),
             model_card_value(model, "BR", 1.0),

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -100,7 +100,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 136);
+    assert_eq!(coverage.len(), 140);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +119,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 136);
+    assert_eq!(records.len(), 140);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -200,15 +200,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 136);
-    assert_eq!(report.expected_canonical_parameter_count, 136);
-    assert_eq!(report.accepted_name_count, 202);
+    assert_eq!(report.canonical_parameter_count, 140);
+    assert_eq!(report.expected_canonical_parameter_count, 140);
+    assert_eq!(report.accepted_name_count, 206);
     assert_eq!(report.aliased_parameter_count, 53);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t136\t136\t202\t53\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t140\t140\t206\t53\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,8 +235,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 135);
-    assert_eq!(report.accepted_name_count, 199);
+    assert_eq!(report.canonical_parameter_count, 139);
+    assert_eq!(report.accepted_name_count, 203);
     assert_eq!(report.aliased_parameter_count, 52);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -253,7 +253,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t135\t136\t199\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t139\t140\t203\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -576,6 +576,38 @@ fn model_card_aliases_build_device_instances() {
     assert_close(mos_model.params.drain_bulk_capacitance, 3.0e-13);
     assert_close(mos_model.params.bulk_junction_potential, 0.9);
     assert_close(mos_model.params.bulk_junction_grading_coefficient, 0.45);
+}
+
+#[test]
+fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
+    let legacy_card = normalize_model_card(
+        "Qlegacy",
+        "npn",
+        &[("IS", 2.0e-14), ("C2", 15.0), ("C4", 20.0)],
+    )
+    .unwrap();
+    let legacy = bjt_from_model_card("Q1", "c", "b", "e", &legacy_card).unwrap();
+
+    assert_close(*legacy_card.parameters.get("C2").unwrap(), 15.0);
+    assert_close(*legacy_card.parameters.get("C4").unwrap(), 20.0);
+    assert_close(legacy.base_emitter_leakage_saturation_current, 3.0e-13);
+    assert_close(legacy.base_collector_leakage_saturation_current, 4.0e-13);
+
+    let explicit_card = normalize_model_card(
+        "Qexplicit",
+        "pnp",
+        &[
+            ("IS", 2.0e-14),
+            ("C2", 15.0),
+            ("ISE", 5.0e-13),
+            ("C4", 20.0),
+            ("ISC", 6.0e-13),
+        ],
+    )
+    .unwrap();
+    let explicit = bjt_from_model_card("Q2", "c", "b", "e", &explicit_card).unwrap();
+    assert_close(explicit.base_emitter_leakage_saturation_current, 5.0e-13);
+    assert_close(explicit.base_collector_leakage_saturation_current, 6.0e-13);
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add legacy SPICE2 BJT model-card `C2` and `C4` leakage-ratio support,
+  deriving `ISE` and `ISC` from `IS` when explicit leakage currents are absent.
 - Add BJT model-card `XCJC` support to partition base-collector depletion
   capacitance between intrinsic and external base nodes in AC and transient
   analysis.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -2019,8 +2019,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
   D: [12, 18, 5, 3],
-  NPN: [39, 56, 13, 4],
-  PNP: [39, 56, 13, 4],
+  NPN: [41, 58, 13, 4],
+  PNP: [41, 58, 13, 4],
   NJF: [5, 11, 5, 3],
   PJF: [5, 11, 5, 3],
   NMOS: [18, 25, 6, 3],
@@ -7980,8 +7980,10 @@ const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   IRB: "IRB",
   XCJC: "XCJC",
   ISE: "ISE",
+  C2: "C2",
   NE: "NE",
   ISC: "ISC",
+  C4: "C4",
   NC: "NC",
   XTB: "XTB",
   BR: "BR",
@@ -8480,13 +8482,14 @@ export function bjtFromModelCard(
     throw invalidElement(name, `expected BJT model card, got ${model.kind}`);
   }
   const p = model.parameters;
+  const saturationCurrent = p.IS ?? 1.0e-14;
   return bjt(
     name,
     collector,
     base,
     emitter,
     model.kind,
-    p.IS ?? 1.0e-14,
+    saturationCurrent,
     p.BF ?? 100.0,
     p.VT ?? 0.02585,
     p.CJE ?? 0.0,
@@ -8505,9 +8508,9 @@ export function bjtFromModelCard(
     p.FC ?? 0.5,
     p.VAR ?? 0.0,
     p.IKF ?? 0.0,
-    p.ISE ?? 0.0,
+    p.ISE ?? (p.C2 ?? 0.0) * saturationCurrent,
     p.NE ?? 1.0,
-    p.ISC ?? 0.0,
+    p.ISC ?? (p.C4 ?? 0.0) * saturationCurrent,
     p.NC ?? 2.0,
     p.XTB ?? 0.0,
     p.BR ?? 1.0,

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -125,7 +125,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(136);
+    expect(coverage).toHaveLength(140);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +145,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(136);
+    expect(records).toHaveLength(140);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -210,15 +210,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 136,
-      expectedCanonicalParameterCount: 136,
-      acceptedNameCount: 202,
+      canonicalParameterCount: 140,
+      expectedCanonicalParameterCount: 140,
+      acceptedNameCount: 206,
       aliasedParameterCount: 53,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t136\t136\t202\t53\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t140\t140\t206\t53\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,8 +241,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(135);
-    expect(report.acceptedNameCount).toBe(199);
+    expect(report.canonicalParameterCount).toBe(139);
+    expect(report.acceptedNameCount).toBe(203);
     expect(report.aliasedParameterCount).toBe(52);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -257,7 +257,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t135\t136\t199\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t139\t140\t203\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -439,6 +439,34 @@ describe("dcOp", () => {
     expectClose(mosModel.params.CBD, 3.0e-13);
     expectClose(mosModel.params.PB, 0.9);
     expectClose(mosModel.params.MJ, 0.45);
+  });
+
+  it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
+    const legacyCard = normalizeModelCard("Qlegacy", "npn", {
+      IS: 2.0e-14,
+      C2: 15.0,
+      C4: 20.0,
+    });
+    const legacy = bjtFromModelCard("Q1", "c", "b", "e", legacyCard);
+
+    expect(legacyCard.parameters).toStrictEqual({
+      IS: 2.0e-14,
+      C2: 15.0,
+      C4: 20.0,
+    });
+    expectClose(legacy.baseEmitterLeakageSaturationCurrent, 3.0e-13);
+    expectClose(legacy.baseCollectorLeakageSaturationCurrent, 4.0e-13);
+
+    const explicitCard = normalizeModelCard("Qexplicit", "pnp", {
+      IS: 2.0e-14,
+      C2: 15.0,
+      ISE: 5.0e-13,
+      C4: 20.0,
+      ISC: 6.0e-13,
+    });
+    const explicit = bjtFromModelCard("Q2", "c", "b", "e", explicitCard);
+    expectClose(explicit.baseEmitterLeakageSaturationCurrent, 5.0e-13);
+    expectClose(explicit.baseCollectorLeakageSaturationCurrent, 6.0e-13);
   });
 
   it("provides cross-language device model audit fixtures", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,17 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language BJT base-collector capacitance partitioning.
+1. Cross-language legacy BJT leakage ratios.
    - Status: current PR completion candidate.
-   - Add Berkeley BJT `XCJC` model-card support in Rust, Python, and
-     TypeScript, defaulting to one.
-   - Partition `CJC` depletion capacitance between the intrinsic
-     base-collector branch and a new external-base/collector charge branch in
-     AC and transient analysis while keeping reverse transit-time diffusion
-     capacitance intrinsic.
+   - Add legacy SPICE2 BJT `C2` and `C4` model-card support in Rust, Python,
+     and TypeScript.
+   - Derive base-emitter `ISE` as `C2 * IS` and base-collector `ISC` as
+     `C4 * IS` only when the corresponding explicit leakage current is absent.
    - Preserve existing behavior by default, extend the supported-parameter
-     coverage gate from 134 to 136 canonical rows, and lock model-card,
-     validation, hierarchy, AC, and transient behavior in all engines.
+     coverage gate from 136 to 140 canonical rows, and lock normalization,
+     derivation, and explicit-current precedence in all engines.
 
 ## Completed Slices
 
@@ -3204,6 +3202,15 @@ the Rust, Python, and TypeScript surfaces together.
    - DC, transient, AC, transfer-function, and noise paths share the
      bias-dependent intrinsic-base topology; the supported-parameter release
      gate now covers 134 canonical rows.
+
+244. Cross-language BJT base-collector capacitance partitioning.
+   - Status: completed in PR 8877.
+   - Rust, Python, and TypeScript BJT model cards now accept `XCJC`, default it
+     to one, and partition `CJC` depletion capacitance between intrinsic and
+     external base-collector branches in AC and transient analysis.
+   - Reverse transit-time diffusion capacitance remains intrinsic, hierarchical
+     expansion preserves the model, and the supported-parameter release gate
+     now covers 136 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- support legacy SPICE2 BJT `C2` and `C4` leakage ratios in Rust, Python, and TypeScript
- derive `ISE = C2 * IS` and `ISC = C4 * IS` only when explicit leakage currents are absent
- expand the supported-parameter release gate from 136 to 140 canonical rows and advance the SPICE implementation plan

## Verification
- Rust: `cargo fmt -p spice-engine -- --check`; `cargo check -p spice-engine`; `cargo clippy -p spice-engine --all-targets -- -D warnings`; `cargo test -p spice-engine`
- Python: Ruff on touched source/tests; 579 tests passed with 88.83% coverage
- TypeScript: `npm run build`; 337 tests passed