### PR TITLE
feat(semantic-ir-to-ruby): classes slice 1 + constants — reflective const_set (0.11.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -46,10 +46,12 @@ through a crafted name.
 empty base class; the pre-emit scan rejects, with a source-positioned error,
 everything deferred to later slices: a **superclass** (inheritance), a
 **non-empty class body** (class-level code / constants), a **namespaced**
-(`Foo::Bar`) class or constant *definition* (`const_set` names one namespace),
-and every **OOP method builtin** (`__def_method__`, `__method__`, `__super__`,
-`__self__`, `__class_method__`, …) — so a method-bearing or inheriting class
-fails cleanly rather than mis-emitting. Instance variables (`@x`), class
+(`Foo::Bar`) class or constant *definition* (`const_set` names one namespace), a
+**singleton class** (`class << self` — `Stmt::SingletonClassDef`, which also
+observes `Feature::Classes`), and every **OOP method builtin** (`__def_method__`,
+`__method__`, `__super__`, `__self__`, `__class_method__`, …) — so a
+method-bearing, inheriting, or singleton-opening class fails cleanly rather than
+mis-emitting. Instance variables (`@x`), class
 variables (`@@x`), and modules remain unaccepted features (their own later
 slices).
 

--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Changelog
 
+## 0.11.0 — classes (slice 1) + constants
+
+Accepts `Feature::Classes` and `Feature::Constants` — the first slice of the OOP
+frontier: an **empty base class** and its **construction**, plus the entangled
+**constants** prerequisite.
+
+- **Classes.** `Stmt::ClassDef { name, superclass: None, body: [] }` — an empty
+  base class — is accepted, and `Foo.new(args…)` (the frontend's `__new__`
+  builtin, whose first argument is the class name) constructs an instance.
+- **Constants.** A `Scope::Const` assignment (`PI = 3`) and reference (`PI`,
+  `Foo::Bar`) are accepted. Constants ride in with Classes because they are
+  **entangled**: a class name IS a Ruby constant, so the frontend records
+  `Constants` in the manifest for any `Foo.new` (the receiver `Foo` is a
+  constant) — an instantiable class cannot compile without it. Accepting
+  Constants also unblocks `raise SomeClass` (a specific exception class is a
+  `Const` reference — a form the 0.10 exceptions slice deferred precisely
+  because Constants was then unaccepted).
+
+**Reflective definition (why not native `class Foo; end` / `PI = 3`).** The
+frontend wraps a program's top-level code in `main`, and Ruby forbids BOTH a
+`class` definition and a constant assignment inside a method body ("class
+definition in method body" / "dynamic constant assignment"). So a class and a
+constant are defined **reflectively**:
+
+- `class Foo; end` → `Object.const_set(:Foo, Class.new)`
+- `PI = 3` → `Object.const_set(:PI, 3)`
+
+`const_set` is legal anywhere, executes in place (no fragile hoisting /
+reordering), and still names the class (`Foo.name == "Foo"`, so `Foo.new` and
+`x.is_a?(Foo)` work). Constant *references* (`Foo.new`, bare `PI`) emit the bare
+constant, which resolves at runtime. This dynamic construction also composes
+cleanly with the next slice's `define_method` for the frontend's hoisted,
+separately-registered methods.
+
+**Injection safety.** Every constant name emitted verbatim — a `ClassDef` name,
+a `__new__` class name, a `Const` reference, and a `Const` assignment target —
+is validated as a Ruby constant path (`Foo` / `Foo::Bar`) by the SAME single
+pre-emit traversal that rejects unlowerable builtins (a unified `ScanHit`,
+**co-total with the emitter**), so a hand-built module cannot inject source
+through a crafted name.
+
+**Totality — deferred shapes rejected cleanly (never `unreachable!`).** Accepting
+`Classes` obligates handling every node it surfaces. This slice supports ONLY an
+empty base class; the pre-emit scan rejects, with a source-positioned error,
+everything deferred to later slices: a **superclass** (inheritance), a
+**non-empty class body** (class-level code / constants), a **namespaced**
+(`Foo::Bar`) class or constant *definition* (`const_set` names one namespace),
+and every **OOP method builtin** (`__def_method__`, `__method__`, `__super__`,
+`__self__`, `__class_method__`, …) — so a method-bearing or inheriting class
+fails cleanly rather than mis-emitting. Instance variables (`@x`), class
+variables (`@@x`), and modules remain unaccepted features (their own later
+slices).
+
 ## 0.10.0 — exceptions (SIR17)
 
 Accepts `Feature::Exceptions` — the first of the OOP/exception frontier, and

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/README.md
+++ b/code/packages/rust/semantic-ir-to-ruby/README.md
@@ -62,14 +62,23 @@ renders as native `def f(a, b = <default>)` (evaluated at call time when the
 argument is omitted; may reference an earlier parameter); and SIR19
 `KeywordParams` — a keyword parameter (`def f(x:)` / `def f(x: 1)`) and keyword
 argument (`f(x: 5)`) render as Ruby's native keyword forms, matched by name (so
-order-independent); and SIR17 `Exceptions` — `begin … rescue … ensure … end`
+order-independent); SIR17 `Exceptions` — `begin … rescue … ensure … end`
 (`TryCatch`) plus the `raise` / `retry` builtins render as native Ruby exception
 handling (a rescue matches by exception-class name, validated as a constant path
-before emit; `raise` of a specific class needs `Constants` and is rejected).
+before emit); and the first OOP slice — `Constants` and `Classes`. A constant
+(`PI = 3`, references `PI` / `Foo::Bar`) and an **empty base class**
+(`class Foo; end` + `Foo.new`) are defined **reflectively** with
+`Object.const_set` — the frontend wraps top-level code in `main`, where a native
+`class`/`= ` constant definition is a Ruby error, whereas `const_set` is legal
+anywhere and still names the class (so `Foo.new` / `x.is_a?(Foo)` work). Every
+constant name emitted verbatim is validated as a constant path (co-total with
+the emitter, no injection); `Constants` also lets `raise SomeClass` compile.
 Rejects `TailCalls`, `Intrinsics`, and every not-yet-wired feature (array
 indexing / slicing via `IndexGet` — `NDArrays`; array-pattern destructuring;
-collection methods, classes/OOP) until its cascade batch
-lands — each a clean, source-positioned `UnsupportedFeature`.
+collection methods; and the rest of OOP — class **methods** / `__method__`
+dispatch, **inheritance** / superclass, instance & class variables, modules —
+plus a non-empty class body or a namespaced class/constant definition) until its
+slice lands — each a clean, source-positioned `UnsupportedFeature`.
 
 ## Verification
 

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -58,6 +58,14 @@ const SUPPORTED_BUILTINS: &[&str] = &[
     // the native Ruby keywords.
     "raise",
     "retry",
+    // OOP classes slice 1 (`Feature::Classes`): `__new__` constructs an instance
+    // — the frontend's lowering of `Foo.new(args…)`.  Its first argument is the
+    // class name (a `StrLit`), emitted verbatim as the `.new` receiver after
+    // constant-path validation in the scan (so no source can inject); the rest
+    // are constructor arguments.  The OTHER OOP builtins (`__def_method__`,
+    // `__method__`, `__super__`, `__self__`, `__class_method__`, …) are
+    // deliberately absent — a module using them is rejected until their slice.
+    "__new__",
 ];
 
 /// Emit a complete self-contained Ruby source file for `m`.
