### PR TITLE
feat(hl03): resume the Learn walk where you left off (phase 7b; grammar-intro reframed)

### DIFF
--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.13.0 — the Learn walk resumes where you left off (HL03 phase 7b)
+
+- **The teaching cursor now persists.** Review progress and the lesson schedule
+  already survived reloads; the Learn cursor didn't — walk to concept 40, close
+  the tab, and you were dumped back at "thanks". New `src/cursorstore.ts` saves
+  the concept index to `localStorage` on every Prev/Next and restores it at
+  startup, so the app resumes exactly where you were. The restored index is
+  **clamped to the current spine** (the curriculum grows and shrinks), and a
+  corrupt / wrong-version / out-of-range blob falls back to concept 0 rather than
+  throwing or pointing off the end.
+- 11 new tests (219 total) with controls that bite: strip the version gate and a
+  stale blob resurfaces; drop the `getItem` guard and a throwing storage breaks
+  startup; a saved index past a now-shorter spine clamps to the last concept.
+  Verified in a real browser — seeding the cursor and reloading opens on
+  "Concept 5 · Greeting · Hello", not concept 1.
+- **Slice 7b (grammar introduction) was reframed:** the curriculum's grammar
+  signal is a single concept tag (`GRAMMAR-THE`, articles) with no dedicated
+  explanation field — too thin to ground an honest "new grammar" note the way
+  scripts have `signature` data. Rather than fabricate one, this slice does the
+  more valuable, fully-grounded resume-cursor work. Grammar introduction can
+  return if the curriculum grows richer grammar metadata.
+
 ## 0.12.0 — introduces a script the first time you meet it (HL03 phase 7a)
 
 - **New writing systems are now introduced as-needed in the Learn sweep.** When

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -43,6 +43,11 @@ confusing"* panel rolls the mistakes up from `confusions(log)`. The review
 `progress.ts` uses for the lesson schedule, with the same defensive parse (a
 corrupt or wrong-version blob restores as empty, never throws).
 
+The **teaching cursor persists too** (`cursorstore.ts`): the concept you walked
+to is saved on each Prev/Next and restored at startup, so the app resumes where
+you left off rather than back at the first concept. The restored index is
+clamped to the current spine, and a bad blob falls back to the start.
+
 ## Concepts mode
 
 The curriculum tags lessons with a shared `concept_tag`, and canonical tags are

--- a/code/programs/typescript/language-ladder/package.json
+++ b/code/programs/typescript/language-ladder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ladder",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "description": "The unified curriculum learning app (HL03): walk the language chain concept by concept, seeing the threads back to what you already know, then review it all with a randomised SRS quiz. (Was the HL02 script-writing-visualizer, whose Browse/Practice/Lessons/Concepts modes it now subsumes.)",
   "type": "module",

