### PR TITLE
feat(adj-formula-stdlib): electricity — Ohm's law + electric power formula library

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_electricity_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_electricity_e2e.rs
@@ -1,0 +1,108 @@
+//! End-to-end tests for the `physics/electricity.adj` library — the foundational
+//! circuit laws (Ohm's law and electric power) — driven through the built CLI
+//! binary against the SHIPPED stdlib. Each proves the same invariant as the other
+//! formula libraries: a consumer states NO arithmetic; it imports the grounded
+//! library, binds the electrical quantities with `observe`, and the engine applies
+//! the cited law on the CPU — computing the EXACT value and rendering the applied
+//! law's citation + trust tier in the `derived` section (the auditable answer).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped electricity library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_electricity_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/physics/electricity.adj")
+        .canonicalize()
+        .expect("shipped electricity.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_elec_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_electricity_lib()).unwrap();
+    std::fs::write(dir.join("electricity.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// voltage — Ohm's law: the current times the resistance.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_electricity_library_and_computes_ohms_law_with_citation() {
+    let dir = scratch("ohm");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"electricity.adj\"\n\
+         observe current(2)\n\
+         observe resistance(3)\n\
+         ? voltage(current, resistance)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied law's result: 2 * 3 = 6.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"voltage\"") && s.contains("\"value\":6"),
+        "voltage(2, 3) = 6: {s}"
+    );
+    // … AND the HyperPhysics citation + trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"")
+            && s.contains("hyperphysics.gsu.edu/hbase/electric/ohmlaw.html"),
+        "applied law carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// power — electric power: the voltage times the current (a distinct law and a
+// distinct source), which COMPOSES with the voltage Ohm's law just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_electric_power_as_voltage_times_current_with_citation() {
+    let dir = scratch("power");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"electricity.adj\"\n\
+         observe voltage(6)\n\
+         observe current(2)\n\
+         ? power(voltage, current)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 6 * 2 = 12, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"power\"") && s.contains("\"value\":12"),
+        "power(6, 2) = 12: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"")
+            && s.contains("hyperphysics.gsu.edu/hbase/electric/elepow.html"),
+        "electric power carries its HyperPhysics citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/physics/electricity.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/electricity.adj
@@ -1,0 +1,75 @@
+% ============================================================================
+% electricity.adj — foundational circuit laws in the ADJ standard library.
+% ============================================================================
+% The electricity entry of the *physics* track, a sibling of `energy-work.adj`:
+% two of the laws a first circuits course opens with — OHM'S LAW (the voltage
+% across a resistor is its current times its resistance) and ELECTRIC POWER (the
+% power delivered is the voltage times the current) — each an importable,
+% byte-provenanced, PARAMETERIZED `formula`. As with every compute library, a
+% consumer states NO arithmetic: it `import`s this file, binds the electrical
+% quantities from its own byte-provenance decomposition, and asks the engine to
+% APPLY the cited law on the CPU. Zero math is performed by the model; the engine
+% computes each value EXACTLY, carrying the law's citation.
+%
+%     import "electricity.adj"
+%     observe current(2)       % "…a 2 A current…"    (span cited by the model)
+%     observe resistance(3)    % "…through 3 Ω…"      (span cited by the model)
+%     ? voltage(current, resistance)   % engine → 6, carrying Ohm's law V = I·R
+%
+% Both laws are EXACT over their parameters — each is a product of two measured
+% quantities. There is no *separately grounded* physical constant here (no ε₀, no
+% elementary charge), so every value the engine returns is exact; a law that needs
+% a measured constant belongs in a different, constant-carrying library. Note the
+% two laws COMPOSE: the `voltage` a consumer computes from Ohm's law can be fed
+% straight back in as the `voltage` parameter of `power` — the same term names the
+% result of one law and an input of the other, exactly as a circuit problem reads.
+%
+%   voltage(current, resistance) = current · resistance    %  V = I·R   (Ohm's law)
+%   power(voltage, current)      = voltage · current        %  P = V·I   (power)
+%
+% The definitions are quoted from Georgia State University's HyperPhysics (a
+% university .edu physics reference — the same primary source `energy-work.adj`
+% cites for kinetic energy), so each `formula` carries the provenance envelope
+% every shipped grounded clause carries; the linter rejects an unsourced one.
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable electrical quantity the laws range
+% over, and each result is the derived quantity. `voltage` appears BOTH as a
+% derived result (of Ohm's law) and as an input (to the power law), so it is a
+% single dictionary term used in both roles. The `surface` lists are the everyday
+% names a decomposer maps onto the canonical term; the trailing comment records
+% the intended SI unit.
+% ----------------------------------------------------------------------------
+dictionary electricity_vocab {
+    define current    : finding  surface "current", "I"                              % electric current, e.g. A
+    define resistance : finding  surface "resistance", "R"                           % resistance, e.g. Ω
+    define voltage    : finding  surface "voltage", "potential difference", "emf", "V"  % voltage, e.g. V
+    define power      : finding  surface "power", "electric power", "P"              % power, e.g. W
+}
+
+% ----------------------------------------------------------------------------
+% The laws. Each is a named, importable, reusable `let` over its formal parameters,
+% bound at apply time, and each carries a definitional quote from HyperPhysics (a
+% quote is required on a shipped formula). Both are products, so the engine returns
+% each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook electricity_laws {
+    use electricity_vocab
+
+    % Ohm's law — the voltage across a conductor is the current through it times
+    % its resistance. HyperPhysics states the proportionality of current to the
+    % applied voltage that Ohm's law expresses as V = I·R.
+    formula voltage(current, resistance) = current * resistance
+        source "For many conductors of electricity, the electric current which will flow through them is directly proportional to the voltage applied to them."
+        locator "https://hyperphysics.gsu.edu/hbase/electric/ohmlaw.html"
+        trust authoritative
+
+    % Electric power — the rate at which a circuit converts electrical energy,
+    % equal to the voltage times the current (P = V·I). HyperPhysics gives the
+    % electric-power relationship this way.
+    formula power(voltage, current) = voltage * current
+        source "The electric power in watts associated with a complete electric circuit or a circuit component represents the rate at which energy is converted from the electrical energy of the moving charges to some other form"
+        locator "https://hyperphysics.gsu.edu/hbase/electric/elepow.html"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/physics/electricity.query.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/electricity.query.adj
@@ -1,0 +1,27 @@
+% ============================================================================
+% electricity.query.adj — worked examples over the physics electricity library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a circuits
+% question: it states NO arithmetic and NO law — it only `import`s the grounded
+% library, `observe`s the electrical quantities it decomposed from the prompt
+% (each a byte-provenanced span, elided here), and asks the engine to APPLY the
+% cited law. The native adj-lang engine binds the parameters, computes each value
+% EXACTLY on the CPU, and returns it with the law's source/locator/trust.
+%
+% The two questions COMPOSE: Ohm's law gives the voltage across the resistor,
+% which is exactly the voltage the power law then multiplies by the current.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli electricity.query.adj
+% ============================================================================
+
+import "electricity.adj"
+
+% A 2 A current through a 3 Ω resistor: voltage = 2 * 3.
+observe current(2)
+observe resistance(3)
+? voltage(current, resistance)     % expect 6   (Ohm's law: V = I·R)
+
+% That 6 V across the resistor, carrying 2 A: power = 6 * 2.
+observe voltage(6)
+? power(voltage, current)          % expect 12  (electric power: P = V·I)


### PR DESCRIPTION
## What

A new **physics** compute library, sibling of `energy-work.adj`: the two foundational circuit laws, each an importable, byte-provenanced, parameterized `formula` grounded from HyperPhysics (the same .edu physics reference `energy-work.adj` cites for kinetic energy).

```
voltage(current, resistance) = current * resistance   % V = I·R  (Ohm's law)
power(voltage, current)      = voltage * current       % P = V·I  (electric power)
```

Both are **exact** over their parameters (products, no measured constant), so the engine returns each value exactly, carrying the applied law's citation + trust tier in the audit `derived` section. A consumer states no arithmetic — it `observe`s the electrical quantities it decomposed and asks the engine to apply the cited law on the CPU.

The two laws **compose**: `voltage` names both the *result* of Ohm's law and an *input* of the power law (a single dictionary term in both roles), exactly as a circuit problem reads. The worked query threads it: `V = I·R → 6`, then `P = V·I → 12`.

## Grounding

Each formula's `source` is a **verbatim quote** from its HyperPhysics page, fetched from the real source per the anti-hallucination discipline (the write-gate linter rejects an unsourced formula):
- Ohm's law → [ohmlaw.html](https://hyperphysics.gsu.edu/hbase/electric/ohmlaw.html): *"For many conductors of electricity, the electric current which will flow through them is directly proportional to the voltage applied to them."*
- Electric power → [elepow.html](https://hyperphysics.gsu.edu/hbase/electric/elepow.html): *"The electric power in watts … represents the rate at which energy is converted…"*

## Verification

- `electricity.query.adj` worked example (V=I·R → 6; P=V·I → 12).
- `formula_electricity_e2e.rs` (2 tests): each law computes the exact value **and** renders its HyperPhysics citation + `authoritative` trust tier through the built CLI. Both pass.

**Data + test only** — no crate source or version change, independent of the other in-flight PRs (distinct files). Advances the "apply math to science" ladder toward the board-exam apex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)