@@ -119,6 +127,18 @@ pub enum ScanHit {
     /// A `rescue` clause exception type that is not a valid Ruby constant path
     /// (would inject source if emitted verbatim).
     RescueType(String, semantic_ir::Span),
+    /// A constant name/path emitted VERBATIM as a Ruby constant that is not a
+    /// valid constant path — so a metacharacter would inject source.  Covers
+    /// every such position: a `Stmt::ClassDef` name, a `__new__` call's class
+    /// name, a `Scope::Const` `VarRef` (`PI`, `Foo::Bar`), and a `Scope::Const`
+    /// `Stmt::Assign` target.  Same injection guard as `RescueType`.
+    ConstantName(String, semantic_ir::Span),
+    /// A construct that is well-formed but beyond this slice's support — a class
+    /// superclass (inheritance), a non-empty class body, or a namespaced
+    /// (`Foo::Bar`) class/constant *definition* (which `const_set` cannot name).
+    /// Carries a human-readable reason.  Deferred to a later slice; rejected
+    /// cleanly rather than mis-emitted.
+    Unsupported(String, semantic_ir::Span),
 }
 
 /// Scan the module — in a SINGLE traversal shared with the unsupported-builtin
@@ -157,8 +177,33 @@ fn scan_stmt(s: &Stmt) -> Option<ScanHit> {
     match s {
         Stmt::LetBinding { value, .. }
         | Stmt::LetStarBinding { value, .. }
-        | Stmt::ExprStmt { expr: value, .. }
-        | Stmt::Assign { value, .. } => scan_expr(value),
+        | Stmt::ExprStmt { expr: value, .. } => scan_expr(value),
+        // An `Stmt::Assign` to a `Scope::Const` target (`PI = 3`) emits the name
+        // VERBATIM as a Ruby constant, so validate it as a constant path (the
+        // same injection guard as a const reference); then scan the value. A
+        // non-const assignment routes the name through `sanitize_ident` (safe).
+        Stmt::Assign {
+            name,
+            scope,
+            value,
+            span,
+        } => {
+            if matches!(scope, Scope::Const) {
+                if !is_valid_constant_path(name) {
+                    Some(ScanHit::ConstantName(name.clone(), span.clone()))
+                } else if name.contains("::") {
+                    // `const_set` cannot name a `Foo::Bar` path.  Deferred.
+                    Some(ScanHit::Unsupported(
+                        "a namespaced constant assignment (`Foo::Bar = …`)".to_string(),
+                        span.clone(),
+                    ))
+                } else {
+                    scan_expr(value)
+                }
+            } else {
+                scan_expr(value)
+            }
+        }
         // A sequence write / iteration has sub-expressions that may themselves
         // hide an unsupported builtin — scan them (and a ForEach body) so the
         // graceful pre-check catches it rather than the emitter.
@@ -209,6 +254,45 @@ fn scan_stmt(s: &Stmt) -> Option<ScanHit> {
                     .as_ref()
                     .and_then(|e| e.iter().find_map(scan_stmt))
             }),
+        // A `Stmt::ClassDef` (`Feature::Classes`).  Slice 1 supports ONLY an
+        // empty-bodied base class → native `class Name\nend`.  At exactly the
+        // position the emitter reaches, validate that:
+        //   - the class NAME is a valid Ruby constant path — it is emitted
+        //     verbatim as the `class` name, so a metacharacter would inject;
+        //   - there is NO superclass (inheritance is a later slice);
+        //   - the body is EMPTY (class-level code / constants are a later slice).
+        // Anything else is rejected cleanly here, never reaching the emitter's
+        // `unreachable!`.  (This is why the emitter's `ClassDef` arm may ignore
+        // `superclass`/`body`: the scan guarantees they are `None`/empty.)
+        Stmt::ClassDef {
+            name,
+            superclass,
+            body,
+            span,
+        } => {
+            if !is_valid_constant_path(name) {
+                Some(ScanHit::ConstantName(name.clone(), span.clone()))
+            } else if name.contains("::") {
+                // `const_set` names a constant in ONE namespace by a bare symbol;
+                // it cannot define a `Foo::Bar` path.  Deferred.
+                Some(ScanHit::Unsupported(
+                    "a namespaced class name (`class Foo::Bar`)".to_string(),
+                    span.clone(),
+                ))
+            } else if superclass.is_some() {
+                Some(ScanHit::Unsupported(
+                    "class inheritance (a superclass)".to_string(),
+                    span.clone(),
+                ))
+            } else if !body.is_empty() {
+                Some(ScanHit::Unsupported(
+                    "a non-empty class body (class-level code or constants)".to_string(),
+                    span.clone(),
+                ))
+            } else {
+                None
+            }
+        }
         _ => None,
     }
 }
