### PR TITLE
feat(adj-tables): RS-5d — interpolated table lookup (closes exact/range/interpolated trio)

### DIFF
--- a/code/grammars/adj_lang/adj_lang.grammar
+++ b/code/grammars/adj_lang/adj_lang.grammar
@@ -143,13 +143,15 @@ functional_decl  = "functional" term ;
 
 query_decl       = QUESTION ( lookup_expr | term ) ;
 
-# `lookup <table> <keycol> = <n> mode range give <valcol>` — a RANGE / BRACKET
-# lookup (ADJ-TABLES RS-5c). A `?`-prefixed recall over a `table` read as a step
-# function: it selects the breakpoint row whose key column is the greatest key
-# `<=` the query value, and returns that row's value column WITH the row's
-# citation (below the smallest key it abstains — "below the table's domain").
+# `lookup <table> <keycol> = <n> mode <mode> give <valcol>` — a table lookup
+# (ADJ-TABLES RS-5c/RS-5d). A `?`-prefixed recall over a `table` read as a numeric
+# function of its key column. `mode range` reads it as a STEP function: it selects
+# the breakpoint row whose key is the greatest key `<=` the query and returns that
+# row's value column verbatim WITH the row's citation. `mode interpolated` reads it
+# as a PIECEWISE-LINEAR function: it blends the two bracketing rows exactly and
+# carries both citations. Outside the table's domain either abstains honestly.
 # `lookup`/`mode`/`give` are IDENT-matched literals — no new lexer tokens — and
-# `mode <name>` selects the tactic (`range` here; `interpolated` is RS-5d).
+# `mode <name>` selects the tactic (`range` or `interpolated`; both built).
 lookup_expr      = "lookup" IDENT IDENT EQUALS signed_number "mode" IDENT "give" IDENT ;
 signed_number    = [ MINUS ] NUMBER ;
 

--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [0.23.0] — 2026-07-23 — RS-5d: interpolated table lookup tactic
+
+Closes the table-lookup trio (exact / range / **interpolated**). A `? lookup … mode interpolated
+give <val>` reads the `table` as a piecewise-linear function: it finds the two breakpoint rows
+that bracket the query key and returns the exact linear blend
+
+```
+v = v0 + (v1 - v0) * (q - k0) / (k1 - k0)
+```
+
+computed entirely on `ExactRational` (`add`/`sub`/`mul`/`div`) — a terminating blend renders every
+digit, a repeating one renders as the reduced fraction (`10/3`), never a rounded `f64`. **Both**
+bracketing rows' citations ride along, so the answer is traceable to the two measured points it
+sits between (nomograms, calibration curves, growth charts). Honest edges:
+
+- **exact hit** (`q` equals a breakpoint): the `0/0` blend is short-circuited to that row's value
+  with its single citation;
+- **out of domain**: below the lowest / above the highest breakpoint abstains with the typed
+  `below_table_domain` / new `above_table_domain` reason — interpolation never extrapolates;
+- **truncated search**: abstains `search_limit_exceeded` rather than blend against a partial scan.
+
+Adds the `AboveTableDomain` abstention reason and an end-to-end suite (`rs5d_interpolated_lookup_e2e`):
+linear blend with both citations, exact-fraction rendering, exact-breakpoint hit, below/above-domain
+abstention, and correct-segment selection. The RS-5c suite's reserved-mode test becomes a
+non-numeric-value-column guard (interpolating `category` is a compile error).
+
 ## [0.22.0] — 2026-07-23 — NUM-6c: render `to_currency` in the audit trail
 
 The derivation-tree renderer gains a `DerivationNode::ToCurrency` arm (NUM-6c): a

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -438,6 +438,16 @@ fn abstention_json(reason: &AbstentionReason) -> String {
             payload(key),
             payload(min_key)
         ),
