### PR TITLE
feat(adj-formula-stdlib): volume-conversions — NIST SP 811 B.9 unit→cubic-metre factors (RS-5 table)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -249,6 +249,54 @@ fn shipped_area_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b4) Shipped table — reference/volume-conversions.adj resolves via import (a
+//      third dimension: VOLUME), and a unit absent from the table abstains.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_volume_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_volume");
+    let src = stdlib().join("reference/volume-conversions.adj");
+    std::fs::copy(&src, dir.join("volume-conversions.adj"))
+        .expect("copy shipped volume-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"volume-conversions.adj\"\n\
+         ? volume_to_cubic_metres(gallon, $M3)\n\
+         ? volume_to_cubic_metres(cubic_foot, $M3)\n\
+         ? volume_to_cubic_metres(barrel, $M3)\n\
+         ? volume_to_cubic_metres(litre, $M3)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 7-figure factors resolve, character-for-character from
+    // the table (scientific notation converted to the same plain decimal).
+    assert!(
+        out.contains("\"M3\":\"0.003785412\""),
+        "shipped U.S. gallon factor: {out}"
+    );
+    assert!(
+        out.contains("\"M3\":\"0.02831685\""),
+        "shipped cubic-foot factor: {out}"
+    );
+    assert!(
+        out.contains("\"M3\":\"0.1589873\""),
+        "shipped petroleum-barrel factor: {out}"
+    );
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `litre` is SI, not a customary unit — not a row, so the engine abstains.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "an absent unit abstains, never a fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/volume-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/volume-conversions.adj
@@ -1,0 +1,68 @@
+% ============================================================================
+% volume-conversions — customary volume-unit → cubic-metre factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of `length-conversions.adj` / `mass-conversions.adj` /
+% `area-conversions.adj`: a native tabular relation ingested VERBATIM from a
+% published NIST conversion table. Each row states the factor converting one
+% customary volume unit to cubic metres:
+%
+%     ? volume_to_cubic_metres(gallon, $M3)       % 0.003785412
+%     ? volume_to_cubic_metres(cubic_foot, $M3)   % 0.02831685
+%
+% Why a `table` and not ten hand-written `relate` clauses: this is exactly the
+% shape reference data comes in — a published table, not prose. The citable
+% artifact IS the NIST conversion-factors table at the `locator` below; every
+% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors
+% for units listed alphabetically"), and the whole table is defended by one
+% provenance envelope rather than repeating `source`/`locator`/`trust` on every
+% row. Each `row` lowers to a ground relation `volume_to_cubic_metres(unit, m3)`,
+% so the exact lookup above is the ordinary SLD binding query — the engine returns
+% the factor WITH this table's citation as its proof, on the CPU, with zero model
+% calls. A looked-up factor is a number, so it can feed a `let`/`formula`
+% downstream (e.g. multiply a volume by it) through the existing slot path.
+%
+% HONESTY NOTE (as for mass-conversions, which quotes NIST's ROUNDED factors, not
+% exact defined ones): the values below are NIST SP 811's published conversion
+% factors, rounded to SEVEN significant figures, transcribed character-for-character
+% from the SP 811 B.9 table (each printed in scientific notation there; the plain
+% decimal is the same value):
+%
+%     gallon (U.S.)                3.785 412 E-03  →  0.003785412
+%     quart (U.S. liquid)          9.463 529 E-04  →  0.0009463529
+%     pint (U.S. liquid)           4.731 765 E-04  →  0.0004731765
+%     fluid ounce (U.S.)           2.957 353 E-05  →  0.00002957353
+%     cubic foot                   2.831 685 E-02  →  0.02831685
+%     cubic inch                   1.638 706 E-05  →  0.00001638706
+%     cup (U.S.)                   2.365 882 E-04  →  0.0002365882
+%     tablespoon                   1.478 676 E-05  →  0.00001478676
+%     teaspoon                     4.928 922 E-06  →  0.000004928922
+%     barrel (petroleum, 42 gal)   1.589 873 E-01  →  0.1589873
+%
+% These are the table's printed 7-figure factors, NOT the underlying exact
+% definitions (e.g. the U.S. gallon is exactly 3.785 411 784 L = 0.003 785 411 784
+% m³; SP 811 rounds it to 0.003785412). The only claim this table makes is "these
+% are the factors NIST SP 811 B.9 prints" — which is exactly what a byte-check
+% against the cited table verifies. `trust authoritative` — a primary, re-fetchable
+% standards reference. (See ADJ-TABLES.md; and feedback_nothing_human_authored —
+% nothing here is asserted "from memory": every factor is a verbatim cell of the
+% cited table.)
+% ============================================================================
+
+table volume_to_cubic_metres {
+    columns unit, cubic_metres
+
+    row (gallon, 0.003785412)
+    row (quart, 0.0009463529)
+    row (pint, 0.0004731765)
+    row (fluid_ounce, 0.00002957353)
+    row (cubic_foot, 0.02831685)
+    row (cubic_inch, 0.00001638706)
+    row (cup, 0.0002365882)
+    row (tablespoon, 0.00001478676)
+    row (teaspoon, 0.000004928922)
+    row (barrel, 0.1589873)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/volume-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/volume-conversions.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% volume-conversions.query.adj — a worked lookup over the volume-conversions table.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a "how many cubic
+% metres in a U.S. gallon?" question: it states no conversion fact — it only
+% `import`s the grounded table and asks binding queries. The native adj-lang
+% engine resolves each `?` against the table's rows (lowered to
+% `volume_to_cubic_metres` relations) and returns the binding + the table's
+% source/locator/trust. A unit not in the table abstains honestly — the engine
+% never invents a factor.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli volume-conversions.query.adj
+% ============================================================================
+
+import "volume-conversions.adj"
+
+? volume_to_cubic_metres(gallon, $M3)       % expect 0.003785412
+? volume_to_cubic_metres(cubic_foot, $M3)   % expect 0.02831685
+? volume_to_cubic_metres(barrel, $M3)       % expect 0.1589873
+? volume_to_cubic_metres(litre, $M3)        % expect abstain — not in the table (litre is SI, not a customary unit)


### PR DESCRIPTION
## What

A `table` sibling of the shipped `length-` / `mass-` / `area-conversions` tables (Facts front): a native tabular relation ingested **verbatim** from NIST Special Publication 811, Appendix B.9. Ten customary volume units → cubic metres:

| unit | m³ factor |
|------|-----------|
| gallon (U.S.) | 0.003785412 |
| quart / pint / fluid_ounce | 0.0009463529 / 0.0004731765 / 0.00002957353 |
| cubic_foot / cubic_inch | 0.02831685 / 0.00001638706 |
| cup / tablespoon / teaspoon | 0.0002365882 / 0.00001478676 / 0.000004928922 |
| barrel (petroleum, 42 gal) | 0.1589873 |

Each cell is the printed 7-figure NIST factor (scientific notation → the same plain decimal), defended by **one** provenance envelope (`source`/`locator`/`trust authoritative`).

## Grounding

Every factor was verified char-for-char against the fetched NIST B.9 page, and cross-checked against the exact definitions: 1 US gal = 3.785411784 L → NIST's 0.003785412; 1 ft³ = 0.028316846592 m³ → 0.02831685; 42-gal barrel → 0.1589873. Nothing is asserted "from memory" — every value is a verbatim cell of the cited table.

## How it works

Each `row` lowers to a ground relation `volume_to_cubic_metres(unit, m3)`, so exact lookup is the ordinary SLD binding query — the engine returns the factor **with the table's citation** as its proof, 0 model calls. An absent unit (e.g. `litre`, which is SI, not customary) **abstains** — never a fabricated factor.

## Changes

- New: `reference/volume-conversions.adj` + `volume-conversions.query.adj` (worked lookup, 3 hits + `litre` abstention).
- Test: `rs5_table_e2e` gains `shipped_volume_conversions_table_resolves_and_abstains` (gallon/cubic_foot/barrel resolve with the NIST locator; litre abstains). **9/9 pass.**

## Verification

- `cargo test -p adj-lang-cli --test rs5_table_e2e` → 9 passed.
- Shipped `.query.adj` driven through the built CLI: each factor renders with the NIST locator; `litre` abstains.
- Security review passed (pure declarative data + static-path test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)