### PR TITLE
feat(idl-lexer): MA-12b idl.tokens + idl-lexer crate

### DIFF
--- a/code/grammars/idl/idl.tokens
+++ b/code/grammars/idl/idl.tokens
@@ -1,0 +1,398 @@
+# IDL (Interactive Data Language) Token Grammar
+# ============================================================================
+#
+# Tokenizes the MA-12b-scoped lexical surface of IDL 5.0-and-later (the
+# square-bracket-subscript language — code/specs/MA12-idl-language.md §1),
+# the science/astronomy array language whose ownership lineage runs
+# RSI -> ITT Visual Information Solutions -> Exelis VIS -> L3Harris
+# Geospatial -> NV5 Geospatial. MA12 §5 makes the one decision this file is
+# structured around: unlike every other array-family grammar already in this
+# repo (apl/j/q/scilab), IDL's *surface* is an Algol/Fortran-family
+# imperative grammar -- statements, PRO/FUNCTION definitions,
+# IF/FOR/WHILE/REPEAT blocks, an infix operator-precedence cascade with
+# WORD operators (EQ/AND/...) -- closer in shape to this repo's
+# algol.tokens/dartmouth_basic.tokens than to any array-family grammar. This
+# file is therefore written to IDL's own shape, not forked from an array
+# sibling; the array *values* come from `array-runtime` at the runtime layer
+# (MA-12d), not from anything in this lexer.
+#
+# This crate (MA-12b) is lexer-only: `code/grammars/idl/idl.grammar` and
+# `idl-parser` are MA-12c, a separate follow-on task. There is no recursion
+# cap here (recursion begins with recursive-descent parsing, MA-12c), the
+# same split every sibling `*-lexer`/`*-parser` pair in this repo already
+# follows.
+#
+# ============================================================================
+# THE ONE QUESTION THIS FILE DOES *NOT* ANSWER (MA12 Â§3 item 3)
+# ----------------------------------------------------------------------------
+# MA12 Â§3 item 3 documents IDL's `/KEYWORD` boolean-shorthand
+# (`PLOT, x, /YLOG` means `PLOT, x, YLOG=1`): a leading `/` immediately
+# before an identifier *inside a call's argument list* introduces a
+# set-boolean keyword, which must be distinguished from `/` as the division
+# operator everywhere else. MA11 (Q) had an analogous problem (`/` as
+# comment-opener vs. REDUCE adverb, resolved in `q-lexer` via
+# whitespace-adjacency pre/post-tokenize hooks -- see q.tokens's own header
+# and q-lexer/src/lib.rs), which raised the question of whether IDL's `/`
+# could be resolved the same way, in this crate, using the same kind of hook.
+#
+# It cannot, and this file deliberately does NOT try. MA12 Â§3 item 3 itself
+# frames the distinction as "a parse-context signal ... resolved the same
+# 'know which production you are inside' way MA11 Â§3 resolved Q's
+# `/`-as-comment-vs-reduce, though here the signal is grammatical position,
+# not whitespace" (emphasis on the contrast). Concretely: `/YLOG` glued with
+# zero whitespace is the boolean-keyword shorthand when it appears as a
+# PROC/FUNCTION call argument (`PLOT, x, /YLOG`), but `a/YLOG` -- the exact
+# same zero-whitespace-before-an-identifier shape -- is ordinary division
+# when `a` and `YLOG` are plain expression operands, e.g. inside
+# `x = a/YLOG`. Whitespace adjacency cannot tell these apart (both are
+# "glued, no space"); the only thing that CAN is whether the parser is
+# currently inside a call's argument-list production at that position --
+# genuine grammar-position information no pre/post-tokenize hook operating
+# on raw characters or a flat token list can see (a hook has no notion of
+# "which nonterminal is currently being parsed"; only a parser with its own
+# production stack does). So, per MA12 Â§3's own framing, this is correctly
+# `idl-parser`'s problem (MA-12c), not this lexer's. SLASH below is an
+# ordinary, single, unconditional division-operator token in every position;
+# `idl-parser` is where the `/`-immediately-before-NAME-inside-an-argument-
+# list production lives.
+#
+# ============================================================================
+# CASE-INSENSITIVITY (confirmed against the NV5/L3Harris/Dartmouth-mirror IDL
+# documentation and multiple independent secondary IDL references, since
+# MA12's own text does not state this explicitly and this repo's
+# discipline is "confirm, don't assume a sibling's convention transfers")
+# ----------------------------------------------------------------------------
+# IDL is documented as NOT case sensitive for its language surface (commands,
+# keywords, procedure/function/variable names may be typed in any case) --
+# the one documented exception is the CONTENTS of a quoted string, which are
+# always taken literally. This is the same case-insensitivity real Dartmouth
+# BASIC and COBOL already have in this repo (dartmouth_basic.tokens,
+# cobol.tokens), but this file does NOT copy their exact mechanism
+# (`case_sensitive: false`, which case-folds EVERY pattern's matching,
+# including plain NAME): doing that would also fold ordinary identifier
+# *values* (a user-typed `MyVar` would lex with a case-altered value), which
+# is a stronger claim than IDL's own documented rule needs and would
+# silently discard the exact spelling a user typed for a plain variable or
+# procedure name. Instead this file uses the narrower `@case_insensitive
+# true` magic comment alone (no `case_sensitive:` line, so it stays at its
+# default of `true`) -- the same combination `dot.tokens`, `excel.tokens`,
+# and `spice/berkeley.tokens` already use in this repo. That combination
+# makes ONLY `keywords:`-block lookup (below) case-insensitive, normalizing
+# a promoted keyword's emitted value to uppercase (`if`/`If`/`IF` all yield
+# KEYWORD("IF")) -- while every ordinary NAME (procedure, function, and
+# variable identifiers) and every STRING literal's content keeps the exact
+# case the user typed, verified directly against `lexer::grammar_lexer`'s
+# own `test_case_insensitive_non_keyword_identifier_preserves_case` /
+# `test_case_sensitive_default_keeps_original_value` tests. Whether
+# `idl-runtime`'s symbol table should itself fold identifier case at lookup
+# time (real IDL folds names internally, e.g. undefined-routine errors
+# report the name in uppercase) is a runtime-layer decision for MA-12d, not
+# a lexer concern -- this crate only guarantees the token VALUE it reports
+# is the exact source text for anything that isn't a reserved word.
+#
+# @version 1
+# @case_insensitive true
+#
+# Strings have no escape mechanism at all in real IDL (no backslash
+# escaping, no doubled-quote escaping) -- to embed the same quote character
+# a real IDL program switches quote style or concatenates via CHR()/STRING().
+# `escapes: none` tells the shared GrammarLexer engine not to apply its own
+# generic escape-interpretation pass to SQ_STRING/DQ_STRING content below
+# (which, since neither pattern's regex recognizes a backslash-escape
+# sequence to begin with, matters only for defensive correctness -- a
+# literal backslash byte inside a string, if one ever appears, passes
+# through unchanged rather than being silently reinterpreted). This mirrors
+# every other math-language grammar already in this repo that has no
+# backslash-escape convention of its own (derive.tokens, maple.tokens,
+# macsyma.tokens, reduce.tokens all set the same directive for the same
+# reason), rather than inheriting Scilab's/MATLAB's doubled-quote (`""`)
+# escaping, which is real syntax in THOSE languages but not documented
+# anywhere for IDL.
+escapes: none
+
+# ============================================================================
+# SECTION 1: The two matrix-product operators (MA12 Â§4), longest-match-first.
+#
+# IDL has TWO distinct matrix-multiplication operators -- `#` and `##` --
+# that differ in which operand's rows/columns pair with which (NV5/L3Harris
+# operator reference); they are NOT one operator typo'd twice. `##` MUST be
+# declared before the bare `#` it starts with, or the bare single-character
+# pattern would win the first-match race and strand a stray `#` behind it --
+# the same longest-match-before-bare-prefix discipline j.tokens/scilab.tokens
+# already use for their own digraphs. Named by GLYPH (not by a semantic
+# name like "MATMUL"), matching this repo's dominant symbol-token-naming
+# convention (PLUS/MINUS/STAR/CARET/HASH in q.tokens, etc.) -- HASH here is
+# IDL's matrix-product operator, a completely different primitive than Q's
+# own HASH (count/take, q.tokens SECTION 2); the glyph is shared, the
+# language is not.
+# ============================================================================
+
+HASH_HASH = "##"
+HASH      = "#"
+
+# ============================================================================
+# SECTION 2: String literals -- single- and double-quoted (MA12 Â§4).
+#
+# IDL has no transpose-vs-string-quote ambiguity the way Scilab's/MATLAB's
+# `'` does (IDL's TRANSPOSE is an ordinary function call, `TRANSPOSE(a)`,
+# not a `'` postfix operator) -- so, unlike scilab.tokens's
+# STRING_PLACEHOLDER dance, this file needs no pre/post-tokenize hook at all
+# for either quote character. Both spellings alias directly to the SAME
+# STRING token type: MA12 Â§2/Â§4 model both as the one runtime-level
+# `IdlValue::Str`, with no quote-style-driven distinction downstream, the
+# same "one token type, two spellings" choice scilab.tokens already made
+# for its own `'...'`/`"..."` pair (MA10 Â§3). No escape sequence is
+# recognized inside either pattern (see the header note on `escapes: none`
+# above) -- the body is simply "every character up to the next matching
+# quote," the same shape Dartmouth BASIC's own STRING_BODY already uses in
+# this repo for the identical "no escapes at all" string convention.
+#
+# Any token name ending in "STRING" has its outer quote characters stripped
+# automatically by the shared GrammarLexer engine (see
+# `code/packages/rust/lexer/src/grammar_lexer.rs`'s own
+# `try_match_token_in_group` quote-handling), so SQ_STRING/DQ_STRING below
+# need no manual quote-stripping code in idl-lexer itself.
+# ============================================================================
+
+SQ_STRING = /'[^']*'/ -> STRING
+DQ_STRING = /"[^"]*"/ -> STRING
+
+# ============================================================================
+# SECTION 3: Arithmetic, assignment, and ordinary punctuation (MA12 Â§4).
+#
+# `+ - * / ^` are the ordinary arithmetic operators (SLASH is ALWAYS
+# division at this layer -- see the header note on the `/KEYWORD` question
+# above). EQUALS is the single `=` glyph used for BOTH statement-level
+# assignment (`x = expr`) AND, inside a call's argument list, keyword
+# binding (`TITLE='flux'`) -- MA12 Â§3 item 2 is explicit that telling these
+# apart is a parser-context concern ("the one place idl-parser must know it
+# is inside a call-argument context to read `=` as keyword-bind rather than
+# assign"), exactly parallel to the `/KEYWORD` question above, so this file
+# emits one unconditional EQUALS token in every position, the same way
+# dartmouth_basic.tokens' own EQ note documents "the parser resolves this by
+# context -- both cases emit EQ here."
+#
+# COLON is the range-subscript separator (`a[s0:s1]`, `a[s0:s1:n]`, MA12
+# Â§4) -- IDL's ONLY use for `:` in this cut's in-scope surface (there is no
+# ternary, no dictionary/struct-literal colon in scope, and no `x:` result-
+# suppression convention the way maple.tokens/reduce.tokens have for their
+# own `;`/`:` pair). STAR is reused for both multiplication AND the
+# all/rest subscript wildcard (`a[*]`, `a[s0:*]`) -- the same "one glyph,
+# two grammar-level meanings, parser's job to tell them apart at the
+# relevant position" discipline as EQUALS/SLASH above, not a second token.
+#
+# No DOT token: IDL's decimal point is consumed entirely inside NUMBER
+# (SECTION 4) and this cut has no other in-scope use for a bare `.` --
+# structures and their `s.tag` field access (the one construct that WOULD
+# need a standalone DOT) are explicitly deferred whole (MA12 Â§4), so a
+# stray `.` outside a numeric literal falls through to the `errors:` catch-
+# all below, an honest failure rather than a silently-accepted token nothing
+# in this cut's grammar can ever use -- the same "absence, not special-cased
+# exclusion" discipline scilab.tokens documents for its own omissions.
+#
+# No `&&`/`||` short-circuit operators: real modern IDL has them, but MA12
+# Â§4/Â§6 do not list them in this cut's in-scope surface (only the classic
+# word operators AND/OR/NOT/XOR and the `&` statement separator below are
+# in scope), so they are simply left out rather than added ahead of the
+# spec that scopes this crate -- consistent with this repo's discipline of
+# implementing exactly what the current spec item lists, not a superset.
+# ============================================================================
+
+PLUS  = "+"
+MINUS = "-"
+STAR  = "*"
+SLASH = "/"
+CARET = "^"
+
+EQUALS = "="
+
+COMMA    = ","
+COLON    = ":"
+LPAREN   = "("
+RPAREN   = ")"
+LBRACKET = "["
+RBRACKET = "]"
+
+# ============================================================================
+# SECTION 4: Lexer trivia with real grammar-level meaning (MA12 Â§3/Â§4/Â§6):
+# `&` (statement separator) and `$` (line continuation). Neither is a
+# skip-section pattern -- both are ordinary, significant tokens.
+#
+# STMT_SEP (`&`) separates multiple statements written on one physical
+# source line (MA12 Â§3's "lexer trivia" bullet / Â§4's "Assignment &
+# statements" bullet) -- unrelated to logical AND, which IDL spells as the
+# WORD keyword `AND` (SECTION 6), so there is no glyph collision to guard
+# against the way Q's `/` has.
+#
+# CONTINUATION (`$`) is the line-continuation character. Per MA12 Â§5 ("the
+# REPL & binary" bullet), `idl-repl`'s own continuation scanner is what
+# actually tracks this character (alongside paren/bracket balance and
+# BEGIN...ENDxxx block depth) to decide whether to keep reading more input
+# before treating a line as complete -- so, unlike a whitespace-only
+# continuation marker that could be silently swallowed as trivia (compare
+# Python's own `LINE_CONTINUATION` in python3.12.tokens, which IS a `skip:`
+# entry because Python's backslash-newline carries no information a later
+# layer needs to see again), `$` must survive into the token stream as its
+# own real token for that later layer to inspect. This file does not try to
+# interpret it any further than that (e.g. it does not suppress the
+# following NEWLINE) -- what "continuation" means operationally is entirely
+# `idl-repl`'s concern, not this lexer's.
+# ============================================================================
+
+STMT_SEP     = "&"
+CONTINUATION = "$"
+
+# ============================================================================
+# SECTION 5: Numeric literals (MA12 Â§2/Â§4).
+#
+# Integer and floating-point, with an optional exponent -- the same shape
+# scilab.tokens' own NUMBER uses (leading-dot floats like `.5` allowed, a
+# digit required on each side of a `.` that IS present so a bare trailing
+# dot is never absorbed). MA12 Â§2/Â§4 explicitly defer IDL's typed numeric
+# tower (byte/int/uint/long/ulong/float/double/complex/dcomplex) and its
+# literal type-suffix spellings (`5L`, `5B`, `5UL`, `1.5D`, ...) to a later
+# item, computing every value in `f64` this cut -- so this pattern
+# deliberately does NOT recognize a trailing type-suffix letter; a source
+# literal spelled with one (e.g. `5L`) lexes as NUMBER("5") followed by a
+# separate NAME("L") token, an honest reflection of this cut's un-typed
+# numeric model rather than a silent guess at what the suffix should mean.
+# ============================================================================
+
+NUMBER = /([0-9]+(\.[0-9]+)?|\.[0-9]+)([eE][+-]?[0-9]+)?/
+
+# ============================================================================
+# SECTION 6: Identifiers, word operators, and control-flow/definition
+# keywords (MA12 Â§3/Â§4/Â§6).
+#
+# NAME requires a LEADING LETTER (never a leading underscore or digit) --
+# documented IDL identifier syntax, confirmed against real IDL naming rules;
+# underscores ARE allowed as continuation characters (real intrinsic names
+# like N_ELEMENTS, PTR_NEW rely on this). Leading-underscore names are a
+# real but narrow exception in full IDL -- the `_EXTRA`/`_REF_EXTRA`
+# keyword-inheritance forwarding mechanism -- and MA12 Â§4 defers that whole
+# mechanism ("this cut implements explicit named keywords only, not
+# keyword pass-through"), so no leading-underscore allowance is needed yet;
+# adding one ahead of that later item would silently accept spellings this
+# cut's grammar has no production for.
+#
+# `keywords:` lists EVERY word this cut reserves -- both MA12 Â§4's word
+# operators (spelled as ordinary identifiers, case-insensitively per the
+# header note, so `eq`/`Eq`/`EQ` all promote) and its control-flow/
+# definition keyword set. Every promoted entry becomes a generic KEYWORD
+# token (per `lexer::grammar_lexer`'s own keyword-promotion mechanism --
+# see `dartmouth_basic.tokens`'s identical convention) whose VALUE (not
+# type) tells one keyword from another, always emitted uppercase per the
+# `@case_insensitive true` directive above; `idl-parser` (MA-12c)
+# distinguishes IF from FOR from EQ by inspecting `token.value`, exactly as
+# scilab-parser/dartmouth-basic-parser already do for their own keyword
+# tokens.
+#
+# Word operators (MA12 Â§4, "Comparisons and logic as named operators"):
+#   EQ NE LT LE GT GE            -- comparison (0/1-valued, this repo's
+#                                    APL/J/Scilab convention)
+#   AND OR NOT XOR                -- logical/bitwise
+# These are ONLY the word spellings -- MA12 Â§4 does not list any symbolic
+# alternative (`==`, `!=`, `<`, `<=`, ...) for IDL's relational operators the
+# way scilab.tokens keeps both `~=`/`<>`, so none is added here.
+#
+# Control flow / definitions (MA12 Â§3's matched-block-terminator family +
+# Â§4's in-scope control-flow/procedure-and-function bullets -- the exact
+# list, no more: CASE/SWITCH/FOREACH and their ENDCASE/ENDSWITCH/
+# ENDFOREACH terminators, and GOTO/COMMON/etc., are all explicitly deferred,
+# MA12 Â§4):
+#   IF THEN ELSE ENDIF ENDELSE    -- conditional, with the matched
+#                                    ENDIF/ENDELSE terminator pair
+#   FOR DO ENDFOR                 -- FOR loop; DO is FOR's mandatory linker
+#   WHILE ENDWHILE                -- WHILE loop (DO below is its own
+#                                    mandatory linker, shared with FOR --
+#                                    one token, two use sites, the same
+#                                    "shared linker keyword" shape
+#                                    scilab.tokens documents for its own
+#                                    `do`)
+#   REPEAT UNTIL ENDREP           -- REPEAT/UNTIL loop with its own matched
+#                                    terminator
+#   BREAK CONTINUE                -- loop control
+#   BEGIN END                     -- the generic block delimiter pair (a
+#                                    bare END also closes ANY block, MA12
+#                                    Â§3 -- "the optional compiler-side
+#                                    'does ENDFOR match a FOR?' check is a
+#                                    nicety the parser can carry, not a
+#                                    semantic requirement")
+#   PRO FUNCTION RETURN           -- procedure/function definition headers
+#                                    and the function-only RETURN statement
+# ============================================================================
+
+NAME = /[a-zA-Z][a-zA-Z0-9_]*/
+
+keywords:
+  EQ
+  NE
+  LT
+  LE
+  GT
+  GE
+  AND
+  OR
+  NOT
+  XOR
+  IF
+  THEN
+  ELSE
+  ENDIF
+  ENDELSE
+  FOR
+  DO
+  ENDFOR
+  WHILE
+  ENDWHILE
+  REPEAT
+  UNTIL
+  ENDREP
+  BREAK
+  CONTINUE
+  BEGIN
+  END
+  PRO
+  FUNCTION
+  RETURN
+
+# ============================================================================
+# SECTION 7: Newlines -- significant (statement terminator, MA12 Â§4).
+#
+# A newline ends a statement, exactly like scilab.tokens/dartmouth_basic.tokens
+# (and unlike maple.tokens/reduce.tokens, whose own statement separator is
+# purely `;`/`:` with no significant newline at all) -- MA12 Â§4's own
+# "STMT_SEP separates multiple statements on one line" bullet only makes
+# sense in a grammar where a newline is ALREADY the ordinary, default
+# statement terminator; `&` is the exception that lets more than one
+# statement share a line, not the rule.
+# ============================================================================
+
+NEWLINE = /\r?\n/
+
+# ============================================================================
+# SECTION 8: Skip -- horizontal whitespace and `;` line comments (MA12 Â§3's
+# "lexer trivia" bullet / Â§5's "REPL & binary" bullet).
+#
+# Unlike Q's own `/` (which needed a pre-tokenize hook because the SAME
+# character is ALSO a real token, the REDUCE adverb, q.tokens SECTION 3),
+# IDL's `;` has no other meaning anywhere in this cut's grammar -- it is
+# ALWAYS a comment-opener, in every position -- so an ordinary declarative
+# `skip:` regex suffices with no hook at all, the same simpler shape
+# scilab.tokens' own `//`/`/* */` comments already use for the identical
+# reason ("Scilab has no `%`-comment ... there is no conflict to guard
+# against"). The comment ends just before the newline, never swallowing it
+# (mirroring q.tokens'/j.tokens' identical choice), so NEWLINE (SECTION 7)
+# stays its own significant token immediately after a commented line.
+# ============================================================================
+
+skip:
+  WHITESPACE = /[ \t]+/
+  COMMENT    = /;[^\n]*/
+
+# ============================================================================
+# SECTION 9: Error recovery.
+# ============================================================================
+
+errors:
+  UNKNOWN = /./