+        AbstentionReason::AboveTableDomain {
+            table,
+            key,
+            max_key,
+        } => format!(
+            "{{\"reason\":\"above_table_domain\",\"table\":\"{}\",\"key\":\"{}\",\"max_key\":\"{}\",\"explanation\":\"the query falls above the highest breakpoint this source defines; interpolation would extrapolate past what the source measured\"}}",
+            payload(table),
+            payload(key),
+            payload(max_key)
+        ),
         AbstentionReason::NonNumericKey { table, column, key } => format!(
             "{{\"reason\":\"non_numeric_key\",\"table\":\"{}\",\"column\":\"{}\",\"key\":\"{}\",\"explanation\":\"a range lookup needs a numeric key; this one could not be read as a number\"}}",
             payload(table),
@@ -465,6 +475,16 @@ enum AbstentionReason {
         table: String,
         key: String,
         min_key: String,
+    },
+    /// The key is above the table's highest breakpoint (ADJ-TABLES RS-5d). An
+    /// `interpolated` lookup needs a breakpoint on *both* sides of the query; above
+    /// the last one there is nothing to interpolate toward, so — rather than
+    /// extrapolate past what the source measured — it abstains. (A `range` lookup
+    /// treats the top breakpoint as an open band and never hits this.)
+    AboveTableDomain {
+        table: String,
+        key: String,
+        max_key: String,
     },
     /// A range lookup was handed a key that is not a number.
     NonNumericKey {
@@ -959,16 +979,20 @@ fn main() -> ExitCode {
         format!(",\"governing\":[{}]", governing.join(","))
     };
 
-    // ADJ-TABLES RS-5c: range / bracket lookups over `table`s read as step
-    // functions. Each resolves to its bracketed value + the matched breakpoint
-    // row's citation (or abstains below the table's domain). 0 answer-time model
-    // calls — exact comparison over the CAS-grounded rows. Omitted when the
-    // program declares no `? lookup … mode range …`, so existing output is
-    // byte-for-byte unchanged.
+    // ADJ-TABLES RS-5c/RS-5d: table lookups. `mode range` reads the table as a step
+    // function (bracketed value + the matched breakpoint row's citation, or abstains
+    // below the domain); `mode interpolated` reads it as a piecewise-linear function
+    // (exact linear blend of the two bracketing rows, both citations, or abstains
+    // outside the domain). Both are 0 answer-time model calls — exact rational
+    // arithmetic over the CAS-grounded rows. Omitted when the program declares no
+    // `? lookup …`, so existing output is byte-for-byte unchanged.
     let lookups: Vec<String> = lowered
         .range_lookups
         .iter()
-        .map(|rl| range_lookup_json(rl, &lowered.kb))
+        .map(|rl| match rl.mode.as_str() {
+            "interpolated" => interpolated_lookup_json(rl, &lowered.kb),
+            _ => range_lookup_json(rl, &lowered.kb),
+        })
         .collect();
     let lookup_section = if lookups.is_empty() {
         String::new()
@@ -1243,6 +1267,223 @@ fn range_lookup_json(rl: &LoweredRangeLookup, kb: &KnowledgeBase) -> String {
                 query_echo(&query_str),
                 esc(&rl.mode),
                 abstention_json(&reason)
+            )
+        }
+    }
+}
+
+/// Resolve an INTERPOLATED lookup (ADJ-TABLES RS-5d) against the grounded table and
+/// render it as JSON. Where a `range` lookup reads the table as a *step* function,
+/// `interpolated` reads it as a *piecewise-linear* one: it finds the two breakpoint
+/// rows that bracket the query — the greatest key `k0 <= q` and the smallest key
+/// `k1 >= q` — and returns the exact linear blend
+///
+/// ```text
+///     v = v0 + (v1 - v0) * (q - k0) / (k1 - k0)
+/// ```
+///
+/// with BOTH bracketing rows' citations riding along, so the interpolated answer is
+/// traceable to the two measured points it sits between (nomograms, growth charts,
+/// calibration curves). Every step is exact `BigRational` arithmetic — no `f64` hop —
+/// so a terminating blend renders all its digits and a repeating one renders as the
+/// reduced fraction, never a rounded float.
+///
+/// Three honest edges:
+/// - **exact hit** (`q` equals a breakpoint key, so `k0 == k1`): the blend is
+///   degenerate (`0/0`), so it is short-circuited to that row's value with its single
+///   citation — no fabricated division.
+/// - **below / above the domain**: interpolation needs a breakpoint on *both* sides;
+///   outside `[min, max]` it abstains (`below_table_domain` / `above_table_domain`)
+///   rather than extrapolate past what the source measured.
+/// - **truncated search**: if enumeration hit a resolution limit we may not have seen
+///   the true bracketing rows, so any interpolation could be wrong; we abstain with
+///   `search_limit_exceeded` instead of blending against a possibly-incomplete scan.
+///
+/// 0 answer-time model calls — pure exact arithmetic over the CAS-grounded rows.
+fn interpolated_lookup_json(rl: &LoweredRangeLookup, kb: &KnowledgeBase) -> String {
+    use logic_engine::compute::ExactRational;
+
+    let cols: Vec<LogicVar> = (0..rl.arity).map(|i| var(&format!("c{i}"))).collect();
+    let goal = compound(
+        rl.table.clone(),
+        cols.iter().map(|v| Term::Var(v.clone())).collect(),
+    );
+    let dag = enumerate_all(&goal, kb);
+
+    let query_str = format!(
+        "lookup {} {} = {} mode {} give {}",
+        rl.table, rl.key_col, rl.key_value, rl.mode, rl.value_col
+    );
+
+    // Render an exact rational for a JSON string binding: prefer a terminating
+    // decimal (all digits), else the reduced fraction (still exact, never a float).
+    let render = |x: &ExactRational| -> String {
+        x.to_exact_decimal_string()
+            .unwrap_or_else(|| format!("{}/{}", x.numerator(), x.denominator()))
+    };
+    let cites_of = |proof: &Proof| -> Vec<String> {
+        proof
+            .via_facts
+            .iter()
+            .filter_map(|fid| kb.fact(*fid))
+            .map(|f| format!("{{{}}}", prov(&f.provenance)))
+            .collect()
+    };
+    let abstain = |reason: AbstentionReason| -> String {
+        format!(
+            "{{\"query\":\"{}\",\"mode\":\"{}\",\"answers\":[],\"abstained\":true,\"abstention\":{}}}",
+            query_echo(&query_str),
+            esc(&rl.mode),
+            abstention_json(&reason)
+        )
+    };
+
+    let q = match numeric_exact_magnitude(&rl.key_value) {
+        Some(x) => x,
+        None => {
+            return abstain(AbstentionReason::NonNumericKey {
+                table: rl.table.clone(),
+                column: rl.key_col.clone(),
+                key: format!("{}", rl.key_value),
+            })
+        }
+    };
+
+    // A truncated scan may have missed the true bracketing rows, which would make
+    // any interpolation wrong — abstain rather than blend against a partial table.
+    if dag.truncated {
+        return abstain(AbstentionReason::SearchLimitExceeded {
+            goal: query_str.clone(),
+        });
+    }
+
+    // Scan every row once, keeping the tightest bracket on each side of `q`:
+    // `lower` = the row with the greatest key `<= q`; `upper` = the row with the
+    // smallest key `>= q`. Comparison and storage are exact.
+    let mut lower: Option<(&Proof, ExactRational, ExactRational)> = None;
+    let mut upper: Option<(&Proof, ExactRational, ExactRational)> = None;
+    for proof in &dag.proofs {
+        let key_term = proof.bindings.walk_var(&cols[rl.key_index]);
+        let Some(k) = numeric_exact_magnitude(&key_term) else {
+            continue; // non-numeric key is impossible post-lowering; skip defensively.
+        };
+        let value_term = proof.bindings.walk_var(&cols[rl.value_index]);
+        let Some(v) = numeric_exact_magnitude(&value_term) else {
+            continue; // non-numeric value is impossible post-lowering (checked); skip.
+        };
+        if k.as_ratio() <= q.as_ratio() {
+            let take = match &lower {
+                None => true,
+                Some((_, lk, _)) => k.as_ratio() > lk.as_ratio(),
+            };
+            if take {
+                lower = Some((proof, k.clone(), v.clone()));
+            }
+        }
+        if k.as_ratio() >= q.as_ratio() {
+            let take = match &upper {
+                None => true,
+                Some((_, uk, _)) => k.as_ratio() < uk.as_ratio(),
+            };
+            if take {
+                upper = Some((proof, k, v));
+            }
+        }
+    }
+
+    // The min/max keys, for an out-of-domain abstention's audit payload.
+    let extremal = |pick_max: bool| -> String {
+        dag.proofs
+            .iter()
+            .filter_map(|pr| numeric_exact_magnitude(&pr.bindings.walk_var(&cols[rl.key_index])))
+            .fold(None, |acc: Option<ExactRational>, k| match acc {
+                None => Some(k),
+                Some(a) => {
+                    let keep = if pick_max {
+                        k.as_ratio() > a.as_ratio()
+                    } else {
+                        k.as_ratio() < a.as_ratio()
+                    };
+                    Some(if keep { k } else { a })
+                }
+            })
+            .map(|k| render(&k))
+            .unwrap_or_else(|| "(empty table)".to_string())
+    };
+
+    match (lower, upper) {
+        // Below the lowest breakpoint — nothing to interpolate down toward.
+        (None, _) => abstain(AbstentionReason::BelowTableDomain {
+            table: rl.table.clone(),
+            key: format!("{}", rl.key_value),
+            min_key: extremal(false),
+        }),
+        // Above the highest breakpoint — nothing to interpolate up toward.
+        (_, None) => abstain(AbstentionReason::AboveTableDomain {
+            table: rl.table.clone(),
+            key: format!("{}", rl.key_value),
+            max_key: extremal(true),
+        }),
+        (Some((lp, k0, v0)), Some((up, k1, v1))) => {
+            // Exact hit on a breakpoint (`k0 == k1 == q`): the blend is `0/0`, so
+            // return that row's value verbatim with its single citation.
+            if k0.as_ratio() == k1.as_ratio() {
+                let cites = cites_of(lp);
+                return format!(
+                    "{{\"query\":\"{}\",\"mode\":\"{}\",\"answers\":[{{\"bindings\":{{\"{}\":\"{}\",\"{}\":\"{}\"}},\"brackets\":{{\"exact\":{{\"{}\":\"{}\",\"{}\":\"{}\"}}}},\"citations\":[{}],\"steps\":{}}}],\"abstained\":false}}",
+                    query_echo(&query_str),
+                    esc(&rl.mode),
+                    esc(&rl.value_col),
+                    esc(&render(&v0)),
+                    esc(&rl.key_col),
+                    esc(&render(&q)),
+                    esc(&rl.key_col),
+                    esc(&render(&k0)),
+                    esc(&rl.value_col),
+                    esc(&render(&v0)),
+                    cites.join(","),
+                    trace_steps_json(lp, kb)
+                );
+            }
+            // Linear blend, all exact: v = v0 + (v1 - v0) * (q - k0) / (k1 - k0).
+            // The denominator is non-zero (k1 > k0 here), so every step is defined.
+            let blended = (|| {
+                let dv = v1.sub(&v0)?;
+                let dq = q.sub(&k0)?;
+                let dk = k1.sub(&k0)?;
+                let frac = dq.div(&dk)?;
+                let scaled = dv.mul(&frac)?;
+                v0.add(&scaled)
+            })();
+            let v = match blended {
+                Some(v) => v,
+                None => {
+                    // Exact arithmetic only fails on a zero denominator, already
+                    // excluded above; abstain rather than emit a wrong number.
+                    return abstain(AbstentionReason::SearchLimitExceeded {
+                        goal: query_str.clone(),
+                    });
+                }
+            };
+            let mut cites = cites_of(lp);
+            cites.extend(cites_of(up));
+            format!(
+                "{{\"query\":\"{}\",\"mode\":\"{}\",\"answers\":[{{\"bindings\":{{\"{}\":\"{}\",\"{}\":\"{}\"}},\"brackets\":{{\"lower\":{{\"{}\":\"{}\",\"{}\":\"{}\"}},\"upper\":{{\"{}\":\"{}\",\"{}\":\"{}\"}}}},\"citations\":[{}]}}],\"abstained\":false}}",
+                query_echo(&query_str),
+                esc(&rl.mode),
+                esc(&rl.value_col),
+                esc(&render(&v)),
+                esc(&rl.key_col),
+                esc(&render(&q)),
+                esc(&rl.key_col),
+                esc(&render(&k0)),
+                esc(&rl.value_col),
+                esc(&render(&v0)),
+                esc(&rl.key_col),
+                esc(&render(&k1)),
+                esc(&rl.value_col),
+                esc(&render(&v1)),
+                cites.join(",")
             )
         }
     }

--- a/code/packages/rust/adj-lang-cli/tests/rs5c_range_lookup_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5c_range_lookup_e2e.rs
@@ -14,9 +14,10 @@
 //!       breakpoint falls in the top band; a value below the smallest key has no
 //!       key `<=` it and honestly ABSTAINS ("below the table's domain"), never a
 //!       fabricated classification.
-//!   (d) GUARDS: a `mode interpolated` is rejected (reserved for RS-5d), an
-//!       unknown value column is a clean compile error, and a non-numeric key
-//!       column is rejected (a range key must be a number).
+//!   (d) GUARDS: `mode interpolated give <non-numeric col>` is rejected (RS-5d
+//!       interpolation needs a numeric value column — you cannot interpolate a
+//!       category label), an unknown value column is a clean compile error, and a
+//!       non-numeric key column is rejected (a range key must be a number).
 
 use std::path::Path;
 use std::process::Command;
@@ -68,18 +69,37 @@ table bmi_categories {
 #[test]
 fn range_lookup_bracket_hit_binds_band_value_with_citation_and_matched_key() {
     let dir = scratch("hit");
-    let src = format!("{BMI_TABLE}\n? lookup bmi_categories min_bmi = 27.3 mode range give category\n");
+    let src =
+        format!("{BMI_TABLE}\n? lookup bmi_categories min_bmi = 27.3 mode range give category\n");
     write(&dir, "case.adj", &src);
     let (ok, out, err) = run_full(&dir.join("case.adj"));
     assert!(ok, "CLI should succeed; stderr={err}");
-    assert!(out.contains("\"lookups\""), "expected a lookups section: {out}");
+    assert!(
+        out.contains("\"lookups\""),
+        "expected a lookups section: {out}"
+    );
     // 27.3 falls in [25, 30) → overweight, selected breakpoint min_bmi = 25.
-    assert!(out.contains("\"category\":\"overweight\""), "wrong band: {out}");
-    assert!(out.contains("\"min_bmi\":\"25\""), "audit should name the matched breakpoint: {out}");
+    assert!(
+        out.contains("\"category\":\"overweight\""),
+        "wrong band: {out}"
+    );
+    assert!(
+        out.contains("\"min_bmi\":\"25\""),
+        "audit should name the matched breakpoint: {out}"
+    );
     // The selected row's citation travels with the answer.
-    assert!(out.contains("example.test/bmi-bands"), "answer must carry the row citation: {out}");
-    assert!(out.contains("\"trust\":\"consensus\""), "citation must carry the trust tier: {out}");
-    assert!(out.contains("\"abstained\":false"), "a hit is not an abstention: {out}");
+    assert!(
+        out.contains("example.test/bmi-bands"),
+        "answer must carry the row citation: {out}"
+    );
+    assert!(
+        out.contains("\"trust\":\"consensus\""),
+        "citation must carry the trust tier: {out}"
+    );
+    assert!(
+        out.contains("\"abstained\":false"),
+        "a hit is not an abstention: {out}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -89,13 +109,20 @@ fn range_lookup_bracket_hit_binds_band_value_with_citation_and_matched_key() {
 #[test]
 fn range_lookup_on_an_exact_breakpoint_selects_that_breakpoint() {
     let dir = scratch("boundary");
-    let src = format!("{BMI_TABLE}\n? lookup bmi_categories min_bmi = 18.5 mode range give category\n");
+    let src =
+        format!("{BMI_TABLE}\n? lookup bmi_categories min_bmi = 18.5 mode range give category\n");
     write(&dir, "case.adj", &src);
     let (ok, out, _err) = run_full(&dir.join("case.adj"));
     assert!(ok);
     // greatest key <= 18.5 is 18.5 itself → normal (exact comparison, no f64 fuzz).
-    assert!(out.contains("\"category\":\"normal\""), "exact boundary must land on the breakpoint: {out}");
-    assert!(out.contains("\"min_bmi\":\"18.5\""), "matched key should be the breakpoint itself: {out}");
+    assert!(
+        out.contains("\"category\":\"normal\""),
+        "exact boundary must land on the breakpoint: {out}"
+    );
+    assert!(
+        out.contains("\"min_bmi\":\"18.5\""),
+        "matched key should be the breakpoint itself: {out}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -106,19 +133,30 @@ fn range_lookup_on_an_exact_breakpoint_selects_that_breakpoint() {
 fn range_lookup_top_band_is_open_and_below_domain_abstains() {
     let dir = scratch("edges");
     // A value above the last breakpoint falls in the top (open) band.
-    let top = format!("{BMI_TABLE}\n? lookup bmi_categories min_bmi = 42 mode range give category\n");
+    let top =
+        format!("{BMI_TABLE}\n? lookup bmi_categories min_bmi = 42 mode range give category\n");
     write(&dir, "top.adj", &top);
     let (ok, out, _e) = run_full(&dir.join("top.adj"));
     assert!(ok);
-    assert!(out.contains("\"category\":\"obese\""), "top-open band should be selected: {out}");
+    assert!(
+        out.contains("\"category\":\"obese\""),
+        "top-open band should be selected: {out}"
+    );
 
     // A value below the smallest key has no key <= it → honest abstention.
-    let below = format!("{BMI_TABLE}\n? lookup bmi_categories min_bmi = -1 mode range give category\n");
+    let below =
+        format!("{BMI_TABLE}\n? lookup bmi_categories min_bmi = -1 mode range give category\n");
     write(&dir, "below.adj", &below);
     let (ok2, out2, _e2) = run_full(&dir.join("below.adj"));
     assert!(ok2);
-    assert!(out2.contains("\"abstained\":true"), "below the domain must abstain, not fabricate: {out2}");
-    assert!(!out2.contains("\"category\":\""), "an abstention has no bound band: {out2}");
+    assert!(
+        out2.contains("\"abstained\":true"),
+        "below the domain must abstain, not fabricate: {out2}"
+    );
+    assert!(
+        !out2.contains("\"category\":\""),
+        "an abstention has no bound band: {out2}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -126,25 +164,40 @@ fn range_lookup_top_band_is_open_and_below_domain_abstains() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn range_lookup_reserved_interpolated_mode_is_rejected() {
+fn interpolated_mode_over_a_non_numeric_value_column_is_rejected() {
+    // `interpolated` (RS-5d) is now a built tactic, but it computes on the VALUE
+    // column, so a non-numeric `give` column (here `category`) is a clean compile
+    // error — you cannot linearly blend "overweight" and "obese".
     let dir = scratch("mode");
-    let src = format!("{BMI_TABLE}\n? lookup bmi_categories min_bmi = 27 mode interpolated give category\n");
+    let src = format!(
+        "{BMI_TABLE}\n? lookup bmi_categories min_bmi = 27 mode interpolated give category\n"
+    );
     write(&dir, "case.adj", &src);
     let (ok, out, err) = run_full(&dir.join("case.adj"));
-    assert!(!ok, "interpolated is RS-5d — must be rejected, not silently run as range");
+    assert!(
+        !ok,
+        "interpolating a non-numeric value column must be rejected"
+    );
     let diag = format!("{out}{err}");
-    assert!(diag.contains("LookupModeUnsupported") || diag.to_lowercase().contains("interpolated"), "diag: {diag}");
+    assert!(
+        diag.contains("LookupNonNumericValueColumn") || diag.to_lowercase().contains("category"),
+        "diag names the non-numeric value column: {diag}"
+    );
 }
 
 #[test]
 fn range_lookup_unknown_value_column_is_a_clean_compile_error() {
     let dir = scratch("col");
-    let src = format!("{BMI_TABLE}\n? lookup bmi_categories min_bmi = 27 mode range give bmi_class\n");
+    let src =
+        format!("{BMI_TABLE}\n? lookup bmi_categories min_bmi = 27 mode range give bmi_class\n");
     write(&dir, "case.adj", &src);
     let (ok, out, err) = run_full(&dir.join("case.adj"));
     assert!(!ok, "an unknown value column must be a compile error");
     let diag = format!("{out}{err}");
-    assert!(diag.contains("LookupUnknownColumn") || diag.contains("bmi_class"), "diag: {diag}");
+    assert!(
+        diag.contains("LookupUnknownColumn") || diag.contains("bmi_class"),
+        "diag: {diag}"
+    );
 }
 
 #[test]
@@ -152,10 +205,14 @@ fn range_lookup_non_numeric_key_column_is_rejected() {
     let dir = scratch("nonnum");
     // Here the *category* (an atom column) is (mis)used as the key — a range key
     // must be numeric, so this is a clean compile error, not a silent skip.
-    let src = format!("{BMI_TABLE}\n? lookup bmi_categories category = 27 mode range give min_bmi\n");
+    let src =
+        format!("{BMI_TABLE}\n? lookup bmi_categories category = 27 mode range give min_bmi\n");
     write(&dir, "case.adj", &src);
     let (ok, out, err) = run_full(&dir.join("case.adj"));
     assert!(!ok, "a non-numeric key column must be rejected");
     let diag = format!("{out}{err}");
-    assert!(diag.contains("LookupNonNumericKeyColumn") || diag.contains("category"), "diag: {diag}");
+    assert!(
+        diag.contains("LookupNonNumericKeyColumn") || diag.contains("category"),
+        "diag: {diag}"
+    );
 }

--- a/code/packages/rust/adj-lang-cli/tests/rs5d_interpolated_lookup_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5d_interpolated_lookup_e2e.rs
@@ -1,0 +1,238 @@
+//! End-to-end tests for ADJ-TABLES RS-5d — the INTERPOLATED lookup tactic —
+//! driven through the built CLI binary. A `table` is read as a piecewise-linear
+//! function: `? lookup <table> <key_col> = <n> mode interpolated give <value_col>`
+//! finds the two breakpoint rows that bracket `n` (greatest key `<= n` and smallest
+//! key `>= n`) and returns the EXACT linear blend
+//!     v = v0 + (v1 - v0) * (n - k0) / (k1 - k0)
+//! carrying BOTH bracketing rows' citations. Five things are proven:
+//!
+//!   (a) LINEAR BLEND: a value strictly between two breakpoints binds the exact
+//!       interpolated value AND both breakpoints' citations, and the audit names
+//!       the lower/upper bracket it sits between.
+//!   (b) EXACTNESS: a blend that does not terminate in base 10 renders as the exact
+//!       reduced fraction (e.g. `10/3`), never a rounded `f64`.
+//!   (c) EXACT HIT: a query equal to a breakpoint key returns THAT row's value with
+//!       its single citation (the `0/0` blend is short-circuited, not divided).
+//!   (d) OUT-OF-DOMAIN: a query below the lowest / above the highest breakpoint
+//!       ABSTAINS (`below_table_domain` / `above_table_domain`) — interpolation
+//!       never extrapolates past what the source measured.
+//!   (e) NUMERIC-VALUE GUARD is covered in the RS-5c suite (a non-numeric `give`
+//!       column is a clean compile error under `mode interpolated`).
+
+use std::path::Path;
+use std::process::Command;
+
+fn scratch(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_rs5d_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run_full(program: &Path) -> (bool, String, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (
+        out.status.success(),
+        String::from_utf8(out.stdout).unwrap(),
+        String::from_utf8(out.stderr).unwrap(),
+    )
+}
+
+fn write(dir: &Path, name: &str, src: &str) {
+    std::fs::write(dir.join(name), src).unwrap();
+}
+
+/// A self-contained calibration table with a numeric key AND numeric value column,
+/// so it can be read as a piecewise-linear function. Two linear segments with
+/// different slopes (0→10 rises by 10/unit; 10→25 rises by 10/unit as well but the
+/// second point makes the bracketing unambiguous).
+const CALIBRATION: &str = r#"
+table calibration {
+    columns input, output
+    row (0, 0)
+    row (10, 100)
+    row (25, 250)
+    source "A worked calibration table mapping instrument input to output units."
+    locator "https://example.test/calibration"
+    trust consensus
+}
+"#;
+
+// ---------------------------------------------------------------------------
+// (a) Linear blend — a value between two breakpoints, both citations ride along.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn interpolated_lookup_blends_between_breakpoints_with_both_citations() {
+    let dir = scratch("blend");
+    // input = 5 sits between (0 → 0) and (10 → 100): 0 + 100*(5-0)/(10-0) = 50.
+    let src =
+        format!("{CALIBRATION}\n? lookup calibration input = 5 mode interpolated give output\n");
+    write(&dir, "case.adj", &src);
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    assert!(!out.contains("\"error\""), "no compile error: {out}");
+    assert!(
+        out.contains("\"mode\":\"interpolated\""),
+        "mode echoed: {out}"
+    );
+    assert!(
+        out.contains("\"output\":\"50\""),
+        "exact linear blend 50: {out}"
+    );
+    assert!(
+        out.contains("\"abstained\":false"),
+        "not an abstention: {out}"
+    );
+    // The audit shows the bracket it fell between …
+    assert!(
+        out.contains("\"lower\":") && out.contains("\"upper\":"),
+        "audit names both brackets: {out}"
+    );
+    // … and BOTH breakpoint rows' citations ride along (two of the same table's).
+    assert_eq!(
+        out.matches("example.test/calibration").count(),
+        2,
+        "both bracketing rows are cited: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (b) Exactness — a non-terminating blend renders as the reduced fraction.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn interpolated_lookup_renders_repeating_blend_as_exact_fraction() {
+    let dir = scratch("frac");
+    // A 0→0, 3→10 segment; at input = 1: 0 + 10*(1-0)/(3-0) = 10/3, which repeats
+    // in base 10 and so must render as the exact fraction, never a rounded float.
+    let table = r#"
+table ramp {
+    columns x, y
+    row (0, 0)
+    row (3, 10)
+    source "A two-point ramp for exact-fraction interpolation."
+    locator "https://example.test/ramp"
+    trust consensus
+}
+"#;
+    let src = format!("{table}\n? lookup ramp x = 1 mode interpolated give y\n");
+    write(&dir, "case.adj", &src);
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    assert!(
+        out.contains("\"y\":\"10/3\""),
+        "repeating blend renders as the exact fraction 10/3, not a float: {out}"
+    );
+    assert!(
+        !out.contains("3.333"),
+        "must not fall back to a rounded decimal: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (c) Exact hit — a query equal to a breakpoint returns that row (single cite).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn interpolated_lookup_exact_breakpoint_returns_that_row() {
+    let dir = scratch("exact");
+    // input = 10 IS a breakpoint (→ 100). The 0/0 blend is short-circuited.
+    let src =
+        format!("{CALIBRATION}\n? lookup calibration input = 10 mode interpolated give output\n");
+    write(&dir, "case.adj", &src);
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    assert!(
+        out.contains("\"output\":\"100\""),
+        "exact breakpoint value: {out}"
+    );
+    assert!(
+        out.contains("\"exact\":"),
+        "audit marks it an exact hit: {out}"
+    );
+    // An exact hit is a single-row answer — no lower/upper bracket pair.
+    assert!(
+        !out.contains("\"lower\":") && !out.contains("\"upper\":"),
+        "an exact hit has no bracketing pair: {out}"
+    );
+    assert!(
+        out.contains("\"abstained\":false"),
+        "not an abstention: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (d) Out-of-domain — below the floor and above the ceiling both abstain.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn interpolated_lookup_below_domain_abstains() {
+    let dir = scratch("below");
+    let src =
+        format!("{CALIBRATION}\n? lookup calibration input = -5 mode interpolated give output\n");
+    write(&dir, "case.adj", &src);
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "below domain abstains: {out}"
+    );
+    assert!(
+        out.contains("below_table_domain"),
+        "names the below-domain reason: {out}"
+    );
+    assert!(!out.contains("\"output\":\""), "no fabricated value: {out}");
+}
+
+#[test]
+fn interpolated_lookup_above_domain_abstains() {
+    let dir = scratch("above");
+    // input = 30 is above the highest breakpoint (25) — nothing to interpolate up
+    // toward, so it abstains rather than extrapolate.
+    let src =
+        format!("{CALIBRATION}\n? lookup calibration input = 30 mode interpolated give output\n");
+    write(&dir, "case.adj", &src);
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    assert!(
+        out.contains("\"abstained\":true"),
+        "above domain abstains: {out}"
+    );
+    assert!(
+        out.contains("above_table_domain"),
+        "names the above-domain reason: {out}"
+    );
+    assert!(
+        !out.contains("\"output\":\""),
+        "no extrapolated value: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (e) Second segment — interpolation picks the correct bracketing pair.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn interpolated_lookup_uses_the_correct_segment() {
+    let dir = scratch("seg2");
+    // input = 15 sits in the SECOND segment, (10 → 100)..(25 → 250):
+    // 100 + (250-100)*(15-10)/(25-10) = 100 + 150*5/15 = 100 + 50 = 150.
+    let src =
+        format!("{CALIBRATION}\n? lookup calibration input = 15 mode interpolated give output\n");
+    write(&dir, "case.adj", &src);
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    assert!(
+        out.contains("\"output\":\"150\""),
+        "second-segment blend 150: {out}"
+    );
+    // The lower bracket must be the 10-row, not the 0-row.
+    assert!(
+        out.contains("\"input\":\"10\""),
+        "lower bracket is the 10 breakpoint: {out}"
+    );
+}

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.62.0] — 2026-07-23
+
+### Added — RS-5d: `mode interpolated` table lookup (ADJ-TABLES §3.3)
+
+The `? lookup <table> <key> = <n> mode interpolated give <val>` tactic is now built — the
+piecewise-linear sibling of `mode range`. Lowering changes:
+
+- The mode dispatch accepts `interpolated` alongside `range` (both are built tactics); an
+  unrecognized mode is still `LowerError::LookupUnknownMode`. The reserved-mode error
+  `LookupModeUnsupported` is **retired** (it existed only to reject `interpolated`).
+- `interpolated` additionally validates that the **value** column is numeric in every row —
+  the new `LowerError::LookupNonNumericValueColumn` — because it computes on the value cells
+  (`v0 + (v1−v0)·(q−k0)/(k1−k0)`); you cannot linearly blend a category label. (`range` returns
+  the value cell verbatim and imposes no such check.)
+
+The lowered form is unchanged (`LoweredRangeLookup` carries the mode through); the interpolation
+arithmetic itself lives in the CLI's exact-rational tactic (see `adj-lang-cli` 0.23.0).
+
 ## [0.61.0] — 2026-07-23
 
 ### Added — NUM-6c: the `to_currency(x, code [, places])` money rendering (ADJ-NUMERIC-SUBSTRATE §4.1, §4.3)

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/_parser_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_parser_grammar.rs
@@ -240,7 +240,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"give"#.to_string() },
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
             ] },
-            line_number: 153,
+            line_number: 155,
         },
         GrammarRule {
             name: r#"signed_number"#.to_string(),
@@ -248,7 +248,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::TokenReference { name: r#"MINUS"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
             ] },
-            line_number: 154,
+            line_number: 156,
         },
         GrammarRule {
             name: r#"let_decl"#.to_string(),
@@ -258,7 +258,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 168,
+            line_number: 170,
         },
         GrammarRule {
             name: r#"expr"#.to_string(),
@@ -272,7 +272,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term_expr"#.to_string() },
                     ] }) },
             ] },
-            line_number: 170,
+            line_number: 172,
         },
         GrammarRule {
             name: r#"term_expr"#.to_string(),
@@ -286,7 +286,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 172,
+            line_number: 174,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -305,7 +305,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 ] },
             ] },
