### PR TITLE
feat(semantic-ir-to-ruby): classes slice 3 — instance variables (@ivars) + self (0.13.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.13.0 — classes slice 3: instance variables (@ivars) + self
+
+Accepts `Feature::InstanceVars` — an instance variable read and write, plus the
+`__self__` builtin. The third OOP slice, and a small one: the slice-2 method
+machinery already does the heavy lifting.
+
+- `@v = x` → `Stmt::Assign { scope: Instance }` → native `@v = x`.
+- `@v` → `Expr::VarRef { scope: Instance }` → native `@v`.
+- `__self__` (a bare `self`) → the native `self` keyword.
+
+The frontend puts the leading `@` in the node's `name`, and the emitter renders
+it **verbatim** (not through `sanitize_ident`, which would mangle the `@`). No
+runtime support is needed: an instance-method body is installed with
+`define_method` (slice 2), which binds `self` to the receiver, so `@v` inside a
+method reads/writes **that instance's** own variable, and it persists across
+dispatches (a counter mutating `@n` across calls works).
+
+**Injection safety.** Both verbatim-emitted instance-variable positions — a
+`Scope::Instance` `Assign` target and `VarRef` — are validated as
+`@<identifier>` (a new `is_valid_ivar_name`) in the SAME pre-emit traversal as
+the builtin/constant scan (co-total with the emitter), so a crafted name (`@v;
+system(...)`, a non-`@` name, `@` + digit) cannot inject source and is rejected
+cleanly.
+
+**Still rejects** class variables (`@@x` — `Feature::ClassVars`), inheritance (a
+superclass / `__super__`), class methods (`__class_method__` /
+`__def_class_method__`), and modules — each a later slice.
+
 ## 0.12.0 — classes slice 2: instance methods
 
 Instance-method **definition** and **dispatch** — the second OOP slice. No new

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/README.md
+++ b/code/packages/rust/semantic-ir-to-ruby/README.md
@@ -79,11 +79,15 @@ top-level function plus `__def_method__` / `__method__` builtins, rendered as
 The reserved `sir_um_` method-name prefix makes dispatch **closed** — no
 reflection/eval built-in is named `sir_um_*`, so a crafted method name can never
 reach `instance_eval`/`send` (anti-RCE); a dispatch to an un-registered
-(built-in) method is rejected cleanly (Collections batch).
+(built-in) method is rejected cleanly (Collections batch). Instance **variables**
+(slice 3): `@v = x` / `@v` (`Scope::Instance`) render as native `@v` and `__self__`
+as native `self`; `define_method` binds `self` to the receiver, so `@v` in a
+method addresses that instance (each `@`-name validated as `@<identifier>`, no
+injection).
 Rejects `TailCalls`, `Intrinsics`, and every not-yet-wired feature (array
 indexing / slicing via `IndexGet` — `NDArrays`; array-pattern destructuring;
 built-in collection methods; and the rest of OOP — **inheritance** / superclass,
-instance & class variables, class methods, modules — plus a non-empty class body
+class variables (`@@x`), class methods, modules — plus a non-empty class body
 or a namespaced class/constant definition) until its slice lands — each a clean,
 source-positioned `UnsupportedFeature`.
 

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -75,6 +75,10 @@ const SUPPORTED_BUILTINS: &[&str] = &[
     // using them is rejected until their slice.
     "__def_method__",
     "__method__",
+    // OOP classes slice 3 (instance variables): `__self__` — the frontend's
+    // lowering of a bare `self` — renders as the native `self` keyword.  (Its
+    // sibling `@ivar` read/write rides on `Scope::Instance`, not a builtin.)
+    "__self__",
 ];
 
 /// Emit a complete self-contained Ruby source file for `m`.
@@ -148,6 +152,11 @@ pub enum ScanHit {
     /// Carries a human-readable reason.  Deferred to a later slice; rejected
     /// cleanly rather than mis-emitted.
     Unsupported(String, semantic_ir::Span),
+    /// A `Scope::Instance` name (`@v`) that is not a valid Ruby instance-variable
+    /// name — it is emitted VERBATIM (a bare `@v` read / write), so a
+    /// metacharacter would inject source.  Same injection guard as `ConstantName`,
+    /// at the instance-variable positions.
+    InstanceVarName(String, semantic_ir::Span),
 }
 
 /// Scan the module — in a SINGLE traversal shared with the unsupported-builtin
@@ -361,6 +370,15 @@ impl Scan {
                 } else {
                     self.expr(value)
                 }
+            } else if matches!(scope, Scope::Instance) {
+                // A `Scope::Instance` target (`@v = …`) emits the name VERBATIM,
+                // so validate it as `@<identifier>` at this position (the same
+                // injection guard as an ivar reference); then scan the value.
+                if !is_valid_ivar_name(name) {
+                    Some(ScanHit::InstanceVarName(name.clone(), span.clone()))
+                } else {
+                    self.expr(value)
+                }
             } else {
                 self.expr(value)
             }
