### PR TITLE
feat(spice): add JFET flicker noise

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add JFET model-card `KF` flicker-noise support with a distinct drain-current
+  `flicker` contribution and Berkeley-default inverse-frequency scaling.
 - Add diode model-card `AF` flicker-noise current-exponent support, defaulting
   to `1` and applying `KF * abs(Id)^AF / frequency` across noise analysis.
 - Add diode model-card `KF` flicker-noise support with a distinct diode-current

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -512,6 +512,7 @@ class JFET:
     lambda_: float = 0.0
     Cgs: float = 0.0
     Cgd: float = 0.0
+    Kf: float = 0.0
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -604,7 +604,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
             element.Af,
         )
     if isinstance(element, JFET):
-        return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_, element.Cgs, element.Cgd)
+        return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_, element.Cgs, element.Cgd, element.Kf)
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
@@ -9055,6 +9055,8 @@ def _eval_jfet(el: JFET, vgs: float, vds: float) -> tuple[float, float, float]:
         raise ValueError(f"JFET '{el.name}' CGS must be finite and non-negative")
     if not math.isfinite(el.Cgd) or el.Cgd < 0.0:
         raise ValueError(f"JFET '{el.name}' CGD must be finite and non-negative")
+    if not math.isfinite(el.Kf) or el.Kf < 0.0:
+        raise ValueError(f"JFET '{el.name}' flicker-noise coefficient must be finite and non-negative")
     if el.polarity == "PJF":
         ids, gm, gds = _eval_njf(-vgs, -vds, -el.vto, el.beta, el.lambda_)
         return -ids, gm, gds
@@ -15319,13 +15321,17 @@ def _collect_noise_sources(
             Vd = 0.0 if _is_ground(el.drain) else dc_x[node_to_idx[el.drain]]
             Vg = 0.0 if _is_ground(el.gate) else dc_x[node_to_idx[el.gate]]
             Vs = 0.0 if _is_ground(el.source) else dc_x[node_to_idx[el.source]]
-            _, gm, _ = _eval_jfet(el, Vg - Vs, Vd - Vs)
+            drain_current, gm, _ = _eval_jfet(el, Vg - Vs, Vd - Vs)
             gm = max(0.0, float(gm))
             if gm > 0.0:
                 psd = kT4 * _MOSFET_CHANNEL_NOISE_GAMMA * gm
                 n_d = None if _is_ground(el.drain) else node_to_idx[el.drain]
                 n_s = None if _is_ground(el.source) else node_to_idx[el.source]
                 sources.append((el.name, "thermal", n_d, n_s, psd, 0.0))
+            if el.Kf > 0.0:
+                n_d = None if _is_ground(el.drain) else node_to_idx[el.drain]
+                n_s = None if _is_ground(el.source) else node_to_idx[el.source]
+                sources.append((el.name, "flicker", n_d, n_s, el.Kf * abs(drain_current), 1.0))
 
         # Capacitors, Inductors, VoltageSources, CurrentSources: noiseless in
         # this first-order model.

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -309,8 +309,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (15, 21, 5, 3),
     "NPN": (41, 58, 13, 4),
     "PNP": (41, 58, 13, 4),
-    "NJF": (5, 11, 5, 3),
-    "PJF": (5, 11, 5, 3),
+    "NJF": (6, 12, 5, 3),
+    "PJF": (6, 12, 5, 3),
     "NMOS": (18, 25, 6, 3),
     "PMOS": (18, 25, 6, 3),
 }
@@ -430,6 +430,7 @@ _JFET_PARAMETER_ALIASES: dict[str, str] = {
     "CGS0": "CGS",
     "CGD": "CGD",
     "CGD0": "CGD",
+    "KF": "KF",
 }
 
 _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