-            line_number: 174,
+            line_number: 176,
         },
         GrammarRule {
             name: r#"agg"#.to_string(),
@@ -321,7 +321,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
             ] },
-            line_number: 176,
+            line_number: 178,
         },
         GrammarRule {
             name: r#"apply"#.to_string(),
@@ -337,7 +337,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
             ] },
-            line_number: 201,
+            line_number: 203,
         },
         GrammarRule {
             name: r#"latex_expr"#.to_string(),
@@ -345,7 +345,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"latex"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 208,
+            line_number: 210,
         },
         GrammarRule {
             name: r#"asciimath_expr"#.to_string(),
@@ -353,7 +353,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"asciimath"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 219,
+            line_number: 221,
         },
         GrammarRule {
             name: r#"mathml_expr"#.to_string(),
@@ -361,7 +361,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"mathml"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 231,
+            line_number: 233,
         },
         GrammarRule {
             name: r#"unicodemath_expr"#.to_string(),
@@ -369,7 +369,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"unicodemath"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 243,
+            line_number: 245,
         },
         GrammarRule {
             name: r#"symbol_decl"#.to_string(),
@@ -379,7 +379,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 253,
+            line_number: 255,
         },
         GrammarRule {
             name: r#"constrain_latex_decl"#.to_string(),
@@ -387,7 +387,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"constrain"#.to_string() },
                 GrammarElement::RuleReference { name: r#"latex_relation"#.to_string() },
             ] },
