### PR TITLE
feat(semantic-ir-to-ruby): classes slice 2 — instance methods via sir_um_ prefix (0.12.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 0.12.0 — classes slice 2: instance methods
+
+Instance-method **definition** and **dispatch** — the second OOP slice. No new
+`Feature` (the frontend lowers a method-bearing class to builtins, not a
+feature-gated node); this wires two builtins:
+
+- `__def_method__("Class", "method", MakeClosure(fn))` — the frontend's
+  registration of a hoisted method — renders as
+  `Class.define_method(:sir_um_method, &closure)`. `define_method` binds `self`
+  to the receiver at call time, and the closure calls the hoisted top-level
+  function, so the method body runs with the instance as `self` (its `@ivars`
+  become reachable once slice 3 accepts them).
+- `__method__(recv, "method", args…)` — instance dispatch — renders as
+  `(recv).public_send(:sir_um_method, args…)`.
+
+**Anti-RCE — the `sir_um_` prefix closes reflection dispatch.** `__method__`
+dispatches by a method name taken from the IR, so a naive
+`recv.public_send(:name)` would be a remote-code-execution sink: a hand-built
+module could pass `"instance_eval"` / `"send"` and reach Ruby's metaprogramming.
+Both registration and dispatch instead go through a **reserved `sir_um_`
+method-name prefix** — no Ruby built-in is named `sir_um_*`, so `public_send`
+with a crafted name can reach *only* a method installed by `__def_method__`,
+never `instance_eval`/`send`/`eval`/any reflection sink. This is the codebase's
+"explicit dispatch, never reflection" invariant, achieved natively (SIR24 §OOP).
+The prefixed name is emitted as a quoted symbol via `emit_symbol` (no injection),
+and the class name in `__def_method__` is validated as a constant path like the
+slice-1 constant positions.
+
+**Totality / clean rejection.** A `__method__` call to a name the module never
+registers via `__def_method__` is a **built-in method call** (`.upcase`, …) — the
+separate Collections batch — and is rejected cleanly (a source-positioned
+`UnsupportedFeature`) rather than compiling to a runtime `NoMethodError` (the
+prefixed `sir_um_upcase` is unbound). The scan collects the module-wide set of
+registered method names in a first pass, then the single co-total traversal
+validates each dispatch against it. A malformed `__def_method__` (missing its
+closure) and the remaining OOP builtins (`__super__`, `__self__`,
+`__class_method__`, `__def_class_method__`) stay rejected (later slices). Class
+**methods**, **inheritance**, `@ivars`, `@@class vars`, and modules remain
+unsupported.
+
 ## 0.11.0 — classes (slice 1) + constants
 
 Accepts `Feature::Classes` and `Feature::Constants` — the first slice of the OOP

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/README.md
+++ b/code/packages/rust/semantic-ir-to-ruby/README.md
@@ -73,12 +73,19 @@ before emit); and the first OOP slice — `Constants` and `Classes`. A constant
 anywhere and still names the class (so `Foo.new` / `x.is_a?(Foo)` work). Every
 constant name emitted verbatim is validated as a constant path (co-total with
 the emitter, no injection); `Constants` also lets `raise SomeClass` compile.
+Instance **methods** (slice 2): a method-bearing class lowers to a hoisted
+top-level function plus `__def_method__` / `__method__` builtins, rendered as
+`Class.define_method(:sir_um_m, &closure)` and `(recv).public_send(:sir_um_m, …)`.
+The reserved `sir_um_` method-name prefix makes dispatch **closed** — no
+reflection/eval built-in is named `sir_um_*`, so a crafted method name can never
+reach `instance_eval`/`send` (anti-RCE); a dispatch to an un-registered
+(built-in) method is rejected cleanly (Collections batch).
 Rejects `TailCalls`, `Intrinsics`, and every not-yet-wired feature (array
 indexing / slicing via `IndexGet` — `NDArrays`; array-pattern destructuring;
-collection methods; and the rest of OOP — class **methods** / `__method__`
-dispatch, **inheritance** / superclass, instance & class variables, modules —
-plus a non-empty class body or a namespaced class/constant definition) until its
-slice lands — each a clean, source-positioned `UnsupportedFeature`.
+built-in collection methods; and the rest of OOP — **inheritance** / superclass,
+instance & class variables, class methods, modules — plus a non-empty class body
+or a namespaced class/constant definition) until its slice lands — each a clean,
+source-positioned `UnsupportedFeature`.
 
 ## Verification
 

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -524,11 +524,15 @@ impl Scan {
                     Some(Expr::StrLit { .. }) => {}
                     _ => return Some(ScanHit::Builtin(name.clone(), span.clone())),
                 }
-                // Require the method-name `StrLit` (args[1]) AND the closure
-                // (args[2], which the emitter renders as `a[2]`).  A malformed
-                // shape is reported as an unlowerable builtin, so the emitter
-                // never indexes past the end.
-                if !matches!(args.get(1), Some(Expr::StrLit { .. })) || args.get(2).is_none() {
+                // Require the method-name `StrLit` (args[1]) AND a `MakeClosure`
+                // (args[2], rendered as `a[2]` and installed with `&(<closure>)`).
+                // A malformed shape — missing the closure, or a non-closure that
+                // would emit `&(<expr>)` and fail at Ruby runtime — is reported as
+                // an unlowerable builtin here, so the emitter never indexes past
+                // the end nor emits a value that cannot become a method body.
+                if !matches!(args.get(1), Some(Expr::StrLit { .. }))
+                    || !matches!(args.get(2), Some(Expr::MakeClosure { .. }))
+                {
                     return Some(ScanHit::Builtin(name.clone(), span.clone()));
                 }
             }

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -7,6 +7,7 @@
 //!
 //! See [SIR25](../../../specs/SIR25-semantic-ir-to-ruby.md) for the design.
 
