### PR TITLE
feat(hl03): "Reset progress" — a two-click way to start over

### DIFF
--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.14.0 — start over: a "Reset progress" control (HL03 polish)
+
+- **You can now clear your progress.** The app persists a lot — the review
+  quiz's SRS state and answer log, the teaching cursor, and the lesson schedule —
+  but had no way to wipe it (handing the tab to someone else, or re-walking from
+  the top). A quiet **"Reset progress"** control sits at the foot of the Learn
+  view; it's a **two-click confirm** (first click arms *"Clear all progress…?"*
+  with Yes / Cancel, second executes) so a stray tap can't erase everything.
+- New pure `src/reset.ts`: `OWNED_STORAGE_KEYS` sources the three keys from the
+  modules that own them (so the list can't drift from what's actually written),
+  and `clearProgress(storage)` removes exactly those — **only keys this app
+  owns**, guarded per-key so one locked key can't turn "start over" into a crash.
+  Executing also resets the in-memory session to concept 0 with an empty review.
+- 6 new tests (225 total) with a control that bites: a `clearProgress` that
+  missed any owned key leaves it behind and fails; unowned keys are left
+  untouched; a throwing `removeItem` still clears the rest. Verified in a real
+  browser — both the link and the armed *"Yes, reset / Cancel"* state render.
+
 ## 0.13.0 — the Learn walk resumes where you left off (HL03 phase 7b)
 
 - **The teaching cursor now persists.** Review progress and the lesson schedule

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -48,6 +48,10 @@ to is saved on each Prev/Next and restored at startup, so the app resumes where
 you left off rather than back at the first concept. The restored index is
 clamped to the current spine, and a bad blob falls back to the start.
 
+A quiet **"Reset progress"** control at the foot of the Learn view clears it all
+(`reset.ts` — only the keys this app owns), behind a two-click confirm so a stray
+tap can't wipe everything.
+
 ## Concepts mode
 
 The curriculum tags lessons with a shared `concept_tag`, and canonical tags are

--- a/code/programs/typescript/language-ladder/package.json
+++ b/code/programs/typescript/language-ladder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ladder",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "description": "The unified curriculum learning app (HL03): walk the language chain concept by concept, seeing the threads back to what you already know, then review it all with a randomised SRS quiz. (Was the HL02 script-writing-visualizer, whose Browse/Practice/Lessons/Concepts modes it now subsumes.)",
   "type": "module",

--- a/code/programs/typescript/language-ladder/src/main.ts
+++ b/code/programs/typescript/language-ladder/src/main.ts
@@ -41,6 +41,7 @@ import { pickNext as pickReviewCell, makeRng, cellKey, type GridCell } from "./q
 import { confusions } from "./mistakes.ts";
 import { loadReview, saveReview } from "./reviewstore.ts";
 import { loadCursor, saveCursor } from "./cursorstore.ts";
