### PR TITLE
feat(spice): add diode flicker exponent

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add diode model-card `AF` flicker-noise current-exponent support, defaulting
+  to `1` and applying `KF * abs(Id)^AF / frequency` across noise analysis.
 - Add diode model-card `KF` flicker-noise support with a distinct diode-current
   `flicker` contribution and Berkeley-default inverse-frequency scaling.
 - Add legacy SPICE2 BJT model-card `C2` and `C4` leakage-ratio support,

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -495,6 +495,7 @@ class Diode:
     Eg: float = 1.11  # energy gap in electron volts
     Rs: float = 0.0  # ohmic series resistance
     Kf: float = 0.0  # flicker-noise coefficient
+    Af: float = 1.0  # flicker-noise current exponent
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -601,6 +601,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
             element.Eg,
             element.Rs,
             element.Kf,
+            element.Af,
         )
     if isinstance(element, JFET):
         return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_, element.Cgs, element.Cgd)
@@ -8678,6 +8679,10 @@ def _diode_effective_vt(el: Diode) -> float:
         raise ValueError(
             f"{el.name}: diode flicker-noise coefficient must be finite and non-negative"
         )
+    if not math.isfinite(el.Af) or el.Af < 0.0:
+        raise ValueError(
+            f"{el.name}: diode flicker-noise exponent must be finite and non-negative"
+        )
     if not math.isfinite(el.Rs) or el.Rs < 0.0:
         raise ValueError(f"{el.name}: diode series resistance must be finite and non-negative")
     if not math.isfinite(el.N) or el.N <= 0.0:
@@ -14413,6 +14418,7 @@ def sens_dc(
                     el.Eg,
                     el.Rs,
                     el.Kf,
+                    el.Af,
                 ),
             )
 
@@ -14715,6 +14721,7 @@ def _vary_element(el: Element, tolerance: float, distribution: str) -> Element:
             el.Eg,
             el.Rs,
             el.Kf,
+            el.Af,
         )
 
     if isinstance(el, BJT):
