### PR TITLE
feat(adj-formula-stdlib): pressure — P = F/A definition formula library (physics track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_pressure_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_pressure_e2e.rs
@@ -1,0 +1,109 @@
+//! End-to-end tests for the `physics/pressure.adj` library — the definition of
+//! pressure (P = F/A) and its exact rearrangement (F = P·A) — driven through the
+//! built CLI binary against the SHIPPED stdlib. Each proves the same invariant as
+//! the other formula libraries: a consumer states NO arithmetic; it imports the
+//! grounded library, binds the mechanical quantities with `observe`, and the engine
+//! applies the cited definition on the CPU — computing the EXACT value and rendering
+//! the definition's citation + trust tier in the `derived` section (the auditable
+//! answer). The two formulas INVERT: 50 N / 2 m² = 25 Pa, and 25 Pa · 2 m² = 50 N.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped pressure library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_pressure_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/physics/pressure.adj")
+        .canonicalize()
+        .expect("shipped pressure.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_press_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_pressure_lib()).unwrap();
+    std::fs::write(dir.join("pressure.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// pressure — the definition: the force divided by the area.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_pressure_library_and_computes_definition_with_citation() {
+    let dir = scratch("def");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"pressure.adj\"\n\
+         observe force(50)\n\
+         observe area(2)\n\
+         ? pressure(force, area)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied definition's result: 50 / 2 = 25.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"pressure\"") && s.contains("\"value\":25"),
+        "pressure(50, 2) = 25: {s}"
+    );
+    // … AND the HyperPhysics citation + trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"")
+            && s.contains("hyperphysics.gsu.edu/hbase/press.html"),
+        "applied definition carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// force — the same definition solved for F: the pressure times the area, which
+// INVERTS the pressure just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_force_as_pressure_times_area_with_citation() {
+    let dir = scratch("force");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"pressure.adj\"\n\
+         observe pressure(25)\n\
+         observe area(2)\n\
+         ? force(pressure, area)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 25 * 2 = 50, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"force\"") && s.contains("\"value\":50"),
+        "force(25, 2) = 50: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"")
+            && s.contains("hyperphysics.gsu.edu/hbase/press.html"),
+        "force carries its HyperPhysics citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/physics/pressure.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/pressure.adj
@@ -1,0 +1,74 @@
+% ============================================================================
+% pressure.adj — the definition of pressure in the ADJ standard library.
+% ============================================================================
+% The pressure entry of the *physics* track, a sibling of `electricity.adj` and
+% `mechanics-laws.adj`: the foundational mechanical definition a first course
+% opens with — PRESSURE IS FORCE PER UNIT AREA — as an importable, byte-provenanced,
+% PARAMETERIZED `formula`, together with its exact rearrangement (the force a given
+% pressure exerts over an area). As with every compute library, a consumer states
+% NO arithmetic: it `import`s this file, binds the mechanical quantities from its own
+% byte-provenance decomposition, and asks the engine to APPLY the cited definition on
+% the CPU. Zero math is performed by the model; the engine computes each value
+% EXACTLY, carrying the definition's citation.
+%
+%     import "pressure.adj"
+%     observe force(50)        % "…a 50 N force…"   (span cited by the model)
+%     observe area(2)          % "…over 2 m²…"      (span cited by the model)
+%     ? pressure(force, area)  % engine → 25, carrying the def P = F/A
+%
+% Both formulas are EXACT over their parameters — one a quotient, one a product of
+% two measured quantities. There is no *separately grounded* physical constant here,
+% so every value the engine returns is exact. The two COMPOSE and invert cleanly:
+% the `pressure` a consumer computes from a force over an area is exactly the
+% `pressure` the `force` formula multiplies back by an area to recover the force.
+%
+%   pressure(force, area) = force / area     %  P = F/A   (definition of pressure)
+%   force(pressure, area) = pressure · area  %  F = P·A   (the same definition, solved for F)
+%
+% Both formulas are defended by the SAME definitional sentence — "Pressure is defined
+% as force per unit area." — because that one definition sanctions the relation read
+% either way (P from F and A, or F from P and A). The quote is transcribed verbatim
+% from Georgia State University's HyperPhysics (a university .edu physics reference —
+% the same primary source `electricity.adj` cites), so each `formula` carries the
+% provenance envelope every shipped grounded clause carries; the linter rejects an
+% unsourced one. (See feedback_nothing_human_authored — the definitional sentence is
+% a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable mechanical quantity the definition
+% ranges over, and each result is the derived quantity. `pressure` and `force`
+% each appear BOTH as a derived result and as an input (of the other formula), so
+% each is a single dictionary term used in both roles. The `surface` lists are the
+% everyday names a decomposer maps onto the canonical term; the trailing comment
+% records the intended SI unit.
+% ----------------------------------------------------------------------------
+dictionary pressure_vocab {
+    define force    : finding  surface "force", "F"                     % force, e.g. N (newtons)
+    define area     : finding  surface "area", "A"                      % area, e.g. m²
+    define pressure : finding  surface "pressure", "P"                  % pressure, e.g. Pa (pascals)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, both ways. Each is a named, importable, reusable `let` over its
+% formal parameters, bound at apply time, and each carries the definitional quote
+% from HyperPhysics (a quote is required on a shipped formula). One is a quotient
+% and one a product, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook pressure_laws {
+    use pressure_vocab
+
+    % Pressure — the force per unit area. HyperPhysics defines pressure as the
+    % force distributed over the area it acts on, i.e. P = F/A.
+    formula pressure(force, area) = force / area
+        source "Pressure is defined as force per unit area."
+        locator "https://hyperphysics.gsu.edu/hbase/press.html"
+        trust authoritative
+
+    % Force — the same definition solved for the force a pressure exerts over an
+    % area (F = P·A). Defended by the SAME definitional sentence, read the other way.
+    formula force(pressure, area) = pressure * area
+        source "Pressure is defined as force per unit area."
+        locator "https://hyperphysics.gsu.edu/hbase/press.html"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/physics/pressure.query.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/pressure.query.adj
@@ -1,0 +1,29 @@
+% ============================================================================
+% pressure.query.adj — worked examples over the physics pressure library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a pressure
+% question: it states NO arithmetic and NO definition — it only `import`s the
+% grounded library, `observe`s the mechanical quantities it decomposed from the
+% prompt (each a byte-provenanced span, elided here), and asks the engine to APPLY
+% the cited definition. The native adj-lang engine binds the parameters, computes
+% each value EXACTLY on the CPU, and returns it with the definition's
+% source/locator/trust.
+%
+% The two questions INVERT: a 50 N force over 2 m² gives a pressure of 25 Pa,
+% which is exactly the pressure the force formula multiplies back by the 2 m² area
+% to recover the 50 N force.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli pressure.query.adj
+% ============================================================================
+
+import "pressure.adj"
+
+% A 50 N force over a 2 m² area: pressure = 50 / 2.
+observe force(50)
+observe area(2)
+? pressure(force, area)     % expect 25   (definition: P = F/A)
+
+% That 25 Pa pressure over the same 2 m² area: force = 25 * 2.
+observe pressure(25)
+? force(pressure, area)      % expect 50   (same definition, solved for F = P·A)


### PR DESCRIPTION
## What

A `formulabook` sibling of `electricity.adj` / `mechanics-laws.adj` (Libraries front): the foundational mechanical definition — **pressure is force per unit area** — as two importable, byte-provenanced, parameterized formulas:

```
pressure(force, area) = force / area     % P = F/A  (definition)
force(pressure, area) = pressure * area  % F = P·A  (same definition, solved for F)
```

Both are **exact** over their parameters (a quotient and a product) and **invert** cleanly: 50 N / 2 m² = 25 Pa, and 25 Pa · 2 m² = 50 N. A consumer states no arithmetic — it imports the library, `observe`s the quantities, and the engine applies the cited definition on the CPU (0 model calls), carrying source/locator/trust.

## Grounding

Both formulas are defended by the **same definitional sentence**, quoted **verbatim** from Georgia State University's HyperPhysics (fetched and byte-verified this session):

> "Pressure is defined as force per unit area."

— that one definition sanctions the relation read either way. `trust authoritative` (a primary university `.edu` physics reference, the same source `electricity.adj` cites). Nothing is asserted from memory; the quote is a verbatim span of the cited page.

## Changes

- New: `physics/pressure.adj` + `pressure.query.adj` (worked inverting example — P from F,A then F back from P,A).
- Test: `formula_pressure_e2e` — `pressure(50,2)=25` with the `press.html` citation; `force(25,2)=50` with the same. **2/2 pass.**

## Verification

- `cargo test -p adj-lang-cli --test formula_pressure_e2e` → 2 passed.
- Shipped `.query.adj` driven through the built CLI: `pressure=25` and `force=50`, each rendering the verbatim HyperPhysics citation + `authoritative` trust.
- Security review passed (pure declarative data + static-path test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)