### PR TITLE
feat(spice): add JFET flicker exponent

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add JFET model-card `AF` flicker-noise current-exponent support, defaulting
+  to `1` and applying `KF * abs(Id)^AF / frequency` across noise analysis.
 - Add JFET model-card `KF` flicker-noise support with a distinct drain-current
   `flicker` contribution and Berkeley-default inverse-frequency scaling.
 - Add diode model-card `AF` flicker-noise current-exponent support, defaulting

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -513,6 +513,7 @@ class JFET:
     Cgs: float = 0.0
     Cgd: float = 0.0
     Kf: float = 0.0
+    Af: float = 1.0
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -604,7 +604,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
             element.Af,
         )
     if isinstance(element, JFET):
-        return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_, element.Cgs, element.Cgd, element.Kf)
+        return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_, element.Cgs, element.Cgd, element.Kf, element.Af)
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
@@ -9057,6 +9057,8 @@ def _eval_jfet(el: JFET, vgs: float, vds: float) -> tuple[float, float, float]:
         raise ValueError(f"JFET '{el.name}' CGD must be finite and non-negative")
     if not math.isfinite(el.Kf) or el.Kf < 0.0:
         raise ValueError(f"JFET '{el.name}' flicker-noise coefficient must be finite and non-negative")
+    if not math.isfinite(el.Af) or el.Af < 0.0:
+        raise ValueError(f"JFET '{el.name}' flicker-noise exponent must be finite and non-negative")
     if el.polarity == "PJF":
         ids, gm, gds = _eval_njf(-vgs, -vds, -el.vto, el.beta, el.lambda_)
         return -ids, gm, gds
@@ -15331,7 +15333,9 @@ def _collect_noise_sources(
             if el.Kf > 0.0:
                 n_d = None if _is_ground(el.drain) else node_to_idx[el.drain]
                 n_s = None if _is_ground(el.source) else node_to_idx[el.source]
-                sources.append((el.name, "flicker", n_d, n_s, el.Kf * abs(drain_current), 1.0))
+                sources.append(
+                    (el.name, "flicker", n_d, n_s, el.Kf * abs(drain_current) ** el.Af, 1.0)
+                )
 
         # Capacitors, Inductors, VoltageSources, CurrentSources: noiseless in
         # this first-order model.

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -309,8 +309,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (15, 21, 5, 3),
     "NPN": (41, 58, 13, 4),
     "PNP": (41, 58, 13, 4),
-    "NJF": (6, 12, 5, 3),
-    "PJF": (6, 12, 5, 3),
+    "NJF": (7, 13, 5, 3),
+    "PJF": (7, 13, 5, 3),
     "NMOS": (18, 25, 6, 3),
     "PMOS": (18, 25, 6, 3),
 }
@@ -431,6 +431,7 @@ _JFET_PARAMETER_ALIASES: dict[str, str] = {
     "CGD": "CGD",
     "CGD0": "CGD",
     "KF": "KF",
+    "AF": "AF",
 }
 
 _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