@@ -15195,7 +15202,7 @@ def _collect_noise_sources(
             sources.append((el.name, "shot", n_a, n_k, psd, 0.0))
             if el.Kf > 0.0:
                 sources.append(
-                    (el.name, "flicker", n_a, n_k, el.Kf * abs(I_D), 1.0)
+                    (el.name, "flicker", n_a, n_k, el.Kf * abs(I_D) ** el.Af, 1.0)
                 )
             if el.Rs > 0.0:
                 sources.append(

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -306,7 +306,7 @@ _MODEL_CARD_SUPPORTED_PARAMETER_KINDS = (
     "PMOS",
 )
 _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
-    "D": (14, 20, 5, 3),
+    "D": (15, 21, 5, 3),
     "NPN": (41, 58, 13, 4),
     "PNP": (41, 58, 13, 4),
     "NJF": (5, 11, 5, 3),
@@ -354,6 +354,7 @@ _DIODE_PARAMETER_ALIASES: dict[str, str] = {
     "EG": "EG",
     "RS": "RS",
     "KF": "KF",
+    "AF": "AF",
 }
 
 _BJT_PARAMETER_ALIASES: dict[str, str] = {
@@ -913,6 +914,7 @@ def diode_from_model_card(
         Eg=p.get("EG", 1.11),
         Rs=p.get("RS", 0.0),
         Kf=p.get("KF", 0.0),
+        Af=p.get("AF", 1.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -407,7 +407,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 142
+    assert len(coverage) == 143
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -422,7 +422,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 142
+    assert len(records) == 143
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -439,8 +439,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     summary = model_card_supported_parameter_coverage_summary()
     assert len(summary) == 7
     assert summary[0].kind == "D"
-    assert summary[0].canonical_parameter_count == 14
-    assert summary[0].accepted_name_count == 20
+    assert summary[0].canonical_parameter_count == 15
+    assert summary[0].accepted_name_count == 21
     assert summary[0].aliased_parameter_count == 5
     assert summary[0].max_alias_count == 3
     assert summary[0].aliased_parameters == ("IS", "VT", "CJO", "VJ", "M")
@@ -465,7 +465,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
         == "kind\tcanonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\taliased_parameters"
     )
-    assert table.splitlines()[1] == "D\t14\t20\t5\t3\tIS|VT|CJO|VJ|M"
+    assert table.splitlines()[1] == "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M"
     assert (
         table.splitlines()[-1]
         == "PMOS\t18\t25\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
@@ -474,8 +474,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert len(records) == 7
     assert records[0] == {
         "kind": "D",
-        "canonical_parameter_count": "14",
-        "accepted_name_count": "20",
+        "canonical_parameter_count": "15",
+        "accepted_name_count": "21",
         "aliased_parameter_count": "5",
         "max_alias_count": "3",
         "aliased_parameters": "IS|VT|CJO|VJ|M",
@@ -483,7 +483,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert format_model_card_supported_parameter_coverage_summary_csv().startswith(
         "kind,canonical_parameter_count,accepted_name_count,"
         "aliased_parameter_count,max_alias_count,aliased_parameters\n"
-        "D,14,20,5,3,IS|VT|CJO|VJ|M\n"
+        "D,15,21,5,3,IS|VT|CJO|VJ|M\n"
     )
     assert (
         json.loads(format_model_card_supported_parameter_coverage_summary_json())
@@ -496,9 +496,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 142
-    assert report.expected_canonical_parameter_count == 142
-    assert report.accepted_name_count == 208
+    assert report.canonical_parameter_count == 143
+    assert report.expected_canonical_parameter_count == 143
+    assert report.accepted_name_count == 209
     assert report.aliased_parameter_count == 53
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -506,7 +506,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t142\t142\t208\t53\t4\t0"
+        "true\t7\t7\t143\t143\t209\t53\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -534,8 +534,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 141
-    assert report.accepted_name_count == 205
+    assert report.canonical_parameter_count == 142
+    assert report.accepted_name_count == 206
     assert report.aliased_parameter_count == 52
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -550,7 +550,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t141\t142\t205\t52\t4\t4\n"
+        "false\t7\t7\t142\t143\t206\t52\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -592,6 +592,7 @@ def test_model_card_aliases_build_device_instances() -> None:
             "EG": 1.05,
             "RS": 10.0,
             "KF": 1.0e-12,
+            "AF": 1.3,
         },
     )
     diode_model = diode_from_model_card("D1", "a", "k", diode_card)
@@ -606,6 +607,7 @@ def test_model_card_aliases_build_device_instances() -> None:
         "EG": 1.05,
         "RS": 10.0,
         "KF": 1.0e-12,
+        "AF": 1.3,
     }
     assert diode_card.unsupported_parameters == ()
     assert diode_model.Is == pytest.approx(2.0e-14)
@@ -618,6 +620,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.05) == diode_model.Eg
     assert pytest.approx(10.0) == diode_model.Rs
     assert pytest.approx(1.0e-12) == diode_model.Kf
+    assert pytest.approx(1.3) == diode_model.Af
 
     bjt_card = normalize_model_card(
         "Qsmall", "npn", {"BETA": 125.0, "BETA_R": 0.25, "CBE": 2.0e-12, "XTI": 2.4, "XTB": 1.5, "EG": 1.05, "VA": 80.0, "VB": 120.0, "IK": 2.0e-3, "IKR": 3.0e-3, "T_NOM": 50.0, "KF": 1.0e-12, "AF": 1.3, "PTF": 30.0, "XTF": 2.0, "ITF": 4.0e-3, "VTF": 0.6, "RE": 12.0, "RC": 13.0, "RB": 14.0, "RBM": 2.0, "IRB": 5.0e-6, "XCJC": 0.4, "ISE": 3.0e-13, "NE": 1.7, "ISC": 4.0e-13, "NC": 1.8, "NF": 1.2, "NR": 1.3, "PE": 0.8, "ME": 0.4, "PC": 0.7, "MC": 0.45, "FC": 0.4}
@@ -2367,7 +2370,7 @@ def test_subcircuit_expansion_preserves_complete_diode_model():
     cell = SubcircuitDefinition(
         "diode-cell",
         ("in",),
-        (Diode("Dcell", "in", "0", Vj=0.8, M=0.4, Fc=0.35, Xti=2.2, Eg=1.05, Rs=10.0, Kf=1.0e-12),),
+        (Diode("Dcell", "in", "0", Vj=0.8, M=0.4, Fc=0.35, Xti=2.2, Eg=1.05, Rs=10.0, Kf=1.0e-12, Af=1.3),),
     )
     c = Circuit()
     c.define_subcircuit(cell)
@@ -2381,6 +2384,7 @@ def test_subcircuit_expansion_preserves_complete_diode_model():
     assert expanded.Eg == pytest.approx(1.05)
     assert expanded.Rs == pytest.approx(10.0)
     assert expanded.Kf == pytest.approx(1.0e-12)
+    assert expanded.Af == pytest.approx(1.3)
 
 
 def test_subcircuit_expansion_preserves_complete_bjt_model():
@@ -2678,6 +2682,13 @@ def test_dc_rejects_invalid_bjt_nominal_temperature():
     circuit = Circuit()
     circuit.add(BJT("Qbad", "c", "b", "0", Tnom=0.0))
     with pytest.raises(ValueError, match="nominal temperature must be finite and positive"):
+        dc_op(circuit)
+
+
+def test_dc_rejects_invalid_diode_flicker_noise_exponent():
+    circuit = Circuit()
+    circuit.add(Diode("Dbad", "a", "0", Af=-1.0))
+    with pytest.raises(ValueError, match="flicker-noise exponent must be finite and non-negative"):
         dc_op(circuit)
 
 
@@ -7315,6 +7326,22 @@ def test_noise_diode_kf_adds_inverse_frequency_flicker_noise() -> None:
 
     assert flicker_psds[0] > 0.0
     assert flicker_psds[0] / flicker_psds[1] == pytest.approx(100.0)
+
+
+def test_noise_diode_af_is_the_current_exponent() -> None:
+    def source_psd(exponent: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vbias", "bias", "0", 1.0))
+        circuit.add(Resistor("Rbias", "bias", "out", 1_000.0))
+        circuit.add(Diode("D1", "out", "0", Kf=1.0e-12, Af=exponent))
+        point = noise_ac(circuit, "out", "Vbias", freqs=[1_000.0]).points[0]
+        return next(
+            entry.source_psd
+            for entry in point.entries
+            if entry.element_name == "D1" and entry.noise_type == "flicker"
+        )
+
+    assert source_psd(2.0) < source_psd(1.0)
 
 
 def test_noise_bjt_collector_resistance_adds_thermal_noise() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add diode model-card `AF` flicker-noise current-exponent support, defaulting
+  to `1` and applying `KF * abs(Id)^AF / frequency` across noise analysis.
 - Add diode model-card `KF` flicker-noise support with a distinct diode-current
   `flicker` contribution and Berkeley-default inverse-frequency scaling.
 - Add legacy SPICE2 BJT model-card `C2` and `C4` leakage-ratio support,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -410,6 +410,7 @@ fn clone_subckt_element(
             );
             mapped.series_resistance = element.series_resistance;
             mapped.flicker_noise_coefficient = element.flicker_noise_coefficient;
+            mapped.flicker_noise_exponent = element.flicker_noise_exponent;
             Element::Diode(mapped)
         }
         Element::Jfet(element) => Element::Jfet(Jfet::with_model_and_capacitance(
@@ -2400,6 +2401,7 @@ pub struct Diode {
     pub energy_gap_electron_volts: f64,
     pub series_resistance: f64,
     pub flicker_noise_coefficient: f64,
+    pub flicker_noise_exponent: f64,
 }
 
 impl Diode {
@@ -2616,6 +2618,7 @@ impl Diode {
             energy_gap_electron_volts,
             series_resistance: 0.0,
             flicker_noise_coefficient: 0.0,
+            flicker_noise_exponent: 1.0,
         }
     }
 }
@@ -3795,7 +3798,7 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     usize,
     usize,
 )] = &[
-    (ModelCardKind::Diode, 14, 20, 5, 3),
+    (ModelCardKind::Diode, 15, 21, 5, 3),
     (ModelCardKind::Npn, 41, 58, 13, 4),
     (ModelCardKind::Pnp, 41, 58, 13, 4),
     (ModelCardKind::Njf, 5, 11, 5, 3),
@@ -3824,6 +3827,7 @@ const DIODE_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("EG", "EG"),
     ("RS", "RS"),
     ("KF", "KF"),
+    ("AF", "AF"),
 ];
 const BJT_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IS", "IS"),
@@ -4510,6 +4514,7 @@ pub fn diode_from_model_card(
     );
     diode.series_resistance = model_card_value(model, "RS", 0.0);
     diode.flicker_noise_coefficient = model_card_value(model, "KF", 0.0);
+    diode.flicker_noise_exponent = model_card_value(model, "AF", 1.0);
     Ok(diode)
 }
 
@@ -22264,7 +22269,8 @@ fn collect_noise_sources(
                         noise_type: NoiseType::Flicker,
                         positive: anode,
                         negative: cathode,
-                        source_psd: diode.flicker_noise_coefficient * current.abs(),
+                        source_psd: diode.flicker_noise_coefficient
+                            * current.abs().powf(diode.flicker_noise_exponent),
                         frequency_exponent: 1.0,
                     });
                 }
