### PR TITLE
feat(num): NUM-6c — to_currency(x, code [, places]) exact money rendering (closes formatter trio)

### DIFF
--- a/code/packages/rust/adj-constraint-solver/CHANGELOG.md
+++ b/code/packages/rust/adj-constraint-solver/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.16.0] - 2026-07-23 — absorb `ComputeExpr::ToCurrency` (NUM-6c)
+
+### Changed
+
+- The solver's `ComputeExpr` walkers gain a `ComputeExpr::ToCurrency` arm (the new NUM-6c
+  `to_currency` rendering, closing the formatter trio): it renders a number to a `CODE d.dd`
+  boundary string, so the LIA/linear/CAS extractors return `None` (out of scope, like the
+  round/to_scientific/to_percent family), the observed-value substitution rebuilds it with its
+  operand substituted (carrying the currency code, place count, and mode), and
+  `is_constant_expr` recurses into its operand. No behaviour change for existing inputs —
+  cross-producer totality for the new engine variant.
+
 ## [0.15.0] - 2026-07-23 — absorb `ComputeExpr::ToPercent` (NUM-6c)
 
 ### Changed

--- a/code/packages/rust/adj-constraint-solver/Cargo.toml
+++ b/code/packages/rust/adj-constraint-solver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-constraint-solver"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Solver bridge for the adj-lang constraint sublanguage. Takes an adj-lang ConstraintSystem (symbols + constrain/solve/check), classifies it, and dispatches the linear-equality case to cas-solve's exact rational Gaussian elimination — returning solved values traced back to the constraints. The first slice (B2a) of the ADJ constraint-solving arc; SAT / linear-integer / inequality feasibility and optimization follow."
 

--- a/code/packages/rust/adj-constraint-solver/src/lib.rs
+++ b/code/packages/rust/adj-constraint-solver/src/lib.rs
@@ -351,10 +351,12 @@ fn expr_to_pred(e: &ComputeExpr) -> Option<Predicate> {
                             coef: c,
                             term: Box::new(pb),
                         })
-                    } else { int_const(b).map(|c| Predicate::Mul {
+                    } else {
+                        int_const(b).map(|c| Predicate::Mul {
                             coef: c,
                             term: Box::new(pa),
-                        }) }
+                        })
+                    }
                 }
                 _ => None, // division / aggregation: out of LIA scope
             }
@@ -371,6 +373,8 @@ fn expr_to_pred(e: &ComputeExpr) -> Option<Predicate> {
         ComputeExpr::ToScientific { .. } => None,
         // `to_percent(x, places)` likewise renders a number to a boundary string (NUM-6c).
         ComputeExpr::ToPercent { .. } => None,
+        // `to_currency(x, code, places)` likewise renders a number to a boundary string (NUM-6c).
+        ComputeExpr::ToCurrency { .. } => None,
     }
 }
 
@@ -669,6 +673,8 @@ fn linearize(e: &ComputeExpr) -> Option<LinForm> {
         ComputeExpr::ToScientific { .. } => None,
         // `to_percent(x, places)` likewise renders a number to a boundary string (NUM-6c).
         ComputeExpr::ToPercent { .. } => None,
+        // `to_currency(x, code, places)` likewise renders a number to a boundary string (NUM-6c).
+        ComputeExpr::ToCurrency { .. } => None,
     }
 }
 
@@ -2029,11 +2035,18 @@ fn substitute_observed(
             mode: *mode,
             expr: Box::new(substitute_observed(expr, variables, kb)),
         },
-        ComputeExpr::ToPercent {
+        ComputeExpr::ToPercent { places, mode, expr } => ComputeExpr::ToPercent {
+            places: *places,
+            mode: *mode,
+            expr: Box::new(substitute_observed(expr, variables, kb)),
+        },
+        ComputeExpr::ToCurrency {
+            code,
             places,
             mode,
             expr,
-        } => ComputeExpr::ToPercent {
+        } => ComputeExpr::ToCurrency {
+            code: code.clone(),
             places: *places,
             mode: *mode,
             expr: Box::new(substitute_observed(expr, variables, kb)),
@@ -2131,6 +2144,8 @@ fn poly_of(e: &ComputeExpr, x: &str) -> Option<Poly> {
         ComputeExpr::ToScientific { .. } => None,
         // `to_percent(x, places)` likewise renders a number to a boundary string (NUM-6c).
         ComputeExpr::ToPercent { .. } => None,
+        // `to_currency(x, code, places)` likewise renders a number to a boundary string (NUM-6c).
+        ComputeExpr::ToCurrency { .. } => None,
     }
 }
 
@@ -2344,6 +2359,8 @@ fn expr_to_ir(e: &ComputeExpr) -> Option<IRNode> {
         ComputeExpr::ToScientific { .. } => None,
         // `to_percent(x, places)` likewise renders a number to a boundary string (NUM-6c).
         ComputeExpr::ToPercent { .. } => None,
+        // `to_currency(x, code, places)` likewise renders a number to a boundary string (NUM-6c).
+        ComputeExpr::ToCurrency { .. } => None,
     }
 }
 
@@ -2371,6 +2388,8 @@ fn is_constant_expr(e: &ComputeExpr) -> bool {
         ComputeExpr::ToScientific { expr, .. } => is_constant_expr(expr),
         // `to_percent(c, n)` is likewise constant iff its operand is.
         ComputeExpr::ToPercent { expr, .. } => is_constant_expr(expr),
+        // `to_currency(c, code, n)` is likewise constant iff its operand is.
+        ComputeExpr::ToCurrency { expr, .. } => is_constant_expr(expr),
     }
 }
 

--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.22.0] — 2026-07-23 — NUM-6c: render `to_currency` in the audit trail
+
+The derivation-tree renderer gains a `DerivationNode::ToCurrency` arm (NUM-6c): a
+`{"node":"to_currency","code":"USD","places":n,"mode":"half_even","rendered":"USD 33.33","value":…,"operand":{…}}`
+object exposing the currency code, the decimal-place count, the stated mode, the rendered
+`CODE d.dd` string, the narrowed numeric value (the rounded amount), and the operand subtree —
+everything `adj-verify` needs to re-render from the exact source. Adds an end-to-end test driving
+`to_currency(x, code [, places])` through the built CLI: exact rendering, trailing-zero padding,
+`0`-places (JPY), the optional-`places` default, and rejection of a negative place count and a
+non-identifier currency code.
+
 ## [0.21.0] — 2026-07-23 — NUM-6c: render `to_percent` in the audit trail
 
 The derivation-tree renderer gains a `DerivationNode::ToPercent` arm (NUM-6c): a

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -215,6 +215,27 @@ fn derivation_tree_json(
             jnum(*result),
             derivation_tree_json(operand, kb)
         ),