+use std::collections::HashSet;
 use std::fmt::Write;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -62,10 +63,18 @@ const SUPPORTED_BUILTINS: &[&str] = &[
     // — the frontend's lowering of `Foo.new(args…)`.  Its first argument is the
     // class name (a `StrLit`), emitted verbatim as the `.new` receiver after
     // constant-path validation in the scan (so no source can inject); the rest
-    // are constructor arguments.  The OTHER OOP builtins (`__def_method__`,
-    // `__method__`, `__super__`, `__self__`, `__class_method__`, …) are
-    // deliberately absent — a module using them is rejected until their slice.
+    // are constructor arguments.
     "__new__",
+    // OOP classes slice 2 (instance methods): `__def_method__("Class", "m",
+    // MakeClosure(fn))` registers a hoisted method on the class, and
+    // `__method__(recv, "m", args…)` dispatches to it.  Both render through a
+    // reserved `sir_um_` method-name PREFIX (`define_method`/`public_send`), so
+    // dispatch is CLOSED — no reflection/eval built-in (none named `sir_um_*`)
+    // is reachable (anti-RCE).  The other OOP builtins (`__super__`, `__self__`,
+    // `__class_method__`, `__def_class_method__`, …) are still absent — a module
+    // using them is rejected until their slice.
+    "__def_method__",
+    "__method__",
 ];
 
 /// Emit a complete self-contained Ruby source file for `m`.
@@ -142,9 +151,19 @@ pub enum ScanHit {
 }
 
 /// Scan the module — in a SINGLE traversal shared with the unsupported-builtin