@@ -1002,6 +1003,7 @@ def jfet_from_model_card(
         lambda_=p.get("LAMBDA", 0.0),
         Cgs=p.get("CGS", 0.0),
         Cgd=p.get("CGD", 0.0),
+        Kf=p.get("KF", 0.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -407,7 +407,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 143
+    assert len(coverage) == 145
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -422,7 +422,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 143
+    assert len(records) == 145
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -496,9 +496,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 143
-    assert report.expected_canonical_parameter_count == 143
-    assert report.accepted_name_count == 209
+    assert report.canonical_parameter_count == 145
+    assert report.expected_canonical_parameter_count == 145
+    assert report.accepted_name_count == 211
     assert report.aliased_parameter_count == 53
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -506,7 +506,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t143\t143\t209\t53\t4\t0"
+        "true\t7\t7\t145\t145\t211\t53\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -534,8 +534,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 142
-    assert report.accepted_name_count == 206
+    assert report.canonical_parameter_count == 144
+    assert report.accepted_name_count == 208
     assert report.aliased_parameter_count == 52
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -550,7 +550,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t142\t143\t206\t52\t4\t4\n"
+        "false\t7\t7\t144\t145\t208\t52\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -663,13 +663,21 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert bjt_model.Mjc == pytest.approx(0.45)
     assert bjt_model.Fc == pytest.approx(0.4)
 
-    jfet_card = normalize_model_card("Jn", "njfet", {"BET": 9.0e-4, "VT0": -1.8, "LAM": 0.02})
+    jfet_card = normalize_model_card(
+        "Jn", "njfet", {"BET": 9.0e-4, "VT0": -1.8, "LAM": 0.02, "KF": 1.0e-12}
+    )
     jfet_model = jfet_from_model_card("J1", "d", "g", "s", jfet_card)
-    assert jfet_card.parameters == {"BETA": 9.0e-4, "VTO": -1.8, "LAMBDA": 0.02}
+    assert jfet_card.parameters == {
+        "BETA": 9.0e-4,
+        "VTO": -1.8,
+        "LAMBDA": 0.02,
+        "KF": 1.0e-12,
+    }
     assert jfet_model.polarity == "NJF"
     assert jfet_model.beta == pytest.approx(9.0e-4)
     assert jfet_model.vto == pytest.approx(-1.8)
     assert jfet_model.lambda_ == pytest.approx(0.02)
+    assert jfet_model.Kf == pytest.approx(1.0e-12)
 
     mos_card = normalize_model_card(
         "Mn",
@@ -703,6 +711,17 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(3.0e-13) == mos_model.model.model.params.CBD
     assert pytest.approx(0.9) == mos_model.model.model.params.PB
     assert pytest.approx(0.45) == mos_model.model.model.params.MJ
+
+
+def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
+    circuit = Circuit()
+    circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))
+
+    with pytest.raises(
+        ValueError,
+        match="flicker-noise coefficient must be finite and non-negative",
+    ):
+        dc_op(circuit)
 
 
 def test_bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() -> None:
@@ -2385,6 +2404,20 @@ def test_subcircuit_expansion_preserves_complete_diode_model():
     assert expanded.Rs == pytest.approx(10.0)
     assert expanded.Kf == pytest.approx(1.0e-12)
     assert expanded.Af == pytest.approx(1.3)
+
+
+def test_subcircuit_expansion_preserves_jfet_flicker_noise_coefficient():
+    cell = SubcircuitDefinition(
+        "jfet-cell",
+        ("d", "g", "s"),
+        (JFET("Jcell", "d", "g", "s", Kf=1.0e-12),),
+    )
+    circuit = Circuit()
+    circuit.define_subcircuit(cell)
+    circuit.add(XInstance("X1", ("d1", "g1", "0"), "jfet-cell"))
+
+    expanded = next(element for element in circuit.elements if isinstance(element, JFET))
+    assert expanded.Kf == pytest.approx(1.0e-12)
 
 
 def test_subcircuit_expansion_preserves_complete_bjt_model():
@@ -7320,6 +7353,27 @@ def test_noise_diode_kf_adds_inverse_frequency_flicker_noise() -> None:
             entry.source_psd
             for entry in point.entries
             if entry.element_name == "D1" and entry.noise_type == "flicker"
+        )
+        for point in result.points
+    ]
+
+    assert flicker_psds[0] > 0.0
+    assert flicker_psds[0] / flicker_psds[1] == pytest.approx(100.0)
+
+
+def test_noise_jfet_kf_adds_inverse_frequency_flicker_noise() -> None:
+    circuit = Circuit()
+    circuit.add(VoltageSource("Vdd", "vdd", "0", 5.0))
+    circuit.add(VoltageSource("Vgate", "gate", "0", 0.0))
+    circuit.add(Resistor("Rload", "vdd", "out", 1_000.0))
+    circuit.add(JFET("J1", "out", "gate", "0", beta=1.0e-3, vto=-2.0, Kf=1.0e-12))
+
+    result = noise_ac(circuit, "out", "Vgate", freqs=[10.0, 1_000.0])
+    flicker_psds = [
+        next(
+            entry.source_psd
+            for entry in point.entries
+            if entry.element_name == "J1" and entry.noise_type == "flicker"
         )
         for point in result.points
     ]

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add JFET model-card `KF` flicker-noise support with a distinct drain-current
+  `flicker` contribution and Berkeley-default inverse-frequency scaling.
 - Add diode model-card `AF` flicker-noise current-exponent support, defaulting
   to `1` and applying `KF * abs(Id)^AF / frequency` across noise analysis.
 - Add diode model-card `KF` flicker-noise support with a distinct diode-current

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -413,18 +413,22 @@ fn clone_subckt_element(
             mapped.flicker_noise_exponent = element.flicker_noise_exponent;
             Element::Diode(mapped)
         }