-            line_number: 255,
+            line_number: 257,
         },
         GrammarRule {
             name: r#"constrain_asciimath_decl"#.to_string(),
@@ -395,7 +395,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"constrain"#.to_string() },
                 GrammarElement::RuleReference { name: r#"asciimath_relation"#.to_string() },
             ] },
-            line_number: 265,
+            line_number: 267,
         },
         GrammarRule {
             name: r#"constrain_decl"#.to_string(),
@@ -405,7 +405,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"relop"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 267,
+            line_number: 269,
         },
         GrammarRule {
             name: r#"latex_relation"#.to_string(),
@@ -413,7 +413,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"latex"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 269,
+            line_number: 271,
         },
         GrammarRule {
             name: r#"asciimath_relation"#.to_string(),
@@ -421,7 +421,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"asciimath"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 271,
+            line_number: 273,
         },
         GrammarRule {
             name: r#"relop"#.to_string(),
@@ -434,7 +434,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NE"#.to_string() },
             ] },
-            line_number: 273,
+            line_number: 275,
         },
         GrammarRule {
             name: r#"solve_decl"#.to_string(),
@@ -449,12 +449,12 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 275,
+            line_number: 277,
         },
         GrammarRule {
             name: r#"check_decl"#.to_string(),
             body: GrammarElement::Literal { value: r#"check"#.to_string() },
-            line_number: 277,
+            line_number: 279,
         },
         GrammarRule {
             name: r#"optimize_decl"#.to_string(),
@@ -465,7 +465,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 284,
+            line_number: 286,
         },
         GrammarRule {
             name: r#"dictionary_decl"#.to_string(),
@@ -476,7 +476,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"define_decl"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 296,
+            line_number: 298,
         },
         GrammarRule {
             name: r#"define_decl"#.to_string(),
@@ -487,7 +487,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"define_kind"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"surface_clause"#.to_string() }) },
             ] },