@@ -24429,6 +24435,12 @@ fn mosfet_charge_dynamic_capacitance(
 }
 
 fn validate_diode(diode: &Diode) -> Result<(), SpiceError> {
+    if !diode.flicker_noise_exponent.is_finite() || diode.flicker_noise_exponent < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: diode.name.clone(),
+            reason: "flicker-noise exponent must be finite and non-negative".to_string(),
+        });
+    }
     if !diode.flicker_noise_coefficient.is_finite() || diode.flicker_noise_coefficient < 0.0 {
         return Err(SpiceError::InvalidElement {
             name: diode.name.clone(),

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -95,7 +95,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 142);
+    assert_eq!(coverage.len(), 143);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -114,7 +114,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 142);
+    assert_eq!(records.len(), 143);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -138,8 +138,8 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     let summary = model_card_supported_parameter_coverage_summary();
     assert_eq!(summary.len(), 7);
     assert_eq!(summary[0].kind, ModelCardKind::Diode);
-    assert_eq!(summary[0].canonical_parameter_count, 14);
-    assert_eq!(summary[0].accepted_name_count, 20);
+    assert_eq!(summary[0].canonical_parameter_count, 15);
+    assert_eq!(summary[0].accepted_name_count, 21);
     assert_eq!(summary[0].aliased_parameter_count, 5);
     assert_eq!(summary[0].max_alias_count, 3);
     assert_eq!(
@@ -163,7 +163,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         lines[0],
         "kind\tcanonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\taliased_parameters"
     );
-    assert_eq!(lines[1], "D\t14\t20\t5\t3\tIS|VT|CJO|VJ|M");
+    assert_eq!(lines[1], "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     assert_eq!(
         lines.last().unwrap(),
         &"PMOS\t18\t25\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
@@ -171,17 +171,17 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     let records = model_card_supported_parameter_coverage_summary_records();
     assert_eq!(records.len(), 7);
     assert_eq!(records[0]["kind"], "D");
-    assert_eq!(records[0]["canonical_parameter_count"], "14");
-    assert_eq!(records[0]["accepted_name_count"], "20");
+    assert_eq!(records[0]["canonical_parameter_count"], "15");
+    assert_eq!(records[0]["accepted_name_count"], "21");
     assert_eq!(records[0]["aliased_parameter_count"], "5");
     assert_eq!(records[0]["max_alias_count"], "3");
     assert_eq!(records[0]["aliased_parameters"], "IS|VT|CJO|VJ|M");
     assert!(format_model_card_supported_parameter_coverage_summary_csv().starts_with(
-        "kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,14,20,5,3,IS|VT|CJO|VJ|M\n"
+        "kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,15,21,5,3,IS|VT|CJO|VJ|M\n"
     ));
     let json = format_model_card_supported_parameter_coverage_summary_json();
     assert!(json.starts_with(
-        "[{\"kind\":\"D\",\"canonical_parameter_count\":\"14\",\"accepted_name_count\":\"20\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
+        "[{\"kind\":\"D\",\"canonical_parameter_count\":\"15\",\"accepted_name_count\":\"21\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
     ));
     assert!(json.ends_with(
         "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"18\",\"accepted_name_count\":\"25\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
@@ -195,15 +195,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 142);
-    assert_eq!(report.expected_canonical_parameter_count, 142);
-    assert_eq!(report.accepted_name_count, 208);
+    assert_eq!(report.canonical_parameter_count, 143);
+    assert_eq!(report.expected_canonical_parameter_count, 143);
+    assert_eq!(report.accepted_name_count, 209);
     assert_eq!(report.aliased_parameter_count, 53);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t142\t142\t208\t53\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t143\t143\t209\t53\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -230,8 +230,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 141);
-    assert_eq!(report.accepted_name_count, 205);
+    assert_eq!(report.canonical_parameter_count, 142);
+    assert_eq!(report.accepted_name_count, 206);
     assert_eq!(report.aliased_parameter_count, 52);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -248,7 +248,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t141\t142\t205\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t142\t143\t206\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -272,10 +272,10 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(dashboard.len(), 7);
     assert_eq!(dashboard[0].kind, ModelCardKind::Diode);
     assert!(dashboard[0].passed);
-    assert_eq!(dashboard[0].canonical_parameter_count, 14);
-    assert_eq!(dashboard[0].expected_canonical_parameter_count, 14);
-    assert_eq!(dashboard[0].accepted_name_count, 20);
-    assert_eq!(dashboard[0].expected_accepted_name_count, 20);
+    assert_eq!(dashboard[0].canonical_parameter_count, 15);
+    assert_eq!(dashboard[0].expected_canonical_parameter_count, 15);
+    assert_eq!(dashboard[0].accepted_name_count, 21);
+    assert_eq!(dashboard[0].expected_accepted_name_count, 21);
     assert_eq!(dashboard[0].aliased_parameter_count, 5);
     assert_eq!(dashboard[0].expected_aliased_parameter_count, 5);
     assert_eq!(dashboard[0].max_alias_count, 3);
@@ -293,7 +293,7 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
         lines[0],
         "kind\tpassed\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\texpected_accepted_name_count\taliased_parameter_count\texpected_aliased_parameter_count\tmax_alias_count\texpected_max_alias_count\tissue_count\tissue_fields"
     );
-    assert_eq!(lines[1], "D\ttrue\t14\t14\t20\t20\t5\t5\t3\t3\t0\t");
+    assert_eq!(lines[1], "D\ttrue\t15\t15\t21\t21\t5\t5\t3\t3\t0\t");
     assert_eq!(
         lines.last().unwrap(),
         &"PMOS\ttrue\t18\t18\t25\t25\t6\t6\t3\t3\t0\t"
@@ -302,15 +302,15 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(records.len(), 7);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["passed"], "true");
-    assert_eq!(records[0]["canonical_parameter_count"], "14");
-    assert_eq!(records[0]["expected_canonical_parameter_count"], "14");
+    assert_eq!(records[0]["canonical_parameter_count"], "15");
+    assert_eq!(records[0]["expected_canonical_parameter_count"], "15");
     assert_eq!(records[0]["issue_count"], "0");
     assert_eq!(records[0]["issue_fields"], "");
     assert!(format_model_card_supported_parameter_coverage_dashboard_csv(&coverage).starts_with(
-        "kind,passed,canonical_parameter_count,expected_canonical_parameter_count,accepted_name_count,expected_accepted_name_count,aliased_parameter_count,expected_aliased_parameter_count,max_alias_count,expected_max_alias_count,issue_count,issue_fields\nD,true,14,14,20,20,5,5,3,3,0,\n"
+        "kind,passed,canonical_parameter_count,expected_canonical_parameter_count,accepted_name_count,expected_accepted_name_count,aliased_parameter_count,expected_aliased_parameter_count,max_alias_count,expected_max_alias_count,issue_count,issue_fields\nD,true,15,15,21,21,5,5,3,3,0,\n"
     ));
     assert!(format_model_card_supported_parameter_coverage_dashboard_json(&coverage).starts_with(
-        "[{\"kind\":\"D\",\"passed\":\"true\",\"canonical_parameter_count\":\"14\",\"expected_canonical_parameter_count\":\"14\""
+        "[{\"kind\":\"D\",\"passed\":\"true\",\"canonical_parameter_count\":\"15\",\"expected_canonical_parameter_count\":\"15\""
     ));
 }
 
