### PR TITLE
feat(semantic-ir-to-c): exceptions — setjmp/longjmp handler stack (SIR17)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog
 
+## 0.12.0 — exceptions (SIR17)
+
+Accepts `Feature::Exceptions`. C has no stack unwinding, so `begin … rescue …
+ensure … end` (`Stmt::TryCatch`) and `raise` lower to a **`setjmp`/`longjmp`
+handler stack** — the C analogue of Go `panic`/`recover`, per the SIR24
+exception-model design.
+
+- **Runtime**: a new `SIR_ERROR` value (`struct SirError { const char *sir_class;
+  SirValue msg; }`); a static stack of `jmp_buf` (`_sir_push_handler`/`_sir_pop_
+  handler`); `_sir_current_error` (the exception being handled); `_sir_raise`
+  (records the error and `longjmp`s to the top handler, or prints `class:
+  message` to stderr and exits non-zero when uncaught); `_sir_raise_value`
+  (re-raises an exception object, or wraps any other value — a message string —
+  in a `RuntimeError`); and a **baked-in exception-class ancestry table**
+  (`RuntimeError`/`ZeroDivisionError`/… → `StandardError` → `Exception`,
+  `KeyError` → `IndexError`, `NoMethodError` → `NameError`) with
+  `_sir_class_is_a` / `_sir_rescue_matches` so `rescue StandardError` catches a
+  raised `RuntimeError`. A single `#include <setjmp.h>` is added to the preamble.
+- **`TryCatch` codegen**: a TWO-handler structure — an OUTER "ensure" handler
+  wraps the whole thing so `ensure` runs even when a rescue body itself raises
+  (Ruby semantics), and an INNER "body" handler catches an exception from the
+  guarded body. The inner handler is popped BEFORE the rescue dispatch, so a
+  raise in a rescue clause (or an unmatched exception) unwinds to the outer
+  handler; the outer handler is popped before `ensure` runs, and an unmatched
+  exception is re-raised (propagated) after `ensure`.
+- **`raise`**: bare (`raise`) re-raises `_sir_current_error`; `raise "msg"`
+  raises a `RuntimeError`; `raise <exception>` re-raises it.
+
+**Injection safety**: a `rescue` clause's exception-type names are emitted as
+**quoted string literals** (`quote_c_string`) passed to `_sir_rescue_matches` —
+never as bare identifiers — so no rescue type can inject source, and the SIR24
+"dispatch is an explicit name-switch" anti-RCE invariant holds. The
+unsupported-builtin pre-check descends into a `TryCatch`'s guarded/rescue/ensure
+bodies (co-total with the emitter).
+
+Deferred to a follow-up (each a clean rejection): `raise SomeClass` (a specific
+class) lowers to a `Const` reference → observes `Feature::Constants`
+(unaccepted) → rejected; `retry` is not yet lowered (rejected by the builtin
+gate — it needs loop machinery in the `setjmp` model).
+
+Documented v0 limitation (correctness, not memory-safety): a *bare* `raise`
+(re-raise) inside a rescue body reads the global current-error, so if a nested
+`begin/rescue` completes between the clause's entry and the bare `raise`, it
+re-raises that inner (already-handled) exception rather than the clause's own —
+faithful `$!` save/restore around nested handling is deferred. (An `ensure` body
+that handles a nested exception does NOT mis-propagate — the escaping exception
+is snapshotted before `ensure` runs; regression-tested.)
+
+First of the exceptions parity arc's C half: with the Ruby backend (0.10.0),
+`Exceptions` is now accepted on all six backends. Verified with hand-built
+modules compiled and run through a real `cc`: a bare rescue catching a message,
+`rescue StandardError` matching a `RuntimeError` via the ancestry, the rescue
+binding, `ensure` on both the normal and the exception path, an unmatched
+exception propagating through an outer handler after the inner `ensure` runs,
+and an uncaught exception exiting non-zero. Bumps semantic-ir-to-c 0.11.0 →
+0.12.0.
+
 ## 0.11.0 — keyword parameters (SIR19)
 
 Accepts `Feature::KeywordParams`, building directly on the `_sir_missing`

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -97,10 +97,16 @@ with an `if (_sir_is_missing(p)) { p = <default>; }` prologue (a later default
 may reference an earlier parameter); and SIR19 `KeywordParams` — a keyword
 argument resolved to its callee's parameter slot **by name** at emit time (KW6),
 producing a plain positional C call (omitted optional keywords filled with
-`_sir_missing()` and substituted by the same default prologue).
+`_sir_missing()` and substituted by the same default prologue); and SIR17
+`Exceptions` — `begin/rescue/ensure` + `raise` lowered to a `setjmp`/`longjmp`
+handler stack (a `SIR_ERROR` value, a baked-in exception-class ancestry table
+for `rescue`-by-class matching, and a two-handler structure so `ensure` runs
+even when a rescue body raises). Rescue-type names are emitted as quoted string
+literals (no injection). `raise SomeClass` (needs `Constants`) and `retry` are
+deferred, rejected cleanly.
 
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
-`Intrinsics`, `NDArrays`, exceptions/OOP, and every
+`Intrinsics`, `NDArrays`, `Constants`/OOP, and every
 other not-yet-wired feature until its batch lands.  `Bignum` stays rejected
 until a bignum runtime ships — a module needing arbitrary precision is refused,
 never silently truncated.

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -103,7 +103,10 @@ pub fn emit_module(m: &Module) -> String {
     // `<math.h>` supplies the C99 `INFINITY` / `NAN` macros used to spell a
     // non-finite `FloatLit` (a finite literal needs no macro). Standard and
     // available on every C99 compiler including MSVC.
-    out.push_str("#include <math.h>\n\n");
+    out.push_str("#include <math.h>\n");
+    // `<setjmp.h>` supplies `jmp_buf`/`setjmp`/`longjmp` for the SIR17 exception
+    // handler stack.
+    out.push_str("#include <setjmp.h>\n\n");
 
     // The runtime, with the display-convention placeholder resolved to a
     // boolean-selected LITERAL (never source text — see the security note in
@@ -533,6 +536,105 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
                 out,
                 "{ipad}(void)_sir_map_set({}, {}, {});",
                 names[0], names[1], names[2]
+            );
+            let _ = writeln!(out, "{pad}}}");
+        }
+        // SIR17 `begin … rescue … ensure … end`.  C has no unwinding, so this
+        // lowers to a TWO-handler `setjmp`/`longjmp` structure:
+        //   - an OUTER "ensure" handler wraps the whole thing, so `ensure` runs
+        //     even when a rescue body itself raises (Ruby semantics);
+        //   - an INNER "body" handler catches an exception from the guarded body.
+        //     It is popped BEFORE the rescue dispatch, so a raise in a rescue
+        //     clause (or an unmatched exception) unwinds to the OUTER handler.
+        // A `rescue` clause matches by class name against the baked-in ancestry
+        // table (`_sir_rescue_matches`); an empty class list is a catch-all.
+        // Exception-type names are emitted as QUOTED string literals (via
+        // `quote_c_string`), so — unlike a language that emits them as bare
+        // constants — no rescue type can inject source.
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            ..
+        } => {
+            let id = fresh_id();
+            let i1 = indent + 1;
+            let i2 = indent + 2;
+            let i3 = indent + 3;
+            let p1 = indent_str(i1);
+            let p2 = indent_str(i2);
+            let p3 = indent_str(i3);
+            let _ = writeln!(out, "{pad}{{");
+            let _ = writeln!(out, "{p1}int _sir_eh{id} = _sir_push_handler();");
+            let _ = writeln!(out, "{p1}volatile int _sir_esc{id} = 0;");
+            let _ = writeln!(
+                out,
+                "{p1}if (setjmp(_sir_handlers[_sir_eh{id}])) {{ _sir_esc{id} = 1; }}"
+            );
+            let _ = writeln!(out, "{p1}if (!_sir_esc{id}) {{");
+            let _ = writeln!(out, "{p2}int _sir_bh{id} = _sir_push_handler();");
+            let _ = writeln!(out, "{p2}volatile int _sir_c{id} = 0;");
+            let _ = writeln!(
+                out,
+                "{p2}if (setjmp(_sir_handlers[_sir_bh{id}])) {{ _sir_c{id} = 1; }}"
+            );
+            let _ = writeln!(out, "{p2}if (!_sir_c{id}) {{");
+            for st in body {
+                emit_stmt(out, st, i3);
+            }
+            let _ = writeln!(out, "{p2}}}");
+            let _ = writeln!(out, "{p2}_sir_pop_handler();");
+            let _ = writeln!(out, "{p2}if (_sir_c{id}) {{");
+            let _ = writeln!(out, "{p3}SirValue _sir_ex{id} = _sir_current_error;");
+            for (k, rc) in rescues.iter().enumerate() {
+                let kw = if k == 0 { "if" } else { "} else if" };
+                if rc.exception_types.is_empty() {
+                    let _ = writeln!(
+                        out,
+                        "{p3}{kw} (_sir_rescue_matches(_sir_ex{id}, NULL, 0)) {{"
+                    );
+                } else {
+                    let lits: Vec<String> =
+                        rc.exception_types.iter().map(|t| quote_c_string(t)).collect();
+                    let _ = writeln!(
+                        out,
+                        "{p3}{kw} (_sir_rescue_matches(_sir_ex{id}, (const char *const[]){{{}}}, {})) {{",
+                        lits.join(", "),
+                        rc.exception_types.len()
+                    );
+                }
+                if let Some(bind) = &rc.binding {
+                    let b = sanitize_ident(bind);
+                    let _ = writeln!(out, "{}SirValue {b} = _sir_ex{id}; (void){b};", indent_str(i3 + 1));
+                }
+                for st in &rc.body {
+                    emit_stmt(out, st, i3 + 1);
+                }
+            }
+            // Unmatched (or no rescue clause): re-raise so it propagates through
+            // the outer ensure handler after `ensure` runs.
+            if rescues.is_empty() {
+                let _ = writeln!(out, "{p3}(void)_sir_raise(_sir_ex{id});");
+            } else {
+                let _ = writeln!(out, "{p3}}} else {{ (void)_sir_raise(_sir_ex{id}); }}");
+            }
+            let _ = writeln!(out, "{p2}}}");
+            let _ = writeln!(out, "{p1}}}");
+            // Snapshot the escaping exception BEFORE `ensure` runs and before
+            // popping this handler: an `ensure` body that itself handles an
+            // exception would otherwise overwrite the global `_sir_current_error`
+            // and propagate the WRONG exception.  (Meaningful only when
+            // `_sir_esc` is set; harmlessly nil on the normal path.)
+            let _ = writeln!(out, "{p1}SirValue _sir_pend{id} = _sir_current_error;");
+            let _ = writeln!(out, "{p1}_sir_pop_handler();");
+            if let Some(ens) = ensure_body {
+                for st in ens {
+                    emit_stmt(out, st, i1);
+                }
+            }
+            let _ = writeln!(
+                out,
+                "{p1}if (_sir_esc{id}) {{ (void)_sir_raise(_sir_pend{id}); }}"
             );
             let _ = writeln!(out, "{pad}}}");
         }