@@ -235,6 +319,21 @@ fn scan_expr(e: &Expr) -> Option<ScanHit> {
         } => {
             if !SUPPORTED_BUILTINS.contains(&name.as_str()) {
                 return Some(ScanHit::Builtin(name.clone(), span.clone()));
+            }
+            // `__new__`'s first argument is the class name, emitted VERBATIM as
+            // the `.new` receiver (`Foo.new(…)`).  Validate it here — at exactly
+            // that emitter position — as a `StrLit` holding a valid Ruby constant
+            // path, so a crafted name cannot inject source.  A malformed shape
+            // (missing / non-string class name) is reported as an unlowerable
+            // builtin rather than silently mis-emitted.
+            if name == "__new__" {
+                match args.first() {
+                    Some(Expr::StrLit { value, span }) if !is_valid_constant_path(value) => {
+                        return Some(ScanHit::ConstantName(value.clone(), span.clone()));
+                    }
+                    Some(Expr::StrLit { .. }) => {}
+                    _ => return Some(ScanHit::Builtin(name.clone(), span.clone())),
+                }
             }
             args.iter().find_map(scan_expr)
         }
@@ -274,6 +373,15 @@ fn scan_expr(e: &Expr) -> Option<ScanHit> {
         // A keyword argument carries its value as a sub-expression — scan it so
         // an unsupported builtin in `f(x: foo())` is reported cleanly.
         Expr::KeywordArg { value, .. } => scan_expr(value),
+        // A `Scope::Const` reference (`Feature::Constants`) is emitted VERBATIM
+        // as a Ruby constant (`PI`, `Foo::Bar`) by `emit_var_ref`, so validate it
+        // as a constant path here — at that emitter position — to bar injection.
+        // (Non-const scopes go through `sanitize_ident`, which is already safe.)
+        Expr::VarRef {
+            name,
+            scope: Scope::Const,
+            span,
+        } if !is_valid_constant_path(name) => Some(ScanHit::ConstantName(name.clone(), span.clone())),
         _ => None,
     }
 }
@@ -365,9 +473,23 @@ fn emit_stmt(s: &Stmt) -> String {
             format!("{} = {}", sanitize_ident(name), emit_expr(value))
         }
         Stmt::ExprStmt { expr, .. } => emit_expr(expr),
-        // SIR16 re-binding: Ruby locals are mutable, so this is a plain `=`.
-        Stmt::Assign { name, value, .. } => {
-            format!("{} = {}", sanitize_ident(name), emit_expr(value))
+        // SIR16 re-binding / SIR-constant definition.
+        // A `Scope::Const` target (`PI = 3`, `Feature::Constants`) CANNOT be a
+        // bare `PI = 3`: the frontend wraps top-level code in `main`, and a
+        // constant assignment inside a method body is a Ruby error ("dynamic
+        // constant assignment").  So define it REFLECTIVELY with `const_set`
+        // (legal anywhere, executes in place), exactly as a class does.  The
+        // scan guarantees a single-segment constant here (valid path, no `::`),
+        // so `:name` is a safe symbol literal.  Every other scope is a mutable
+        // local — a plain `=` after `sanitize_ident`.
+        Stmt::Assign {
+            name, scope, value, ..
+        } => {
+            if matches!(scope, Scope::Const) {
+                format!("Object.const_set(:{}, {})", name, emit_expr(value))
+            } else {
+                format!("{} = {}", sanitize_ident(name), emit_expr(value))
+            }
         }
         // SIR16 loop: Ruby's `while` re-tests the (already-bool) condition each
         // iteration.  The body's statements run for effect; its value is nil and
@@ -520,8 +642,23 @@ fn emit_stmt(s: &Stmt) -> String {
             s.push_str("end");
             s
         }
-        // Other SIR16+ statements (index-set/class) are not accepted; the
-        // capability check rejects such modules before emit.
+        // OOP classes slice 1 (`Feature::Classes`): an empty base-class
+        // declaration.  It CANNOT be a native `class Foo; end` block: the
+        // frontend wraps a program's top-level code in `main`, and Ruby forbids
+        // BOTH a `class` definition and a constant assignment inside a method
+        // body.  So define the class REFLECTIVELY — `Object.const_set(:Foo,
+        // Class.new)` — which is legal anywhere, names the class (`Foo.name ==
+        // "Foo"`, so `Foo.new` and `x.is_a?(Foo)` work), and executes in place
+        // (no fragile hoisting / reordering).  The scan guarantees, at this
+        // position, that `name` is a single-segment constant (valid path, no
+        // `::`), `superclass` is `None`, and `body` is empty — so `:name` is a
+        // safe symbol literal and `Class.new` takes no base / body.  (This
+        // dynamic construction also composes with the next slice's
+        // `define_method` for the frontend's hoisted, separately-registered
+        // methods.)
+        Stmt::ClassDef { name, .. } => format!("Object.const_set(:{name}, Class.new)"),
+        // Other not-yet-supported statements (e.g. index-set, module/singleton
+        // defs) are rejected by the capability check / scan before emit.
         other => unreachable!("Ruby backend reached unsupported statement: {other:?}"),
     }
 }