@@ -1004,6 +1005,7 @@ def jfet_from_model_card(
         Cgs=p.get("CGS", 0.0),
         Cgd=p.get("CGD", 0.0),
         Kf=p.get("KF", 0.0),
+        Af=p.get("AF", 1.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -407,7 +407,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 145
+    assert len(coverage) == 147
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -422,7 +422,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 145
+    assert len(records) == 147
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -496,9 +496,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 145
-    assert report.expected_canonical_parameter_count == 145
-    assert report.accepted_name_count == 211
+    assert report.canonical_parameter_count == 147
+    assert report.expected_canonical_parameter_count == 147
+    assert report.accepted_name_count == 213
     assert report.aliased_parameter_count == 53
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -506,7 +506,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t145\t145\t211\t53\t4\t0"
+        "true\t7\t7\t147\t147\t213\t53\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -534,8 +534,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 144
-    assert report.accepted_name_count == 208
+    assert report.canonical_parameter_count == 146
+    assert report.accepted_name_count == 210
     assert report.aliased_parameter_count == 52
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -550,7 +550,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t144\t145\t208\t52\t4\t4\n"
+        "false\t7\t7\t146\t147\t210\t52\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -664,7 +664,9 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert bjt_model.Fc == pytest.approx(0.4)
 
     jfet_card = normalize_model_card(
-        "Jn", "njfet", {"BET": 9.0e-4, "VT0": -1.8, "LAM": 0.02, "KF": 1.0e-12}
+        "Jn",
+        "njfet",
+        {"BET": 9.0e-4, "VT0": -1.8, "LAM": 0.02, "KF": 1.0e-12, "AF": 1.3},
     )
     jfet_model = jfet_from_model_card("J1", "d", "g", "s", jfet_card)
     assert jfet_card.parameters == {
@@ -672,12 +674,14 @@ def test_model_card_aliases_build_device_instances() -> None:
         "VTO": -1.8,
         "LAMBDA": 0.02,
         "KF": 1.0e-12,
+        "AF": 1.3,
     }
     assert jfet_model.polarity == "NJF"
     assert jfet_model.beta == pytest.approx(9.0e-4)
     assert jfet_model.vto == pytest.approx(-1.8)
     assert jfet_model.lambda_ == pytest.approx(0.02)
     assert jfet_model.Kf == pytest.approx(1.0e-12)
+    assert jfet_model.Af == pytest.approx(1.3)
 
     mos_card = normalize_model_card(
         "Mn",
@@ -720,6 +724,17 @@ def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     with pytest.raises(
         ValueError,
         match="flicker-noise coefficient must be finite and non-negative",
+    ):
+        dc_op(circuit)
+
+
+def test_dc_rejects_invalid_jfet_flicker_noise_exponent() -> None:
+    circuit = Circuit()
+    circuit.add(JFET("J1", "drain", "gate", "0", Af=-1.0))
+
+    with pytest.raises(
+        ValueError,
+        match="flicker-noise exponent must be finite and non-negative",
     ):
         dc_op(circuit)
 
@@ -2406,11 +2421,11 @@ def test_subcircuit_expansion_preserves_complete_diode_model():
     assert expanded.Af == pytest.approx(1.3)
 
 
-def test_subcircuit_expansion_preserves_jfet_flicker_noise_coefficient():
+def test_subcircuit_expansion_preserves_jfet_flicker_noise_parameters():
     cell = SubcircuitDefinition(
         "jfet-cell",
         ("d", "g", "s"),
-        (JFET("Jcell", "d", "g", "s", Kf=1.0e-12),),
+        (JFET("Jcell", "d", "g", "s", Kf=1.0e-12, Af=1.3),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2418,6 +2433,7 @@ def test_subcircuit_expansion_preserves_jfet_flicker_noise_coefficient():
 
     expanded = next(element for element in circuit.elements if isinstance(element, JFET))
     assert expanded.Kf == pytest.approx(1.0e-12)
+    assert expanded.Af == pytest.approx(1.3)
 
 
 def test_subcircuit_expansion_preserves_complete_bjt_model():
@@ -7380,6 +7396,34 @@ def test_noise_jfet_kf_adds_inverse_frequency_flicker_noise() -> None:
 
     assert flicker_psds[0] > 0.0
     assert flicker_psds[0] / flicker_psds[1] == pytest.approx(100.0)
+
+
+def test_noise_jfet_af_is_the_current_exponent() -> None:
+    def source_psd(exponent: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vdd", "vdd", "0", 5.0))
+        circuit.add(VoltageSource("Vgate", "gate", "0", 0.0))
+        circuit.add(Resistor("Rload", "vdd", "out", 1_000.0))
+        circuit.add(
+            JFET(
+                "J1",
+                "out",
+                "gate",
+                "0",
+                beta=1.0e-3,
+                vto=-2.0,
+                Kf=1.0e-12,
+                Af=exponent,
+            )
+        )
+        point = noise_ac(circuit, "out", "Vgate", freqs=[1_000.0]).points[0]
+        return next(
+            entry.source_psd
+            for entry in point.entries
+            if entry.element_name == "J1" and entry.noise_type == "flicker"
+        )
+
+    assert source_psd(2.0) < source_psd(1.0)
 
 
 def test_noise_diode_af_is_the_current_exponent() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add JFET model-card `AF` flicker-noise current-exponent support, defaulting
+  to `1` and applying `KF * abs(Id)^AF / frequency` across noise analysis.
 - Add JFET model-card `KF` flicker-noise support with a distinct drain-current
   `flicker` contribution and Berkeley-default inverse-frequency scaling.
 - Add diode model-card `AF` flicker-noise current-exponent support, defaulting

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -427,6 +427,7 @@ fn clone_subckt_element(
                 element.gate_drain_capacitance,
             );
             mapped.flicker_noise_coefficient = element.flicker_noise_coefficient;
+            mapped.flicker_noise_exponent = element.flicker_noise_exponent;
             Element::Jfet(mapped)
         }
         Element::Bjt(element) => {
@@ -2815,6 +2816,7 @@ pub struct Jfet {
     pub gate_source_capacitance: f64,
     pub gate_drain_capacitance: f64,
     pub flicker_noise_coefficient: f64,
+    pub flicker_noise_exponent: f64,
 }
 
 impl Jfet {
@@ -2884,6 +2886,7 @@ impl Jfet {
             gate_source_capacitance,
             gate_drain_capacitance,
             flicker_noise_coefficient: 0.0,
+            flicker_noise_exponent: 1.0,
         }
     }
 }
@@ -3807,8 +3810,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     (ModelCardKind::Diode, 15, 21, 5, 3),
     (ModelCardKind::Npn, 41, 58, 13, 4),
     (ModelCardKind::Pnp, 41, 58, 13, 4),
-    (ModelCardKind::Njf, 6, 12, 5, 3),
-    (ModelCardKind::Pjf, 6, 12, 5, 3),
+    (ModelCardKind::Njf, 7, 13, 5, 3),
+    (ModelCardKind::Pjf, 7, 13, 5, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
     (ModelCardKind::Pmos, 18, 25, 6, 3),
 ];
@@ -3908,6 +3911,7 @@ const JFET_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("CGD", "CGD"),
     ("CGD0", "CGD"),
     ("KF", "KF"),
+    ("AF", "AF"),
 ];
 const MOS_LEVEL1_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("LEVEL", "LEVEL"),
@@ -4635,6 +4639,7 @@ pub fn jfet_from_model_card(
         model_card_value(model, "CGD", 0.0),
     );
     jfet.flicker_noise_coefficient = model_card_value(model, "KF", 0.0);
+    jfet.flicker_noise_exponent = model_card_value(model, "AF", 1.0);
     Ok(jfet)
 }
 
@@ -22461,7 +22466,8 @@ fn collect_noise_sources(
                         noise_type: NoiseType::Flicker,
                         positive: drain,
                         negative: source,
-                        source_psd: jfet.flicker_noise_coefficient * result.drain_current.abs(),
+                        source_psd: jfet.flicker_noise_coefficient
+                            * result.drain_current.abs().powf(jfet.flicker_noise_exponent),
                         frequency_exponent: 1.0,
                     });
                 }
@@ -24857,6 +24863,12 @@ fn validate_jfet(jfet: &Jfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: jfet.name.clone(),
             reason: "flicker-noise coefficient must be finite and non-negative".to_string(),
+        });
+    }
+    if !jfet.flicker_noise_exponent.is_finite() || jfet.flicker_noise_exponent < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: jfet.name.clone(),
+            reason: "flicker-noise exponent must be finite and non-negative".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -95,7 +95,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 145);
+    assert_eq!(coverage.len(), 147);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -114,7 +114,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 145);
+    assert_eq!(records.len(), 147);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -195,15 +195,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 145);
-    assert_eq!(report.expected_canonical_parameter_count, 145);
-    assert_eq!(report.accepted_name_count, 211);
+    assert_eq!(report.canonical_parameter_count, 147);
+    assert_eq!(report.expected_canonical_parameter_count, 147);
+    assert_eq!(report.accepted_name_count, 213);
     assert_eq!(report.aliased_parameter_count, 53);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t145\t145\t211\t53\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t147\t147\t213\t53\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -230,8 +230,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 144);
