### PR TITLE
feat(adj-formula-stdlib): si-prefixes — NIST metric prefix → power-of-ten exponent (RS-5 table)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -297,6 +297,45 @@ fn shipped_volume_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b5) Shipped table — reference/si-prefixes.adj resolves via import (prefix →
+//      power-of-ten exponent, incl. NEGATIVE exponents), and an absent prefix
+//      abstains. This is the original concrete trigger for the `table` construct.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_si_prefixes_table_resolves_signed_exponents_and_abstains() {
+    let dir = scratch("shipped_siprefix");
+    let src = stdlib().join("reference/si-prefixes.adj");
+    std::fs::copy(&src, dir.join("si-prefixes.adj")).expect("copy shipped si-prefixes.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"si-prefixes.adj\"\n\
+         ? si_prefix_to_exponent(kilo, $E)\n\
+         ? si_prefix_to_exponent(milli, $E)\n\
+         ? si_prefix_to_exponent(pico, $E)\n\
+         ? si_prefix_to_exponent(zetta, $E)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST prefix → integer-exponent rows resolve, including the negatives.
+    assert!(out.contains("\"E\":\"3\""), "kilo = 3: {out}");
+    assert!(out.contains("\"E\":\"-3\""), "milli = -3 (negative exponent): {out}");
+    assert!(out.contains("\"E\":\"-12\""), "pico = -12: {out}");
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("metric-si-prefixes"),
+        "carries the NIST SI-prefixes locator: {out}"
+    );
+    // `zetta` is a real SI prefix but not in this row set — the engine abstains
+    // rather than inventing an exponent.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "an absent prefix abstains, never a fabricated exponent: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/si-prefixes.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/si-prefixes.adj
@@ -1,0 +1,51 @@
+% ============================================================================
+% si-prefixes — SI (metric) prefix → power-of-ten exponent (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of the `*-conversions.adj` references: a native tabular
+% relation ingested VERBATIM from the NIST "Metric (SI) Prefixes" table. Each row
+% maps an SI prefix to the base-10 EXPONENT it denotes (the integer n in 10ⁿ):
+%
+%     ? si_prefix_to_exponent(kilo, $E)     % 3    (kilo = 10³)
+%     ? si_prefix_to_exponent(milli, $E)    % -3   (milli = 10⁻³)
+%
+% Why a `table`, and why the EXPONENT rather than the factor string: this is exactly
+% the shape reference data comes in — a published table, not prose — and it was the
+% concrete trigger for the `table` construct (RS-5): NIST prints these factors as
+% "10³", "10⁻³", … with the power as a rendered SUPERSCRIPT, so a byte-quotable
+% *sentence* naming both prefix and value does not exist, and quoting the superscript
+% glyph is fragile. Storing the plain signed INTEGER exponent removes that fragility
+% entirely: the value is `3`, `-3`, `12`, `-12` — a number a byte-check verifies
+% against the cited table, and a number that can feed a `let`/`formula` downstream
+% (e.g. as the exponent of a power). The whole table is defended by one provenance
+% envelope; each `row` lowers to a ground relation `si_prefix_to_exponent(prefix, n)`,
+% so exact lookup is the ordinary SLD binding query — the engine returns the exponent
+% WITH this table's citation, on the CPU, 0 model calls, and a prefix not in the
+% table (an SI prefix this row set omits, or a non-prefix) abstains honestly.
+%
+% The prefixes and exponents below are the NIST SP / "Metric (SI) Prefixes" values,
+% transcribed as the plain integer power of ten each prefix names (NIST spells the
+% 10¹ prefix "deka"). `trust authoritative` — a primary, re-fetchable standards
+% reference. (See ADJ-TABLES.md; and feedback_nothing_human_authored — every
+% exponent is a verbatim cell of the cited table, nothing asserted from memory.)
+% ============================================================================
+
+table si_prefix_to_exponent {
+    columns prefix, exponent
+
+    row (tera, 12)
+    row (giga, 9)
+    row (mega, 6)
+    row (kilo, 3)
+    row (hecto, 2)
+    row (deka, 1)
+    row (deci, -1)
+    row (centi, -2)
+    row (milli, -3)
+    row (micro, -6)
+    row (nano, -9)
+    row (pico, -12)
+
+    source "Metric (SI) Prefixes"
+    locator "https://www.nist.gov/pml/owm/metric-si-prefixes"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/si-prefixes.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/si-prefixes.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% si-prefixes.query.adj — a worked lookup over the si-prefixes table.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a "what power of
+% ten does 'kilo' mean?" question: it states no fact — it only `import`s the
+% grounded table and asks binding queries. The native adj-lang engine resolves each
+% `?` against the table's rows (lowered to `si_prefix_to_exponent` relations) and
+% returns the binding + the table's source/locator/trust. A prefix not in the table
+% abstains honestly — the engine never invents an exponent.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli si-prefixes.query.adj
+% ============================================================================
+
+import "si-prefixes.adj"
+
+? si_prefix_to_exponent(kilo, $E)    % expect 3    (kilo = 10³)
+? si_prefix_to_exponent(mega, $E)    % expect 6    (mega = 10⁶)
+? si_prefix_to_exponent(milli, $E)   % expect -3   (milli = 10⁻³)
+? si_prefix_to_exponent(pico, $E)    % expect -12  (pico = 10⁻¹²)
+? si_prefix_to_exponent(zetta, $E)   % expect abstain — not in this row set


### PR DESCRIPTION
## What

A `table` sibling of the `*-conversions` references (Facts front): a native tabular relation ingested **verbatim** from the NIST **"Metric (SI) Prefixes"** table. 12 prefixes (tera…pico) → the base-10 **integer exponent** each denotes:

```
? si_prefix_to_exponent(kilo, $E)    % 3    (kilo = 10³)
? si_prefix_to_exponent(milli, $E)   % -3   (milli = 10⁻³)
? si_prefix_to_exponent(pico, $E)    % -12  (pico = 10⁻¹²)
```

## Why this, why the exponent

This was the **original concrete trigger** for the `table` construct (RS-5): NIST prints these factors with the power as a rendered **superscript** (10³, 10⁻³), so no byte-quotable *sentence* names both prefix and value, and quoting the superscript glyph is fragile. Storing the plain **signed integer exponent** removes that fragility — the value is a number a byte-check verifies against the cited table, and a number that can feed a `let`/`formula` as an exponent downstream. The `table` construct is exactly the faithful home tabular reference data needed.

## Grounding

Prefix names + integer exponents byte-verified against the fetched NIST page (NIST spells the 10¹ prefix "deka"). One provenance envelope defends the whole table; `trust authoritative`. Nothing asserted from memory.

## How it works

Each row lowers to a ground relation `si_prefix_to_exponent(prefix, n)`, so exact lookup is the ordinary SLD binding query — the engine returns the exponent **with the NIST citation**, 0 model calls. A prefix absent from this row set (e.g. `zetta`) **abstains** — never a fabricated exponent.

## Changes

- New: `reference/si-prefixes.adj` + `si-prefixes.query.adj` (worked lookup, 4 hits + `zetta` abstention).
- Test: `rs5_table_e2e` gains `shipped_si_prefixes_table_resolves_signed_exponents_and_abstains` (kilo=3, milli=−3, pico=−12 with the NIST locator; zetta abstains) — also exercises **negative-exponent** row cells. **10/10 pass.**

## Verification

- `cargo test -p adj-lang-cli --test rs5_table_e2e` → 10 passed.
- Shipped `.query.adj` driven through the built CLI: each exponent renders with the NIST locator; `zetta` abstains.
- Security review passed (pure declarative data + static-path test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)