-        Element::Jfet(element) => Element::Jfet(Jfet::with_model_and_capacitance(
-            format!("{instance_name}.{}", element.name),
-            map_subckt_node(&element.drain, instance_name, node_map),
-            map_subckt_node(&element.gate, instance_name, node_map),
-            map_subckt_node(&element.source, instance_name, node_map),
-            element.polarity,
-            element.beta,
-            element.threshold_voltage,
-            element.channel_length_modulation,
-            element.gate_source_capacitance,
-            element.gate_drain_capacitance,
-        )),
+        Element::Jfet(element) => {
+            let mut mapped = Jfet::with_model_and_capacitance(
+                format!("{instance_name}.{}", element.name),
+                map_subckt_node(&element.drain, instance_name, node_map),
+                map_subckt_node(&element.gate, instance_name, node_map),
+                map_subckt_node(&element.source, instance_name, node_map),
+                element.polarity,
+                element.beta,
+                element.threshold_voltage,
+                element.channel_length_modulation,
+                element.gate_source_capacitance,
+                element.gate_drain_capacitance,
+            );
+            mapped.flicker_noise_coefficient = element.flicker_noise_coefficient;
+            Element::Jfet(mapped)
+        }
         Element::Bjt(element) => {
             let mut expanded = Bjt::with_model_temperature_depletion_early_rolloff_junction_leakage_and_reverse_beta_parameters(
                 format!("{instance_name}.{}", element.name),
@@ -2810,6 +2814,7 @@ pub struct Jfet {
     pub channel_length_modulation: f64,
     pub gate_source_capacitance: f64,
     pub gate_drain_capacitance: f64,
+    pub flicker_noise_coefficient: f64,
 }
 
 impl Jfet {
@@ -2878,6 +2883,7 @@ impl Jfet {
             channel_length_modulation,
             gate_source_capacitance,
             gate_drain_capacitance,
+            flicker_noise_coefficient: 0.0,
         }
     }
 }
@@ -3801,8 +3807,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     (ModelCardKind::Diode, 15, 21, 5, 3),
     (ModelCardKind::Npn, 41, 58, 13, 4),
     (ModelCardKind::Pnp, 41, 58, 13, 4),
-    (ModelCardKind::Njf, 5, 11, 5, 3),
-    (ModelCardKind::Pjf, 5, 11, 5, 3),
+    (ModelCardKind::Njf, 6, 12, 5, 3),
+    (ModelCardKind::Pjf, 6, 12, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
     (ModelCardKind::Pmos, 18, 25, 6, 3),
 ];
@@ -3901,6 +3907,7 @@ const JFET_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("CGS0", "CGS"),
     ("CGD", "CGD"),
     ("CGD0", "CGD"),
+    ("KF", "KF"),
 ];
 const MOS_LEVEL1_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("LEVEL", "LEVEL"),
