### PR TITLE
feat(hl03): persist the Learn review quiz to localStorage (+ slice 6d was a no-op)

### DIFF
--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.11.0 — the review quiz remembers you (HL03 phase 6, persistence)
+
+- **The Learn-mode review quiz now persists between visits.** New
+  `src/reviewstore.ts` saves the review `Progress` (per-cell Leitner state + the
+  answer log) and the SRS session clock to `localStorage` after every answer,
+  and restores them at startup — so promotions, demotions, and logged confusions
+  survive a reload. Mirrors `progress.ts` (which does this for the lesson
+  schedule): the engine stays pure, all (de)serialization is pure and
+  unit-tested, and the untrusted blob is validated field-by-field — a corrupt,
+  wrong-version, or wrong-shaped payload restores as **empty rather than
+  throwing** (a study app that won't start over one bad key is worse than lost
+  progress). States are stored as `[cellKey, QuizState]` entry pairs, sidestepping
+  the `__proto__`/key-escaping hazards of an object map.
+- 9 new tests (194 total), including controls that bite: strip the version gate
+  and a stale blob surfaces; drop the `getItem` guard and a throwing storage
+  breaks startup. Verified in a real browser — seeding a saved review and
+  reloading restores "1 answered" (fresh is "0").
+- **Slice 6d (retire the standalone artifacts) was a no-op:** the HL03 spec's
+  "script field-guide, spot-the-script quiz, letter-reading trainer" were only
+  ever ephemeral exploratory Artifacts, never committed to the repo (no matching
+  files or history), and their capabilities already live in Browse / Practice /
+  Concepts. Nothing to remove — so this slice does the persistence work instead.
+
 ## 0.10.0 — renamed to **language-ladder** (HL03 phase 6, slice 6c)
 
 - **The app is renamed `script-writing-visualizer` → `language-ladder`.** The

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -30,8 +30,11 @@ concept×language grid up to the cursor), leaning on what you keep missing
 from the **same concept in other languages** — the cross-language look-alikes
 the interleaving targets (Telugu ధన్యవాద vs Hindi धन्यवाद). Answers thread
 through `applyAnswer` (promote a hit, demote + log a miss), and a *"what you keep
-confusing"* panel rolls the mistakes up from `confusions(log)`. Progress lives in
-memory for now; persistence is a later slice.
+confusing"* panel rolls the mistakes up from `confusions(log)`. The review
+**persists** (`reviewstore.ts`): its SRS state and answer log are saved to
+`localStorage` after every answer and restored at startup — the same pattern
+`progress.ts` uses for the lesson schedule, with the same defensive parse (a
+corrupt or wrong-version blob restores as empty, never throws).
 
 ## Concepts mode
 

--- a/code/programs/typescript/language-ladder/package.json
+++ b/code/programs/typescript/language-ladder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ladder",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "description": "The unified curriculum learning app (HL03): walk the language chain concept by concept, seeing the threads back to what you already know, then review it all with a randomised SRS quiz. (Was the HL02 script-writing-visualizer, whose Browse/Practice/Lessons/Concepts modes it now subsumes.)",
   "type": "module",

--- a/code/programs/typescript/language-ladder/src/main.ts
+++ b/code/programs/typescript/language-ladder/src/main.ts
@@ -34,12 +34,12 @@ import { buildPool, type PoolEntry } from "./interleave.ts";
 import { loadLessons, indicesByLanguage, nextDue } from "./lessons.ts";
 import {
   planSession,
-  initProgress,
   applyAnswer,
   type Progress,
 } from "./sessionplan.ts";
 import { pickNext as pickReviewCell, makeRng, cellKey, type GridCell } from "./quiz.ts";
 import { confusions } from "./mistakes.ts";