-            line_number: 298,
+            line_number: 300,
         },
         GrammarRule {
             name: r#"define_kind"#.to_string(),
@@ -515,7 +515,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                 ] },
             ] },
-            line_number: 300,
+            line_number: 302,
         },
         GrammarRule {
             name: r#"surface_clause"#.to_string(),
@@ -527,7 +527,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 306,
+            line_number: 308,
         },
         GrammarRule {
             name: r#"rulebook_decl"#.to_string(),
@@ -538,7 +538,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 323,
+            line_number: 325,
         },
         GrammarRule {
             name: r#"use_decl"#.to_string(),
@@ -546,7 +546,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"use"#.to_string() },
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
             ] },
-            line_number: 325,
+            line_number: 327,
         },
         GrammarRule {
             name: r#"formulabook_decl"#.to_string(),
@@ -557,7 +557,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"formulabook_item"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 356,
+            line_number: 358,
         },
         GrammarRule {
             name: r#"formulabook_item"#.to_string(),
@@ -565,7 +565,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"use_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"formula_decl"#.to_string() },
             ] },
-            line_number: 358,
+            line_number: 360,
         },
         GrammarRule {
             name: r#"formula_decl"#.to_string(),
@@ -578,7 +578,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"formula_body"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 360,
+            line_number: 362,
         },
         GrammarRule {
             name: r#"formula_params"#.to_string(),
@@ -589,7 +589,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                     ] }) },
             ] },