@@ -487,6 +505,18 @@ fn is_valid_constant_path(name: &str) -> bool {
         })
 }
 
+/// Whether `name` is a syntactically valid Ruby instance-variable name — a `@`
+/// followed by an identifier (`@v`, `@_x1`).  The frontend puts the `@` in the
+/// node's `name`, and the emitter renders `@v` VERBATIM (a bare local/ivar write
+/// or read), so this gates out any name carrying a metacharacter that could
+/// inject source.  (A `@@class` variable is `Scope::ClassVar`, a later slice.)
+fn is_valid_ivar_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars.next() == Some('@')
+        && matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
 impl Scan {
     fn expr(&self, e: &Expr) -> Option<ScanHit> {
         match e {
@@ -609,6 +639,14 @@ impl Scan {
             scope: Scope::Const,
             span,
         } if !is_valid_constant_path(name) => Some(ScanHit::ConstantName(name.clone(), span.clone())),
+        // A `Scope::Instance` reference (`@v`, `Feature::InstanceVars`) is emitted
+        // VERBATIM by `emit_var_ref`, so validate it as `@<identifier>` here — at
+        // that emitter position — to bar injection.
+        Expr::VarRef {
+            name,
+            scope: Scope::Instance,
+            span,
+        } if !is_valid_ivar_name(name) => Some(ScanHit::InstanceVarName(name.clone(), span.clone())),
         _ => None,
     }
     }
@@ -715,6 +753,13 @@ fn emit_stmt(s: &Stmt) -> String {
         } => {
             if matches!(scope, Scope::Const) {
                 format!("Object.const_set(:{}, {})", name, emit_expr(value))
+            } else if matches!(scope, Scope::Instance) {
+                // A `Scope::Instance` target (`@v = …`, `Feature::InstanceVars`,
+                // OOP slice 3): the name already INCLUDES the `@`, emitted VERBATIM
+                // (the scan validated it as `@<identifier>`, so no injection).
+                // Inside a `define_method`-installed method `self` is the receiver,
+                // so this writes the instance's own variable.
+                format!("{} = {}", name, emit_expr(value))
             } else {
                 format!("{} = {}", sanitize_ident(name), emit_expr(value))
             }
@@ -1075,8 +1120,16 @@ fn emit_var_ref(name: &str, scope: Scope) -> String {
         // `first_scan_issue` has already validated the name as a constant path at
         // this position, so it carries no injectable metacharacter.
         Scope::Const => name.to_string(),
-        // Remaining scopes (`Instance`, `ClassVar`) belong to later OOP slices'
-        // features, not yet accepted → their modules are rejected before emit.
+        // A `Scope::Instance` reference (`Feature::InstanceVars`, OOP slice 3) is
+        // a Ruby instance variable — the name already INCLUDES the `@` (`@v`),
+        // emitted VERBATIM (NOT through `sanitize_ident`, which would mangle the
+        // `@`).  `first_scan_issue` validated it as `@<identifier>` at this
+        // position, so it carries no injectable metacharacter.  Inside a
+        // `define_method`-installed method (slice 2) `self` IS the receiver, so
+        // `@v` reads the instance's own variable — no runtime plumbing.
+        Scope::Instance => name.to_string(),
+        // `Scope::ClassVar` (`@@x`) is a later OOP slice's feature, not yet
+        // accepted → such a module is rejected before emit.
         other => unreachable!("Ruby backend reached unsupported var scope: {other:?}"),
     }
 }
@@ -1171,6 +1224,9 @@ fn emit_builtin(name: &str, args: &[Expr]) -> String {
             parts.extend_from_slice(&a[2..]);
             format!("({}).public_send({})", a[0], parts.join(", "))
         }
+        // OOP classes slice 3: a bare `self` → the native `self` keyword.  Inside
+        // a `define_method`-installed method (slice 2) `self` is the receiver.
+        "__self__" => "self".to_string(),
         // Unreachable: first_scan_issue rejected anything else.
         other => unreachable!("v0 Ruby backend reached unsupported builtin: {other}"),
     }

