### PR TITLE
feat(spice): add diode series resistance

### DIFF
--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -493,6 +493,7 @@ class Diode:
     Fc: float = 0.5  # forward-bias depletion coefficient
     Xti: float = 3.0  # saturation-current temperature exponent
     Eg: float = 1.11  # energy gap in electron volts
+    Rs: float = 0.0  # ohmic series resistance
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -599,6 +599,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
             element.Fc,
             element.Xti,
             element.Eg,
+            element.Rs,
         )
     if isinstance(element, JFET):
         return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_, element.Cgs, element.Cgd)
@@ -7254,7 +7255,10 @@ def _element_nodes(el: Element) -> list[str]:
     if isinstance(el, CustomModel):
         return [el.n_plus, el.n_minus]
     if isinstance(el, Diode):
-        return [el.anode, el.cathode]
+        nodes = [el.anode, el.cathode]
+        if el.Rs > 0.0:
+            nodes.append(_diode_intrinsic_anode_node(el))
+        return nodes
     if isinstance(el, JFET):
         return [el.drain, el.gate, el.source]
     if isinstance(el, Mosfet):
@@ -8650,22 +8654,27 @@ def _stamp_diode(
 
     Newton: I0 = Is*(exp(Vd0/(N*Vt)) - 1), gd = (Is/(N*Vt))*exp(Vd0/(N*Vt)).
     Stamp gd as conductance + (gd*Vd0 - I0) as current source from cathode."""
-    Va = 0.0 if _is_ground(el.anode) else x[node_to_idx[el.anode]]
+    intrinsic_anode = _diode_intrinsic_anode_node(el)
+    Va = 0.0 if _is_ground(intrinsic_anode) else x[node_to_idx[intrinsic_anode]]
     Vk = 0.0 if _is_ground(el.cathode) else x[node_to_idx[el.cathode]]
     Vd = Va - Vk
     # Clamp to avoid exp overflow
     Vd = min(Vd, 0.7 * el.N)
     I0, gd = _diode_current_conductance(el, Vd)
 
-    _stamp_g(G, node_to_idx, el.anode, el.cathode, gd)
+    _stamp_g(G, node_to_idx, intrinsic_anode, el.cathode, gd)
     Ieq = I0 - gd * Vd
-    if not _is_ground(el.anode):
-        b[node_to_idx[el.anode]] -= Ieq
+    if not _is_ground(intrinsic_anode):
+        b[node_to_idx[intrinsic_anode]] -= Ieq
     if not _is_ground(el.cathode):
         b[node_to_idx[el.cathode]] += Ieq
+    if el.Rs > 0.0:
+        _stamp_g(G, node_to_idx, el.anode, intrinsic_anode, 1.0 / el.Rs)
 
 
 def _diode_effective_vt(el: Diode) -> float:
+    if not math.isfinite(el.Rs) or el.Rs < 0.0:
+        raise ValueError(f"{el.name}: diode series resistance must be finite and non-negative")
     if not math.isfinite(el.N) or el.N <= 0.0:
         raise ValueError(f"{el.name}: diode emission coefficient must be finite and positive")
     if not math.isfinite(el.Vt) or el.Vt <= 0.0:
@@ -8712,6 +8721,10 @@ def _diode_charge_state_name(el: Diode) -> str:
     return f"_D_{el.name}_charge"
 
 
+def _diode_intrinsic_anode_node(el: Diode) -> str:
+    return el.anode if el.Rs == 0.0 else f"_D_{el.name}_anode"
+
+
 def _diode_has_charge_storage(el: Diode) -> bool:
     return el.Cjo > 0.0 or el.Tt > 0.0
 
@@ -8733,7 +8746,9 @@ def _diode_depletion_capacitance(el: Diode, vd: float) -> float:
 
 
 def _diode_charge_voltage(el: Diode, node_voltages: dict[str, float]) -> float:
-    return _node_voltage(el.anode, node_voltages) - _node_voltage(el.cathode, node_voltages)
+    return _node_voltage(_diode_intrinsic_anode_node(el), node_voltages) - _node_voltage(
+        el.cathode, node_voltages
+    )
 
 
 def _bjt_base_emitter_charge_state_name(el: BJT) -> str:
@@ -12682,7 +12697,8 @@ def _stamp_ac(
         # Small-signal model: linearised conductance gd = (Is/(N*Vt))·exp(Vd/(N*Vt)).
         # The dynamic (differential) conductance is the derivative of
         # I = Is*(exp(Vd/(N*Vt)) − 1) with respect to Vd, evaluated at the OP.
-        Va = 0.0 if _is_ground(el.anode) else dc_x[node_to_idx[el.anode]]
+        intrinsic_anode = _diode_intrinsic_anode_node(el)
+        Va = 0.0 if _is_ground(intrinsic_anode) else dc_x[node_to_idx[intrinsic_anode]]
         Vk = 0.0 if _is_ground(el.cathode) else dc_x[node_to_idx[el.cathode]]
         Vd = Va - Vk
         _, gd = _diode_current_conductance(el, Vd)
@@ -12691,10 +12707,12 @@ def _stamp_ac(
         _stamp_g_c(
             G,
             node_to_idx,
-            el.anode,
+            intrinsic_anode,
             el.cathode,
             gd + 1j * omega * (depletion_capacitance + diffusion_capacitance),
         )
+        if el.Rs > 0.0:
+            _stamp_g_c(G, node_to_idx, el.anode, intrinsic_anode, 1.0 / el.Rs)
 
     elif isinstance(el, JFET):
         Vd = 0.0 if _is_ground(el.drain) else dc_x[node_to_idx[el.drain]]
@@ -13396,11 +13414,18 @@ def _build_ss_matrix(
 
         elif isinstance(el, Diode):
             # Small-signal conductance: gd = dI/dVd = (Is/(N*Vt))·exp(Vd/(N*Vt)).
-            Va = 0.0 if _is_ground(el.anode) else dc_x[node_to_idx[el.anode]]
+            intrinsic_anode = _diode_intrinsic_anode_node(el)
+            Va = (
+                0.0
+                if _is_ground(intrinsic_anode)
+                else dc_x[node_to_idx[intrinsic_anode]]
+            )
             Vk = 0.0 if _is_ground(el.cathode) else dc_x[node_to_idx[el.cathode]]
             Vd = Va - Vk
             _, gd = _diode_current_conductance(el, Vd)
-            _stamp_g(G, node_to_idx, el.anode, el.cathode, gd)
+            _stamp_g(G, node_to_idx, intrinsic_anode, el.cathode, gd)
+            if el.Rs > 0.0:
+                _stamp_g(G, node_to_idx, el.anode, intrinsic_anode, 1.0 / el.Rs)
 
         elif isinstance(el, JFET):
             Vd = 0.0 if _is_ground(el.drain) else dc_x[node_to_idx[el.drain]]
@@ -14381,6 +14406,7 @@ def sens_dc(
                     el.Fc,
                     el.Xti,
                     el.Eg,
+                    el.Rs,
                 ),
             )
 
@@ -14681,6 +14707,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             el.Fc,
             el.Xti,
             el.Eg,
+            el.Rs,
         )
 
     if isinstance(el, BJT):
@@ -15142,14 +15169,34 @@ def _collect_noise_sources(
             # because we are evaluating at the operating point, not iterating Newton.
             # (The 0.7 V clamp in the Newton loop prevents divergence during
             # iterations; at convergence, Vd is the physically correct value.)
-            Va = 0.0 if _is_ground(el.anode) else dc_x[node_to_idx[el.anode]]
+            intrinsic_anode = _diode_intrinsic_anode_node(el)
+            Va = (
+                0.0
+                if _is_ground(intrinsic_anode)
+                else dc_x[node_to_idx[intrinsic_anode]]
+            )
             Vk = 0.0 if _is_ground(el.cathode) else dc_x[node_to_idx[el.cathode]]
             Vd = Va - Vk  # actual operating-point junction voltage
             I_D, _ = _diode_current_conductance(el, Vd, clamp_forward=False)
             psd = q2 * abs(I_D)
-            n_a = None if _is_ground(el.anode) else node_to_idx[el.anode]
+            n_a = (
+                None
+                if _is_ground(intrinsic_anode)
+                else node_to_idx[intrinsic_anode]
+            )
             n_k = None if _is_ground(el.cathode) else node_to_idx[el.cathode]
             sources.append((el.name, "shot", n_a, n_k, psd, 0.0))
+            if el.Rs > 0.0:
+                sources.append(
+                    (
+                        f"{el.name}:RS",
+                        "thermal",
+                        node_to_idx.get(el.anode),
+                        node_to_idx.get(intrinsic_anode),
+                        kT4 / el.Rs,
+                        0.0,
+                    )
+                )
 
         elif isinstance(el, BJT):
             # Shot noise on the base-emitter junction: S_i = 2q |I_C|

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -306,7 +306,7 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
     "PMOS",
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
-    "D": (12, 18, 5, 3),
+    "D": (13, 19, 5, 3),
     "NPN": (41, 58, 13, 4),
     "PNP": (41, 58, 13, 4),
     "NJF": (5, 11, 5, 3),
@@ -352,6 +352,7 @@ _DIODE_PARAMETER_ALIASES: dict[str, str] = {
     "FC": "FC",
     "XTI": "XTI",
     "EG": "EG",
+    "RS": "RS",
 }
 
 _BJT_PARAMETER_ALIASES: dict[str, str] = {
@@ -909,6 +910,7 @@ def diode_from_model_card(
         Fc=p.get("FC", 0.5),
         Xti=p.get("XTI", 3.0),
         Eg=p.get("EG", 1.11),
+        Rs=p.get("RS", 0.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -298,9 +298,6 @@ from spice_engine import (
     format_model_card_supported_parameter_coverage_summary_json,
     format_model_card_supported_parameter_coverage_summary_table,
     format_model_card_supported_parameter_coverage_table,
-    format_model_card_unsupported_parameter_issue_csv,
-    format_model_card_unsupported_parameter_issue_json,
-    format_model_card_unsupported_parameter_issue_table,
     format_noise_table,
     format_pole_zero_table,
     format_pss_table,
@@ -331,8 +328,6 @@ from spice_engine import (
     model_card_supported_parameter_coverage_records,
     model_card_supported_parameter_coverage_summary,
     model_card_supported_parameter_coverage_summary_records,
-    model_card_unsupported_parameter_issue_records,
-    model_card_unsupported_parameter_issues,
     mosfet_from_model_card,
     noise_ac,
     noise_ac_corners,
@@ -412,7 +407,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 140
+    assert len(coverage) == 141
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -427,7 +422,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 140
+    assert len(records) == 141
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -444,8 +439,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     summary = model_card_supported_parameter_coverage_summary()
     assert len(summary) == 7
     assert summary[0].kind == "D"
-    assert summary[0].canonical_parameter_count == 12
-    assert summary[0].accepted_name_count == 18
+    assert summary[0].canonical_parameter_count == 13
+    assert summary[0].accepted_name_count == 19
     assert summary[0].aliased_parameter_count == 5
     assert summary[0].max_alias_count == 3
     assert summary[0].aliased_parameters == ("IS", "VT", "CJO", "VJ", "M")
@@ -470,7 +465,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
         == "kind\tcanonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\taliased_parameters"
     )
-    assert table.splitlines()[1] == "D\t12\t18\t5\t3\tIS|VT|CJO|VJ|M"
+    assert table.splitlines()[1] == "D\t13\t19\t5\t3\tIS|VT|CJO|VJ|M"
     assert (
         table.splitlines()[-1]
         == "PMOS\t18\t25\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
@@ -479,8 +474,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert len(records) == 7
     assert records[0] == {
         "kind": "D",
-        "canonical_parameter_count": "12",
-        "accepted_name_count": "18",
+        "canonical_parameter_count": "13",
+        "accepted_name_count": "19",
         "aliased_parameter_count": "5",
         "max_alias_count": "3",
         "aliased_parameters": "IS|VT|CJO|VJ|M",
@@ -488,7 +483,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert format_model_card_supported_parameter_coverage_summary_csv().startswith(
         "kind,canonical_parameter_count,accepted_name_count,"
         "aliased_parameter_count,max_alias_count,aliased_parameters\n"
-        "D,12,18,5,3,IS|VT|CJO|VJ|M\n"
+        "D,13,19,5,3,IS|VT|CJO|VJ|M\n"
     )
     assert (
         json.loads(format_model_card_supported_parameter_coverage_summary_json())
@@ -501,9 +496,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 140
-    assert report.expected_canonical_parameter_count == 140
-    assert report.accepted_name_count == 206
+    assert report.canonical_parameter_count == 141
+    assert report.expected_canonical_parameter_count == 141
+    assert report.accepted_name_count == 207
     assert report.aliased_parameter_count == 53
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -511,7 +506,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t140\t140\t206\t53\t4\t0"
+        "true\t7\t7\t141\t141\t207\t53\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -539,8 +534,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 139
-    assert report.accepted_name_count == 203
+    assert report.canonical_parameter_count == 140
+    assert report.accepted_name_count == 204
     assert report.aliased_parameter_count == 52
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -555,7 +550,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t139\t140\t203\t52\t4\t4\n"
+        "false\t7\t7\t140\t141\t204\t52\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -608,35 +603,9 @@ def test_model_card_aliases_build_device_instances() -> None:
         "FC": 0.35,
         "XTI": 2.2,
         "EG": 1.05,
+        "RS": 10.0,
     }
-    assert diode_card.unsupported_parameters == ("RS",)
-    diode_issues = model_card_unsupported_parameter_issues(diode_card)
-    assert len(diode_issues) == 1
-    assert diode_issues[0].model_name == "Dfast"
-    assert diode_issues[0].kind == "D"
-    assert diode_issues[0].parameter == "RS"
-    assert diode_issues[0].message == "unsupported D model-card parameter RS"
-    assert format_model_card_unsupported_parameter_issue_table(diode_card) == (
-        "model_name\tkind\tparameter\tmessage\n"
-        "Dfast\tD\tRS\tunsupported D model-card parameter RS"
-    )
-    diode_issue_records = model_card_unsupported_parameter_issue_records(diode_card)
-    assert diode_issue_records == [
-        {
-            "model_name": "Dfast",
-            "kind": "D",
-            "parameter": "RS",
-            "message": "unsupported D model-card parameter RS",
-        }
-    ]
-    assert format_model_card_unsupported_parameter_issue_csv(diode_card) == (
-        "model_name,kind,parameter,message\n"
-        "Dfast,D,RS,unsupported D model-card parameter RS\n"
-    )
-    assert (
-        json.loads(format_model_card_unsupported_parameter_issue_json(diode_card))
-        == diode_issue_records
-    )
+    assert diode_card.unsupported_parameters == ()
     assert diode_model.Is == pytest.approx(2.0e-14)
     assert diode_model.Cjo == pytest.approx(1.5e-12)
     assert diode_model.Tt == pytest.approx(4.0e-9)
@@ -645,6 +614,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(0.35) == diode_model.Fc
     assert pytest.approx(2.2) == diode_model.Xti
     assert pytest.approx(1.05) == diode_model.Eg
+    assert pytest.approx(10.0) == diode_model.Rs
 
     bjt_card = normalize_model_card(
         "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "VTF": 0.6, "RE": 12.0, "RC": 13.0, "RB": 14.0, "RBM": 2.0, "IRB": 5.0e-6, "XCJC": 0.4, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
@@ -2394,7 +2364,7 @@ def test_subcircuit_expansion_preserves_complete_diode_model():
     cell = SubcircuitDefinition(
         "diode-cell",
         ("in",),
-        (Diode("Dcell", "in", "0", Vj=0.8, M=0.4, Fc=0.35, Xti=2.2, Eg=1.05),),
+        (Diode("Dcell", "in", "0", Vj=0.8, M=0.4, Fc=0.35, Xti=2.2, Eg=1.05, Rs=10.0),),
     )
     c = Circuit()
     c.define_subcircuit(cell)
@@ -2406,6 +2376,7 @@ def test_subcircuit_expansion_preserves_complete_diode_model():
     assert expanded.Fc == pytest.approx(0.35)
     assert expanded.Xti == pytest.approx(2.2)
     assert expanded.Eg == pytest.approx(1.05)
+    assert expanded.Rs == pytest.approx(10.0)
 
 
 def test_subcircuit_expansion_preserves_complete_bjt_model():
@@ -2514,6 +2485,21 @@ def test_diode_emission_coefficient_reduces_forward_current():
     assert base_result.converged
     assert high_n_result.converged
     assert abs(high_n_result.branch_currents["I(V1)"]) < abs(base_result.branch_currents["I(V1)"]) * 1e-3
+
+
+def test_diode_series_resistance_limits_fixed_bias_current():
+    ideal = Circuit()
+    ideal.add(VoltageSource("V1", "a", "0", voltage=0.7))
+    ideal.add(Diode("D1", "a", "0"))
+
+    limited = Circuit()
+    limited.add(VoltageSource("V1", "a", "0", voltage=0.7))
+    limited.add(Diode("D1", "a", "0", Rs=100.0))
+
+    ideal_current = abs(dc_op(ideal).branch_currents["I(V1)"])
+    limited_current = abs(dc_op(limited).branch_currents["I(V1)"])
+    assert limited_current < ideal_current
+    assert limited_current <= 0.7 / 100.0
 
 
 def test_diode_breakdown_voltage_increases_reverse_current():
@@ -7290,6 +7276,21 @@ def test_noise_bjt_emitter_resistance_adds_thermal_noise() -> None:
 
     assert emitter_resistance.noise_type == "thermal"
     assert emitter_resistance.source_psd > 0.0
+
+
+def test_noise_diode_series_resistance_adds_thermal_noise() -> None:
+    circuit = Circuit()
+    circuit.add(VoltageSource("Vbias", "bias", "0", 1.0))
+    circuit.add(Resistor("Rbias", "bias", "out", 1_000.0))
+    circuit.add(Diode("D1", "out", "0", Rs=100.0))
+
+    result = noise_ac(circuit, "out", "Vbias", freqs=[1_000.0])
+    series_resistance = next(
+        entry for entry in result.points[0].entries if entry.element_name == "D1:RS"
+    )
+
+    assert series_resistance.noise_type == "thermal"
+    assert series_resistance.source_psd > 0.0
 
 
 def test_noise_bjt_collector_resistance_adds_thermal_noise() -> None:

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -390,23 +390,27 @@ fn clone_subckt_element(
             cloned.negative = map_subckt_node(&element.negative, instance_name, node_map);
             Element::CustomModel(cloned)
         }
-        Element::Diode(element) => Element::Diode(Diode::with_model_and_temperature_parameters(
-            format!("{instance_name}.{}", element.name),
-            map_subckt_node(&element.anode, instance_name, node_map),
-            map_subckt_node(&element.cathode, instance_name, node_map),
-            element.saturation_current,
-            element.thermal_voltage,
-            element.emission_coefficient,
-            element.breakdown_voltage,
-            element.breakdown_current,
-            element.junction_capacitance,
-            element.transit_time,
-            element.junction_potential,
-            element.grading_coefficient,
-            element.forward_bias_depletion_coefficient,
-            element.saturation_current_temperature_exponent,
-            element.energy_gap_electron_volts,
-        )),
+        Element::Diode(element) => {
+            let mut mapped = Diode::with_model_and_temperature_parameters(
+                format!("{instance_name}.{}", element.name),
+                map_subckt_node(&element.anode, instance_name, node_map),
+                map_subckt_node(&element.cathode, instance_name, node_map),
+                element.saturation_current,
+                element.thermal_voltage,
+                element.emission_coefficient,
+                element.breakdown_voltage,
+                element.breakdown_current,
+                element.junction_capacitance,
+                element.transit_time,
+                element.junction_potential,
+                element.grading_coefficient,
+                element.forward_bias_depletion_coefficient,
+                element.saturation_current_temperature_exponent,
+                element.energy_gap_electron_volts,
+            );
+            mapped.series_resistance = element.series_resistance;
+            Element::Diode(mapped)
+        }
         Element::Jfet(element) => Element::Jfet(Jfet::with_model_and_capacitance(
             format!("{instance_name}.{}", element.name),
             map_subckt_node(&element.drain, instance_name, node_map),
@@ -2393,6 +2397,7 @@ pub struct Diode {
     pub forward_bias_depletion_coefficient: f64,
     pub saturation_current_temperature_exponent: f64,
     pub energy_gap_electron_volts: f64,
+    pub series_resistance: f64,
 }
 
 impl Diode {
@@ -2607,6 +2612,7 @@ impl Diode {
             forward_bias_depletion_coefficient,
             saturation_current_temperature_exponent,
             energy_gap_electron_volts,
+            series_resistance: 0.0,
         }
     }
 }
@@ -3786,7 +3792,7 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
     usize,
 )] = &[
-    (ModelCardKind::Diode, 12, 18, 5, 3),
+    (ModelCardKind::Diode, 13, 19, 5, 3),
     (ModelCardKind::Npn, 41, 58, 13, 4),
     (ModelCardKind::Pnp, 41, 58, 13, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
@@ -3813,6 +3819,7 @@ const DIODE_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("FC", "FC"),
     ("XTI", "XTI"),
     ("EG", "EG"),
+    ("RS", "RS"),
 ];
 const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IS", "IS"),
@@ -4480,7 +4487,7 @@ pub fn diode_from_model_card(
     if model.kind != ModelCardKind::Diode {
         return Err(model_card_kind_error(&name, "diode", model.kind));
     }
-    Ok(Diode::with_model_and_temperature_parameters(
+    let mut diode = Diode::with_model_and_temperature_parameters(
         name,
         anode,
         cathode,
@@ -4496,7 +4503,9 @@ pub fn diode_from_model_card(
         model_card_value(model, "FC", 0.5),
         model_card_value(model, "XTI", 3.0),
         model_card_value(model, "EG", 1.11),
-    ))
+    );
+    diode.series_resistance = model_card_value(model, "RS", 0.0);
+    Ok(diode)
 }
 
 pub fn bjt_from_model_card(
@@ -21765,7 +21774,8 @@ fn build_ac_matrix(
             ),
             Element::Diode(diode) => {
                 validate_diode(diode)?;
-                let anode = node_index(node_indices, &diode.anode);
+                let intrinsic_anode = diode_intrinsic_anode_node(diode);
+                let anode = node_index(node_indices, &intrinsic_anode);
                 let cathode = node_index(node_indices, &diode.cathode);
                 let voltage = vector_voltage(operating_point, anode)
                     - vector_voltage(operating_point, cathode);
@@ -21777,6 +21787,14 @@ fn build_ac_matrix(
                     cathode,
                     Complex::new(conductance, omega * capacitance),
                 );
+                if diode.series_resistance > 0.0 {
+                    stamp_complex_conductance(
+                        &mut matrix,
+                        node_index(node_indices, &diode.anode),
+                        anode,
+                        Complex::new(1.0 / diode.series_resistance, 0.0),
+                    );
+                }
             }
             Element::Jfet(jfet) => {
                 stamp_ac_jfet_small_signal(jfet, node_indices, &mut matrix, operating_point, omega)?
@@ -21877,12 +21895,21 @@ fn build_small_signal_matrix(
             ),
             Element::Diode(diode) => {
                 validate_diode(diode)?;
-                let anode = node_index(node_indices, &diode.anode);
+                let intrinsic_anode = diode_intrinsic_anode_node(diode);
+                let anode = node_index(node_indices, &intrinsic_anode);
                 let cathode = node_index(node_indices, &diode.cathode);
                 let voltage = vector_voltage(operating_point, anode)
                     - vector_voltage(operating_point, cathode);
                 let (_, conductance) = diode_current_conductance(diode, voltage);
                 stamp_conductance(&mut matrix, anode, cathode, conductance);
+                if diode.series_resistance > 0.0 {
+                    stamp_conductance(
+                        &mut matrix,
+                        node_index(node_indices, &diode.anode),
+                        anode,
+                        1.0 / diode.series_resistance,
+                    );
+                }
             }
             Element::Jfet(jfet) => {
                 stamp_jfet_small_signal(jfet, node_indices, &mut matrix, operating_point)?
@@ -21999,6 +22026,9 @@ fn collect_node_indices(circuit: &Circuit) -> HashMap<String, usize> {
             Element::Diode(diode) => {
                 insert_node(&mut names, &diode.anode);
                 insert_node(&mut names, &diode.cathode);
+                if diode.series_resistance > 0.0 {
+                    insert_node(&mut names, &diode_intrinsic_anode_node(diode));
+                }
             }
             Element::Jfet(jfet) => {
                 insert_node(&mut names, &jfet.drain);
@@ -22208,7 +22238,8 @@ fn collect_noise_sources(
             }
             Element::Diode(diode) => {
                 validate_diode(diode)?;
-                let anode = node_index(node_indices, &diode.anode);
+                let intrinsic_anode = diode_intrinsic_anode_node(diode);
+                let anode = node_index(node_indices, &intrinsic_anode);
                 let cathode = node_index(node_indices, &diode.cathode);
                 let anode_voltage = vector_voltage(operating_point, anode);
                 let cathode_voltage = vector_voltage(operating_point, cathode);
@@ -22222,6 +22253,16 @@ fn collect_noise_sources(
                     source_psd: 2.0 * ELECTRON_CHARGE * current.abs(),
                     frequency_exponent: 0.0,
                 });
+                if diode.series_resistance > 0.0 {
+                    sources.push(NoiseSource {
+                        element_name: format!("{}:RS", diode.name),
+                        noise_type: NoiseType::Thermal,
+                        positive: node_index(node_indices, &diode.anode),
+                        negative: anode,
+                        source_psd: 4.0 * BOLTZMANN * temperature_kelvin / diode.series_resistance,
+                        frequency_exponent: 0.0,
+                    });
+                }
             }
             Element::Bjt(bjt) => {
                 validate_bjt(bjt)?;
@@ -22728,7 +22769,8 @@ fn stamp_diode(
     operating_point: &[f64],
 ) -> Result<(), SpiceError> {
     validate_diode(diode)?;
-    let anode = node_index(node_indices, &diode.anode);
+    let intrinsic_anode = diode_intrinsic_anode_node(diode);
+    let anode = node_index(node_indices, &intrinsic_anode);
     let cathode = node_index(node_indices, &diode.cathode);
     let voltage = anode.map_or(0.0, |index| operating_point[index])
         - cathode.map_or(0.0, |index| operating_point[index]);
@@ -22741,6 +22783,14 @@ fn stamp_diode(
     }
     if let Some(index) = cathode {
         rhs[index] += equivalent_current;
+    }
+    if diode.series_resistance > 0.0 {
+        stamp_conductance(
+            matrix,
+            node_index(node_indices, &diode.anode),
+            anode,
+            1.0 / diode.series_resistance,
+        );
     }
     stamp_diode_charge(diode, capacitor_states, node_indices, matrix, rhs)?;
     Ok(())
@@ -22778,7 +22828,8 @@ fn stamp_diode_charge(
         }
         TransientMethod::Euler => conductance * state.previous_voltage,
     };
-    let anode = node_index(node_indices, &diode.anode);
+    let intrinsic_anode = diode_intrinsic_anode_node(diode);
+    let anode = node_index(node_indices, &intrinsic_anode);
     let cathode = node_index(node_indices, &diode.cathode);
     stamp_conductance(matrix, anode, cathode, conductance);
     if let Some(index) = anode {
@@ -23985,7 +24036,16 @@ fn diode_depletion_capacitance(diode: &Diode, voltage: f64) -> f64 {
 }
 
 fn diode_charge_voltage(diode: &Diode, node_voltages: &BTreeMap<String, f64>) -> f64 {
-    voltage_at(node_voltages, &diode.anode) - voltage_at(node_voltages, &diode.cathode)
+    voltage_at(node_voltages, &diode_intrinsic_anode_node(diode))
+        - voltage_at(node_voltages, &diode.cathode)
+}
+
+fn diode_intrinsic_anode_node(diode: &Diode) -> String {
+    if diode.series_resistance == 0.0 {
+        diode.anode.clone()
+    } else {
+        format!("_D_{}_anode", diode.name)
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -24354,6 +24414,12 @@ fn mosfet_charge_dynamic_capacitance(
 }
 
 fn validate_diode(diode: &Diode) -> Result<(), SpiceError> {
+    if !diode.series_resistance.is_finite() || diode.series_resistance < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: diode.name.clone(),
+            reason: "series resistance must be finite and non-negative".to_string(),
+        });
+    }
     if !diode.saturation_current.is_finite() || diode.saturation_current <= 0.0 {
         return Err(SpiceError::InvalidElement {
             name: diode.name.clone(),

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -51,10 +51,7 @@ use spice_engine::{
     format_model_card_supported_parameter_coverage_summary_csv,
     format_model_card_supported_parameter_coverage_summary_json,
     format_model_card_supported_parameter_coverage_summary_table,
-    format_model_card_supported_parameter_coverage_table,
-    format_model_card_unsupported_parameter_issue_csv,
-    format_model_card_unsupported_parameter_issue_json,
-    format_model_card_unsupported_parameter_issue_table, format_temperature_dc_table,
+    format_model_card_supported_parameter_coverage_table, format_temperature_dc_table,
     jfet_from_model_card, measure_dc_sweep_deck, measure_dc_sweep_probe,
     model_card_supported_parameter_coverage, model_card_supported_parameter_coverage_dashboard,
     model_card_supported_parameter_coverage_dashboard_records,
@@ -62,15 +59,13 @@ use spice_engine::{
     model_card_supported_parameter_coverage_gate_issue_records,
     model_card_supported_parameter_coverage_records,
     model_card_supported_parameter_coverage_summary,
-    model_card_supported_parameter_coverage_summary_records,
-    model_card_unsupported_parameter_issue_records, model_card_unsupported_parameter_issues,
-    mosfet_from_model_card, normalize_model_card, normalize_model_card_type,
-    resolve_deck_initial_conditions, BSource, Bjt, BjtPolarity, Cccs, Ccvs, Circuit,
-    CornerOverride, CornerSpec, CornerTemperatureDcResult, CurrentSource, CustomModel,
-    DcConvergenceAid, DcOpOptions, Diode, Element, Inductor, Jfet, JfetPolarity, ModelCardKind,
-    Mosfet, MosfetLevel1Params, MosfetType, Resistor, SinWaveform, SpiceError,
-    SubcircuitDefinition, SubcircuitElement, TemperatureDcResult, Vccs, Vcvs, VoltageSource,
-    Waveform, XInstance,
+    model_card_supported_parameter_coverage_summary_records, mosfet_from_model_card,
+    normalize_model_card, normalize_model_card_type, resolve_deck_initial_conditions, BSource, Bjt,
+    BjtPolarity, Cccs, Ccvs, Circuit, CornerOverride, CornerSpec, CornerTemperatureDcResult,
+    CurrentSource, CustomModel, DcConvergenceAid, DcOpOptions, Diode, Element, Inductor, Jfet,
+    JfetPolarity, ModelCardKind, Mosfet, MosfetLevel1Params, MosfetType, Resistor, SinWaveform,
+    SpiceError, SubcircuitDefinition, SubcircuitElement, TemperatureDcResult, Vccs, Vcvs,
+    VoltageSource, Waveform, XInstance,
 };
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -100,7 +95,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 140);
+    assert_eq!(coverage.len(), 141);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -119,7 +114,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 140);
+    assert_eq!(records.len(), 141);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -143,8 +138,8 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     let summary = model_card_supported_parameter_coverage_summary();
     assert_eq!(summary.len(), 7);
     assert_eq!(summary[0].kind, ModelCardKind::Diode);
-    assert_eq!(summary[0].canonical_parameter_count, 12);
-    assert_eq!(summary[0].accepted_name_count, 18);
+    assert_eq!(summary[0].canonical_parameter_count, 13);
+    assert_eq!(summary[0].accepted_name_count, 19);
     assert_eq!(summary[0].aliased_parameter_count, 5);
     assert_eq!(summary[0].max_alias_count, 3);
     assert_eq!(
@@ -168,7 +163,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         lines[0],
         "kind\tcanonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\taliased_parameters"
     );
-    assert_eq!(lines[1], "D\t12\t18\t5\t3\tIS|VT|CJO|VJ|M");
+    assert_eq!(lines[1], "D\t13\t19\t5\t3\tIS|VT|CJO|VJ|M");
     assert_eq!(
         lines.last().unwrap(),
         &"PMOS\t18\t25\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
@@ -176,17 +171,17 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     let records = model_card_supported_parameter_coverage_summary_records();
     assert_eq!(records.len(), 7);
     assert_eq!(records[0]["kind"], "D");
-    assert_eq!(records[0]["canonical_parameter_count"], "12");
-    assert_eq!(records[0]["accepted_name_count"], "18");
+    assert_eq!(records[0]["canonical_parameter_count"], "13");
+    assert_eq!(records[0]["accepted_name_count"], "19");
     assert_eq!(records[0]["aliased_parameter_count"], "5");
     assert_eq!(records[0]["max_alias_count"], "3");
     assert_eq!(records[0]["aliased_parameters"], "IS|VT|CJO|VJ|M");
     assert!(format_model_card_supported_parameter_coverage_summary_csv().starts_with(
-        "kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,12,18,5,3,IS|VT|CJO|VJ|M\n"
+        "kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,13,19,5,3,IS|VT|CJO|VJ|M\n"
     ));
     let json = format_model_card_supported_parameter_coverage_summary_json();
     assert!(json.starts_with(
-        "[{\"kind\":\"D\",\"canonical_parameter_count\":\"12\",\"accepted_name_count\":\"18\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
+        "[{\"kind\":\"D\",\"canonical_parameter_count\":\"13\",\"accepted_name_count\":\"19\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
     ));
     assert!(json.ends_with(
         "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"18\",\"accepted_name_count\":\"25\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
@@ -200,15 +195,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 140);
-    assert_eq!(report.expected_canonical_parameter_count, 140);
-    assert_eq!(report.accepted_name_count, 206);
+    assert_eq!(report.canonical_parameter_count, 141);
+    assert_eq!(report.expected_canonical_parameter_count, 141);
+    assert_eq!(report.accepted_name_count, 207);
     assert_eq!(report.aliased_parameter_count, 53);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t140\t140\t206\t53\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t141\t141\t207\t53\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -235,8 +230,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 139);
-    assert_eq!(report.accepted_name_count, 203);
+    assert_eq!(report.canonical_parameter_count, 140);
+    assert_eq!(report.accepted_name_count, 204);
     assert_eq!(report.aliased_parameter_count, 52);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -253,7 +248,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t139\t140\t203\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t140\t141\t204\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -277,10 +272,10 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(dashboard.len(), 7);
     assert_eq!(dashboard[0].kind, ModelCardKind::Diode);
     assert!(dashboard[0].passed);
-    assert_eq!(dashboard[0].canonical_parameter_count, 12);
-    assert_eq!(dashboard[0].expected_canonical_parameter_count, 12);
-    assert_eq!(dashboard[0].accepted_name_count, 18);
-    assert_eq!(dashboard[0].expected_accepted_name_count, 18);
+    assert_eq!(dashboard[0].canonical_parameter_count, 13);
+    assert_eq!(dashboard[0].expected_canonical_parameter_count, 13);
+    assert_eq!(dashboard[0].accepted_name_count, 19);
+    assert_eq!(dashboard[0].expected_accepted_name_count, 19);
     assert_eq!(dashboard[0].aliased_parameter_count, 5);
     assert_eq!(dashboard[0].expected_aliased_parameter_count, 5);
     assert_eq!(dashboard[0].max_alias_count, 3);
@@ -298,7 +293,7 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
         lines[0],
         "kind\tpassed\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\texpected_accepted_name_count\taliased_parameter_count\texpected_aliased_parameter_count\tmax_alias_count\texpected_max_alias_count\tissue_count\tissue_fields"
     );
-    assert_eq!(lines[1], "D\ttrue\t12\t12\t18\t18\t5\t5\t3\t3\t0\t");
+    assert_eq!(lines[1], "D\ttrue\t13\t13\t19\t19\t5\t5\t3\t3\t0\t");
     assert_eq!(
         lines.last().unwrap(),
         &"PMOS\ttrue\t18\t18\t25\t25\t6\t6\t3\t3\t0\t"
@@ -307,15 +302,15 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(records.len(), 7);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["passed"], "true");
-    assert_eq!(records[0]["canonical_parameter_count"], "12");
-    assert_eq!(records[0]["expected_canonical_parameter_count"], "12");
+    assert_eq!(records[0]["canonical_parameter_count"], "13");
+    assert_eq!(records[0]["expected_canonical_parameter_count"], "13");
     assert_eq!(records[0]["issue_count"], "0");
     assert_eq!(records[0]["issue_fields"], "");
     assert!(format_model_card_supported_parameter_coverage_dashboard_csv(&coverage).starts_with(
-        "kind,passed,canonical_parameter_count,expected_canonical_parameter_count,accepted_name_count,expected_accepted_name_count,aliased_parameter_count,expected_aliased_parameter_count,max_alias_count,expected_max_alias_count,issue_count,issue_fields\nD,true,12,12,18,18,5,5,3,3,0,\n"
+        "kind,passed,canonical_parameter_count,expected_canonical_parameter_count,accepted_name_count,expected_accepted_name_count,aliased_parameter_count,expected_aliased_parameter_count,max_alias_count,expected_max_alias_count,issue_count,issue_fields\nD,true,13,13,19,19,5,5,3,3,0,\n"
     ));
     assert!(format_model_card_supported_parameter_coverage_dashboard_json(&coverage).starts_with(
-        "[{\"kind\":\"D\",\"passed\":\"true\",\"canonical_parameter_count\":\"12\",\"expected_canonical_parameter_count\":\"12\""
+        "[{\"kind\":\"D\",\"passed\":\"true\",\"canonical_parameter_count\":\"13\",\"expected_canonical_parameter_count\":\"13\""
     ));
 }
 
@@ -382,37 +377,8 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*diode_card.parameters.get("FC").unwrap(), 0.35);
     assert_close(*diode_card.parameters.get("XTI").unwrap(), 2.2);
     assert_close(*diode_card.parameters.get("EG").unwrap(), 1.05);
-    assert_eq!(diode_card.unsupported_parameters, vec!["RS".to_string()]);
-    let diode_issues = model_card_unsupported_parameter_issues(&diode_card);
-    assert_eq!(diode_issues.len(), 1);
-    assert_eq!(diode_issues[0].model_name, "Dfast");
-    assert_eq!(diode_issues[0].kind, ModelCardKind::Diode);
-    assert_eq!(diode_issues[0].parameter, "RS");
-    assert_eq!(
-        diode_issues[0].message,
-        "unsupported D model-card parameter RS"
-    );
-    assert_eq!(
-        format_model_card_unsupported_parameter_issue_table(&diode_card),
-        "model_name\tkind\tparameter\tmessage\nDfast\tD\tRS\tunsupported D model-card parameter RS"
-    );
-    let diode_issue_records = model_card_unsupported_parameter_issue_records(&diode_card);
-    assert_eq!(diode_issue_records.len(), 1);
-    assert_eq!(diode_issue_records[0]["model_name"], "Dfast");
-    assert_eq!(diode_issue_records[0]["kind"], "D");
-    assert_eq!(diode_issue_records[0]["parameter"], "RS");
-    assert_eq!(
-        diode_issue_records[0]["message"],
-        "unsupported D model-card parameter RS"
-    );
-    assert_eq!(
-        format_model_card_unsupported_parameter_issue_csv(&diode_card),
-        "model_name,kind,parameter,message\nDfast,D,RS,unsupported D model-card parameter RS\n"
-    );
-    assert_eq!(
-        format_model_card_unsupported_parameter_issue_json(&diode_card),
-        "[{\"model_name\":\"Dfast\",\"kind\":\"D\",\"parameter\":\"RS\",\"message\":\"unsupported D model-card parameter RS\"}]\n"
-    );
+    assert_close(*diode_card.parameters.get("RS").unwrap(), 10.0);
+    assert!(diode_card.unsupported_parameters.is_empty());
     assert_close(diode_model.saturation_current, 2.0e-14);
     assert_close(diode_model.junction_capacitance, 1.5e-12);
     assert_close(diode_model.transit_time, 4.0e-9);
@@ -421,6 +387,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(diode_model.forward_bias_depletion_coefficient, 0.35);
     assert_close(diode_model.saturation_current_temperature_exponent, 2.2);
     assert_close(diode_model.energy_gap_electron_volts, 1.05);
+    assert_close(diode_model.series_resistance, 10.0);
 
     let bjt_card = normalize_model_card(
         "Qsmall",
@@ -1414,7 +1381,7 @@ fn dc_subcircuit_instance_expands_resistor_divider() {
 
 #[test]
 fn subcircuit_expansion_preserves_complete_diode_model() {
-    let diode = Diode::with_model_and_temperature_parameters(
+    let mut diode = Diode::with_model_and_temperature_parameters(
         "Dcell",
         "in",
         "0",
@@ -1431,6 +1398,7 @@ fn subcircuit_expansion_preserves_complete_diode_model() {
         2.2,
         1.05,
     );
+    diode.series_resistance = 10.0;
     let mut circuit = Circuit::new();
     circuit
         .define_subcircuit(SubcircuitDefinition::new(
@@ -1456,6 +1424,7 @@ fn subcircuit_expansion_preserves_complete_diode_model() {
     assert_close(expanded.forward_bias_depletion_coefficient, 0.35);
     assert_close(expanded.saturation_current_temperature_exponent, 2.2);
     assert_close(expanded.energy_gap_electron_volts, 1.05);
+    assert_close(expanded.series_resistance, 10.0);
 }
 
 #[test]
@@ -1768,6 +1737,28 @@ fn dc_diode_emission_coefficient_reduces_fixed_bias_current() {
         high_n_result.branch_current("V1").unwrap().abs()
             < base_result.branch_current("V1").unwrap().abs() * 1.0e-3
     );
+}
+
+#[test]
+fn dc_diode_series_resistance_limits_fixed_bias_current() {
+    let mut ideal = Circuit::new();
+    ideal.add(Element::VoltageSource(VoltageSource::new(
+        "V1", "a", "0", 0.7,
+    )));
+    ideal.add(Element::Diode(Diode::new("D1", "a", "0")));
+
+    let mut limited = Circuit::new();
+    limited.add(Element::VoltageSource(VoltageSource::new(
+        "V1", "a", "0", 0.7,
+    )));
+    let mut diode = Diode::new("D1", "a", "0");
+    diode.series_resistance = 100.0;
+    limited.add(Element::Diode(diode));
+
+    let ideal_current = dc_op(&ideal).unwrap().branch_current("V1").unwrap().abs();
+    let limited_current = dc_op(&limited).unwrap().branch_current("V1").unwrap().abs();
+    assert!(limited_current < ideal_current);
+    assert!(limited_current <= 0.7 / 100.0);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -1,9 +1,33 @@
 use spice_engine::{
     device_model_noise_audit_fixtures, format_corner_noise_table, format_noise_table, noise_ac,
     noise_ac_corners, noise_ac_corners_parallel, noise_ac_default, Bjt, Capacitor, Circuit,
-    CornerOverride, CornerSpec, CurrentSource, Element, Mosfet, MosfetLevel1Params, MosfetType,
-    NoiseType, Resistor, SpiceError, VoltageSource,
+    CornerOverride, CornerSpec, CurrentSource, Diode, Element, Mosfet, MosfetLevel1Params,
+    MosfetType, NoiseType, Resistor, SpiceError, VoltageSource,
 };
+
+#[test]
+fn diode_series_resistance_adds_thermal_noise() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vbias", "bias", "0", 1.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rbias", "bias", "out", 1_000.0,
+    )));
+    let mut diode = Diode::new("D1", "out", "0");
+    diode.series_resistance = 100.0;
+    circuit.add(Element::Diode(diode));
+
+    let result = noise_ac(&circuit, "out", "Vbias", &[1_000.0], 300.0).unwrap();
+    let series_resistance = result.points[0]
+        .entries
+        .iter()
+        .find(|entry| entry.element_name == "D1:RS")
+        .unwrap();
+
+    assert_eq!(series_resistance.noise_type, NoiseType::Thermal);
+    assert!(series_resistance.source_psd > 0.0);
+}
 
 #[test]
 fn bjt_forward_beta_rolloff_reduces_shot_noise() {

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1676,6 +1676,7 @@ export interface Diode {
   readonly forwardBiasDepletionCoefficient: number;
   readonly saturationCurrentTemperatureExponent: number;
   readonly energyGapElectronVolts: number;
+  readonly seriesResistance: number;
 }
 
 export type JfetPolarity = "NJF" | "PJF";
@@ -2018,7 +2019,7 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_KINDS: readonly ModelCardKind[] = 
 const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
-  D: [12, 18, 5, 3],
+  D: [13, 19, 5, 3],
   NPN: [41, 58, 13, 4],
   PNP: [41, 58, 13, 4],
   NJF: [5, 11, 5, 3],
@@ -3606,7 +3607,7 @@ function cloneSubcktElement(
     case "custom-model":
       return { ...element, name, positive: mapSubcktNode(element.positive, instanceName, nodeMap), negative: mapSubcktNode(element.negative, instanceName, nodeMap) };
     case "diode":
-      return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient, element.breakdownVoltage, element.breakdownCurrent, element.junctionCapacitance, element.transitTime, element.junctionPotential, element.gradingCoefficient, element.forwardBiasDepletionCoefficient, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts);
+      return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient, element.breakdownVoltage, element.breakdownCurrent, element.junctionCapacitance, element.transitTime, element.junctionPotential, element.gradingCoefficient, element.forwardBiasDepletionCoefficient, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.seriesResistance);
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
@@ -7568,6 +7569,7 @@ export function diode(
   forwardBiasDepletionCoefficient = 0.5,
   saturationCurrentTemperatureExponent = 3.0,
   energyGapElectronVolts = 1.11,
+  seriesResistance = 0.0,
 ): Diode {
   return {
     kind: "diode",
@@ -7586,6 +7588,7 @@ export function diode(
     forwardBiasDepletionCoefficient,
     saturationCurrentTemperatureExponent,
     energyGapElectronVolts,
+    seriesResistance,
   };
 }
 
@@ -7938,6 +7941,7 @@ const DIODE_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   FC: "FC",
   XTI: "XTI",
   EG: "EG",
+  RS: "RS",
 };
 
 const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -8468,6 +8472,7 @@ export function diodeFromModelCard(
     p.FC ?? 0.5,
     p.XTI ?? 3.0,
     p.EG ?? 1.11,
+    p.RS ?? 0.0,
   );
 }
 
@@ -17854,15 +17859,24 @@ function buildSmallSignalMatrix(
         break;
       case "diode":
         validateDiode(element);
-        const diodeVoltage = vectorVoltage(operatingPoint, nodeIndex(nodeIndices, element.anode)) -
+        const diodeAnode = diodeIntrinsicAnodeNode(element);
+        const diodeVoltage = vectorVoltage(operatingPoint, nodeIndex(nodeIndices, diodeAnode)) -
           vectorVoltage(operatingPoint, nodeIndex(nodeIndices, element.cathode));
         const [, diodeConductance] = diodeCurrentConductance(element, diodeVoltage);
         stampConductance(
           matrix,
-          nodeIndex(nodeIndices, element.anode),
+          nodeIndex(nodeIndices, diodeAnode),
           nodeIndex(nodeIndices, element.cathode),
           diodeConductance,
         );
+        if (element.seriesResistance > 0.0) {
+          stampConductance(
+            matrix,
+            nodeIndex(nodeIndices, element.anode),
+            nodeIndex(nodeIndices, diodeAnode),
+            1.0 / element.seriesResistance,
+          );
+        }
         break;
       case "jfet":
         stampJfetSmallSignal(element, nodeIndices, matrix, operatingPoint);
@@ -18036,16 +18050,25 @@ function buildAcMatrix(
         break;
       case "diode":
         validateDiode(element);
-        const diodeVoltage = vectorVoltage(operatingPoint, nodeIndex(nodeIndices, element.anode)) -
+        const diodeAnode = diodeIntrinsicAnodeNode(element);
+        const diodeVoltage = vectorVoltage(operatingPoint, nodeIndex(nodeIndices, diodeAnode)) -
           vectorVoltage(operatingPoint, nodeIndex(nodeIndices, element.cathode));
         const [, diodeConductance] = diodeCurrentConductance(element, diodeVoltage);
         const diodeCapacitance = diodeDynamicCapacitance(element, diodeVoltage);
         stampComplexConductance(
           matrix,
-          nodeIndex(nodeIndices, element.anode),
+          nodeIndex(nodeIndices, diodeAnode),
           nodeIndex(nodeIndices, element.cathode),
           complex(diodeConductance, omega * diodeCapacitance),
         );
+        if (element.seriesResistance > 0.0) {
+          stampComplexConductance(
+            matrix,
+            nodeIndex(nodeIndices, element.anode),
+            nodeIndex(nodeIndices, diodeAnode),
+            complex(1.0 / element.seriesResistance, 0.0),
+          );
+        }
         break;
       case "jfet":
         stampAcJfetSmallSignal(element, nodeIndices, matrix, operatingPoint, omega);
@@ -18290,6 +18313,9 @@ function collectNodeIndices(circuit: Circuit): Map<string, number> {
       case "diode":
         insertNode(names, element.anode);
         insertNode(names, element.cathode);
+        if (element.seriesResistance > 0.0) {
+          insertNode(names, diodeIntrinsicAnodeNode(element));
+        }
         break;
       case "jfet":
         insertNode(names, element.drain);
@@ -18449,7 +18475,8 @@ function collectNoiseSources(
       });
     } else if (element.kind === "diode") {
       validateDiode(element);
-      const anode = nodeIndex(nodeIndices, element.anode);
+      const intrinsicAnode = diodeIntrinsicAnodeNode(element);
+      const anode = nodeIndex(nodeIndices, intrinsicAnode);
       const cathode = nodeIndex(nodeIndices, element.cathode);
       const anodeVoltage = vectorVoltage(operatingPoint, anode);
       const cathodeVoltage = vectorVoltage(operatingPoint, cathode);
@@ -18462,6 +18489,16 @@ function collectNoiseSources(
         sourcePsd: 2.0 * ELECTRON_CHARGE * Math.abs(current),
         frequencyExponent: 0.0,
       });
+      if (element.seriesResistance > 0.0) {
+        sources.push({
+          elementName: `${element.name}:RS`,
+          noiseType: "thermal",
+          positive: nodeIndex(nodeIndices, element.anode),
+          negative: anode,
+          sourcePsd: 4.0 * BOLTZMANN * temperatureKelvin / element.seriesResistance,
+          frequencyExponent: 0.0,
+        });
+      }
     } else if (element.kind === "bjt") {
       validateBjt(element);
       const emitterNode = bjtIntrinsicEmitterNode(element);
@@ -18951,7 +18988,8 @@ function stampDiode(
   operatingPoint: readonly number[],
 ): void {
   validateDiode(element);
-  const anode = nodeIndex(nodeIndices, element.anode);
+  const intrinsicAnode = diodeIntrinsicAnodeNode(element);
+  const anode = nodeIndex(nodeIndices, intrinsicAnode);
   const cathode = nodeIndex(nodeIndices, element.cathode);
   const voltage =
     (anode === undefined ? 0.0 : operatingPoint[anode]) -
@@ -18965,6 +19003,14 @@ function stampDiode(
   }
   if (cathode !== undefined) {
     rhs[cathode] += equivalentCurrent;
+  }
+  if (element.seriesResistance > 0.0) {
+    stampConductance(
+      matrix,
+      nodeIndex(nodeIndices, element.anode),
+      anode,
+      1.0 / element.seriesResistance,
+    );
   }
   stampDiodeCharge(element, capacitorStates, nodeIndices, matrix, rhs);
 }
@@ -19000,7 +19046,7 @@ function stampDiodeCharge(
           (4.0 * state.previousVoltage - state.previousPreviousVoltage) /
           (2.0 * state.timeStep)
         : conductance * state.previousVoltage;
-  const anode = nodeIndex(nodeIndices, element.anode);
+  const anode = nodeIndex(nodeIndices, diodeIntrinsicAnodeNode(element));
   const cathode = nodeIndex(nodeIndices, element.cathode);
   stampConductance(matrix, anode, cathode, conductance);
   if (anode !== undefined) {
@@ -19737,6 +19783,9 @@ function validateReactiveElements(circuit: Circuit): void {
 }
 
 function validateDiode(element: Diode): void {
+  if (!Number.isFinite(element.seriesResistance) || element.seriesResistance < 0.0) {
+    throw invalidElement(element.name, "series resistance must be finite and non-negative");
+  }
   if (!Number.isFinite(element.saturationCurrent) || element.saturationCurrent <= 0.0) {
     throw invalidElement(element.name, "saturation current must be finite and positive");
   }
@@ -19815,6 +19864,12 @@ function diodeChargeStateName(element: Diode): string {
   return `_D_${element.name}_charge`;
 }
 
+function diodeIntrinsicAnodeNode(element: Diode): string {
+  return element.seriesResistance === 0.0
+    ? element.anode
+    : `_D_${element.name}_anode`;
+}
+
 function diodeHasChargeStorage(element: Diode): boolean {
   return element.junctionCapacitance > 0.0 || element.transitTime > 0.0;
 }
@@ -19841,7 +19896,8 @@ function diodeDepletionCapacitance(element: Diode, voltage: number): number {
 }
 
 function diodeChargeVoltage(element: Diode, nodeVoltages: ReadonlyMap<string, number>): number {
-  return voltageAt(nodeVoltages, element.anode) - voltageAt(nodeVoltages, element.cathode);
+  return voltageAt(nodeVoltages, diodeIntrinsicAnodeNode(element)) -
+    voltageAt(nodeVoltages, element.cathode);
 }
 
 type BjtChargeStateKind =

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -79,9 +79,6 @@ import {
   formatModelCardSupportedParameterCoverageSummaryJson,
   formatModelCardSupportedParameterCoverageSummaryTable,
   formatModelCardSupportedParameterCoverageTable,
-  formatModelCardUnsupportedParameterIssueCsv,
-  formatModelCardUnsupportedParameterIssueJson,
-  formatModelCardUnsupportedParameterIssueTable,
   formatMeasurementTable,
   formatTemperatureDcTable,
   inductor,
@@ -95,8 +92,6 @@ import {
   modelCardSupportedParameterCoverageRecords,
   modelCardSupportedParameterCoverageSummary,
   modelCardSupportedParameterCoverageSummaryRecords,
-  modelCardUnsupportedParameterIssueRecords,
-  modelCardUnsupportedParameterIssues,
   mosfet,
   mosfetFromModelCard,
   normalizeModelCard,
@@ -125,7 +120,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(140);
+    expect(coverage).toHaveLength(141);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -145,7 +140,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(140);
+    expect(records).toHaveLength(141);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -163,8 +158,8 @@ describe("dcOp", () => {
     expect(summary).toHaveLength(7);
     expect(summary[0]).toStrictEqual({
       kind: "D",
-      canonicalParameterCount: 12,
-      acceptedNameCount: 18,
+      canonicalParameterCount: 13,
+      acceptedNameCount: 19,
       aliasedParameterCount: 5,
       maxAliasCount: 3,
       aliasedParameters: ["IS", "VT", "CJO", "VJ", "M"],
@@ -183,7 +178,7 @@ describe("dcOp", () => {
     expect(table.split("\n")[0]).toBe(
       "kind\tcanonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\taliased_parameters",
     );
-    expect(table.split("\n")[1]).toBe("D\t12\t18\t5\t3\tIS|VT|CJO|VJ|M");
+    expect(table.split("\n")[1]).toBe("D\t13\t19\t5\t3\tIS|VT|CJO|VJ|M");
     expect(table.split("\n").at(-1)).toBe(
       "PMOS\t18\t25\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
     );
@@ -191,14 +186,14 @@ describe("dcOp", () => {
     expect(records).toHaveLength(7);
     expect(records[0]).toStrictEqual({
       kind: "D",
-      canonical_parameter_count: "12",
-      accepted_name_count: "18",
+      canonical_parameter_count: "13",
+      accepted_name_count: "19",
       aliased_parameter_count: "5",
       max_alias_count: "3",
       aliased_parameters: "IS|VT|CJO|VJ|M",
     });
     expect(formatModelCardSupportedParameterCoverageSummaryCsv()).toMatch(
-      /^kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,12,18,5,3,IS\|VT\|CJO\|VJ\|M\n/,
+      /^kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,13,19,5,3,IS\|VT\|CJO\|VJ\|M\n/,
     );
     expect(JSON.parse(formatModelCardSupportedParameterCoverageSummaryJson())).toStrictEqual(records);
   });
@@ -210,15 +205,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 140,
-      expectedCanonicalParameterCount: 140,
-      acceptedNameCount: 206,
+      canonicalParameterCount: 141,
+      expectedCanonicalParameterCount: 141,
+      acceptedNameCount: 207,
       aliasedParameterCount: 53,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t140\t140\t206\t53\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t141\t141\t207\t53\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -241,8 +236,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(139);
-    expect(report.acceptedNameCount).toBe(203);
+    expect(report.canonicalParameterCount).toBe(140);
+    expect(report.acceptedNameCount).toBe(204);
     expect(report.aliasedParameterCount).toBe(52);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -257,7 +252,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t139\t140\t203\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t140\t141\t204\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -295,33 +290,9 @@ describe("dcOp", () => {
       FC: 0.35,
       XTI: 2.2,
       EG: 1.05,
+      RS: 10.0,
     });
-    expect(diodeCard.unsupportedParameters).toStrictEqual(["RS"]);
-    const diodeIssues = modelCardUnsupportedParameterIssues(diodeCard);
-    expect(diodeIssues).toStrictEqual([
-      {
-        modelName: "Dfast",
-        kind: "D",
-        parameter: "RS",
-        message: "unsupported D model-card parameter RS",
-      },
-    ]);
-    expect(formatModelCardUnsupportedParameterIssueTable(diodeCard)).toBe(
-      "model_name\tkind\tparameter\tmessage\nDfast\tD\tRS\tunsupported D model-card parameter RS",
-    );
-    const diodeIssueRecords = modelCardUnsupportedParameterIssueRecords(diodeCard);
-    expect(diodeIssueRecords).toStrictEqual([
-      {
-        model_name: "Dfast",
-        kind: "D",
-        parameter: "RS",
-        message: "unsupported D model-card parameter RS",
-      },
-    ]);
-    expect(formatModelCardUnsupportedParameterIssueCsv(diodeCard)).toBe(
-      "model_name,kind,parameter,message\nDfast,D,RS,unsupported D model-card parameter RS\n",
-    );
-    expect(JSON.parse(formatModelCardUnsupportedParameterIssueJson(diodeCard))).toStrictEqual(diodeIssueRecords);
+    expect(diodeCard.unsupportedParameters).toStrictEqual([]);
     expectClose(diodeModel.saturationCurrent, 2.0e-14);
     expectClose(diodeModel.junctionCapacitance, 1.5e-12);
     expectClose(diodeModel.transitTime, 4.0e-9);
@@ -330,6 +301,7 @@ describe("dcOp", () => {
     expectClose(diodeModel.forwardBiasDepletionCoefficient, 0.35);
     expectClose(diodeModel.saturationCurrentTemperatureExponent, 2.2);
     expectClose(diodeModel.energyGapElectronVolts, 1.05);
+    expectClose(diodeModel.seriesResistance, 10.0);
 
     const bjtCard = normalizeModelCard("Qsmall", "npn", {
       BETA: 125.0,
@@ -1043,7 +1015,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("diode-cell", ["in"], [
-        diode("Dcell", "in", "0", 2.0e-14, 0.026, 1.2, 6.0, 2.0e-6, 1.5e-12, 4.0e-9, 0.8, 0.4, 0.35, 2.2, 1.05),
+        diode("Dcell", "in", "0", 2.0e-14, 0.026, 1.2, 6.0, 2.0e-6, 1.5e-12, 4.0e-9, 0.8, 0.4, 0.35, 2.2, 1.05, 10.0),
       ]),
     );
     circuit.add(xInstance("X1", ["a"], "diode-cell"));
@@ -1058,6 +1030,7 @@ describe("dcOp", () => {
     expectClose(expanded.forwardBiasDepletionCoefficient, 0.35);
     expectClose(expanded.saturationCurrentTemperatureExponent, 2.2);
     expectClose(expanded.energyGapElectronVolts, 1.05);
+    expectClose(expanded.seriesResistance, 10.0);
   });
 
   it("preserves the complete BJT model through subcircuit expansion", () => {
@@ -1270,6 +1243,40 @@ describe("dcOp", () => {
     expect(Math.abs(highNResult.branchCurrent("V1")!)).toBeLessThan(
       Math.abs(baseResult.branchCurrent("V1")!) * 1.0e-3,
     );
+  });
+
+  it("limits fixed-bias diode current with series resistance", () => {
+    const ideal = new Circuit();
+    ideal.add(voltageSource("V1", "a", "0", 0.7));
+    ideal.add(diode("D1", "a", "0"));
+
+    const limited = new Circuit();
+    limited.add(voltageSource("V1", "a", "0", 0.7));
+    limited.add(
+      diode(
+        "D1",
+        "a",
+        "0",
+        1.0e-15,
+        0.02585,
+        1.0,
+        undefined,
+        1.0e-3,
+        0.0,
+        0.0,
+        1.0,
+        0.5,
+        0.5,
+        3.0,
+        1.11,
+        100.0,
+      ),
+    );
+
+    const idealCurrent = Math.abs(dcOp(ideal).branchCurrent("V1")!);
+    const limitedCurrent = Math.abs(dcOp(limited).branchCurrent("V1")!);
+    expect(limitedCurrent).toBeLessThan(idealCurrent);
+    expect(limitedCurrent).toBeLessThanOrEqual(0.7 / 100.0);
   });
 
   it("uses diode breakdown voltage in reverse-bias current", () => {

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -5,6 +5,7 @@ import {
   capacitor,
   bjt,
   currentSource,
+  diode,
   deviceModelNoiseAuditFixtures,
   formatCornerNoiseTable,
   formatNoiseTable,
@@ -19,6 +20,19 @@ const BOLTZMANN = 1.380_649e-23;
 const MOSFET_CHANNEL_NOISE_GAMMA = 2.0 / 3.0;
 
 describe("noiseAc", () => {
+  it("adds thermal noise for diode series resistance", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vbias", "bias", "0", 1.0));
+    circuit.add(resistor("Rbias", "bias", "out", 1_000.0));
+    circuit.add({ ...diode("D1", "out", "0"), seriesResistance: 100.0 });
+
+    const entry = noiseAc(circuit, "out", "Vbias", [1_000.0], 300.0).points[0]?.entries
+      .find((candidate) => candidate.elementName === "D1:RS");
+
+    expect(entry?.noiseType).toBe("thermal");
+    expect(entry?.sourcePsd).toBeGreaterThan(0.0);
+  });
+
   it("uses BJT forward beta roll-off to reduce shot noise", () => {
     function sourcePsd(forwardBetaRolloffCurrent: number): number {
       const circuit = new Circuit();

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language legacy BJT leakage ratios.
+1. Cross-language diode series resistance.
    - Status: current PR completion candidate.
-   - Add legacy SPICE2 BJT `C2` and `C4` model-card support in Rust, Python,
-     and TypeScript.
-   - Derive base-emitter `ISE` as `C2 * IS` and base-collector `ISC` as
-     `C4 * IS` only when the corresponding explicit leakage current is absent.
-   - Preserve existing behavior by default, extend the supported-parameter
-     coverage gate from 136 to 140 canonical rows, and lock normalization,
-     derivation, and explicit-current precedence in all engines.
+   - Add Berkeley diode `RS` model-card support in Rust, Python, and TypeScript,
+     defaulting to zero and inserting an intrinsic anode behind the configured
+     external series resistance.
+   - Keep DC, transient, AC, transfer-function, hierarchy, temperature, and
+     noise paths on the shared topology, including resistor thermal noise.
+   - Extend the supported-parameter coverage gate from 140 to 141 canonical
+     rows and lock normalization plus fixed-bias current limiting in all engines.
 
 ## Completed Slices
 
@@ -3211,6 +3211,14 @@ the Rust, Python, and TypeScript surfaces together.
    - Reverse transit-time diffusion capacitance remains intrinsic, hierarchical
      expansion preserves the model, and the supported-parameter release gate
      now covers 136 canonical rows.
+
+245. Cross-language legacy BJT leakage ratios.
+   - Status: completed in PR 8881.
+   - Rust, Python, and TypeScript BJT model cards now accept legacy SPICE2
+     `C2` and `C4` leakage ratios.
+   - `ISE` defaults to `C2 * IS` and `ISC` defaults to `C4 * IS`, while
+     explicit `ISE` and `ISC` retain precedence; the supported-parameter
+     release gate now covers 140 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- accept Berkeley diode `RS` model-card parameters in Rust, Python, and TypeScript
- stamp an intrinsic anode series resistance across DC, transient, AC, transfer-function, hierarchy, temperature, and noise paths
- advance the supported-parameter gate to 141 canonical rows and record the completed legacy BJT leakage slice

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo check -p spice-engine`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python Ruff on touched SPICE sources/tests
- Python SPICE suite: 581 passed, 88.72% coverage
- TypeScript `npm run build`
- TypeScript SPICE suite: 339 passed