@@ -704,8 +841,15 @@ fn emit_var_ref(name: &str, scope: Scope) -> String {
         Scope::Local | Scope::Param | Scope::Capture => sanitize_ident(name),
         Scope::Global => format!("sir_global_get({})", quote_ruby_string(name)),
         Scope::Builtin => format!("sir_builtin_closure({})", quote_ruby_string(name)),
-        // SIR17+ scopes belong to features v0 does not accept → unreachable.
-        other => unreachable!("v0 Ruby backend reached unsupported var scope: {other:?}"),
+        // A `Scope::Const` reference (`Feature::Constants`) is a Ruby constant —
+        // emitted VERBATIM as `PI` / `Foo::Bar` (NOT through `sanitize_ident`,
+        // which would lowercase-prefix an uppercase name away from constant-hood).
+        // `first_scan_issue` has already validated the name as a constant path at
+        // this position, so it carries no injectable metacharacter.
+        Scope::Const => name.to_string(),
+        // Remaining scopes (`Instance`, `ClassVar`) belong to later OOP slices'
+        // features, not yet accepted → their modules are rejected before emit.
+        other => unreachable!("Ruby backend reached unsupported var scope: {other:?}"),
     }
 }
 
@@ -760,6 +904,19 @@ fn emit_builtin(name: &str, args: &[Expr]) -> String {
             }
         }
         "retry" => "retry".to_string(),
+        // OOP classes slice 1: `Foo.new(args…)`.  `args[0]` is a `StrLit`
+        // holding the class name, emitted VERBATIM as the constant receiver
+        // (the scan validated it as a constant path at this position, so no
+        // source can inject); `args[1..]` (already in `a`) are the constructor
+        // arguments.  Native Ruby construction — no runtime helper.
+        "__new__" => {
+            let class = match args.first() {
+                Some(Expr::StrLit { value, .. }) => value.clone(),
+                // The scan rejects a malformed `__new__` before emit.
+                _ => unreachable!("__new__ requires a string class-name first argument"),
+            };
+            format!("{class}.new({})", a[1..].join(", "))
+        }
         // Unreachable: first_scan_issue rejected anything else.
         other => unreachable!("v0 Ruby backend reached unsupported builtin: {other}"),
     }

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -293,6 +293,19 @@ fn scan_stmt(s: &Stmt) -> Option<ScanHit> {
                 None
             }
         }
+        // A `Stmt::SingletonClassDef` (`class << self`) ALSO observes
+        // `Feature::Classes` in the validator (a singleton class is a
+        // class-opening construct, not its own feature) — so accepting `Classes`
+        // obligates handling it too, or a hand-built module carrying it would
+        // pass validation + the capability check and reach the emitter's
+        // `unreachable!` (a DoS).  It is deferred to a later OOP slice; reject it
+        // cleanly here.  (`Stmt::ModuleDef` is NOT handled here because it
+        // observes the unaccepted `Feature::Modules`, so the capability check
+        // rejects such a module before this scan.)
+        Stmt::SingletonClassDef { span, .. } => Some(ScanHit::Unsupported(
+            "a singleton class (`class << self`)".to_string(),
+            span.clone(),
+        )),
         _ => None,
     }
 }

--- a/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
@@ -143,6 +143,49 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // rejected; `raise "message"`, a bare re-raise, and `rescue` by a standard
     // class or catch-all are the accepted forms.
     Feature::Exceptions,
