### PR TITLE
test(q-to-semantic-ir): Q oracle corpus 2-1 gap + stale doc-count fix (front3, task #115)

### DIFF
--- a/code/packages/rust/q-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/q-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## [0.1.2] - 2026-07-23
+
+### Added
+
+- **`tests/oracle.rs`**: one new corpus case,
+  `whitespace_sensitive_strand_vs_subtraction_no_space_at_all` (`2-1` →
+  `1`) — the third spelling of MA11 §3 bullet 2's negative-literal-vs-
+  subtraction disambiguation, alongside the pre-existing `2 -1` (strand)
+  and `2 - 1` (spaced subtraction) cases. `q-lexer`'s own
+  `no_space_at_all_is_also_subtraction`/`no_space_at_all_stays_subtraction`
+  tests and `q-runtime`'s own `scalar("2-1\n") == 1.0` assertion already
+  confirmed the *lexer*/*runtime* resolve this correctly in isolation, but
+  neither exercised the resolved CST shape through this crate's own
+  lowering → `semantic-ir-to-javascript` → real `node` — this case closes
+  that gap, confirmed to pass end-to-end (`known_bug: None`).
+
+### Fixed (documentation only — no code/behavior change)
+
+- `README.md`'s own "Testing" section had described `tests/oracle.rs` as a
+  "33-case" corpus (and cited "5 of the 33 cases" as a known-bug gap) since
+  the very first commit (`0.1.0`, #8826) — but the corpus was already
+  50 cases at that point (confirmed via `git show` against that commit),
+  and the 5-case display gap it described was already fixed in `0.1.1`
+  (every entry has run `known_bug: None` since then). Both counts were
+  stale from day one, not a regression introduced later. Also corrected
+  `tests/test_lower.rs`'s documented count (56 → the actual 57). Past
+  `CHANGELOG.md` entries below are left as originally written (an
+  append-only historical record of what was believed true at the time,
+  not a live spec) — this entry is the correction, not a rewrite of
+  `[0.1.0]`/`[0.1.1]`. `README.md` now states the accurate, current counts
+  (51-case oracle corpus after the addition above, 57 `test_lower.rs`
+  cases) and drops the stale known-bug framing, since task #109 already
+  closed that gap.
+
+### Testing
+
+- `cargo test -p q-to-semantic-ir`: all 81 tests pass (12 `e2e_node`, 1
+  `oracle` covering the 51-case `CORPUS`, 57 `test_lower`, 10
+  `test_validator`, 1 doctest).
+
 ## [0.1.1] - 2026-07-23
 
 ### Fixed (in the shared `semantic-ir-to-javascript` crate — task #109)

--- a/code/packages/rust/q-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/q-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "q-to-semantic-ir"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Q (kdb+) CST → narrow-waist Semantic IR (SIR22 array/matrix domain, reusing APL/J's addendum). MA-11e, front2 Wave 5."
 

--- a/code/packages/rust/q-to-semantic-ir/README.md
+++ b/code/packages/rust/q-to-semantic-ir/README.md
@@ -110,13 +110,22 @@ rationale.
 cargo test -p q-to-semantic-ir -- --nocapture
 ```
 
-- `tests/test_lower.rs` — 56 unit tests over exact `Expr`/`Function` shapes
+- `tests/test_lower.rs` — 57 unit tests over exact `Expr`/`Function` shapes
   for every grammar production.
 - `tests/test_validator.rs` — 10 capability-acceptance tests against the
   shared SIR validator and `semantic-ir-to-javascript`.
 - `tests/e2e_node.rs` — 12 tests actually running compiled programs through
   `node`, weighted toward the function-literal machinery.
-- `tests/oracle.rs` (HML01 §7) — 33-case oracle/golden corpus cross-checking
+- `tests/oracle.rs` (HML01 §7) — 51-case oracle/golden corpus cross-checking
   `q-runtime` (ground truth) against this crate → `semantic-ir-to-javascript`
-  → real `node`. See `CHANGELOG.md` for the one documented, pre-existing,
-  not-fixed-here shared-crate display gap (5 of the 33 cases).
+  → real `node`: every one of the 17 primitive verbs (monadic and dyadic),
+  all three whitespace-sensitive strand-vs-subtraction spellings (`2 -1`,
+  `2 - 1`, and fully-glued `2-1`), reduce/scan/each, dual list-literal
+  syntax, chained/global assignment, and the full function-literal surface
+  (named, inline, implicit/explicit params, multi-statement bodies, and the
+  higher-order `MakeClosure`/`IndirectCall` case). All 51 cases pass
+  end-to-end today — task #109 fixed the one shared-crate display gap this
+  corpus originally found (`SIR_DISPLAY_Q_ASCII_MINUS` in
+  `semantic-ir-to-javascript`; see `CHANGELOG.md`'s `[0.1.1]` entry). The
+  `known_bug` field stays on `Case` for a future genuine bug to reuse, unused
+  by any entry today.

--- a/code/packages/rust/q-to-semantic-ir/tests/oracle.rs
+++ b/code/packages/rust/q-to-semantic-ir/tests/oracle.rs
@@ -123,6 +123,28 @@ const CORPUS: &[Case] = &[
         expected: "1",
         known_bug: None,
     },
+    // Third spelling of the same disambiguation: NO space at all on either
+    // side (`2-1`, fully glued). MA11 §3 bullet 2's rule only folds a `-`
+    // into a signed-numeric-literal token when it is "at a position where a
+    // new list-stranding element may start" -- i.e. preceded by whitespace
+    // after a completed noun. With no preceding space, `2-1` never reaches
+    // that check at all (confirmed directly: `q-lexer`'s own
+    // `no_space_at_all_is_also_subtraction`/`no_space_at_all_stays_
+    // subtraction` tests and `q-runtime`'s own `scalar("2-1\n") == 1.0`
+    // assertion, both tokenizing/evaluating this as ordinary subtraction,
+    // never a two-element strand) -- so this lowers to the exact same
+    // `ElementwiseOp` shape as `2 - 1` above, just reached via a different
+    // tokenization path. Genuinely new coverage here: those two upstream
+    // tests only confirm the *lexer*/*runtime* get this right in isolation;
+    // this case confirms the SAME resolved CST shape also lowers correctly
+    // through `q-to-semantic-ir` -> `semantic-ir-to-javascript` -> `node`,
+    // not just through `q-runtime`'s own evaluator.
+    Case {
+        name: "whitespace_sensitive_strand_vs_subtraction_no_space_at_all",
+        source: "2-1\n",
+        expected: "1",
+        known_bug: None,
+    },
 
     // --- All 6 comparisons (always 0/1, never negative -- no display gap) ---
     Case { name: "comparison_eq_true", source: "3=3\n", expected: "1", known_bug: None },


### PR DESCRIPTION
## Summary

front3 task (least-recently-used front rotation): investigate Q's oracle/golden test coverage against the pattern established by every sibling array-family language (MATLAB #64, Octave #67, APL #77, J #93, Derive #94, Reduce #95, Maple #96, Scilab #97).

**Finding: the task's original premise was stale.** Q already has its oracle/golden test pair — `tests/oracle.rs` was added in #8826 (MA-11e kickoff) and extended in #8864 (task #109's ASCII-minus display fix), both already merged. No new oracle-test crate/harness was needed.

