### PR TITLE
feat(adj-facts-stdlib): area-conversions — NIST exact unit→square-metre factors (RS-5 table)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -206,6 +206,49 @@ fn shipped_mass_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b3) Shipped table — reference/area-conversions.adj resolves via import (a
+//      second dimension: AREA), and a unit absent from the table abstains.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_area_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_area");
+    let src = stdlib().join("reference/area-conversions.adj");
+    std::fs::copy(&src, dir.join("area-conversions.adj"))
+        .expect("copy shipped area-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"area-conversions.adj\"\n\
+         ? area_to_square_metres(acre, $SqMetres)\n\
+         ? area_to_square_metres(square_mile, $SqMetres)\n\
+         ? area_to_square_metres(hectare, $SqMetres)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST exact-column factors resolve, character-for-character from the
+    // table (digit-group spaces removed, no digit changed).
+    assert!(
+        out.contains("\"SqMetres\":\"4046.8564224\""),
+        "shipped acre factor: {out}"
+    );
+    assert!(
+        out.contains("\"SqMetres\":\"2589988.110336\""),
+        "shipped square-mile factor: {out}"
+    );
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("revised-unit-conversion-factors"),
+        "carries the NIST locator: {out}"
+    );
+    // `hectare` is not a row — the engine abstains rather than inventing a factor.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "an absent unit abstains, never a fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/area-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/area-conversions.adj
@@ -1,0 +1,49 @@
+% ============================================================================
+% area-conversions — exact area-unit → square-metre factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A sibling of `length-conversions`: a native tabular relation ingested VERBATIM
+% from the SAME published NIST conversion table. Each row states an EXACT factor
+% converting one customary AREA unit to square metres:
+%
+%     ? area_to_square_metres(acre, $SqMetres)        % 4046.8564224
+%     ? area_to_square_metres(square_mile, $SqMetres) % 2589988.110336
+%
+% Why a `table` and not three hand-written `relate` clauses: this is exactly the
+% shape reference data comes in — a published table, not prose. The citable
+% artifact IS the NIST conversion-factors table at the `locator` below, whose
+% "International foot metric equivalent" column is headed **(exact)**. Every
+% factor here appears CHARACTER-FOR-CHARACTER in that column of the table (the
+% page prints them with digit-group spaces, which a number literal cannot carry,
+% so the spaces are removed but no digit is changed):
+%
+%     square rod  →  "25.292 852 64 m2"        →  25.29285264
+%     acre        →  "4046.856 422 4 m2"       →  4046.8564224
+%     square mile →  "2 589 988.110 336 m2"    →  2589988.110336
+%
+% These are the areas of the customary units defined by the 1959 international
+% yard-and-pound agreement (an acre is 4046.8564224 m² because it is exactly one
+% chain × one furlong, and 20.1168 m × 201.168 m = 4046.8564224 m²; a square mile
+% is 1609.344² m²). The whole table is defended by ONE provenance envelope rather
+% than repeating `source`/`locator`/`trust` on every row. Each `row` lowers to a
+% ground relation `area_to_square_metres(unit, square_metres)`, so the exact
+% lookup above is the ordinary SLD binding query — the engine returns the factor
+% WITH this table's citation as its proof, on the CPU, with zero model calls. A
+% looked-up factor is a number, so it can feed a `let`/`formula` downstream (e.g.
+% multiply a measurement by it) through the existing slot path.
+%
+% `trust authoritative` — a primary, re-fetchable standards reference. (See
+% ADJ-TABLES.md; and feedback_nothing_human_authored — nothing here is asserted
+% "from memory": every factor is a verbatim cell of the cited table.)
+% ============================================================================
+
+table area_to_square_metres {
+    columns unit, square_metres
+
+    row (square_rod, 25.29285264)
+    row (acre, 4046.8564224)
+    row (square_mile, 2589988.110336)
+
+    source "Defined with respect to meter"
+    locator "https://www.nist.gov/pml/us-surveyfoot/revised-unit-conversion-factors"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/area-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/area-conversions.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% area-conversions.query.adj — a worked lookup over the area-conversions table.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a "how many
+% square metres in an acre?" question: it states no conversion fact — it only
+% `import`s the grounded table and asks binding queries. The native adj-lang
+% engine resolves each `?` against the table's rows (lowered to
+% `area_to_square_metres` relations) and returns the binding + the table's
+% source/locator/trust. A unit not in the table abstains honestly — the engine
+% never invents a factor.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli area-conversions.query.adj
+% ============================================================================
+
+import "area-conversions.adj"
+
+? area_to_square_metres(square_rod, $SqMetres)   % expect 25.29285264
+? area_to_square_metres(acre, $SqMetres)         % expect 4046.8564224
+? area_to_square_metres(square_mile, $SqMetres)  % expect 2589988.110336
+? area_to_square_metres(hectare, $SqMetres)      % expect abstain — not in the table


### PR DESCRIPTION
## What

A second `reference/` conversion **dimension** (area) alongside the shipped length- and mass-conversions tables. The exact customary-area → square-metre factors, ingested verbatim from the **same** NIST *Revised Unit Conversion Factors* page that `length-conversions` already cites — whose "International foot metric equivalent" column is headed **(exact)**. Reuses the RS-5 `table` construct, so there is **no engine change**.

Each row is a character-for-character cell of the cited table (the page prints digit-group spaces, which an ADJ number literal cannot carry, so the spaces are removed but no digit is changed):

| unit | NIST cell (verbatim) | row value |
|------|----------------------|-----------|
| square rod | `25.292 852 64 m2` | `25.29285264` |
| acre | `4046.856 422 4 m2` | `4046.8564224` |
| square mile | `2 589 988.110 336 m2` | `2589988.110336` |

These are the areas of the 1959-agreement customary units (an acre is exactly one chain × one furlong: `20.1168 m × 201.168 m = 4046.8564224 m²`).

## How it fits

One provenance envelope (`source`/`locator`/`trust authoritative`) defends the whole table; each `row` lowers to a ground `area_to_square_metres(unit, square_metres)` relation, so exact lookup is the ordinary SLD binding query — the engine returns the factor **with the table's citation** as its proof, on the CPU, with zero model calls. A looked-up factor is a number, so it can feed a downstream `let`/`formula`.

## Verification

- Worked `area-conversions.query.adj` (3 hits + one honest abstention).
- E2e test `shipped_area_conversions_table_resolves_and_abstains` (added to `rs5_table_e2e.rs`): the acre and square-mile factors resolve with the NIST locator, and an absent unit (`hectare`) **abstains** rather than fabricating a factor. All 8 RS-5 table tests pass; `/security-review` passed (no findings).

**Data + test only** — no crate source or version change, so this is independent of the in-flight NUM-6c PR (which touches a different test file). Grounded strictly from a real fetched source per the anti-hallucination discipline (every factor is a verbatim table cell, not asserted from memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)