--- a/code/programs/typescript/language-ladder/src/cursorstore.ts
+++ b/code/programs/typescript/language-ladder/src/cursorstore.ts
@@ -1,0 +1,95 @@
+// ---------------------------------------------------------------------------
+// cursorstore.ts — remembering WHERE you are in the walk, between visits.
+//
+// The Learn session walks the concept spine, and the review quiz already
+// remembers your SRS state (reviewstore.ts) and the lesson schedule remembers
+// its own (progress.ts). But the teaching cursor — which concept you had walked
+// to — reset to 0 on every reload. Walk to concept 40, close the tab, come back,
+// and you were dumped at "thanks" again. This gives the cursor a memory too, so
+// the app resumes exactly where you left off.
+//
+// Deliberately tiny: the persisted state is a single integer index. Everything
+// except the reused localStorage adapter is pure, and — like its siblings — the
+// stored blob is UNTRUSTED, so a corrupt, wrong-version, or out-of-range value
+// falls back to 0 (the start) rather than throwing or pointing off the end of
+// the spine.
+// ---------------------------------------------------------------------------
+
+import { type StorageLike, browserStorage } from "./progress.ts";
+
+export { browserStorage };
+export type { StorageLike };
+
+/** Bump when the saved shape changes incompatibly; older payloads are dropped. */
+export const CURSOR_SCHEMA_VERSION = 1;
+
+/** The key we own in localStorage. Namespaced so nothing else collides. */
+export const CURSOR_STORAGE_KEY = "language-ladder:cursor:v1";
+
+/** What we persist — just the concept index, wrapped with a version. */
+export interface SavedCursor {
+  version: number;
+  index: number;
+}
+
+/** Clamp an index into the valid range for a spine of `length` concepts. */
+export function clampCursor(index: number, length: number): number {
+  if (!Number.isFinite(index) || length <= 0) return 0;
+  return Math.max(0, Math.min(Math.trunc(index), length - 1));
+}
+
+/**
+ * Parse whatever was in storage into a raw (unclamped) non-negative index.
+ *
+ * Untrusted input: non-JSON, wrong version, wrong shape, or a negative /
+ * non-finite index all yield 0. The caller clamps the result to the current
+ * spine length (which can change as the curriculum grows), so parsing and
+ * bounding stay separate concerns.
+ */
+export function parseCursor(raw: string | null): number {
+  if (raw === null || raw === "") return 0;
+
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    return 0;
+  }
+  if (typeof data !== "object" || data === null || Array.isArray(data)) return 0;
+
+  const record = data as Record<string, unknown>;
+  if (record.version !== CURSOR_SCHEMA_VERSION) return 0;
+
+  const index = record.index;
+  if (typeof index !== "number" || !Number.isFinite(index) || index < 0) return 0;
+  return Math.trunc(index);
+}
+
+// --- the only impure part (delegated to progress.ts's port) ----------------
+
+/** Load the saved concept cursor, clamped to the current spine `length`. */
+export function loadCursor(storage: StorageLike | null, length: number): number {
+  if (!storage) return 0;
+  let raw: string | null;
+  try {
+    raw = storage.getItem(CURSOR_STORAGE_KEY);
+  } catch {
+    return 0;
+  }
+  return clampCursor(parseCursor(raw), length);
+}
+
+/** Persist the concept cursor. Silent on failure (Safari private mode, quota). */
+export function saveCursor(storage: StorageLike | null, index: number): boolean {
+  if (!storage) return false;
+  try {
+    const payload: SavedCursor = {
+      version: CURSOR_SCHEMA_VERSION,
+      index: Math.max(0, Math.trunc(Number.isFinite(index) ? index : 0)),
+    };
+    storage.setItem(CURSOR_STORAGE_KEY, JSON.stringify(payload));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/code/programs/typescript/language-ladder/src/main.ts
+++ b/code/programs/typescript/language-ladder/src/main.ts
@@ -40,6 +40,7 @@ import {
 import { pickNext as pickReviewCell, makeRng, cellKey, type GridCell } from "./quiz.ts";
 import { confusions } from "./mistakes.ts";
 import { loadReview, saveReview } from "./reviewstore.ts";
+import { loadCursor, saveCursor } from "./cursorstore.ts";
 import {
   scriptsById,
   firstIntroductionByScript,
@@ -156,6 +157,11 @@ let reviewSession = restoredReview.session; // advances once per answered questi
 let reviewCell: GridCell | null = null; // the question currently on screen
 let reviewOptions: GridCell[] = []; // its answer options (one is `reviewCell`)
 let reviewChosen: string | null = null; // cellKey of the picked option; null = unanswered
+
+// Resume the teaching walk where it was left off: restore the concept cursor
+// from storage, clamped to the current spine (the curriculum may have grown or
+// shrunk since the save). A missing/corrupt value starts at 0.
+conceptCursor = loadCursor(REVIEW_STORAGE, CONCEPT_SPINE.length);
 
 // Constant for the page's lifetime: lesson indices grouped by language, and the
 // round-robin pool over those groups. Computing them once is why consecutive
@@ -677,6 +683,7 @@ function renderLearnNav(): HTMLElement {
     if (conceptCursor > 0) {
       conceptCursor -= 1;
       reviewCell = null; // covered set changed — draw the next review from it
+      saveCursor(REVIEW_STORAGE, conceptCursor); // resume here next visit
       render();
     }
   };
@@ -687,6 +694,7 @@ function renderLearnNav(): HTMLElement {
     if (conceptCursor < CONCEPT_SPINE.length - 1) {
       conceptCursor += 1;
       reviewCell = null; // covered set changed — draw the next review from it
+      saveCursor(REVIEW_STORAGE, conceptCursor); // resume here next visit
       render();
     }
   };

--- a/code/programs/typescript/language-ladder/tests/cursorstore.test.ts
+++ b/code/programs/typescript/language-ladder/tests/cursorstore.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import {
+  clampCursor,
+  parseCursor,
+  loadCursor,
+  saveCursor,
+  CURSOR_SCHEMA_VERSION,
+  CURSOR_STORAGE_KEY,
+  type StorageLike,
+} from "../src/cursorstore";
+
+describe("clampCursor", () => {
+  it("bounds an index into [0, length-1]", () => {
+    expect(clampCursor(5, 10)).toBe(5);
+    expect(clampCursor(999, 10)).toBe(9); // past the end → last concept
+    expect(clampCursor(-3, 10)).toBe(0);
+    expect(clampCursor(3.9, 10)).toBe(3); // truncated
+  });
+
+  it("an empty spine or a non-finite index clamps to 0", () => {
+    expect(clampCursor(4, 0)).toBe(0);
+    expect(clampCursor(NaN, 10)).toBe(0);
+    expect(clampCursor(Infinity, 10)).toBe(0);
+  });
+});
+
+describe("parseCursor — defensive against untrusted input", () => {
+  it("reads a well-formed blob", () => {
+    expect(parseCursor(JSON.stringify({ version: CURSOR_SCHEMA_VERSION, index: 12 }))).toBe(12);
+  });
+
+  it("CONTROL: a wrong-version blob is dropped to 0, not trusted", () => {
+    const stale = JSON.stringify({ version: 999, index: 12 });
+    // Remove the version gate and this would return 12 and fail.
+    expect(parseCursor(stale)).toBe(0);
+  });
+
+  it("non-JSON, null, arrays, and non-object blobs return 0 (no throw)", () => {
+    expect(parseCursor("not json{")).toBe(0);
+    expect(parseCursor(null)).toBe(0);
+    expect(parseCursor("[]")).toBe(0);
+    expect(parseCursor("42")).toBe(0);
+  });
+
+  it("a missing / non-numeric / negative index returns 0", () => {
+    expect(parseCursor(JSON.stringify({ version: CURSOR_SCHEMA_VERSION }))).toBe(0);
+    expect(parseCursor(JSON.stringify({ version: CURSOR_SCHEMA_VERSION, index: "x" }))).toBe(0);
+    expect(parseCursor(JSON.stringify({ version: CURSOR_SCHEMA_VERSION, index: -1 }))).toBe(0);
+    expect(parseCursor(JSON.stringify({ version: CURSOR_SCHEMA_VERSION, index: null }))).toBe(0);
+  });
+});
+
+describe("loadCursor / saveCursor — through a fake storage port", () => {
+  function fakeStorage(): StorageLike & { data: Map<string, string> } {
+    const data = new Map<string, string>();
+    return {
+      data,
+      getItem: (k) => data.get(k) ?? null,
+      setItem: (k, v) => void data.set(k, v),
+    };
+  }
+
+  it("save then load round-trips the index, clamped to the spine", () => {
+    const store = fakeStorage();
+    expect(saveCursor(store, 7)).toBe(true);
+    expect(store.data.get(CURSOR_STORAGE_KEY)).toBe(
+      JSON.stringify({ version: CURSOR_SCHEMA_VERSION, index: 7 }),
+    );
+    expect(loadCursor(store, 186)).toBe(7);
+  });
+
+  it("a saved index past the (now shorter) spine clamps down on load", () => {
+    const store = fakeStorage();
+    saveCursor(store, 40);
+    // Curriculum shrank to 10 concepts since the save → resume at the last one.
+    expect(loadCursor(store, 10)).toBe(9);
+  });
+
+  it("null storage is a no-op / start-at-0, never a crash", () => {
+    expect(saveCursor(null, 5)).toBe(false);
+    expect(loadCursor(null, 100)).toBe(0);
+  });
+
+  it("CONTROL: a storage whose getItem throws loads 0 rather than propagating", () => {
+    const throwing: StorageLike = {
+      getItem: () => {
+        throw new Error("SecurityError");
+      },
+      setItem: () => {},
+    };
+    // Without the try/catch in loadCursor this would throw and break startup.
+    expect(loadCursor(throwing, 50)).toBe(0);
+  });
+
+  it("no saved value starts at 0", () => {
+    expect(loadCursor(fakeStorage(), 50)).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

The review quiz and the lesson schedule already survived reloads; the **Learn teaching cursor didn't** — walk to concept 40, close the tab, come back, and you were dumped at "thanks" again. This gives the cursor a memory too, so the app **resumes where you left off**.

- New pure `src/cursorstore.ts`: saves the concept index to `localStorage` on each **Prev/Next** and restores it at startup, **clamped to the current spine** (the curriculum grows and shrinks). Untrusted-blob-safe, mirroring `reviewstore.ts` / `progress.ts`: a corrupt / wrong-version / out-of-range payload → concept 0, never a throw or an index off the end.
- `main.ts` loads after `CONCEPT_SPINE`/`REVIEW_STORAGE` are ready and saves on both nav buttons; reuses the same storage handle under a distinct key (`language-ladder:cursor:v1`).

## Verification

- **11 new tests (219 total)** with controls that bite: strip the version gate → a stale blob resurfaces; drop the `getItem` guard → a throwing storage breaks startup; a saved index past a now-shorter spine clamps to the last concept.
- **Real browser** (headless, shared profile): seeding the cursor and reloading opens on **"Concept 5 · Greeting · Hello"**, not concept 1.
- Correctness/security review (subagent): **clean** — init order, clamp, defensive parse, wiring symmetry, key non-collision all verified.

## Grammar-intro was reframed, not built

The originally-planned 7b was grammar introduction. But the curriculum's grammar signal is a **single concept tag** (`GRAMMAR-THE`, articles) with no dedicated explanation field — too thin to ground an honest "new grammar" note the way scripts have `signature` data. Rather than fabricate one, this slice does the **fully-grounded resume-cursor work** instead. Grammar-intro can return when the curriculum grows richer grammar metadata.

Builds on #8897 (script introduction, merged).