-    assert_eq!(report.accepted_name_count, 208);
+    assert_eq!(report.canonical_parameter_count, 146);
+    assert_eq!(report.accepted_name_count, 210);
     assert_eq!(report.aliased_parameter_count, 52);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -248,7 +248,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t144\t145\t208\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t146\t147\t210\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -514,6 +514,7 @@ fn model_card_aliases_build_device_instances() {
             ("VT0", -1.8),
             ("LAM", 0.02),
             ("KF", 1.0e-12),
+            ("AF", 1.3),
         ],
     )
     .unwrap();
@@ -522,11 +523,13 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*jfet_card.parameters.get("VTO").unwrap(), -1.8);
     assert_close(*jfet_card.parameters.get("LAMBDA").unwrap(), 0.02);
     assert_close(*jfet_card.parameters.get("KF").unwrap(), 1.0e-12);
+    assert_close(*jfet_card.parameters.get("AF").unwrap(), 1.3);
     assert_eq!(jfet_model.polarity, JfetPolarity::Njf);
     assert_close(jfet_model.beta, 9.0e-4);
     assert_close(jfet_model.threshold_voltage, -1.8);
     assert_close(jfet_model.channel_length_modulation, 0.02);
     assert_close(jfet_model.flicker_noise_coefficient, 1.0e-12);