@@ -4607,7 +4614,7 @@ pub fn jfet_from_model_card(
         ModelCardKind::Pjf => JfetPolarity::Pjf,
         _ => return Err(model_card_kind_error(&name, "JFET", model.kind)),
     };
-    Ok(Jfet::with_model_and_capacitance(
+    let mut jfet = Jfet::with_model_and_capacitance(
         name,
         drain,
         gate,
@@ -4626,7 +4633,9 @@ pub fn jfet_from_model_card(
         model_card_value(model, "LAMBDA", 0.0),
         model_card_value(model, "CGS", 0.0),
         model_card_value(model, "CGD", 0.0),
-    ))
+    );
+    jfet.flicker_noise_coefficient = model_card_value(model, "KF", 0.0);
+    Ok(jfet)
 }
 
 pub fn mosfet_from_model_card(
@@ -22446,6 +22455,16 @@ fn collect_noise_sources(
                         frequency_exponent: 0.0,
                     });
                 }
+                if jfet.flicker_noise_coefficient > 0.0 {
+                    sources.push(NoiseSource {
+                        element_name: jfet.name.clone(),
+                        noise_type: NoiseType::Flicker,
+                        positive: drain,
+                        negative: source,
+                        source_psd: jfet.flicker_noise_coefficient * result.drain_current.abs(),
+                        frequency_exponent: 1.0,
+                    });
+                }
             }
             Element::Mosfet(mosfet) => {
                 validate_mosfet(mosfet)?;
@@ -24832,6 +24851,12 @@ fn validate_jfet(jfet: &Jfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: jfet.name.clone(),
             reason: "gate-drain capacitance must be finite and non-negative".to_string(),
+        });
+    }
+    if !jfet.flicker_noise_coefficient.is_finite() || jfet.flicker_noise_coefficient < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: jfet.name.clone(),
+            reason: "flicker-noise coefficient must be finite and non-negative".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -95,7 +95,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 143);
+    assert_eq!(coverage.len(), 145);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -114,7 +114,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 143);
+    assert_eq!(records.len(), 145);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -195,15 +195,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 143);
-    assert_eq!(report.expected_canonical_parameter_count, 143);
-    assert_eq!(report.accepted_name_count, 209);
+    assert_eq!(report.canonical_parameter_count, 145);
+    assert_eq!(report.expected_canonical_parameter_count, 145);
+    assert_eq!(report.accepted_name_count, 211);
     assert_eq!(report.aliased_parameter_count, 53);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t143\t143\t209\t53\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t145\t145\t211\t53\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -230,8 +230,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 142);