+    // ── SIR constants ────────────────────────────────────────────────────
+    // `Feature::Constants` is observed by a `Scope::Const` name (an uppercase
+    // identifier or a `Foo::Bar` path).  Two nodes carry it, both handled:
+    //   `PI = 3`   → `Stmt::Assign { scope: Const, .. }` → native `PI = 3`
+    //   `PI` / `Foo::Bar` → `Expr::VarRef { scope: Const, .. }` → native `PI`
+    // A Ruby constant is emitted VERBATIM (not through `sanitize_ident`, which
+    // would prefix an uppercase name and destroy its constant-hood); the
+    // pre-emit scan validates every such name as a constant path (`Foo` /
+    // `Foo::Bar`), so a hand-built module cannot inject source through one.
+    //
+    // Constants is folded in with `Classes` because the two are ENTANGLED: the
+    // frontend records `Constants` in the manifest for any `Foo.new` (the
+    // receiver `Foo` is a constant), so an instantiable class cannot compile
+    // without it.  Accepting it also lets `raise SomeClass` compile (a specific
+    // exception class is a `Const` reference — a form the exceptions slice
+    // deferred precisely because Constants was unaccepted).
+    Feature::Constants,
+    // ── OOP classes, slice 1: empty declaration + construction ───────────
+    // `Feature::Classes` is observed by a module holding at least one
+    // `Stmt::ClassDef`.  This first slice accepts ONLY the minimal shape a
+    // frontend emits for `class Foo; end` — an empty-bodied, base (no
+    // superclass) class — plus `Foo.new`, which the frontend lowers to a
+    // `__new__` builtin whose first argument is the class name (a `StrLit`).
+    //   `class Foo; end`  → `Stmt::ClassDef { name: "Foo", superclass: None, body: [] }`
+    //                        → native Ruby `class Foo\nend`
+    //   `Foo.new(args…)`  → `BuiltinCall("__new__", [StrLit("Foo"), args…])`
+    //                        → native Ruby `Foo.new(args…)`
+    // Ruby is a class-based OO language, so both render as NATIVE Ruby (no
+    // runtime method-table like the Go/Rust/C value backends need).
+    //
+    // TOTALITY — accepting this feature obligates handling every node it can
+    // now surface.  `Classes` gates only `Stmt::ClassDef`, handled below; the
+    // OOP *builtins* (`__def_method__`, `__method__`, `__super__`, `__self__`,
+    // `__class_method__`, …) are NOT in `SUPPORTED_BUILTINS`, so a method-bearing
+    // class is rejected cleanly by the pre-emit scan, never reaching an
+    // `unreachable!`.  Within this slice the scan also rejects the two class
+    // shapes deferred to later slices — a **superclass** (inheritance) and a
+    // **non-empty class body** (class-level code / constants) — and validates
+    // the class name (of both `ClassDef` and `__new__`) as a Ruby constant path
+    // so a hand-built module cannot inject source through a crafted name.
+    // Instance variables / class variables / constants / modules remain
+    // unaccepted features (their own later slices).
+    Feature::Classes,
 ];
 
 impl Backend for RubyBackend {
@@ -206,6 +249,34 @@ impl Backend for RubyBackend {
                     message: format!(
                         "the Ruby backend cannot emit the rescue exception type `{name}` \
                          (not a valid Ruby constant path)"
+                    ),
+                    span,
+                });
+            }
+            // A constant name/path (a `ClassDef` name, a `__new__` class name, a
+            // `Const` reference, or a `Const` assignment target) that is not a
+            // valid Ruby constant path — it is emitted verbatim, so a
+            // metacharacter could inject source.
+            Some(emit::ScanHit::ConstantName(name, span)) => {
+                return Err(BackendError {
+                    kind: BackendErrorKind::UnsupportedFeature,
+                    message: format!(
+                        "the Ruby backend cannot emit the constant name `{name}` \
+                         (not a valid Ruby constant path)"
+                    ),
+                    span,
+                });
+            }
+            // A well-formed construct beyond this slice's support (class
+            // inheritance, a non-empty class body, or a namespaced class /
+            // constant definition) — deferred to a later slice, rejected cleanly
+            // rather than mis-emitted.
+            Some(emit::ScanHit::Unsupported(reason, span)) => {
+                return Err(BackendError {
+                    kind: BackendErrorKind::UnsupportedFeature,
+                    message: format!(
+                        "the Ruby backend does not yet support {reason} \
+                         (deferred to a later slice)"
                     ),
                     span,
                 });

--- a/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
@@ -1553,6 +1553,23 @@ fn a_non_empty_class_body_is_rejected_cleanly() {
 }
 
 #[test]
+fn a_singleton_class_is_rejected_cleanly() {
+    // Regression (security review): `Stmt::SingletonClassDef` (`class << self`)
+    // ALSO observes `Feature::Classes` in the validator, so accepting `Classes`
+    // obligates handling it — a hand-built module carrying one must be rejected
+    // cleanly, NOT reach the emitter's `unreachable!` (a DoS on a
+    // producer-agnostic module).
+    let singleton = Stmt::SingletonClassDef {
+        target: "self".into(),
+        body: vec![],
+        span: s2(),
+    };
+    let err = compile(&class_module(vec![singleton]))
+        .expect_err("a singleton class must be rejected, not panic");
+    assert_eq!(err.kind, semantic_ir::BackendErrorKind::UnsupportedFeature);
+}
+
+#[test]
 fn a_namespaced_class_name_is_rejected_cleanly() {
     // `const_set` names a constant in one namespace; a `Foo::Bar` class name is
     // deferred (not injectable — a valid path — but not yet supported).

--- a/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
@@ -1393,3 +1393,236 @@ fn injectable_rescue_type_in_the_function_value_is_rejected() {
         "an injectable rescue type in the function value must be rejected"
     );
 }
+
+// ── OOP classes slice 1 + constants (Feature::Classes, Feature::Constants) ──
+//
+// The first OOP slice: an EMPTY base class (`class Foo; end`) plus construction
+// (`Foo.new`), and the entangled `Constants` prerequisite (a class name IS a
+// Ruby constant, so any `Foo.new` makes the frontend observe `Constants`).
+//
+// Neither a native `class Foo; end` block nor a bare `PI = 3` can be emitted:
+// the frontend wraps a program's top-level code in `main`, and Ruby forbids
+// BOTH a class definition and a constant assignment inside a method body. So a
+// class / constant is defined REFLECTIVELY with `Object.const_set` — legal
+// anywhere, executing in place — which still names the class (`Foo.name`).
+//
+// Positive cases go through the real Ruby frontend + interpreter (skipping when
+// `ruby` is absent); rejection / injection cases are hand-built modules, since
+// the frontend never PRODUCES an out-of-slice or injectable shape.
+
+/// A `main` module carrying `stmts`, declaring Classes + Constants + Strings.
+fn class_module(stmts: Vec<Stmt>) -> Module {
+    Module {
+        name: "clsprog".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Classes,
+            Feature::Constants,
+            Feature::Strings,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s2() }, span: s2() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new().with_source_language("test"),
+            span: s2(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s2(),
+    }
+}
+fn classdef(name: &str, superclass: Option<&str>, body: Vec<Stmt>) -> Stmt {
+    Stmt::ClassDef {
+        name: name.into(),
+        superclass: superclass.map(Into::into),
+        body,
+        span: s2(),
+    }
+}
+fn new_expr(class: &str, args: Vec<Expr>) -> Expr {
+    let mut a = vec![strlit(class)];
+    a.extend(args);
+    Expr::BuiltinCall { name: "__new__".into(), args: a, effects: EffectSet::PURE, span: s2() }
+}
+fn const_assign(name: &str, value: Expr) -> Stmt {
+    Stmt::Assign { name: name.into(), scope: Scope::Const, value, span: s2() }
+}
+fn const_ref(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Const, span: s2() }
+}
+fn let_bind(name: &str, value: Expr) -> Stmt {
+    Stmt::LetBinding { name: name.into(), sir_type: None, value, span: s2() }
+}
+
+// ---- positive, through the real frontend + interpreter --------------------
+
+#[test]
+fn e2e_empty_class_declaration_and_construction() {
+    // `class Foo; end; x = Foo.new; puts "ok"` runs cleanly and prints "ok".
+    // Proves the empty class emits, is instantiable, and the program is valid
+    // Ruby (a `class`/`const` inside `main` would otherwise be a SyntaxError).
+    let rb = ruby_to_ruby("class Foo\nend\nx = Foo.new\nputs \"ok\"\n");
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "ok"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn empty_class_emits_reflective_const_set() {
+    // The empty class becomes `Object.const_set(:Foo, Class.new)` and the
+    // construction a native `Foo.new(...)` — NOT a native `class Foo` block
+    // (illegal inside the `main` method the frontend wraps top-level code in).
+    let rb = ruby_to_ruby("class Foo\nend\nx = Foo.new\n");
+    assert!(
+        rb.contains("Object.const_set(:Foo, Class.new)"),
+        "empty class → reflective const_set:\n{rb}"
+    );
+    assert!(rb.contains("Foo.new"), "construction → native .new:\n{rb}");
+    assert!(!rb.contains("class Foo\n"), "must NOT emit a native class block:\n{rb}");
+}
+
+#[test]
+fn e2e_constant_definition_and_reference() {
+    // `PI = 3; puts PI` prints "3" — the constant is defined reflectively and
+    // the bare reference resolves at runtime.  (Constants rides in with Classes.)
+    let rb = ruby_to_ruby("PI = 3\nputs PI\n");
+    assert!(
+        rb.contains("Object.const_set(:PI, 3)"),
+        "constant → reflective const_set:\n{rb}"
+    );
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "3"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn e2e_constant_used_in_an_expression() {
+    // A constant reference participates in arithmetic: `N = 5; puts N + 1` → 6.
+    let rb = ruby_to_ruby("N = 5\nputs N + 1\n");
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "6"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn raise_of_a_constant_exception_class_now_compiles() {
+    // Accepting `Constants` also unblocks `raise SomeClass` (a specific
+    // exception class is a `Const` reference) — a form the exceptions slice
+    // deferred precisely because `Constants` was then unaccepted.  A hand-built
+    // module `raise(ArgumentError)` (producer-agnostic — the bundled frontend
+    // lowers a bare `raise Foo` as a call, not a const ref) now compiles, and
+    // the const-referenced class is emitted as a bare Ruby constant.
+    let raise_const = Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "raise".into(),
+            args: vec![const_ref("ArgumentError")],
+            effects: EffectSet::PURE,
+            span: s2(),
+        },
+        span: s2(),
+    };
+    let rb = compile(&class_module(vec![raise_const]))
+        .expect("raise of a const exception class must compile")
+        .source;
+    assert!(rb.contains("raise(ArgumentError)"), "raise a bare constant class:\n{rb}");
+}
+
+// ---- hand-built: totality (deferred shapes rejected, never panicked) ------
+
+#[test]
+fn a_class_with_a_superclass_is_rejected_cleanly() {
+    // Inheritance is a later slice; a `class Foo < Bar` is rejected, not emitted.
+    let m = class_module(vec![classdef("Foo", Some("Bar"), vec![])]);
+    let err = compile(&m).expect_err("a superclass must be rejected");
+    assert_eq!(err.kind, semantic_ir::BackendErrorKind::UnsupportedFeature);
+}
+
+#[test]
+fn a_non_empty_class_body_is_rejected_cleanly() {
+    // Class-level code / constants are a later slice; a non-empty body rejects.
+    let m = class_module(vec![classdef("Foo", None, vec![puts(strlit("hi"))])]);
+    assert!(compile(&m).is_err(), "a non-empty class body must be rejected");
+}
+
+#[test]
+fn a_namespaced_class_name_is_rejected_cleanly() {
+    // `const_set` names a constant in one namespace; a `Foo::Bar` class name is
+    // deferred (not injectable — a valid path — but not yet supported).
+    let m = class_module(vec![classdef("Foo::Bar", None, vec![])]);
+    assert!(compile(&m).is_err(), "a namespaced class name must be rejected");
+}
+
+#[test]
+fn a_method_bearing_class_is_rejected_cleanly() {
+    // A class with a method surfaces the `__def_method__` registration builtin,
+    // which is NOT supported this slice → rejected cleanly (never `unreachable!`).
+    let def_method = Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "__def_method__".into(),
+            args: vec![strlit("Foo"), strlit("greet")],
+            effects: EffectSet::PURE,
+            span: s2(),
+        },
+        span: s2(),
+    };
+    let m = class_module(vec![classdef("Foo", None, vec![]), def_method]);
+    let err = compile(&m).expect_err("a __def_method__ builtin must be rejected");
+    assert_eq!(err.kind, semantic_ir::BackendErrorKind::UnsupportedFeature);
+}
+
+#[test]
+fn an_instance_method_call_is_rejected_cleanly() {
+    // `x.foo` lowers to the `__method__` dispatch builtin (a later slice) — a
+    // hand-built module carrying it is rejected, not emitted.
+    let call = Expr::BuiltinCall {
+        name: "__method__".into(),
+        args: vec![new_expr("Foo", vec![]), strlit("foo")],
+        effects: EffectSet::PURE,
+        span: s2(),
+    };
+    let m = class_module(vec![classdef("Foo", None, vec![]), puts(call)]);
+    assert!(compile(&m).is_err(), "a __method__ call must be rejected");
+}
+
+// ---- hand-built: injection (a crafted constant name cannot inject) --------
+
+#[test]
+fn an_injectable_class_name_is_rejected() {
+    // A `ClassDef` name is emitted into a `const_set` symbol / would name a
+    // class; a metacharacter-bearing name must be rejected, never emitted.
+    let m = class_module(vec![classdef("Foo\n  system('boom')", None, vec![])]);
+    let err = compile(&m).expect_err("an injectable class name must be rejected");
+    assert_eq!(err.kind, semantic_ir::BackendErrorKind::UnsupportedFeature);
+}
+
+#[test]
+fn an_injectable_new_class_name_is_rejected() {
+    // `__new__`'s class-name argument is emitted VERBATIM as the `.new` receiver
+    // — a crafted name (even with no matching ClassDef) must be rejected.
+    let m = class_module(vec![let_bind("x", new_expr("Foo.new; system('boom')", vec![]))]);
+    assert!(compile(&m).is_err(), "an injectable __new__ class name must be rejected");
+}
+
+#[test]
+fn an_injectable_constant_reference_is_rejected() {
+    // A `Scope::Const` reference is emitted verbatim as a Ruby constant, so a
+    // crafted name must be rejected before it can inject source.
+    let m = class_module(vec![puts(const_ref("PI; system('boom')"))]);
+    assert!(compile(&m).is_err(), "an injectable const reference must be rejected");
+}
+
+#[test]
+fn an_injectable_constant_assignment_target_is_rejected() {
+    // A `Scope::Const` assignment target is emitted into a `const_set` symbol; a
+    // crafted target must be rejected.
+    let m = class_module(vec![const_assign("PI\n=1; system('x')", ilit(1))]);
+    assert!(compile(&m).is_err(), "an injectable const assignment must be rejected");
+}

