### PR TITLE
feat(semantic-ir-to-ruby): exceptions — native begin/rescue/ensure (SIR17)

### DIFF
--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 0.10.0 — exceptions (SIR17)
+
+Accepts `Feature::Exceptions` — the first of the OOP/exception frontier, and
+self-contained (a `rescue` clause matches by exception-class NAME, an advisory
+string, so it is separable from `Classes`). Ruby handles exceptions natively, so
+this needs no runtime support:
+
+- `Stmt::TryCatch` renders `begin … rescue … ensure … end`. Each `rescue`
+  clause lists its exception classes by name, optionally binds the caught
+  exception to a local (`rescue Foo => e`), and runs its body; an empty class
+  list is a bare catch-all. `ensure`, when present, runs afterwards.
+- The `raise` builtin renders the native `raise` — bare (re-raise the exception
+  being handled), with a message string (`raise "boom"` → `RuntimeError`), or
+  with an exception object. `retry` renders the native `retry`.
+- `raise SomeClass` (a specific exception class) lowers to a `Const` reference,
+  which observes `Feature::Constants` (not accepted) → such a module is rejected;
+  `raise "message"`, a bare re-raise, and `rescue` by a standard class
+  (`StandardError`, …) or catch-all are the accepted forms.
+
+**Injection safety**: a `rescue` clause's exception-type name is emitted verbatim
+as a Ruby constant reference (it must stay capitalized, so it cannot be routed
+through `sanitize_ident`). A `compile`-time gate rejects any module whose rescue
+type is not a valid Ruby constant path (`Foo` / `Foo::Bar`) — so a hand-built
+module cannot inject source through a crafted type name. Crucially, this check is
+folded into the SAME single traversal as the unsupported-builtin pre-check
+(a unified `ScanHit`), so it is **co-total with the emitter**: every `TryCatch`
+the emitter can reach — including ones nested in a call argument, a function's
+trailing value, a `SeqSet`/`MapSet` sub-expression, or any other expression
+position — is validated. (Security review caught a first attempt using a
+separate, hand-picked walk that missed several of those positions; the unified
+walk cannot drift.) The caught exception's binding, being an ordinary local,
+goes through `sanitize_ident` as usual; a `raise`d message string is quoted by
+`quote_ruby_string`.
+
+Documented limitation: a `rescue` by an advisory class name that is not a live
+Ruby constant (a user-defined exception class, which needs the not-yet-accepted
+`Classes` feature) raises `NameError` at runtime; standard classes and bare
+`rescue` always work.
+
+First of the exceptions parity arc: Go/Rust/Python/JS already accept `Exceptions`
+(C is tracked next). Verified through a real `ruby` with hand-built modules: a
+bare rescue catching a raised message, `ensure` always running, a rescue binding,
+a typed `rescue StandardError`, the native emit shape, and the injectable-type
+rejection. Bumps semantic-ir-to-ruby 0.9.0 → 0.10.0.
+
 ## 0.9.0 — keyword parameters (SIR19)
 
 Accepts `Feature::KeywordParams`. Ruby has native keyword arguments, so this is

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/README.md
+++ b/code/packages/rust/semantic-ir-to-ruby/README.md
@@ -62,10 +62,13 @@ renders as native `def f(a, b = <default>)` (evaluated at call time when the
 argument is omitted; may reference an earlier parameter); and SIR19
 `KeywordParams` — a keyword parameter (`def f(x:)` / `def f(x: 1)`) and keyword
 argument (`f(x: 5)`) render as Ruby's native keyword forms, matched by name (so
-order-independent).
+order-independent); and SIR17 `Exceptions` — `begin … rescue … ensure … end`
+(`TryCatch`) plus the `raise` / `retry` builtins render as native Ruby exception
+handling (a rescue matches by exception-class name, validated as a constant path
+before emit; `raise` of a specific class needs `Constants` and is rejected).
 Rejects `TailCalls`, `Intrinsics`, and every not-yet-wired feature (array
 indexing / slicing via `IndexGet` — `NDArrays`; array-pattern destructuring;
-collection methods, exceptions, OOP) until its cascade batch
+collection methods, classes/OOP) until its cascade batch
 lands — each a clean, source-positioned `UnsupportedFeature`.
 
 ## Verification

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -22,7 +22,7 @@ use crate::runtime::RUNTIME;
 static LOOP_TEMP_ID: AtomicUsize = AtomicUsize::new(0);
 
 /// Builtins the v0 backend lowers.  A `BuiltinCall` to anything else is