-    assert_eq!(report.accepted_name_count, 206);
+    assert_eq!(report.canonical_parameter_count, 144);
+    assert_eq!(report.accepted_name_count, 208);
     assert_eq!(report.aliased_parameter_count, 52);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -248,7 +248,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t142\t143\t206\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t144\t145\t208\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -509,17 +509,24 @@ fn model_card_aliases_build_device_instances() {
     let jfet_card = normalize_model_card(
         "Jn",
         "njfet",
-        &[("BET", 9.0e-4), ("VT0", -1.8), ("LAM", 0.02)],
+        &[
+            ("BET", 9.0e-4),
+            ("VT0", -1.8),
+            ("LAM", 0.02),
+            ("KF", 1.0e-12),
+        ],
     )
     .unwrap();
     let jfet_model = jfet_from_model_card("J1", "d", "g", "s", &jfet_card).unwrap();
     assert_close(*jfet_card.parameters.get("BETA").unwrap(), 9.0e-4);
     assert_close(*jfet_card.parameters.get("VTO").unwrap(), -1.8);
     assert_close(*jfet_card.parameters.get("LAMBDA").unwrap(), 0.02);
+    assert_close(*jfet_card.parameters.get("KF").unwrap(), 1.0e-12);
     assert_eq!(jfet_model.polarity, JfetPolarity::Njf);
     assert_close(jfet_model.beta, 9.0e-4);
     assert_close(jfet_model.threshold_voltage, -1.8);
     assert_close(jfet_model.channel_length_modulation, 0.02);
+    assert_close(jfet_model.flicker_noise_coefficient, 1.0e-12);
 
     let mos_card = normalize_model_card(
         "Mn",
@@ -1435,6 +1442,37 @@ fn subcircuit_expansion_preserves_complete_diode_model() {
     assert_close(expanded.series_resistance, 10.0);
     assert_close(expanded.flicker_noise_coefficient, 1.0e-12);
     assert_close(expanded.flicker_noise_exponent, 1.3);
+}
+
+#[test]
+fn subcircuit_expansion_preserves_jfet_flicker_noise_coefficient() {
+    let mut jfet = Jfet::new("Jcell", "d", "g", "s");
+    jfet.flicker_noise_coefficient = 1.0e-12;
+    let mut circuit = Circuit::new();
+    circuit
+        .define_subcircuit(SubcircuitDefinition::new(
+            "jfet-cell",
+            vec!["d".to_string(), "g".to_string(), "s".to_string()],
+            vec![SubcircuitElement::from(Element::Jfet(jfet))],
+        ))
+        .unwrap();
+    circuit
+        .instantiate(XInstance::new(
+            "X1",
+            vec!["d1".to_string(), "g1".to_string(), "0".to_string()],
+            "jfet-cell",
+        ))
+        .unwrap();
+
+    let expanded = circuit
+        .elements()
+        .iter()
+        .find_map(|element| match element {
+            Element::Jfet(jfet) => Some(jfet),
+            _ => None,
+        })
+        .unwrap();
+    assert_close(expanded.flicker_noise_coefficient, 1.0e-12);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -1,7 +1,7 @@
 use spice_engine::{
     device_model_noise_audit_fixtures, format_corner_noise_table, format_noise_table, noise_ac,
     noise_ac_corners, noise_ac_corners_parallel, noise_ac_default, Bjt, Capacitor, Circuit,
-    CornerOverride, CornerSpec, CurrentSource, Diode, Element, Mosfet, MosfetLevel1Params,
+    CornerOverride, CornerSpec, CurrentSource, Diode, Element, Jfet, Mosfet, MosfetLevel1Params,
     MosfetType, NoiseType, Resistor, SpiceError, VoltageSource,
 };
 
@@ -270,6 +270,63 @@ fn diode_flicker_noise_uses_kf_with_inverse_frequency_scaling() {
 
     assert!(flicker_psd(0) > 0.0);
     assert_close(flicker_psd(0) / flicker_psd(1), 100.0, 1.0e-10);
+}
+
+#[test]
+fn jfet_flicker_noise_uses_kf_with_inverse_frequency_scaling() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vdd", "vdd", "0", 5.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 0.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "vdd", "out", 1_000.0,
+    )));
+    let mut jfet = Jfet::with_model(
+        "J1",
+        "out",
+        "gate",
+        "0",
+        spice_engine::JfetPolarity::Njf,
+        1.0e-3,
+        -2.0,
+        0.0,
+    );
+    jfet.flicker_noise_coefficient = 1.0e-12;
+    circuit.add(Element::Jfet(jfet));
+
+    let result = noise_ac(&circuit, "out", "Vgate", &[10.0, 1_000.0], 300.0).unwrap();
+    let flicker_psd = |point_index: usize| {
+        result.points[point_index]
+            .entries
+            .iter()
+            .find(|entry| entry.element_name == "J1" && entry.noise_type == NoiseType::Flicker)
+            .unwrap()
+            .source_psd
+    };
+
+    assert!(flicker_psd(0) > 0.0);
+    assert_close(flicker_psd(0) / flicker_psd(1), 100.0, 1.0e-10);
+}
+
+#[test]
+fn jfet_rejects_invalid_flicker_noise_coefficient() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 0.0,
+    )));
+    let mut jfet = Jfet::new("J1", "out", "gate", "0");
+    jfet.flicker_noise_coefficient = -1.0;
+    circuit.add(Element::Jfet(jfet));
+
+    let error = noise_ac(&circuit, "out", "Vgate", &[1_000.0], 300.0).unwrap_err();
+    assert!(matches!(
+        error,
+        SpiceError::InvalidElement { reason, .. }
+            if reason == "flicker-noise coefficient must be finite and non-negative"
+    ));
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add JFET model-card `KF` flicker-noise support with a distinct drain-current
+  `flicker` contribution and Berkeley-default inverse-frequency scaling.
 - Add diode model-card `AF` flicker-noise current-exponent support, defaulting
   to `1` and applying `KF * abs(Id)^AF / frequency` across noise analysis.
 - Add diode model-card `KF` flicker-noise support with a distinct diode-current

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1695,6 +1695,7 @@ export interface Jfet {
   readonly channelLengthModulation: number;
   readonly gateSourceCapacitance: number;
   readonly gateDrainCapacitance: number;
+  readonly flickerNoiseCoefficient: number;
 }
 
 export type BjtPolarity = "NPN" | "PNP";