+    assert_close(jfet_model.flicker_noise_exponent, 1.3);
 
     let mos_card = normalize_model_card(
         "Mn",
@@ -1445,9 +1448,10 @@ fn subcircuit_expansion_preserves_complete_diode_model() {
 }
 
 #[test]
-fn subcircuit_expansion_preserves_jfet_flicker_noise_coefficient() {
+fn subcircuit_expansion_preserves_jfet_flicker_noise_parameters() {
     let mut jfet = Jfet::new("Jcell", "d", "g", "s");
     jfet.flicker_noise_coefficient = 1.0e-12;
+    jfet.flicker_noise_exponent = 1.3;
     let mut circuit = Circuit::new();
     circuit
         .define_subcircuit(SubcircuitDefinition::new(
@@ -1473,6 +1477,7 @@ fn subcircuit_expansion_preserves_jfet_flicker_noise_coefficient() {
         })
         .unwrap();
     assert_close(expanded.flicker_noise_coefficient, 1.0e-12);
+    assert_close(expanded.flicker_noise_exponent, 1.3);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -330,6 +330,63 @@ fn jfet_rejects_invalid_flicker_noise_coefficient() {
 }
 
 #[test]
+fn jfet_rejects_invalid_flicker_noise_exponent() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 0.0,
+    )));
+    let mut jfet = Jfet::new("J1", "out", "gate", "0");
+    jfet.flicker_noise_exponent = -1.0;
+    circuit.add(Element::Jfet(jfet));
+
+    let error = noise_ac(&circuit, "out", "Vgate", &[1_000.0], 300.0).unwrap_err();
+    assert!(matches!(
+        error,
+        SpiceError::InvalidElement { reason, .. }
+            if reason == "flicker-noise exponent must be finite and non-negative"
+    ));
+}
+
+#[test]
+fn jfet_flicker_noise_uses_af_current_exponent() {
+    let source_psd = |exponent: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vdd", "vdd", "0", 5.0,
+        )));
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vgate", "gate", "0", 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rload", "vdd", "out", 1_000.0,
+        )));
+        let mut jfet = Jfet::with_model(
+            "J1",
+            "out",
+            "gate",
+            "0",
+            spice_engine::JfetPolarity::Njf,
+            1.0e-3,
+            -2.0,
+            0.0,
+        );
+        jfet.flicker_noise_coefficient = 1.0e-12;
+        jfet.flicker_noise_exponent = exponent;
+        circuit.add(Element::Jfet(jfet));
+        noise_ac(&circuit, "out", "Vgate", &[1_000.0], 300.0)
+            .unwrap()
+            .points[0]
+            .entries
+            .iter()
+            .find(|entry| entry.element_name == "J1" && entry.noise_type == NoiseType::Flicker)
+            .unwrap()
+            .source_psd
+    };
+
+    assert!(source_psd(2.0) < source_psd(1.0));
+}
+
+#[test]
 fn diode_flicker_noise_uses_af_current_exponent() {
     let source_psd = |exponent: f64| {
         let mut circuit = Circuit::new();

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add JFET model-card `AF` flicker-noise current-exponent support, defaulting
+  to `1` and applying `KF * abs(Id)^AF / frequency` across noise analysis.
 - Add JFET model-card `KF` flicker-noise support with a distinct drain-current
   `flicker` contribution and Berkeley-default inverse-frequency scaling.
 - Add diode model-card `AF` flicker-noise current-exponent support, defaulting

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1696,6 +1696,7 @@ export interface Jfet {
   readonly gateSourceCapacitance: number;
   readonly gateDrainCapacitance: number;
   readonly flickerNoiseCoefficient: number;
+  readonly flickerNoiseExponent: number;
 }
 
 export type BjtPolarity = "NPN" | "PNP";
@@ -2025,8 +2026,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   D: [15, 21, 5, 3],
   NPN: [41, 58, 13, 4],
   PNP: [41, 58, 13, 4],
-  NJF: [6, 12, 5, 3],
-  PJF: [6, 12, 5, 3],
+  NJF: [7, 13, 5, 3],
+  PJF: [7, 13, 5, 3],
   NMOS: [18, 25, 6, 3],
   PMOS: [18, 25, 6, 3],
 };
@@ -3612,7 +3613,7 @@ function cloneSubcktElement(
     case "diode":
       return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient, element.breakdownVoltage, element.breakdownCurrent, element.junctionCapacitance, element.transitTime, element.junctionPotential, element.gradingCoefficient, element.forwardBiasDepletionCoefficient, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.seriesResistance, element.flickerNoiseCoefficient, element.flickerNoiseExponent);
     case "jfet":
-      return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance, element.flickerNoiseCoefficient);
+      return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance, element.flickerNoiseCoefficient, element.flickerNoiseExponent);
     case "bjt":
       return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees, element.forwardTransitTimeBiasCoefficient, element.forwardTransitTimeCurrent, element.forwardTransitTimeVoltage, element.emitterResistance, element.collectorResistance, element.baseResistance, element.minimumBaseResistance, element.baseResistanceHalfCurrent, element.baseCollectorCapacitanceFraction);
     case "mosfet":