-            line_number: 362,
+            line_number: 364,
         },
         GrammarRule {
             name: r#"formula_body"#.to_string(),
@@ -605,7 +605,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
                 ] },
             ] },
-            line_number: 375,
+            line_number: 377,
         },
         GrammarRule {
             name: r#"formula_step"#.to_string(),
@@ -615,7 +615,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 377,
+            line_number: 379,
         },
         GrammarRule {
             name: r#"table_decl"#.to_string(),
@@ -629,7 +629,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 411,
+            line_number: 413,
         },
         GrammarRule {
             name: r#"columns_decl"#.to_string(),
@@ -641,7 +641,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                     ] }) },
             ] },
-            line_number: 413,
+            line_number: 415,
         },
         GrammarRule {
             name: r#"table_row"#.to_string(),
@@ -660,7 +660,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
                     ] }) },
             ] },
-            line_number: 421,
+            line_number: 423,
         },
         GrammarRule {
             name: r#"row_item"#.to_string(),
@@ -669,7 +669,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 423,
+            line_number: 425,
         },
         GrammarRule {
             name: r#"import_decl"#.to_string(),
@@ -677,7 +677,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"import"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 439,
+            line_number: 441,
         },
         GrammarRule {
             name: r#"annotation"#.to_string(),
@@ -688,7 +688,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"cites_annotation"#.to_string() },
                 GrammarElement::RuleReference { name: r#"quote_annotation"#.to_string() },
             ] },