@@ -2024,8 +2025,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   D: [15, 21, 5, 3],
   NPN: [41, 58, 13, 4],
   PNP: [41, 58, 13, 4],
-  NJF: [5, 11, 5, 3],
-  PJF: [5, 11, 5, 3],
+  NJF: [6, 12, 5, 3],
+  PJF: [6, 12, 5, 3],
   NMOS: [18, 25, 6, 3],
   PMOS: [18, 25, 6, 3],
 };
@@ -3611,7 +3612,7 @@ function cloneSubcktElement(
     case "diode":
       return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient, element.breakdownVoltage, element.breakdownCurrent, element.junctionCapacitance, element.transitTime, element.junctionPotential, element.gradingCoefficient, element.forwardBiasDepletionCoefficient, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.seriesResistance, element.flickerNoiseCoefficient, element.flickerNoiseExponent);
     case "jfet":
-      return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance);
+      return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance, element.flickerNoiseCoefficient);
     case "bjt":
       return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees, element.forwardTransitTimeBiasCoefficient, element.forwardTransitTimeCurrent, element.forwardTransitTimeVoltage, element.emitterResistance, element.collectorResistance, element.baseResistance, element.minimumBaseResistance, element.baseResistanceHalfCurrent, element.baseCollectorCapacitanceFraction);
     case "mosfet":
@@ -7756,6 +7757,7 @@ export function jfet(
   channelLengthModulation = 0.0,
   gateSourceCapacitance = 0.0,
   gateDrainCapacitance = 0.0,
+  flickerNoiseCoefficient = 0.0,
 ): Jfet {
   return {
     kind: "jfet",
@@ -7769,6 +7771,7 @@ export function jfet(
     channelLengthModulation,
     gateSourceCapacitance,
     gateDrainCapacitance,
+    flickerNoiseCoefficient,
   };
 }
 
@@ -8025,6 +8028,7 @@ const JFET_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   CGS0: "CGS",
   CGD: "CGD",
   CGD0: "CGD",
+  KF: "KF",
 };
 
 const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -8568,6 +8572,7 @@ export function jfetFromModelCard(
     p.LAMBDA ?? 0.0,
     p.CGS ?? 0.0,
     p.CGD ?? 0.0,
+    p.KF ?? 0.0,
   );
 }
 
@@ -18647,6 +18652,16 @@ function collectNoiseSources(
           frequencyExponent: 0.0,
         });
       }