--- a/code/grammars/idl/idl.tokens
+++ b/code/grammars/idl/idl.tokens
@@ -23,9 +23,9 @@
 # follows.
 #
 # ============================================================================
-# THE ONE QUESTION THIS FILE DOES *NOT* ANSWER (MA12 Â§3 item 3)
+# THE ONE QUESTION THIS FILE DOES *NOT* ANSWER (MA12 §3 item 3)
 # ----------------------------------------------------------------------------
-# MA12 Â§3 item 3 documents IDL's `/KEYWORD` boolean-shorthand
+# MA12 §3 item 3 documents IDL's `/KEYWORD` boolean-shorthand
 # (`PLOT, x, /YLOG` means `PLOT, x, YLOG=1`): a leading `/` immediately
 # before an identifier *inside a call's argument list* introduces a
 # set-boolean keyword, which must be distinguished from `/` as the division
@@ -35,9 +35,9 @@
 # and q-lexer/src/lib.rs), which raised the question of whether IDL's `/`
 # could be resolved the same way, in this crate, using the same kind of hook.
 #
-# It cannot, and this file deliberately does NOT try. MA12 Â§3 item 3 itself
+# It cannot, and this file deliberately does NOT try. MA12 §3 item 3 itself
 # frames the distinction as "a parse-context signal ... resolved the same
-# 'know which production you are inside' way MA11 Â§3 resolved Q's
+# 'know which production you are inside' way MA11 §3 resolved Q's
 # `/`-as-comment-vs-reduce, though here the signal is grammatical position,
 # not whitespace" (emphasis on the contrast). Concretely: `/YLOG` glued with
 # zero whitespace is the boolean-keyword shorthand when it appears as a
@@ -50,7 +50,7 @@
 # genuine grammar-position information no pre/post-tokenize hook operating
 # on raw characters or a flat token list can see (a hook has no notion of
 # "which nonterminal is currently being parsed"; only a parser with its own
-# production stack does). So, per MA12 Â§3's own framing, this is correctly
+# production stack does). So, per MA12 §3's own framing, this is correctly
 # `idl-parser`'s problem (MA-12c), not this lexer's. SLASH below is an
 # ordinary, single, unconditional division-operator token in every position;
 # `idl-parser` is where the `/`-immediately-before-NAME-inside-an-argument-
@@ -111,7 +111,7 @@
 escapes: none
 
 # ============================================================================
-# SECTION 1: The two matrix-product operators (MA12 Â§4), longest-match-first.
+# SECTION 1: The two matrix-product operators (MA12 §4), longest-match-first.
 #
 # IDL has TWO distinct matrix-multiplication operators -- `#` and `##` --
 # that differ in which operand's rows/columns pair with which (NV5/L3Harris
@@ -131,17 +131,17 @@ HASH_HASH = "##"
 HASH      = "#"
 
 # ============================================================================
-# SECTION 2: String literals -- single- and double-quoted (MA12 Â§4).
+# SECTION 2: String literals -- single- and double-quoted (MA12 §4).
 #
 # IDL has no transpose-vs-string-quote ambiguity the way Scilab's/MATLAB's
 # `'` does (IDL's TRANSPOSE is an ordinary function call, `TRANSPOSE(a)`,
 # not a `'` postfix operator) -- so, unlike scilab.tokens's
 # STRING_PLACEHOLDER dance, this file needs no pre/post-tokenize hook at all
 # for either quote character. Both spellings alias directly to the SAME
-# STRING token type: MA12 Â§2/Â§4 model both as the one runtime-level
+# STRING token type: MA12 §2/§4 model both as the one runtime-level
 # `IdlValue::Str`, with no quote-style-driven distinction downstream, the
 # same "one token type, two spellings" choice scilab.tokens already made
-# for its own `'...'`/`"..."` pair (MA10 Â§3). No escape sequence is
+# for its own `'...'`/`"..."` pair (MA10 §3). No escape sequence is
 # recognized inside either pattern (see the header note on `escapes: none`
 # above) -- the body is simply "every character up to the next matching
 # quote," the same shape Dartmouth BASIC's own STRING_BODY already uses in