@@ -7758,6 +7759,7 @@ export function jfet(
   gateSourceCapacitance = 0.0,
   gateDrainCapacitance = 0.0,
   flickerNoiseCoefficient = 0.0,
+  flickerNoiseExponent = 1.0,
 ): Jfet {
   return {
     kind: "jfet",
@@ -7772,6 +7774,7 @@ export function jfet(
     gateSourceCapacitance,
     gateDrainCapacitance,
     flickerNoiseCoefficient,
+    flickerNoiseExponent,
   };
 }
 
@@ -8029,6 +8032,7 @@ const JFET_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   CGD: "CGD",
   CGD0: "CGD",
   KF: "KF",
+  AF: "AF",
 };
 
 const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -8573,6 +8577,7 @@ export function jfetFromModelCard(
     p.CGS ?? 0.0,
     p.CGD ?? 0.0,
     p.KF ?? 0.0,
+    p.AF ?? 1.0,
   );
 }
 
@@ -18658,7 +18663,9 @@ function collectNoiseSources(
           noiseType: "flicker",
           positive: drain,
           negative: source,
-          sourcePsd: element.flickerNoiseCoefficient * Math.abs(result.drainCurrent),
+          sourcePsd:
+            element.flickerNoiseCoefficient *
+            Math.abs(result.drainCurrent) ** element.flickerNoiseExponent,
           frequencyExponent: 1.0,
         });
       }