-/// check — for the first thing `compile` must reject: an unlowerable builtin or
-/// an injectable `rescue` type.  Returns it (with a span) or `None`.
+/// check — for the first thing `compile` must reject: an unlowerable builtin, an
+/// injectable `rescue`/constant name, an out-of-slice class shape, or (OOP slice
+/// 2) an instance-method dispatch (`__method__`) to a method the module never
+/// defines.  Returns it (with a span) or `None`.
+///
+/// The traversal is a [`Scan`] carrying the set of method names the module
+/// registers via `__def_method__` — the CLOSED set `__method__` may dispatch to.
+/// A first collection pass gathers that set (a dispatch can textually precede
+/// its registration), then the single scan validates against it.
 pub fn first_scan_issue(m: &Module) -> Option<ScanHit> {
+    let scan = Scan {
+        registered_methods: collect_registered_methods(m),
+    };
     for f in &m.functions {
         // A SIR19 parameter default is an expression evaluated at call time, so
         // a builtin nested in it (`def g(x = foo())`) must be pre-checked too —
@@ -152,32 +171,174 @@ pub fn first_scan_issue(m: &Module) -> Option<ScanHit> {
         // `unreachable!`.  Scan each default before the body.
         for p in &f.params {
             if let Some(default) = &p.default {
-                if let Some(hit) = scan_expr(default) {
+                if let Some(hit) = scan.expr(default) {
                     return Some(hit);
                 }
             }
         }
-        if let Some(hit) = scan_block(&f.body) {
+        if let Some(hit) = scan.block(&f.body) {
             return Some(hit);
         }
     }
     None
 }
 
-fn scan_block(b: &Block) -> Option<ScanHit> {
-    for s in &b.stmts {
-        if let Some(hit) = scan_stmt(s) {
-            return Some(hit);
+/// Walk the whole module and collect the method names registered via
+/// `__def_method__("Class", "method", closure)` — the closed set that
+/// `__method__` dispatch may target (OOP slice 2).  A `__method__` call to any
+/// OTHER name is a built-in-method call (the separate Collections batch),
+/// rejected until then.  (The `sir_um_` dispatch prefix is the SECURITY
+/// guarantee against reflection-RCE; this allowlist is for clean COMPILE-TIME
+/// rejection of not-yet-supported built-in dispatch.)
+fn collect_registered_methods(m: &Module) -> HashSet<String> {
+    fn from_expr(e: &Expr, out: &mut HashSet<String>) {
+        match e {
+            Expr::BuiltinCall { name, args, .. } => {
+                if name == "__def_method__" {
+                    if let Some(Expr::StrLit { value, .. }) = args.get(1) {
+                        out.insert(value.clone());
+                    }
+                }
+                for a in args {
+                    from_expr(a, out);
+                }
+            }
+            Expr::If {
+                cond,
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                from_expr(cond, out);
+                from_block(then_branch, out);
+                from_block(else_branch, out);
+            }
+            Expr::Block(b) => from_block(b, out),
+            Expr::DirectCall { args, .. } => args.iter().for_each(|a| from_expr(a, out)),
+            Expr::IndirectCall { target, args, .. } => {
+                from_expr(target, out);
+                args.iter().for_each(|a| from_expr(a, out));
+            }
+            Expr::MakeClosure { captures, .. } => {
+                captures.iter().for_each(|c| from_expr(&c.value, out))
+            }
+            Expr::Convert { value, .. } => from_expr(value, out),
+            Expr::SeqLit { items, .. } => items.iter().for_each(|i| from_expr(i, out)),
+            Expr::SeqIndex { seq, index, .. } => {
+                from_expr(seq, out);
+                from_expr(index, out);
+            }
+            Expr::SeqLen { seq, .. } => from_expr(seq, out),
+            Expr::MapLit { entries, .. } => entries.iter().for_each(|e| {
+                from_expr(&e.key, out);
+                from_expr(&e.value, out);
+            }),
+            Expr::MapGet { map, key, .. } => {
+                from_expr(map, out);
+                from_expr(key, out);
+            }
+            Expr::LogicalAnd { lhs, rhs, .. } | Expr::LogicalOr { lhs, rhs, .. } => {
+                from_expr(lhs, out);
+                from_expr(rhs, out);
+            }
+            Expr::KeywordArg { value, .. } => from_expr(value, out),
+            _ => {}
         }
     }
-    scan_expr(&b.value)
+    fn from_stmt(s: &Stmt, out: &mut HashSet<String>) {
+        match s {
+            Stmt::LetBinding { value, .. }
+            | Stmt::LetStarBinding { value, .. }
+            | Stmt::ExprStmt { expr: value, .. }
+            | Stmt::Assign { value, .. } => from_expr(value, out),
+            Stmt::SeqSet {
+                seq, index, value, ..
+            } => {
+                from_expr(seq, out);
+                from_expr(index, out);
+                from_expr(value, out);
+            }
+            Stmt::MapSet {
+                map, key, value, ..
+            } => {
+                from_expr(map, out);
+                from_expr(key, out);
+                from_expr(value, out);
+            }
+            Stmt::While { cond, body, .. } => {
+                from_expr(cond, out);
+                from_block(body, out);
+            }
+            Stmt::ForEach { iter, body, .. } => {
+                from_expr(iter, out);
+                from_block(body, out);
+            }
+            Stmt::ForRange {
+                start,
+                stop,
+                step,
+                body,
+                ..
+            } => {
+                from_expr(start, out);
+                from_expr(stop, out);
+                from_expr(step, out);
+                from_block(body, out);
+            }
+            Stmt::TryCatch {
+                body,
+                rescues,
+                ensure_body,
+                ..
+            } => {
+                body.iter().for_each(|s| from_stmt(s, out));
+                rescues
+                    .iter()
+                    .for_each(|rc| rc.body.iter().for_each(|s| from_stmt(s, out)));
+                if let Some(e) = ensure_body {
+                    e.iter().for_each(|s| from_stmt(s, out));
+                }
+            }
+            _ => {}
+        }
+    }
+    fn from_block(b: &Block, out: &mut HashSet<String>) {
+        b.stmts.iter().for_each(|s| from_stmt(s, out));
+        from_expr(&b.value, out);
+    }
+    let mut out = HashSet::new();
+    for f in &m.functions {
+        for p in &f.params {
+            if let Some(d) = &p.default {
+                from_expr(d, &mut out);
+            }
+        }
+        from_block(&f.body, &mut out);
+    }
+    out
 }
 
-fn scan_stmt(s: &Stmt) -> Option<ScanHit> {
-    match s {
+/// The pre-emit scan, carrying the module's registered-method allowlist so the
+/// single co-total traversal can validate `__method__` dispatch.
+struct Scan {
+    registered_methods: HashSet<String>,
+}
+
+impl Scan {
+    fn block(&self, b: &Block) -> Option<ScanHit> {
+        for s in &b.stmts {
+            if let Some(hit) = self.stmt(s) {
+                return Some(hit);
+            }
+        }
+        self.expr(&b.value)
+    }
+
+    fn stmt(&self, s: &Stmt) -> Option<ScanHit> {
+        match s {
         Stmt::LetBinding { value, .. }
         | Stmt::LetStarBinding { value, .. }
-        | Stmt::ExprStmt { expr: value, .. } => scan_expr(value),
+        | Stmt::ExprStmt { expr: value, .. } => self.expr(value),
         // An `Stmt::Assign` to a `Scope::Const` target (`PI = 3`) emits the name
         // VERBATIM as a Ruby constant, so validate it as a constant path (the
         // same injection guard as a const reference); then scan the value. A
@@ -198,10 +359,10 @@ fn scan_stmt(s: &Stmt) -> Option<ScanHit> {
                         span.clone(),
                     ))
                 } else {
-                    scan_expr(value)
+                    self.expr(value)
                 }
             } else {
-                scan_expr(value)
+                self.expr(value)
             }
         }
         // A sequence write / iteration has sub-expressions that may themselves
@@ -209,29 +370,29 @@ fn scan_stmt(s: &Stmt) -> Option<ScanHit> {
         // graceful pre-check catches it rather than the emitter.
         Stmt::SeqSet {
             seq, index, value, ..
-        } => scan_expr(seq)
-            .or_else(|| scan_expr(index))
-            .or_else(|| scan_expr(value)),
+        } => self.expr(seq)
+            .or_else(|| self.expr(index))
+            .or_else(|| self.expr(value)),
         Stmt::MapSet {
             map, key, value, ..
-        } => scan_expr(map)
-            .or_else(|| scan_expr(key))
-            .or_else(|| scan_expr(value)),
+        } => self.expr(map)
+            .or_else(|| self.expr(key))
+            .or_else(|| self.expr(value)),
         // Compound-statement bodies must be scanned too, or an unsupported
         // builtin hidden in a loop body survives the pre-check and reaches the
         // emitter's `unreachable!`. (`While` was a pre-existing scan hole.)
-        Stmt::While { cond, body, .. } => scan_expr(cond).or_else(|| scan_block(body)),
-        Stmt::ForEach { iter, body, .. } => scan_expr(iter).or_else(|| scan_block(body)),
+        Stmt::While { cond, body, .. } => self.expr(cond).or_else(|| self.block(body)),
+        Stmt::ForEach { iter, body, .. } => self.expr(iter).or_else(|| self.block(body)),
         Stmt::ForRange {
             start,
             stop,
             step,
             body,
             ..
-        } => scan_expr(start)
-            .or_else(|| scan_expr(stop))
-            .or_else(|| scan_expr(step))
-            .or_else(|| scan_block(body)),
+        } => self.expr(start)
+            .or_else(|| self.expr(stop))
+            .or_else(|| self.expr(step))
+            .or_else(|| self.block(body)),
         // A `begin … rescue … ensure … end`.  Check each rescue clause's
         // exception-type NAMES here (this arm is reached by the SAME complete
         // traversal as the builtin scan, so EVERY `TryCatch` the emitter reaches
@@ -247,12 +408,12 @@ fn scan_stmt(s: &Stmt) -> Option<ScanHit> {
             .flat_map(|rc| rc.exception_types.iter())
             .find(|t| !is_valid_constant_path(t))
             .map(|t| ScanHit::RescueType(t.clone(), span.clone()))
-            .or_else(|| body.iter().find_map(scan_stmt))
-            .or_else(|| rescues.iter().find_map(|rc| rc.body.iter().find_map(scan_stmt)))
+            .or_else(|| body.iter().find_map(|s| self.stmt(s)))
+            .or_else(|| rescues.iter().find_map(|rc| rc.body.iter().find_map(|s| self.stmt(s))))
             .or_else(|| {
                 ensure_body
                     .as_ref()
-                    .and_then(|e| e.iter().find_map(scan_stmt))
+                    .and_then(|e| e.iter().find_map(|s| self.stmt(s)))
             }),
         // A `Stmt::ClassDef` (`Feature::Classes`).  Slice 1 supports ONLY an
         // empty-bodied base class → native `class Name\nend`.  At exactly the
@@ -308,6 +469,7 @@ fn scan_stmt(s: &Stmt) -> Option<ScanHit> {
         )),
         _ => None,
     }
+    }
 }
 
 /// Whether `name` is a syntactically valid Ruby constant path (`Foo`,
@@ -325,8 +487,9 @@ fn is_valid_constant_path(name: &str) -> bool {
         })
 }
 
