### PR TITLE
feat(hl03): jump to any concept from the Learn nav

### DIFF
--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.15.0 — jump to any concept (HL03 polish)
+
+- **A "jump to concept" picker in the Learn nav.** Walking 186 concepts one
+  Next-click at a time is a long way to get anywhere; the nav row is now
+  `← Previous | [jump ▾] | Next →`, where the picker is a native `<select>` of
+  the whole book-ordered spine (`1. courtesy · thanks`, `2. farewell`, …) with
+  free keyboard type-ahead. Selecting one jumps the cursor straight there.
+- All three controls now funnel through one `jumpToConcept(index)` — it clamps,
+  resets the review draw (the covered set changed), persists the cursor (so the
+  jump is where you resume next visit, via the existing `cursorstore`), and
+  re-renders. No new persistence surface; it reuses the tested cursor save/clamp.
+- **A slice was abandoned, honestly:** the planned "romanization under the review
+  options" turned out un-grounded — only ~54 of ~700 lessons populate a
+  `romanization` field, and the Indic vocabulary (where script-shape guessing is
+  the real gap) carries its romanization inside the *gloss* text instead. Showing
+  it would render inconsistent subtext for <8% of options, so it was dropped
+  rather than faked; this jump-picker was built instead. 225 tests still pass;
+  verified in a real browser.
+
 ## 0.14.0 — start over: a "Reset progress" control (HL03 polish)
 
 - **You can now clear your progress.** The app persists a lot — the review

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -20,8 +20,9 @@ numbered sweep — one card per language that teaches it, in chain order
 own script, its etymology hook, and the **connections back** to earlier
 languages that share a root, so the cross-language memory the interleaving is
 meant to build is made visible rather than left implicit. Prev / Next walk the
-spine; consolidation lessons (`practice`/`review`) are left to the review quiz,
-not the teaching sweep.
+spine, and a **jump picker** (a `<select>` of the whole book-ordered spine) leaps
+straight to any concept; consolidation lessons (`practice`/`review`) are left to
+the review quiz, not the teaching sweep.
 
 The session **introduces writing systems as-needed** (`scriptintro.ts`): the
 first time the walk reaches a non-Latin script — Arabic, then Devanagari, then

--- a/code/programs/typescript/language-ladder/package.json
+++ b/code/programs/typescript/language-ladder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ladder",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "description": "The unified curriculum learning app (HL03): walk the language chain concept by concept, seeing the threads back to what you already know, then review it all with a randomised SRS quiz. (Was the HL02 script-writing-visualizer, whose Browse/Practice/Lessons/Concepts modes it now subsumes.)",
   "type": "module",

--- a/code/programs/typescript/language-ladder/src/main.ts
+++ b/code/programs/typescript/language-ladder/src/main.ts
@@ -680,31 +680,48 @@ function renderTeachingStep(
 }
 
 /** Prev / Next along the concept spine — walking the curriculum forward. */
