### PR TITLE
feat(semantic-ir-to-ruby): classes slice 4 — inheritance + super (0.14.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.14.0 — classes slice 4: inheritance + super
+
+Class **inheritance** and `super`. No new `Feature` (a superclass rides on
+`Stmt::ClassDef`; `super` is a builtin).
+
+- `class Dog < Animal` → `ClassDef { superclass: Some("Animal") }` →
+  `Object.const_set(:Dog, Class.new(Animal))`. The subclass inherits Animal's
+  ancestry natively — `Dog.new.is_a?(Animal)` holds, and method resolution walks
+  up it. The superclass is a bare constant **reference** (a `::` path is allowed
+  here — it references, not defines), validated as a constant path.
+- `super` (bare or with args — the frontend forwards the method's arguments
+  explicitly in both cases) → `__super__("m", "Dog", args…)` →
+  `(Dog).superclass.instance_method(:sir_um_m).bind(self).call(args…)`.
+
+**Why an explicit ancestry walk (not native `super`).** A method body lives in a
+hoisted top-level function (slice 2), not a real method context, so native bare
+`super` is unavailable there. Instead the superclass's method is fetched as an
+`UnboundMethod` from `<DefiningClass>.superclass`, bound to `self` (the receiver,
+inherited via slice 2's `define_method` binding), and called. This resolves up a
+multi-level chain correctly (`A → B → C`, each `super` climbing one level).
+
+**Anti-RCE preserved.** The super'd method name is emitted as a `sir_um_`-prefixed
+quoted symbol, so `instance_method` can only fetch a user-defined method — never
+a reflection/eval built-in — exactly as `__method__` dispatch (slice 2). The
+defining-class name is emitted verbatim as a bare constant and validated as a
+constant path (co-total injection guard), as is the superclass in `Class.new`.
+
+**Still rejects** class variables (`@@x`, `Feature::ClassVars`), class methods
+(`__class_method__` / `__def_class_method__`), and modules — each a later slice.
+
 ## 0.13.1 — `is_ruby_keyword` missing `__ENCODING__` (task #116 audit)
 
 Follow-up to task #110/#112 (`semantic-ir-to-javascript`/`-typescript`'s

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.13.1"
+version = "0.14.0"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/README.md
+++ b/code/packages/rust/semantic-ir-to-ruby/README.md
@@ -83,12 +83,17 @@ reach `instance_eval`/`send` (anti-RCE); a dispatch to an un-registered
 (slice 3): `@v = x` / `@v` (`Scope::Instance`) render as native `@v` and `__self__`
 as native `self`; `define_method` binds `self` to the receiver, so `@v` in a
 method addresses that instance (each `@`-name validated as `@<identifier>`, no
-injection).
+injection). **Inheritance** (slice 4): `class Dog < Animal` →
+`Object.const_set(:Dog, Class.new(Animal))` (native ancestry), and `super` →
+`(Dog).superclass.instance_method(:sir_um_m).bind(self).call(…)` — an explicit
+ancestry walk (the body is a hoisted function, so native `super` is unavailable),
+still `sir_um_`-prefixed so `instance_method` can only fetch a user method
+(anti-RCE); the superclass and defining-class names are constant-path validated.
 Rejects `TailCalls`, `Intrinsics`, and every not-yet-wired feature (array
 indexing / slicing via `IndexGet` — `NDArrays`; array-pattern destructuring;
-built-in collection methods; and the rest of OOP — **inheritance** / superclass,
-class variables (`@@x`), class methods, modules — plus a non-empty class body
-or a namespaced class/constant definition) until its slice lands — each a clean,
+built-in collection methods; and the rest of OOP — class variables (`@@x`),
+class methods, modules — plus a non-empty class body or a namespaced
+class/constant definition) until its slice lands — each a clean,
 source-positioned `UnsupportedFeature`.
 
 ## Verification

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -79,6 +79,10 @@ const SUPPORTED_BUILTINS: &[&str] = &[
     // lowering of a bare `self` — renders as the native `self` keyword.  (Its
     // sibling `@ivar` read/write rides on `Scope::Instance`, not a builtin.)
     "__self__",
+    // OOP classes slice 4 (inheritance): `__super__("m", "Class", args…)` — a
+    // `super` call — dispatches the superclass's `sir_um_m` on `self`.  (The
+    // subclass relation itself rides on `Stmt::ClassDef { superclass }`.)
+    "__super__",
 ];
 
 /// Emit a complete self-contained Ruby source file for `m`.
@@ -458,9 +462,17 @@ impl Scan {
                     "a namespaced class name (`class Foo::Bar`)".to_string(),
                     span.clone(),
                 ))
