### PR TITLE
fix: audit semantic-ir-to-* backends' reserved-word lists for gaps beyond eval/arguments (front1, task #116)

### DIFF
--- a/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.10.1 — `is_python_keyword` missing two of Python's four soft keywords (task #116 audit)
+
+Follow-up to task #110/#112 (`semantic-ir-to-javascript`/`-typescript`'s
+`eval`/`arguments` gap): a broader audit of every `semantic-ir-to-*`
+backend's reserved-word check for the same class of bug — a contextual
+keyword, reserved only in some grammar positions, missing from the
+identifier-safety list.
+
+`is_python_keyword` (`emit.rs`) already treated `match` and `case` as
+unsafe defensively, even though neither is a syntactic keyword — both are
+"soft keywords" (`keyword.softkwlist`), reserved only inside a `match`
+statement's own grammar, and otherwise ordinary identifiers. But Python's
+official soft-keyword set has *four* entries, not two: `_`, `case`,
+`match`, `type` (`_` and `match`/`case` since 3.10's structural pattern
+matching, PEP 634-636; `type` since 3.12's type-alias statement, PEP
+695). `_` and `type` were missing, so a SIR identifier named `_` or
+`type` was previously emitted verbatim by `sanitize_ident` instead of
+being suffixed.
+
+Fixed by adding both to the existing soft-keyword group in
+`is_python_keyword`'s `matches!` list (same style as the existing
+`match`/`case` entries; no restructuring). New unit test
+`is_python_keyword_flags_remaining_soft_keywords` pins both as reserved,
+confirms `sanitize_ident` suffixes them (`_` → `__`, `type` → `type_`),
+and confirms ordinary look-alike identifiers (`_x`, `typing`, `types`)
+are untouched.
+
 ## 0.10.0 — operator-spelling comparisons: `==`, `!=`, `<=`, `>=`
 
 The Ruby frontend lowers a comparison chain to `==`/`!=`/`<=`/`>=` builtins,

--- a/code/packages/rust/semantic-ir-to-python/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-python"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 description = "Semantic IR → self-contained Python 3 source code (SIR14). Third backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -2165,8 +2165,19 @@ fn is_python_keyword(s: &str) -> bool {
             | "while"
             | "with"
             | "yield"
+            // Soft keywords (`keyword.softkwlist`): not syntactic keywords —
+            // freely usable as ordinary identifiers everywhere outside a
+            // narrow grammar position (`match`/`case` in a `match`
+            // statement since 3.10; `_` as a wildcard capture pattern since
+            // 3.10; `type` in a `type X = ...` alias statement since
+            // 3.12's PEP 695). This backend already treated `match`/`case`
+            // as unsafe defensively; `_` and `type` are the other two
+            // entries of the same official soft-keyword set and were
+            // missing.
             | "match"
             | "case"
+            | "_"
+            | "type"
     )
 }
 