-/// rejected by [`first_unsupported_builtin`] (mirroring the C backend), so a
+/// rejected by [`first_scan_issue`] (mirroring the C backend), so a
 /// module using e.g. the `__method__` collection-dispatch protocol fails
 /// cleanly rather than emitting a call with no lowering.
 const SUPPORTED_BUILTINS: &[&str] = &[
@@ -53,6 +53,11 @@ const SUPPORTED_BUILTINS: &[&str] = &[
     "puts",
     "global_get",
     "global_set",
+    // SIR17 exceptions (`Feature::Exceptions`): `raise` (re-raise / raise a
+    // message or exception) and `retry` (restart the `begin` body) render as
+    // the native Ruby keywords.
+    "raise",
+    "retry",
 ];
 
 /// Emit a complete self-contained Ruby source file for `m`.
@@ -104,9 +109,22 @@ fn emit_globals_comment(out: &mut String, globals: &[Global]) {
     out.push_str("\n\n");
 }
 
-/// Scan the module for a `BuiltinCall` whose name the v0 backend cannot lower.
-/// Returns the first such `(name, span)` so `compile` can reject it cleanly.
-pub fn first_unsupported_builtin(m: &Module) -> Option<(String, semantic_ir::Span)> {
+/// A problem the pre-emit scan found — reported by `compile` as a clean
+/// rejection.  Both live in ONE traversal ([`first_scan_issue`]) so the check
+/// can never drift out of coverage with the emitter (a lesson from a rescue-type
+/// injection: a hand-picked subset walk missed positions the emitter reaches).
+pub enum ScanHit {
+    /// A `BuiltinCall` whose name the v0 backend cannot lower.
+    Builtin(String, semantic_ir::Span),
+    /// A `rescue` clause exception type that is not a valid Ruby constant path
+    /// (would inject source if emitted verbatim).
+    RescueType(String, semantic_ir::Span),
+}
+
+/// Scan the module — in a SINGLE traversal shared with the unsupported-builtin
+/// check — for the first thing `compile` must reject: an unlowerable builtin or
+/// an injectable `rescue` type.  Returns it (with a span) or `None`.
+pub fn first_scan_issue(m: &Module) -> Option<ScanHit> {
     for f in &m.functions {
         // A SIR19 parameter default is an expression evaluated at call time, so
         // a builtin nested in it (`def g(x = foo())`) must be pre-checked too —
@@ -126,7 +144,7 @@ pub fn first_unsupported_builtin(m: &Module) -> Option<(String, semantic_ir::Spa
     None
 }
 
-fn scan_block(b: &Block) -> Option<(String, semantic_ir::Span)> {
+fn scan_block(b: &Block) -> Option<ScanHit> {
     for s in &b.stmts {
         if let Some(hit) = scan_stmt(s) {
             return Some(hit);
@@ -135,7 +153,7 @@ fn scan_block(b: &Block) -> Option<(String, semantic_ir::Span)> {
     scan_expr(&b.value)
 }
 
-fn scan_stmt(s: &Stmt) -> Option<(String, semantic_ir::Span)> {
+fn scan_stmt(s: &Stmt) -> Option<ScanHit> {
     match s {
         Stmt::LetBinding { value, .. }
         | Stmt::LetStarBinding { value, .. }
@@ -169,17 +187,54 @@ fn scan_stmt(s: &Stmt) -> Option<(String, semantic_ir::Span)> {
             .or_else(|| scan_expr(stop))
             .or_else(|| scan_expr(step))
             .or_else(|| scan_block(body)),
+        // A `begin … rescue … ensure … end`.  Check each rescue clause's
+        // exception-type NAMES here (this arm is reached by the SAME complete
+        // traversal as the builtin scan, so EVERY `TryCatch` the emitter reaches
+        // is validated — no separate, drift-prone walk).  Then scan the guarded
+        // body, every rescue clause body, and the ensure body for builtins.
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            span,
+        } => rescues
+            .iter()
+            .flat_map(|rc| rc.exception_types.iter())
+            .find(|t| !is_valid_constant_path(t))
+            .map(|t| ScanHit::RescueType(t.clone(), span.clone()))
+            .or_else(|| body.iter().find_map(scan_stmt))
+            .or_else(|| rescues.iter().find_map(|rc| rc.body.iter().find_map(scan_stmt)))
+            .or_else(|| {
+                ensure_body
+                    .as_ref()
+                    .and_then(|e| e.iter().find_map(scan_stmt))
+            }),
         _ => None,
     }
 }
 
-fn scan_expr(e: &Expr) -> Option<(String, semantic_ir::Span)> {
+/// Whether `name` is a syntactically valid Ruby constant path (`Foo`,
+/// `Foo::Bar`) — a non-empty `::`-separated list of identifier segments, each
+/// starting with a letter or `_` and continuing with `[A-Za-z0-9_]`.  A `rescue`
+/// clause's exception type is emitted verbatim, so this gates out any name
+/// carrying a metacharacter (space, `;`, `(`, quote, newline, …) that could
+/// inject source.
+fn is_valid_constant_path(name: &str) -> bool {
+    !name.is_empty()
+        && name.split("::").all(|seg| {
+            let mut chars = seg.chars();
+            matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '_')
+                && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+        })
+}
+
+fn scan_expr(e: &Expr) -> Option<ScanHit> {
     match e {
         Expr::BuiltinCall {
             name, args, span, ..
         } => {
             if !SUPPORTED_BUILTINS.contains(&name.as_str()) {
-                return Some((name.clone(), span.clone()));
+                return Some(ScanHit::Builtin(name.clone(), span.clone()));
             }
             args.iter().find_map(scan_expr)
         }
@@ -424,7 +479,48 @@ fn emit_stmt(s: &Stmt) -> String {
             s.push_str("end");
             s
         }
-        // Other SIR16+ statements (index-set/class/try) are not accepted; the
+        // SIR17 `begin … rescue … ensure … end`.  Ruby handles exceptions
+        // natively, so each part renders directly.  A `rescue` clause lists its
+        // exception classes by name (validated as constant paths before emit, so
+        // no source can inject), optionally binds the caught exception to a
+        // `sanitize_ident`-safe local, and runs its body; an empty class list is
+        // a bare catch-all `rescue`.  `ensure`, when present, runs afterwards.
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            ..
+        } => {
+            let mut s = String::from("begin\n");
+            for st in body {
+                s.push_str(&emit_stmt(st));
+                s.push('\n');
+            }
+            for rc in rescues {
+                s.push_str("rescue");
+                if !rc.exception_types.is_empty() {
+                    let _ = write!(s, " {}", rc.exception_types.join(", "));
+                }
+                if let Some(bind) = &rc.binding {
+                    let _ = write!(s, " => {}", sanitize_ident(bind));
+                }
+                s.push('\n');
+                for st in &rc.body {
+                    s.push_str(&emit_stmt(st));
+                    s.push('\n');
+                }
+            }
+            if let Some(ens) = ensure_body {
+                s.push_str("ensure\n");
+                for st in ens {
+                    s.push_str(&emit_stmt(st));
+                    s.push('\n');
+                }
+            }
+            s.push_str("end");
+            s
+        }
+        // Other SIR16+ statements (index-set/class) are not accepted; the
         // capability check rejects such modules before emit.
         other => unreachable!("Ruby backend reached unsupported statement: {other:?}"),
     }
@@ -651,7 +747,20 @@ fn emit_builtin(name: &str, args: &[Expr]) -> String {
         "puts" => format!("sir_puts({})", a.join(", ")),
         "global_get" => format!("sir_global_get({})", arg(&a, 0)),
         "global_set" => format!("sir_global_set({}, {})", arg(&a, 0), arg(&a, 1)),
-        // Unreachable: first_unsupported_builtin rejected anything else.
+        // SIR17 exceptions.  `raise` with no argument re-raises the exception
+        // being handled (`$!`); with a message string it raises a `RuntimeError`
+        // (`raise "boom"`); with an exception object it re-raises that.  Each
+        // argument is an already-emitted expression (a `StrLit` is quoted, so no
+        // source can inject).  `retry` restarts the enclosing `begin` body.
+        "raise" => {
+            if a.is_empty() {
+                "raise".to_string()
+            } else {
+                format!("raise({})", a.join(", "))
+            }
+        }
+        "retry" => "retry".to_string(),
+        // Unreachable: first_scan_issue rejected anything else.
         other => unreachable!("v0 Ruby backend reached unsupported builtin: {other}"),
     }
 }

--- a/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
@@ -132,6 +132,17 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // (unlike the Go/C backends' KW6 lowering).  A keyword default rides on this
     // feature (an optional keyword), not `DefaultParams`.
     Feature::KeywordParams,
+    // ── SIR17 exceptions ─────────────────────────────────────────────
+    // `Stmt::TryCatch` (`begin … rescue … ensure … end`) and the `raise` /
+    // `retry` builtins render as Ruby's NATIVE exception handling — no runtime
+    // support (Ruby raises/rescues by exception class natively).  A `rescue`
+    // clause matches by exception-class NAME (advisory strings the frontend
+    // takes from source; validated as constant paths before emit) and may bind
+    // the caught exception to a local.  `raise SomeClass` (a specific class) is
+    // a `Const` reference → it observes `Feature::Constants` (unaccepted) and is
+    // rejected; `raise "message"`, a bare re-raise, and `rescue` by a standard
+    // class or catch-all are the accepted forms.
+    Feature::Exceptions,
 ];
 
 impl Backend for RubyBackend {
@@ -173,15 +184,33 @@ impl Backend for RubyBackend {
         //    other reserved builtins) are not gated by an unaccepted feature, so
         //    reject a module that uses a builtin v0 cannot lower rather than
         //    emit a call with no lowering.
-        if let Some((name, span)) = emit::first_unsupported_builtin(module) {
-            return Err(BackendError {
-                kind: BackendErrorKind::UnsupportedFeature,
-                message: format!(
-                    "the v0 Ruby backend does not yet lower the `{name}` builtin \
-                     (deferred to a later feature batch)"
-                ),
-                span,
-            });
+        //    A single traversal reports BOTH an unlowerable builtin AND an
+        //    injectable `rescue` type (a `rescue` clause name is emitted verbatim
+        //    as a Ruby constant reference, so it must be a valid constant path —
+        //    otherwise a hand-built module could inject source).  Sharing one
+        //    walk keeps the check co-total with the emitter.
+        match emit::first_scan_issue(module) {
+            Some(emit::ScanHit::Builtin(name, span)) => {
+                return Err(BackendError {
+                    kind: BackendErrorKind::UnsupportedFeature,
+                    message: format!(
+                        "the v0 Ruby backend does not yet lower the `{name}` builtin \
+                         (deferred to a later feature batch)"
+                    ),
+                    span,
+                });
+            }
+            Some(emit::ScanHit::RescueType(name, span)) => {
+                return Err(BackendError {
+                    kind: BackendErrorKind::UnsupportedFeature,
+                    message: format!(
+                        "the Ruby backend cannot emit the rescue exception type `{name}` \
+                         (not a valid Ruby constant path)"
+                    ),
+                    span,
+                });
+            }
+            None => {}
         }
 
         // 4. Emit.

--- a/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
@@ -1217,3 +1217,179 @@ fn rest_and_keyword_rest_params_emit_splat_syntax() {
     .source;
     assert!(rb.contains("def f(a, *rest, x:, **opts)"), "splat syntax:\n{rb}");
 }
+
+// ── SIR17 exceptions ────────────────────────────────────────────────────────
+// `Feature::Exceptions` — `begin … rescue … ensure … end` (`Stmt::TryCatch`)
+// and the `raise` / `retry` builtins render as Ruby's native exception
+// handling. Hand-built modules prove the catch/ensure/binding behaviour through
+// a real `ruby`.
+
+use semantic_ir::RescueClause;
+
+fn raise_(arg: Option<Expr>) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "raise".into(),
+            args: arg.into_iter().collect(),
+            effects: EffectSet::PURE,
+            span: s2(),
+        },
+        span: s2(),
+    }
+}
+fn rescue_clause(types: Vec<&str>, binding: Option<&str>, body: Vec<Stmt>) -> RescueClause {
+    RescueClause {
+        exception_types: types.into_iter().map(String::from).collect(),
+        binding: binding.map(String::from),
+        body,
+        span: s2(),
+    }
+}
+fn trycatch(body: Vec<Stmt>, rescues: Vec<RescueClause>, ensure_body: Option<Vec<Stmt>>) -> Stmt {
+    Stmt::TryCatch { body, rescues, ensure_body, span: s2() }
+}
+fn exc_module(stmts: Vec<Stmt>) -> Module {
+    let mut m = seq_module(stmts);
+    m.manifest = FeatureManifest::from_features(&[Feature::Exceptions, Feature::Strings]);
+    m
+}
+fn run_exc(stmts: Vec<Stmt>) -> Option<String> {
+    run_ruby(&compile(&exc_module(stmts)).expect("exception module must compile, not panic").source)
+}
+
+#[test]
+fn bare_rescue_catches_a_raised_message() {
+    // `begin; raise "boom"; rescue; puts "caught"; end` — the raised
+    // `RuntimeError` is caught by the bare (catch-all) rescue.
+    let out = run_exc(vec![trycatch(
+        vec![raise_(Some(strlit("boom")))],
+        vec![rescue_clause(vec![], None, vec![puts(strlit("caught"))])],
+        None,
+    )]);
+    match out {
+        Some(o) => assert_eq!(o, "caught"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn ensure_body_always_runs() {
+    // `begin; puts "body"; ensure; puts "cleanup"; end` — no exception, but the
+    // ensure still runs after the body.
+    let out = run_exc(vec![trycatch(
+        vec![puts(strlit("body"))],
+        vec![],
+        Some(vec![puts(strlit("cleanup"))]),
+    )]);
+    match out {
+        Some(o) => assert_eq!(o, "body\ncleanup"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn rescue_binds_the_caught_exception() {
+    // `begin; raise "x"; rescue => e; puts "got"; end` — the binding `e` is in
+    // scope in the clause body (a `Scope::Local`); the clause runs.
+    let out = run_exc(vec![trycatch(
+        vec![raise_(Some(strlit("x")))],
+        vec![rescue_clause(vec![], Some("e"), vec![puts(strlit("got"))])],
+        None,
+    )]);
+    match out {
+        Some(o) => assert_eq!(o, "got"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn rescue_matches_a_standard_exception_class() {
+    // `begin; raise "x"; rescue StandardError; puts "std"; end` — a
+    // `RuntimeError` is a `StandardError`, so the typed clause matches.
+    let out = run_exc(vec![trycatch(
+        vec![raise_(Some(strlit("x")))],
+        vec![rescue_clause(vec!["StandardError"], None, vec![puts(strlit("std"))])],
+        None,
+    )]);
+    match out {
+        Some(o) => assert_eq!(o, "std"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn exception_emits_native_begin_rescue_ensure() {
+    // Emit-shape: the native keywords are present.
+    let rb = compile(&exc_module(vec![trycatch(
+        vec![raise_(Some(strlit("x")))],
+        vec![rescue_clause(vec!["StandardError"], Some("e"), vec![puts(strlit("c"))])],
+        Some(vec![puts(strlit("f"))]),
+    )]))
+    .expect("compile")
+    .source;
+    assert!(rb.contains("begin"), "begin:\n{rb}");
+    assert!(rb.contains("rescue StandardError => e"), "typed rescue + binding:\n{rb}");
+    assert!(rb.contains("ensure"), "ensure:\n{rb}");
+}
+
+#[test]
+fn injectable_rescue_type_is_rejected_cleanly() {
+    // A rescue exception-type name is emitted verbatim as a constant reference,
+    // so a name carrying source (a hand-built module could) must be rejected —
+    // never emitted. `compile` returns an Err, not injectable Ruby.
+    let m = exc_module(vec![trycatch(
+        vec![puts(strlit("x"))],
+        vec![rescue_clause(vec!["Foo; system('rm -rf /')"], None, vec![puts(strlit("y"))])],
+        None,
+    )]);
+    let err = compile(&m).expect_err("an injectable rescue type must be rejected");
+    assert_eq!(err.kind, semantic_ir::BackendErrorKind::UnsupportedFeature);
+}
+
+#[test]
+fn injectable_rescue_type_nested_in_a_call_argument_is_rejected() {
+    // Regression (security review): a `TryCatch` hidden in an EXPRESSION position
+    // (here a `Block` used as a `puts` argument) is still reached by the emitter,
+    // so its rescue types must be validated too. The pre-emit scan is co-total
+    // with the emitter — a hand-picked subset walk had missed this position.
+    let payload = "StandardError\nSTDERR.puts('INJECTED')\nrescue";
+    let bad_try = trycatch(
+        vec![puts(strlit("x"))],
+        vec![rescue_clause(vec![payload], None, vec![puts(strlit("y"))])],
+        None,
+    );
+    let block_arg = Expr::Block(Box::new(Block {
+        stmts: vec![bad_try],
+        value: Expr::NilLit { span: s2() },
+        span: s2(),
+    }));
+    let m = exc_module(vec![puts(block_arg)]);
+    assert!(
+        compile(&m).is_err(),
+        "an injectable rescue type nested in a call argument must be rejected"
+    );
+}
+
+#[test]
+fn injectable_rescue_type_in_the_function_value_is_rejected() {
+    // Regression (security review): a `TryCatch` in the function's trailing
+    // VALUE (not its statement list) is emitted too, so the scan must visit
+    // `f.body.value` — not only `f.body.stmts`.
+    let bad_try = trycatch(
+        vec![puts(strlit("x"))],
+        vec![rescue_clause(vec!["Foo; system('boom')"], None, vec![puts(strlit("y"))])],
+        None,
+    );
+    let mut m = exc_module(vec![]);
+    if let Some(main) = m.functions.iter_mut().find(|f| f.name == "main") {
+        main.body.value = Expr::Block(Box::new(Block {
+            stmts: vec![bad_try],
+            value: Expr::NilLit { span: s2() },
+            span: s2(),
+        }));
+    }
+    assert!(
+        compile(&m).is_err(),
+        "an injectable rescue type in the function value must be rejected"
+    );
+}

--- a/code/specs/SIR25-semantic-ir-to-ruby.md
+++ b/code/specs/SIR25-semantic-ir-to-ruby.md
@@ -74,12 +74,14 @@ SIR26 integer conversions (`Conversions`, `SizedIntegers`, `Unsigned`,
 `WrappingArithmetic`); and the SIR16 batches `Loops` + `MutableBindings`
 (0.3.0), `Sequences` (native `Array`, 0.4.0), `Maps` (native `Hash`, 0.5.0),
 `Floats` (native `Float`, 0.6.0), and `ShortCircuit` (native `&&`/`||`, 0.7.0);
-and the SIR19 parameter batches `DefaultParams` (native `def f(a, b =
+the SIR19 parameter batches `DefaultParams` (native `def f(a, b =
 <default>)`, 0.8.0) and `KeywordParams` (native `def f(x:)` / `f(x: 5)`, matched
-by name, 0.9.0).
+by name, 0.9.0); and SIR17 `Exceptions` (native `begin/rescue/ensure` +
+`raise`/`retry`, 0.10.0 — rescue types validated as constant paths; `raise` of a
+specific class needs `Constants`, rejected).
 
 **Still rejects** `TailCalls`, `Intrinsics`, `NDArrays`,
-exceptions/OOP, and every not-yet-landed feature (each rejection is a clean,
+`Classes`/OOP, and every not-yet-landed feature (each rejection is a clean,
 source-positioned `UnsupportedFeature`).
 
 ## Value model


### PR DESCRIPTION
## What

Adds SIR17 **exceptions** to the Ruby backend (`semantic-ir-to-ruby` 0.9.0 → 0.10.0) — the **first slice of the OOP/exception frontier**, and self-contained: a `rescue` clause matches by exception-class *name* (an advisory string), so `Exceptions` is separable from `Classes`. Ruby handles exceptions natively — no runtime support:

- `Stmt::TryCatch` → `begin … rescue … ensure … end`. Each `rescue` clause lists its exception classes by name, optionally binds the caught exception (`rescue Foo => e`), and runs its body; an empty list is a bare catch-all. `ensure` runs afterwards.
- `raise` → native `raise` (bare re-raise / a message string → `RuntimeError` / an exception object); `retry` → `retry`.
- `raise SomeClass` (a specific class) lowers to a `Const` reference → observes `Feature::Constants` (unaccepted) → rejected; `raise "message"`, bare re-raise, and `rescue` by a standard class / catch-all are accepted.

## Injection safety (the crux)

A `rescue` type name is emitted **verbatim** as a Ruby constant reference (it must stay capitalized, so `sanitize_ident` can't be used). A `compile`-time gate rejects any module whose rescue type is not a valid Ruby constant path. Crucially, this check is **folded into the same single traversal as the unsupported-builtin pre-check** (a unified `ScanHit`), so it is **co-total with the emitter** — every `TryCatch` the emitter reaches (nested in a call argument, a function's trailing value, a `SeqSet`/`MapSet` sub-expression, an `if` branch, …) is validated.

**Security review (2 rounds):** the first attempt used a separate hand-picked walk that **missed** several of those positions — a verified source-injection. The fix deletes it and folds the check into the proven-complete scan; the unified walk cannot drift. Two regression tests pin the previously-missed positions. Re-review passed clean.

## Verification

- `cargo test -p semantic-ir-to-ruby` — **62 tests green** (8 new) through a real `ruby`: a bare rescue catching a raised message, `ensure` always running, a rescue binding, a typed `rescue StandardError`, the native emit shape, and three injectable-type rejections (direct, nested-in-call-arg, in-function-value).
- `cargo clippy -p semantic-ir-to-ruby --all-targets` clean.
- SIR25 spec capability section synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)