@@ -19513,6 +19520,12 @@ function validateJfet(element: Jfet): void {
     throw invalidElement(
       element.name,
       "flicker-noise coefficient must be finite and non-negative",
+    );
+  }
+  if (!Number.isFinite(element.flickerNoiseExponent) || element.flickerNoiseExponent < 0.0) {
+    throw invalidElement(
+      element.name,
+      "flicker-noise exponent must be finite and non-negative",
     );
   }
 }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -120,7 +120,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(145);
+    expect(coverage).toHaveLength(147);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -140,7 +140,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(145);
+    expect(records).toHaveLength(147);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -205,15 +205,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 145,
-      expectedCanonicalParameterCount: 145,
-      acceptedNameCount: 211,
+      canonicalParameterCount: 147,
+      expectedCanonicalParameterCount: 147,
+      acceptedNameCount: 213,
       aliasedParameterCount: 53,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t145\t145\t211\t53\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t147\t147\t213\t53\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -236,8 +236,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(144);
-    expect(report.acceptedNameCount).toBe(208);
+    expect(report.canonicalParameterCount).toBe(146);
+    expect(report.acceptedNameCount).toBe(210);
     expect(report.aliasedParameterCount).toBe(52);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -252,7 +252,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t144\t145\t208\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t146\t147\t210\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -383,14 +383,15 @@ describe("dcOp", () => {
     expectClose(bjtModel.baseCollectorGradingCoefficient, 0.45);
     expectClose(bjtModel.forwardBiasDepletionCoefficient, 0.4);
 
-    const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02, KF: 1.0e-12 });
+    const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02, KF: 1.0e-12, AF: 1.3 });
     const jfetModel = jfetFromModelCard("J1", "d", "g", "s", jfetCard);
-    expect(jfetCard.parameters).toStrictEqual({ BETA: 9.0e-4, VTO: -1.8, LAMBDA: 0.02, KF: 1.0e-12 });
+    expect(jfetCard.parameters).toStrictEqual({ BETA: 9.0e-4, VTO: -1.8, LAMBDA: 0.02, KF: 1.0e-12, AF: 1.3 });
     expect(jfetModel.polarity).toBe("NJF");
     expectClose(jfetModel.beta, 9.0e-4);
     expectClose(jfetModel.thresholdVoltage, -1.8);
     expectClose(jfetModel.channelLengthModulation, 0.02);
     expectClose(jfetModel.flickerNoiseCoefficient, 1.0e-12);