-fn scan_expr(e: &Expr) -> Option<ScanHit> {
-    match e {
+impl Scan {
+    fn expr(&self, e: &Expr) -> Option<ScanHit> {
+        match e {
         Expr::BuiltinCall {
             name, args, span, ..
         } => {
@@ -348,44 +511,91 @@ fn scan_expr(e: &Expr) -> Option<ScanHit> {
                     _ => return Some(ScanHit::Builtin(name.clone(), span.clone())),
                 }
             }
-            args.iter().find_map(scan_expr)
+            // OOP slice 2 — instance-method definition/dispatch.
+            // `__def_method__("Class", "method", closure)` emits the CLASS name
+            // verbatim (a `const_set` receiver), so validate it as a constant
+            // path; the method name and closure are rendered safely (a quoted
+            // symbol / a scanned closure).
+            if name == "__def_method__" {
+                match args.first() {
+                    Some(Expr::StrLit { value, span }) if !is_valid_constant_path(value) => {
+                        return Some(ScanHit::ConstantName(value.clone(), span.clone()));
+                    }
+                    Some(Expr::StrLit { .. }) => {}
+                    _ => return Some(ScanHit::Builtin(name.clone(), span.clone())),
+                }
+                // Require the method-name `StrLit` (args[1]) AND the closure
+                // (args[2], which the emitter renders as `a[2]`).  A malformed
+                // shape is reported as an unlowerable builtin, so the emitter
+                // never indexes past the end.
+                if !matches!(args.get(1), Some(Expr::StrLit { .. })) || args.get(2).is_none() {
+                    return Some(ScanHit::Builtin(name.clone(), span.clone()));
+                }
+            }
+            // `__method__(recv, "method", args…)` dispatches to a method by name.
+            // The name is rendered as a `sir_um_`-PREFIXED quoted symbol via
+            // `public_send`, so no source can inject AND no reflection/eval
+            // built-in (none of which is named `sir_um_*`) is reachable — the
+            // anti-RCE guarantee.  Additionally reject, cleanly, a dispatch to a
+            // method the module never registers via `__def_method__`: that is a
+            // BUILT-IN method call (`.upcase`, …), deferred to the Collections
+            // batch, so it must not compile-then-`NoMethodError` at runtime.
+            if name == "__method__" {
+                match args.get(1) {
+                    Some(Expr::StrLit { value, span }) => {
+                        if !self.registered_methods.contains(value) {
+                            return Some(ScanHit::Unsupported(
+                                format!(
+                                    "a call to the built-in method `{value}` (only \
+                                     user-defined methods dispatch this slice; \
+                                     built-in methods are the Collections batch)"
+                                ),
+                                span.clone(),
+                            ));
+                        }
+                    }
+                    _ => return Some(ScanHit::Builtin(name.clone(), span.clone())),
+                }
+            }
+            args.iter().find_map(|a| self.expr(a))
         }
         Expr::If {
             cond,
             then_branch,
             else_branch,
             ..
-        } => scan_expr(cond)
-            .or_else(|| scan_block(then_branch))
-            .or_else(|| scan_block(else_branch)),
-        Expr::Block(b) => scan_block(b),
-        Expr::DirectCall { args, .. } => args.iter().find_map(scan_expr),
+        } => self
+            .expr(cond)
+            .or_else(|| self.block(then_branch))
+            .or_else(|| self.block(else_branch)),
+        Expr::Block(b) => self.block(b),
+        Expr::DirectCall { args, .. } => args.iter().find_map(|a| self.expr(a)),
         // An `IndirectCall` renders its `target` too (`sir_apply(<target>, …)`),
         // so a deferred builtin hidden in the callee position — not just the
         // args — must be pre-checked, or it would reach the emitter's
         // `unreachable!`.  (Found by security review while wiring the param
         // default scan, which routes through here.)
         Expr::IndirectCall { target, args, .. } => {
-            scan_expr(target).or_else(|| args.iter().find_map(scan_expr))
+            self.expr(target).or_else(|| args.iter().find_map(|a| self.expr(a)))
         }
-        Expr::MakeClosure { captures, .. } => captures.iter().find_map(|c| scan_expr(&c.value)),
-        Expr::Convert { value, .. } => scan_expr(value),
+        Expr::MakeClosure { captures, .. } => captures.iter().find_map(|c| self.expr(&c.value)),
+        Expr::Convert { value, .. } => self.expr(value),
         // A sequence literal's items are themselves expressions — scan each so
         // an unsupported builtin nested in `[foo(), bar()]` is caught by the
         // graceful pre-check rather than reaching the emitter.
-        Expr::SeqLit { items, .. } => items.iter().find_map(scan_expr),
-        Expr::SeqIndex { seq, index, .. } => scan_expr(seq).or_else(|| scan_expr(index)),
-        Expr::SeqLen { seq, .. } => scan_expr(seq),
+        Expr::SeqLit { items, .. } => items.iter().find_map(|i| self.expr(i)),
+        Expr::SeqIndex { seq, index, .. } => self.expr(seq).or_else(|| self.expr(index)),
+        Expr::SeqLen { seq, .. } => self.expr(seq),
         Expr::MapLit { entries, .. } => entries
             .iter()
-            .find_map(|e| scan_expr(&e.key).or_else(|| scan_expr(&e.value))),
-        Expr::MapGet { map, key, .. } => scan_expr(map).or_else(|| scan_expr(key)),
+            .find_map(|e| self.expr(&e.key).or_else(|| self.expr(&e.value))),
+        Expr::MapGet { map, key, .. } => self.expr(map).or_else(|| self.expr(key)),
         Expr::LogicalAnd { lhs, rhs, .. } | Expr::LogicalOr { lhs, rhs, .. } => {
-            scan_expr(lhs).or_else(|| scan_expr(rhs))
+            self.expr(lhs).or_else(|| self.expr(rhs))
         }
         // A keyword argument carries its value as a sub-expression — scan it so
         // an unsupported builtin in `f(x: foo())` is reported cleanly.
-        Expr::KeywordArg { value, .. } => scan_expr(value),
+        Expr::KeywordArg { value, .. } => self.expr(value),
         // A `Scope::Const` reference (`Feature::Constants`) is emitted VERBATIM
         // as a Ruby constant (`PI`, `Foo::Bar`) by `emit_var_ref`, so validate it
         // as a constant path here — at that emitter position — to bar injection.
@@ -396,6 +606,7 @@ fn scan_expr(e: &Expr) -> Option<ScanHit> {
             span,
         } if !is_valid_constant_path(name) => Some(ScanHit::ConstantName(name.clone(), span.clone())),
         _ => None,
+    }
     }
 }
 