+import { clearProgress, removableStorage } from "./reset.ts";
 import {
   scriptsById,
   firstIntroductionByScript,
@@ -63,6 +64,7 @@ import taxonomyJson from "../../../../learning/human-languages/concepts/taxonomy
 import type { Taxonomy } from "@coding-adventures/human-language-data/src/types.ts";
 import {
   browserStorage,
+  emptyProgress,
   fromSaved,
   loadProgress,
   saveProgress,
@@ -162,6 +164,10 @@ let reviewChosen: string | null = null; // cellKey of the picked option; null = 
 // from storage, clamped to the current spine (the curriculum may have grown or
 // shrunk since the save). A missing/corrupt value starts at 0.
 conceptCursor = loadCursor(REVIEW_STORAGE, CONCEPT_SPINE.length);
+
+// "Reset progress" is a two-click confirm: the first click ARMS it (so a stray
+// tap can't wipe everything), the second executes. This flag is that arming.
+let resetArmed = false;
 
 // Constant for the page's lifetime: lesson indices grouped by language, and the
 // round-robin pool over those groups. Computing them once is why consecutive
@@ -757,6 +763,65 @@ function renderLearn(): HTMLElement {
   // The review pass: a cumulative, SRS-weighted quiz over everything covered so
   // far (this concept and all before it). `plan.reviewGrid` is exactly that grid.
   wrap.appendChild(renderReview(plan.reviewGrid));
+
+  // A quiet way to start over — clears every persisted key, two-click confirmed.
+  wrap.appendChild(renderReset());
+  return wrap;
+}
+
+/** Clear all persisted progress and reset the in-memory session to the start. */
+function executeReset(): void {
+  clearProgress(removableStorage());
+  // Review + teaching cursor.
+  reviewProgress = { states: new Map(), log: [] };
+  reviewSession = 0;
+  reviewCell = null;
+  reviewOptions = [];
+  reviewChosen = null;
+  conceptCursor = 0;
+  // The Lessons-mode schedule is one of the cleared keys, so its in-memory state
+  // must be zeroed too — otherwise Lessons still shows the old stats and the next
+  // grade would `persistLessons()` the stale schedule straight back into the key
+  // we just wiped, defeating the reset until a reload.
+  savedProgress = emptyProgress();
+  lessonSchedule = fromSaved(LESSON_IDS, savedProgress);
+  lessonSession = savedProgress.session;
+  lessonIndex = null;
+  lessonRevealed = false;
+  lessonCursor = -1;
+  resetArmed = false;
+  render();
+}
+
+/**
+ * The "Reset progress" footer — a two-click confirm so a stray tap can't wipe
+ * everything. First click arms it (swaps in a warning + Yes/Cancel); the second
+ * (Yes) executes; Cancel disarms.
+ */
+function renderReset(): HTMLElement {
+  const wrap = el("div", "learn__reset");
+  if (!resetArmed) {
+    const btn = el("button", "reset-link") as HTMLButtonElement;
+    btn.textContent = "Reset progress";
+    btn.onclick = () => {
+      resetArmed = true;
+      render();
+    };
+    wrap.appendChild(btn);
+    return wrap;
+  }
+  const warn = el("span", "reset-warn");
+  warn.textContent = "Clear all progress — review, mistakes, and your place in the walk?";
+  const yes = el("button", "reset-yes") as HTMLButtonElement;
+  yes.textContent = "Yes, reset";
+  yes.onclick = () => executeReset();
+  const cancel = el("button", "reset-cancel") as HTMLButtonElement;
+  cancel.textContent = "Cancel";
+  cancel.onclick = () => {
+    resetArmed = false;
+    render();
+  };
+  wrap.append(warn, yes, cancel);
   return wrap;
 }
 

--- a/code/programs/typescript/language-ladder/src/reset.ts
+++ b/code/programs/typescript/language-ladder/src/reset.ts
@@ -1,0 +1,59 @@
+// ---------------------------------------------------------------------------
+// reset.ts — starting over.
+//
+// The app now remembers a lot between visits: the review quiz's SRS state and
+// answer log (reviewstore.ts), the teaching cursor (cursorstore.ts), and the
+// lesson schedule (progress.ts). That is good — until you want a clean slate
+// (you're handing the tab to someone else, or you want to re-walk from the top).
+// There was no way to clear it. This is that way.
+//
+// The rule that keeps this safe: clear ONLY the keys this app owns. We import
+// the canonical key constants from the modules that own them rather than
+// re-typing the strings, so the list can never drift out of sync with what is
+// actually written. Everything here is pure over a tiny storage port, so "did we
+// clear every owned key?" is unit-testable without a browser.
+// ---------------------------------------------------------------------------
+
+import { STORAGE_KEY as LESSON_SCHEDULE_KEY } from "./progress.ts";
+import { REVIEW_STORAGE_KEY } from "./reviewstore.ts";
+import { CURSOR_STORAGE_KEY } from "./cursorstore.ts";
+
+/**
+ * Every localStorage key this app owns. Sourced from the owning modules'
+ * exported constants so it stays in lockstep with what is written — add a new
+ * persisted key there and it is removed here for free (once added to this list).
+ */
+export const OWNED_STORAGE_KEYS: readonly string[] = [
+  REVIEW_STORAGE_KEY,
+  CURSOR_STORAGE_KEY,
+  LESSON_SCHEDULE_KEY,
+];
+
+/** The slice of the Storage API a reset needs — just removal. Easy to fake. */
+export interface RemovableStorage {
+  removeItem(key: string): void;
+}
+
+/**
+ * Remove every owned key. Silent per-key on failure (a locked/So-full storage
+ * shouldn't turn "start over" into a crash), and a null storage is a no-op.
+ */
+export function clearProgress(storage: RemovableStorage | null): void {
+  if (!storage) return;
+  for (const key of OWNED_STORAGE_KEYS) {
+    try {
+      storage.removeItem(key);
+    } catch {
+      /* keep going — clearing the rest still helps */
+    }
+  }
+}
+
+/** `localStorage` (which supports removeItem) when available, else null. */
+export function removableStorage(): RemovableStorage | null {
+  try {
+    return typeof localStorage === "undefined" ? null : localStorage;
+  } catch {
+    return null;
+  }
+}

--- a/code/programs/typescript/language-ladder/src/styles.css
+++ b/code/programs/typescript/language-ladder/src/styles.css
@@ -372,3 +372,43 @@ body {
 }
 .confusions__list { margin: 0; padding-left: 18px; }
 .confusions__list li { font-size: 0.9rem; line-height: 1.6; }
+
+/* "Reset progress" footer — a quiet, two-click destructive control. */
+.learn__reset {
+  margin-top: 28px;
+  padding-top: 14px;
+  border-top: 1px solid var(--line);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.reset-link {
+  border: 0;
+  background: none;
+  color: var(--muted);
+  font-size: 0.8rem;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 2px 0;
+}
+.reset-link:hover { color: var(--ff); }
+.reset-warn { font-size: 0.85rem; color: var(--ink); }
+.reset-yes {
+  border: 1px solid var(--ff);
+  background: var(--ff);
+  color: #fff;
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+.reset-cancel {
+  border: 1px solid var(--line);
+  background: var(--card);
+  color: var(--ink);
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-size: 0.82rem;
+  cursor: pointer;
+}

--- a/code/programs/typescript/language-ladder/tests/reset.test.ts
+++ b/code/programs/typescript/language-ladder/tests/reset.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import {
+  OWNED_STORAGE_KEYS,
+  clearProgress,
+  type RemovableStorage,
+} from "../src/reset";
+import { REVIEW_STORAGE_KEY } from "../src/reviewstore";
+import { CURSOR_STORAGE_KEY } from "../src/cursorstore";
+import { STORAGE_KEY as LESSON_SCHEDULE_KEY } from "../src/progress";
+
+function fakeStore(seed: Record<string, string> = {}): RemovableStorage & {
+  data: Map<string, string>;
+} {
+  const data = new Map(Object.entries(seed));
+  return { data, removeItem: (k) => void data.delete(k) };
+}
+
+describe("OWNED_STORAGE_KEYS", () => {
+  it("lists exactly the three keys the app persists, sourced from their owners", () => {
+    // If a persisted key were forgotten here, a reset would silently leave state
+    // behind — so pin the set explicitly.
+    expect(new Set(OWNED_STORAGE_KEYS)).toEqual(
+      new Set([REVIEW_STORAGE_KEY, CURSOR_STORAGE_KEY, LESSON_SCHEDULE_KEY]),
+    );
+  });
+});
+
+describe("clearProgress", () => {
+  it("removes every owned key", () => {
+    const store = fakeStore({
+      [REVIEW_STORAGE_KEY]: "r",
+      [CURSOR_STORAGE_KEY]: "c",
+      [LESSON_SCHEDULE_KEY]: "l",
+    });
+    clearProgress(store);
+    expect(store.data.size).toBe(0);
+  });
+
+  it("CONTROL: fails loudly if any owned key is left behind", () => {
+    // Reconstruct the store, clear it, and assert NONE of the owned keys survive.
+    // A clearProgress that missed (say) the cursor key would leave it in `data`
+    // and fail this assertion — the check the OWNED list exists to guarantee.
+    const seed: Record<string, string> = {};
+    for (const k of OWNED_STORAGE_KEYS) seed[k] = "x";
+    const store = fakeStore(seed);
+    clearProgress(store);
+    for (const k of OWNED_STORAGE_KEYS) {
+      expect(store.data.has(k)).toBe(false);
+    }
+  });
+
+  it("leaves keys the app does NOT own untouched", () => {
+    const store = fakeStore({
+      [REVIEW_STORAGE_KEY]: "r",
+      "someone-elses-key": "keep me",
+    });
+    clearProgress(store);
+    expect(store.data.has(REVIEW_STORAGE_KEY)).toBe(false);
+    expect(store.data.get("someone-elses-key")).toBe("keep me");
+  });
+
+  it("a null storage is a no-op, not a crash", () => {
+    expect(() => clearProgress(null)).not.toThrow();
+  });
+
+  it("keeps clearing even if one removeItem throws", () => {
+    const data = new Map<string, string>(OWNED_STORAGE_KEYS.map((k) => [k, "x"]));
+    const flaky: RemovableStorage = {
+      removeItem: (k) => {
+        if (k === CURSOR_STORAGE_KEY) throw new Error("locked");
+        data.delete(k);
+      },
+    };
+    clearProgress(flaky);
+    // the throwing key remains, but the others were still cleared
+    expect(data.has(CURSOR_STORAGE_KEY)).toBe(true);
+    expect(data.has(REVIEW_STORAGE_KEY)).toBe(false);
+    expect(data.has(LESSON_SCHEDULE_KEY)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

The app persists a lot now — the review quiz's SRS state + answer log, the teaching cursor, and the lesson schedule — but had **no way to clear it** (handing the tab to someone else, or re-walking from the top). This adds a quiet **"Reset progress"** control at the foot of the Learn view, behind a **two-click confirm** (first click arms *"Clear all progress…?"* with Yes / Cancel, second executes) so a stray tap can't wipe everything.

- New pure `src/reset.ts`: `OWNED_STORAGE_KEYS` sources the three keys from the modules that own them (no duplicated strings — the list can't drift from what's actually written), and `clearProgress(storage)` removes exactly those, guarded per-key so one locked key can't turn "start over" into a crash. **Only keys this app owns** are touched.
- `executeReset` clears storage **and zeroes all in-memory state** — review, cursor, **and the Lessons-mode schedule**. The last one matters: the lesson schedule is one of the cleared keys, so leaving `lessonSchedule`/`lessonSession`/`savedProgress` stale would show old stats in Lessons mode and re-persist the stale schedule on the next grade, defeating the reset until reload — **caught in review and fixed** before this PR.

## Verification

- **6 new tests (225 total)** with a control that bites: a `clearProgress` that missed any owned key leaves it behind and fails; unowned keys are untouched; a throwing `removeItem` still clears the rest.
- **Real browser** (headless screenshot, read back): both the subtle **"Reset progress"** link and the armed **"Clear all progress…? / Yes, reset / Cancel"** state render correctly.
- Correctness/security review (subagent): clean apart from the stale-lesson-state issue above, which is fixed.

## Scope

The reset control. Next candidates: romanization on the review-quiz options for non-Latin scripts; a spine progress indicator.

Builds on #8905 (Learn walk resume, merged).