+    expectClose(jfetModel.flickerNoiseExponent, 1.3);
 
     const mosCard = normalizeModelCard("Mn", "nmos", {
       LEVEL: 1.0,
@@ -1042,11 +1043,15 @@ describe("dcOp", () => {
     expectClose(expanded.flickerNoiseExponent, 1.3);
   });
 
-  it("preserves the JFET flicker-noise coefficient through subcircuit expansion", () => {
+  it("preserves JFET flicker-noise parameters through subcircuit expansion", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("jfet-cell", ["d", "g", "s"], [
-        { ...jfet("Jcell", "d", "g", "s"), flickerNoiseCoefficient: 1.0e-12 },
+        {
+          ...jfet("Jcell", "d", "g", "s"),
+          flickerNoiseCoefficient: 1.0e-12,
+          flickerNoiseExponent: 1.3,
+        },
       ]),
     );
     circuit.add(xInstance("X1", ["d1", "g1", "0"], "jfet-cell"));
@@ -1057,6 +1062,7 @@ describe("dcOp", () => {
       throw new Error("expected expanded JFET");
     }
     expectClose(expanded.flickerNoiseCoefficient, 1.0e-12);
+    expectClose(expanded.flickerNoiseExponent, 1.3);
   });
 
   it("preserves the complete BJT model through subcircuit expansion", () => {

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -49,6 +49,35 @@ describe("noiseAc", () => {
     );
   });
 
+  it("rejects an invalid JFET flicker-noise exponent", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vgate", "gate", "0", 0.0));
+    circuit.add({ ...jfet("J1", "out", "gate", "0"), flickerNoiseExponent: -1.0 });
+
+    expect(() => noiseAc(circuit, "out", "Vgate", [1_000.0])).toThrow(
+      /flicker-noise exponent must be finite and non-negative/,
+    );
+  });
+
+  it("uses JFET AF as the current exponent", () => {
+    function sourcePsd(exponent: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vdd", "vdd", "0", 5.0));
+      circuit.add(voltageSource("Vgate", "gate", "0", 0.0));
+      circuit.add(resistor("Rload", "vdd", "out", 1_000.0));
+      circuit.add({
+        ...jfet("J1", "out", "gate", "0"),
+        flickerNoiseCoefficient: 1.0e-12,
+        flickerNoiseExponent: exponent,
+      });
+      return noiseAc(circuit, "out", "Vgate", [1_000.0], 300.0).points[0]!.entries
+        .find((entry) => entry.elementName === "J1" && entry.noiseType === "flicker")!
+        .sourcePsd;
+    }
+
+    expect(sourcePsd(2.0)).toBeLessThan(sourcePsd(1.0));
+  });
+
   it("adds thermal noise for diode series resistance", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vbias", "bias", "0", 1.0));

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language JFET flicker-noise coefficient.
+1. Cross-language JFET flicker-noise current exponent.
    - Status: current PR completion candidate.
-   - Add Berkeley JFET `KF` model-card support in Rust, Python, and TypeScript,
-     defaulting to zero and emitting a distinct drain-current flicker source as
-     `KF * abs(Id) / frequency`.
-   - Preserve `KF` through hierarchy and cloning while validating finite
+   - Add Berkeley JFET `AF` model-card support in Rust, Python, and TypeScript,
+     defaulting to one and applying it to the existing drain-current flicker
+     source as `KF * abs(Id)^AF / frequency`.
+   - Preserve `AF` through hierarchy and cloning while validating finite
      non-negative values in every engine.
-   - Extend the supported-parameter coverage gate from 143 to 145 canonical
-     rows and lock inverse-frequency noise scaling in all engines.
+   - Extend the supported-parameter coverage gate from 145 to 147 canonical
+     rows and lock current-exponent behavior in all engines.
 
 ## Completed Slices
 
@@ -3244,6 +3244,14 @@ the Rust, Python, and TypeScript surfaces together.
    - Hierarchy and cloning paths preserve `AF`, finite non-negative validation
      is shared across analyses, and the supported-parameter release gate now
      covers 143 canonical rows.
+
+249. Cross-language JFET flicker-noise coefficient.
+   - Status: completed in PR 8910.
+   - Rust, Python, and TypeScript JFET model cards now accept `KF`, default it
+     to zero, and emit a distinct drain-current flicker-noise contribution.
+   - Hierarchy and cloning paths preserve `KF`, finite non-negative validation
+     is shared across analyses, and the supported-parameter release gate now
+     covers 145 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley JFET `AF` model-card support across Rust, Python, and TypeScript
- apply `KF * abs(Id)^AF / frequency` while preserving and validating the exponent through hierarchy
- reconcile the SPICE plan and advance the supported-parameter gate to 147 canonical rows

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo check -p spice-engine`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python Ruff check on touched files
- Python full suite: 589 passed, 88.74% coverage
- `npm run build`
- TypeScript full suite: 347 passed