+      if (element.flickerNoiseCoefficient > 0.0) {
+        sources.push({
+          elementName: element.name,
+          noiseType: "flicker",
+          positive: drain,
+          negative: source,
+          sourcePsd: element.flickerNoiseCoefficient * Math.abs(result.drainCurrent),
+          frequencyExponent: 1.0,
+        });
+      }
     } else if (element.kind === "mosfet") {
       validateMosfet(element);
       const drain = nodeIndex(nodeIndices, element.drain);
@@ -19493,6 +19508,12 @@ function validateJfet(element: Jfet): void {
   }
   if (!Number.isFinite(element.gateDrainCapacitance) || element.gateDrainCapacitance < 0.0) {
     throw invalidElement(element.name, "gate-drain capacitance must be finite and non-negative");
+  }
+  if (!Number.isFinite(element.flickerNoiseCoefficient) || element.flickerNoiseCoefficient < 0.0) {
+    throw invalidElement(
+      element.name,
+      "flicker-noise coefficient must be finite and non-negative",
+    );
   }
 }
 

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -120,7 +120,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(143);
+    expect(coverage).toHaveLength(145);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -140,7 +140,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(143);
+    expect(records).toHaveLength(145);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -205,15 +205,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 143,
-      expectedCanonicalParameterCount: 143,
-      acceptedNameCount: 209,
+      canonicalParameterCount: 145,
+      expectedCanonicalParameterCount: 145,
+      acceptedNameCount: 211,
       aliasedParameterCount: 53,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t143\t143\t209\t53\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t145\t145\t211\t53\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -236,8 +236,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(142);
-    expect(report.acceptedNameCount).toBe(206);
+    expect(report.canonicalParameterCount).toBe(144);
+    expect(report.acceptedNameCount).toBe(208);
     expect(report.aliasedParameterCount).toBe(52);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -252,7 +252,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t142\t143\t206\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t144\t145\t208\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -383,13 +383,14 @@ describe("dcOp", () => {
     expectClose(bjtModel.baseCollectorGradingCoefficient, 0.45);
     expectClose(bjtModel.forwardBiasDepletionCoefficient, 0.4);
 
-    const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02 });
+    const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02, KF: 1.0e-12 });
     const jfetModel = jfetFromModelCard("J1", "d", "g", "s", jfetCard);
-    expect(jfetCard.parameters).toStrictEqual({ BETA: 9.0e-4, VTO: -1.8, LAMBDA: 0.02 });
+    expect(jfetCard.parameters).toStrictEqual({ BETA: 9.0e-4, VTO: -1.8, LAMBDA: 0.02, KF: 1.0e-12 });
     expect(jfetModel.polarity).toBe("NJF");
     expectClose(jfetModel.beta, 9.0e-4);
     expectClose(jfetModel.thresholdVoltage, -1.8);
     expectClose(jfetModel.channelLengthModulation, 0.02);