+/**
+ * Move the teaching cursor to `index` (clamped), the one place all navigation
+ * funnels through — Prev, Next, and the jump picker. Resets the review draw
+ * (the covered set changed), persists so the app resumes here, and re-renders.
+ * A no-op if the target is where we already are.
+ */
+function jumpToConcept(index: number): void {
+  const target = Math.max(0, Math.min(index, CONCEPT_SPINE.length - 1));
+  if (target === conceptCursor) return;
+  conceptCursor = target;
+  reviewCell = null;
+  saveCursor(REVIEW_STORAGE, conceptCursor);
+  render();
+}
+
 function renderLearnNav(): HTMLElement {
   const nav = el("div", "learn__nav");
+
   const prev = el("button", "opt") as HTMLButtonElement;
-  prev.textContent = "← Previous concept";
+  prev.textContent = "← Previous";
   prev.disabled = conceptCursor === 0;
-  prev.onclick = () => {
-    if (conceptCursor > 0) {
-      conceptCursor -= 1;
-      reviewCell = null; // covered set changed — draw the next review from it
-      saveCursor(REVIEW_STORAGE, conceptCursor); // resume here next visit
-      render();
-    }
-  };
+  prev.onclick = () => jumpToConcept(conceptCursor - 1);
+
+  // Jump anywhere in the spine — 186 concepts is a long walk to Next through.
+  // A native <select> gives free keyboard type-ahead over the book-ordered list.
+  const jump = el("select", "learn__jump") as HTMLSelectElement;
+  jump.title = "Jump to concept";
+  CONCEPT_SPINE.forEach((concept, i) => {
+    const opt = el("option", "") as HTMLOptionElement;
+    opt.value = String(i);
+    opt.textContent = `${i + 1}. ${conceptTitle(concept)}`;
+    if (i === conceptCursor) opt.selected = true;
+    jump.appendChild(opt);
+  });
+  jump.onchange = () => jumpToConcept(Number(jump.value));
+
   const next = el("button", "opt") as HTMLButtonElement;
-  next.textContent = "Next concept →";
+  next.textContent = "Next →";
   next.disabled = conceptCursor >= CONCEPT_SPINE.length - 1;
-  next.onclick = () => {
-    if (conceptCursor < CONCEPT_SPINE.length - 1) {
-      conceptCursor += 1;
-      reviewCell = null; // covered set changed — draw the next review from it
-      saveCursor(REVIEW_STORAGE, conceptCursor); // resume here next visit
-      render();
-    }
-  };
-  nav.append(prev, next);
+  next.onclick = () => jumpToConcept(conceptCursor + 1);
+
+  nav.append(prev, jump, next);
   return nav;
 }
 

--- a/code/programs/typescript/language-ladder/src/styles.css
+++ b/code/programs/typescript/language-ladder/src/styles.css
@@ -322,7 +322,20 @@ body {
 }
 .step__script-sig { margin: 5px 0 0; font-size: 0.85rem; line-height: 1.5; color: var(--ink); }
 
-.learn__nav { display: flex; justify-content: space-between; gap: 10px; margin-top: 20px; }
+.learn__nav { display: flex; align-items: center; gap: 10px; margin-top: 20px; }
+/* The jump picker grows to fill the space between Prev and Next. */
+.learn__jump {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: 1px solid var(--line);
+  background: var(--card);
+  color: var(--ink);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+.learn__jump:hover { border-color: var(--accent); }
 .learn__nav .opt {
   border: 1px solid var(--line);
   background: var(--card);


### PR DESCRIPTION
## What

Walking **186 concepts** one Next-click at a time is a long way to get anywhere. The Learn nav is now **`← Previous | [jump ▾] | Next →`**, where the picker is a native `<select>` of the whole book-ordered spine (`1. courtesy · thanks`, `2. farewell`, …) with free keyboard type-ahead. Selecting one jumps the cursor straight there.

- All three controls funnel through one **`jumpToConcept(index)`**: it clamps, resets the review draw (the covered set changed), persists the cursor via the existing `cursorstore` (so a jump is where you resume next visit), and re-renders. **No new persistence surface** — it reuses the already-tested `saveCursor`/clamp.

## Honest note — a slice was abandoned, not faked

The originally-planned slice was *"romanization under the review quiz options"* (so a non-Latin option tests meaning, not just script-shape). It turned out **un-grounded**: only **~54 of ~700** lessons populate a `romanization` frontmatter field, and the Indic vocabulary — exactly where picking by script-shape is the real gap — carries its romanization inside the **gloss** text instead. Showing the field would render inconsistent subtext for **<8%** of options, worse than nothing. So it was dropped rather than faked, and this jump-picker was built in its place.

## Verification

- **225 tests** still pass. No new pure helper — the nav is DOM wiring over the already-tested cursor primitives (`cursorstore`).
- **Real browser** (headless screenshot, read back): the picker renders with the **current concept selected**, grows to fill the nav row, Previous disabled at concept 1.
- Correctness review (subagent): **clean** — clamp, no select/cursor drift, range invariant, `textContent`-only, and confirmed **no romanization leftovers** from the abandoned branch.

Builds on #8911 ("Reset progress", merged).