@@ -930,6 +1141,32 @@ fn emit_builtin(name: &str, args: &[Expr]) -> String {
             };
             format!("{class}.new({})", a[1..].join(", "))
         }
+        // OOP classes slice 2 — register a hoisted instance method on the class.
+        // `args[0]` = class name (`StrLit`, a bare validated constant receiver),
+        // `args[1]` = method name (`StrLit`), `args[2]` = a `MakeClosure` (already
+        // emitted in `a[2]` as `->(*__sir_args){ Class__m(*__sir_args) }`).  The
+        // method name is rendered under a RESERVED `sir_um_` prefix as a quoted
+        // symbol via `emit_symbol` (so it cannot inject and never collides with a
+        // built-in), then installed with `define_method`.  `define_method` binds
+        // `self` to the receiver at call time, so the hoisted body sees the
+        // instance (its `@ivars`, once slice 3 lands).
+        "__def_method__" => {
+            let class = str_arg(args, 0);
+            let sym = emit_symbol(&format!("sir_um_{}", str_arg(args, 1)));
+            format!("{class}.define_method({sym}, &({}))", a[2])
+        }
+        // Dispatch an instance method: `(recv).public_send(:sir_um_<m>, args…)`.
+        // The `sir_um_` prefix makes this a CLOSED dispatch — `public_send` can
+        // only reach methods installed by `__def_method__` (no built-in is named
+        // `sir_um_*`), so a crafted method name cannot reach `instance_eval` /
+        // `send` / any reflection sink.  `args[0]` = receiver (`a[0]`), `args[1]`
+        // = method name, `args[2..]` (in `a`) = call arguments.
+        "__method__" => {
+            let sym = emit_symbol(&format!("sir_um_{}", str_arg(args, 1)));
+            let mut parts = vec![sym];
+            parts.extend_from_slice(&a[2..]);
+            format!("({}).public_send({})", a[0], parts.join(", "))
+        }
         // Unreachable: first_scan_issue rejected anything else.
         other => unreachable!("v0 Ruby backend reached unsupported builtin: {other}"),
     }