+        // A `to_currency(x, code, places)` rendering (NUM-6c): the audit exposes the currency
+        // code, the decimal-place count, the rounding mode, the `rendered` `CODE d.dd` string,
+        // the narrowed numeric `value` (the rounded amount), and the operand subtree — so a
+        // checker can re-round the operand's exact value and confirm the rendered form
+        // (ADJ-NUMERIC-SUBSTRATE §4.3).
+        D::ToCurrency {
+            code,
+            places,
+            mode,
+            rendered,
+            operand,
+            result,
+        } => format!(
+            "{{\"node\":\"to_currency\",\"code\":\"{}\",\"places\":{},\"mode\":\"{}\",\"rendered\":\"{}\",\"value\":{},\"operand\":{}}}",
+            esc(code),
+            places,
+            rounding_mode_name(*mode),
+            esc(rendered),
+            jnum(*result),
+            derivation_tree_json(operand, kb)
+        ),
     }
 }
 

--- a/code/packages/rust/adj-lang-cli/tests/num6c_to_currency_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/num6c_to_currency_e2e.rs
@@ -1,0 +1,110 @@
+//! End-to-end tests for the NUM-6c `to_currency(x, code [, places])` money rendering, driven
+//! through the built `adj-lang-cli` binary. They prove the whole path — native application
+//! surface (with a bare-identifier currency code, lexed lowercase and normalized to the
+//! canonical uppercase ISO-4217 form) → adapter/lower → the engine's exact
+//! base-10 rounding → the audit JSON — works together: the amount is rounded **exactly** (no
+//! `f64` hop), the rendered `CODE d.dd` string and the narrowed exact amount agree, the audit
+//! exposes the rendering (`node:to_currency`, `code`, `places`, `mode`, `rendered`, the
+//! operand subtree), the `places` arg is optional (a documented default) and `0` is valid, and
+//! a bad `places` is a clean compile error (ADJ-NUMERIC-SUBSTRATE §4.1, §4.3).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_num6cc_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(src: &str, tag: &str) -> (bool, String) {
+    let dir = scratch(tag);
+    let p = dir.join("case.adj");
+    std::fs::write(&p, src).unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(&p)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn to_currency_renders_amount_with_code_and_audits_the_rendering() {
+    // $100 split 3 ways = 33.333… → 2 places (half-even) = "USD 33.33", the narrowed amount
+    // held as the EXACT fraction 3333/100 — no lossy f64 hop.
+    let (ok, s) = run("let r = to_currency(100 / 3, usd, 2)\n? r\n", "value");
+    assert!(ok, "cli should succeed: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    assert!(
+        s.contains("\"rendered\":\"USD 33.33\""),
+        "renders 100/3 → USD 33.33: {s}"
+    );
+    // The exact sidecar is the true narrowed amount (33.33 = 3333/100).
+    assert!(
+        s.contains("\"num\":\"3333\"") && s.contains("\"den\":\"100\""),
+        "carries the exact narrowed amount 3333/100: {s}"
+    );
+    // The audit trail exposes the rendering as a first-class, checkable step: the node type,
+    // the currency code, the place count, the stated mode, and the rendered string.
+    assert!(
+        s.contains("\"node\":\"to_currency\"")
+            && s.contains("\"code\":\"USD\"")
+            && s.contains("\"places\":2")
+            && s.contains("\"mode\":\"half_even\""),
+        "audit records node/code/places/mode: {s}"
+    );
+}
+
+#[test]
+fn to_currency_pads_trailing_zeros_and_zero_places_drops_the_point() {
+    // An exact amount 2469/2 = 1234.5 → 2 places pads: "USD 1234.50".
+    let (ok, s) = run("let r = to_currency(2469 / 2, usd, 2)\n? r\n", "pad");
+    assert!(ok, "cli should succeed: {s}");
+    assert!(
+        s.contains("\"rendered\":\"USD 1234.50\""),
+        "1234.5 → USD 1234.50: {s}"
+    );
+    // JPY has no minor unit: 0 places drops the decimal point. 7/2 = 3.5 → "JPY 4" (half-even).
+    let (ok2, s2) = run("let r = to_currency(7 / 2, jpy, 0)\n? r\n", "zero");
+    assert!(ok2, "cli should succeed: {s2}");
+    assert!(
+        s2.contains("\"rendered\":\"JPY 4\"") && s2.contains("\"code\":\"JPY\""),
+        "3.5 at 0 places → JPY 4: {s2}"
+    );
+}
+
+#[test]
+fn to_currency_places_argument_is_optional() {
+    // `to_currency(x, code)` without a place count uses the default (two decimal places).
+    let (ok, s) = run("let r = to_currency(5, eur)\n? r\n", "default");
+    assert!(ok, "cli should succeed: {s}");
+    assert!(
+        s.contains("\"rendered\":\"EUR 5.00\"") && s.contains("\"places\":2"),
+        "the default is two decimal places: {s}"
+    );
+}
+
+#[test]
+fn a_negative_place_count_is_a_compile_error() {
+    let (ok, s) = run("let r = to_currency(100 / 3, usd, -1)\n? r\n", "negplaces");
+    assert!(
+        !ok || s.contains("\"error\""),
+        "a negative place count must be rejected: {s}"
+    );
+    assert!(
+        !s.contains("\"node\":\"to_currency\""),
+        "must not emit a rendering node: {s}"
+    );
+}
+
+#[test]
+fn a_numeric_currency_code_is_a_compile_error() {
+    // The code must be a bare identifier (`USD`), not a number — `to_currency(x, 2)` with the
+    // code slot filled by a number is a clean compile error, never a mis-render.
+    let (ok, s) = run("let r = to_currency(100 / 3, 2)\n? r\n", "numcode");
+    assert!(
+        !ok || s.contains("\"error\""),
+        "a numeric currency code must be rejected: {s}"
+    );
+}

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.61.0] — 2026-07-23
+
+### Added — NUM-6c: the `to_currency(x, code [, places])` money rendering (ADJ-NUMERIC-SUBSTRATE §4.1, §4.3)
+
+```
+let due  = to_currency(subtotal + tax, usd)      % → "USD 42.50"
+let yen  = to_currency(price, jpy, 0)            % → "JPY 1980"
+```
+
+- `to_currency` joins `round_to`/`round_sig`/`to_scientific`/`to_percent` as a built-in
+  recognised during `Apply` lowering (same native comma-list surface, no new grammar). It lowers
+  to the new `logic_engine::ComputeExpr::ToCurrency` node via a new `ExprAst::ToCurrency(expr,
+  code, places)` AST node, under the default half-even mode.
+- The **currency code** is the second argument, written as a **bare identifier** (`usd`) — it
+  parses as an `ExprAst::Ref` and is read directly at the intercept, never resolved as a slot or
+  expanded. Identifiers lex lowercase, so the code is normalized to the canonical uppercase
+  ISO-4217 form for the rendered string and the audit record (`usd` → `USD 42.50`). A
+  missing/non-identifier code (e.g. a number in the code slot) is a clean compile error.
+- The `places` third argument is **optional**: `to_currency(x, code)` uses the documented default
+  (`DEFAULT_CURRENCY_PLACES = 2`, the common minor-unit precision). A stated count must be a
+  non-negative integer literal (`≥ 0` — `to_currency(x, jpy, 0)`) within the cap
+  (`MAX_ROUND_PLACES = 100`); anything else, or the wrong argument count, is a clean compile error.
+- All four expression walkers carry the new node (cloning the code string), so it composes inside
+  formula bodies, `let`s, and predicate application positions exactly like the other precision ops.
+
 ## [0.60.0] — 2026-07-23
 
 ### Added — NUM-6c: the `to_percent(x [, places])` percentage rendering (ADJ-NUMERIC-SUBSTRATE §4.1, §4.3)

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.60.0"
+version = "0.61.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -288,6 +288,16 @@ pub enum ExprAst {
     /// surface `to_percent(x [, places])`, recognised as a built-in in [`ExprAst::Apply`]
     /// lowering (same comma-list grammar as `round_to`/`to_scientific`).
     ToPercent(Box<ExprAst>, u32),