@@ -2219,6 +2230,27 @@ mod tests {
         let r = sanitize_ident("null?");
         assert!(r.starts_with('_'));
         assert!(r.contains("null"));
+    }
+
+    #[test]
+    fn is_python_keyword_flags_remaining_soft_keywords() {
+        // `_` and `type` are the other two entries of Python's
+        // `keyword.softkwlist` (`_`, `case`, `match`, `type`) — this
+        // backend already treated `match`/`case` as unsafe; `_` and
+        // `type` were missing.
+        assert!(is_python_keyword("_"));
+        assert!(is_python_keyword("type"));
+        assert!(sanitize_ident("_").starts_with('_'));
+        assert_eq!(sanitize_ident("_"), "__");
+        assert_eq!(sanitize_ident("type"), "type_");
+
+        // Ordinary identifiers — including close look-alikes — are
+        // unaffected by the addition.
+        assert!(!is_python_keyword("_x"));
+        assert!(!is_python_keyword("typing"));
+        assert!(!is_python_keyword("types"));
+        assert_eq!(sanitize_ident("_x"), "_x");
+        assert_eq!(sanitize_ident("typing"), "typing");
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.13.1 — `is_ruby_keyword` missing `__ENCODING__` (task #116 audit)
+
+Follow-up to task #110/#112 (`semantic-ir-to-javascript`/`-typescript`'s
+`eval`/`arguments` gap): a broader audit of every `semantic-ir-to-*`
+backend's reserved-word check for the same class of bug.
+
+`is_ruby_keyword` (`emit.rs`) already listed two of Ruby's three
+magic-constant keywords, `__FILE__` and `__LINE__`, but not the third,
+`__ENCODING__`. All three are genuine lexical keywords, not plain
+identifiers — `__ENCODING__ = 5` is a `SyntaxError` under MRI (verified
+against Ruby 3.4.9), exactly like `__FILE__ = 5` or `__LINE__ = 5`. A
+SIR identifier named `__ENCODING__` was previously emitted verbatim by
+`sanitize_ident` instead of being suffixed.
+
+Fixed by adding `__ENCODING__` to the existing magic-constant group in
+`is_ruby_keyword`'s `matches!` list (same style as the existing
+`__FILE__`/`__LINE__` entries; no restructuring). New test
+`sanitize_ident_flags_encoding_magic_constant`
+(`tests/emit_tests.rs`) pins it as reserved and confirms ordinary
+look-alike identifiers (`encoding`, `__encoding__`) are untouched.
+
 ## 0.13.0 — classes slice 3: instance variables (@ivars) + self
 
 Accepts `Feature::InstanceVars` — an instance variable read and write, plus the

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -1345,6 +1345,13 @@ fn is_ruby_keyword(s: &str) -> bool {
             | "yield"
             | "__FILE__"
             | "__LINE__"
+            // `__ENCODING__` is the third of Ruby's three magic-constant
+            // keywords (alongside `__FILE__`/`__LINE__` above) — a real
+            // lexical keyword, not a plain identifier: `__ENCODING__ = 5`
+            // is a `SyntaxError` (verified against MRI/Ruby 3.4), exactly
+            // like the other two. It was missing from this list even
+            // though its two siblings were already here.
+            | "__ENCODING__"
             | "__method__"
             | "lambda"
             | "proc"

--- a/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
@@ -123,6 +123,21 @@ fn sanitize_ident_handles_keywords_and_namespace() {
     assert_eq!(sanitize_ident("Foo"), "_Foo"); // locals may not start uppercase
 }
 
+#[test]
+fn sanitize_ident_flags_encoding_magic_constant() {
+    // `__ENCODING__` is Ruby's third magic-constant keyword, alongside
+    // `__FILE__`/`__LINE__` (which were already covered here) —
+    // `__ENCODING__ = 5` is a SyntaxError under MRI, confirmed against
+    // Ruby 3.4. It was missing from `is_ruby_keyword`'s list even though
+    // its two siblings were already present.
+    assert_eq!(sanitize_ident("__ENCODING__"), "__ENCODING___");
+
+    // Ordinary identifiers — including close look-alikes — are
+    // unaffected by the addition.
+    assert_eq!(sanitize_ident("encoding"), "encoding");
+    assert_eq!(sanitize_ident("__encoding__"), "__encoding__");
+}
+
 // ── end-to-end (skips when `ruby` is absent) ────────────────────────────────
 
 #[test]

--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 0.39.1 — `is_rust_keyword` missing `crate`/`extern`/`self`/`Self`/`super` (task #116 audit)
+
+Follow-up to task #110/#112 (`semantic-ir-to-javascript`/`-typescript`'s
+`eval`/`arguments` gap): a broader audit of every `semantic-ir-to-*`
+backend's reserved-word check for the same class of bug.
+
+`is_rust_keyword` (`emit.rs`) already carried a comment explaining that
+`crate`/`self`/`super`/`extern` can't be wrapped in `r#` raw-identifier
+syntax and need to fall back to the underscore-encoded form instead —
+but the mechanism it used (having `is_rust_keyword` return `false` for
+these words) didn't work: `sanitize_ident`'s first branch,
+`is_valid_rust_ident(s) && !is_rust_keyword(s)`, was then *true* for all
+of them (they're valid identifier shapes and, per `is_rust_keyword`,
+apparently not keywords), so they were passed straight through
+unmodified — the exact bug class this audit targets. Verified against
+rustc 1.97: a bare `let self = 5;` / `let crate = 5;` / `let super = 5;`
+/ `let extern = 5;` is a compile error in every case, so all four (plus
+`Self`, which was also entirely absent from the list) are genuine
+reserved words.
+
+`Self`/`self`/`super`/`crate` additionally cannot be raw identifiers at
+all — `r#self`, `r#Self`, `r#super`, and `r#crate` are each rejected by
+rustc with "cannot be a raw identifier" (they carry path-resolution
+meaning `r#` can't override), unlike ordinary keywords such as `extern`
+where `r#extern` compiles fine (verified empirically).
+
+Fixed in two parts, keeping `is_rust_keyword`'s shape unchanged:
+- Added `crate`, `extern`, `self`, `Self`, `super` to `is_rust_keyword`'s
+  `matches!` list, so all five are now correctly recognized as keywords.
+- Added a small `is_raw_incompatible_keyword` helper (`self`, `Self`,
+  `super`, `crate`) that `sanitize_ident` checks before choosing between
+  the `r#` path and the underscore-encoded fallback, so those four route
+  to the fallback (`self` → `__self`, etc.) instead of generating
+  invalid `r#self`-style output; `extern` takes the normal `r#extern`
+  path like any other keyword.
+
+New unit test
+`is_rust_keyword_flags_path_keywords_missing_from_the_original_list`
+pins all five as reserved, confirms `extern` raw-encodes while the other
+four fall back to underscore-encoding, and confirms ordinary look-alike
+identifiers (`crate_name`, `myself`, `superclass`) are untouched. The
+existing `compile_and_run_*` integration tests (which shell out to
+`rustc`) continue to pass, confirming the fallback path still produces
+compilable Rust.
+
 ## 0.39.0 — operator-spelling comparisons: `==`, `!=`, `<=`, `>=`
 
 The Ruby frontend lowers a comparison chain to operator-spelling builtins

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.39.0"
+version = "0.39.1"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -2334,11 +2334,15 @@ pub fn sanitize_ident(s: &str) -> String {
     if is_valid_rust_ident(s) && !is_rust_keyword(s) {
         return s.to_string();
     }
-    if is_rust_keyword(s) {
+    if is_rust_keyword(s) && !is_raw_incompatible_keyword(s) {
         // Raw-identifier syntax — keeps the original spelling
         // visible in tooling.
         return format!("r#{}", s);
     }
+    // Either not a valid identifier shape, or a keyword that raw-identifier
+    // syntax cannot represent (`self` / `Self` / `super` / `crate` — rustc
+    // rejects `r#self` etc. outright with "cannot be a raw identifier",
+    // verified against rustc 1.97), so hex-encode instead.
     let mut out = String::with_capacity(s.len() + 4);
     out.push('_'); // prefix so the result never starts with a digit
     out.push('_');
@@ -2350,6 +2354,15 @@ pub fn sanitize_ident(s: &str) -> String {
         }
     }
     out
+}
+
+/// The subset of `is_rust_keyword` that raw-identifier syntax cannot
+/// represent. rustc special-cases these because they carry path-resolution
+/// meaning `r#` can't override — `r#self`, `r#Self`, `r#super`, and
+/// `r#crate` are all hard compile errors ("cannot be a raw identifier"),
+/// unlike ordinary keywords (e.g. `r#extern`, `r#fn`) which raw-encode fine.
+fn is_raw_incompatible_keyword(s: &str) -> bool {
+    matches!(s, "self" | "Self" | "super" | "crate")
 }
 
 fn is_valid_rust_ident(s: &str) -> bool {
@@ -2370,19 +2383,21 @@ fn is_valid_rust_ident(s: &str) -> bool {
 }
 
 fn is_rust_keyword(s: &str) -> bool {
-    // 2021-edition keywords + reserved.  `r#` raw-identifier
-    // syntax can wrap most of these; some (`crate`, `self`,
-    // `super`, `extern`) cannot — for those we fall back to the
-    // underscore-encoded form below by ALSO returning `false`
-    // here.  In v0 we accept the `r#` form for all common
-    // keywords; the few un-raw-able ones get encoded.
+    // 2021-edition strict + reserved keywords (The Rust Reference,
+    // "Keywords" chapter). `r#` raw-identifier syntax can wrap most of
+    // these; `self`/`Self`/`super`/`crate` cannot (verified against
+    // rustc 1.97 — see `is_raw_incompatible_keyword`, which routes those
+    // four to the underscore-encoded fallback in `sanitize_ident`
+    // instead of `r#`.
     matches!(
         s,
         "as" | "break"
             | "const"
             | "continue"
+            | "crate"
             | "else"
             | "enum"
+            | "extern"
             | "false"
             | "fn"
             | "for"
@@ -2398,8 +2413,11 @@ fn is_rust_keyword(s: &str) -> bool {
             | "pub"
             | "ref"
             | "return"
+            | "self"
+            | "Self"
             | "static"
             | "struct"
+            | "super"
             | "trait"
             | "true"
             | "type"
@@ -2479,6 +2497,41 @@ mod tests {
     fn sanitize_uses_raw_for_keywords() {
         assert_eq!(sanitize_ident("fn"), "r#fn");
         assert_eq!(sanitize_ident("type"), "r#type");
+    }
+
+    #[test]
+    fn is_rust_keyword_flags_path_keywords_missing_from_the_original_list() {
+        // `crate`, `extern`, `self`, `Self`, and `super` are genuine Rust
+        // keywords (a bare `let self = 5;` etc. is a compile error under
+        // rustc 1.97) but were missing from `is_rust_keyword`, so
+        // `sanitize_ident` passed them through completely unmodified
+        // (`is_valid_rust_ident(s) && !is_rust_keyword(s)` was true for
+        // all five).
+        assert!(is_rust_keyword("crate"));
+        assert!(is_rust_keyword("extern"));
+        assert!(is_rust_keyword("self"));
+        assert!(is_rust_keyword("Self"));
+        assert!(is_rust_keyword("super"));
+
+        // `extern` raw-encodes fine, like the pre-existing entries.
+        assert_eq!(sanitize_ident("extern"), "r#extern");
+
+        // `self`/`Self`/`super`/`crate` cannot be raw identifiers (rustc
+        // rejects `r#self` etc. outright), so they must fall back to the
+        // underscore-encoded form instead of `r#`.
+        assert_eq!(sanitize_ident("self"), "__self");
+        assert_eq!(sanitize_ident("Self"), "__Self");
+        assert_eq!(sanitize_ident("super"), "__super");
+        assert_eq!(sanitize_ident("crate"), "__crate");
+
+        // Ordinary identifiers — including close look-alikes — are
+        // unaffected by the addition.
+        assert!(!is_rust_keyword("crate_name"));
+        assert!(!is_rust_keyword("myself"));
+        assert!(!is_rust_keyword("superclass"));
+        assert_eq!(sanitize_ident("crate_name"), "crate_name");
+        assert_eq!(sanitize_ident("myself"), "myself");
+        assert_eq!(sanitize_ident("superclass"), "superclass");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

front1 hardening task following the exact pattern of #8891/#8893 (tasks #110/#112): those PRs each independently found the same class of bug — a contextual/strict-mode reserved word missing from a backend's identifier-safety check — in `semantic-ir-to-javascript`'s `is_js_reserved` and `semantic-ir-to-typescript`'s `is_ts_reserved` (both missing `eval`/`arguments`). This PR audits every OTHER `semantic-ir-to-*` backend for the same class of gap.

**Audited all 7 backends** (c, go, javascript, python, ruby, rust, typescript; JS/TS excluded since already fixed):

**Genuine gaps found and fixed (3 backends):**
- **`semantic-ir-to-python`**: `is_python_keyword` already flagged soft keywords `match`/`case` but was missing the other two entries of Python's official `keyword.softkwlist` — `_` and `type`. Verified via `python3 -c "import keyword; print(keyword.softkwlist)"` → `['_', 'case', 'match', 'type']`.
- **`semantic-ir-to-ruby`**: `is_ruby_keyword` had two of Ruby's three magic-constant keywords (`__FILE__`, `__LINE__`) but not the third, `__ENCODING__`. Verified against Ruby 3.4.9: `__ENCODING__ = 5` is a `SyntaxError` ("Can't assign to __ENCODING__"), identical to the other two.
- **`semantic-ir-to-rust`** (most severe finding): the code's own comment already described `crate`/`self`/`super`/`extern` as needing special handling, but the mechanism was broken — `sanitize_ident`'s first branch was true for all of them, so they passed through **completely unsanitized**. Verified against real `rustc 1.97`: bare `let self/crate/super/extern = ...` all fail to compile, and `r#self`/`r#Self`/`r#super`/`r#crate` are separately rejected by rustc ("cannot be a raw identifier") while `r#extern` compiles fine. Fixed by adding all five (`crate`, `extern`, `self`, `Self`, `super`) to the keyword list, with a new `is_raw_incompatible_keyword` helper routing the four raw-incompatible words to the existing hex-fallback path instead of generating invalid `r#self`-style output.

**Verified complete, no changes made:**
- **`semantic-ir-to-go`**: all 25 official Go keywords present; predeclared identifiers (legally shadowable, not true keywords) already covered defensively anyway.
- **`semantic-ir-to-c`**: all 37 ISO C99 keywords present (crate targets C99 only, confirmed via its own README/tests), plus defensive `bool`/`true`/`false`/`NULL` entries.

## Test plan

- [x] Independently re-ran all three touched crates' test suites (not just agent-reported): `semantic-ir-to-python` 101/101 pass, `semantic-ir-to-ruby` 84/84 pass, `semantic-ir-to-rust` 125 unit tests + 24 `compile_and_run_*` integration test files (which shell out to real `rustc` to compile and execute generated code) all pass
- [x] Independently verified every factual claim directly against real toolchains before trusting the fix: `rustc 1.97` confirms `r#self`/`r#Self`/`r#super`/`r#crate` are rejected ("cannot be a raw identifier") while `r#extern` compiles; `python3`'s own `keyword.softkwlist` matches the claimed `['_', 'case', 'match', 'type']`; `ruby 3.4.9` confirms `__ENCODING__ = 5` raises `SyntaxError` identically to `__FILE__`/`__LINE__`
- [x] `/security-review` — passed clean; reviewer traced the full `sanitize_ident` control-flow paths in all three backends and confirmed every newly-flagged keyword routes through an existing sanitization path (no gap where a flagged keyword falls through unmodified), and that the fix strictly narrows (never widens) the set of identifiers emitted verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)