### PR TITLE
feat(gc-core-capi): __gc_set_tenure_age / __gc_tenure_age C ABI (generational aging tunable)

### DIFF
--- a/code/packages/rust/gc-core-capi/CHANGELOG.md
+++ b/code/packages/rust/gc-core-capi/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this crate are documented here.
 
+## 0.14.0 - 2026-07-23 — generational tenuring-age C ABI
+
+Exposes gc-core 0.11.0's tunable generational **tenuring age** across the C ABI so native
+consumers can tune how many collections a young object survives before promotion:
+
+- `void __gc_set_tenure_age(int64_t threshold)` → `FlatHeap::set_tenure_age`. The `i64`
+  argument is clamped to `1..=255` (`0`/negatives → `1`, over-large → `255`) before the
+  `u8` cast, so tenuring always terminates.
+- `int64_t __gc_tenure_age(void)` → the current threshold (default `1` = immediate
+  tenuring).
+
+Both are thin `with_heap` wrappers over the process-wide heap, declared in `gc_core.h`.
+One host test (`c_abi_set_and_get_tenure_age_clamps`) covers the round-trip + clamp; the
+aging *behaviour* is covered by gc-core's own tests. Purely additive; no existing symbol
+changes. gc-core-capi 0.13.0 → 0.14.0.
+
 ## 0.13.0 - 2026-07-21 — twig-compat precise/observability aliases (AOT00-T1 increment C)
 
 Two `__twig_gc_*` aliases the native code generators emit for the GC-stress

--- a/code/packages/rust/gc-core-capi/Cargo.toml
+++ b/code/packages/rust/gc-core-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core-capi"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "C ABI for gc-core's flat-native heap — the gc_runtime_<target> archive linked into native-AOT output (LANG16 / AOT00 T1)."
 license = "MIT"

--- a/code/packages/rust/gc-core-capi/include/gc_core.h
+++ b/code/packages/rust/gc-core-capi/include/gc_core.h
@@ -100,6 +100,15 @@ int64_t __gc_live_bytes(void);
 /* Collections run since process start (or last __gc_reset). */
 int64_t __gc_collection_count(void);
 
+/* Set the generational tenuring age: a young object is promoted to the old
+ * generation only after surviving `threshold` collections (default 1 = immediate
+ * tenuring). A larger value keeps short-lived objects young longer so a cheap minor
+ * GC reclaims them. Clamped to 1..=255 (0/negative -> 1). Safe at any time. */
+void __gc_set_tenure_age(int64_t threshold);
+
+/* The current generational tenuring age (see __gc_set_tenure_age). */
+int64_t __gc_tenure_age(void);
+
 /* Drop the whole heap (frees everything) and reset counters. */
 void __gc_reset(void);
 

--- a/code/packages/rust/gc-core-capi/src/lib.rs
+++ b/code/packages/rust/gc-core-capi/src/lib.rs
@@ -223,6 +223,24 @@ pub extern "C" fn __gc_collection_count() -> i64 {
     with_heap(|h| h.collection_count() as i64)
 }
 
+/// Set the **generational tenuring age**: a young object is promoted to the old
+/// generation only after surviving `threshold` collections (default `1` =
+/// immediate tenuring). A larger value keeps short-lived-but-not-instantly-dead
+/// objects in the young generation longer so a cheap minor GC reclaims them.
+/// `threshold` is clamped to `1..=255` (`0` and negatives → `1`; the u8 field caps
+/// at `255`), so tenuring always terminates. Idempotent; safe at any time.
+#[no_mangle]
+pub extern "C" fn __gc_set_tenure_age(threshold: i64) {
+    let t = threshold.clamp(1, u8::MAX as i64) as u8;
+    with_heap(|h| h.set_tenure_age(t));
+}
+
+/// The current generational tenuring age (see [`__gc_set_tenure_age`]).
+#[no_mangle]
+pub extern "C" fn __gc_tenure_age() -> i64 {
+    with_heap(|h| h.tenure_age() as i64)
+}
+
 /// Drop the entire heap, freeing every outstanding block, and reset counters.
 /// Primarily for tests and deterministic process teardown.
 #[no_mangle]
@@ -518,6 +536,35 @@ mod tests {
         __gc_reset();
         assert_eq!(__gc_live_bytes(), 0);
         assert_eq!(__gc_collection_count(), 0);
+    }
+
+    /// The generational tenuring age is settable + gettable through the C ABI and
+    /// clamps the threshold to `1..=255`. (The *behaviour* aging drives — a survivor
+    /// staying young `threshold-1` collections — is covered by gc-core's own tests;
+    /// this checks the ABI wiring and the `i64 → u8` clamp.)
+    #[test]
+    fn c_abi_set_and_get_tenure_age_clamps() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        __gc_reset();
+
+        // Default is immediate tenuring.
+        assert_eq!(__gc_tenure_age(), 1, "default threshold is 1");
+
+        // Round-trips a normal value.
+        __gc_set_tenure_age(4);
+        assert_eq!(__gc_tenure_age(), 4);
+
+        // Clamps: 0 and negatives → 1; > u8::MAX → 255.
+        __gc_set_tenure_age(0);
+        assert_eq!(__gc_tenure_age(), 1, "0 clamps to 1");
+        __gc_set_tenure_age(-9);
+        assert_eq!(__gc_tenure_age(), 1, "negative clamps to 1");
+        __gc_set_tenure_age(1000);
+        assert_eq!(__gc_tenure_age(), 255, "over-large clamps to u8::MAX");
+
+        // `__gc_reset` drops the heap but a fresh heap re-defaults to 1.
+        __gc_reset();
+        assert_eq!(__gc_tenure_age(), 1, "reset restores the default threshold");
     }
 
     /// `__gc_register_kind` + `__gc_alloc_kind` give **precise** interior tracing


### PR DESCRIPTION
## What

Exposes gc-core 0.11.0's tunable generational **tenuring age** across the C ABI so native consumers (twig-aot, the `__twig_gc_*` runtime) can tune how many collections a young object survives before promotion — the follow-up noted when [generational aging](https://github.com/adhithyan15/coding-adventures/pull/8880) landed.

- `void __gc_set_tenure_age(int64_t threshold)` → `FlatHeap::set_tenure_age`. The `i64` arg is clamped to `1..=255` (`0`/negatives → 1, over-large → 255) **before** the `u8` cast, so the cast is always lossless and tenuring always terminates.
- `int64_t __gc_tenure_age(void)` → the current threshold (default `1` = immediate tenuring).

Thin `with_heap` wrappers (same process-wide-mutex pattern as the sibling exports); declared in `gc_core.h`. **Purely additive** — no existing symbol changes, no `unsafe`, no pointers.

## Validation

- One host test (`c_abi_set_and_get_tenure_age_clamps`: round-trip + clamp of 0 / negative / over-large); the aging *behaviour* is covered by gc-core's own tests. 29 gc-core-capi tests pass; clippy clean.
- Adversarial `/security-review`: **SAFE TO PUSH** — clamp sound for all `i64` (incl. `MIN`/`MAX`), FFI signatures match the header, no unsoundness (tenure_age only delays promotion, never frees early).

gc-core-capi 0.13.0 → 0.14.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)