--- a/code/specs/SIR25-semantic-ir-to-ruby.md
+++ b/code/specs/SIR25-semantic-ir-to-ruby.md
@@ -76,13 +76,30 @@ SIR26 integer conversions (`Conversions`, `SizedIntegers`, `Unsigned`,
 `Floats` (native `Float`, 0.6.0), and `ShortCircuit` (native `&&`/`||`, 0.7.0);
 the SIR19 parameter batches `DefaultParams` (native `def f(a, b =
 <default>)`, 0.8.0) and `KeywordParams` (native `def f(x:)` / `f(x: 5)`, matched
-by name, 0.9.0); and SIR17 `Exceptions` (native `begin/rescue/ensure` +
-`raise`/`retry`, 0.10.0 — rescue types validated as constant paths; `raise` of a
-specific class needs `Constants`, rejected).
+by name, 0.9.0); SIR17 `Exceptions` (native `begin/rescue/ensure` +
+`raise`/`retry`, 0.10.0 — rescue types validated as constant paths); and the
+first OOP slice, `Constants` + `Classes` (0.11.0). A constant (`PI = 3`;
+references `PI` / `Foo::Bar`) and an **empty base class** (`class Foo; end` +
+`Foo.new`) are defined **reflectively** with `Object.const_set` rather than a
+native `class`/`= ` block: the frontend wraps a program's top-level code in
+`main`, where both a `class` definition and a constant assignment are Ruby
+errors, whereas `const_set` is legal anywhere, executes in place, and still names
+the class (`Foo.name == "Foo"`, so `Foo.new` / `x.is_a?(Foo)` work). The two
+features are **entangled** — a class name is a Ruby constant, so the frontend
+records `Constants` for any `Foo.new` — hence they land together; `Constants`
+also unblocks `raise SomeClass` (a `Const` reference the 0.10 slice deferred).
+Every verbatim-emitted constant name (a `ClassDef` name, a `__new__` class name,
+a `Const` reference, a `Const` assignment target) is validated as a constant path
+in the SAME pre-emit traversal as the builtin scan (co-total with the emitter),
+so no name can inject.
 