What this PR actually does, after confirming the existing 50-case corpus already covers all 17 primitive verbs, reduce/scan/each, both list-literal syntaxes, and the full function-literal surface:

- **Adds one missing corpus case**: `whitespace_sensitive_strand_vs_subtraction_no_space_at_all` (`"2-1\n"` → `"1"`) — the third spelling of Q's signature strand-vs-subtraction disambiguation (alongside the pre-existing `2 -1` strand and `2 - 1` spaced-subtraction cases). `q-lexer`'s and `q-runtime`'s own unit tests already confirm this in isolation; this closes the gap of confirming it end-to-end through `q-to-semantic-ir` → `semantic-ir-to-javascript` → real `node`.
- **Fixes a stale doc/reality mismatch**: `README.md` had claimed a "33-case" oracle corpus with a "5 known_bug cases" gap since its very first commit (#8826) — the corpus was already 50 cases at that point, and the known-bug gap was fully fixed in `0.1.1` (task #109). Corrected to the accurate current count (51) and dropped the stale known-bug framing. Also fixed `test_lower.rs`'s documented count (56 → actual 57).
- Bumped `q-to-semantic-ir` to `0.1.2`, added a CHANGELOG entry (append-only — prior `[0.1.0]`/`[0.1.1]` entries left as the original historical record).

No runtime, lexer, parser, or codegen source files were touched — this is a test-fixture and documentation-only change.

## Test plan

- [x] `cargo test -p q-to-semantic-ir` — all 81 tests pass (independently re-run, not just agent-reported): 12 `e2e_node`, 1 `oracle` (covering the 51-case corpus), 57 `test_lower`, 10 `test_validator`, 1 doctest
- [x] Confirmed via `git log --follow` that `tests/oracle.rs` predates this PR (added #8826, extended #8864) — the "Q is missing oracle tests" premise was verified false before proceeding
- [x] `/security-review` — passed clean (pure test-fixture + docs change, no new code paths, no dynamic/external input)

🤖 Generated with [Claude Code](https://claude.com/claude-code)