--- a/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
@@ -183,9 +183,22 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // **non-empty class body** (class-level code / constants) — and validates
     // the class name (of both `ClassDef` and `__new__`) as a Ruby constant path
     // so a hand-built module cannot inject source through a crafted name.
-    // Instance variables / class variables / constants / modules remain
-    // unaccepted features (their own later slices).
+    // Class variables / modules remain unaccepted features (their own slices).
     Feature::Classes,
+    // ── OOP classes, slice 3: instance variables (`@ivars`) ──────────────
+    // `Feature::InstanceVars` is observed by a `Scope::Instance` name (`@v`).
+    // Two nodes carry it, both handled natively:
+    //   `@v = x` → `Stmt::Assign { scope: Instance, .. }` → native `@v = x`
+    //   `@v`     → `Expr::VarRef  { scope: Instance, .. }` → native `@v`
+    // The frontend puts the leading `@` in the node's `name`, emitted VERBATIM;
+    // the pre-emit scan validates it as `@<identifier>` (co-total with the
+    // emitter) so no name can inject.  Instance-method bodies are installed with
+    // `define_method` (slice 2), which binds `self` to the receiver, so `@v`
+    // inside a method reads/writes the instance's own variable — no runtime
+    // support.  The `__self__` builtin (a bare `self`) rides in here too,
+    // rendering the native `self`.  `@@class` variables are the separate
+    // `Feature::ClassVars` (a later slice), still rejected.
+    Feature::InstanceVars,
 ];
 
 impl Backend for RubyBackend {
@@ -277,6 +290,18 @@ impl Backend for RubyBackend {
                     message: format!(
                         "the Ruby backend does not yet support {reason} \
                          (deferred to a later slice)"
+                    ),
+                    span,
+                });
+            }
+            // A `Scope::Instance` name emitted verbatim (a `@v` read / write) that
+            // is not a valid `@identifier` — a metacharacter could inject source.
+            Some(emit::ScanHit::InstanceVarName(name, span)) => {
+                return Err(BackendError {
+                    kind: BackendErrorKind::UnsupportedFeature,
+                    message: format!(
+                        "the Ruby backend cannot emit the instance variable `{name}` \
+                         (not a valid `@identifier`)"
                     ),
                     span,
                 });

--- a/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
@@ -1825,8 +1825,9 @@ fn an_injectable_def_method_class_name_is_rejected() {
 #[test]
 fn still_rejected_super_self_classmethod_builtins() {
     // The remaining OOP builtins are later slices — a hand-built module carrying
-    // any is rejected cleanly (never `unreachable!`).
-    for bad in ["__super__", "__self__", "__class_method__", "__def_class_method__"] {
+    // any is rejected cleanly (never `unreachable!`).  (`__self__` landed in
+    // slice 3, so it is no longer in this list.)
+    for bad in ["__super__", "__class_method__", "__def_class_method__"] {
         let call = Expr::BuiltinCall {
             name: bad.into(),
             args: vec![strlit("Foo"), strlit("m")],
@@ -1836,4 +1837,133 @@ fn still_rejected_super_self_classmethod_builtins() {
         let m = method_module(vec![puts(call)]);
         assert!(compile(&m).is_err(), "`{bad}` must still be rejected");
     }
+}
+
+// ── OOP classes slice 3 — instance variables (@ivars) + self ────────────────
+//
+// `@v = x` / `@v` lower to a `Scope::Instance` `Assign` / `VarRef` whose `name`
+// already includes the `@`. They render as native `@v = x` / `@v` (the name
+// emitted verbatim, validated as `@<identifier>` by the scan — no injection).
+// Instance-method bodies are installed with `define_method` (slice 2), which
+// binds `self` to the receiver, so `@v` inside a method reads/writes the
+// instance's own variable with no runtime plumbing. A bare `self` (`__self__`)
+// renders the native `self`.
+
+/// A `main` module carrying `stmts`, declaring InstanceVars (+ Strings) — for
+/// hand-built ivar shapes (the frontend only produces `@v` inside a method body).
+fn ivar_module(stmts: Vec<Stmt>) -> Module {
+    Module {
+        name: "ivprog".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::InstanceVars,
+            Feature::MutableBindings,
+            Feature::Strings,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s2() }, span: s2() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new().with_source_language("test"),
+            span: s2(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s2(),
+    }
+}
+fn ivar_ref(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Instance, span: s2() }
+}
+fn ivar_assign(name: &str, value: Expr) -> Stmt {
+    Stmt::Assign { name: name.into(), scope: Scope::Instance, value, span: s2() }
+}
+
+// ---- positive, through the real frontend + interpreter --------------------
+
+#[test]
+fn e2e_instance_variable_set_and_get() {
+    // `class Box; def set(v); @v=v; end; def get; @v; end; end` — a set writes
+    // the instance's `@v`, a later get reads it back through `self`.
+    let rb = ruby_to_ruby(
+        "class Box\n  def set(v)\n    @v = v\n  end\n  def get\n    @v\n  end\nend\n\
+         b = Box.new\nb.set(7)\nputs b.get\n",
+    );
+    assert!(rb.contains("@v = "), "native ivar write:\n{rb}");
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "7"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn e2e_instance_variable_mutation_across_calls() {
+    // A counter mutating `@n` across method calls — proves the ivar persists on
+    // the instance between dispatches, and `@n = @n + 1` reads then writes it.
+    let rb = ruby_to_ruby(
+        "class Counter\n  def start\n    @n = 0\n  end\n  def inc\n    @n = @n + 1\n  end\n  \
+         def value\n    @n\n  end\nend\n\
+         c = Counter.new\nc.start\nc.inc\nc.inc\nputs c.value\n",
+    );
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "2"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+// ---- hand-built: emit shape + self ----------------------------------------
+
+#[test]
+fn ivar_read_and_write_emit_verbatim() {
+    // `@v = 1` then a read of `@v` render as native `@v` — the leading `@` is
+    // preserved (NOT routed through `sanitize_ident`, which would mangle it).
+    let m = ivar_module(vec![ivar_assign("@v", ilit(1)), puts(ivar_ref("@v"))]);
+    let rb = compile(&m).expect("ivar module compiles").source;
+    assert!(rb.contains("@v = 1"), "ivar write verbatim:\n{rb}");
+    assert!(rb.contains("sir_puts(@v)"), "ivar read verbatim:\n{rb}");
+}
+
+#[test]
+fn self_builtin_emits_native_self() {
+    // `__self__` (a bare `self`) renders the native `self` keyword.
+    let self_call = Expr::BuiltinCall {
+        name: "__self__".into(),
+        args: vec![],
+        effects: EffectSet::PURE,
+        span: s2(),
+    };
+    let m = ivar_module(vec![puts(self_call)]);
+    let rb = compile(&m).expect("self module compiles").source;
+    assert!(rb.contains("sir_puts(self)"), "native self:\n{rb}");
+}
+
+// ---- hand-built: injection (a crafted ivar name cannot inject) ------------
+
+#[test]
+fn an_injectable_ivar_write_name_is_rejected() {
+    // A `Scope::Instance` assignment target is emitted verbatim, so a crafted
+    // name must be rejected before it can inject source.
+    let m = ivar_module(vec![ivar_assign("@v = 1; system('boom')", ilit(1))]);
+    let err = compile(&m).expect_err("an injectable ivar write must be rejected");
+    assert_eq!(err.kind, semantic_ir::BackendErrorKind::UnsupportedFeature);
+}
+
+#[test]
+fn an_injectable_ivar_read_name_is_rejected() {
+    // Likewise an ivar REFERENCE name.
+    let m = ivar_module(vec![puts(ivar_ref("@v; system('boom')"))]);
+    assert!(compile(&m).is_err(), "an injectable ivar read must be rejected");
+}
+
+#[test]
+fn a_non_at_ivar_name_is_rejected() {
+    // A `Scope::Instance` name that does not start with `@` (or is just `@`) is
+    // malformed — rejected, never emitted as a bare identifier.
+    assert!(compile(&ivar_module(vec![ivar_assign("v", ilit(1))])).is_err(), "no @");
+    assert!(compile(&ivar_module(vec![ivar_assign("@", ilit(1))])).is_err(), "bare @");
+    assert!(compile(&ivar_module(vec![ivar_assign("@1x", ilit(1))])).is_err(), "@ + digit");
 }

--- a/code/specs/SIR25-semantic-ir-to-ruby.md
+++ b/code/specs/SIR25-semantic-ir-to-ruby.md
@@ -103,15 +103,23 @@ so `public_send` with an IR-supplied method name can reach only a method
 installed by `__def_method__` — never `instance_eval`/`send`/`eval` (the
 "explicit dispatch, never reflection" anti-RCE invariant, achieved natively).
 `define_method` binds `self` to the receiver, so the hoisted body sees the
-instance (its `@ivars` become reachable when slice 3 accepts them). A `__method__`
-to a name the module never registers is a **built-in method call** (the
-Collections batch) — rejected cleanly (the scan collects the module's registered
-method names, then validates each dispatch), never a runtime `NoMethodError`.
+instance. A `__method__` to a name the module never registers is a **built-in
+method call** (the Collections batch) — rejected cleanly (the scan collects the
+module's registered method names, then validates each dispatch), never a runtime
+`NoMethodError`.
+
+The third OOP slice (0.13.0) adds instance **variables**: `@v = x` and `@v`
+(`Scope::Instance`, `Feature::InstanceVars`) render as native `@v` (the name
+includes the leading `@`, emitted verbatim), and the `__self__` builtin as native
+`self`. Because a method body is installed with `define_method`, `self` is the
+receiver, so `@v` in a method reads/writes that instance's own variable and
+persists across dispatches — no runtime support. Each `@`-name is validated as
+`@<identifier>` in the co-total scan (no injection).
 
 **Still rejects** `TailCalls`, `Intrinsics`, `NDArrays`, and every not-yet-landed
 feature — including the rest of OOP: **inheritance** (a superclass / `__super__`),
-class methods (`__class_method__` / `__def_class_method__`), instance variables
-(`@x`), class variables (`@@x`), and modules; plus a malformed `__def_method__`, a
+class methods (`__class_method__` / `__def_class_method__`), class variables
+(`@@x`), and modules; plus a malformed `__def_method__`, a
 non-empty class body, a namespaced (`Foo::Bar`) class/constant *definition*
 (`const_set` names one namespace), and a **singleton class** (`class << self` —
 `Stmt::SingletonClassDef`, which also observes `Feature::Classes`, so accepting
@@ -155,6 +163,8 @@ or temporaries:
 | `BuiltinCall("__new__", [name, args…])` | `<name>.new(<args>)` — native construction |
 | `BuiltinCall("__def_method__", [class, m, closure])` | `<class>.define_method(:sir_um_<m>, &closure)` — reserved-prefix registration |
 | `BuiltinCall("__method__", [recv, m, args…])` | `(<recv>).public_send(:sir_um_<m>, <args>)` — closed prefixed dispatch (anti-RCE) |
+| `VarRef { Instance }` / `Assign { Instance }` | `@v` — native instance variable (name incl. `@`, verbatim, validated `@<identifier>`) |
+| `BuiltinCall("__self__", [])` | `self` — native |
 | `If` | `(if sir_truthy(<cond>) then <then> else <else> end)` |
 | `LogicalAnd { lhs, rhs }` | `(<lhs> && <rhs>)` — native short-circuit, yields the deciding operand |
 | `LogicalOr { lhs, rhs }` | `(<lhs> \|\| <rhs>)` — native short-circuit, yields the deciding operand |
@@ -254,8 +264,9 @@ growing `ACCEPTED_FEATURES`, the runtime, and the conformance corpus in lockstep
 5. **Exceptions / OOP** — `begin/rescue` (native, landed 0.10); then OOP in
    slices: `Constants` + an empty `class`/`Foo.new` (reflective `const_set`,
    landed 0.11), instance **methods** (`define_method`/`public_send` under a
-   reserved `sir_um_` prefix, landed 0.12), then **instance/class variables**,
-   **inheritance** (`superclass`/`super`), class methods, and **modules**/mixins.
+   reserved `sir_um_` prefix, landed 0.12), instance **variables** (`@v`, native,
+   landed 0.13), then **inheritance** (`superclass`/`super`), **class variables**
+   (`@@x`), class methods, and **modules**/mixins.
 6. **Collections** — the `__method__` catalog for built-in `String`/`Array`/
    `Hash`/numeric methods (Ruby methods are largely native), sharing the same
    `__method__` dispatch surface as OOP.


### PR DESCRIPTION
## What

The **third OOP slice**: instance-variable read/write plus the `__self__` builtin. Bumps `semantic-ir-to-ruby` 0.12.0 → 0.13.0. A small slice — slice 2's `define_method` machinery already carries the semantics.

- `@v = x` → `Stmt::Assign { scope: Instance }` → native `@v = x`
- `@v` → `Expr::VarRef { scope: Instance }` → native `@v`
- `__self__` (a bare `self`) → native `self`

Accepts `Feature::InstanceVars`. The frontend puts the leading `@` in the node's `name`; the emitter renders it **verbatim** (not through `sanitize_ident`, which would mangle the `@`). **No runtime support**: an instance-method body is installed with `define_method` (slice 2), which binds `self` to the receiver, so `@v` inside a method reads/writes *that instance's* own variable and persists across dispatches — verified with a counter mutating `@n` across calls (`start`/`inc`/`inc`/`value` → `2`).

## Injection safety

Both verbatim `@`-name positions (a `Scope::Instance` `Assign` target and `VarRef`) are validated as `@<identifier>` (new `is_valid_ivar_name`) in the **same co-total** pre-emit traversal as the builtin/constant scan, so a crafted name (`@v; system(...)`, a non-`@` name, `@`+digit, bare `@`) is rejected cleanly rather than injected.

## Security review

A read-only security sub-agent reviewed the diff with injection as the focus and returned **PASSED — no vulnerabilities**: both verbatim emit sites are guarded co-totally (traced against every recursive emit position, including hoisted method-body functions), `is_valid_ivar_name` rejects all metacharacters and the `@`-only/`@digit`/non-`@` cases, `__self__` uses no name arg, and `Feature::InstanceVars` gates only `Scope::Instance` (both handled) with `@@x`/`ClassVar` still rejected.

## Totality

Still rejects class variables (`@@x`, `Feature::ClassVars`), inheritance (superclass / `__super__`), class methods (`__class_method__` / `__def_class_method__`), and modules — each a later slice.

## Tests

90 tests pass (new: frontend+interpreter e2e for ivar set/get and a mutating counter; hand-built for verbatim `@v` emit, `__self__` → `self`, and four injection/malformed-`@`-name rejections). The stale slice-2 test listing `__self__` as rejected was updated (now supported). `cargo clippy` clean. CHANGELOG, README, and SIR25 spec (node table + roadmap) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)