-**Still rejects** `TailCalls`, `Intrinsics`, `NDArrays`,
-`Classes`/OOP, and every not-yet-landed feature (each rejection is a clean,
-source-positioned `UnsupportedFeature`).
+**Still rejects** `TailCalls`, `Intrinsics`, `NDArrays`, and every not-yet-landed
+feature — including the rest of OOP: class **methods** (the `__def_method__` /
+`__method__` dispatch builtins), **inheritance** (a superclass / `__super__`),
+instance variables (`@x`), class variables (`@@x`), and modules; plus a
+non-empty class body and a namespaced (`Foo::Bar`) class/constant *definition*
+(`const_set` names one namespace). Each rejection is a clean, source-positioned
+`UnsupportedFeature`.
 
 ## Value model
 
@@ -114,6 +131,10 @@ or temporaries:
 | `VarRef { Local\|Param\|Capture }` | `<name>` |
 | `VarRef { Global }` | `sir_global_get("<name>")` |
 | `VarRef { Builtin }` | `sir_builtin_closure("<name>")` |
+| `VarRef { Const }` | `<name>` — the bare Ruby constant (`PI` / `Foo::Bar`), validated as a constant path |
+| `ClassDef { name, superclass: None, body: [] }` | `Object.const_set(:<name>, Class.new)` — reflective (a native `class` block is illegal in the `main` method) |
+| `Assign { Const }` | `Object.const_set(:<name>, <value>)` — reflective constant definition |
+| `BuiltinCall("__new__", [name, args…])` | `<name>.new(<args>)` — native construction |
 | `If` | `(if sir_truthy(<cond>) then <then> else <else> end)` |
 | `LogicalAnd { lhs, rhs }` | `(<lhs> && <rhs>)` — native short-circuit, yields the deciding operand |
 | `LogicalOr { lhs, rhs }` | `(<lhs> \|\| <rhs>)` — native short-circuit, yields the deciding operand |