@@ -947,6 +1184,17 @@ fn join_op(a: &[String], op: &str, empty: &str) -> String {
 /// The i-th argument, or `nil` if the frontend under-supplied (defensive).
 fn arg(a: &[String], i: usize) -> String {
     a.get(i).cloned().unwrap_or_else(|| "nil".to_string())
+}
+
+/// The i-th argument's raw `StrLit` value — for an OOP builtin whose class /
+/// method name is a compile-time string the emitter renders specially (a bare
+/// constant receiver, or a `sir_um_`-prefixed symbol).  The pre-emit scan
+/// guarantees this position is a `StrLit`, so a non-string is unreachable.
+fn str_arg(args: &[Expr], i: usize) -> String {
+    match args.get(i) {
+        Some(Expr::StrLit { value, .. }) => value.clone(),
+        _ => unreachable!("OOP builtin requires a string argument at position {i}"),
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
@@ -1578,35 +1578,22 @@ fn a_namespaced_class_name_is_rejected_cleanly() {
 }
 
 #[test]
-fn a_method_bearing_class_is_rejected_cleanly() {
-    // A class with a method surfaces the `__def_method__` registration builtin,
-    // which is NOT supported this slice → rejected cleanly (never `unreachable!`).
+fn a_malformed_def_method_missing_its_closure_is_rejected_cleanly() {
+    // Totality: `__def_method__` is now supported (slice 2), but the emitter
+    // renders its closure argument (`args[2]`); a malformed registration missing
+    // it must be rejected in the scan, so the emitter never indexes past the end.
     let def_method = Stmt::ExprStmt {
         expr: Expr::BuiltinCall {
             name: "__def_method__".into(),
-            args: vec![strlit("Foo"), strlit("greet")],
+            args: vec![strlit("Foo"), strlit("greet")], // no closure
             effects: EffectSet::PURE,
             span: s2(),
         },
         span: s2(),
     };
     let m = class_module(vec![classdef("Foo", None, vec![]), def_method]);
-    let err = compile(&m).expect_err("a __def_method__ builtin must be rejected");
+    let err = compile(&m).expect_err("a __def_method__ with no closure must be rejected");
     assert_eq!(err.kind, semantic_ir::BackendErrorKind::UnsupportedFeature);
-}
-
-#[test]
-fn an_instance_method_call_is_rejected_cleanly() {
-    // `x.foo` lowers to the `__method__` dispatch builtin (a later slice) — a
-    // hand-built module carrying it is rejected, not emitted.
-    let call = Expr::BuiltinCall {
-        name: "__method__".into(),
-        args: vec![new_expr("Foo", vec![]), strlit("foo")],
-        effects: EffectSet::PURE,
-        span: s2(),
-    };
-    let m = class_module(vec![classdef("Foo", None, vec![]), puts(call)]);
-    assert!(compile(&m).is_err(), "a __method__ call must be rejected");
 }
 
 // ---- hand-built: injection (a crafted constant name cannot inject) --------
@@ -1642,4 +1629,195 @@ fn an_injectable_constant_assignment_target_is_rejected() {
     // crafted target must be rejected.
     let m = class_module(vec![const_assign("PI\n=1; system('x')", ilit(1))]);
     assert!(compile(&m).is_err(), "an injectable const assignment must be rejected");
+}
+
+// ── OOP classes slice 2 — instance methods (define_method / public_send) ────
+//
+// A method-bearing class lowers to a HOISTED top-level function `Class__method`,
+// a `__def_method__("Class", "method", MakeClosure(fn))` registration, and a
+// `__method__(recv, "method", args…)` dispatch. This slice renders the
+// registration as `Class.define_method(:sir_um_method, &closure)` and the
+// dispatch as `(recv).public_send(:sir_um_method, args…)`.
+//
+// The reserved `sir_um_` method-name PREFIX is the anti-RCE guarantee: no
+// reflection/eval built-in is named `sir_um_*`, so `public_send` with a crafted
+// name can NEVER reach `instance_eval` / `send` / etc. — it can only reach a
+// method installed by `__def_method__`.  A `__method__` to an UNregistered name
+// (a built-in method call like `.upcase`) is rejected cleanly (Collections batch).
+
+fn method_module(stmts: Vec<Stmt>) -> Module {
+    method_module_fns(stmts, vec![])
+}
+/// A `main` module carrying `stmts`, plus `extra` hoisted method functions (a
+/// `MakeClosure` in a `__def_method__` references one by name, and the validator
+/// requires the target to exist).
+fn method_module_fns(stmts: Vec<Stmt>, extra: Vec<Function>) -> Module {
+    let mut functions = vec![Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts, value: Expr::NilLit { span: s2() }, span: s2() },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new().with_source_language("test"),
+        span: s2(),
+    }];
+    functions.extend(extra);
+    Module {
+        name: "methprog".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Classes,
+            Feature::Constants,
+            Feature::Strings,
+            Feature::Closures,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions,
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s2(),
+    }
+}
+/// A minimal hoisted method function (no params, `nil` body) — enough for the
+/// validator to resolve a `MakeClosure` that names it.
+fn hoisted(name: &str) -> Function {
+    Function {
+        name: name.into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: vec![], value: Expr::NilLit { span: s2() }, span: s2() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: s2(),
+    }
+}
+fn make_closure(fn_name: &str) -> Expr {
+    Expr::MakeClosure { fn_name: fn_name.into(), captures: vec![], span: s2() }
+}
+fn def_method(class: &str, method: &str, fn_name: &str) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "__def_method__".into(),
+            args: vec![strlit(class), strlit(method), make_closure(fn_name)],
+            effects: EffectSet::PURE,
+            span: s2(),
+        },
+        span: s2(),
+    }
+}
+fn method_call(recv: Expr, method: &str, args: Vec<Expr>) -> Expr {
+    let mut a = vec![recv, strlit(method)];
+    a.extend(args);
+    Expr::BuiltinCall { name: "__method__".into(), args: a, effects: EffectSet::PURE, span: s2() }
+}
+
+// ---- positive, through the real frontend + interpreter --------------------
+
+#[test]
+fn e2e_instance_method_call() {
+    // `class Greeter; def greet; puts "hi"; end; end; Greeter.new.greet` → "hi".
+    let rb = ruby_to_ruby("class Greeter\n  def greet\n    puts \"hi\"\n  end\nend\ng = Greeter.new\ng.greet\n");
+    assert!(rb.contains("define_method(:sir_um_greet"), "prefixed registration:\n{rb}");
+    assert!(rb.contains("public_send(:sir_um_greet"), "prefixed dispatch:\n{rb}");
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "hi"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn e2e_instance_method_with_args_and_return() {
+    // A method with parameters and a return value: `add(a, b) = a + b`.
+    let rb = ruby_to_ruby("class Adder\n  def add(a, b)\n    a + b\n  end\nend\nputs Adder.new.add(2, 3)\n");
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "5"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+// ---- hand-built: anti-RCE (the sir_um_ prefix closes reflection dispatch) --
+
+#[test]
+fn dispatch_is_prefixed_so_reflection_is_unreachable() {
+    // Even when the method name coincides with a dangerous reflection built-in
+    // (`instance_eval`), the `sir_um_` prefix means the emitted `public_send`
+    // targets `:sir_um_instance_eval` — a name no built-in has — so Ruby's real
+    // `instance_eval` is UNREACHABLE.  (The method is registered so it passes the
+    // allowlist; the prefix is what neutralises the RCE.)
+    let recv = new_expr("Foo", vec![]);
+    let m = method_module_fns(
+        vec![
+            classdef("Foo", None, vec![]),
+            def_method("Foo", "instance_eval", "Foo__x"),
+            puts(method_call(recv, "instance_eval", vec![strlit("system('boom')")])),
+        ],
+        vec![hoisted("Foo__x")],
+    );
+    let rb = compile(&m).expect("registered dispatch compiles").source;
+    assert!(rb.contains(":sir_um_instance_eval"), "prefixed symbol:\n{rb}");
+    assert!(!rb.contains(".instance_eval("), "must NOT emit a bare instance_eval call:\n{rb}");
+    assert!(
+        !rb.contains("public_send(:instance_eval"),
+        "must NOT dispatch to the unprefixed reflection name:\n{rb}"
+    );
+}
+
+// ---- hand-built: totality / clean rejection -------------------------------
+
+#[test]
+fn dispatch_to_an_unregistered_method_is_rejected_cleanly() {
+    // `__method__(recv, "upcase")` with no `__def_method__` registering `upcase`
+    // is a BUILT-IN method call (Collections batch) — rejected cleanly, so it
+    // does NOT compile-then-`NoMethodError` at runtime (`sir_um_upcase` is unbound).
+    let recv = new_expr("Foo", vec![]);
+    let m = method_module(vec![
+        classdef("Foo", None, vec![]),
+        puts(method_call(recv, "upcase", vec![])),
+    ]);
+    let err = compile(&m).expect_err("a built-in method dispatch must be rejected");
+    assert_eq!(err.kind, semantic_ir::BackendErrorKind::UnsupportedFeature);
+}
+
+#[test]
+fn a_registered_method_dispatches_across_the_whole_module() {
+    // The allowlist is module-wide: a method registered anywhere lets its
+    // dispatch compile (the receiver need not be statically the defining class).
+    let m = method_module_fns(
+        vec![
+            classdef("Foo", None, vec![]),
+            def_method("Foo", "greet", "Foo__greet"),
+            puts(method_call(new_expr("Foo", vec![]), "greet", vec![])),
+        ],
+        vec![hoisted("Foo__greet")],
+    );
+    assert!(compile(&m).is_ok(), "a registered-method dispatch must compile");
+}
+
+#[test]
+fn an_injectable_def_method_class_name_is_rejected() {
+    // `__def_method__`'s class name is emitted as the bare `const_set`/receiver
+    // constant, so a crafted class name must be rejected (injection guard).
+    let m = method_module_fns(
+        vec![def_method("Foo\n  system('x')", "greet", "Foo__greet")],
+        vec![hoisted("Foo__greet")],
+    );
+    assert!(compile(&m).is_err(), "an injectable def_method class name must be rejected");
+}
+
+#[test]
+fn still_rejected_super_self_classmethod_builtins() {
+    // The remaining OOP builtins are later slices — a hand-built module carrying
+    // any is rejected cleanly (never `unreachable!`).
+    for bad in ["__super__", "__self__", "__class_method__", "__def_class_method__"] {
+        let call = Expr::BuiltinCall {
+            name: bad.into(),
+            args: vec![strlit("Foo"), strlit("m")],
+            effects: EffectSet::PURE,
+            span: s2(),
+        };
+        let m = method_module(vec![puts(call)]);
+        assert!(compile(&m).is_err(), "`{bad}` must still be rejected");
+    }
 }

--- a/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
@@ -1594,6 +1594,22 @@ fn a_malformed_def_method_missing_its_closure_is_rejected_cleanly() {
     let m = class_module(vec![classdef("Foo", None, vec![]), def_method]);
     let err = compile(&m).expect_err("a __def_method__ with no closure must be rejected");
     assert_eq!(err.kind, semantic_ir::BackendErrorKind::UnsupportedFeature);
+
+    // Likewise a NON-closure third argument (which would emit `&(5)` and fail at
+    // Ruby runtime) is rejected at compile time, not mis-emitted.
+    let non_closure = Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "__def_method__".into(),
+            args: vec![strlit("Foo"), strlit("greet"), ilit(5)],
+            effects: EffectSet::PURE,
+            span: s2(),
+        },
+        span: s2(),
+    };
+    assert!(
+        compile(&class_module(vec![classdef("Foo", None, vec![]), non_closure])).is_err(),
+        "a __def_method__ whose third arg is not a closure must be rejected"
+    );
 }
 
 // ---- hand-built: injection (a crafted constant name cannot inject) --------