@@ -158,13 +158,13 @@ SQ_STRING = /'[^']*'/ -> STRING
 DQ_STRING = /"[^"]*"/ -> STRING
 
 # ============================================================================
-# SECTION 3: Arithmetic, assignment, and ordinary punctuation (MA12 Â§4).
+# SECTION 3: Arithmetic, assignment, and ordinary punctuation (MA12 §4).
 #
 # `+ - * / ^` are the ordinary arithmetic operators (SLASH is ALWAYS
 # division at this layer -- see the header note on the `/KEYWORD` question
 # above). EQUALS is the single `=` glyph used for BOTH statement-level
 # assignment (`x = expr`) AND, inside a call's argument list, keyword
-# binding (`TITLE='flux'`) -- MA12 Â§3 item 2 is explicit that telling these
+# binding (`TITLE='flux'`) -- MA12 §3 item 2 is explicit that telling these
 # apart is a parser-context concern ("the one place idl-parser must know it
 # is inside a call-argument context to read `=` as keyword-bind rather than
 # assign"), exactly parallel to the `/KEYWORD` question above, so this file
@@ -173,7 +173,7 @@ DQ_STRING = /"[^"]*"/ -> STRING
 # context -- both cases emit EQ here."
 #
 # COLON is the range-subscript separator (`a[s0:s1]`, `a[s0:s1:n]`, MA12
-# Â§4) -- IDL's ONLY use for `:` in this cut's in-scope surface (there is no
+# §4) -- IDL's ONLY use for `:` in this cut's in-scope surface (there is no
 # ternary, no dictionary/struct-literal colon in scope, and no `x:` result-
 # suppression convention the way maple.tokens/reduce.tokens have for their
 # own `;`/`:` pair). STAR is reused for both multiplication AND the
@@ -184,14 +184,14 @@ DQ_STRING = /"[^"]*"/ -> STRING
 # No DOT token: IDL's decimal point is consumed entirely inside NUMBER
 # (SECTION 4) and this cut has no other in-scope use for a bare `.` --
 # structures and their `s.tag` field access (the one construct that WOULD
-# need a standalone DOT) are explicitly deferred whole (MA12 Â§4), so a
+# need a standalone DOT) are explicitly deferred whole (MA12 §4), so a
 # stray `.` outside a numeric literal falls through to the `errors:` catch-
 # all below, an honest failure rather than a silently-accepted token nothing
 # in this cut's grammar can ever use -- the same "absence, not special-cased
 # exclusion" discipline scilab.tokens documents for its own omissions.
 #
 # No `&&`/`||` short-circuit operators: real modern IDL has them, but MA12
-# Â§4/Â§6 do not list them in this cut's in-scope surface (only the classic
+# §4/§6 do not list them in this cut's in-scope surface (only the classic
 # word operators AND/OR/NOT/XOR and the `&` statement separator below are
 # in scope), so they are simply left out rather than added ahead of the
 # spec that scopes this crate -- consistent with this repo's discipline of
@@ -214,17 +214,17 @@ LBRACKET = "["
 RBRACKET = "]"
 
 # ============================================================================
-# SECTION 4: Lexer trivia with real grammar-level meaning (MA12 Â§3/Â§4/Â§6):
+# SECTION 4: Lexer trivia with real grammar-level meaning (MA12 §3/§4/§6):
 # `&` (statement separator) and `$` (line continuation). Neither is a
 # skip-section pattern -- both are ordinary, significant tokens.
 #
 # STMT_SEP (`&`) separates multiple statements written on one physical
-# source line (MA12 Â§3's "lexer trivia" bullet / Â§4's "Assignment &
+# source line (MA12 §3's "lexer trivia" bullet / §4's "Assignment &
 # statements" bullet) -- unrelated to logical AND, which IDL spells as the
 # WORD keyword `AND` (SECTION 6), so there is no glyph collision to guard
 # against the way Q's `/` has.
 #
-# CONTINUATION (`$`) is the line-continuation character. Per MA12 Â§5 ("the
+# CONTINUATION (`$`) is the line-continuation character. Per MA12 §5 ("the
 # REPL & binary" bullet), `idl-repl`'s own continuation scanner is what
 # actually tracks this character (alongside paren/bracket balance and
 # BEGIN...ENDxxx block depth) to decide whether to keep reading more input
@@ -243,12 +243,12 @@ STMT_SEP     = "&"
 CONTINUATION = "$"
 
 # ============================================================================
-# SECTION 5: Numeric literals (MA12 Â§2/Â§4).
+# SECTION 5: Numeric literals (MA12 §2/§4).
 #
 # Integer and floating-point, with an optional exponent -- the same shape
 # scilab.tokens' own NUMBER uses (leading-dot floats like `.5` allowed, a
 # digit required on each side of a `.` that IS present so a bare trailing
-# dot is never absorbed). MA12 Â§2/Â§4 explicitly defer IDL's typed numeric
+# dot is never absorbed). MA12 §2/§4 explicitly defer IDL's typed numeric
 # tower (byte/int/uint/long/ulong/float/double/complex/dcomplex) and its
 # literal type-suffix spellings (`5L`, `5B`, `5UL`, `1.5D`, ...) to a later
 # item, computing every value in `f64` this cut -- so this pattern
@@ -262,20 +262,20 @@ NUMBER = /([0-9]+(\.[0-9]+)?|\.[0-9]+)([eE][+-]?[0-9]+)?/
 
 # ============================================================================
 # SECTION 6: Identifiers, word operators, and control-flow/definition
-# keywords (MA12 Â§3/Â§4/Â§6).
+# keywords (MA12 §3/§4/§6).
 #
 # NAME requires a LEADING LETTER (never a leading underscore or digit) --
 # documented IDL identifier syntax, confirmed against real IDL naming rules;
 # underscores ARE allowed as continuation characters (real intrinsic names
 # like N_ELEMENTS, PTR_NEW rely on this). Leading-underscore names are a
 # real but narrow exception in full IDL -- the `_EXTRA`/`_REF_EXTRA`
-# keyword-inheritance forwarding mechanism -- and MA12 Â§4 defers that whole
+# keyword-inheritance forwarding mechanism -- and MA12 §4 defers that whole
 # mechanism ("this cut implements explicit named keywords only, not
 # keyword pass-through"), so no leading-underscore allowance is needed yet;
 # adding one ahead of that later item would silently accept spellings this
 # cut's grammar has no production for.
 #
-# `keywords:` lists EVERY word this cut reserves -- both MA12 Â§4's word
+# `keywords:` lists EVERY word this cut reserves -- both MA12 §4's word
 # operators (spelled as ordinary identifiers, case-insensitively per the
 # header note, so `eq`/`Eq`/`EQ` all promote) and its control-flow/
 # definition keyword set. Every promoted entry becomes a generic KEYWORD
@@ -287,19 +287,19 @@ NUMBER = /([0-9]+(\.[0-9]+)?|\.[0-9]+)([eE][+-]?[0-9]+)?/
 # scilab-parser/dartmouth-basic-parser already do for their own keyword
 # tokens.
 #
-# Word operators (MA12 Â§4, "Comparisons and logic as named operators"):
+# Word operators (MA12 §4, "Comparisons and logic as named operators"):
 #   EQ NE LT LE GT GE            -- comparison (0/1-valued, this repo's
 #                                    APL/J/Scilab convention)
 #   AND OR NOT XOR                -- logical/bitwise
-# These are ONLY the word spellings -- MA12 Â§4 does not list any symbolic
+# These are ONLY the word spellings -- MA12 §4 does not list any symbolic
 # alternative (`==`, `!=`, `<`, `<=`, ...) for IDL's relational operators the
 # way scilab.tokens keeps both `~=`/`<>`, so none is added here.
 #
-# Control flow / definitions (MA12 Â§3's matched-block-terminator family +
-# Â§4's in-scope control-flow/procedure-and-function bullets -- the exact
+# Control flow / definitions (MA12 §3's matched-block-terminator family +
+# §4's in-scope control-flow/procedure-and-function bullets -- the exact
 # list, no more: CASE/SWITCH/FOREACH and their ENDCASE/ENDSWITCH/
 # ENDFOREACH terminators, and GOTO/COMMON/etc., are all explicitly deferred,
-# MA12 Â§4):
+# MA12 §4):
 #   IF THEN ELSE ENDIF ENDELSE    -- conditional, with the matched
 #                                    ENDIF/ENDELSE terminator pair
 #   FOR DO ENDFOR                 -- FOR loop; DO is FOR's mandatory linker
@@ -314,7 +314,7 @@ NUMBER = /([0-9]+(\.[0-9]+)?|\.[0-9]+)([eE][+-]?[0-9]+)?/
 #   BREAK CONTINUE                -- loop control
 #   BEGIN END                     -- the generic block delimiter pair (a
 #                                    bare END also closes ANY block, MA12
-#                                    Â§3 -- "the optional compiler-side
+#                                    §3 -- "the optional compiler-side
 #                                    'does ENDFOR match a FOR?' check is a
 #                                    nicety the parser can carry, not a
 #                                    semantic requirement")
@@ -357,11 +357,11 @@ keywords:
   RETURN
 
 # ============================================================================
-# SECTION 7: Newlines -- significant (statement terminator, MA12 Â§4).
+# SECTION 7: Newlines -- significant (statement terminator, MA12 §4).
 #
 # A newline ends a statement, exactly like scilab.tokens/dartmouth_basic.tokens
 # (and unlike maple.tokens/reduce.tokens, whose own statement separator is
-# purely `;`/`:` with no significant newline at all) -- MA12 Â§4's own
+# purely `;`/`:` with no significant newline at all) -- MA12 §4's own
 # "STMT_SEP separates multiple statements on one line" bullet only makes
 # sense in a grammar where a newline is ALREADY the ordinary, default
 # statement terminator; `&` is the exception that lets more than one
@@ -371,8 +371,8 @@ keywords:
 NEWLINE = /\r?\n/
 
 # ============================================================================