@@ -210,8 +231,14 @@ growing `ACCEPTED_FEATURES`, the runtime, and the conformance corpus in lockstep
 4. **[`Convert`](SIR26-integer-conversions.md)** — render integer
    narrow/reinterpret via mask helpers (`sir_u8`/`sir_i32`/…) — the C→Ruby
    faithfulness payoff.
-5. **Collections / exceptions / OOP** — the `__method__` catalog (Ruby methods
-   are largely native), `begin/rescue`, `class`/`module` (native).
+5. **Exceptions / OOP** — `begin/rescue` (native, landed 0.10); then OOP in
+   slices: `Constants` + an empty `class`/`Foo.new` (reflective `const_set`,
+   landed 0.11), then class **methods** (`define_method` for the frontend's
+   hoisted, separately-registered methods), **instance/class variables**,
+   **inheritance** (`superclass`/`super`), and **modules**/mixins.
+6. **Collections** — the `__method__` catalog for built-in `String`/`Array`/
+   `Hash`/numeric methods (Ruby methods are largely native), sharing the same
+   `__method__` dispatch surface as OOP.
 
 ## Out of scope (v0)
 

--- a/code/specs/SIR25-semantic-ir-to-ruby.md
+++ b/code/specs/SIR25-semantic-ir-to-ruby.md
@@ -97,8 +97,11 @@ so no name can inject.
 feature — including the rest of OOP: class **methods** (the `__def_method__` /
 `__method__` dispatch builtins), **inheritance** (a superclass / `__super__`),
 instance variables (`@x`), class variables (`@@x`), and modules; plus a
-non-empty class body and a namespaced (`Foo::Bar`) class/constant *definition*
-(`const_set` names one namespace). Each rejection is a clean, source-positioned
+non-empty class body, a namespaced (`Foo::Bar`) class/constant *definition*
+(`const_set` names one namespace), and a **singleton class** (`class << self` —
+`Stmt::SingletonClassDef`, which also observes `Feature::Classes`, so accepting
+`Classes` obligates rejecting it in the scan lest it reach the emitter's
+`unreachable!`). Each rejection is a clean, source-positioned
 `UnsupportedFeature`.
 
 ## Value model


### PR DESCRIPTION
## What

First slice of the **OOP frontier** for the Ruby backend: an **empty base class** (`class Foo; end`) plus **construction** (`Foo.new`), and the entangled **`Constants`** prerequisite (`PI = 3`, references `PI` / `Foo::Bar`). Bumps `semantic-ir-to-ruby` 0.10.0 → 0.11.0.

## Why the two land together

A class name **is** a Ruby constant, so the frontend records `Feature::Constants` in the manifest for any `Foo.new` (the receiver `Foo` is a constant) — an instantiable class cannot compile without `Constants` accepted. Accepting `Constants` also unblocks `raise SomeClass` (a specific exception class is a `Const` reference — a form the 0.10 exceptions slice deferred precisely because `Constants` was then unaccepted).

## Reflective definition (not native `class` / `=`)

The frontend wraps a program's top-level code in `main`, and Ruby forbids **both** a `class` definition and a constant assignment inside a method body. So they are defined reflectively:

- `class Foo; end` → `Object.const_set(:Foo, Class.new)`
- `PI = 3` → `Object.const_set(:PI, 3)`

`const_set` is legal anywhere, executes in place (no fragile hoisting / reordering), and still **names** the class (`Foo.name == "Foo"`, so `Foo.new` and `x.is_a?(Foo)` work). Constant references emit the bare constant, resolved at runtime. This dynamic construction also composes cleanly with the next slice's `define_method` for the frontend's hoisted, separately-registered methods.

## Injection safety (co-total with the emitter)

Every constant name emitted verbatim — a `ClassDef` name, a `__new__` class name, a `Const` reference, and a `Const` assignment target — is validated as a Ruby constant path (`Foo` / `Foo::Bar`) by the **same single pre-emit traversal** that rejects unlowerable builtins (a unified `ScanHit`), so a hand-built module cannot inject source through a crafted name.

## Totality — deferred shapes rejected cleanly (never `unreachable!`)

Accepting `Feature::Classes` obligates handling **every** node it surfaces. This slice supports only an empty base class; the scan rejects, with a source-positioned error, everything deferred to later slices: a **superclass** (inheritance), a **non-empty class body**, a **namespaced** (`Foo::Bar`) class/constant *definition*, a **singleton class** (`class << self` — which *also* observes `Feature::Classes`), and every **OOP method builtin** (`__def_method__`, `__method__`, `__super__`, `__self__`, `__class_method__`). Instance/class variables and modules remain unaccepted features.

## Security review

A read-only security sub-agent reviewed the diff and caught one **HIGH** totality gap: `Stmt::SingletonClassDef` also observes `Feature::Classes`, so a producer-agnostic module carrying one would have reached the emitter's `unreachable!` (DoS). Fixed in a `fix(security)` commit (scan-arm rejection + regression test). All other injection / co-totality / manifest-trust concerns were verified clean.

## Tests

77 tests pass (15 new): frontend + interpreter end-to-end for the empty-class and constant paths; hand-built producer-agnostic tests for every deferred-shape rejection (superclass, non-empty body, namespaced name, singleton class, `__def_method__`, `__method__`) and the four constant-name injection guards. `cargo clippy` clean. CHANGELOG, README, and the SIR25 spec (capability declaration, node table, roadmap) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)