--- a/code/specs/SIR25-semantic-ir-to-ruby.md
+++ b/code/specs/SIR25-semantic-ir-to-ruby.md
@@ -93,10 +93,25 @@ a `Const` reference, a `Const` assignment target) is validated as a constant pat
 in the SAME pre-emit traversal as the builtin scan (co-total with the emitter),
 so no name can inject.
 
+The second OOP slice (0.12.0) adds instance-method **definition** and
+**dispatch**: a method-bearing class lowers to a hoisted top-level function plus
+`__def_method__("Class", "m", MakeClosure(fn))` and `__method__(recv, "m",
+args…)`, rendered as `Class.define_method(:sir_um_m, &closure)` and
+`(recv).public_send(:sir_um_m, args…)`. A **reserved `sir_um_` method-name
+prefix** makes dispatch CLOSED: no reflection/eval built-in is named `sir_um_*`,
+so `public_send` with an IR-supplied method name can reach only a method
+installed by `__def_method__` — never `instance_eval`/`send`/`eval` (the
+"explicit dispatch, never reflection" anti-RCE invariant, achieved natively).
+`define_method` binds `self` to the receiver, so the hoisted body sees the
+instance (its `@ivars` become reachable when slice 3 accepts them). A `__method__`
+to a name the module never registers is a **built-in method call** (the
+Collections batch) — rejected cleanly (the scan collects the module's registered
+method names, then validates each dispatch), never a runtime `NoMethodError`.
+
 **Still rejects** `TailCalls`, `Intrinsics`, `NDArrays`, and every not-yet-landed