+import { loadReview, saveReview } from "./reviewstore.ts";
 import {
   sweepableConcepts,
   activeChain,
@@ -129,8 +129,13 @@ const CONCEPT_SPINE = sweepableConcepts(CONCEPT_LESSONS, activeChain(ACTIVE_COUN
 // Look up a lesson's word by its cell so a logged confusion (stored as a cellKey)
 // can be shown as the actual word, not an opaque id.
 const LESSON_BY_ID = new Map(LESSONS.map((l) => [l.id, l]));
-let reviewProgress: Progress = initProgress();
-let reviewSession = 0; // advances once per answered question — the SRS clock
+// Restore the review's SRS state + answer log from localStorage so the quiz
+// remembers you between visits (reusing the same storage port progress.ts owns).
+// A missing, corrupt, or wrong-version blob restores as empty — never throws.
+const REVIEW_STORAGE = browserStorage();
+const restoredReview = loadReview(REVIEW_STORAGE);
+let reviewProgress: Progress = restoredReview.progress;
+let reviewSession = restoredReview.session; // advances once per answered question — the SRS clock
 let reviewCell: GridCell | null = null; // the question currently on screen
 let reviewOptions: GridCell[] = []; // its answer options (one is `reviewCell`)
 let reviewChosen: string | null = null; // cellKey of the picked option; null = unanswered
@@ -857,6 +862,8 @@ function renderReview(grid: GridCell[]): HTMLElement {
       // confusion (which wrong word was picked) on a miss; advance the SRS clock.
       reviewProgress = applyAnswer(reviewProgress, cell, correct, reviewSession, correct ? undefined : k);
       reviewSession += 1;
+      // Persist immediately so a reload resumes exactly here. Silent on failure.
+      saveReview(REVIEW_STORAGE, reviewProgress, reviewSession);
       render();
     };
     opts.appendChild(b);

--- a/code/programs/typescript/language-ladder/src/reviewstore.ts
+++ b/code/programs/typescript/language-ladder/src/reviewstore.ts
@@ -1,0 +1,208 @@
+// ---------------------------------------------------------------------------
+// reviewstore.ts — remembering the Learn-mode review quiz, between visits.
+//
+// THE PROBLEM. The review quiz (sessionplan.ts `applyAnswer`) keeps a `Progress`
+// — per-cell Leitner state plus the answer log — in memory only, so a reload
+// wiped every promotion, demotion, and logged confusion. The SRS could adapt
+// within a session but forgot you the moment you left. This module gives it a
+// memory, the same way `progress.ts` did for the lesson schedule.
+//
+// THE DESIGN, borrowed wholesale from progress.ts:
+//   1. The engine (quiz.ts / sessionplan.ts / mistakes.ts) stays pure. Nothing
+//      there knows about storage; the (de)serialization lives entirely here.
+//   2. Everything except the reused `localStorage` adapter is pure, so the
+//      round-trip is unit-testable without a browser.
+//   3. The stored blob is UNTRUSTED (hand-editable, half-written by another tab,
+//      left by an older build). Every field is validated and a bad or
+//      wrong-version payload falls back to EMPTY rather than throwing — a study
+//      app that won't start because of one bad key is worse than lost progress.
+//
+// WHY A NEW KEY AND MODULE rather than extending progress.ts: that file persists
+// the *lesson schedule* (id-keyed, positional scheduler state). The review quiz
+// persists a *different* thing — cellKey-keyed `QuizState` plus an answer log —
+// so it gets its own key and its own shape. Sharing the code would mean one
+// blob with two unrelated schemas.
+// ---------------------------------------------------------------------------
+
+import { MAX_BOX } from "./scheduler.ts";
+import type { QuizState } from "./quiz.ts";
+import type { AnswerRecord } from "./mistakes.ts";
+import type { Progress } from "./sessionplan.ts";
+// Reuse the exact storage port progress.ts already proved out — no second copy.
+import { type StorageLike, browserStorage } from "./progress.ts";
+
+export { browserStorage };
+export type { StorageLike };
+
+/** Bump when the saved shape changes incompatibly; older payloads are dropped. */
+export const REVIEW_SCHEMA_VERSION = 1;
+
+/** The key we own in localStorage. Namespaced so nothing else collides. */
+export const REVIEW_STORAGE_KEY = "language-ladder:review:v1";
+
+/**
+ * What we persist. Deliberately flat and boring.
+ *
+ * `states` is an ARRAY of [cellKey, QuizState] pairs, not an object: a cellKey is
+ * a JSON string (`["CONCEPT","language","lesson-id"]`) and could contain any
+ * character, so an entries array sidesteps both key-escaping and the `__proto__`
+ * hazard that an object map would invite.
+ */
+export interface SavedReview {
+  version: number;
+  /** The review SRS clock — how many questions have been answered. */
+  session: number;
+  states: Array<[string, QuizState]>;
+  log: AnswerRecord[];
+}
+
+/** A fresh, empty saved record. */
+export function emptyReview(): SavedReview {
+  return { version: REVIEW_SCHEMA_VERSION, session: 0, states: [], log: [] };
+}
+
+/** A fresh, empty in-memory Progress + session (what `fromSavedReview` returns on nothing). */
+export function emptyRestored(): { progress: Progress; session: number } {
+  return { progress: { states: new Map(), log: [] }, session: 0 };
+}
+
+function int(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? Math.trunc(value) : 0;
+}
+
+function clampBox(box: unknown): number {
+  return Math.max(0, Math.min(MAX_BOX, int(box)));
+}
+
+/** Normalize one persisted cell state, clamping every field to a sane range. */
+function cleanState(value: unknown): QuizState | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  const s = value as Record<string, unknown>;
+  return {
+    box: clampBox(s.box),
+    dueAtSession: int(s.dueAtSession),
+    lapses: Math.max(0, int(s.lapses)),
+    reps: Math.max(0, int(s.reps)),
+  };
+}
+
+/** In-memory Progress + session → a saveable record. */
+export function toSavedReview(progress: Progress, session: number): SavedReview {
+  return {
+    version: REVIEW_SCHEMA_VERSION,
+    session: Math.max(0, int(session)),
+    states: [...progress.states.entries()],
+    log: progress.log,
+  };
+}
+
+/**
+ * A saved record → in-memory Progress + session.
+ *
+ * Every entry is re-validated (the caller may hand us the raw parse result), so
+ * a malformed state or log row is dropped rather than trusted.
+ */
+export function fromSavedReview(saved: SavedReview): { progress: Progress; session: number } {
+  const states = new Map<string, QuizState>();
+  // Guard the shape too — this is a public entry point that may be handed a raw,
+  // untrusted object directly (not only well-formed `parseReview` output).
+  const savedStates = Array.isArray(saved.states) ? saved.states : [];
+  for (const pair of savedStates) {
+    if (!Array.isArray(pair) || pair.length !== 2) continue;
+    const [key, rawState] = pair;
+    if (typeof key !== "string") continue;
+    const state = cleanState(rawState);
+    if (state) states.set(key, state);
+  }
+
+  const log: AnswerRecord[] = [];
+  const savedLog = Array.isArray(saved.log) ? saved.log : [];
+  for (const row of savedLog) {
+    if (typeof row !== "object" || row === null || Array.isArray(row)) continue;
+    const r = row as Record<string, unknown>;
+    if (typeof r.cellKey !== "string" || typeof r.correct !== "boolean") continue;
+    const record: AnswerRecord = { cellKey: r.cellKey, correct: r.correct };
+    // chosenKey is only meaningful on a miss; keep it only when it's a string.
+    if (!r.correct && typeof r.chosenKey === "string") record.chosenKey = r.chosenKey;
+    log.push(record);
+  }
+
+  return { progress: { states, log }, session: Math.max(0, int(saved.session)) };
+}
+
+/**
+ * Parse whatever was in storage, defensively. Untrusted input in, valid
+ * `SavedReview` out — a wrong version, non-JSON, or wrong-shaped blob yields
+ * `emptyReview()` rather than throwing.
+ */
+export function parseReview(raw: string | null): SavedReview {
+  if (raw === null || raw === "") return emptyReview();
+
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    return emptyReview();
+  }
+  if (typeof data !== "object" || data === null || Array.isArray(data)) return emptyReview();
+
+  const record = data as Record<string, unknown>;
+  // Version gate: an older/newer incompatible shape is dropped, not migrated.
+  if (record.version !== REVIEW_SCHEMA_VERSION) return emptyReview();
+
+  const session = Math.max(0, int(record.session));
+
+  const states: Array<[string, QuizState]> = [];
+  if (Array.isArray(record.states)) {
+    for (const pair of record.states) {
+      if (!Array.isArray(pair) || pair.length !== 2) continue;
+      const [key, rawState] = pair;
+      if (typeof key !== "string") continue;
+      const state = cleanState(rawState);
+      if (state) states.push([key, state]);
+    }
+  }
+
+  const log: AnswerRecord[] = [];
+  if (Array.isArray(record.log)) {
+    for (const row of record.log) {
+      if (typeof row !== "object" || row === null || Array.isArray(row)) continue;
+      const r = row as Record<string, unknown>;
+      if (typeof r.cellKey !== "string" || typeof r.correct !== "boolean") continue;
+      const clean: AnswerRecord = { cellKey: r.cellKey, correct: r.correct };
+      if (!r.correct && typeof r.chosenKey === "string") clean.chosenKey = r.chosenKey;
+      log.push(clean);
+    }
+  }
+
+  return { version: REVIEW_SCHEMA_VERSION, session, states, log };
+}
+
+// --- the only impure part (delegated to progress.ts's port) ----------------
+
+/** Load the saved review, restored into an in-memory Progress + session. */
+export function loadReview(storage: StorageLike | null): { progress: Progress; session: number } {
+  if (!storage) return emptyRestored();
+  let raw: string | null;
+  try {
+    raw = storage.getItem(REVIEW_STORAGE_KEY);
+  } catch {
+    return emptyRestored();
+  }
+  return fromSavedReview(parseReview(raw));
+}
+
+/** Persist the review Progress + session. Silent on failure (Safari private mode, quota). */
+export function saveReview(
+  storage: StorageLike | null,
+  progress: Progress,
+  session: number,
+): boolean {
+  if (!storage) return false;
+  try {
+    storage.setItem(REVIEW_STORAGE_KEY, JSON.stringify(toSavedReview(progress, session)));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/code/programs/typescript/language-ladder/tests/reviewstore.test.ts
+++ b/code/programs/typescript/language-ladder/tests/reviewstore.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest";
+import {
+  toSavedReview,
+  fromSavedReview,
+  parseReview,
+  loadReview,
+  saveReview,
+  emptyReview,
+  REVIEW_SCHEMA_VERSION,
+  type SavedReview,
+  type StorageLike,
+} from "../src/reviewstore";
+import type { Progress } from "../src/sessionplan";
+import type { QuizState } from "../src/quiz";
+
+function progressOf(
+  entries: Array<[string, QuizState]>,
+  log: Progress["log"] = [],
+): Progress {
+  return { states: new Map(entries), log };
+}
+
+const ST: QuizState = { box: 2, dueAtSession: 7, lapses: 1, reps: 3 };
+
+describe("toSavedReview / fromSavedReview — the round trip", () => {
+  it("preserves states, log, and session exactly", () => {
+    const progress = progressOf(
+      [
+        ['["THANKS","hindi","hi-t"]', ST],
+        ['["THANKS","tamil","ta-t"]', { box: 0, dueAtSession: 9, lapses: 0, reps: 1 }],
+      ],
+      [
+        { cellKey: '["THANKS","tamil","ta-t"]', correct: false, chosenKey: '["THANKS","hindi","hi-t"]' },
+        { cellKey: '["THANKS","hindi","hi-t"]', correct: true },
+      ],
+    );
+    const restored = fromSavedReview(toSavedReview(progress, 9));
+    expect(restored.session).toBe(9);
+    expect([...restored.progress.states.entries()]).toEqual([...progress.states.entries()]);
+    expect(restored.progress.log).toEqual(progress.log);
+  });
+
+  it("CONTROL: tolerates a raw non-array states/log without throwing", () => {
+    // fromSavedReview is a public entry point; a caller may hand it an untrusted
+    // object whose fields aren't arrays. Without the Array.isArray guards the
+    // for...of would throw; it must instead yield an empty restore.
+    const bogus = { version: REVIEW_SCHEMA_VERSION, session: 2, states: "nope", log: 42 } as unknown as SavedReview;
+    const restored = fromSavedReview(bogus);
+    expect([...restored.progress.states.entries()]).toEqual([]);
+    expect(restored.progress.log).toEqual([]);
+    expect(restored.session).toBe(2);
+  });
+
+  it("a wrong answer keeps its chosenKey; a correct one never carries one", () => {
+    const saved: SavedReview = {
+      version: REVIEW_SCHEMA_VERSION,
+      session: 1,
+      states: [],
+      // a correct row with a stray chosenKey must be sanitized away on restore
+      log: [{ cellKey: "a", correct: true, chosenKey: "sneaky" } as never],
+    };
+    const restored = fromSavedReview(saved);
+    expect(restored.progress.log).toEqual([{ cellKey: "a", correct: true }]);
+  });
+});
+
+describe("parseReview — defensive against untrusted input", () => {
+  it("round-trips a well-formed blob", () => {
+    const saved = toSavedReview(progressOf([['["C","spanish","es"]', ST]]), 4);
+    const parsed = parseReview(JSON.stringify(saved));
+    expect(parsed).toEqual(saved);
+  });
+
+  it("CONTROL: a wrong-version blob loads EMPTY, not the stale data", () => {
+    const stale = { version: 999, session: 5, states: [["k", ST]], log: [] };
+    const parsed = parseReview(JSON.stringify(stale));
+    // If the version gate were removed, this would surface the stale state and fail.
+    expect(parsed).toEqual(emptyReview());
+    expect(parsed.states).toEqual([]);
+  });
+
+  it("non-JSON, null, and non-object blobs load empty rather than throwing", () => {
+    expect(parseReview("not json{")).toEqual(emptyReview());
+    expect(parseReview(null)).toEqual(emptyReview());
+    expect(parseReview("[]")).toEqual(emptyReview());
+    expect(parseReview("42")).toEqual(emptyReview());
+  });
+
+  it("drops malformed state rows and clamps out-of-range fields", () => {
+    const blob = JSON.stringify({
+      version: REVIEW_SCHEMA_VERSION,
+      session: -3, // clamped to 0
+      states: [
+        ["good", { box: 999, dueAtSession: 2.9, lapses: -1, reps: "x" }], // clamped/coerced
+        ["bad-not-a-pair"], // dropped (length !== 2)
+        [42, ST], // dropped (key not a string)
+        "nope", // dropped (not an array)
+      ],
+      log: [
+        { cellKey: "k", correct: false, chosenKey: "j" }, // kept
+        { cellKey: 5, correct: true }, // dropped (cellKey not a string)
+        { correct: true }, // dropped (no cellKey)
+        null, // dropped
+      ],
+    });
+    const parsed = parseReview(blob);
+    expect(parsed.session).toBe(0);
+    expect(parsed.states).toEqual([
+      ["good", { box: 5 /* MAX_BOX */, dueAtSession: 2, lapses: 0, reps: 0 }],
+    ]);
+    expect(parsed.log).toEqual([{ cellKey: "k", correct: false, chosenKey: "j" }]);
+  });
+});
+
+describe("loadReview / saveReview — through a fake storage port", () => {
+  function fakeStorage(): StorageLike & { data: Map<string, string> } {
+    const data = new Map<string, string>();
+    return {
+      data,
+      getItem: (k) => data.get(k) ?? null,
+      setItem: (k, v) => void data.set(k, v),
+    };
+  }
+
+  it("save then load restores the same Progress + session", () => {
+    const store = fakeStorage();
+    const progress = progressOf(
+      [['["C","latin","la"]', ST]],
+      [{ cellKey: '["C","latin","la"]', correct: true }],
+    );
+    expect(saveReview(store, progress, 6)).toBe(true);
+    const { progress: back, session } = loadReview(store);
+    expect(session).toBe(6);
+    expect([...back.states.entries()]).toEqual([...progress.states.entries()]);
+    expect(back.log).toEqual(progress.log);
+  });
+
+  it("a null storage (private mode / SSR) is a no-op, not a crash", () => {
+    expect(saveReview(null, progressOf([]), 0)).toBe(false);
+    expect(loadReview(null)).toEqual({ progress: { states: new Map(), log: [] }, session: 0 });
+  });
+
+  it("CONTROL: a storage whose getItem throws loads empty rather than propagating", () => {
+    const throwing: StorageLike = {
+      getItem: () => {
+        throw new Error("SecurityError");
+      },
+      setItem: () => {},
+    };
+    // If loadReview didn't guard getItem, this would throw and break app startup.
+    expect(loadReview(throwing)).toEqual({ progress: { states: new Map(), log: [] }, session: 0 });
+  });
+});


### PR DESCRIPTION
## What

The Learn-mode **review quiz now remembers you between visits.** It kept its `Progress` (per-cell Leitner state + the answer log) in memory only, so a reload wiped every promotion, demotion, and logged confusion. This gives it a memory — the same way `progress.ts` already does for the lesson schedule.

- **New `src/reviewstore.ts`**: pure (de)serializers over the review `Progress` + SRS session, plus `load`/`save` that reuse `progress.ts`'s storage port. States persist as `[cellKey, QuizState]` **entry pairs** (not an object map) — a `cellKey` is arbitrary JSON, so the array form sidesteps `__proto__`/key-escaping hazards. The stored blob is **untrusted**: every field is validated and clamped, and a corrupt, wrong-version, or wrong-shaped payload restores as **empty rather than throwing** (a study app that won't start over one bad key is worse than lost progress).
- **`main.ts`** loads at startup (before the review-state `let`s) and saves after every `applyAnswer`, persisting the post-increment session so a reload resumes exactly.

## Verification

- **10 new tests (195 total)** with controls that bite: strip the version gate → a stale blob surfaces; drop the `getItem` guard → a throwing storage breaks startup; hand `fromSavedReview` a non-array field → it must not throw.
- **Real browser** (headless Chrome, shared profile): seeding a saved review and reloading restores **"1 answered"** where a fresh load shows **"0"** — proving the startup-restore path works end to end. Header/glyphs render unchanged.
- Correctness/security review (subagent): clean — round-trip fidelity, defensive parse, no prototype-pollution vector, module-init order all confirmed. Its one optional nit (guard `fromSavedReview`'s loops for direct untrusted callers) is **applied**.

## Slice 6d was a no-op

The HL03 spec's *script field-guide / spot-the-script quiz / letter-reading trainer* were only ever **ephemeral Artifacts, never committed** (no matching files or git history), and their capabilities already live in Browse / Practice / Concepts. Nothing to retire — so this slice does the persistence work instead.

## Scope

Review persistence + the 6d finding. Next: **phase 7** (as-needed script/grammar introduction wired into the session).

Builds on #8882 (rename to language-ladder, merged).