### PR TITLE
feat(hl03): introduce a writing system the first time you meet it (phase 7a)

### DIFF
--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.12.0 — introduces a script the first time you meet it (HL03 phase 7a)
+
+- **New writing systems are now introduced as-needed in the Learn sweep.** When
+  the walk first reaches a non-Latin script — Arabic, then Devanagari (Hindi),
+  then Tamil — that step's card carries a compact **"New script"** note: the
+  script's name, its system (abjad / abugida), and *how to recognise it*, pulled
+  straight from the script data's `signature` field (e.g. Devanagari's "a
+  horizontal head-line runs across the top; letters hang beneath it like laundry
+  on a line"). It appears **once**, at the earliest concept in book order that
+  teaches the script, and never again.
+- New pure `src/scriptintro.ts`: `LANGUAGE_SCRIPT`/`scriptOf` map each chain
+  language to its writing system, `firstIntroductionByScript` computes the intro
+  concept per script from the spine + lessons, and `scriptIntroFor` returns the
+  note for a step or null. **Grounded, never invented:** a script with no JSON
+  data (Kannada / Telugu / Malayalam today) gets no note — the mapping still
+  knows the language's script, but the note is gated on having real data.
+- 13 new tests (208 total) with controls that bite: the *second* appearance of a
+  script must not re-introduce it; a script absent from the available-data set
+  yields no note. Verified in a real browser — concept #1 (COURTESY-THANKS)
+  shows the note on its Arabic / Devanagari / Tamil stops and nothing on the
+  data-less Dravidian stops. Grammar-intro is the next slice (7b).
+
 ## 0.11.0 — the review quiz remembers you (HL03 phase 6, persistence)
 
 - **The Learn-mode review quiz now persists between visits.** New

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -23,6 +23,13 @@ meant to build is made visible rather than left implicit. Prev / Next walk the
 spine; consolidation lessons (`practice`/`review`) are left to the review quiz,
 not the teaching sweep.
 
+The session **introduces writing systems as-needed** (`scriptintro.ts`): the
+first time the walk reaches a non-Latin script — Arabic, then Devanagari, then
+Tamil — that step gets a compact *"New script"* note (name, system, and how to
+recognise it, from the script data's `signature`), shown once at the earliest
+concept that teaches it. It's grounded: a script with no data (Kannada / Telugu
+/ Malayalam today) gets no note rather than an invented one.
+
 Below the sweep sits the **review pass** — the second mechanism. A randomised,
 SRS-weighted quiz draws over everything covered so far (`plan.reviewGrid`, the
 concept×language grid up to the cursor), leaning on what you keep missing

--- a/code/programs/typescript/language-ladder/package.json
+++ b/code/programs/typescript/language-ladder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ladder",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "description": "The unified curriculum learning app (HL03): walk the language chain concept by concept, seeing the threads back to what you already know, then review it all with a randomised SRS quiz. (Was the HL02 script-writing-visualizer, whose Browse/Practice/Lessons/Concepts modes it now subsumes.)",
   "type": "module",