-# SECTION 8: Skip -- horizontal whitespace and `;` line comments (MA12 Â§3's
-# "lexer trivia" bullet / Â§5's "REPL & binary" bullet).
+# SECTION 8: Skip -- horizontal whitespace and `;` line comments (MA12 §3's
+# "lexer trivia" bullet / §5's "REPL & binary" bullet).
 #
 # Unlike Q's own `/` (which needed a pre-tokenize hook because the SAME
 # character is ALSO a real token, the REDUCE adverb, q.tokens SECTION 3),

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -280,6 +280,7 @@ members = [
     "q-runtime",
     "q-repl",
     "q-to-semantic-ir",
+    "idl-lexer",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/idl-lexer/BUILD
+++ b/code/packages/rust/idl-lexer/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-idl-lexer -- --nocapture

--- a/code/packages/rust/idl-lexer/BUILD_windows
+++ b/code/packages/rust/idl-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-idl-lexer -- --nocapture

--- a/code/packages/rust/idl-lexer/CHANGELOG.md
+++ b/code/packages/rust/idl-lexer/CHANGELOG.md
@@ -1,0 +1,82 @@
+# Changelog
+
+## [0.1.0] - 2026-07-23
+
+### Added
+
+- Initial grammar-driven Rust IDL tokenizer (MA12 §6, task MA-12b).
+- `code/grammars/idl/idl.tokens`, written to IDL's own Algol/Fortran-family
+  imperative grammar shape (MA12 §5) rather than forked from an array
+  sibling. Covers the MA-12b-scoped surface: `;` line comments, `$` line
+  continuation (a real, significant token — not stripped as trivia), `&`
+  statement separator, single- and double-quoted strings (unified to one
+  `STRING` token type, no escape mechanism — real IDL strings have none),
+  the word operators `EQ NE LT LE GT GE` (comparison) and `AND OR NOT XOR`
+  (logical), the two matrix-product operators `#`/`##` (longest-match-first,
+  `##` before `#`), `[`/`]` subscript brackets, ordinary
+  arithmetic/punctuation (`+ - * / ^ = , : ( )`), integer/float numeric
+  literals (including leading-dot floats and exponents; IDL's typed numeric
+  tower and literal type suffixes like `5L`/`1.5D` are explicitly deferred,
+  MA12 §2/§4), identifiers (must start with a letter — leading-underscore
+  names are reserved for the deferred `_EXTRA`/`_REF_EXTRA` mechanism), and
+  the closed control-flow/definition keyword set `IF THEN ELSE ENDIF ENDELSE
+  FOR DO ENDFOR WHILE ENDWHILE REPEAT UNTIL ENDREP BREAK CONTINUE BEGIN END
+  PRO FUNCTION RETURN`.
+- Case-insensitivity via `# @case_insensitive true` alone (no
+  `case_sensitive: false`) — the same combination `dot.tokens`/
+  `excel.tokens`/`spice/berkeley.tokens` already use in this repo. Only
+  `keywords:`-block lookup folds case; ordinary `NAME` tokens and `STRING`
+  contents keep the exact case the source used. This was confirmed against
+  documented IDL case-insensitivity (multiple independent secondary IDL
+  references, since MA12's own text does not state it explicitly) rather
+  than assumed from a sibling grammar's convention.
+- **Finding: the `/KEYWORD`-vs-division question (MA12 §3 item 3) is
+  correctly a parser-level concern, not a lexer one, and this crate does
+  not attempt to resolve it.** Q's (MA11) analogous `/`-comment-vs-REDUCE
+  ambiguity is resolved in `q-lexer` via whitespace-adjacency pre/post-
+  tokenize hooks. That strategy does not transfer here: `PLOT, x, /YLOG`
+  (boolean shorthand) and `x = a/YLOG` (ordinary division) both have `/`
+  glued to an identifier with zero intervening whitespace on either side —
+  no character-adjacency test can tell them apart, because the actual
+  distinguishing fact is whether the parser is currently inside a call's
+  argument-list production, which only a parser (with a production stack)
+  can know. `idl.tokens` therefore emits `SLASH` as one ordinary,
+  unconditional division token in every position; the `/KEYWORD` production
+  belongs entirely to `idl-parser` (MA-12c).
+- **No pre/post-tokenize hooks at all** — a direct consequence of the
+  finding above, plus the fact that IDL has no transpose operator to
+  collide with `'`/`"` (unlike Scilab) and `;` has no other meaning
+  anywhere in this cut's grammar (unlike Q's dual-use `/`). `idl.tokens` is
+  entirely declarative; `create_idl_lexer` installs nothing beyond the
+  compiled grammar — simpler than every sibling array-family `*-lexer`
+  crate in this repo.
+- `code/packages/rust/Cargo.toml` workspace registration alongside the
+  other array-language lexer/parser/runtime/repl/to-semantic-ir crate
+  groups (only `idl-lexer` itself is added; the sibling `idl-parser`/
+  `idl-runtime`/`idl-repl`/`idl-to-semantic-ir` crates do not exist yet —
+  they are MA-12c/d/e, separate follow-on tasks).
+- No recursion-depth cap in this crate, by design: `idl-lexer` performs no
+  recursive descent at all (that begins with `idl-parser`, MA-12c) — the
+  same split every sibling `*-lexer`/`*-parser` pair in this repo already
+  follows.
+- 59 tests (5 lib smoke tests + 53 integration tests + 1 doc test) covering:
+  every word operator and control-flow/definition keyword (including
+  case-insensitive lookup and that plain identifiers preserve their exact
+  case); `;` comments (including one containing characters outside the
+  grammar's alphabet, and not swallowing the terminating newline); `$`
+  continuation surviving as its own token; `&` statement separation; both
+  quote styles unifying to `STRING` (including each quote style embedding
+  the other verbatim, since there is no escape mechanism); the `##`-vs-`#`
+  longest-match regression (including three- and four-hash chains); array
+  literals and every in-scope subscript form (plain, negative-from-end,
+  ranged, strided, `*`-wildcard, 2-D); a `PRO` definition, a `FUNCTION`
+  definition with `RETURN`, an `IF...THEN...ENDIF` block, and a procedure
+  call mixing positional arguments, a keyword argument, and the `/KEYWORD`
+  boolean shorthand; the `SLASH`-is-always-division finding, demonstrated
+  by comparing the call-argument and ordinary-division cases directly;
+  numeric literals (integers, leading-dot floats, exponents, and the
+  deferred-type-suffix honest-non-handling); identifier rules (leading
+  letter required, underscore allowed as a continuation character but not
+  as a leading character); and unrecognized-character errors for every
+  deferred/out-of-scope construct exercised (`@`, `?`, struct-style `s.tag`,
+  brace literals).

--- a/code/packages/rust/idl-lexer/Cargo.toml
+++ b/code/packages/rust/idl-lexer/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "coding-adventures-idl-lexer"
+version = "0.1.0"
+edition = "2021"
+description = "Tokenizer for IDL (Interactive Data Language), the science/astronomy array frontend (MA12 MA-12b)"
+license = "MIT"
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }

--- a/code/packages/rust/idl-lexer/README.md
+++ b/code/packages/rust/idl-lexer/README.md
@@ -1,0 +1,125 @@
+# coding-adventures-idl-lexer
+
+IDL (Interactive Data Language) tokenizer backed by
+`code/grammars/idl/idl.tokens`, compiled to Rust and statically linked into
+the crate.
+
+The runtime path does not read grammar files from disk, which keeps it
+suitable for a future WASM facade.
+
+## Where this fits
+
+This is the first crate of IDL's frontend — MA-12b from
+[`MA12-idl-language.md`](../../../specs/MA12-idl-language.md), the spec that
+fixes IDL's version-era decision (targeting IDL 5.0-and-later's
+square-bracket-subscript language, MA12 §1), confirms `array-runtime` needs
+no changes for IDL's value model (MA12 §2), and fixes the one genuinely new
+grammar/evaluator problem this repo's array family has not seen before — a
+keyword-argument calling convention layered over a procedure/function split
+(MA12 §3) — entirely at the design level, before any lexer/parser/runtime
+code lands. The crate layout mirrors MA12 §6's rollout: `idl-lexer` (this
+crate, MA-12b) → `idl-parser` (MA-12c) → `idl-runtime`/`idl-repl` (MA-12d) →
+`idl-to-semantic-ir` (MA-12e).
+
+Unlike every other array-family frontend already in this repo (`apl-lexer`,
+`j-lexer`, `q-lexer`, `scilab-lexer`), IDL's *surface* is an Algol/Fortran-
+family imperative grammar — statements, `PRO`/`FUNCTION` definitions,
+`IF`/`FOR`/`WHILE`/`REPEAT` blocks, an infix operator-precedence cascade with
+word operators (`EQ`/`AND`/...) — closer in shape to this repo's
+`algol-lexer`/`dartmouth-basic-lexer` than to any array-family lexer (MA12
+§5). So `idl.tokens` is written to IDL's own shape rather than forked from
+an array sibling.
+
+## Scope
+
+Covers the MA-12b-scoped lexical surface fixed by
+[MA12 §6](../../../specs/MA12-idl-language.md#6-crate-layout-and-rollout-one-item--one-pr):
+`;` line comments, `$` line continuation (a real token, not stripped — see
+below), `&` statement separator, single- and double-quoted strings (unified
+to one `STRING` token type, no escape mechanism), the word operators
+`EQ NE LT LE GT GE` (comparison) and `AND OR NOT XOR` (logical), the two
+matrix-product operators `#`/`##` (longest-match-first), `[`/`]` subscript
+brackets, ordinary arithmetic/punctuation (`+ - * / ^ = , : ( )`), integer
+and floating-point numeric literals, identifiers, and the closed
+control-flow/definition keyword set `IF THEN ELSE ENDIF ENDELSE FOR DO
+ENDFOR WHILE ENDWHILE REPEAT UNTIL ENDREP BREAK CONTINUE BEGIN END PRO
+FUNCTION RETURN`.
+
+This crate only tokenizes. There is no `idl-parser`/`idl.grammar` here (that
+is a separate follow-on task, MA-12c) and no recursion-depth cap (that is a
+parser-level concern for MA-12c, the same split `apl-lexer`/`j-lexer` vs.
+`apl-parser`/`j-parser` already establish in this repo).
+
+## The `/`-before-identifier question: resolved as a parser concern, not a lexer one
+
+MA12 §3 item 3 documents IDL's `/KEYWORD` boolean shorthand (`PLOT, x,
+/YLOG` means `PLOT, x, YLOG=1`), and asks whether the lexer can tell a
+boolean-keyword `/` apart from an ordinary division `/`. Q (MA11) had an
+analogous-looking problem — `/` as a comment-opener vs. the REDUCE adverb —
+which `q-lexer` resolves with `GrammarLexer` pre/post-tokenize hooks keyed
+on **whitespace adjacency** (is there a space immediately before this `/`?).
+
+That strategy does **not** transfer to IDL, and this crate does not try to
+force it to. MA12 §3 item 3 itself says the distinguishing signal here is
+"grammatical position, not whitespace" — and checking that claim directly
+confirms it: `PLOT, x, /YLOG` (boolean shorthand) and `x = a/YLOG` (ordinary
+division) both have `/` glued to an identifier with **zero** intervening
+whitespace, on **either** side. No adjacency test — no hook operating on
+raw characters or a flat token list — can tell these two apart, because the
+only fact that distinguishes them is whether the parser is currently inside
+a call's argument-list production at that source position, which is
+information only a parser (with its own production stack) has. So:
+
+- `idl.tokens`/`idl-lexer` emit `SLASH` as one ordinary, unconditional
+  division-operator token, in every position, with **no** pre/post-tokenize
+  hook at all.
+- The `/KEYWORD`-vs-division production belongs entirely to `idl-parser`
+  (MA-12c), which is the first layer with enough context (an
+  argument-list production) to make the call correctly.
+
+This is also why `idl-lexer` needs **no custom lexer code whatsoever** —
+unlike `q-lexer` (two hooks) and `scilab-lexer` (one hook, for `'`
+transpose-vs-string), `idl.tokens` is entirely declarative and
+`create_idl_lexer` installs nothing beyond the compiled grammar. IDL has no
+transpose operator to collide with `'`, and `;` (IDL's comment marker) has
+no other meaning anywhere in this cut's grammar the way Q's `/` does, so
+even the comment-stripping is an ordinary `skip:` regex.
+
+## Case-insensitivity
+
+IDL is documented as not case sensitive for its language surface (keywords,
+procedure/function/variable names), except for the contents of a quoted
+string. `idl.tokens` sets `# @case_insensitive true` (no
+`case_sensitive: false`) — the same combination `dot.tokens`,
+`excel.tokens`, and `spice/berkeley.tokens` already use in this repo. That
+combination makes **only** `keywords:`-block lookup case-insensitive
+(`if`/`If`/`IF` all promote to `KEYWORD("IF")`), while ordinary `NAME`
+tokens and `STRING` contents keep the **exact** case the source text used —
+deliberately narrower than copying `dartmouth_basic.tokens`'s/
+`cobol.tokens`'s own `case_sensitive: false` mechanism, which case-folds
+every pattern's matched value, including plain identifiers. See
+`code/grammars/idl/idl.tokens`'s own header comment for the full reasoning.
+
+## Usage
+
+```rust
+use coding_adventures_idl_lexer::tokenize_idl;
+
+let tokens = tokenize_idl("PRO GREET, name\n  PRINT, name\nEND");
+```
+
+`tokenize_idl` panics on a malformed source string; use `create_idl_lexer`
+directly (or `try_tokenize_idl`) if you need the `Result`-returning form
+instead.
+
+## Where this fits
+
+`idl-lexer` is the first of IDL's frontend crates
+([MA-12b](../../../specs/MA12-idl-language.md#6-crate-layout-and-rollout-one-item--one-pr)),
+following MA-12a's design spec. The sibling `idl-parser` crate (MA-12c) will
+consume this crate's token stream against `code/grammars/idl/idl.grammar` —
+including the one genuinely new grammar production this language needs, the
+procedure-call statement and its keyword-argument argument-list (MA12 §3)
+— to build the `GrammarASTNode` CST that a future `idl-runtime` (MA-12d)
+will evaluate, alongside `idl-repl` and `idl-to-semantic-ir` (MA-12e), per
+[HML00](../../../specs/HML00-historical-math-languages-roadmap.md) Wave 6.

--- a/code/packages/rust/idl-lexer/required_capabilities.json
+++ b/code/packages/rust/idl-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/idl-lexer",
+  "capabilities": [],
+  "justification": "Pure computation over statically linked grammar data. No filesystem, network, process, DOM, or environment access needed."
+}

--- a/code/packages/rust/idl-lexer/src/_grammar.rs
+++ b/code/packages/rust/idl-lexer/src/_grammar.rs
@@ -1,0 +1,203 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: idl.tokens
+// Regenerate with: grammar-tools compile-tokens idl.tokens
+//
+// This file embeds a TokenGrammar as native Rust data structures.
+// Call `token_grammar()` instead of reading and parsing the .tokens file.
+
+#[allow(unused_imports)]
+use grammar_tools::token_grammar::{ModeTransition, PatternGroup, TokenDefinition, TokenGrammar, TransitionAction};
+#[allow(unused_imports)]
+use std::collections::HashMap;
+
+pub fn token_grammar() -> TokenGrammar {
+    TokenGrammar {
+        definitions: vec![
+            TokenDefinition {
+                name: r#"HASH_HASH"#.to_string(),
+                pattern: r#"##"#.to_string(),
+                is_regex: false,
+                line_number: 130,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"HASH"#.to_string(),
+                pattern: r#"#"#.to_string(),
+                is_regex: false,
+                line_number: 131,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"SQ_STRING"#.to_string(),
+                pattern: r#"'[^']*'"#.to_string(),
+                is_regex: true,
+                line_number: 157,
+                alias: Some(r#"STRING"#.to_string()),
+            },
+            TokenDefinition {
+                name: r#"DQ_STRING"#.to_string(),
+                pattern: r#""[^"]*""#.to_string(),
+                is_regex: true,
+                line_number: 158,
+                alias: Some(r#"STRING"#.to_string()),
+            },
+            TokenDefinition {
+                name: r#"PLUS"#.to_string(),
+                pattern: r#"+"#.to_string(),
+                is_regex: false,
+                line_number: 201,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"MINUS"#.to_string(),
+                pattern: r#"-"#.to_string(),
+                is_regex: false,
+                line_number: 202,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"STAR"#.to_string(),
+                pattern: r#"*"#.to_string(),
+                is_regex: false,
+                line_number: 203,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"SLASH"#.to_string(),
+                pattern: r#"/"#.to_string(),
+                is_regex: false,
+                line_number: 204,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"CARET"#.to_string(),
+                pattern: r#"^"#.to_string(),
+                is_regex: false,
+                line_number: 205,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"EQUALS"#.to_string(),
+                pattern: r#"="#.to_string(),
+                is_regex: false,
+                line_number: 207,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"COMMA"#.to_string(),
+                pattern: r#","#.to_string(),
+                is_regex: false,
+                line_number: 209,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"COLON"#.to_string(),
+                pattern: r#":"#.to_string(),
+                is_regex: false,
+                line_number: 210,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LPAREN"#.to_string(),
+                pattern: r#"("#.to_string(),
+                is_regex: false,
+                line_number: 211,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RPAREN"#.to_string(),
+                pattern: r#")"#.to_string(),
+                is_regex: false,
+                line_number: 212,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LBRACKET"#.to_string(),
+                pattern: r#"["#.to_string(),
+                is_regex: false,
+                line_number: 213,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RBRACKET"#.to_string(),
+                pattern: r#"]"#.to_string(),
+                is_regex: false,
+                line_number: 214,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"STMT_SEP"#.to_string(),
+                pattern: r#"&"#.to_string(),
+                is_regex: false,
+                line_number: 242,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"CONTINUATION"#.to_string(),
+                pattern: r#"$"#.to_string(),
+                is_regex: false,
+                line_number: 243,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NUMBER"#.to_string(),
+                pattern: r#"([0-9]+(\.[0-9]+)?|\.[0-9]+)([eE][+-]?[0-9]+)?"#.to_string(),
+                is_regex: true,
+                line_number: 261,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NAME"#.to_string(),
+                pattern: r#"[a-zA-Z][a-zA-Z0-9_]*"#.to_string(),
+                is_regex: true,
+                line_number: 325,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NEWLINE"#.to_string(),
+                pattern: r#"\r?\n"#.to_string(),
+                is_regex: true,
+                line_number: 371,
+                alias: None,
+            },
+        ],
+        keywords: vec![r#"EQ"#.to_string(), r#"NE"#.to_string(), r#"LT"#.to_string(), r#"LE"#.to_string(), r#"GT"#.to_string(), r#"GE"#.to_string(), r#"AND"#.to_string(), r#"OR"#.to_string(), r#"NOT"#.to_string(), r#"XOR"#.to_string(), r#"IF"#.to_string(), r#"THEN"#.to_string(), r#"ELSE"#.to_string(), r#"ENDIF"#.to_string(), r#"ENDELSE"#.to_string(), r#"FOR"#.to_string(), r#"DO"#.to_string(), r#"ENDFOR"#.to_string(), r#"WHILE"#.to_string(), r#"ENDWHILE"#.to_string(), r#"REPEAT"#.to_string(), r#"UNTIL"#.to_string(), r#"ENDREP"#.to_string(), r#"BREAK"#.to_string(), r#"CONTINUE"#.to_string(), r#"BEGIN"#.to_string(), r#"END"#.to_string(), r#"PRO"#.to_string(), r#"FUNCTION"#.to_string(), r#"RETURN"#.to_string()],
+        mode: None,
+        skip_definitions: vec![
+            TokenDefinition {
+                name: r#"WHITESPACE"#.to_string(),
+                pattern: r#"[ \t]+"#.to_string(),
+                is_regex: true,
+                line_number: 390,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"COMMENT"#.to_string(),
+                pattern: r#";[^\n]*"#.to_string(),
+                is_regex: true,
+                line_number: 391,
+                alias: None,
+            },
+        ],
+        reserved_keywords: vec![],
+        escapes: Some(r#"none"#.to_string()),
+        error_definitions: vec![
+            TokenDefinition {
+                name: r#"UNKNOWN"#.to_string(),
+                pattern: r#"."#.to_string(),
+                is_regex: true,
+                line_number: 398,
+                alias: None,
+            },
+        ],
+        groups: HashMap::new(),
+        case_sensitive: true,
+        version: 1,
+        case_insensitive: true,
+        context_keywords: vec![],
+        soft_keywords: vec![],
+        layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
+    }
+}

--- a/code/packages/rust/idl-lexer/src/lib.rs
+++ b/code/packages/rust/idl-lexer/src/lib.rs
@@ -1,0 +1,178 @@
+//! # IDL Lexer — tokenizing IDL (Interactive Data Language).
+//!
+//! IDL (Research Systems Inc., 1977; today NV5 Geospatial) is the
+//! science/astronomy array language whose lineage runs RSI -> ITT Visual
+//! Information Solutions -> Exelis VIS -> L3Harris Geospatial -> NV5
+//! Geospatial (`code/specs/MA12-idl-language.md` §1). Unlike every other
+//! array-family frontend already in this repo (APL/J/Q/Scilab), IDL's
+//! *surface* is an Algol/Fortran-family imperative grammar — statements,
+//! `PRO`/`FUNCTION` definitions, `IF`/`FOR`/`WHILE`/`REPEAT` blocks, an
+//! infix operator-precedence cascade with word operators (`EQ`/`AND`/...)
+//! — closer in shape to this repo's `algol-lexer`/`dartmouth-basic-lexer`
+//! than to any array-family lexer (MA12 §5). This crate does not
+//! hand-write tokenization — it loads the compiled
+//! `code/grammars/idl/idl.tokens` grammar and feeds it to the generic
+//! [`GrammarLexer`]. `idl-lexer` only tokenizes; there is no `idl-parser`
+//! or `idl.grammar` here (that is MA-12c, a separate follow-on task) and
+//! no recursion-depth cap (that begins with recursive-descent parsing,
+//! MA-12c — the same split every sibling `*-lexer`/`*-parser` pair in this
+//! repo already follows).
+//!
+//! ## No pre/post-tokenize hooks — and why that is a deliberate finding, not an omission
+//!
+//! Every prior array-family lexer that had a same-character/two-meaning
+//! ambiguity to resolve (Scilab's `'` transpose-vs-string-open, Q's `/`
+//! comment-vs-REDUCE) needed a `GrammarLexer::add_pre_tokenize` /
+//! `add_post_tokenize` hook, because the shared engine's declarative
+//! `.tokens` layer has no lookaround and cannot express "does this
+//! character have whitespace/a particular token type next to it." IDL has
+//! an analogous-*looking* ambiguity — MA12 §3 item 3's `/KEYWORD` boolean
+//! shorthand (`PLOT, x, /YLOG`) versus `/` as ordinary division — but,
+//! unlike Q's `/`, it genuinely cannot be resolved by any hook operating on
+//! raw characters or a flat token list, at any adjacency: `PLOT, x, /YLOG`
+//! and `x = a/YLOG` both have `/` glued to an identifier with zero
+//! intervening whitespace, yet mean different things, because the
+//! distinguishing fact is *which grammar production is currently being
+//! parsed* (is this position inside a call's argument list?) — genuine
+//! parse-context information no lexer-level hook has access to. MA12 §3
+//! item 3 says this explicitly: the signal is "grammatical position, not
+//! whitespace." So this crate emits `SLASH` as one ordinary, unconditional
+//! division-operator token in every position, full stop, and installs no
+//! hooks at all — the `/KEYWORD` production is `idl-parser`'s problem
+//! (MA-12c), not tokenized differently here. See `code/grammars/idl/idl.tokens`'s
+//! own header comment for the fuller argument.
+//!
+//! The same absence of ambiguity applies to IDL's two quote characters (no
+//! transpose operator exists to collide with `'`) and to `;` (no other
+//! token in this cut's grammar shares that character the way Q's `/` does)
+//! — so `idl.tokens` is entirely declarative, and this crate is a thin
+//! wrapper with zero custom lexer code, simpler than every sibling array
+//! frontend's own `*-lexer` crate.
+//!
+//! ## Case-insensitivity
+//!
+//! IDL is documented as not case sensitive for its language surface
+//! (keywords, procedure/function/variable names), except for the contents
+//! of a quoted string. `idl.tokens` sets `# @case_insensitive true` (no
+//! `case_sensitive: false`), so only `keywords:`-block lookup folds case —
+//! `if`/`If`/`IF` all promote to `KEYWORD("IF")` — while ordinary `NAME`
+//! tokens and `STRING` contents keep the exact case the source text used.
+//! See `idl.tokens`'s own header comment for the full reasoning and the
+//! precedent (`dot.tokens`/`excel.tokens`/`spice/berkeley.tokens` already
+//! use the identical combination in this repo).
+
+use lexer::grammar_lexer::GrammarLexer;
+use lexer::token::Token;
+
+mod _grammar;
+
+// ===========================================================================
+// Public API
+// ===========================================================================
+
+/// Create a [`GrammarLexer`] configured for IDL source.
+///
+/// No pre/post-tokenize hooks are installed — see this module's own doc
+/// comment for why `idl.tokens` needs none (unlike `q-lexer`/`scilab-lexer`).
+pub fn create_idl_lexer(source: &str) -> GrammarLexer<'_> {
+    let grammar = _grammar::token_grammar();
+    GrammarLexer::new(source, &grammar)
+}
+
+/// Tokenize IDL source text into a vector of tokens (ending in `EOF`).
+///
+/// # Panics
+///
+/// Panics on an unrecognized character. Use [`try_tokenize_idl`] for a
+/// `Result`-returning version instead.
+///
+/// # Example
+///
+/// ```
+/// use coding_adventures_idl_lexer::tokenize_idl;
+///
+/// let tokens = tokenize_idl("PRINT, 'hello'\n");
+/// ```
+pub fn tokenize_idl(source: &str) -> Vec<Token> {
+    create_idl_lexer(source)
+        .tokenize()
+        .unwrap_or_else(|err| panic!("IDL tokenization failed: {err}"))
+}
+
+/// Tokenize IDL source text, returning a `Result` instead of panicking.
+pub fn try_tokenize_idl(source: &str) -> Result<Vec<Token>, String> {
+    create_idl_lexer(source)
+        .tokenize()
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+    use lexer::token::TokenType;
+
+    fn types(source: &str) -> Vec<String> {
+        tokenize_idl(source)
+            .into_iter()
+            .filter(|t| t.type_ != TokenType::Eof)
+            .map(|t| t.effective_type_name().to_string())
+            .collect()
+    }
+
+    fn values(source: &str) -> Vec<String> {
+        tokenize_idl(source)
+            .into_iter()
+            .filter(|t| t.type_ != TokenType::Eof)
+            .map(|t| t.value)
+            .collect()
+    }
+
+    // A handful of smoke tests directly against the public API; the crate's
+    // `tests/test_tokenizer.rs` covers the full grammar plus a much larger
+    // set of edge cases (mirroring q-lexer's/scilab-lexer's own split
+    // between a small in-module smoke suite and the exhaustive integration
+    // test file).
+
+    #[test]
+    fn tokenizes_a_print_statement_with_a_single_quoted_string() {
+        // PRINT is an ordinary library-routine NAME, not a reserved
+        // keyword -- MA12 Â§4 lists it alongside PLOT/SIN/TOTAL/etc. as an
+        // intrinsic procedure/function, resolved by name at a later layer,
+        // not part of the closed keyword set Â§3/Â§6 fix (IF/FOR/.../EQ/
+        // AND/...). Only THOSE are promoted to KEYWORD here.
+        assert_eq!(types("PRINT, 'hello'"), vec!["NAME", "COMMA", "STRING"]);
+        assert_eq!(values("PRINT, 'hello'"), vec!["PRINT", ",", "hello"]);
+    }
+
+    #[test]
+    fn keyword_lookup_is_case_insensitive_but_names_preserve_case() {
+        assert_eq!(types("if"), vec!["KEYWORD"]);
+        assert_eq!(values("if"), vec!["IF"]);
+        assert_eq!(values("MyVar"), vec!["MyVar"]);
+    }
+
+    #[test]
+    fn slash_is_always_plain_division_at_the_lexer_layer() {
+        // The /KEYWORD-vs-division question is idl-parser's (MA-12c), not
+        // this crate's -- see this module's own doc comment. PLOT is an
+        // ordinary library-routine NAME (see the test above), not a
+        // keyword.
+        assert_eq!(types("a/YLOG"), vec!["NAME", "SLASH", "NAME"]);
+        assert_eq!(
+            types("PLOT, x, /YLOG"),
+            vec!["NAME", "COMMA", "NAME", "COMMA", "SLASH", "NAME",]
+        );
+    }
+
+    #[test]
+    fn tokenize_idl_panics_on_malformed_source() {
+        let result = std::panic::catch_unwind(|| tokenize_idl("@"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn create_idl_lexer_exposes_the_result_returning_api() {
+        assert!(create_idl_lexer("x = 1").tokenize().is_ok());
+        assert!(create_idl_lexer("@").tokenize().is_err());
+    }
+}

--- a/code/packages/rust/idl-lexer/src/lib.rs
+++ b/code/packages/rust/idl-lexer/src/lib.rs
@@ -136,9 +136,9 @@ mod unit_tests {
     #[test]
     fn tokenizes_a_print_statement_with_a_single_quoted_string() {
         // PRINT is an ordinary library-routine NAME, not a reserved
-        // keyword -- MA12 Â§4 lists it alongside PLOT/SIN/TOTAL/etc. as an
+        // keyword -- MA12 §4 lists it alongside PLOT/SIN/TOTAL/etc. as an
         // intrinsic procedure/function, resolved by name at a later layer,
-        // not part of the closed keyword set Â§3/Â§6 fix (IF/FOR/.../EQ/
+        // not part of the closed keyword set §3/§6 fix (IF/FOR/.../EQ/
         // AND/...). Only THOSE are promoted to KEYWORD here.
         assert_eq!(types("PRINT, 'hello'"), vec!["NAME", "COMMA", "STRING"]);
         assert_eq!(values("PRINT, 'hello'"), vec!["PRINT", ",", "hello"]);

--- a/code/packages/rust/idl-lexer/tests/test_tokenizer.rs
+++ b/code/packages/rust/idl-lexer/tests/test_tokenizer.rs
@@ -1,0 +1,594 @@
+use coding_adventures_idl_lexer::{create_idl_lexer, tokenize_idl, try_tokenize_idl};
+use lexer::token::TokenType;
+
+fn token_types(source: &str) -> Vec<String> {
+    tokenize_idl(source)
+        .into_iter()
+        .filter(|token| token.type_ != TokenType::Eof)
+        .map(|token| token.effective_type_name().to_string())
+        .collect()
+}
+
+fn token_values(source: &str) -> Vec<String> {
+    tokenize_idl(source)
+        .into_iter()
+        .filter(|token| token.type_ != TokenType::Eof)
+        .map(|token| token.value)
+        .collect()
+}
+
+// ===========================================================================
+// `;` line comments (MA12 Â§3/Â§6) -- an ordinary skip: pattern, no hook.
+// ===========================================================================
+
+#[test]
+fn semicolon_opens_a_comment_to_end_of_line() {
+    assert_eq!(
+        token_types("x = 1 ; a trailing comment"),
+        vec!["NAME", "EQUALS", "NUMBER"]
+    );
+}
+
+#[test]
+fn comment_does_not_swallow_the_terminating_newline() {
+    assert_eq!(
+        token_types("x = 1 ; a comment\ny = 2"),
+        vec!["NAME", "EQUALS", "NUMBER", "NEWLINE", "NAME", "EQUALS", "NUMBER"]
+    );
+}
+
+#[test]
+fn whole_line_comment_between_two_statements() {
+    assert_eq!(
+        token_types("x = 1\n; a whole comment line\ny = 2"),
+        vec!["NAME", "EQUALS", "NUMBER", "NEWLINE", "NEWLINE", "NAME", "EQUALS", "NUMBER"]
+    );
+}
+
+#[test]
+fn comment_containing_characters_outside_the_grammars_alphabet() {
+    // A comment's content is arbitrary text and must never be re-lexed as
+    // code -- characters this grammar has no token for at all (here `@`
+    // and `\`, both out of scope) must not cause a lexer error when they
+    // only ever appear inside a comment.
+    assert!(try_tokenize_idl("x = 1 ; cost is @5 \\ off\ny = 2").is_ok());
+}
+
+// ===========================================================================
+// `$` line continuation -- a real token, not stripped (MA12 Â§5).
+// ===========================================================================
+
+#[test]
+fn dollar_is_its_own_continuation_token_not_silently_stripped() {
+    assert_eq!(
+        token_types("x = 1 + $\n    2"),
+        vec![
+            "NAME",
+            "EQUALS",
+            "NUMBER",
+            "PLUS",
+            "CONTINUATION",
+            "NEWLINE",
+            "NUMBER"
+        ]
+    );
+}
+
+// ===========================================================================
+// `&` statement separator (MA12 Â§3/Â§4/Â§6).
+// ===========================================================================
+
+#[test]
+fn ampersand_separates_statements_on_one_line() {
+    assert_eq!(
+        token_types("x = 1 & y = 2"),
+        vec!["NAME", "EQUALS", "NUMBER", "STMT_SEP", "NAME", "EQUALS", "NUMBER"]
+    );
+}
+
+// ===========================================================================
+// Single- and double-quoted strings (MA12 Â§2/Â§4) -- unified STRING type.
+// ===========================================================================
+
+#[test]
+fn single_quoted_string_literal() {
+    assert_eq!(token_types("'hello'"), vec!["STRING"]);
+    assert_eq!(token_values("'hello'"), vec!["hello"]);
+}
+
+#[test]
+fn double_quoted_string_literal() {
+    assert_eq!(token_types("\"hello\""), vec!["STRING"]);
+    assert_eq!(token_values("\"hello\""), vec!["hello"]);
+}
+
+#[test]
+fn both_quote_styles_produce_the_same_token_type() {
+    assert_eq!(token_types("'flux'"), token_types("\"flux\""));
+}
+
+#[test]
+fn empty_string_literals_of_both_styles() {
+    assert_eq!(token_types("''"), vec!["STRING"]);
+    assert_eq!(token_values("''"), vec![String::new()]);
+    assert_eq!(token_types("\"\""), vec!["STRING"]);
+    assert_eq!(token_values("\"\""), vec![String::new()]);
+}
+
+#[test]
+fn a_double_quote_may_appear_inside_a_single_quoted_string_and_vice_versa() {
+    // No escape mechanism, per the header note in idl.tokens -- but a
+    // string delimited by one quote style may freely contain the OTHER
+    // quote character verbatim (the real-IDL idiom for embedding a quote).
+    assert_eq!(token_values("'say \"hi\"'"), vec!["say \"hi\""]);
+    assert_eq!(token_values("\"it's fine\""), vec!["it's fine"]);
+}
+
+// ===========================================================================
+// Word operators -- comparison and logical (MA12 Â§4), case-insensitive.
+// ===========================================================================
+
+#[test]
+fn tokenizes_every_comparison_word_operator() {
+    assert_eq!(
+        token_types("EQ NE LT LE GT GE"),
+        vec!["KEYWORD", "KEYWORD", "KEYWORD", "KEYWORD", "KEYWORD", "KEYWORD"]
+    );
+    assert_eq!(
+        token_values("EQ NE LT LE GT GE"),
+        vec!["EQ", "NE", "LT", "LE", "GT", "GE"]
+    );
+}
+
+#[test]
+fn tokenizes_every_logical_word_operator() {
+    assert_eq!(
+        token_types("AND OR NOT XOR"),
+        vec!["KEYWORD", "KEYWORD", "KEYWORD", "KEYWORD"]
+    );
+    assert_eq!(
+        token_values("AND OR NOT XOR"),
+        vec!["AND", "OR", "NOT", "XOR"]
+    );
+}
+
+#[test]
+fn word_operators_have_no_symbolic_alternative_spelling() {
+    // MA12 Â§4 lists ONLY the word forms for IDL's relational operators --
+    // no `<`/`<=`/`!=` symbolic spelling is in this cut's scope, and
+    // idl.tokens has no LT/LE/NE glyph token at all -- `<` falls through to
+    // an honest lex error rather than silently meaning something.
+    assert!(try_tokenize_idl("a < b").is_err());
+    assert!(try_tokenize_idl("a <= b").is_err());
+    // `==` is NOT an error, but not for the reason a MATLAB-family reader
+    // might expect: `=` (EQUALS) is a real, single-character token here
+    // (assignment/keyword-binding, SECTION 3), so "==" simply lexes as two
+    // separate EQUALS tokens -- there is no EQUALS_EQUALS digraph. Whether
+    // that is meaningful is a parser-level question this crate does not
+    // answer.
+    assert_eq!(
+        token_types("a == b"),
+        vec!["NAME", "EQUALS", "EQUALS", "NAME"]
+    );
+}
+
+#[test]
+fn word_operator_keyword_lookup_is_case_insensitive() {
+    assert_eq!(token_types("eq"), vec!["KEYWORD"]);
+    assert_eq!(token_values("eq"), vec!["EQ"]);
+    assert_eq!(token_values("Eq"), vec!["EQ"]);
+    assert_eq!(token_values("and"), vec!["AND"]);
+}
+
+#[test]
+fn a_comparison_expression_using_word_operators() {
+    assert_eq!(
+        token_types("IF x EQ 1 THEN y = 2"),
+        vec!["KEYWORD", "NAME", "KEYWORD", "NUMBER", "KEYWORD", "NAME", "EQUALS", "NUMBER",]
+    );
+}
+
+// ===========================================================================
+// Control-flow / definition keywords (MA12 Â§3/Â§4/Â§6), case-insensitive.
+// ===========================================================================
+
+#[test]
+fn tokenizes_if_then_else_endif_endelse() {
+    assert_eq!(
+        token_types("IF THEN ELSE ENDIF ENDELSE"),
+        vec!["KEYWORD", "KEYWORD", "KEYWORD", "KEYWORD", "KEYWORD"]
+    );
+    assert_eq!(
+        token_values("IF THEN ELSE ENDIF ENDELSE"),
+        vec!["IF", "THEN", "ELSE", "ENDIF", "ENDELSE"]
+    );
+}
+
+#[test]
+fn tokenizes_for_do_endfor_and_while_endwhile_sharing_do() {
+    assert_eq!(token_values("FOR DO ENDFOR"), vec!["FOR", "DO", "ENDFOR"]);
+    assert_eq!(
+        token_values("WHILE DO ENDWHILE"),
+        vec!["WHILE", "DO", "ENDWHILE"]
+    );
+}
+
+#[test]
+fn tokenizes_repeat_until_endrep() {
+    assert_eq!(
+        token_values("REPEAT UNTIL ENDREP"),
+        vec!["REPEAT", "UNTIL", "ENDREP"]
+    );
+}
+
+#[test]
+fn tokenizes_break_and_continue() {
+    assert_eq!(token_types("BREAK"), vec!["KEYWORD"]);
+    assert_eq!(token_types("CONTINUE"), vec!["KEYWORD"]);
+}
+
+#[test]
+fn tokenizes_begin_and_generic_end() {
+    assert_eq!(token_values("BEGIN END"), vec!["BEGIN", "END"]);
+}
+
+#[test]
+fn tokenizes_pro_function_return() {
+    assert_eq!(
+        token_values("PRO FUNCTION RETURN"),
+        vec!["PRO", "FUNCTION", "RETURN"]
+    );
+}
+
+#[test]
+fn keywords_are_case_insensitive_but_names_are_not_altered() {
+    assert_eq!(token_types("pro"), vec!["KEYWORD"]);
+    assert_eq!(token_values("pro"), vec!["PRO"]);
+    assert_eq!(token_types("Pro"), vec!["KEYWORD"]);
+    assert_eq!(token_values("Pro"), vec!["PRO"]);
+
+    // A non-keyword identifier keeps its EXACT original casing -- only
+    // `keywords:`-block lookup folds case, per idl.tokens's own header note.
+    assert_eq!(token_types("MyProc"), vec!["NAME"]);
+    assert_eq!(token_values("MyProc"), vec!["MyProc"]);
+}
+
+// ===========================================================================
+// A PRO definition, a FUNCTION definition (MA12 Â§3/Â§4).
+// ===========================================================================
+
+#[test]
+fn tokenizes_a_pro_definition_header_and_end() {
+    // PRO GREET, name
+    //   PRINT, name
+    // END
+    //
+    // PRINT is an ordinary library-routine NAME, not a reserved keyword --
+    // MA12 Â§4 lists it alongside PLOT/SIN/TOTAL/etc. as an intrinsic
+    // procedure/function resolved by name at a later layer, distinct from
+    // the closed keyword set Â§3/Â§6 fix (PRO/END/IF/.../EQ/AND/...).
+    let src = "PRO GREET, name\n  PRINT, name\nEND";
+    assert_eq!(
+        token_types(src),
+        vec![
+            "KEYWORD", "NAME", "COMMA", "NAME", "NEWLINE", "NAME", "COMMA", "NAME", "NEWLINE",
+            "KEYWORD",
+        ]
+    );
+}
+
+#[test]
+fn tokenizes_a_function_definition_with_return() {
+    // FUNCTION DOUBLE, x
+    //   RETURN, x*2
+    // END
+    let src = "FUNCTION DOUBLE, x\n  RETURN, x*2\nEND";
+    assert_eq!(
+        token_types(src),
+        vec![
+            "KEYWORD", "NAME", "COMMA", "NAME", "NEWLINE", "KEYWORD", "COMMA", "NAME", "STAR",
+            "NUMBER", "NEWLINE", "KEYWORD",
+        ]
+    );
+}
+
+// ===========================================================================
+// Procedure call with keyword arguments and the `/KEYWORD` shorthand
+// (MA12 Â§3 items 2-3) -- the LEXER'S job is only to emit the ordinary
+// token stream; the boolean-shorthand PRODUCTION itself is idl-parser's.
+// ===========================================================================
+
+#[test]
+fn tokenizes_a_procedure_call_with_keyword_arguments_and_boolean_shorthand() {
+    // PLOT, x, TITLE='flux', /YLOG
+    let src = "PLOT, x, TITLE='flux', /YLOG";
+    assert_eq!(
+        token_types(src),
+        vec![
+            "NAME", "COMMA", "NAME", "COMMA", "NAME", "EQUALS", "STRING", "COMMA", "SLASH", "NAME",
+        ]
+    );
+    assert_eq!(token_values(src)[0], "PLOT");
+    assert_eq!(token_values(src)[6], "flux");
+    assert_eq!(token_values(src)[9], "YLOG");
+}
+
+#[test]
+fn slash_before_an_identifier_is_always_plain_division_at_this_layer() {
+    // The exact same zero-whitespace "/IDENT" shape as the boolean
+    // shorthand above, but in ordinary expression position -- MA12 Â§3
+    // item 3 frames telling these apart as a parse-context (grammatical
+    // position) concern, not a lexer one, so both must tokenize IDENTICALLY
+    // here: SLASH then NAME, with no special-casing. Compare the trailing
+    // two tokens of each snippet -- one is a call argument, the other an
+    // ordinary division expression, yet the lexer sees the same shape.
+    assert_eq!(token_types("a/YLOG"), vec!["NAME", "SLASH", "NAME"]);
+    // "PLOT, x, /YLOG"  -> NAME COMMA NAME COMMA SLASH NAME  (6 tokens)
+    // "y = a/YLOG"      -> NAME EQUALS NAME SLASH NAME       (5 tokens)
+    let call_tail = &token_types("PLOT, x, /YLOG")[4..];
+    let division_tail = &token_types("y = a/YLOG")[3..];
+    assert_eq!(call_tail, vec!["SLASH", "NAME"]);
+    assert_eq!(division_tail, vec!["SLASH", "NAME"]);
+    assert_eq!(call_tail, division_tail);
+}
+
+// ===========================================================================
+// IF...THEN...ENDIF block (MA12 Â§4).
+// ===========================================================================
+
+#[test]
+fn tokenizes_an_if_then_endif_block() {
+    // IF x EQ 1 THEN BEGIN
+    //   y = 2
+    // ENDIF
+    let src = "IF x EQ 1 THEN BEGIN\n  y = 2\nENDIF";
+    assert_eq!(
+        token_types(src),
+        vec![
+            "KEYWORD", "NAME", "KEYWORD", "NUMBER", "KEYWORD", "KEYWORD", "NEWLINE", "NAME",
+            "EQUALS", "NUMBER", "NEWLINE", "KEYWORD",
+        ]
+    );
+}
+
+// ===========================================================================
+// Array literals and subscripting (MA12 Â§4).
+// ===========================================================================
+
+#[test]
+fn tokenizes_an_array_literal() {
+    assert_eq!(
+        token_types("[1, 2, 3]"),
+        vec!["LBRACKET", "NUMBER", "COMMA", "NUMBER", "COMMA", "NUMBER", "RBRACKET"]
+    );
+}
+
+#[test]
+fn tokenizes_simple_subscripting() {
+    assert_eq!(
+        token_types("a[0]"),
+        vec!["NAME", "LBRACKET", "NUMBER", "RBRACKET"]
+    );
+}
+
+#[test]
+fn tokenizes_negative_from_end_subscripting() {
+    // a[-1] -- unary MINUS, resolved at a later layer (MA12 Â§2 note 2).
+    assert_eq!(
+        token_types("a[-1]"),
+        vec!["NAME", "LBRACKET", "MINUS", "NUMBER", "RBRACKET"]
+    );
+}
+
+#[test]
+fn tokenizes_ranged_and_strided_subscripts() {
+    assert_eq!(
+        token_types("a[s0:s1]"),
+        vec!["NAME", "LBRACKET", "NAME", "COLON", "NAME", "RBRACKET"]
+    );
+    assert_eq!(
+        token_types("a[s0:s1:n]"),
+        vec!["NAME", "LBRACKET", "NAME", "COLON", "NAME", "COLON", "NAME", "RBRACKET"]
+    );
+}
+
+#[test]
+fn tokenizes_the_all_rest_wildcard_subscript() {
+    // a[*] and a[s0:*] -- STAR is reused; the wildcard MEANING is a parser
+    // concern, per idl.tokens's own SECTION 3 note.
+    assert_eq!(
+        token_types("a[*]"),
+        vec!["NAME", "LBRACKET", "STAR", "RBRACKET"]
+    );
+    assert_eq!(
+        token_types("a[s0:*]"),
+        vec!["NAME", "LBRACKET", "NAME", "COLON", "STAR", "RBRACKET"]
+    );
+}
+
+#[test]
+fn tokenizes_two_dimensional_subscripting() {
+    assert_eq!(
+        token_types("a[i, j]"),
+        vec!["NAME", "LBRACKET", "NAME", "COMMA", "NAME", "RBRACKET"]
+    );
+}
+
+// ===========================================================================
+// Matrix-product operators: the `##` vs `#` longest-match regression
+// (MA12 Â§4/Â§6).
+// ===========================================================================
+
+#[test]
+fn double_hash_wins_over_bare_hash_by_longest_match() {
+    assert_eq!(token_types("##"), vec!["HASH_HASH"]);
+    assert_eq!(token_types("#"), vec!["HASH"]);
+}
+
+#[test]
+fn matrix_product_operators_between_operands() {
+    assert_eq!(token_types("a # b"), vec!["NAME", "HASH", "NAME"]);
+    assert_eq!(token_types("a ## b"), vec!["NAME", "HASH_HASH", "NAME"]);
+}
+
+#[test]
+fn three_hashes_lex_as_double_hash_then_bare_hash() {
+    // A regression on the greedy/first-match interaction: "###" must lex
+    // as HASH_HASH then HASH (longest match at each position), never as
+    // HASH three times or HASH_HASH swallowing all three characters.
+    assert_eq!(token_types("###"), vec!["HASH_HASH", "HASH"]);
+}
+
+#[test]
+fn four_hashes_lex_as_two_double_hashes() {
+    assert_eq!(token_types("####"), vec!["HASH_HASH", "HASH_HASH"]);
+}
+
+// ===========================================================================
+// Arithmetic and assignment (MA12 Â§4).
+// ===========================================================================
+
+#[test]
+fn tokenizes_ordinary_arithmetic_operators() {
+    assert_eq!(
+        token_types("a + b - c * d / e ^ f"),
+        vec![
+            "NAME", "PLUS", "NAME", "MINUS", "NAME", "STAR", "NAME", "SLASH", "NAME", "CARET",
+            "NAME",
+        ]
+    );
+}
+
+#[test]
+fn equals_is_one_token_for_both_assignment_and_keyword_binding() {
+    // MA12 Â§3 item 2: telling these apart is idl-parser's job, not this
+    // lexer's -- both contexts emit the same EQUALS token here.
+    assert_eq!(token_types("x = 1"), vec!["NAME", "EQUALS", "NUMBER"]);
+    assert_eq!(
+        token_types("TITLE='flux'"),
+        vec!["NAME", "EQUALS", "STRING"]
+    );
+}
+
+// ===========================================================================
+// Numeric literals (MA12 Â§2/Â§4).
+// ===========================================================================
+
+#[test]
+fn tokenizes_integers_and_decimals() {
+    assert_eq!(token_types("42"), vec!["NUMBER"]);
+    assert_eq!(token_values("3.14"), vec!["3.14"]);
+}
+
+#[test]
+fn tokenizes_leading_dot_floats() {
+    assert_eq!(token_types(".5"), vec!["NUMBER"]);
+    assert_eq!(token_values(".5"), vec![".5"]);
+}
+
+#[test]
+fn tokenizes_numbers_with_exponents() {
+    assert_eq!(token_values("1e10"), vec!["1e10"]);
+    assert_eq!(token_values("1e-5"), vec!["1e-5"]);
+    assert_eq!(token_values("2.5E+3"), vec!["2.5E+3"]);
+}
+
+#[test]
+fn typed_numeric_suffixes_are_not_part_of_this_cuts_number_token() {
+    // MA12 Â§2/Â§4 defer IDL's typed numeric tower entirely -- a literal
+    // spelled with a type suffix (`5L`) lexes as NUMBER("5") followed by a
+    // separate NAME("L"), an honest reflection of the un-typed f64 model
+    // rather than a silent guess at what the suffix should mean.
+    assert_eq!(token_types("5L"), vec!["NUMBER", "NAME"]);
+    assert_eq!(token_values("5L"), vec!["5", "L"]);
+}
+
+// ===========================================================================
+// Identifiers.
+// ===========================================================================
+
+#[test]
+fn identifier_must_start_with_a_letter() {
+    assert_eq!(token_types("N_ELEMENTS"), vec!["NAME"]);
+    assert_eq!(token_values("x9"), vec!["x9"]);
+}
+
+#[test]
+fn underscore_is_a_valid_continuation_character() {
+    assert_eq!(token_types("PTR_NEW"), vec!["NAME"]);
+    assert_eq!(token_values("PTR_NEW"), vec!["PTR_NEW"]);
+}
+
+#[test]
+fn leading_underscore_identifier_is_not_a_valid_name_this_cut() {
+    // _EXTRA/_REF_EXTRA (deferred, MA12 Â§4) would need a leading
+    // underscore, which NAME does not allow in this cut -- a bare leading
+    // `_` has no token at all and falls through to an honest lex error.
+    assert!(try_tokenize_idl("_EXTRA").is_err());
+}
+
+// ===========================================================================
+// Newlines and whitespace.
+// ===========================================================================
+
+#[test]
+fn newline_is_its_own_significant_token() {
+    assert_eq!(
+        token_types("x = 1\ny = 2"),
+        vec!["NAME", "EQUALS", "NUMBER", "NEWLINE", "NAME", "EQUALS", "NUMBER"]
+    );
+}
+
+#[test]
+fn skips_ordinary_whitespace() {
+    assert_eq!(token_types("x   =   1"), vec!["NAME", "EQUALS", "NUMBER"]);
+}
+
+// ===========================================================================
+// Errors.
+// ===========================================================================
+
+#[test]
+fn unrecognized_character_is_an_error() {
+    // `@`, `?`, `.` (outside a NUMBER), `\`, `{`, `}` are all deferred/out
+    // of scope per MA12 Â§4 -- none has a token in this cut's grammar.
+    assert!(try_tokenize_idl("a@b").is_err());
+    assert!(try_tokenize_idl("a?b").is_err());
+    assert!(try_tokenize_idl("s.tag").is_err());
+    assert!(try_tokenize_idl("{1:2}").is_err());
+}
+
+#[test]
+fn tokenize_idl_panics_on_malformed_source() {
+    let result = std::panic::catch_unwind(|| tokenize_idl("@"));
+    assert!(result.is_err());
+}
+
+#[test]
+fn create_idl_lexer_exposes_the_result_returning_api() {
+    assert!(create_idl_lexer("x = 1").tokenize().is_ok());
+    assert!(create_idl_lexer("@").tokenize().is_err());
+}
+
+// ===========================================================================
+// End-to-end: a small, realistic "textbook IDL session" snippet.
+// ===========================================================================
+
+#[test]
+fn tokenizes_a_small_end_to_end_snippet() {
+    // PRO GREET, name        ; say hello
+    //   PRINT, 'Hello, ', name
+    // END
+    // PRINT is an ordinary library-routine NAME, not a keyword (see
+    // `tokenizes_a_pro_definition_header_and_end` above).
+    let src = "PRO GREET, name        ; say hello\n  PRINT, 'Hello, ', name\nEND";
+    assert_eq!(
+        token_types(src),
+        vec![
+            "KEYWORD", "NAME", "COMMA", "NAME", "NEWLINE", "NAME", "COMMA", "STRING", "COMMA",
+            "NAME", "NEWLINE", "KEYWORD",
+        ]
+    );
+    assert_eq!(token_values(src)[0], "PRO");
+    assert_eq!(token_values(src)[7], "Hello, ");
+}

--- a/code/packages/rust/idl-lexer/tests/test_tokenizer.rs
+++ b/code/packages/rust/idl-lexer/tests/test_tokenizer.rs
@@ -18,7 +18,7 @@ fn token_values(source: &str) -> Vec<String> {
 }
 
 // ===========================================================================
-// `;` line comments (MA12 Â§3/Â§6) -- an ordinary skip: pattern, no hook.
+// `;` line comments (MA12 §3/§6) -- an ordinary skip: pattern, no hook.
 // ===========================================================================
 
 #[test]
@@ -55,7 +55,7 @@ fn comment_containing_characters_outside_the_grammars_alphabet() {
 }
 
 // ===========================================================================
-// `$` line continuation -- a real token, not stripped (MA12 Â§5).
+// `$` line continuation -- a real token, not stripped (MA12 §5).
 // ===========================================================================
 
 #[test]
@@ -75,7 +75,7 @@ fn dollar_is_its_own_continuation_token_not_silently_stripped() {
 }
 
 // ===========================================================================
-// `&` statement separator (MA12 Â§3/Â§4/Â§6).
+// `&` statement separator (MA12 §3/§4/§6).
 // ===========================================================================
 
 #[test]
@@ -87,7 +87,7 @@ fn ampersand_separates_statements_on_one_line() {
 }
 
 // ===========================================================================
-// Single- and double-quoted strings (MA12 Â§2/Â§4) -- unified STRING type.
+// Single- and double-quoted strings (MA12 §2/§4) -- unified STRING type.
 // ===========================================================================
 
 #[test]
@@ -125,7 +125,7 @@ fn a_double_quote_may_appear_inside_a_single_quoted_string_and_vice_versa() {
 }
 
 // ===========================================================================
-// Word operators -- comparison and logical (MA12 Â§4), case-insensitive.
+// Word operators -- comparison and logical (MA12 §4), case-insensitive.
 // ===========================================================================
 
 #[test]
@@ -154,7 +154,7 @@ fn tokenizes_every_logical_word_operator() {
 
 #[test]
 fn word_operators_have_no_symbolic_alternative_spelling() {
-    // MA12 Â§4 lists ONLY the word forms for IDL's relational operators --
+    // MA12 §4 lists ONLY the word forms for IDL's relational operators --
     // no `<`/`<=`/`!=` symbolic spelling is in this cut's scope, and
     // idl.tokens has no LT/LE/NE glyph token at all -- `<` falls through to
     // an honest lex error rather than silently meaning something.
@@ -189,7 +189,7 @@ fn a_comparison_expression_using_word_operators() {
 }
 
 // ===========================================================================
-// Control-flow / definition keywords (MA12 Â§3/Â§4/Â§6), case-insensitive.
+// Control-flow / definition keywords (MA12 §3/§4/§6), case-insensitive.
 // ===========================================================================
 
 #[test]
@@ -254,7 +254,7 @@ fn keywords_are_case_insensitive_but_names_are_not_altered() {
 }
 
 // ===========================================================================
-// A PRO definition, a FUNCTION definition (MA12 Â§3/Â§4).
+// A PRO definition, a FUNCTION definition (MA12 §3/§4).
 // ===========================================================================
 
 #[test]
@@ -264,9 +264,9 @@ fn tokenizes_a_pro_definition_header_and_end() {
     // END
     //
     // PRINT is an ordinary library-routine NAME, not a reserved keyword --
-    // MA12 Â§4 lists it alongside PLOT/SIN/TOTAL/etc. as an intrinsic
+    // MA12 §4 lists it alongside PLOT/SIN/TOTAL/etc. as an intrinsic
     // procedure/function resolved by name at a later layer, distinct from
-    // the closed keyword set Â§3/Â§6 fix (PRO/END/IF/.../EQ/AND/...).
+    // the closed keyword set §3/§6 fix (PRO/END/IF/.../EQ/AND/...).
     let src = "PRO GREET, name\n  PRINT, name\nEND";
     assert_eq!(
         token_types(src),
@@ -294,7 +294,7 @@ fn tokenizes_a_function_definition_with_return() {
 
 // ===========================================================================
 // Procedure call with keyword arguments and the `/KEYWORD` shorthand
-// (MA12 Â§3 items 2-3) -- the LEXER'S job is only to emit the ordinary
+// (MA12 §3 items 2-3) -- the LEXER'S job is only to emit the ordinary
 // token stream; the boolean-shorthand PRODUCTION itself is idl-parser's.
 // ===========================================================================
 
@@ -316,7 +316,7 @@ fn tokenizes_a_procedure_call_with_keyword_arguments_and_boolean_shorthand() {
 #[test]
 fn slash_before_an_identifier_is_always_plain_division_at_this_layer() {
     // The exact same zero-whitespace "/IDENT" shape as the boolean
-    // shorthand above, but in ordinary expression position -- MA12 Â§3
+    // shorthand above, but in ordinary expression position -- MA12 §3
     // item 3 frames telling these apart as a parse-context (grammatical
     // position) concern, not a lexer one, so both must tokenize IDENTICALLY
     // here: SLASH then NAME, with no special-casing. Compare the trailing
@@ -333,7 +333,7 @@ fn slash_before_an_identifier_is_always_plain_division_at_this_layer() {
 }
 
 // ===========================================================================
-// IF...THEN...ENDIF block (MA12 Â§4).
+// IF...THEN...ENDIF block (MA12 §4).
 // ===========================================================================
 
 #[test]
@@ -352,7 +352,7 @@ fn tokenizes_an_if_then_endif_block() {
 }
 
 // ===========================================================================
-// Array literals and subscripting (MA12 Â§4).
+// Array literals and subscripting (MA12 §4).
 // ===========================================================================
 
 #[test]
@@ -373,7 +373,7 @@ fn tokenizes_simple_subscripting() {
 
 #[test]
 fn tokenizes_negative_from_end_subscripting() {
-    // a[-1] -- unary MINUS, resolved at a later layer (MA12 Â§2 note 2).
+    // a[-1] -- unary MINUS, resolved at a later layer (MA12 §2 note 2).
     assert_eq!(
         token_types("a[-1]"),
         vec!["NAME", "LBRACKET", "MINUS", "NUMBER", "RBRACKET"]
@@ -416,7 +416,7 @@ fn tokenizes_two_dimensional_subscripting() {
 
 // ===========================================================================
 // Matrix-product operators: the `##` vs `#` longest-match regression
-// (MA12 Â§4/Â§6).
+// (MA12 §4/§6).
 // ===========================================================================
 
 #[test]
@@ -445,7 +445,7 @@ fn four_hashes_lex_as_two_double_hashes() {
 }
 
 // ===========================================================================
-// Arithmetic and assignment (MA12 Â§4).
+// Arithmetic and assignment (MA12 §4).
 // ===========================================================================
 
 #[test]
@@ -461,7 +461,7 @@ fn tokenizes_ordinary_arithmetic_operators() {
 
 #[test]
 fn equals_is_one_token_for_both_assignment_and_keyword_binding() {
-    // MA12 Â§3 item 2: telling these apart is idl-parser's job, not this
+    // MA12 §3 item 2: telling these apart is idl-parser's job, not this
     // lexer's -- both contexts emit the same EQUALS token here.
     assert_eq!(token_types("x = 1"), vec!["NAME", "EQUALS", "NUMBER"]);
     assert_eq!(
@@ -471,7 +471,7 @@ fn equals_is_one_token_for_both_assignment_and_keyword_binding() {
 }
 
 // ===========================================================================
-// Numeric literals (MA12 Â§2/Â§4).
+// Numeric literals (MA12 §2/§4).
 // ===========================================================================
 
 #[test]
@@ -495,7 +495,7 @@ fn tokenizes_numbers_with_exponents() {
 
 #[test]
 fn typed_numeric_suffixes_are_not_part_of_this_cuts_number_token() {
-    // MA12 Â§2/Â§4 defer IDL's typed numeric tower entirely -- a literal
+    // MA12 §2/§4 defer IDL's typed numeric tower entirely -- a literal
     // spelled with a type suffix (`5L`) lexes as NUMBER("5") followed by a
     // separate NAME("L"), an honest reflection of the un-typed f64 model
     // rather than a silent guess at what the suffix should mean.
@@ -521,7 +521,7 @@ fn underscore_is_a_valid_continuation_character() {
 
 #[test]
 fn leading_underscore_identifier_is_not_a_valid_name_this_cut() {
-    // _EXTRA/_REF_EXTRA (deferred, MA12 Â§4) would need a leading
+    // _EXTRA/_REF_EXTRA (deferred, MA12 §4) would need a leading
     // underscore, which NAME does not allow in this cut -- a bare leading
     // `_` has no token at all and falls through to an honest lex error.
     assert!(try_tokenize_idl("_EXTRA").is_err());
@@ -551,7 +551,7 @@ fn skips_ordinary_whitespace() {
 #[test]
 fn unrecognized_character_is_an_error() {
     // `@`, `?`, `.` (outside a NUMBER), `\`, `{`, `}` are all deferred/out
-    // of scope per MA12 Â§4 -- none has a token in this cut's grammar.
+    // of scope per MA12 §4 -- none has a token in this cut's grammar.
     assert!(try_tokenize_idl("a@b").is_err());
     assert!(try_tokenize_idl("a?b").is_err());
     assert!(try_tokenize_idl("s.tag").is_err());


### PR DESCRIPTION
## Summary

MA-12b, the second implementation item in IDL's Wave-6 rollout (following the merged MA12-idl-language.md kickoff spec, #8890): the lexer for IDL (Interactive Data Language), the science/astronomy array language whose surface is Algol/Fortran-family (statements, `PRO`/`FUNCTION`, `IF`/`FOR`/`WHILE`/`REPEAT` blocks, word operators) rather than array-family like APL/J/Q/Scilab.

- `code/grammars/idl/idl.tokens` — new declarative grammar covering the MA-12b-scoped surface: `;` line comments, `$` line continuation (a real, significant token), `&` statement separator, single/double-quoted strings (unified to one `STRING` type, no escapes), word operators (`EQ NE LT LE GT GE AND OR NOT XOR`), the two matrix-product operators `#`/`##` (longest-match-first), `[`/`]` subscript brackets, ordinary arithmetic/punctuation, numeric literals, identifiers, and the closed control-flow/definition keyword set.
- `code/packages/rust/idl-lexer/` — new crate wrapping the shared `GrammarLexer` (README, CHANGELOG, Cargo.toml, generated `_grammar.rs`, 59 tests: 5 lib smoke + 53 integration + 1 doc test).
- Workspace registration in `code/packages/rust/Cargo.toml`.

**Key design finding**: MA12 §3 item 3's `/KEYWORD` boolean-shorthand-vs-division question is correctly a parser-level concern, not a lexer one — unlike Q's analogous `/`-comment-vs-REDUCE ambiguity (resolved via whitespace-adjacency hooks in `q-lexer`), IDL's `/YLOG` is glued with zero whitespace on either side in both the boolean-shorthand and division readings, so only grammar-position (inside a call's argument list or not) disambiguates it — information only `idl-parser` (MA-12c) has. This crate therefore installs zero pre/post-tokenize hooks, simpler than every sibling array-family lexer.

## Test plan

- [x] `cargo test -p coding-adventures-idl-lexer` — 53 integration + 5 lib + 1 doc test, all passing (independently re-run after fixes below, not just agent-reported)
- [x] `cargo clippy -p coding-adventures-idl-lexer --all-targets -- -D warnings` — clean
- [x] Fixed a double-UTF-8-encoded section-sign mojibake ("MA12 Â§3" instead of "MA12 §3") introduced across `idl.tokens`, `lib.rs`, and `test_tokenizer.rs` comments during authoring — confirmed via byte-level diff that the merged spec file this content quotes from has clean `§` characters throughout, so the corruption was introduced fresh, not inherited; fixed in a separate commit, re-tested clean.
- [x] `/security-review` — passed clean, including a specific ReDoS check on all 6 new regex patterns (all single bounded repeats; `regex` crate's finite-automaton engine forecloses catastrophic backtracking structurally regardless of pattern shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)