@@ -1121,6 +1223,19 @@ fn emit_var_ref(out: &mut String, name: &str, scope: Scope) {
 
 /// A builtin call whose arguments are all simple.
 fn emit_builtin_simple(out: &mut String, name: &str, args: &[Expr], indent: usize) {
+    // SIR17 `raise`: no argument re-raises the exception being handled; one
+    // argument raises it (an exception object as-is, any other value — a message
+    // string — wrapped in a `RuntimeError`).  Never returns (longjmp/exit).
+    if name == "raise" {
+        if args.is_empty() {
+            out.push_str("_sir_raise(_sir_current_error)");
+        } else {
+            out.push_str("_sir_raise_value(");
+            emit_expr(out, &args[0], indent);
+            out.push(')');
+        }
+        return;
+    }
     // Variadic-shaped builtins take (count, args...).
     if let Some(helper) = variadic_helper(name) {
         let _ = write!(out, "{}({}", helper, args.len());
@@ -1152,6 +1267,14 @@ fn emit_builtin_simple(out: &mut String, name: &str, args: &[Expr], indent: usiz
 
 /// The already-hoisted-args variant used by [`emit_compound_call`].
 fn emit_builtin_with_names(out: &mut String, name: &str, names: &[String]) {
+    if name == "raise" {
+        if names.is_empty() {
+            out.push_str("_sir_raise(_sir_current_error)");
+        } else {
+            let _ = write!(out, "_sir_raise_value({})", names[0]);
+        }
+        return;
+    }
     if let Some(helper) = variadic_helper(name) {
         let _ = write!(out, "{}({}", helper, names.len());
         for n in names {
@@ -1204,7 +1327,9 @@ fn variadic_helper(name: &str) -> Option<&'static str> {
 /// by [`first_unsupported_builtin`] rather than emitted as a call that fails at
 /// runtime.
 fn is_supported_builtin(name: &str) -> bool {
-    variadic_helper(name).is_some() || fixed_helper(name).is_some() || matches!(name, "and" | "or")
+    variadic_helper(name).is_some()
+        || fixed_helper(name).is_some()
+        || matches!(name, "and" | "or" | "raise")
 }
 
 /// The first `BuiltinCall` whose name the v0 emitter cannot lower, if any.  A
@@ -1234,49 +1359,71 @@ pub fn first_unsupported_builtin(m: &Module) -> Option<(String, Span)> {
 }
 
 fn scan_block_for_builtin(b: &Block) -> Option<(String, Span)> {
-    for s in &b.stmts {
-        let inner = match s {
-            Stmt::LetBinding { value, .. }
-            | Stmt::LetStarBinding { value, .. }
-            | Stmt::ExprStmt { expr: value, .. }
-            | Stmt::Assign { value, .. } => scan_expr_for_builtin(value),
-            // Loop bodies must be scanned too, or an unsupported builtin hidden
-            // in a `while`/`for` body escapes the pre-check and hits the
-            // emitter's `unreachable!`. (`While` was a pre-existing scan hole.)
-            Stmt::While { cond, body, .. } => {
-                scan_expr_for_builtin(cond).or_else(|| scan_block_for_builtin(body))
-            }
-            Stmt::ForRange {
-                start,
-                stop,
-                step,
-                body,
-                ..
-            } => scan_expr_for_builtin(start)
-                .or_else(|| scan_expr_for_builtin(stop))
-                .or_else(|| scan_expr_for_builtin(step))
-                .or_else(|| scan_block_for_builtin(body)),
-            // Sequence write / iteration bodies likewise carry sub-expressions.
-            Stmt::SeqSet {
-                seq, index, value, ..
-            } => scan_expr_for_builtin(seq)
-                .or_else(|| scan_expr_for_builtin(index))
-                .or_else(|| scan_expr_for_builtin(value)),
-            Stmt::MapSet {
-                map, key, value, ..
-            } => scan_expr_for_builtin(map)
-                .or_else(|| scan_expr_for_builtin(key))
-                .or_else(|| scan_expr_for_builtin(value)),
-            Stmt::ForEach { iter, body, .. } => {
-                scan_expr_for_builtin(iter).or_else(|| scan_block_for_builtin(body))
-            }
-            _ => None,
-        };
-        if inner.is_some() {
-            return inner;
+    b.stmts
+        .iter()
+        .find_map(scan_stmt_for_builtin)
+        .or_else(|| scan_expr_for_builtin(&b.value))
+}
+
+fn scan_stmt_for_builtin(s: &Stmt) -> Option<(String, Span)> {
+    match s {
+        Stmt::LetBinding { value, .. }
+        | Stmt::LetStarBinding { value, .. }
+        | Stmt::ExprStmt { expr: value, .. }
+        | Stmt::Assign { value, .. } => scan_expr_for_builtin(value),
+        // Loop bodies must be scanned too, or an unsupported builtin hidden
+        // in a `while`/`for` body escapes the pre-check and hits the
+        // emitter's `unreachable!`. (`While` was a pre-existing scan hole.)
+        Stmt::While { cond, body, .. } => {
+            scan_expr_for_builtin(cond).or_else(|| scan_block_for_builtin(body))
         }
+        Stmt::ForRange {
+            start,
+            stop,
+            step,
+            body,
+            ..
+        } => scan_expr_for_builtin(start)
+            .or_else(|| scan_expr_for_builtin(stop))
+            .or_else(|| scan_expr_for_builtin(step))
+            .or_else(|| scan_block_for_builtin(body)),
+        // Sequence write / iteration bodies likewise carry sub-expressions.
+        Stmt::SeqSet {
+            seq, index, value, ..
+        } => scan_expr_for_builtin(seq)
+            .or_else(|| scan_expr_for_builtin(index))
+            .or_else(|| scan_expr_for_builtin(value)),
+        Stmt::MapSet {
+            map, key, value, ..
+        } => scan_expr_for_builtin(map)
+            .or_else(|| scan_expr_for_builtin(key))
+            .or_else(|| scan_expr_for_builtin(value)),
+        Stmt::ForEach { iter, body, .. } => {
+            scan_expr_for_builtin(iter).or_else(|| scan_block_for_builtin(body))
+        }
+        // A `begin … rescue … ensure … end` — scan the guarded body, every
+        // rescue clause body, and the ensure body, so an unsupported builtin
+        // hidden in any of them is caught by the pre-check, not the emitter.
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            ..
+        } => body
+            .iter()
+            .find_map(scan_stmt_for_builtin)
+            .or_else(|| {
+                rescues
+                    .iter()
+                    .find_map(|rc| rc.body.iter().find_map(scan_stmt_for_builtin))
+            })
+            .or_else(|| {
+                ensure_body
+                    .as_ref()
+                    .and_then(|e| e.iter().find_map(scan_stmt_for_builtin))
+            }),
+        _ => None,
     }
-    scan_expr_for_builtin(&b.value)
 }
 
 fn scan_expr_for_builtin(e: &Expr) -> Option<(String, Span)> {

--- a/code/packages/rust/semantic-ir-to-c/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/lib.rs
@@ -137,6 +137,16 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // positional `SirValue` C parameter like any other; only the call site
     // resolves by name.
     Feature::KeywordParams,
+    // ── SIR17 exceptions ─────────────────────────────────────────────
+    // `Stmt::TryCatch` (`begin/rescue/ensure`) + the `raise` builtin lower to a
+    // `setjmp`/`longjmp` handler stack (a new `SIR_ERROR` runtime value, a
+    // baked-in exception-class ancestry table for `rescue`-by-class matching,
+    // and a two-handler structure so `ensure` runs even when a rescue body
+    // raises).  Rescue-type names are emitted as QUOTED string literals, so no
+    // rescue type can inject source.  `raise SomeClass` (a specific class) is a
+    // `Const` reference → observes `Feature::Constants` (unaccepted) → rejected;
+    // `retry` is not yet lowered (rejected by the builtin gate) — both deferred.
+    Feature::Exceptions,
 ];
 
 impl Backend for CBackend {

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -48,7 +48,10 @@ typedef enum {
      * with `_sir_missing()`; the callee's prologue replaces each such parameter
      * with its default expression BEFORE the body runs, so a `SIR_MISSING` value
      * is never observed by user code (never printed, compared, or stored). */
-    SIR_MISSING
+    SIR_MISSING,
+    /* A SIR17 exception value (`raise`d and `rescue`d) — a class name plus an
+     * optional message. */
+    SIR_ERROR
 } SirTag;
 
 typedef struct SirValue SirValue;
@@ -56,6 +59,7 @@ typedef struct SirPair SirPair;
 typedef struct SirClosure SirClosure;
 typedef struct SirSeq SirSeq;
 typedef struct SirMap SirMap;
+typedef struct SirError SirError;
 
 struct SirValue {
     SirTag tag;
@@ -68,10 +72,17 @@ struct SirValue {
         SirClosure *clo;  /* SIR_CLOSURE */
         SirSeq *seq;      /* SIR_SEQ */
         SirMap *map;      /* SIR_MAP */
+        SirError *err;    /* SIR_ERROR */
     } as;
 };
 
 struct SirPair { SirValue car; SirValue cdr; };
+
+/* A SIR17 exception (`raise`/`rescue`).  `sir_class` is the interned exception
+ * class name (`"RuntimeError"`, `"StandardError"`, …), matched against a
+ * `rescue` clause via the baked-in ancestry table.  `msg` is the message (a
+ * `SIR_STR`, or nil for a bare `raise Class` — then the class name is shown). */
+struct SirError { const char *sir_class; SirValue msg; };
 
 /* A SIR16 sequence (`[1, 2, 3]`) — a heap-boxed dynamic array. `items` points
  * at `len` `SirValue`s (arena-allocated, never freed like every other heap
@@ -394,6 +405,10 @@ int _sir_value_eq_d(SirValue a, SirValue b, int depth) {
             return 1;
         }
         case SIR_CLOSURE: return a.as.clo == b.as.clo;
+        /* Two exceptions are equal only when they are the SAME handle (Ruby's
+         * default `==` is object identity), so a `rescue => e` binding compares
+         * equal to itself. */
+        case SIR_ERROR:   return a.as.err == b.as.err;
         default:          return 0;
     }
 }
@@ -745,9 +760,131 @@ void _sir_fmt(FILE *out, SirValue v) {
         case SIR_SEQ:   _sir_fmt_seq(out, v); break;
         case SIR_MAP:   _sir_fmt_map(out, v); break;
         case SIR_CLOSURE: fputs("#<closure>", out); break;
+        /* An exception prints as its message (Ruby's `exception.message`): the
+         * raised message when present, else the class name — so `rescue => e;
+         * print(e)` shows something meaningful. */
+        case SIR_ERROR:
+            if (v.as.err->msg.tag == SIR_NIL) fputs(v.as.err->sir_class, out);
+            else _sir_fmt(out, v.as.err->msg);
+            break;
         default: break;
     }
     _sir_fmt_depth--;
+}
+
+/* ---- SIR17 exceptions (setjmp/longjmp handler stack) -------- */
+
+/* Construct an exception value.  `class` is interned; `msg` is a `SIR_STR` (or
+ * nil for a bare `raise Class`, whose message defaults to the class name). */
+SirValue _sir_error(const char *sir_class, SirValue msg) {
+    SirError *e = (SirError *)_sir_alloc(sizeof(SirError));
+    e->sir_class = _sir_intern(sir_class);
+    e->msg = msg;
+    SirValue v;
+    v.tag = SIR_ERROR; v.as.err = e;
+    return v;
+}
+
+/* The built-in exception-class ancestry (`sub → super`), baked in from the
+ * shared exception hierarchy so a `rescue StandardError` matches a raised
+ * `RuntimeError`.  A NULL super terminates the chain (`Exception` is the root).
+ * An unlisted class is treated as having no super (matches only itself / a bare
+ * rescue) — a user exception class needs the OOP `Classes` batch. */
+static const char *_sir_class_super(const char *cls) {
+    static const struct { const char *sub; const char *sup; } A[] = {
+        { "RuntimeError", "StandardError" },
+        { "ArgumentError", "StandardError" },
+        { "TypeError", "StandardError" },
+        { "NameError", "StandardError" },
+        { "NoMethodError", "NameError" },
+        { "IndexError", "StandardError" },
+        { "KeyError", "IndexError" },
+        { "RangeError", "StandardError" },
+        { "ZeroDivisionError", "StandardError" },
+        { "IOError", "StandardError" },
+        { "StopIteration", "StandardError" },
+        { "NotImplementedError", "StandardError" },
+        { "StandardError", "Exception" },
+    };
+    for (size_t i = 0; i < sizeof(A) / sizeof(A[0]); i++) {
+        if (strcmp(cls, A[i].sub) == 0) return A[i].sup;
+    }
+    return NULL;
+}
+
+/* True iff exception class `actual` IS-A `target` — equal, or descends from it
+ * through the ancestry chain. */
+int _sir_class_is_a(const char *actual, const char *target) {
+    const char *cur = actual;
+    while (cur) {
+        if (strcmp(cur, target) == 0) return 1;
+        cur = _sir_class_super(cur);
+    }
+    return 0;
+}
+
+/* Does exception `err` match a `rescue` clause listing `n` class names?  An
+ * empty list (`n == 0`, a bare `rescue`) catches every exception; otherwise the
+ * error's class must be-a one of the listed classes. */
+int _sir_rescue_matches(SirValue err, const char *const *classes, int n) {
+    if (err.tag != SIR_ERROR) return 0;
+    if (n == 0) return 1;
+    for (int i = 0; i < n; i++) {
+        if (_sir_class_is_a(err.as.err->sir_class, classes[i])) return 1;
+    }
+    return 0;
+}
+
+/* The handler stack.  A `TryCatch` pushes a `jmp_buf` and `setjmp`s it; `raise`
+ * `longjmp`s to the top.  Single-threaded emitted program, so a plain static
+ * stack is safe.  `_sir_current_error` holds the exception being handled (for a
+ * bare re-`raise` and for the rescue-clause dispatch). */
+#define SIR_MAX_HANDLERS 1024
+static jmp_buf _sir_handlers[SIR_MAX_HANDLERS];
+static int _sir_handler_top = -1;
+static SirValue _sir_current_error;
+
+/* Push a handler slot and return its index (to `setjmp`).  Overflowing the
+ * fixed stack is a hard error (pathological handler nesting). */
+int _sir_push_handler(void) {
+    if (_sir_handler_top + 1 >= SIR_MAX_HANDLERS) {
+        fprintf(stderr, "sir: exception handler stack overflow\n");
+        exit(1);
+    }
+    return ++_sir_handler_top;
+}
+void _sir_pop_handler(void) {
+    if (_sir_handler_top >= 0) _sir_handler_top--;
+}
+
+/* Raise (or re-raise) an exception.  Records it as the current error and
+ * `longjmp`s to the top handler; with no handler installed, it is uncaught —
+ * print `class: message` to stderr and exit non-zero (Ruby's default).  Returns
+ * `SirValue` only to fit the builtin-call expression contract; it never returns
+ * normally (`longjmp`/`exit`). */
+SirValue _sir_raise(SirValue exc) {
+    _sir_current_error = exc;
+    if (_sir_handler_top >= 0) {
+        longjmp(_sir_handlers[_sir_handler_top], 1);
+    }
+    if (exc.tag == SIR_ERROR) {
+        fputs(exc.as.err->sir_class, stderr);
+        if (exc.as.err->msg.tag != SIR_NIL) {
+            fputs(": ", stderr);
+            _sir_fmt(stderr, exc.as.err->msg);
+        }
+    }
+    fputc('\n', stderr);
+    exit(1);
+    return _sir_nil(); /* unreachable */
+}
+
+/* `raise <value>`: an exception object is re-raised as-is; any other value
+ * (typically a message string) becomes a `RuntimeError` carrying it — matching
+ * Ruby's `raise "boom"`. */
+SirValue _sir_raise_value(SirValue v) {
+    if (v.tag == SIR_ERROR) return _sir_raise(v);
+    return _sir_raise(_sir_error("RuntimeError", v));
 }
 
 SirValue _sir_print_v(SirValue *xs, int n) {

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_exceptions.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_exceptions.rs
@@ -1,0 +1,275 @@
+//! Execution proof for SIR17 exceptions on the C backend — hand-build modules
+//! (producer-agnostic), emit C, compile with a real gcc/clang-style compiler,
+//! run, assert stdout. Skips gracefully when no `cc` is present.
+//!
+//! C has no unwinding, so `begin … rescue … ensure … end` lowers to a
+//! `setjmp`/`longjmp` handler stack with a baked-in exception-class ancestry
+//! table. These tests drive the whole path through a real `cc`: catching a
+//! raised message, class matching via the ancestry (`rescue StandardError`
+//! catches a `RuntimeError`), the rescue binding, `ensure` on the normal AND the
+//! exception path, and propagation of an unmatched exception through an outer
+//! handler (with the inner `ensure` still running).
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, RescueClause,
+    Span, Stmt, CURRENT_SIR_VERSION,
+};
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    for cand in ["cc", "clang", "gcc"] {
+        if Command::new(cand)
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+        {
+            return Some(cand.to_string());
+        }
+    }
+    None
+}
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+/// Compile + run; returns `(stdout, exit_success)`. Does NOT assert success (an
+/// uncaught exception exits non-zero on purpose).
+fn run_raw(module: &Module) -> Option<(String, bool)> {
+    let cc = find_cc()?;
+    let artifact = semantic_ir_to_c::compile(module).expect("C backend compile (no panic)");
+    let dir = std::env::temp_dir();
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let stem = format!("sirc_exc_{}_{}", std::process::id(), n);
+    let cpath: PathBuf = dir.join(format!("{stem}.c"));
+    let exe: PathBuf = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::File::create(&cpath)
+        .and_then(|mut f| f.write_all(artifact.source.as_bytes()))
+        .expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-Werror=unused-variable", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        artifact.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    Some((
+        String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"),
+        r.status.success(),
+    ))
+}
+
+/// Compile + run, asserting the program exits 0 (the common case).
+fn run(module: &Module) -> Option<String> {
+    run_raw(module).map(|(out, ok)| {
+        assert!(ok, "program exited non-zero; stdout:\n{out}");
+        out
+    })
+}
+
+fn s() -> Span {
+    Span::synthetic()
+}
+fn strlit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+fn bc(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+fn puts(arg: Expr) -> Stmt {
+    Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: s() }
+}
+fn raise_(arg: Option<Expr>) -> Stmt {
+    Stmt::ExprStmt { expr: bc("raise", arg.into_iter().collect()), span: s() }
+}
+fn local(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: semantic_ir::Scope::Local, span: s() }
+}
+fn rescue_clause(types: Vec<&str>, binding: Option<&str>, body: Vec<Stmt>) -> RescueClause {
+    RescueClause {
+        exception_types: types.into_iter().map(String::from).collect(),
+        binding: binding.map(String::from),
+        body,
+        span: s(),
+    }
+}
+fn trycatch(body: Vec<Stmt>, rescues: Vec<RescueClause>, ensure_body: Option<Vec<Stmt>>) -> Stmt {
+    Stmt::TryCatch { body, rescues, ensure_body, span: s() }
+}
+/// A `main` module running `stmts`, declaring Exceptions + Strings.
+fn exc_module(stmts: Vec<Stmt>) -> Module {
+    Module {
+        name: "excprog".into(),
+        manifest: FeatureManifest::from_features(&[Feature::Exceptions, Feature::Strings]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+#[test]
+fn bare_rescue_catches_a_raised_message() {
+    // `begin; raise "boom"; rescue; puts "caught"; end` → the `RuntimeError` is
+    // caught by the bare rescue; the program exits 0.
+    match run(&exc_module(vec![trycatch(
+        vec![raise_(Some(strlit("boom")))],
+        vec![rescue_clause(vec![], None, vec![puts(strlit("caught"))])],
+        None,
+    )])) {
+        Some(out) => assert_eq!(out, "caught\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn rescue_standard_class_matches_a_runtime_error() {
+    // `rescue StandardError` catches a `RuntimeError` via the ancestry table.
+    match run(&exc_module(vec![trycatch(
+        vec![raise_(Some(strlit("x")))],
+        vec![rescue_clause(vec!["StandardError"], None, vec![puts(strlit("std"))])],
+        None,
+    )])) {
+        Some(out) => assert_eq!(out, "std\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn rescue_binds_the_caught_exception() {
+    // `begin; raise "boom"; rescue => e; puts(e); end` — `e` prints as its
+    // message (`_sir_fmt` of a `SIR_ERROR` shows the message).
+    match run(&exc_module(vec![trycatch(
+        vec![raise_(Some(strlit("boom")))],
+        vec![rescue_clause(vec![], Some("e"), vec![puts(local("e"))])],
+        None,
+    )])) {
+        Some(out) => assert_eq!(out, "boom\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn ensure_runs_on_both_the_normal_and_the_exception_path() {
+    // Normal path: `begin; puts "body"; ensure; puts "cleanup"; end`.
+    let normal = run(&exc_module(vec![trycatch(
+        vec![puts(strlit("body"))],
+        vec![],
+        Some(vec![puts(strlit("cleanup"))]),
+    )]));
+    if let Some(out) = normal {
+        assert_eq!(out, "body\ncleanup\n");
+    }
+    // Exception path: the body raises, a rescue catches, ensure STILL runs.
+    let caught = run(&exc_module(vec![trycatch(
+        vec![raise_(Some(strlit("x")))],
+        vec![rescue_clause(vec![], None, vec![puts(strlit("caught"))])],
+        Some(vec![puts(strlit("cleanup"))]),
+    )]));
+    match caught {
+        Some(out) => assert_eq!(out, "caught\ncleanup\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn unmatched_exception_propagates_after_inner_ensure_runs() {
+    // Inner `rescue TypeError` does NOT match a `RuntimeError`, so it propagates
+    // — but the inner `ensure` runs first — and the OUTER bare rescue catches it.
+    // `begin; begin; raise "x"; rescue TypeError; puts "inner"; ensure; puts
+    // "cleanup"; end; rescue; puts "outer"; end` → `cleanup`, then `outer`.
+    let inner = trycatch(
+        vec![raise_(Some(strlit("x")))],
+        vec![rescue_clause(vec!["TypeError"], None, vec![puts(strlit("inner"))])],
+        Some(vec![puts(strlit("cleanup"))]),
+    );
+    match run(&exc_module(vec![trycatch(
+        vec![inner],
+        vec![rescue_clause(vec![], None, vec![puts(strlit("outer"))])],
+        None,
+    )])) {
+        Some(out) => assert_eq!(out, "cleanup\nouter\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn uncaught_exception_exits_non_zero() {
+    // A `raise` with no enclosing handler is uncaught → the program exits
+    // non-zero (Ruby's default). Nothing is printed to stdout.
+    match run_raw(&exc_module(vec![raise_(Some(strlit("boom")))])) {
+        Some((out, ok)) => {
+            assert!(!ok, "an uncaught exception must exit non-zero");
+            assert_eq!(out, "", "nothing on stdout for an uncaught exception");
+        }
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn ensure_that_handles_a_nested_exception_does_not_change_what_propagates() {
+    // Regression (security review): the exception that ESCAPES an inner
+    // begin/rescue must be snapshotted before `ensure` runs — an `ensure` body
+    // that itself raises-and-rescues would otherwise overwrite the global
+    // current-error and propagate the WRONG exception. The outer rescue must see
+    // "original", not the ensure's "swallowed".
+    let nested_in_ensure = trycatch(
+        vec![raise_(Some(strlit("swallowed")))],
+        vec![rescue_clause(vec![], None, vec![puts(strlit("ensure-handled"))])],
+        None,
+    );
+    let inner = trycatch(
+        vec![raise_(Some(strlit("original")))],
+        vec![rescue_clause(vec!["TypeError"], None, vec![puts(strlit("wrong"))])],
+        Some(vec![nested_in_ensure]),
+    );
+    match run(&exc_module(vec![trycatch(
+        vec![inner],
+        vec![rescue_clause(vec![], Some("e"), vec![puts(local("e"))])],
+        None,
+    )])) {
+        Some(out) => assert_eq!(out, "ensure-handled\noriginal\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn exception_emits_the_setjmp_handler_shape() {
+    // Emit-shape: the setjmp handler stack + ancestry-based matching are present.
+    let src = semantic_ir_to_c::compile(&exc_module(vec![trycatch(
+        vec![raise_(Some(strlit("x")))],
+        vec![rescue_clause(vec!["StandardError"], Some("e"), vec![puts(local("e"))])],
+        Some(vec![puts(strlit("done"))]),
+    )]))
+    .expect("compile")
+    .source;
+    assert!(src.contains("#include <setjmp.h>"), "setjmp header:\n{src}");
+    assert!(src.contains("_sir_push_handler()"), "handler push:\n{src}");
+    assert!(src.contains("_sir_rescue_matches("), "rescue matching:\n{src}");
+    assert!(src.contains("\"StandardError\""), "quoted rescue type (no injection):\n{src}");
+}

--- a/code/specs/SIR24-semantic-ir-to-c.md
+++ b/code/specs/SIR24-semantic-ir-to-c.md
@@ -86,14 +86,18 @@ already carried the float path), `ShortCircuit` (0.9.0 — `LogicalAnd`/
 (SIR19, 0.10.0 — the `SIR_MISSING` sentinel now exists in the runtime; a
 `DirectCall` pads omitted trailing defaults with `_sir_missing()` and each
 function opens with an `if (_sir_is_missing(p)) { p = <default>; }` prologue),
-and `KeywordParams` (SIR19, 0.11.0 — KW6: a `KeywordArg` is resolved to its
+`KeywordParams` (SIR19, 0.11.0 — KW6: a `KeywordArg` is resolved to its
 callee's parameter slot BY NAME at emit time, using the thread-local signature
-map's parameter names, producing a plain positional call).
+map's parameter names, producing a plain positional call), and `Exceptions`
+(SIR17, 0.12.0 — the `setjmp`/`longjmp` handler stack of §"Exception model":
+`SIR_ERROR` value, a baked-in class-ancestry table for `rescue`-by-class
+matching, a two-handler structure so `ensure` runs even when a rescue body
+raises; `raise SomeClass` and `retry` deferred).
 
 **Still rejects** (clean, source-positioned `UnsupportedFeature`):
 `TailCalls` (C does not guarantee TCO), `Intrinsics` (empty whitelist), and
-every not-yet-landed feature (`NDArrays`,
-`Exceptions`, `Classes`, … — see the roadmap).  `Bignum` stays
+every not-yet-landed feature (`NDArrays`, `Constants`,
+`Classes`, … — see the roadmap).  `Bignum` stays
 rejected until a bignum runtime ships, so a module that *needs* arbitrary
 precision is refused rather than silently truncated.
 


### PR DESCRIPTION
## What

Adds SIR17 **exceptions** to the C backend (`semantic-ir-to-c` 0.11.0 → 0.12.0) — the session's biggest runtime addition. With the Ruby backend (#8883), `Feature::Exceptions` is now accepted on **all six** backends.

C has no stack unwinding, so `begin … rescue … ensure … end` (`Stmt::TryCatch`) and `raise` lower to a **`setjmp`/`longjmp` handler stack** (the C analogue of Go `panic`/`recover`, per the SIR24 exception-model design).

- **Runtime**: a `SIR_ERROR` value (`struct SirError { const char *sir_class; SirValue msg; }`); a static `jmp_buf` stack; `_sir_current_error`; `_sir_raise` / `_sir_raise_value`; and a **baked-in exception-class ancestry table** (`RuntimeError`/… → `StandardError` → `Exception`, `KeyError` → `IndexError`, `NoMethodError` → `NameError`) with `_sir_class_is_a` / `_sir_rescue_matches`, so `rescue StandardError` catches a raised `RuntimeError`.
- **`TryCatch` codegen**: a **two-handler** structure — an outer "ensure" handler wraps the whole thing so `ensure` runs even when a rescue body itself raises; an inner "body" handler catches from the guarded body and is popped before the rescue dispatch (so a raise in a rescue clause, or an unmatched exception, unwinds to the outer handler). The escaping exception is **snapshotted before `ensure` runs** and re-raised after.

## Safety

- **Injection**: rescue exception-type names are emitted as **quoted string literals** passed to `_sir_rescue_matches` — never bare identifiers — so no rescue type can inject source (SIR24's explicit-name-switch invariant).
- **Security review passed** — no memory-safety or injection issues: handler-stack balance verified on all paths, no `longjmp` to a returned frame, `volatile` locals correct, ancestry acyclic, totality clean. The one **LOW** correctness note (an `ensure` that handles a nested exception clobbering the propagated one) is **fixed** (snapshot) and regression-tested.

**Deferred** (each a clean rejection): `raise SomeClass` (a `Const` → needs `Constants`); `retry` (needs loop machinery). Documented v0 limitation: a bare `raise` after a nested begin/rescue re-raises the inner already-handled exception (`$!` save/restore deferred).

## Verification

- `cargo test -p semantic-ir-to-c` — **47 tests green** (8 new), compiled and run through a real `cc`: bare-rescue catch, ancestry class match, rescue binding, `ensure` on the normal AND exception path, unmatched propagation through an outer handler after the inner `ensure` runs, uncaught exits non-zero, and the ensure-does-not-mis-propagate regression.
- `cargo clippy -p semantic-ir-to-c --all-targets` clean.
- SIR24 spec §"Exception model" marked landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)