+    /// A **currency formatting** — `to_currency(x, code [, places])` (NUM-6c). A rendering
+    /// op like [`ExprAst::ToPercent`] but carrying a currency **code** string (the first
+    /// field) alongside the decimal `places` (the second): it renders the money amount `x`
+    /// to `places` base-10-exact decimal places and prefixes the code (ADJ-NUMERIC-SUBSTRATE
+    /// §4.1, §4.3). Lowers to the distinct `logic_engine::ComputeExpr::ToCurrency` node
+    /// under the default half-even mode. `places ≥ 0` (default resolved at lowering); the
+    /// `code` is a bare identifier (`USD`) taken verbatim from the surface. Produced by the
+    /// native application surface `to_currency(x, code [, places])`, recognised as a built-in
+    /// in [`ExprAst::Apply`] lowering (same comma-list grammar as `round_to`/`to_percent`).
+    ToCurrency(Box<ExprAst>, String, u32),
     /// An aggregation over every observation of a slot.
     Agg(AggOp, String),
     /// A **formula application** used as a sub-expression: `name(arg₁, …, argₙ)`

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -1240,6 +1240,16 @@ fn lower_expr(expr: &ExprAst) -> ComputeExpr {
             mode: bignum_core::RoundingMode::HalfEven,
             expr: Box::new(lower_expr(a)),
         },