@@ -367,6 +367,7 @@ fn model_card_aliases_build_device_instances() {
             ("EG", 1.05),
             ("RS", 10.0),
             ("KF", 1.0e-12),
+            ("AF", 1.3),
         ],
     )
     .unwrap();
@@ -380,6 +381,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*diode_card.parameters.get("EG").unwrap(), 1.05);
     assert_close(*diode_card.parameters.get("RS").unwrap(), 10.0);
     assert_close(*diode_card.parameters.get("KF").unwrap(), 1.0e-12);
+    assert_close(*diode_card.parameters.get("AF").unwrap(), 1.3);
     assert!(diode_card.unsupported_parameters.is_empty());
     assert_close(diode_model.saturation_current, 2.0e-14);
     assert_close(diode_model.junction_capacitance, 1.5e-12);
@@ -391,6 +393,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(diode_model.energy_gap_electron_volts, 1.05);
     assert_close(diode_model.series_resistance, 10.0);
     assert_close(diode_model.flicker_noise_coefficient, 1.0e-12);
+    assert_close(diode_model.flicker_noise_exponent, 1.3);
 
     let bjt_card = normalize_model_card(
         "Qsmall",
@@ -1403,6 +1406,7 @@ fn subcircuit_expansion_preserves_complete_diode_model() {
     );
     diode.series_resistance = 10.0;
     diode.flicker_noise_coefficient = 1.0e-12;
+    diode.flicker_noise_exponent = 1.3;
     let mut circuit = Circuit::new();
     circuit
         .define_subcircuit(SubcircuitDefinition::new(
@@ -1430,6 +1434,7 @@ fn subcircuit_expansion_preserves_complete_diode_model() {
     assert_close(expanded.energy_gap_electron_volts, 1.05);
     assert_close(expanded.series_resistance, 10.0);
     assert_close(expanded.flicker_noise_coefficient, 1.0e-12);
+    assert_close(expanded.flicker_noise_exponent, 1.3);
 }
 
 #[test]
@@ -2077,6 +2082,18 @@ fn dc_rejects_invalid_bjt_nominal_temperature() {
     assert!(error
         .to_string()
         .contains("nominal temperature must be finite and positive"));
+}
+
+#[test]
+fn dc_rejects_invalid_diode_flicker_noise_exponent() {
+    let mut diode = Diode::new("Dbad", "a", "0");
+    diode.flicker_noise_exponent = -1.0;
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Diode(diode));
+    let error = dc_op(&circuit).unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("flicker-noise exponent must be finite and non-negative"));
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -273,6 +273,33 @@ fn diode_flicker_noise_uses_kf_with_inverse_frequency_scaling() {
 }
 
 #[test]
+fn diode_flicker_noise_uses_af_current_exponent() {
+    let source_psd = |exponent: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vbias", "bias", "0", 1.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rbias", "bias", "out", 1_000.0,
+        )));
+        let mut diode = Diode::new("D1", "out", "0");
+        diode.flicker_noise_coefficient = 1.0e-12;
+        diode.flicker_noise_exponent = exponent;
+        circuit.add(Element::Diode(diode));
+        noise_ac(&circuit, "out", "Vbias", &[1_000.0], 300.0)
+            .unwrap()
+            .points[0]
+            .entries
+            .iter()
+            .find(|entry| entry.element_name == "D1" && entry.noise_type == NoiseType::Flicker)
+            .unwrap()
+            .source_psd
+    };
+
+    assert!(source_psd(2.0) < source_psd(1.0));
+}
+
+#[test]
 fn bjt_flicker_noise_uses_af_base_current_exponent() {
     let source_psd = |exponent: f64| {
         let mut circuit = Circuit::new();

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add diode model-card `AF` flicker-noise current-exponent support, defaulting
+  to `1` and applying `KF * abs(Id)^AF / frequency` across noise analysis.
 - Add diode model-card `KF` flicker-noise support with a distinct diode-current
   `flicker` contribution and Berkeley-default inverse-frequency scaling.
 - Add legacy SPICE2 BJT model-card `C2` and `C4` leakage-ratio support,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1678,6 +1678,7 @@ export interface Diode {
   readonly energyGapElectronVolts: number;
   readonly seriesResistance: number;
   readonly flickerNoiseCoefficient: number;
+  readonly flickerNoiseExponent: number;
 }
 
 export type JfetPolarity = "NJF" | "PJF";
@@ -2020,7 +2021,7 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_KINDS: readonly ModelCardKind[] = 
 const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   Record<ModelCardKind, readonly [number, number, number, number]>
 > = {
-  D: [14, 20, 5, 3],
+  D: [15, 21, 5, 3],
   NPN: [41, 58, 13, 4],
   PNP: [41, 58, 13, 4],
   NJF: [5, 11, 5, 3],
@@ -3608,7 +3609,7 @@ function cloneSubcktElement(
     case "custom-model":
       return { ...element, name, positive: mapSubcktNode(element.positive, instanceName, nodeMap), negative: mapSubcktNode(element.negative, instanceName, nodeMap) };
     case "diode":
-      return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient, element.breakdownVoltage, element.breakdownCurrent, element.junctionCapacitance, element.transitTime, element.junctionPotential, element.gradingCoefficient, element.forwardBiasDepletionCoefficient, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.seriesResistance, element.flickerNoiseCoefficient);
+      return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient, element.breakdownVoltage, element.breakdownCurrent, element.junctionCapacitance, element.transitTime, element.junctionPotential, element.gradingCoefficient, element.forwardBiasDepletionCoefficient, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.seriesResistance, element.flickerNoiseCoefficient, element.flickerNoiseExponent);
     case "jfet":
       return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
     case "bjt":
@@ -7572,6 +7573,7 @@ export function diode(
   energyGapElectronVolts = 1.11,
   seriesResistance = 0.0,
   flickerNoiseCoefficient = 0.0,
+  flickerNoiseExponent = 1.0,
 ): Diode {
   return {
     kind: "diode",
@@ -7592,6 +7594,7 @@ export function diode(
     energyGapElectronVolts,
     seriesResistance,
     flickerNoiseCoefficient,
+    flickerNoiseExponent,
   };
 }
 
@@ -7946,6 +7949,7 @@ const DIODE_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   EG: "EG",
   RS: "RS",
   KF: "KF",
+  AF: "AF",
 };
 
 const BJT_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -8478,6 +8482,7 @@ export function diodeFromModelCard(
     p.EG ?? 1.11,
     p.RS ?? 0.0,
     p.KF ?? 0.0,
+    p.AF ?? 1.0,
   );
 }
 
@@ -18500,7 +18505,9 @@ function collectNoiseSources(
           noiseType: "flicker",
           positive: anode,
           negative: cathode,
-          sourcePsd: element.flickerNoiseCoefficient * Math.abs(current),
+          sourcePsd:
+            element.flickerNoiseCoefficient *
+            Math.abs(current) ** element.flickerNoiseExponent,
           frequencyExponent: 1.0,
         });
       }