+    expectClose(jfetModel.flickerNoiseCoefficient, 1.0e-12);
 
     const mosCard = normalizeModelCard("Mn", "nmos", {
       LEVEL: 1.0,
@@ -1039,6 +1040,23 @@ describe("dcOp", () => {
     expectClose(expanded.seriesResistance, 10.0);
     expectClose(expanded.flickerNoiseCoefficient, 1.0e-12);
     expectClose(expanded.flickerNoiseExponent, 1.3);
+  });
+
+  it("preserves the JFET flicker-noise coefficient through subcircuit expansion", () => {
+    const circuit = new Circuit();
+    circuit.defineSubcircuit(
+      subcircuitDefinition("jfet-cell", ["d", "g", "s"], [
+        { ...jfet("Jcell", "d", "g", "s"), flickerNoiseCoefficient: 1.0e-12 },
+      ]),
+    );
+    circuit.add(xInstance("X1", ["d1", "g1", "0"], "jfet-cell"));
+
+    const expanded = circuit.elements().find((element) => element.kind === "jfet");
+    expect(expanded?.kind).toBe("jfet");
+    if (expanded?.kind !== "jfet") {
+      throw new Error("expected expanded JFET");
+    }
+    expectClose(expanded.flickerNoiseCoefficient, 1.0e-12);
   });
 
   it("preserves the complete BJT model through subcircuit expansion", () => {

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -9,6 +9,7 @@ import {
   deviceModelNoiseAuditFixtures,
   formatCornerNoiseTable,
   formatNoiseTable,
+  jfet,
   mosfet,
   noiseAc,
   noiseAcCorners,
@@ -20,6 +21,34 @@ const BOLTZMANN = 1.380_649e-23;
 const MOSFET_CHANNEL_NOISE_GAMMA = 2.0 / 3.0;
 
 describe("noiseAc", () => {
+  it("adds inverse-frequency JFET flicker noise from KF", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vdd", "vdd", "0", 5.0));
+    circuit.add(voltageSource("Vgate", "gate", "0", 0.0));
+    circuit.add(resistor("Rload", "vdd", "out", 1_000.0));
+    circuit.add({ ...jfet("J1", "out", "gate", "0"), flickerNoiseCoefficient: 1.0e-12 });
+
+    const result = noiseAc(circuit, "out", "Vgate", [10.0, 1_000.0], 300.0);
+    const flickerPsds = result.points.map((point) =>
+      point.entries.find(
+        (entry) => entry.elementName === "J1" && entry.noiseType === "flicker",
+      )!.sourcePsd
+    );
+
+    expect(flickerPsds[0]).toBeGreaterThan(0.0);
+    expect(flickerPsds[0]! / flickerPsds[1]!).toBeCloseTo(100.0, 10);
+  });
+
+  it("rejects an invalid JFET flicker-noise coefficient", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vgate", "gate", "0", 0.0));
+    circuit.add({ ...jfet("J1", "out", "gate", "0"), flickerNoiseCoefficient: -1.0 });
+
+    expect(() => noiseAc(circuit, "out", "Vgate", [1_000.0])).toThrow(
+      /flicker-noise coefficient must be finite and non-negative/,
+    );
+  });
+
   it("adds thermal noise for diode series resistance", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vbias", "bias", "0", 1.0));

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language diode flicker-noise current exponent.
+1. Cross-language JFET flicker-noise coefficient.
    - Status: current PR completion candidate.
-   - Add Berkeley diode `AF` model-card support in Rust, Python, and TypeScript,
-     defaulting to one and applying it to the existing diode-current flicker
-     source as `KF * abs(Id)^AF / frequency`.
-   - Preserve `AF` through hierarchy, temperature, sensitivity, and Monte Carlo
-     cloning while validating finite non-negative values in every engine.
-   - Extend the supported-parameter coverage gate from 142 to 143 canonical
-     rows and lock current-exponent behavior in all engines.
+   - Add Berkeley JFET `KF` model-card support in Rust, Python, and TypeScript,
+     defaulting to zero and emitting a distinct drain-current flicker source as
+     `KF * abs(Id) / frequency`.
+   - Preserve `KF` through hierarchy and cloning while validating finite
+     non-negative values in every engine.
+   - Extend the supported-parameter coverage gate from 143 to 145 canonical
+     rows and lock inverse-frequency noise scaling in all engines.
 
 ## Completed Slices
 
@@ -3236,6 +3236,14 @@ the Rust, Python, and TypeScript surfaces together.
    - Hierarchy and cloning paths preserve `KF`, finite non-negative validation
      is shared across analyses, and the supported-parameter release gate now
      covers 142 canonical rows.
+
+248. Cross-language diode flicker-noise current exponent.
+   - Status: completed in PR 8902.
+   - Rust, Python, and TypeScript diode model cards now accept `AF`, default it
+     to one, and apply `KF * abs(Id)^AF / frequency` to diode flicker noise.
+   - Hierarchy and cloning paths preserve `AF`, finite non-negative validation
+     is shared across analyses, and the supported-parameter release gate now
+     covers 143 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley JFET `KF` model-card support across Rust, Python, and TypeScript
- emit validated drain-current flicker noise with inverse-frequency scaling and preserve `KF` through subcircuit expansion
- advance the supported-parameter gate to 145 rows and reconcile the SPICE completion plan after diode `AF`

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo check -p spice-engine`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python Ruff check on touched files
- Python full package tests: 587 passed, 88.74% coverage
- TypeScript `npm run build`
- TypeScript full package tests: 345 passed