-feature — including the rest of OOP: class **methods** (the `__def_method__` /
-`__method__` dispatch builtins), **inheritance** (a superclass / `__super__`),
-instance variables (`@x`), class variables (`@@x`), and modules; plus a
+feature — including the rest of OOP: **inheritance** (a superclass / `__super__`),
+class methods (`__class_method__` / `__def_class_method__`), instance variables
+(`@x`), class variables (`@@x`), and modules; plus a malformed `__def_method__`, a
 non-empty class body, a namespaced (`Foo::Bar`) class/constant *definition*
 (`const_set` names one namespace), and a **singleton class** (`class << self` —
 `Stmt::SingletonClassDef`, which also observes `Feature::Classes`, so accepting
@@ -138,6 +153,8 @@ or temporaries:
 | `ClassDef { name, superclass: None, body: [] }` | `Object.const_set(:<name>, Class.new)` — reflective (a native `class` block is illegal in the `main` method) |
 | `Assign { Const }` | `Object.const_set(:<name>, <value>)` — reflective constant definition |
 | `BuiltinCall("__new__", [name, args…])` | `<name>.new(<args>)` — native construction |
+| `BuiltinCall("__def_method__", [class, m, closure])` | `<class>.define_method(:sir_um_<m>, &closure)` — reserved-prefix registration |
+| `BuiltinCall("__method__", [recv, m, args…])` | `(<recv>).public_send(:sir_um_<m>, <args>)` — closed prefixed dispatch (anti-RCE) |
 | `If` | `(if sir_truthy(<cond>) then <then> else <else> end)` |
 | `LogicalAnd { lhs, rhs }` | `(<lhs> && <rhs>)` — native short-circuit, yields the deciding operand |
 | `LogicalOr { lhs, rhs }` | `(<lhs> \|\| <rhs>)` — native short-circuit, yields the deciding operand |
@@ -236,9 +253,9 @@ growing `ACCEPTED_FEATURES`, the runtime, and the conformance corpus in lockstep
    faithfulness payoff.
 5. **Exceptions / OOP** — `begin/rescue` (native, landed 0.10); then OOP in
    slices: `Constants` + an empty `class`/`Foo.new` (reflective `const_set`,
-   landed 0.11), then class **methods** (`define_method` for the frontend's
-   hoisted, separately-registered methods), **instance/class variables**,
-   **inheritance** (`superclass`/`super`), and **modules**/mixins.
+   landed 0.11), instance **methods** (`define_method`/`public_send` under a
+   reserved `sir_um_` prefix, landed 0.12), then **instance/class variables**,
+   **inheritance** (`superclass`/`super`), class methods, and **modules**/mixins.
 6. **Collections** — the `__method__` catalog for built-in `String`/`Array`/
    `Hash`/numeric methods (Ruby methods are largely native), sharing the same
    `__method__` dispatch surface as OOP.


### PR DESCRIPTION
## What

The **second OOP slice** for the Ruby backend: instance-method **definition** and **dispatch**. Bumps `semantic-ir-to-ruby` 0.11.0 → 0.12.0. No new `Feature` (a method-bearing class lowers to builtins, not a feature-gated node); wires two:

- `__def_method__("Class", "m", MakeClosure(fn))` → `Class.define_method(:sir_um_m, &closure)`
- `__method__(recv, "m", args…)` → `(recv).public_send(:sir_um_m, args…)`

The frontend hoists a method body to a top-level function `Class__m` (already emitted) and registers it via `__def_method__`; instance calls dispatch via `__method__`. `define_method` binds `self` to the receiver, and the closure calls the hoisted function with implicit `self`, so the body runs with the instance as `self` (its `@ivars` become reachable once slice 3 accepts them — verified empirically).

## Anti-RCE — the reserved `sir_um_` prefix closes reflection dispatch

`__method__` dispatches by a method name taken from the IR, so a naive `recv.public_send(:name)` would be a **remote-code-execution sink** — a hand-built module could pass `"instance_eval"` / `"send"` to reach Ruby's metaprogramming. Both registration and dispatch instead go through a **reserved `sir_um_` method-name prefix**: no Ruby built-in (and no `sir_*` runtime helper) is named `sir_um_*`, so `public_send` with a crafted name can reach *only* a method installed by `__def_method__` — never `instance_eval`/`send`/`eval`/any reflection sink. This is the codebase's "explicit dispatch, never reflection" invariant (SIR24 §OOP), achieved natively. The prefixed name is a quoted symbol via `emit_symbol` (no injection); the `__def_method__` class name is validated as a constant path.

## Totality / clean rejection

The scan was restructured into a `Scan` struct carrying the module-wide set of `__def_method__`-registered names (collected in a first pass, since a dispatch can textually precede its registration). A `__method__` to an unregistered name is a **built-in method call** (`.upcase`, …) — the separate Collections batch — rejected cleanly rather than compiling to a runtime `NoMethodError`. A malformed `__def_method__` (missing/non-`MakeClosure` closure arg) and the remaining OOP builtins (`__super__`, `__self__`, `__class_method__`, `__def_class_method__`) stay rejected (later slices). Instance/class variables, inheritance, and modules remain unsupported.

## Security review

A read-only security sub-agent reviewed the diff with the RCE surface as the explicit focus and returned **PASSED — no vulnerabilities**: the `sir_um_` prefix is applied at both emit sites and can't be bypassed, method names route through safe quoting, the scan's shape checks are co-total with every index the emitter uses, and the class name is constant-path-validated. One **non-security** robustness note (a non-closure `args[2]` would compile-then-crash) was addressed in a follow-up commit (require a `MakeClosure`, + test).

## Tests

83 tests pass (new: frontend+interpreter e2e for a no-arg method and an arg+return method; hand-built — the prefix neutralises a registered `instance_eval` dispatch, an unregistered dispatch rejects, a malformed/non-closure `__def_method__` rejects, an injectable `__def_method__` class name rejects, the still-deferred OOP builtins reject). `cargo clippy` clean. CHANGELOG, README, and the SIR25 spec (node table + roadmap) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)