--- a/code/programs/typescript/language-ladder/src/main.ts
+++ b/code/programs/typescript/language-ladder/src/main.ts
@@ -41,6 +41,12 @@ import { pickNext as pickReviewCell, makeRng, cellKey, type GridCell } from "./q
 import { confusions } from "./mistakes.ts";
 import { loadReview, saveReview } from "./reviewstore.ts";
 import {
+  scriptsById,
+  firstIntroductionByScript,
+  scriptIntroFor,
+  type ScriptIntro,
+} from "./scriptintro.ts";
+import {
   sweepableConcepts,
   activeChain,
   LANGUAGE_CHAIN,
@@ -109,6 +115,17 @@ const CONCEPT_LESSONS = LESSONS.filter((l) => !CONSOLIDATION_TYPES.has(l.type));
 // by any active language, in the order the book first introduces them. Constant
 // for the page's lifetime (the curriculum does not change while it is open).
 const CONCEPT_SPINE = sweepableConcepts(CONCEPT_LESSONS, activeChain(ACTIVE_COUNT));
+
+// Script introductions (phase 7). Index the script data by id, then precompute
+// which concept is the FIRST (in book order) to teach each non-Latin script we
+// have data for — the single place its "new script" note should appear. Both
+// are constant for the page's lifetime and grounded in the real scripts JSON.
+const SCRIPTS_BY_ID = scriptsById(SCRIPTS);
+const SCRIPT_INTRO_AT = firstIntroductionByScript(
+  CONCEPT_SPINE,
+  CONCEPT_LESSONS,
+  new Set(SCRIPTS_BY_ID.keys()),
+);
 
 // --- the Learn-mode review quiz (HL03 phase 6, slice 6b-2) ------------------
 //
@@ -576,7 +593,11 @@ function firstGloss(teaching: SessionStep[]): string {
 }
 
 /** One stop of the sweep: a language, its word(s) for the concept, its threads back. */
-function renderTeachingStep(step: SessionStep, ordinal: number): HTMLElement {
+function renderTeachingStep(
+  step: SessionStep,
+  ordinal: number,
+  intro: ScriptIntro | null,
+): HTMLElement {
   const card = el("div", "step");
 
   const head = el("div", "step__head");
@@ -592,6 +613,23 @@ function renderTeachingStep(step: SessionStep, ordinal: number): HTMLElement {
     head.appendChild(badge);
   }
   card.appendChild(head);
+
+  // A new writing system, the first time the walk reaches it — what it is and
+  // how to recognise it, straight from the script data (never invented).
+  if (intro) {
+    const note = el("div", "step__script");
+    const label = el("span", "step__script-label");
+    label.textContent = `New script — ${intro.name}`;
+    const sys = el("span", "step__script-system");
+    sys.textContent = intro.system;
+    note.append(label, sys);
+    if (intro.signature) {
+      const sig = el("p", "step__script-sig");
+      sig.textContent = intro.signature;
+      note.appendChild(sig);
+    }
+    card.appendChild(note);
+  }
 
   for (const lesson of step.lessons) {
     const row = el("div", "step__word");
@@ -699,7 +737,10 @@ function renderLearn(): HTMLElement {
     wrap.appendChild(none);
   } else {
     const sweep = el("div", "sweep");
-    plan.teaching.forEach((step, i) => sweep.appendChild(renderTeachingStep(step, i)));
+    plan.teaching.forEach((step, i) => {
+      const intro = scriptIntroFor(concept, step.language, SCRIPT_INTRO_AT, SCRIPTS_BY_ID);
+      sweep.appendChild(renderTeachingStep(step, i, intro));
+    });
     wrap.appendChild(sweep);
   }
 

--- a/code/programs/typescript/language-ladder/src/scriptintro.ts
+++ b/code/programs/typescript/language-ladder/src/scriptintro.ts
@@ -1,0 +1,128 @@
+// ---------------------------------------------------------------------------
+// scriptintro.ts — introducing a writing system the first time you meet it.
+//
+// The Learn session walks concepts in book order, each across the language
+// chain. The chain crosses writing systems: Latin (Spanish…German), then the
+// Arabic abjad, then the Devanagari and Dravidian abugidas. A learner shouldn't
+// be dropped into an unfamiliar script with no warning — the book "introduces
+// scripts as needed", and so should the app.
+//
+// This module answers one question, purely: for each non-Latin script the
+// curriculum uses, WHICH concept is the first (in book order) to teach it? That
+// concept's card is where the "new script" note belongs; every later appearance
+// is old news. The note's content is pulled straight from the script data
+// (`data/scripts/*.json` → `signature`), never invented — a script we have no
+// data for simply gets no note.
+//
+// Everything here is pure and data-driven, so "is this the first Devanagari
+// stop?" is unit-testable without a browser.
+// ---------------------------------------------------------------------------
+
+import type { ChainLanguage } from "./sequence.ts";
+import type { ScriptData } from "./types.ts";
+
+/**
+ * Which writing system each chain language uses. The four Latin-script languages
+ * map to "latin" — the base the learner already reads, so it is never
+ * "introduced". The Dravidian trio (kannada/telugu/malayalam) map to their own
+ * scripts even though we may not yet have `signature` data for them: the mapping
+ * is the truth about the language; whether a NOTE shows is gated separately on
+ * having data, so we never fabricate one.
+ */
+export const LANGUAGE_SCRIPT: Record<ChainLanguage, string> = {
+  spanish: "latin",
+  latin: "latin",
+  french: "latin",
+  german: "latin",
+  arabic: "arabic",
+  hindi: "devanagari",
+  tamil: "tamil",
+  kannada: "kannada",
+  telugu: "telugu",
+  malayalam: "malayalam",
+};
+
+/** The script id a language is written in; "latin" for anything off the chain. */
+export function scriptOf(language: string): string {
+  return LANGUAGE_SCRIPT[language as ChainLanguage] ?? "latin";
+}
+
+/** Index script data by its `script` id for O(1) lookup. */
+export function scriptsById(scripts: ScriptData[]): Map<string, ScriptData> {
+  const byId = new Map<string, ScriptData>();
+  for (const s of scripts) byId.set(s.script, s);
+  return byId;
+}
+
+/** The minimal lesson shape this module needs (concept tag + language). */
+interface ConceptLesson {
+  concept: string;
+  language: string;
+}
+
+/**
+ * For each non-Latin script the spine actually teaches AND we have data for, the
+ * concept tag at which it is FIRST introduced (earliest in book order).
+ *
+ * `orderedConcepts` is the book-ordered spine; a lesson whose concept is not on
+ * the spine (e.g. a writing lesson, concept "") is ignored. A script maps to the
+ * earliest spine position among all lessons written in it. Only scripts present
+ * in `available` are returned — the gate that keeps us from ever showing a note
+ * for a script with no `signature` data.
+ */
+export function firstIntroductionByScript(
+  orderedConcepts: string[],
+  lessons: ConceptLesson[],
+  available: Set<string>,
+): Map<string, string> {
+  const order = new Map<string, number>();
+  orderedConcepts.forEach((concept, index) => {
+    // First wins: a concept tag appears once in the spine, but guard anyway.
+    if (!order.has(concept)) order.set(concept, index);
+  });
+
+  const earliest = new Map<string, number>(); // script id → smallest spine index
+  for (const lesson of lessons) {
+    const index = order.get(lesson.concept);
+    if (index === undefined) continue; // concept not on the spine
+    const script = scriptOf(lesson.language);
+    if (script === "latin" || !available.has(script)) continue; // base / no data
+    const prev = earliest.get(script);
+    if (prev === undefined || index < prev) earliest.set(script, index);
+  }
+
+  const introAt = new Map<string, string>();
+  for (const [script, index] of earliest) introAt.set(script, orderedConcepts[index]!);
+  return introAt;
+}
+
+/** A "new script" note to show on a teaching step: the script + how to spot it. */
+export interface ScriptIntro {
+  /** Display name, e.g. "Devanagari". */
+  name: string;
+  /** Writing-system class, e.g. "abugida" / "abjad". */
+  system: string;
+  /** The recognition cue (the script's `signature`), or "" if none recorded. */
+  signature: string;
+}
+
+/**
+ * The intro to show for one teaching step, or null if none applies.
+ *
+ * Returns a note only when ALL hold: the step's language is non-Latin, we have
+ * data for its script, and `concept` is exactly where that script is first
+ * introduced. Everywhere else — a later concept, a Latin stop, a script with no
+ * data — returns null, so the note fires once and only once, on real data.
+ */
+export function scriptIntroFor(
+  concept: string,
+  language: string,
+  introAt: Map<string, string>,
+  byId: Map<string, ScriptData>,
+): ScriptIntro | null {
+  const script = scriptOf(language);
+  if (introAt.get(script) !== concept) return null;
+  const data = byId.get(script);
+  if (!data) return null; // gated already, but keep the type honest
+  return { name: data.name, system: data.system, signature: data.signature ?? "" };
+}

--- a/code/programs/typescript/language-ladder/src/styles.css
+++ b/code/programs/typescript/language-ladder/src/styles.css
@@ -298,6 +298,30 @@ body {
   padding: 5px 10px;
   border-radius: 0 4px 4px 0;
 }
+/* "New script" note — the first time the walk reaches a writing system. */
+.step__script {
+  margin: 8px 0 10px;
+  padding: 8px 12px;
+  background: #fff8ec;
+  border: 1px solid #f0dcae;
+  border-left: 3px solid var(--ff);
+  border-radius: 0 6px 6px 0;
+}
+.step__script-label {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ff);
+}
+.step__script-system {
+  margin-left: 8px;
+  font-size: 0.75rem;
+  color: var(--muted);
+  font-style: italic;
+}
+.step__script-sig { margin: 5px 0 0; font-size: 0.85rem; line-height: 1.5; color: var(--ink); }
+
 .learn__nav { display: flex; justify-content: space-between; gap: 10px; margin-top: 20px; }
 .learn__nav .opt {
   border: 1px solid var(--line);

--- a/code/programs/typescript/language-ladder/tests/scriptintro.test.ts
+++ b/code/programs/typescript/language-ladder/tests/scriptintro.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import {
+  scriptOf,
+  scriptsById,
+  firstIntroductionByScript,
+  scriptIntroFor,
+  LANGUAGE_SCRIPT,
+} from "../src/scriptintro";
+import type { ScriptData } from "../src/types";
+
+function scriptData(script: string, name: string, signature?: string): ScriptData {
+  return {
+    script,
+    name,
+    font: "",
+    direction: "ltr",
+    system: "abugida",
+    signature,
+    letters: [],
+  };
+}
+
+describe("scriptOf / LANGUAGE_SCRIPT", () => {
+  it("maps chain languages to their writing systems, Latin languages to 'latin'", () => {
+    expect(scriptOf("hindi")).toBe("devanagari");
+    expect(scriptOf("arabic")).toBe("arabic");
+    expect(scriptOf("tamil")).toBe("tamil");
+    expect(scriptOf("spanish")).toBe("latin");
+    expect(scriptOf("german")).toBe("latin");
+  });
+
+  it("an unknown / off-chain language is treated as Latin (no intro)", () => {
+    expect(scriptOf("klingon")).toBe("latin");
+  });
+
+  it("every chain language has a mapping", () => {
+    // all ten chain entries present
+    expect(Object.keys(LANGUAGE_SCRIPT).length).toBe(10);
+  });
+});
+
+describe("firstIntroductionByScript — first occurrence in book order", () => {
+  // spine in book order; the same script recurs across concepts.
+  const spine = ["THANKS", "HELLO", "NAME"];
+  const lessons = [
+    { concept: "THANKS", language: "spanish" }, // latin — ignored
+    { concept: "THANKS", language: "hindi" }, // devanagari FIRST here
+    { concept: "THANKS", language: "arabic" }, // arabic FIRST here
+    { concept: "HELLO", language: "hindi" }, // devanagari again — NOT an intro
+    { concept: "NAME", language: "tamil" }, // tamil FIRST here (but no data below)
+  ];
+  const available = new Set(["devanagari", "arabic", "tamil"]);
+
+  it("returns the earliest concept for each non-Latin script we have data for", () => {
+    const introAt = firstIntroductionByScript(spine, lessons, available);
+    expect(introAt.get("devanagari")).toBe("THANKS");
+    expect(introAt.get("arabic")).toBe("THANKS");
+    expect(introAt.get("tamil")).toBe("NAME");
+    expect(introAt.has("latin")).toBe(false); // base script never introduced
+  });
+
+  it("CONTROL: the SECOND appearance of a script is not its intro concept", () => {
+    const introAt = firstIntroductionByScript(spine, lessons, available);
+    // Devanagari appears in THANKS (index 0) and HELLO (index 1); the intro is
+    // THANKS. If the helper tracked the last occurrence instead of the first,
+    // this would be "HELLO" and fail.
+    expect(introAt.get("devanagari")).not.toBe("HELLO");
+    expect(introAt.get("devanagari")).toBe("THANKS");
+  });
+
+  it("omits scripts with no data — we never fabricate a note", () => {
+    const introAt = firstIntroductionByScript(spine, lessons, new Set(["arabic"]));
+    expect(introAt.has("devanagari")).toBe(false); // not in `available`
+    expect(introAt.has("tamil")).toBe(false);
+    expect(introAt.get("arabic")).toBe("THANKS");
+  });
+
+  it("ignores lessons whose concept is off the spine (e.g. writing lessons)", () => {
+    const withWriting = [...lessons, { concept: "", language: "tamil" }];
+    const introAt = firstIntroductionByScript(spine, withWriting, available);
+    expect(introAt.get("tamil")).toBe("NAME"); // the "" concept contributes nothing
+  });
+});
+
+describe("scriptIntroFor — the note for one step", () => {
+  const introAt = new Map([
+    ["devanagari", "THANKS"],
+    ["arabic", "THANKS"],
+  ]);
+  const byId = new Map([
+    ["devanagari", scriptData("devanagari", "Devanagari", "A head-line runs across the top.")],
+    ["arabic", scriptData("arabic", "Arabic", "Right-to-left cursive with dots.")],
+  ]);
+
+  it("returns the note exactly at the introducing concept", () => {
+    expect(scriptIntroFor("THANKS", "hindi", introAt, byId)).toEqual({
+      name: "Devanagari",
+      system: "abugida",
+      signature: "A head-line runs across the top.",
+    });
+  });
+
+  it("returns null at a LATER concept (the script is old news by then)", () => {
+    expect(scriptIntroFor("HELLO", "hindi", introAt, byId)).toBeNull();
+  });
+
+  it("returns null for a Latin-script language", () => {
+    expect(scriptIntroFor("THANKS", "spanish", introAt, byId)).toBeNull();
+  });
+
+  it("returns null when there is no data for the script, even if introAt names it", () => {
+    const introAtTamil = new Map([["tamil", "THANKS"]]);
+    expect(scriptIntroFor("THANKS", "tamil", introAtTamil, byId)).toBeNull();
+  });
+
+  it("tolerates a missing signature (empty string, not undefined)", () => {
+    const byIdNoSig = new Map([["devanagari", scriptData("devanagari", "Devanagari")]]);
+    expect(scriptIntroFor("THANKS", "hindi", introAt, byIdNoSig)).toEqual({
+      name: "Devanagari",
+      system: "abugida",
+      signature: "",
+    });
+  });
+});
+
+describe("scriptsById", () => {
+  it("indexes script data by its script id", () => {
+    const byId = scriptsById([scriptData("arabic", "Arabic"), scriptData("tamil", "Tamil")]);
+    expect(byId.get("arabic")?.name).toBe("Arabic");
+    expect(byId.get("tamil")?.name).toBe("Tamil");
+    expect(byId.get("missing")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

The Learn sweep crosses writing systems — Latin, then the Arabic abjad, then the Devanagari and Dravidian abugidas — and used to drop the learner into each with no warning. The book *"introduces scripts as needed"*; now the app does too.

The first time the walk reaches a **non-Latin script**, that step's card carries a compact **"New script"** note: the script's name, its system (abjad / abugida), and *how to recognise it* — pulled straight from the script data's `signature` field (e.g. Devanagari's *"a horizontal head-line runs across the top; letters hang beneath it like laundry on a line"*). It shows **once**, at the earliest concept in book order that teaches the script, and never again.

## Grounded, never invented

- New pure `src/scriptintro.ts`: `LANGUAGE_SCRIPT`/`scriptOf` map each chain language to its writing system; `firstIntroductionByScript` computes the intro concept per script from the spine + lessons; `scriptIntroFor` returns the note for a step or `null`.
- A script with **no JSON data** (Kannada / Telugu / Malayalam today) gets **no note** — the mapping still knows the language's script, but the note is gated on real data. Off-chain scripts we *do* have (Cyrillic/Hebrew/Chinese/Gujarati) never fire, since no chain language maps to them.

## Verification

- **13 new tests (208 total)** with controls that bite: the *second* appearance of a script must not re-introduce it; a script absent from the available-data set yields no note.
- **Real browser** (headless screenshot, read back): concept #1 (COURTESY-THANKS) shows the note on its **Arabic / Devanagari / Tamil** stops with their real signatures, and **nothing** on the data-less Dravidian stops or the Latin base. All glyphs render, no tofu.
- Correctness/security review (subagent): **clean** — earliest-not-last, data-gating, module-init order, single call site, `textContent`-only all verified.

## Scope

Script introduction (7a). Next: **7b** — grammar introduction (a brief note when a concept first introduces a grammar idea, e.g. `GRAMMAR-THE`).

Builds on #8889 (review persistence, merged).