@@ -19798,6 +19805,15 @@ function validateReactiveElements(circuit: Circuit): void {
 }
 
 function validateDiode(element: Diode): void {
+  if (
+    !Number.isFinite(element.flickerNoiseExponent) ||
+    element.flickerNoiseExponent < 0.0
+  ) {
+    throw invalidElement(
+      element.name,
+      "flicker-noise exponent must be finite and non-negative",
+    );
+  }
   if (
     !Number.isFinite(element.flickerNoiseCoefficient) ||
     element.flickerNoiseCoefficient < 0.0

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -120,7 +120,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(142);
+    expect(coverage).toHaveLength(143);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -140,7 +140,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(142);
+    expect(records).toHaveLength(143);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -158,8 +158,8 @@ describe("dcOp", () => {
     expect(summary).toHaveLength(7);
     expect(summary[0]).toStrictEqual({
       kind: "D",
-      canonicalParameterCount: 14,
-      acceptedNameCount: 20,
+      canonicalParameterCount: 15,
+      acceptedNameCount: 21,
       aliasedParameterCount: 5,
       maxAliasCount: 3,
       aliasedParameters: ["IS", "VT", "CJO", "VJ", "M"],
@@ -178,7 +178,7 @@ describe("dcOp", () => {
     expect(table.split("\n")[0]).toBe(
       "kind\tcanonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\taliased_parameters",
     );
-    expect(table.split("\n")[1]).toBe("D\t14\t20\t5\t3\tIS|VT|CJO|VJ|M");
+    expect(table.split("\n")[1]).toBe("D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     expect(table.split("\n").at(-1)).toBe(
       "PMOS\t18\t25\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
     );
@@ -186,14 +186,14 @@ describe("dcOp", () => {
     expect(records).toHaveLength(7);
     expect(records[0]).toStrictEqual({
       kind: "D",
-      canonical_parameter_count: "14",
-      accepted_name_count: "20",
+      canonical_parameter_count: "15",
+      accepted_name_count: "21",
       aliased_parameter_count: "5",
       max_alias_count: "3",
       aliased_parameters: "IS|VT|CJO|VJ|M",
     });
     expect(formatModelCardSupportedParameterCoverageSummaryCsv()).toMatch(
-      /^kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,14,20,5,3,IS\|VT\|CJO\|VJ\|M\n/,
+      /^kind,canonical_parameter_count,accepted_name_count,aliased_parameter_count,max_alias_count,aliased_parameters\nD,15,21,5,3,IS\|VT\|CJO\|VJ\|M\n/,
     );
     expect(JSON.parse(formatModelCardSupportedParameterCoverageSummaryJson())).toStrictEqual(records);
   });
@@ -205,15 +205,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 142,
-      expectedCanonicalParameterCount: 142,
-      acceptedNameCount: 208,
+      canonicalParameterCount: 143,
+      expectedCanonicalParameterCount: 143,
+      acceptedNameCount: 209,
       aliasedParameterCount: 53,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t142\t142\t208\t53\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t143\t143\t209\t53\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -236,8 +236,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(141);
-    expect(report.acceptedNameCount).toBe(205);
+    expect(report.canonicalParameterCount).toBe(142);
+    expect(report.acceptedNameCount).toBe(206);
     expect(report.aliasedParameterCount).toBe(52);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -252,7 +252,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t141\t142\t205\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t142\t143\t206\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -280,6 +280,7 @@ describe("dcOp", () => {
       EG: 1.05,
       RS: 10.0,
       KF: 1.0e-12,
+      AF: 1.3,
     });
     const diodeModel = diodeFromModelCard("D1", "a", "k", diodeCard);
     expect(diodeCard.parameters).toStrictEqual({
@@ -293,6 +294,7 @@ describe("dcOp", () => {
       EG: 1.05,
       RS: 10.0,
       KF: 1.0e-12,
+      AF: 1.3,
     });
     expect(diodeCard.unsupportedParameters).toStrictEqual([]);
     expectClose(diodeModel.saturationCurrent, 2.0e-14);
@@ -305,6 +307,7 @@ describe("dcOp", () => {
     expectClose(diodeModel.energyGapElectronVolts, 1.05);
     expectClose(diodeModel.seriesResistance, 10.0);
     expectClose(diodeModel.flickerNoiseCoefficient, 1.0e-12);
+    expectClose(diodeModel.flickerNoiseExponent, 1.3);
 
     const bjtCard = normalizeModelCard("Qsmall", "npn", {
       BETA: 125.0,
@@ -1018,7 +1021,7 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("diode-cell", ["in"], [
-        diode("Dcell", "in", "0", 2.0e-14, 0.026, 1.2, 6.0, 2.0e-6, 1.5e-12, 4.0e-9, 0.8, 0.4, 0.35, 2.2, 1.05, 10.0, 1.0e-12),
+        diode("Dcell", "in", "0", 2.0e-14, 0.026, 1.2, 6.0, 2.0e-6, 1.5e-12, 4.0e-9, 0.8, 0.4, 0.35, 2.2, 1.05, 10.0, 1.0e-12, 1.3),
       ]),
     );
     circuit.add(xInstance("X1", ["a"], "diode-cell"));
@@ -1035,6 +1038,7 @@ describe("dcOp", () => {
     expectClose(expanded.energyGapElectronVolts, 1.05);
     expectClose(expanded.seriesResistance, 10.0);
     expectClose(expanded.flickerNoiseCoefficient, 1.0e-12);
+    expectClose(expanded.flickerNoiseExponent, 1.3);
   });
 
   it("preserves the complete BJT model through subcircuit expansion", () => {
@@ -1462,6 +1466,14 @@ describe("dcOp", () => {
     const circuit = new Circuit();
     circuit.add({ ...bjt("Qbad", "c", "b", "0"), nominalTemperatureKelvin: 0.0 });
     expect(() => dcOp(circuit)).toThrowError("nominal temperature must be finite and positive");
+  });
+
+  it("rejects invalid diode flicker noise exponents", () => {
+    const circuit = new Circuit();
+    circuit.add({ ...diode("Dbad", "a", "0"), flickerNoiseExponent: -1.0 });
+    expect(() => dcOp(circuit)).toThrowError(
+      "flicker-noise exponent must be finite and non-negative",
+    );
   });
 
   it("rejects invalid BJT flicker noise coefficients", () => {

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -144,6 +144,23 @@ describe("noiseAc", () => {
     expect(flickerPsds[0]).toBeGreaterThan(0.0);
     expect(flickerPsds[0] / flickerPsds[1]).toBeCloseTo(100.0, 12);
   });
+  it("uses diode AF as the current exponent", () => {
+    function sourcePsd(exponent: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vbias", "bias", "0", 1.0));
+      circuit.add(resistor("Rbias", "bias", "out", 1_000.0));
+      circuit.add({
+        ...diode("D1", "out", "0"),
+        flickerNoiseCoefficient: 1.0e-12,
+        flickerNoiseExponent: exponent,
+      });
+      return noiseAc(circuit, "out", "Vbias", [1_000.0], 300.0).points[0]!.entries
+        .find((entry) => entry.elementName === "D1" && entry.noiseType === "flicker")!
+        .sourcePsd;
+    }
+
+    expect(sourcePsd(2.0)).toBeLessThan(sourcePsd(1.0));
+  });
   it("uses BJT AF as the base-current exponent", () => {
     function sourcePsd(exponent: number): number {
       const circuit = new Circuit();

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language diode flicker-noise coefficient.
+1. Cross-language diode flicker-noise current exponent.
    - Status: current PR completion candidate.
-   - Add Berkeley diode `KF` model-card support in Rust, Python, and TypeScript,
-     defaulting to zero and emitting a distinct diode-current flicker-noise
-     contribution.
-   - Preserve `KF` through hierarchy, temperature, sensitivity, and Monte Carlo
+   - Add Berkeley diode `AF` model-card support in Rust, Python, and TypeScript,
+     defaulting to one and applying it to the existing diode-current flicker
+     source as `KF * abs(Id)^AF / frequency`.
+   - Preserve `AF` through hierarchy, temperature, sensitivity, and Monte Carlo
      cloning while validating finite non-negative values in every engine.
-   - Extend the supported-parameter coverage gate from 141 to 142 canonical
-     rows and lock inverse-frequency noise scaling in all engines.
+   - Extend the supported-parameter coverage gate from 142 to 143 canonical
+     rows and lock current-exponent behavior in all engines.
 
 ## Completed Slices
 
@@ -3228,6 +3228,14 @@ the Rust, Python, and TypeScript surfaces together.
    - DC, transient, AC, transfer-function, hierarchy, temperature, and noise
      paths share the intrinsic-anode topology, including resistor thermal
      noise; the supported-parameter release gate now covers 141 canonical rows.
+
+247. Cross-language diode flicker-noise coefficient.
+   - Status: completed in PR 8894.
+   - Rust, Python, and TypeScript diode model cards now accept `KF`, default it
+     to zero, and emit a distinct diode-current flicker-noise contribution.
+   - Hierarchy and cloning paths preserve `KF`, finite non-negative validation
+     is shared across analyses, and the supported-parameter release gate now
+     covers 142 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley diode `AF` model-card support across Rust, Python, and TypeScript
- apply `AF` to diode flicker noise as `KF * abs(Id)^AF / frequency` with a default of one
- preserve and validate the exponent across cloning paths, and advance the coverage gate to 143 canonical parameters

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo check -p spice-engine`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python Ruff on touched files
- Python `pytest -q` (584 passed)
- TypeScript `npm run build`
- TypeScript `npm test` (342 passed)