-            } else if superclass.is_some() {
-                Some(ScanHit::Unsupported(
-                    "class inheritance (a superclass)".to_string(),
+            } else if superclass
+                .as_deref()
+                .is_some_and(|s| !is_valid_constant_path(s))
+            {
+                // OOP slice 4: a superclass (`class Dog < Animal`) is emitted as
+                // the `Class.new(<superclass>)` argument — a bare constant
+                // REFERENCE — so validate it as a constant path (a `::` path IS
+                // allowed here: it references, not defines).  A crafted name is
+                // rejected so it cannot inject source.
+                Some(ScanHit::ConstantName(
+                    superclass.clone().unwrap_or_default(),
                     span.clone(),
                 ))
             } else if !body.is_empty() {
@@ -586,6 +598,23 @@ impl Scan {
                                 ),
                                 span.clone(),
                             ));
+                        }
+                    }
+                    _ => return Some(ScanHit::Builtin(name.clone(), span.clone())),
+                }
+            }
+            // `__super__("m", "Class", args…)` (OOP slice 4) dispatches the
+            // superclass's method.  args[0] is the method NAME (rendered as a
+            // `sir_um_`-prefixed quoted symbol — safe), args[1] is the DEFINING
+            // class emitted VERBATIM as a bare constant (`<Class>.superclass…`),
+            // so validate it as a constant path here (injection guard); the
+            // forwarded args (args[2..]) are scanned below.  A malformed shape is
+            // reported as an unlowerable builtin.
+            if name == "__super__" {
+                match (args.first(), args.get(1)) {
+                    (Some(Expr::StrLit { .. }), Some(Expr::StrLit { value, span })) => {
+                        if !is_valid_constant_path(value) {
+                            return Some(ScanHit::ConstantName(value.clone(), span.clone()));
                         }
                     }
                     _ => return Some(ScanHit::Builtin(name.clone(), span.clone())),
@@ -928,8 +957,16 @@ fn emit_stmt(s: &Stmt) -> String {
         // safe symbol literal and `Class.new` takes no base / body.  (This
         // dynamic construction also composes with the next slice's
         // `define_method` for the frontend's hoisted, separately-registered
-        // methods.)
-        Stmt::ClassDef { name, .. } => format!("Object.const_set(:{name}, Class.new)"),
+        // methods.)  OOP slice 4: a superclass (`class Dog < Animal`) becomes
+        // `Class.new(Animal)` — the superclass is a bare constant REFERENCE (the
+        // scan validated it as a constant path), so the subclass inherits its
+        // ancestry natively (`Dog.new.is_a?(Animal)`, and `super` resolves up it).
+        Stmt::ClassDef {
+            name, superclass, ..
+        } => match superclass {
+            Some(sup) => format!("Object.const_set(:{name}, Class.new({sup}))"),
+            None => format!("Object.const_set(:{name}, Class.new)"),
+        },
         // Other not-yet-supported statements (e.g. index-set, module/singleton
         // defs) are rejected by the capability check / scan before emit.
         other => unreachable!("Ruby backend reached unsupported statement: {other:?}"),
@@ -1227,6 +1264,23 @@ fn emit_builtin(name: &str, args: &[Expr]) -> String {
         // OOP classes slice 3: a bare `self` → the native `self` keyword.  Inside
         // a `define_method`-installed method (slice 2) `self` is the receiver.
         "__self__" => "self".to_string(),
+        // OOP classes slice 4: a `super` call.  `args[0]` = method name, `args[1]`
+        // = the DEFINING class (a bare validated constant), `args[2..]` (in `a`) =
+        // the forwarded arguments.  A method body lives in a hoisted top-level
+        // function (not a real method context), so native `super` cannot be used;
+        // dispatch EXPLICITLY up the ancestry: fetch the superclass's method as an
+        // `UnboundMethod`, bind it to `self` (the receiver, inherited via slice
+        // 2's `define_method`), and call it.  The method name is `sir_um_`-prefixed
+        // (a quoted symbol), so `instance_method` can only fetch a user method —
+        // never a reflection built-in (anti-RCE, as with `__method__` dispatch).
+        "__super__" => {
+            let class = str_arg(args, 1);
+            let sym = emit_symbol(&format!("sir_um_{}", str_arg(args, 0)));
+            format!(
+                "({class}).superclass.instance_method({sym}).bind(self).call({})",
+                a[2..].join(", ")
+            )
+        }
         // Unreachable: first_scan_issue rejected anything else.
         other => unreachable!("v0 Ruby backend reached unsupported builtin: {other}"),
     }

--- a/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
@@ -1553,14 +1553,6 @@ fn raise_of_a_constant_exception_class_now_compiles() {
 // ---- hand-built: totality (deferred shapes rejected, never panicked) ------
 
 #[test]
-fn a_class_with_a_superclass_is_rejected_cleanly() {
-    // Inheritance is a later slice; a `class Foo < Bar` is rejected, not emitted.
-    let m = class_module(vec![classdef("Foo", Some("Bar"), vec![])]);
-    let err = compile(&m).expect_err("a superclass must be rejected");
-    assert_eq!(err.kind, semantic_ir::BackendErrorKind::UnsupportedFeature);
-}
-
-#[test]
 fn a_non_empty_class_body_is_rejected_cleanly() {
     // Class-level code / constants are a later slice; a non-empty body rejects.
     let m = class_module(vec![classdef("Foo", None, vec![puts(strlit("hi"))])]);
@@ -1841,8 +1833,8 @@ fn an_injectable_def_method_class_name_is_rejected() {
 fn still_rejected_super_self_classmethod_builtins() {
     // The remaining OOP builtins are later slices — a hand-built module carrying
     // any is rejected cleanly (never `unreachable!`).  (`__self__` landed in
-    // slice 3, so it is no longer in this list.)
-    for bad in ["__super__", "__class_method__", "__def_class_method__"] {
+    // slice 3 and `__super__` in slice 4, so they are no longer in this list.)
+    for bad in ["__class_method__", "__def_class_method__"] {
         let call = Expr::BuiltinCall {
             name: bad.into(),
             args: vec![strlit("Foo"), strlit("m")],
@@ -1981,4 +1973,114 @@ fn a_non_at_ivar_name_is_rejected() {
     assert!(compile(&ivar_module(vec![ivar_assign("v", ilit(1))])).is_err(), "no @");
     assert!(compile(&ivar_module(vec![ivar_assign("@", ilit(1))])).is_err(), "bare @");
     assert!(compile(&ivar_module(vec![ivar_assign("@1x", ilit(1))])).is_err(), "@ + digit");
+}
+
+// ── OOP classes slice 4 — inheritance + super ───────────────────────────────
+//
+// `class Dog < Animal` lowers to `ClassDef { superclass: Some("Animal") }`,
+// emitted as `Object.const_set(:Dog, Class.new(Animal))` — the subclass inherits
+// Animal's ancestry natively. `super` (bare or with args, both forwarded
+// explicitly by the frontend) lowers to `__super__("m", "Dog", args…)`, emitted
+// as `(Dog).superclass.instance_method(:sir_um_m).bind(self).call(args…)` — an
+// explicit ancestry walk (the method body lives in a hoisted top-level function,
+// not a real method context, so native `super` cannot be used). The `sir_um_`
+// prefix keeps it anti-RCE: `instance_method` can only fetch a user method.
+
+fn super_call(method: &str, class: &str, args: Vec<Expr>) -> Expr {
+    let mut a = vec![strlit(method), strlit(class)];
+    a.extend(args);
+    Expr::BuiltinCall { name: "__super__".into(), args: a, effects: EffectSet::PURE, span: s2() }
+}
+
+// ---- positive, through the real frontend + interpreter --------------------
+
+#[test]
+fn e2e_bare_super_calls_the_superclass_method() {
+    // `class B; def name; "B"; end; end; class D < B; def name; super; end; end`
+    // — D#name with a bare `super` returns B#name's result.
+    let rb = ruby_to_ruby(
+        "class B\n  def name\n    \"B\"\n  end\nend\n\
+         class D < B\n  def name\n    super\n  end\nend\nputs D.new.name\n",
+    );
+    assert!(rb.contains("Class.new(B)"), "subclass inherits B:\n{rb}");
+    assert!(
+        rb.contains(".superclass.instance_method(:sir_um_name)"),
+        "explicit prefixed super dispatch:\n{rb}"
+    );
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "B"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn e2e_super_with_args_and_a_result() {
+    // `super(x)` forwards an argument and the subclass uses the returned value.
+    let rb = ruby_to_ruby(
+        "class B\n  def add(x)\n    x + 1\n  end\nend\n\
+         class D < B\n  def add(x)\n    super(x) + 10\n  end\nend\nputs D.new.add(5)\n",
+    );
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "16"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn e2e_super_walks_a_multi_level_chain() {
+    // A→B→C: each `super` climbs one level, proving `instance_method` resolves up
+    // the ancestry and each level's defining-class in `__super__` is correct.
+    let rb = ruby_to_ruby(
+        "class A\n  def v\n    1\n  end\nend\n\
+         class B < A\n  def v\n    super + 10\n  end\nend\n\
+         class C < B\n  def v\n    super + 100\n  end\nend\nputs C.new.v\n",
+    );
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "111"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+// ---- hand-built: emit shape + injection -----------------------------------
+
+#[test]
+fn subclass_emits_class_new_with_the_superclass() {
+    let m = class_module(vec![
+        classdef("Animal", None, vec![]),
+        classdef("Dog", Some("Animal"), vec![]),
+    ]);
+    let rb = compile(&m).expect("subclass module compiles").source;
+    assert!(rb.contains("Object.const_set(:Dog, Class.new(Animal))"), "subclass emit:\n{rb}");
+}
+
+#[test]
+fn an_injectable_superclass_name_is_rejected() {
+    // `class Foo < <super>` emits `Class.new(<super>)`, a bare constant — a
+    // crafted superclass name must be rejected (injection guard).
+    let m = class_module(vec![classdef("Foo", Some("Bar\n  system('boom')"), vec![])]);
+    let err = compile(&m).expect_err("an injectable superclass name must be rejected");
+    assert_eq!(err.kind, semantic_ir::BackendErrorKind::UnsupportedFeature);
+}
+
+#[test]
+fn an_injectable_super_class_name_is_rejected() {
+    // `__super__`'s class argument is emitted verbatim as `(<class>).superclass…`,
+    // so a crafted name must be rejected.
+    let m = method_module(vec![puts(super_call("greet", "Dog\n  system('x')", vec![]))]);
+    assert!(compile(&m).is_err(), "an injectable __super__ class must be rejected");
+}
+
+#[test]
+fn a_malformed_super_missing_the_class_is_rejected() {
+    // `__super__` needs a method-name StrLit AND a defining-class StrLit (rendered
+    // as `str_arg(args, 1)`); a missing/non-string class is rejected, so the
+    // emitter never indexes past the end.
+    let bad = Expr::BuiltinCall {
+        name: "__super__".into(),
+        args: vec![strlit("greet")], // no class arg
+        effects: EffectSet::PURE,
+        span: s2(),
+    };
+    let m = method_module(vec![puts(bad)]);
+    assert!(compile(&m).is_err(), "a malformed __super__ must be rejected");
 }

--- a/code/specs/SIR25-semantic-ir-to-ruby.md
+++ b/code/specs/SIR25-semantic-ir-to-ruby.md
@@ -116,10 +116,21 @@ receiver, so `@v` in a method reads/writes that instance's own variable and
 persists across dispatches — no runtime support. Each `@`-name is validated as
 `@<identifier>` in the co-total scan (no injection).
 
+The fourth OOP slice (0.14.0) adds **inheritance** and `super`. `class Dog <
+Animal` (`ClassDef { superclass: Some("Animal") }`) becomes
+`Object.const_set(:Dog, Class.new(Animal))` — the subclass inherits Animal's
+ancestry natively (the superclass is a validated bare constant reference). `super`
+(bare or explicit, the frontend forwards arguments in both) →
+`__super__("m", "Dog", args…)` → `(Dog).superclass.instance_method(:sir_um_m)
+.bind(self).call(args…)`: an EXPLICIT ancestry walk, because a method body lives
+in a hoisted top-level function (not a real method context) where native `super`
+is unavailable. It resolves a multi-level chain correctly, and the `sir_um_`
+prefix keeps `instance_method` restricted to user methods (anti-RCE).
+
 **Still rejects** `TailCalls`, `Intrinsics`, `NDArrays`, and every not-yet-landed
-feature — including the rest of OOP: **inheritance** (a superclass / `__super__`),
-class methods (`__class_method__` / `__def_class_method__`), class variables
-(`@@x`), and modules; plus a malformed `__def_method__`, a
+feature — including the rest of OOP: class methods (`__class_method__` /
+`__def_class_method__`), class variables (`@@x`), and modules; plus a malformed
+`__def_method__`, a
 non-empty class body, a namespaced (`Foo::Bar`) class/constant *definition*
 (`const_set` names one namespace), and a **singleton class** (`class << self` —
 `Stmt::SingletonClassDef`, which also observes `Feature::Classes`, so accepting
@@ -165,6 +176,8 @@ or temporaries:
 | `BuiltinCall("__method__", [recv, m, args…])` | `(<recv>).public_send(:sir_um_<m>, <args>)` — closed prefixed dispatch (anti-RCE) |
 | `VarRef { Instance }` / `Assign { Instance }` | `@v` — native instance variable (name incl. `@`, verbatim, validated `@<identifier>`) |
 | `BuiltinCall("__self__", [])` | `self` — native |
+| `ClassDef { superclass: Some(S) }` | `Object.const_set(:<name>, Class.new(<S>))` — native inheritance (`S` a validated constant ref) |
+| `BuiltinCall("__super__", [m, class, args…])` | `(<class>).superclass.instance_method(:sir_um_<m>).bind(self).call(<args>)` — explicit prefixed ancestry walk |
 | `If` | `(if sir_truthy(<cond>) then <then> else <else> end)` |
 | `LogicalAnd { lhs, rhs }` | `(<lhs> && <rhs>)` — native short-circuit, yields the deciding operand |
 | `LogicalOr { lhs, rhs }` | `(<lhs> \|\| <rhs>)` — native short-circuit, yields the deciding operand |
@@ -265,8 +278,9 @@ growing `ACCEPTED_FEATURES`, the runtime, and the conformance corpus in lockstep
    slices: `Constants` + an empty `class`/`Foo.new` (reflective `const_set`,
    landed 0.11), instance **methods** (`define_method`/`public_send` under a
    reserved `sir_um_` prefix, landed 0.12), instance **variables** (`@v`, native,
-   landed 0.13), then **inheritance** (`superclass`/`super`), **class variables**
-   (`@@x`), class methods, and **modules**/mixins.
+   landed 0.13), **inheritance** + `super` (`Class.new(Super)` + an explicit
+   ancestry walk, landed 0.14), then **class variables** (`@@x`), class methods,
+   and **modules**/mixins.
 6. **Collections** — the `__method__` catalog for built-in `String`/`Array`/
    `Hash`/numeric methods (Ruby methods are largely native), sharing the same
    `__method__` dispatch surface as OOP.


### PR DESCRIPTION
## What

The **fourth OOP slice**: class inheritance and `super`. Bumps `semantic-ir-to-ruby` 0.13.0 → 0.14.0. No new `Feature` (a superclass rides on `Stmt::ClassDef`; `super` is a builtin).

- `class Dog < Animal` → `ClassDef { superclass: Some("Animal") }` → `Object.const_set(:Dog, Class.new(Animal))` — the subclass inherits Animal's ancestry natively.
- `super` / `super(x)` (the frontend forwards the method's arguments explicitly in both) → `__super__("m", "Dog", args…)` → `(Dog).superclass.instance_method(:sir_um_m).bind(self).call(args…)`.

## Why an explicit ancestry walk (not native `super`)

A method body lives in a hoisted top-level function (slice 2), not a real method context, so native bare `super` is unavailable there. Instead the superclass's method is fetched as an `UnboundMethod` from `<DefiningClass>.superclass`, bound to `self` (the receiver, inherited via slice 2's `define_method` binding), and called. Verified end-to-end: bare `super`, `super(x)` with a forwarded argument and a used result (`16`), and a three-level `A→B→C` chain where each `super` climbs one level (`→ 111`).

## Anti-RCE preserved

The super'd method name is emitted as a `sir_um_`-prefixed quoted symbol (via `emit_symbol`), so `instance_method` can only fetch a user-defined method — never a reflection/eval built-in — exactly as `__method__` dispatch (slice 2). The defining-class name (in `__super__`) and the superclass (in `Class.new`) are emitted verbatim as bare constants and each validated as a constant path in the co-total scan.

## Security review

A read-only security sub-agent reviewed the diff with injection + RCE as the focus and returned **PASSED — no vulnerabilities**: both verbatim constant emits are validated at exactly the emitter's position in the single co-total traversal, the super dispatch is `sir_um_`-prefixed with no unprefixed path, and the scan guarantees `__super__`'s `args[0]`/`args[1]` are `StrLit` so `str_arg`/`a[2..]` never panic.

## Totality

Still rejects class variables (`@@x`, `Feature::ClassVars`), class methods (`__class_method__` / `__def_class_method__`), and modules — each a later slice.

## Tests

96 tests pass (new: frontend+interpreter e2e for bare `super`, `super(x)` with a result, and a 3-level chain; hand-built for the subclass `Class.new(Super)` emit, an injectable superclass name, an injectable `__super__` class, and a malformed `__super__`). Two stale tests updated (the "superclass is rejected" test removed — now supported; `__super__` dropped from the still-rejected-builtins list). `cargo clippy` clean. CHANGELOG, README, and SIR25 spec (node table + roadmap) updated.

Note (a **frontend** quirk, not this backend): a bare `super` followed by another statement in a method mis-lowers to an invalid module; `super` as the method value or with explicit args lowers cleanly, and only clean forms are used in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)