-            line_number: 451,
+            line_number: 453,
         },
         GrammarRule {
             name: r#"source_annotation"#.to_string(),
@@ -696,7 +696,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"source"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 458,
+            line_number: 460,
         },
         GrammarRule {
             name: r#"locator_annotation"#.to_string(),
@@ -704,7 +704,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 459,
+            line_number: 461,
         },
         GrammarRule {
             name: r#"trust_annotation"#.to_string(),
@@ -712,7 +712,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"trust"#.to_string() },
                 GrammarElement::RuleReference { name: r#"trust_tier"#.to_string() },
             ] },
-            line_number: 460,
+            line_number: 462,
         },
         GrammarRule {
             name: r#"cites_annotation"#.to_string(),
@@ -722,7 +722,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 461,
+            line_number: 463,
         },
         GrammarRule {
             name: r#"quote_annotation"#.to_string(),
@@ -734,7 +734,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"snapshot"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 469,
+            line_number: 471,
         },
         GrammarRule {
             name: r#"trust_tier"#.to_string(),
@@ -745,7 +745,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"inferred"#.to_string() },
                 GrammarElement::Literal { value: r#"unattributed"#.to_string() },
             ] },
-            line_number: 471,
+            line_number: 473,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -769,7 +769,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 493,
+            line_number: 495,
         },
     ],
         version: 1,

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -410,17 +410,25 @@ pub enum Statement {
     /// as the single-hop special case of the differential.
     Query { conclusion: Term },
     /// `? lookup <table> <key_col> = <n> mode <mode> give <value_col>` — a
-    /// RANGE / BRACKET lookup over a [`Statement::Table`] read as a step function
-    /// (ADJ-TABLES RS-5c). Unlike [`Query`] (exact SLD unification on the key), a
-    /// range lookup selects the breakpoint row whose `key_col` is the greatest key
-    /// `<= key_value`, and returns that row's `value_col` **with the row's
-    /// citation** — the tactic for tax brackets, dose bands, and reference-range
-    /// classification. A query below the smallest key abstains ("below the table's
-    /// domain"). `mode` selects the tactic: `range` here; `interpolated` is
-    /// reserved for RS-5d ([`crate::LowerError::LookupModeUnsupported`]).
+    /// RANGE / INTERPOLATED lookup over a [`Statement::Table`] (ADJ-TABLES RS-5c/RS-5d).
+    /// Unlike [`Query`] (exact SLD unification on the key), the `mode` selects a
+    /// numeric tactic over the table's breakpoints:
+    /// - `range` reads the table as a **step function**: it selects the breakpoint
+    ///   row whose `key_col` is the greatest key `<= key_value` and returns that
+    ///   row's `value_col` verbatim — tax brackets, dose bands, reference-range
+    ///   classification. A query below the smallest key abstains ("below the table's
+    ///   domain").
+    /// - `interpolated` reads it as a **piecewise-linear function**: it finds the two
+    ///   bracketing rows `k0 <= key_value <= k1` and returns the exact linear blend
+    ///   `v0 + (v1−v0)·(key_value−k0)/(k1−k0)` — nomograms, growth charts, calibration
+    ///   curves. Both bracketing rows' citations ride along. A query outside `[min,
+    ///   max]` abstains (below- or above-domain); it never extrapolates. The value
+    ///   column must be numeric ([`crate::LowerError::LookupNonNumericValueColumn`]).
+    ///
+    /// An unrecognized mode is [`crate::LowerError::LookupUnknownMode`].
     RangeLookup {
-        /// The `table` to read as a step function (must be a declared table:
-        /// [`crate::LowerError::LookupUnknownTable`]).
+        /// The `table` to read as a step / piecewise-linear function (must be a
+        /// declared table: [`crate::LowerError::LookupUnknownTable`]).
         table: String,
         /// The numeric key column the query value is compared against (must be one
         /// of the table's columns and hold only numbers:
@@ -430,7 +438,7 @@ pub enum Statement {
         /// The concrete query value to classify. Carried as a [`NumLit`] (sign
         /// already folded in) so no digit is lost before the exact comparison.
         key_value: NumLit,
-        /// The lookup tactic named at the call site (`range`; `interpolated` = RS-5d).
+        /// The lookup tactic named at the call site (`range` or `interpolated`).
         mode: String,
         /// The column whose cell is returned for the selected breakpoint row (must
         /// be one of the table's columns: [`crate::LowerError::LookupUnknownColumn`]).

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -283,16 +283,21 @@ pub enum LowerError {
         column: String,
         row: usize,
     },
-    /// A lookup named `mode <name>` for a mode that is spec'd but not yet built
-    /// (ADJ-TABLES RS-5d) — today only `interpolated`. Rejected explicitly (rather
-    /// than silently treated as `range`) so the reserved surface is honest about
-    /// what the engine can do. Carries the requested mode.
-    LookupModeUnsupported {
-        mode: String,
+    /// An `interpolated` lookup's VALUE column holds a non-numeric cell (ADJ-TABLES
+    /// RS-5d). `mode interpolated` computes `v0 + (v1−v0)·(q−k0)/(k1−k0)` between the
+    /// two bracketing rows, so the `give` column must be a number in every row — you
+    /// cannot interpolate a category label. (A `range` lookup returns the cell
+    /// verbatim, so it imposes no such requirement; this check is interpolation-only.)
+    /// Carries the table, the value column, and the offending row index (0-based).
+    LookupNonNumericValueColumn {
+        table: String,
+        column: String,
+        row: usize,
     },
     /// A lookup named a `mode` that is not a recognized tactic at all (ADJ-TABLES
-    /// RS-5c). The valid modes are `range` (built) and `interpolated` (reserved,
-    /// RS-5d). Carries the unrecognized mode.
+    /// RS-5c/RS-5d). The valid modes are `range` (bracket / step function) and
+    /// `interpolated` (linear between breakpoints); both are built. Carries the
+    /// unrecognized mode.
     LookupUnknownMode {
         mode: String,
     },
@@ -638,14 +643,12 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                         .ok_or_else(|| LowerError::LookupUnknownTable {
                             table: table.clone(),
                         })?;
-                // Mode: `range` is built; `interpolated` is the reserved RS-5d
-                // tactic (rejected honestly, not silently treated as range); any
-                // other word is not a tactic at all.
+                // Mode: `range` reads the table as a step function (bracket
+                // lookup); `interpolated` reads it as a piecewise-linear function
+                // between breakpoints (RS-5d). Both are built; any other word is not
+                // a tactic at all.
                 match mode.as_str() {
-                    "range" => {}
-                    "interpolated" => {
-                        return Err(LowerError::LookupModeUnsupported { mode: mode.clone() })
-                    }
+                    "range" | "interpolated" => {}
                     _ => return Err(LowerError::LookupUnknownMode { mode: mode.clone() }),
                 }
                 let key_index = columns.iter().position(|c| c == key_col).ok_or_else(|| {
@@ -673,6 +676,23 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                             column: key_col.clone(),
                             row: i,
                         });
+                    }
+                }
+                // `interpolated` additionally computes on the VALUE column, so it
+                // too must be numeric in every row (RS-5d). `range` returns the value
+                // cell verbatim (it may be a category label), so it skips this check.
+                if mode == "interpolated" {
+                    for (i, row) in rows.iter().enumerate() {
+                        if !matches!(
+                            row.cells.get(value_index),
+                            Some(crate::ast::TableCell::Number(_))
+                        ) {
+                            return Err(LowerError::LookupNonNumericValueColumn {
+                                table: table.clone(),
+                                column: value_col.clone(),
+                                row: i,
+                            });
+                        }
                     }
                 }
                 range_lookups.push(LoweredRangeLookup {

--- a/code/specs/ADJ-TABLES.md
+++ b/code/specs/ADJ-TABLES.md
@@ -139,20 +139,40 @@ table, the key column bound to a concrete value, the mode, and the value column 
   binding query.
 - The table declaration is **unchanged** — a `range` table is an ordinary table read
   differently. The key column must be numeric (checked at lower time: `LookupNonNumericKeyColumn`);
-  an unknown table or column is `LookupUnknownTable` / `LookupUnknownColumn`; `mode interpolated`
-  is reserved for RS-5d (`LookupModeUnsupported`).
+  an unknown table or column is `LookupUnknownTable` / `LookupUnknownColumn`; an unrecognized mode
+  is `LookupUnknownMode`. `mode interpolated` is now built (RS-5d, §3.3) and additionally requires
+  a numeric **value** column (`LookupNonNumericValueColumn`).
 - A hit returns the value column **with the selected breakpoint row's citation** (the same
   `via_facts → provenance` flow as exact lookup) and records the matched key in the audit, so the
   answer names *which* bracket it fell in. A query **below the smallest key** has no key `≤` it
   and honestly **abstains** — "below the table's domain", not a fabricated classification.
 
-### 3.3 Interpolated lookup (spec'd here, built in a follow-up)
+### 3.3 Interpolated lookup (RS-5d, built)
 
-For sampled continuous functions (nomograms, calibration curves), the lookup **linearly
-interpolates** between the two rows that bracket the query key, computing on the exact
-`BigRational` arithmetic already in the compute evaluator. No interpolation code exists in the
-engine today; this tactic is genuinely new. Interpolation is only defined for numeric key and
-value columns; a non-numeric column is a compile/lookup error.
+For sampled continuous functions (nomograms, calibration curves, growth charts), `mode
+interpolated` reads the table as a **piecewise-linear** function. It finds the two rows that
+bracket the query key — the greatest key `k0 ≤ q` and the smallest key `k1 ≥ q` — and returns the
+exact linear blend
+
+```
+v = v0 + (v1 − v0) · (q − k0) / (k1 − k0)
+```
+
+computed entirely on the exact `BigRational` arithmetic already in the compute evaluator (`add`/
+`sub`/`mul`/`div`), so a terminating blend renders every digit and a repeating one renders as the
+reduced fraction — never a rounded `f64`. **Both** bracketing rows' citations ride along, so the
+answer is traceable to the two measured points it sits between. Three honest edges:
+
+- **Exact hit** (`q` equals a breakpoint, `k0 = k1`): the `0/0` blend is short-circuited to that
+  row's value with its single citation — no fabricated division.
+- **Out of domain**: interpolation needs a breakpoint on *both* sides of `q`. Below the lowest key
+  it abstains `below_table_domain`; above the highest, `above_table_domain` — it never extrapolates
+  past what the source measured.
+- **Truncated search**: if enumeration hit a resolution limit the true bracket may be unseen, so it
+  abstains `search_limit_exceeded` rather than blend against a partial scan.
+
+Interpolation is only defined for numeric key **and** value columns; a non-numeric value column is
+a compile error (`LookupNonNumericValueColumn`) — you cannot linearly blend a category label.
 
 ---
 
@@ -214,7 +234,7 @@ per conversion, one table cites the NIST page once and every conversion is audit
 | RS-5b | grammar + AST + adapter + lower; rows→relations; **exact lookup** e2e; shipped NIST table | **this PR** |
 | RS-5c | **range/bracket** lookup tactic (reuses the exact `BigRational` order) + e2e (inline BMI bands) | shipped |
 | RS-5e | **per-row provenance** — a row's `{ … }` block overrides the envelope; the answer cites the SELECTED row's span | **this PR** |
-| RS-5d | **interpolated** lookup tactic (new, on `BigRational`) + e2e (nomogram) | follow-up |
+| RS-5d | **interpolated** lookup tactic (exact linear blend on `BigRational`, both citations, out-of-domain abstention) + e2e (calibration curve) | shipped |
 
 **Explicitly deferred:** multi-key composite lookup beyond positional binding; typed/dimensioned
 columns (columns are untyped atoms/numbers today). These are additive and do not change the


### PR DESCRIPTION
## What

Adds the **interpolated** table-lookup tactic (ADJ-TABLES RS-5d), closing the exact / range / **interpolated** trio. A `? lookup <table> <key> = <n> mode interpolated give <val>` reads a `table` as a **piecewise-linear** function: it finds the two breakpoint rows bracketing the key and returns the exact linear blend

```
v = v0 + (v1 − v0) · (q − k0) / (k1 − k0)
```

computed entirely on `ExactRational` (`add`/`sub`/`mul`/`div`) — a terminating blend renders every digit, a repeating one the reduced fraction (`10/3`), never a rounded `f64`. **Both** bracketing rows' citations ride along, so the answer is traceable to the two measured points it sits between (nomograms, calibration curves, growth charts).

## Why

The `table` substrate already read as an *exact* relation (RS-5b) and a *step function* (RS-5c). Interpolation is the third and last reading, and it's the one that unblocks sampled continuous reference data on the Facts front. It stays exact (rational arithmetic), so it's a clean increment, not the transcendentals tunnel.

## Honest edges

- **exact hit** (`q` equals a breakpoint, `k0 = k1`): the `0/0` blend is short-circuited to that row's value with its single citation — no fabricated division.
- **out of domain**: below the lowest / above the highest breakpoint abstains (`below_table_domain` / new `above_table_domain`) — interpolation never extrapolates.
- **truncated search**: abstains `search_limit_exceeded` rather than blend against a partial scan.

## Changes

- **adj-lang** (0.62.0): mode dispatch accepts `interpolated` alongside `range`; retires `LookupModeUnsupported`; adds `LookupNonNumericValueColumn` (interpolation needs a numeric value column — you can't blend a category label). Grammar comment + regen (line-number metadata only; no rule change).
- **adj-lang-cli** (0.23.0): `interpolated_lookup_json` tactic + `AboveTableDomain` abstention reason.
- **Tests**: new `rs5d_interpolated_lookup_e2e` (6 cases: blend + both citations, exact-fraction render, exact-hit, below/above-domain abstain, correct-segment). The RS-5c reserved-mode test becomes a non-numeric-value-column guard.
- **Spec** ADJ-TABLES §3.3 rewritten + roadmap row marked shipped.

## Verification

- `cargo test -p adj-lang -p adj-lang-cli` green (177 lib + all integration, 0 failures).
- `cargo clippy -p adj-lang -p adj-lang-cli` clean.
- Grammar regenerated; only `line_number` metadata shifted.
- Security review passed (JSON escaping, no division-by-zero/panics/unsafe, DoS guard, no fabricated-citation path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)