+        // `to_currency(x, code, places)` (NUM-6c): the money rendering. Lowers to the
+        // distinct engine `ToCurrency` node so the currency code, the decimal-place count,
+        // and the default half-even mode ride along and the exact-path audit records both
+        // the exact source amount and the rendered `CODE d.dd` string.
+        ExprAst::ToCurrency(a, code, places) => ComputeExpr::ToCurrency {
+            code: code.clone(),
+            places: *places,
+            mode: bignum_core::RoundingMode::HalfEven,
+            expr: Box::new(lower_expr(a)),
+        },
         ExprAst::Call2(f, a, b) => ComputeExpr::Bin(
             lower_bin_fn(*f),
             Box::new(lower_expr(a)),
@@ -1572,6 +1582,7 @@ fn collect_refs(expr: &ExprAst, out: &mut Vec<String>) {
         | ExprAst::RoundTo(a, _)
         | ExprAst::ToScientific(a, _)
         | ExprAst::ToPercent(a, _)
+        | ExprAst::ToCurrency(a, _, _)
         | ExprAst::Trunc(a)
         | ExprAst::Sign(a)
         | ExprAst::Call(_, a) => collect_refs(a, out),
@@ -1638,6 +1649,13 @@ const DEFAULT_SCI_FIGURES: u32 = 6;
 /// a concrete `places` count and the audit records what was used. Unlike the significant-
 /// figure ops, `places = 0` is a valid explicit argument (`to_percent(x, 0) = "50%"`).
 const DEFAULT_PERCENT_PLACES: u32 = 2;
+
+/// The decimal-place count `to_currency(x, code)` uses when the surface omits it (NUM-6c).
+/// Two is the common minor-unit precision (cents, pence) and matches the ISO-4217 default
+/// for the major currencies; an explicit `to_currency(x, code, n)` overrides it (e.g. `0`
+/// for JPY, `3` for KWD). Applied at lowering, so the engine node always carries a concrete
+/// `places` count and the audit records what was used. `places = 0` is a valid argument.
+const DEFAULT_CURRENCY_PLACES: u32 = 2;
 
 /// Maximum AST-nesting depth the expansion/substitution/clone walkers may descend
 /// in a single expression (ADJ-RULE-SUBSTRATE RS-1). The node budget bounds total
@@ -1724,8 +1742,9 @@ fn charged_clone(
         ExprAst::ToScientific(a, n) => {
             ExprAst::ToScientific(Box::new(charged_clone(a, budget, d)?), *n)
         }
-        ExprAst::ToPercent(a, n) => {
-            ExprAst::ToPercent(Box::new(charged_clone(a, budget, d)?), *n)
+        ExprAst::ToPercent(a, n) => ExprAst::ToPercent(Box::new(charged_clone(a, budget, d)?), *n),
+        ExprAst::ToCurrency(a, code, n) => {
+            ExprAst::ToCurrency(Box::new(charged_clone(a, budget, d)?), code.clone(), *n)
         }
         ExprAst::Trunc(a) => ExprAst::Trunc(Box::new(charged_clone(a, budget, d)?)),
         ExprAst::Sign(a) => ExprAst::Sign(Box::new(charged_clone(a, budget, d)?)),
@@ -1869,7 +1888,11 @@ fn expand_rec(
                     {
                         *v as u32
                     }
-                    _ => return Err(LowerError::FormulaBadArgument { formula: name.clone() }),
+                    _ => {
+                        return Err(LowerError::FormulaBadArgument {
+                            formula: name.clone(),
+                        })
+                    }
                 };
                 let spec = if name == "round_sig" {
                     logic_engine::RoundSpec::SigFigures(n)
@@ -1898,9 +1921,7 @@ fn expand_rec(
                 let figures = if args.len() == 2 {
                     match &args[1] {
                         ExprAst::Lit(v)
-                            if v.fract() == 0.0
-                                && *v >= 1.0
-                                && *v <= MAX_ROUND_PLACES as f64 =>
+                            if v.fract() == 0.0 && *v >= 1.0 && *v <= MAX_ROUND_PLACES as f64 =>
                         {
                             *v as u32
                         }
@@ -1935,9 +1956,7 @@ fn expand_rec(
                 let places = if args.len() == 2 {
                     match &args[1] {
                         ExprAst::Lit(v)
-                            if v.fract() == 0.0
-                                && *v >= 0.0
-                                && *v <= MAX_ROUND_PLACES as f64 =>
+                            if v.fract() == 0.0 && *v >= 0.0 && *v <= MAX_ROUND_PLACES as f64 =>
                         {
                             *v as u32
                         }
@@ -1952,6 +1971,55 @@ fn expand_rec(
                 };
                 let value = expand_rec(&args[0], formulas, depth, chain, active, budget, d)?;
                 return Ok(ExprAst::ToPercent(Box::new(value), places));
+            }
+            // NUM-6c built-in: `to_currency(x, code [, places])` — the money rendering.
+            // Recognised by NAME here, before the user-formula lookup. The SECOND argument
+            // is the currency CODE — a bare identifier (`USD`) taken verbatim: it parses as
+            // an `ExprAst::Ref` and is NOT resolved as a slot (we read its name directly and
+            // never expand it). `places` is OPTIONAL (3rd arg): default [`DEFAULT_CURRENCY_PLACES`];
+            // a stated count must be a NON-NEGATIVE integer literal (`≥ 0` — `to_currency(x,
+            // JPY, 0)`) within the precision cap [`MAX_ROUND_PLACES`]. A missing/non-identifier
+            // code, a non-integer/negative/oversized/non-literal `places`, or the wrong argument
+            // count is a clean compile error.
+            if name == "to_currency" {
+                if args.len() < 2 || args.len() > 3 {
+                    return Err(LowerError::FormulaArity {
+                        formula: name.clone(),
+                        expected: 3,
+                        got: args.len(),
+                    });
+                }
+                // The code is a bare identifier (an un-expanded `Ref`); anything else is a
+                // bad argument (a number, a formula application, an already-substituted value).
+                // Identifiers lex lowercase (`usd`), but currency codes are canonically the
+                // uppercase ISO-4217 form, so we normalize to uppercase for the rendered
+                // `CODE d.dd` string and the audit record — `usd` → `USD 33.33`.
+                let code = match &args[1] {
+                    ExprAst::Ref(c) if !c.is_empty() => c.to_uppercase(),
+                    _ => {
+                        return Err(LowerError::FormulaBadArgument {
+                            formula: name.clone(),
+                        })
+                    }
+                };
+                let places = if args.len() == 3 {
+                    match &args[2] {
+                        ExprAst::Lit(v)
+                            if v.fract() == 0.0 && *v >= 0.0 && *v <= MAX_ROUND_PLACES as f64 =>
+                        {
+                            *v as u32
+                        }
+                        _ => {
+                            return Err(LowerError::FormulaBadArgument {
+                                formula: name.clone(),
+                            })
+                        }
+                    }
+                } else {
+                    DEFAULT_CURRENCY_PLACES
+                };
+                let value = expand_rec(&args[0], formulas, depth, chain, active, budget, d)?;
+                return Ok(ExprAst::ToCurrency(Box::new(value), code, places));
             }
             // Resolve the callee against the SAME registry the top-level query path
             // uses. An unknown name is a clean, specific error — distinct from an
@@ -2050,6 +2118,11 @@ fn expand_rec(
         )),
         ExprAst::ToPercent(a, n) => Ok(ExprAst::ToPercent(
             Box::new(expand_rec(a, formulas, depth, chain, active, budget, d)?),
+            *n,
+        )),
+        ExprAst::ToCurrency(a, code, n) => Ok(ExprAst::ToCurrency(
+            Box::new(expand_rec(a, formulas, depth, chain, active, budget, d)?),
+            code.clone(),
             *n,
         )),
         ExprAst::Trunc(a) => Ok(ExprAst::Trunc(Box::new(expand_rec(
@@ -2239,6 +2312,11 @@ fn substitute_expr(
         ExprAst::ToPercent(a, n) => {
             ExprAst::ToPercent(Box::new(substitute_expr(a, subst, budget, d)?), *n)
         }
+        ExprAst::ToCurrency(a, code, n) => ExprAst::ToCurrency(
+            Box::new(substitute_expr(a, subst, budget, d)?),
+            code.clone(),
+            *n,
+        ),
         ExprAst::Trunc(a) => ExprAst::Trunc(Box::new(substitute_expr(a, subst, budget, d)?)),
         ExprAst::Sign(a) => ExprAst::Sign(Box::new(substitute_expr(a, subst, budget, d)?)),
         ExprAst::Call(f, a) => ExprAst::Call(*f, Box::new(substitute_expr(a, subst, budget, d)?)),

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.49.0] — 2026-07-23 — NUM-6c: `to_currency` — money rendering (base-10-exact)
+
+Completes the NUM-6c formatter trio (`ADJ-NUMERIC-SUBSTRATE.md` §4.1, §4.3): a **rendering**
+op that renders a money amount to a stated number of base-10-exact decimal places and prefixes
+a currency code. Unlike `to_scientific`/`to_percent` it carries a **string** (the currency
+code), so it is a distinct node shape.
+
+### Added
+
+- `ComputeExpr::ToCurrency { code, places, mode, expr }` and the matching
+  `DerivationNode::ToCurrency { code, places, mode, rendered, operand, result }`. `result` is
+  the rounded amount the string denotes (`"USD 1234.50"` → `1234.5`).
+- `currency(r, places, mode)` — renders an exact amount as a fixed-point decimal (no code; the
+  caller prefixes it) and returns the narrowed amount alongside, both from one rounding. The
+  scaled integer is `C = round(x·10^places)` under `mode`; the string places the point `places`
+  from `C`'s right (`1234.5 → "1234.50"` at 2 places), the narrowed amount is `C / 10^places`.
+  `places = 0` drops the decimal point; zero renders `"CODE 0.00"`. All big-integer/-decimal —
+  base-10-exact money, no `f64` hop. Dimension-preserving.
+- Extracted a shared `fixed_decimal_body` helper (used by both `percent` and `currency`) — the
+  decimal-point placement + leading-zero padding, behaviour-preserving for `to_percent`.
+
 ## [0.48.0] — 2026-07-23 — NUM-6c: `to_percent` — percentage rendering (exact)
 
 Adds the second NUM-6c formatter (`ADJ-NUMERIC-SUBSTRATE.md` §4.1, §4.3): a **rendering**

--- a/code/packages/rust/logic-engine/Cargo.toml
+++ b/code/packages/rust/logic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logic-engine"
-version = "0.48.0"
+version = "0.49.0"
 edition = "2021"
 description = "Probability-aware facts, rules, KB, SLD find-first/enumerate + WMC posterior + LP19e likelihood-ratio Bayesian aggregation."
 

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -182,7 +182,10 @@ impl ExactRational {
         if !(0..=MAX_EXACT_POW).contains(&exp) {
             return None;
         }
-        self.0.try_pow(exp as i32, MAX_EXACT_POW_BITS).ok().map(Self)
+        self.0
+            .try_pow(exp as i32, MAX_EXACT_POW_BITS)
+            .ok()
+            .map(Self)
     }
 }
 
@@ -452,6 +455,22 @@ pub enum ComputeExpr {
         mode: RoundingMode,
         expr: Box<ComputeExpr>,
     },
+    /// A **currency formatting** — `to_currency(x, code [, places])` (NUM-6c). A rendering
+    /// op like [`ComputeExpr::ToPercent`], but it carries a currency **code** string (not
+    /// just a numeric precision), so it is a distinct node shape: it renders the money
+    /// amount `x` to `places` base-10-exact decimal places under `mode` and prefixes the
+    /// stated code (`to_currency(1234.5, USD, 2) = "USD 1234.50"`). The narrowed numeric
+    /// value is the rounded amount (`"USD 1234.50"` → `246900/200 = 1234.5`), so a
+    /// downstream predicate over the binding still sees the money magnitude, and the audit
+    /// carries both the exact source and the rendered form (ADJ-NUMERIC-SUBSTRATE §4.1,
+    /// §4.3). `places ≥ 0`; the default (2, the common minor-unit precision) is resolved at
+    /// lowering. Dimension-preserving (the `code` is a rendering label, not a re-typing).
+    ToCurrency {
+        code: String,
+        places: u32,
+        mode: RoundingMode,
+        expr: Box<ComputeExpr>,
+    },
 }
 
 /// *What* precision a [`ComputeExpr::Round`] narrows to. NUM-6a ships the
@@ -534,6 +553,20 @@ pub enum DerivationNode {
         operand: Box<DerivationNode>,
         result: f64,
     },
+    /// A **currency rendering** node (NUM-6c) — the audit record for a
+    /// `to_currency(x, code, places)`. Carries the `code`/`places`/`mode` it rendered
+    /// under, the `rendered` `CODE d.dd` string, and its single `operand` subtree (the
+    /// exact source amount), so `adj-verify` can re-round the operand's exact value and
+    /// confirm the `rendered` form (ADJ-NUMERIC-SUBSTRATE §4.3). `result` is the narrowed
+    /// numeric value — the rounded money amount.
+    ToCurrency {
+        code: String,
+        places: u32,
+        mode: RoundingMode,
+        rendered: String,
+        operand: Box<DerivationNode>,
+        result: f64,
+    },
 }
 
 impl DerivationNode {
@@ -547,6 +580,7 @@ impl DerivationNode {
             DerivationNode::Round { result, .. } => *result,
             DerivationNode::ToScientific { result, .. } => *result,
             DerivationNode::ToPercent { result, .. } => *result,
+            DerivationNode::ToCurrency { result, .. } => *result,
         }
     }
 }
@@ -954,11 +988,16 @@ fn eval(
             expr,
         } => eval_to_scientific(*figures, *mode, expr, kb, depth),
 
-        ComputeExpr::ToPercent {
+        ComputeExpr::ToPercent { places, mode, expr } => {
+            eval_to_percent(*places, *mode, expr, kb, depth)
+        }
+
+        ComputeExpr::ToCurrency {
+            code,
             places,
             mode,
             expr,
-        } => eval_to_percent(*places, *mode, expr, kb, depth),
+        } => eval_to_currency(code, *places, *mode, expr, kb, depth),
 
         ComputeExpr::Agg(op, slot) => {
             let observations = kb.observed_values_all(slot);
@@ -1136,18 +1175,33 @@ fn eval_unary(
             ComputeOp::Abs => Some(ExactRational::from_ratio(r.as_ratio().abs())),
             ComputeOp::Floor => {
                 let (q, rem) = n.div_rem(d);
-                int(if rem.is_negative() { &q - &BigInteger::one() } else { q })
+                int(if rem.is_negative() {
+                    &q - &BigInteger::one()
+                } else {
+                    q
+                })
             }
             ComputeOp::Ceil => {
                 let (q, rem) = n.div_rem(d);
-                int(if rem.is_positive() { &q + &BigInteger::one() } else { q })
+                int(if rem.is_positive() {
+                    &q + &BigInteger::one()
+                } else {
+                    q
+                })
             }
             ComputeOp::Round => {
                 let (q, rem) = n.div_rem(d);
-                let twice = { let a = rem.abs(); &a + &a };
+                let twice = {
+                    let a = rem.abs();
+                    &a + &a
+                };
                 if twice >= *d {
                     // fractional part ≥ 1/2 → round away from zero (ties away from zero)
-                    int(if n.is_negative() { &q - &BigInteger::one() } else { &q + &BigInteger::one() })
+                    int(if n.is_negative() {
+                        &q - &BigInteger::one()
+                    } else {
+                        &q + &BigInteger::one()
+                    })
                 } else {
                     int(q)
                 }
@@ -1215,7 +1269,9 @@ fn eval_round(
     // narrowing as a clean number — the same "no silently-wrong number" guard the
     // other ops apply.
     if !result.is_finite() {
-        return Err(ComputeError::NonFinite { op: ComputeOp::Round });
+        return Err(ComputeError::NonFinite {
+            op: ComputeOp::Round,
+        });
     }
     Ok((
         DerivationNode::Round {
@@ -1363,11 +1419,8 @@ fn scientific(r: &ExactRational, figures: u32, mode: RoundingMode) -> (String, E
     } else {
         (num, &den * &ten_to((-p) as u32))
     };
-    let c_bd = BigDecimal::from_integer(dividend).div_round(
-        &BigDecimal::from_integer(divisor),
-        0,
-        mode,
-    );
+    let c_bd =
+        BigDecimal::from_integer(dividend).div_round(&BigDecimal::from_integer(divisor), 0, mode);
     let mut c = bigdecimal_to_integer(&c_bd);
 
     // Rounding carry: `9.99…` at 3 figs rounds to `10.0…` = `10^figures`. Bump the
@@ -1482,28 +1535,106 @@ fn percent(r: &ExactRational, places: u32, mode: RoundingMode) -> (String, Exact
     );
     let c = bigdecimal_to_integer(&c_bd);
     let neg = c.is_negative();
-    let mag = c.abs().to_string();
-
-    // Place the decimal point `places` from the right of the magnitude digits, padding on
-    // the left so there is always at least one integer digit (`0.05`, not `.05`).
-    let body = if places == 0 {
-        mag
-    } else {
-        let p = places as usize;
-        let mag = if mag.len() <= p {
-            format!("{}{}", "0".repeat(p + 1 - mag.len()), mag)
-        } else {
-            mag
-        };
-        let split = mag.len() - p;
-        format!("{}.{}", &mag[..split], &mag[split..])
-    };
+    let body = fixed_decimal_body(c.abs().to_string(), places);
     let sign = if neg { "-" } else { "" };
     let rendered = format!("{sign}{body}%");
 
     // Narrowed fraction = C / 10^(places+2) (the percentage magnitude divided back by 100).
     let narrowed = ExactRational::from_ratio(BigRational::new(c, ten_to(scale_pow)));
     (rendered, narrowed)
+}
+
+/// Format a non-negative integer's digit string `mag` as a fixed-point decimal with exactly
+/// `places` fractional digits: it places the decimal point `places` from the right, padding on
+/// the left so there is always at least one integer digit (`"0.05"`, not `".05"`). `places = 0`
+/// returns the integer digits unchanged. Shared by [`percent`] and [`currency`] — the only
+/// difference between those renderers is the scale factor and the suffix/prefix around this body.
+fn fixed_decimal_body(mag: String, places: u32) -> String {
+    if places == 0 {
+        return mag;
+    }
+    let p = places as usize;
+    let mag = if mag.len() <= p {
+        format!("{}{}", "0".repeat(p + 1 - mag.len()), mag)
+    } else {
+        mag
+    };
+    let split = mag.len() - p;
+    format!("{}.{}", &mag[..split], &mag[split..])
+}
+
+/// Evaluate `to_currency(x, code, places)` (NUM-6c): render the money amount `x` to `places`
+/// base-10-exact decimal places, prefixed with the currency `code` (`"USD 1234.50"`). A
+/// **rendering** op — the narrowed numeric value is the rounded amount (so a downstream
+/// predicate over the binding still sees the money magnitude) and the exact sidecar backs the
+/// audit (ADJ-NUMERIC-SUBSTRATE §4.1, §4.3). Dimension-preserving.
+#[inline(never)]
+fn eval_to_currency(
+    code: &str,
+    places: u32,
+    mode: RoundingMode,
+    expr: &ComputeExpr,
+    kb: &KnowledgeBase,
+    depth: usize,
+) -> Result<(DerivationNode, Dimension, Option<ExactRational>), ComputeError> {
+    let (operand, dim, exact) = eval(expr, kb, depth + 1)?;
+    let (rendered, exact_out, result) = match &exact {
+        Some(r) => {
+            let (amount, narrowed) = currency(r, places, mode);
+            let value = narrowed.to_f64();
+            (format!("{code} {amount}"), Some(narrowed), value)
+        }
+        None => {
+            // Already-inexact operand: format the lossy `f64` to `places` decimals.
+            let value = operand.value();
+            (format!("{code} {:.*}", places as usize, value), None, value)
+        }
+    };
+    // A non-finite operand must not render as a clean money string — same guard as the
+    // other ops (op label reuses `Round`: `to_currency` is a rounding-based narrowing).
+    if !result.is_finite() {
+        return Err(ComputeError::NonFinite {
+            op: ComputeOp::Round,
+        });
+    }
+    Ok((
+        DerivationNode::ToCurrency {
+            code: code.to_string(),
+            places,
+            mode,
+            rendered,
+            operand: Box::new(operand),
+            result,
+        },
+        dim,
+        exact_out,
+    ))
+}
+
+/// Render an exact money amount as a fixed-point decimal string with exactly `places` decimal
+/// places (no currency code — the caller prefixes it), and return the **narrowed amount**
+/// alongside — both from one rounding so they always agree. The scaled integer is
+/// `C = round(x · 10^places)` under `mode`; the string places the decimal point `places` from
+/// `C`'s right (`1234.5 → "1234.50"` at 2 places), and the narrowed amount is `C / 10^places`.
+/// Zero and `places = 0` are handled by the shared padding path. All arithmetic is exact
+/// big-integer/-decimal — base-10-exact money, no `f64` hop.
+fn currency(r: &ExactRational, places: u32, mode: RoundingMode) -> (String, ExactRational) {
+    // `C = round(r · 10^places)` — the amount's digits scaled to an integer.
+    let dividend = r.numerator() * &ten_to(places);
+    let c_bd = BigDecimal::from_integer(dividend).div_round(
+        &BigDecimal::from_integer(r.denominator().clone()),
+        0,
+        mode,
+    );
+    let c = bigdecimal_to_integer(&c_bd);
+    let neg = c.is_negative();
+    let body = fixed_decimal_body(c.abs().to_string(), places);
+    let sign = if neg { "-" } else { "" };
+    let amount = format!("{sign}{body}");
+
+    // Narrowed amount = C / 10^places.
+    let narrowed = ExactRational::from_ratio(BigRational::new(c, ten_to(places)));
+    (amount, narrowed)
 }
 
 /// Round an `f64` to `spec`'s precision — the fallback for an operand that carried
@@ -1984,12 +2115,7 @@ mod tests {
         // both operands share a dimension and the remainder carries it (NOT collapsed
         // to Scalar). The exact-rational sidecar is dropped (like gcd/lcm).
         let kb = kb_with(vec![quantity("a", 7, "mmol"), quantity("b", 3, "mmol")]);
-        let d = compute(
-            "m",
-            &bin(ComputeOp::Mod, refexpr("a"), refexpr("b")),
-            &kb,
-        )
-        .unwrap();
+        let d = compute("m", &bin(ComputeOp::Mod, refexpr("a"), refexpr("b")), &kb).unwrap();
         assert_eq!(d.value, 1.0);
         assert_eq!(d.dim, kb.observed_dimensioned("a").unwrap().0.dim);
         assert_eq!(d.exact, None);
@@ -2002,7 +2128,11 @@ mod tests {
         // unlike gcd/lcm).
         let neg = compute(
             "m",
-            &bin(ComputeOp::Mod, ComputeExpr::Lit(-7.0), ComputeExpr::Lit(3.0)),
+            &bin(
+                ComputeOp::Mod,
+                ComputeExpr::Lit(-7.0),
+                ComputeExpr::Lit(3.0),
+            ),
             &kb_with(vec![]),
         )
         .unwrap();
@@ -2877,10 +3007,7 @@ mod tests {
         // ⌊log₁₀(num/den)⌋ for a spread of values, incl. the boundary cases (exact
         // powers of ten, values just under a power, sub-1 values).
         let e = |num: i64, den: i64| {
-            super::msd_exponent(
-                &BigInteger::from_i64(num),
-                &BigInteger::from_i64(den),
-            )
+            super::msd_exponent(&BigInteger::from_i64(num), &BigInteger::from_i64(den))
         };
         assert_eq!(e(314159, 1000), 2); // 314.159 → MSD at 10^2
         assert_eq!(e(314, 100), 0); // 3.14 → 10^0
@@ -3116,7 +3243,7 @@ mod tests {
         let small = compute("r", &to_pct(2, frac(1, 2000)), &kb).unwrap();
         assert_eq!(pct_rendered_of(&small), "0.05%");
         assert_eq!(small.exact, ExactRational::new(5, 10000)); // 0.0005
-        // Negative: −1/4 = −0.25 → 1 place = "-25.0%", value exactly −1/4.
+                                                               // Negative: −1/4 = −0.25 → 1 place = "-25.0%", value exactly −1/4.
         let neg = compute("r", &to_pct(1, frac(-1, 4)), &kb).unwrap();
         assert_eq!(pct_rendered_of(&neg), "-25.0%");
         assert_eq!(neg.exact, ExactRational::new(-1, 4));
@@ -3143,6 +3270,77 @@ mod tests {
         // 1/7 = 0.142857… → 3 places = "14.286%" (half-even on the 4th place: …57→6).
         assert_eq!(pct_rendered_of(&d), "14.286%");
         assert_eq!(d.exact, ExactRational::new(14286, 100000)); // 0.14286
+        assert_eq!(d.dim, Dimension::Money("usd".into()));
+    }
+
+    // ---- NUM-6c: to_currency(x, code, places) — the money rendering ----
+
+    fn to_cur(code: &str, places: u32, inner: ComputeExpr) -> ComputeExpr {
+        ComputeExpr::ToCurrency {
+            code: code.to_string(),
+            places,
+            mode: RoundingMode::HalfEven,
+            expr: Box::new(inner),
+        }
+    }
+    fn cur_rendered_of(d: &Derived) -> String {
+        match &d.tree {
+            DerivationNode::ToCurrency { rendered, .. } => rendered.clone(),
+            other => panic!("expected ToCurrency node, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn to_currency_renders_amount_with_code_and_padded_places() {
+        let kb = KnowledgeBase::new();
+        // 2469/2 = 1234.5 → 2 places pads the trailing zero: "USD 1234.50", value exactly 2469/2.
+        let a = compute("r", &to_cur("USD", 2, frac(2469, 2)), &kb).unwrap();
+        assert_eq!(cur_rendered_of(&a), "USD 1234.50");
+        assert_eq!(a.exact, ExactRational::new(2469, 2));
+        // A repeating amount 10/3 = 3.333… → 2 places (half-even) = "EUR 3.33", value 333/100.
+        let b = compute("r", &to_cur("EUR", 2, frac(10, 3)), &kb).unwrap();
+        assert_eq!(cur_rendered_of(&b), "EUR 3.33");
+        assert_eq!(b.exact, ExactRational::new(333, 100));
+    }
+
+    #[test]
+    fn to_currency_zero_places_sub_one_sign_and_zero() {
+        let kb = KnowledgeBase::new();
+        // 0 places drops the decimal point: 7/2 = 3.5 → "JPY 4" (half-even to nearest even).
+        let z = compute("r", &to_cur("JPY", 0, frac(7, 2)), &kb).unwrap();
+        assert_eq!(cur_rendered_of(&z), "JPY 4");
+        assert_eq!(z.exact, ExactRational::new(4, 1));
+        // Sub-one amount 1/20 = 0.05 → 2 places = "USD 0.05" (leading zero preserved).
+        let small = compute("r", &to_cur("USD", 2, frac(1, 20)), &kb).unwrap();
+        assert_eq!(cur_rendered_of(&small), "USD 0.05");
+        assert_eq!(small.exact, ExactRational::new(1, 20));
+        // Negative: −5/4 = −1.25 → "USD -1.25", value exactly −5/4.
+        let neg = compute("r", &to_cur("USD", 2, frac(-5, 4)), &kb).unwrap();
+        assert_eq!(cur_rendered_of(&neg), "USD -1.25");
+        assert_eq!(neg.exact, ExactRational::new(-5, 4));
+        // Zero → "USD 0.00", exact 0.
+        let zero = compute("r", &to_cur("USD", 2, ComputeExpr::Lit(0.0)), &kb).unwrap();
+        assert_eq!(cur_rendered_of(&zero), "USD 0.00");
+        assert_eq!(zero.exact, ExactRational::new(0, 1));
+    }
+
+    #[test]
+    fn to_currency_is_base_ten_exact_and_preserves_dimension() {
+        // The exactness point: a bill split three ways stays exact until the render. $100
+        // / 3 = 33.333… → "USD 33.33" at 2 places; the money dimension survives.
+        let kb = kb_with(vec![money("bill", 100, "usd")]);
+        let expr = to_cur(
+            "USD",
+            2,
+            ComputeExpr::Bin(
+                ComputeOp::Div,
+                Box::new(refexpr("bill")),
+                Box::new(ComputeExpr::Lit(3.0)),
+            ),
+        );
+        let d = compute("r", &expr, &kb).unwrap();
+        assert_eq!(cur_rendered_of(&d), "USD 33.33");
+        assert_eq!(d.exact, ExactRational::new(3333, 100)); // 33.33 exactly
         assert_eq!(d.dim, Dimension::Money("usd".into()));
     }
 }

--- a/code/specs/ADJ-NUMERIC-SUBSTRATE.md
+++ b/code/specs/ADJ-NUMERIC-SUBSTRATE.md
@@ -177,7 +177,18 @@ tests → impl → security-review → babysit:
   fixed-point `d.dd%` string, and carries the narrowed *fraction* as the numeric value
   (`"33.33%"` → `3333/10000`); native `to_percent(x [, places])` surface (optional `places`,
   default 2; `≥ 0`, so `to_percent(x, 0) = "50%"`), the §4.3 audit record (`node:to_percent`),
-  and an end-to-end formula test. `to_currency` and per-`KnowledgeBase` precision follow.
+  and an end-to-end formula test. **`to_currency(x, code [, places])`** ✅ **shipped**, closing
+  the formatter trio — `ComputeExpr::ToCurrency { code, places, mode, expr }`: rounds `x` to
+  `places` decimal places on the exact base-10 path (`C = round(x·10^places)` via `BigDecimal`,
+  no `f64` hop), renders the fixed-point `CODE d.dd` string (leading-zero padded; `places = 0`
+  drops the point, e.g. JPY), and carries the narrowed *fraction* as the numeric value
+  (`to_currency(100/3, USD, 2)` → `"USD 33.33"`, exact `3333/100`); native
+  `to_currency(x, code [, places])` surface — the `code` is a bare identifier (lexed lowercase,
+  normalized to the canonical uppercase ISO-4217 form; a non-identifier code is a compile error),
+  `places` optional (default 2, `≥ 0`) — the §4.3 audit record
+  (`node:to_currency`, `code`, `places`, `mode`, `rendered`, operand subtree), and an
+  end-to-end formula test. Per-`KnowledgeBase` `BigDouble` precision (the configurable default
+  §3 defers here) follows.
 
 ---
 


### PR DESCRIPTION
## What

Adds the third and final **NUM-6c** formatter — `to_currency(x, code [, places])` — closing the `to_scientific` / `to_percent` / `to_currency` trio (ADJ-NUMERIC-SUBSTRATE §4.1, §4.3). Like the other two it is a **rendering op**: it rounds the exact source on the base-10 `BigDecimal` path (**no `f64` hop**) and carries **both** the rendered `CODE d.dd` string and the narrowed exact fraction from *one* rounding, so the boundary string can never disagree with the value it denotes and stays re-derivable from the source (the audit-trail / byte-provenance north star).

```
let due = to_currency(subtotal + tax, usd)   % → "USD 42.50"
let yen = to_currency(price, jpy, 0)          % → "JPY 1980"   (0 places drops the point)
```

## Layers

- **logic-engine 0.49.0** — new `ComputeExpr::ToCurrency { code, places, mode, expr }` + `DerivationNode::ToCurrency { .. }`. `currency(r, places, mode)`: `C = round(r·10^places)` via `BigDecimal::from_integer(dividend).div_round(&from_integer(denom), 0, mode)`; `fixed_decimal_body` places the decimal point (leading-zero padded; `places == 0` drops it, e.g. JPY). Narrowed value = `C / 10^places`. `fixed_decimal_body` is **extracted and shared with `to_percent`** (its 4 tests pass unchanged). 3 engine unit tests.
- **adj-lang 0.61.0** — `to_currency` `Apply`-intercept (arity 2..3, no new grammar). The code is a bare identifier read from `args[1]` as an un-expanded `Ref`; identifiers lex lowercase, so it is **normalized to the canonical uppercase ISO-4217 form** for render/audit (`usd` → `USD 33.33`). A non-identifier code (a number in the slot) is a clean compile error. `places` optional (default 2, `≥ 0`, `≤ 100`). AST `ExprAst::ToCurrency(expr, code, places)` + all 4 walkers.
- **adj-constraint-solver 0.16.0** — cross-producer totality: the 6 arms (5 out-of-scope `None`, `substitute_observed` rebuild, `is_constant_expr` recurse).
- **adj-lang-cli 0.22.0** — renders `node:to_currency` (code/places/mode/rendered/value/operand) in the derivation tree, both string fields JSON-escaped.

## Verification

- 3 engine unit tests + 5 end-to-end tests driving the built CLI (exact render `100/3,usd,2`→`USD 33.33` exact `3333/100`; trailing-zero pad `2469/2`→`USD 1234.50`; 0-places JPY `7/2`→`JPY 4`; optional `places`; negative-place-count + numeric-code compile errors).
- Full affected-crate `cargo test` (logic-engine, adj-lang, adj-lang-cli, adj-constraint-solver) green; clippy clean; `/security-review` passed (no findings).

Closes the NUM-6c formatter trio. Remaining for NUM-6 (#287): per-`KnowledgeBase` `BigDouble` precision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)