### PR TITLE
feat(spice): add JFET junction potential

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add JFET model-card `PB` gate-junction-potential support with `VJ` as an
+  alias, bias-dependent `CGS`/`CGD` depletion capacitance in AC and transient
+  analysis, hierarchy preservation, and finite-positive validation.
 - Add JFET model-card `AF` flicker-noise current-exponent support, defaulting
   to `1` and applying `KF * abs(Id)^AF / frequency` across noise analysis.
 - Add JFET model-card `KF` flicker-noise support with a distinct drain-current

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -514,6 +514,7 @@ class JFET:
     Cgd: float = 0.0
     Kf: float = 0.0
     Af: float = 1.0
+    Pb: float = 1.0
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -604,7 +604,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
             element.Af,
         )
     if isinstance(element, JFET):
-        return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_, element.Cgs, element.Cgd, element.Kf, element.Af)
+        return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_, element.Cgs, element.Cgd, element.Kf, element.Af, element.Pb)
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
@@ -8919,6 +8919,26 @@ def _jfet_charge_state_voltage(n_plus: str, n_minus: str, node_voltages: dict[st
     return _node_voltage(n_plus, node_voltages) - _node_voltage(n_minus, node_voltages)
 
 
+def _jfet_charge_dynamic_capacitance(
+    el: JFET, zero_bias_capacitance: float, junction_voltage: float
+) -> float:
+    grading_coefficient = 0.5
+    forward_bias_depletion_coefficient = 0.5
+    oriented_voltage = -junction_voltage if el.polarity == "PJF" else junction_voltage
+    normalized_voltage = oriented_voltage / el.Pb
+    if normalized_voltage < forward_bias_depletion_coefficient:
+        return zero_bias_capacitance / ((1.0 - normalized_voltage) ** grading_coefficient)
+    transition_scale = (1.0 - forward_bias_depletion_coefficient) ** (
+        1.0 + grading_coefficient
+    )
+    continuation = (
+        1.0
+        - forward_bias_depletion_coefficient * (1.0 + grading_coefficient)
+        + grading_coefficient * normalized_voltage
+    )
+    return zero_bias_capacitance * continuation / transition_scale
+
+
 def _mosfet_gate_source_charge_state_name(el: Mosfet) -> str:
     return f"_M_{el.name}_gs_charge"
 
@@ -9059,6 +9079,8 @@ def _eval_jfet(el: JFET, vgs: float, vds: float) -> tuple[float, float, float]:
         raise ValueError(f"JFET '{el.name}' flicker-noise coefficient must be finite and non-negative")
     if not math.isfinite(el.Af) or el.Af < 0.0:
         raise ValueError(f"JFET '{el.name}' flicker-noise exponent must be finite and non-negative")
+    if not math.isfinite(el.Pb) or el.Pb <= 0.0:
+        raise ValueError(f"JFET '{el.name}' PB must be finite and positive")
     if el.polarity == "PJF":
         ids, gm, gds = _eval_njf(-vgs, -vds, -el.vto, el.beta, el.lambda_)
         return -ids, gm, gds
@@ -10203,6 +10225,7 @@ def _build_transient_companions(
         elif isinstance(el, JFET):
             for state_name, n_plus, n_minus, capacitance in _jfet_charge_state_specs(el):
                 v_prev = cap_voltages.get(state_name, 0.0)
+                capacitance = _jfet_charge_dynamic_capacitance(el, capacitance, v_prev)
                 if method == "trap":
                     g_eq = 2.0 * capacitance / h
                     I_eq = g_eq * v_prev + cap_currents.get(state_name, 0.0)
@@ -10465,6 +10488,7 @@ def _update_reactive_state(
                 v_new = _jfet_charge_state_voltage(n_plus, n_minus, op.node_voltages)
                 v_prev = cap_voltages.get(state_name, v_new)
                 v_older = cap_voltages_older.get(state_name, v_prev)
+                capacitance = _jfet_charge_dynamic_capacitance(el, capacitance, v_prev)
 
                 if method == "trap":
                     g_eq = 2.0 * capacitance / h
@@ -12735,9 +12759,11 @@ def _stamp_ac(
         _, gm_j, gds_j = _eval_jfet(el, Vg - Vs, Vd - Vs)
         _stamp_g_c(G, node_to_idx, el.drain, el.source, gds_j + 0j)
         if el.Cgs > 0.0:
-            _stamp_g_c(G, node_to_idx, el.gate, el.source, 1j * omega * el.Cgs)
+            cgs = _jfet_charge_dynamic_capacitance(el, el.Cgs, Vg - Vs)
+            _stamp_g_c(G, node_to_idx, el.gate, el.source, 1j * omega * cgs)
         if el.Cgd > 0.0:
-            _stamp_g_c(G, node_to_idx, el.gate, el.drain, 1j * omega * el.Cgd)
+            cgd = _jfet_charge_dynamic_capacitance(el, el.Cgd, Vg - Vd)
+            _stamp_g_c(G, node_to_idx, el.gate, el.drain, 1j * omega * cgd)
         if not _is_ground(el.drain):
             d = node_to_idx[el.drain]
             if not _is_ground(el.gate):

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -309,8 +309,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (15, 21, 5, 3),
     "NPN": (41, 58, 13, 4),
     "PNP": (41, 58, 13, 4),
-    "NJF": (7, 13, 5, 3),
-    "PJF": (7, 13, 5, 3),
+    "NJF": (8, 15, 6, 3),
+    "PJF": (8, 15, 6, 3),
     "NMOS": (18, 25, 6, 3),
     "PMOS": (18, 25, 6, 3),
 }
@@ -432,6 +432,8 @@ _JFET_PARAMETER_ALIASES: dict[str, str] = {
     "CGD0": "CGD",
     "KF": "KF",
     "AF": "AF",
+    "PB": "PB",
+    "VJ": "PB",
 }
 
 _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
@@ -1006,6 +1008,7 @@ def jfet_from_model_card(
         Cgd=p.get("CGD", 0.0),
         Kf=p.get("KF", 0.0),
         Af=p.get("AF", 1.0),
+        Pb=p.get("PB", 1.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -407,7 +407,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 147
+    assert len(coverage) == 149
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -422,7 +422,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 147
+    assert len(records) == 149
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -496,17 +496,17 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 147
-    assert report.expected_canonical_parameter_count == 147
-    assert report.accepted_name_count == 213
-    assert report.aliased_parameter_count == 53
+    assert report.canonical_parameter_count == 149
+    assert report.expected_canonical_parameter_count == 149
+    assert report.accepted_name_count == 217
+    assert report.aliased_parameter_count == 55
     assert report.max_alias_count == 4
     assert report.issues == ()
     assert format_model_card_supported_parameter_coverage_gate_report(report) == (
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t147\t147\t213\t53\t4\t0"
+        "true\t7\t7\t149\t149\t217\t55\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -534,9 +534,9 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 146
-    assert report.accepted_name_count == 210
-    assert report.aliased_parameter_count == 52
+    assert report.canonical_parameter_count == 148
+    assert report.accepted_name_count == 214
+    assert report.aliased_parameter_count == 54
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
@@ -550,7 +550,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t146\t147\t210\t52\t4\t4\n"
+        "false\t7\t7\t148\t149\t214\t54\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -666,7 +666,14 @@ def test_model_card_aliases_build_device_instances() -> None:
     jfet_card = normalize_model_card(
         "Jn",
         "njfet",
-        {"BET": 9.0e-4, "VT0": -1.8, "LAM": 0.02, "KF": 1.0e-12, "AF": 1.3},
+        {
+            "BET": 9.0e-4,
+            "VT0": -1.8,
+            "LAM": 0.02,
+            "KF": 1.0e-12,
+            "AF": 1.3,
+            "VJ": 0.8,
+        },
     )
     jfet_model = jfet_from_model_card("J1", "d", "g", "s", jfet_card)
     assert jfet_card.parameters == {
@@ -675,6 +682,7 @@ def test_model_card_aliases_build_device_instances() -> None:
         "LAMBDA": 0.02,
         "KF": 1.0e-12,
         "AF": 1.3,
+        "PB": 0.8,
     }
     assert jfet_model.polarity == "NJF"
     assert jfet_model.beta == pytest.approx(9.0e-4)
@@ -682,6 +690,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert jfet_model.lambda_ == pytest.approx(0.02)
     assert jfet_model.Kf == pytest.approx(1.0e-12)
     assert jfet_model.Af == pytest.approx(1.3)
+    assert jfet_model.Pb == pytest.approx(0.8)
 
     mos_card = normalize_model_card(
         "Mn",
@@ -736,6 +745,14 @@ def test_dc_rejects_invalid_jfet_flicker_noise_exponent() -> None:
         ValueError,
         match="flicker-noise exponent must be finite and non-negative",
     ):
+        dc_op(circuit)
+
+
+def test_dc_rejects_invalid_jfet_junction_potential() -> None:
+    circuit = Circuit()
+    circuit.add(JFET("J1", "drain", "gate", "0", Pb=0.0))
+
+    with pytest.raises(ValueError, match="PB must be finite and positive"):
         dc_op(circuit)
 
 
@@ -1409,6 +1426,42 @@ def test_transient_jfet_gate_source_capacitance_slows_gate_step() -> None:
     assert uncharged_first > 0.5
     assert charged_first < 0.01
     assert charged_first < uncharged_first
+
+
+def test_transient_jfet_junction_potential_shapes_gate_charge() -> None:
+    def final_gate_voltage(pb: float) -> float:
+        circuit = Circuit()
+        circuit.add(
+            VoltageSource(
+                "Vstep",
+                "in",
+                "0",
+                0.0,
+                waveform=PwlWaveform(
+                    ((0.0, 0.0), (2.0e-7, 0.4), (2.0e-6, 0.4))
+                ),
+            )
+        )
+        circuit.add(Resistor("Rin", "in", "gate", 1_000.0))
+        circuit.add(Resistor("Rdrain", "drain", "0", 1_000.0))
+        circuit.add(
+            JFET(
+                "J1",
+                "drain",
+                "gate",
+                "0",
+                beta=1.0e-12,
+                vto=-2.0,
+                Cgs=1.0e-9,
+                Pb=pb,
+            )
+        )
+        result = transient(
+            circuit, t_stop=2.0e-6, t_step=2.0e-7, method="euler"
+        )
+        return result.points[-1].node_voltages["gate"]
+
+    assert final_gate_voltage(0.5) < final_gate_voltage(2.0)
 
 
 def test_transient_mosfet_overlap_capacitance_slows_gate_step() -> None:
@@ -2421,11 +2474,11 @@ def test_subcircuit_expansion_preserves_complete_diode_model():
     assert expanded.Af == pytest.approx(1.3)
 
 
-def test_subcircuit_expansion_preserves_jfet_flicker_noise_parameters():
+def test_subcircuit_expansion_preserves_complete_jfet_model():
     cell = SubcircuitDefinition(
         "jfet-cell",
         ("d", "g", "s"),
-        (JFET("Jcell", "d", "g", "s", Kf=1.0e-12, Af=1.3),),
+        (JFET("Jcell", "d", "g", "s", Kf=1.0e-12, Af=1.3, Pb=0.8),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2434,6 +2487,7 @@ def test_subcircuit_expansion_preserves_jfet_flicker_noise_parameters():
     expanded = next(element for element in circuit.elements if isinstance(element, JFET))
     assert expanded.Kf == pytest.approx(1.0e-12)
     assert expanded.Af == pytest.approx(1.3)
+    assert expanded.Pb == pytest.approx(0.8)
 
 
 def test_subcircuit_expansion_preserves_complete_bjt_model():
@@ -3616,6 +3670,32 @@ def test_ac_jfet_gate_source_capacitance_shunts_high_frequency_gate_drive() -> N
 
     assert without_capacitance > 0.9
     assert with_capacitance < without_capacitance / 100.0
+
+
+def test_ac_jfet_junction_potential_shapes_reverse_biased_gate_capacitance() -> None:
+    def gate_amplitude(pb: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vac", "in", "0", -0.5, ac=AcSource(1.0)))
+        circuit.add(Resistor("Rin", "in", "gate", 1_000.0))
+        circuit.add(Resistor("Rdrain", "drain", "0", 1_000.0))
+        circuit.add(
+            JFET(
+                "J1",
+                "drain",
+                "gate",
+                "0",
+                beta=1.0e-12,
+                vto=-2.0,
+                Cgs=1.0e-9,
+                Pb=pb,
+            )
+        )
+        result = ac_sweep(
+            circuit, f_start=100_000.0, f_stop=100_000.0, n_points=1
+        )
+        return abs(result.points[0].node_voltages["gate"])
+
+    assert gate_amplitude(0.5) > gate_amplitude(2.0)
 
 
 def test_jfet_transient_source_follower_charges_output_capacitor() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add JFET model-card `PB` gate-junction-potential support with `VJ` as an
+  alias, bias-dependent `CGS`/`CGD` depletion capacitance in AC and transient
+  analysis, hierarchy preservation, and finite-positive validation.
 - Add JFET model-card `AF` flicker-noise current-exponent support, defaulting
   to `1` and applying `KF * abs(Id)^AF / frequency` across noise analysis.
 - Add JFET model-card `KF` flicker-noise support with a distinct drain-current

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -428,6 +428,7 @@ fn clone_subckt_element(
             );
             mapped.flicker_noise_coefficient = element.flicker_noise_coefficient;
             mapped.flicker_noise_exponent = element.flicker_noise_exponent;
+            mapped.junction_potential = element.junction_potential;
             Element::Jfet(mapped)
         }
         Element::Bjt(element) => {
@@ -2817,6 +2818,7 @@ pub struct Jfet {
     pub gate_drain_capacitance: f64,
     pub flicker_noise_coefficient: f64,
     pub flicker_noise_exponent: f64,
+    pub junction_potential: f64,
 }
 
 impl Jfet {
@@ -2887,6 +2889,7 @@ impl Jfet {
             gate_drain_capacitance,
             flicker_noise_coefficient: 0.0,
             flicker_noise_exponent: 1.0,
+            junction_potential: 1.0,
         }
     }
 }
@@ -3810,8 +3813,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     (ModelCardKind::Diode, 15, 21, 5, 3),
     (ModelCardKind::Npn, 41, 58, 13, 4),
     (ModelCardKind::Pnp, 41, 58, 13, 4),
-    (ModelCardKind::Njf, 7, 13, 5, 3),
-    (ModelCardKind::Pjf, 7, 13, 5, 3),
+    (ModelCardKind::Njf, 8, 15, 6, 3),
+    (ModelCardKind::Pjf, 8, 15, 6, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
     (ModelCardKind::Pmos, 18, 25, 6, 3),
 ];
@@ -3912,6 +3915,8 @@ const JFET_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("CGD0", "CGD"),
     ("KF", "KF"),
     ("AF", "AF"),
+    ("PB", "PB"),
+    ("VJ", "PB"),
 ];
 const MOS_LEVEL1_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("LEVEL", "LEVEL"),
@@ -4640,6 +4645,7 @@ pub fn jfet_from_model_card(
     );
     jfet.flicker_noise_coefficient = model_card_value(model, "KF", 0.0);
     jfet.flicker_noise_exponent = model_card_value(model, "AF", 1.0);
+    jfet.junction_potential = model_card_value(model, "PB", 1.0);
     Ok(jfet)
 }
 
@@ -23614,7 +23620,8 @@ fn stamp_jfet_charge(
         else {
             continue;
         };
-        let capacitance = spec.capacitance;
+        let capacitance =
+            jfet_charge_dynamic_capacitance(jfet, spec.capacitance, state.previous_voltage);
         if capacitance <= 0.0 {
             continue;
         }
@@ -23994,18 +24001,28 @@ fn stamp_ac_jfet_small_signal(
         gate_voltage - source_voltage,
         drain_voltage - source_voltage,
     );
+    let gate_source_capacitance = jfet_charge_dynamic_capacitance(
+        jfet,
+        jfet.gate_source_capacitance,
+        gate_voltage - source_voltage,
+    );
+    let gate_drain_capacitance = jfet_charge_dynamic_capacitance(
+        jfet,
+        jfet.gate_drain_capacitance,
+        gate_voltage - drain_voltage,
+    );
     stamp_complex_conductance(matrix, drain, source, Complex::new(result.gds, 0.0));
     stamp_complex_conductance(
         matrix,
         gate,
         source,
-        Complex::new(0.0, omega * jfet.gate_source_capacitance),
+        Complex::new(0.0, omega * gate_source_capacitance),
     );
     stamp_complex_conductance(
         matrix,
         gate,
         drain,
-        Complex::new(0.0, omega * jfet.gate_drain_capacitance),
+        Complex::new(0.0, omega * gate_drain_capacitance),
     );
     stamp_complex_transconductance(
         matrix,
@@ -24336,6 +24353,29 @@ fn jfet_charge_state_voltage(
     node_voltages: &BTreeMap<String, f64>,
 ) -> f64 {
     voltage_at(node_voltages, spec.positive) - voltage_at(node_voltages, spec.negative)
+}
+
+fn jfet_charge_dynamic_capacitance(
+    jfet: &Jfet,
+    zero_bias_capacitance: f64,
+    junction_voltage: f64,
+) -> f64 {
+    const GRADING_COEFFICIENT: f64 = 0.5;
+    const FORWARD_BIAS_DEPLETION_COEFFICIENT: f64 = 0.5;
+
+    let oriented_voltage = match jfet.polarity {
+        JfetPolarity::Njf => junction_voltage,
+        JfetPolarity::Pjf => -junction_voltage,
+    };
+    let normalized_voltage = oriented_voltage / jfet.junction_potential;
+    if normalized_voltage < FORWARD_BIAS_DEPLETION_COEFFICIENT {
+        return zero_bias_capacitance / (1.0 - normalized_voltage).powf(GRADING_COEFFICIENT);
+    }
+    let transition_scale =
+        (1.0 - FORWARD_BIAS_DEPLETION_COEFFICIENT).powf(1.0 + GRADING_COEFFICIENT);
+    let continuation = 1.0 - FORWARD_BIAS_DEPLETION_COEFFICIENT * (1.0 + GRADING_COEFFICIENT)
+        + GRADING_COEFFICIENT * normalized_voltage;
+    zero_bias_capacitance * continuation / transition_scale
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -24869,6 +24909,12 @@ fn validate_jfet(jfet: &Jfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: jfet.name.clone(),
             reason: "flicker-noise exponent must be finite and non-negative".to_string(),
+        });
+    }
+    if !jfet.junction_potential.is_finite() || jfet.junction_potential <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: jfet.name.clone(),
+            reason: "junction potential must be finite and positive".to_string(),
         });
     }
     Ok(())
@@ -25455,7 +25501,11 @@ fn update_capacitor_states(
                 .map(|spec| {
                     (
                         jfet_charge_state_voltage(&spec, node_voltages),
-                        spec.capacitance,
+                        jfet_charge_dynamic_capacitance(
+                            jfet,
+                            spec.capacitance,
+                            state.previous_voltage,
+                        ),
                     )
                 }),
             Element::Mosfet(mosfet) => mosfet_charge_state_specs(mosfet)

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -1425,6 +1425,42 @@ fn ac_jfet_gate_source_capacitance_shunts_high_frequency_gate_drive() {
 }
 
 #[test]
+fn ac_jfet_junction_potential_shapes_reverse_biased_gate_capacitance() {
+    fn gate_amplitude(junction_potential: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "in", "0", -0.5, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "gate", 1_000.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rdrain", "drain", "0", 1_000.0,
+        )));
+        let mut jfet = Jfet::with_model_and_capacitance(
+            "J1",
+            "drain",
+            "gate",
+            "0",
+            JfetPolarity::Njf,
+            1.0e-12,
+            -2.0,
+            0.0,
+            1.0e-9,
+            0.0,
+        );
+        jfet.junction_potential = junction_potential;
+        circuit.add(Element::Jfet(jfet));
+        ac_sweep(&circuit, 100_000.0, 100_000.0, 1).unwrap()[0]
+            .voltage("gate")
+            .unwrap()
+            .abs()
+    }
+
+    assert!(gate_amplitude(0.5) > gate_amplitude(2.0));
+}
+
+#[test]
 fn ac_current_source_supports_explicit_magnitude_and_phase() {
     let mut circuit = Circuit::new();
     circuit.add(Element::CurrentSource(CurrentSource::with_ac(

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -95,7 +95,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 147);
+    assert_eq!(coverage.len(), 149);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -114,7 +114,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 147);
+    assert_eq!(records.len(), 149);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -195,15 +195,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 147);
-    assert_eq!(report.expected_canonical_parameter_count, 147);
-    assert_eq!(report.accepted_name_count, 213);
-    assert_eq!(report.aliased_parameter_count, 53);
+    assert_eq!(report.canonical_parameter_count, 149);
+    assert_eq!(report.expected_canonical_parameter_count, 149);
+    assert_eq!(report.accepted_name_count, 217);
+    assert_eq!(report.aliased_parameter_count, 55);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t147\t147\t213\t53\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t149\t149\t217\t55\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -230,9 +230,9 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 146);
-    assert_eq!(report.accepted_name_count, 210);
-    assert_eq!(report.aliased_parameter_count, 52);
+    assert_eq!(report.canonical_parameter_count, 148);
+    assert_eq!(report.accepted_name_count, 214);
+    assert_eq!(report.aliased_parameter_count, 54);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
     assert_eq!(report.issues[0].kind, "NMOS");
@@ -248,7 +248,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t146\t147\t210\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t148\t149\t214\t54\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -515,6 +515,7 @@ fn model_card_aliases_build_device_instances() {
             ("LAM", 0.02),
             ("KF", 1.0e-12),
             ("AF", 1.3),
+            ("VJ", 0.8),
         ],
     )
     .unwrap();
@@ -524,12 +525,14 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*jfet_card.parameters.get("LAMBDA").unwrap(), 0.02);
     assert_close(*jfet_card.parameters.get("KF").unwrap(), 1.0e-12);
     assert_close(*jfet_card.parameters.get("AF").unwrap(), 1.3);
+    assert_close(*jfet_card.parameters.get("PB").unwrap(), 0.8);
     assert_eq!(jfet_model.polarity, JfetPolarity::Njf);
     assert_close(jfet_model.beta, 9.0e-4);
     assert_close(jfet_model.threshold_voltage, -1.8);
     assert_close(jfet_model.channel_length_modulation, 0.02);
     assert_close(jfet_model.flicker_noise_coefficient, 1.0e-12);
     assert_close(jfet_model.flicker_noise_exponent, 1.3);
+    assert_close(jfet_model.junction_potential, 0.8);
 
     let mos_card = normalize_model_card(
         "Mn",
@@ -1448,10 +1451,11 @@ fn subcircuit_expansion_preserves_complete_diode_model() {
 }
 
 #[test]
-fn subcircuit_expansion_preserves_jfet_flicker_noise_parameters() {
+fn subcircuit_expansion_preserves_complete_jfet_model() {
     let mut jfet = Jfet::new("Jcell", "d", "g", "s");
     jfet.flicker_noise_coefficient = 1.0e-12;
     jfet.flicker_noise_exponent = 1.3;
+    jfet.junction_potential = 0.8;
     let mut circuit = Circuit::new();
     circuit
         .define_subcircuit(SubcircuitDefinition::new(
@@ -1478,6 +1482,7 @@ fn subcircuit_expansion_preserves_jfet_flicker_noise_parameters() {
         .unwrap();
     assert_close(expanded.flicker_noise_coefficient, 1.0e-12);
     assert_close(expanded.flicker_noise_exponent, 1.3);
+    assert_close(expanded.junction_potential, 0.8);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -348,6 +348,24 @@ fn jfet_rejects_invalid_flicker_noise_exponent() {
 }
 
 #[test]
+fn jfet_rejects_invalid_junction_potential() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 0.0,
+    )));
+    let mut jfet = Jfet::new("J1", "out", "gate", "0");
+    jfet.junction_potential = 0.0;
+    circuit.add(Element::Jfet(jfet));
+
+    let error = noise_ac(&circuit, "out", "Vgate", &[1_000.0], 300.0).unwrap_err();
+    assert!(matches!(
+        error,
+        SpiceError::InvalidElement { reason, .. }
+            if reason == "junction potential must be finite and positive"
+    ));
+}
+
+#[test]
 fn jfet_flicker_noise_uses_af_current_exponent() {
     let source_psd = |exponent: f64| {
         let mut circuit = Circuit::new();

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -280,6 +280,52 @@ fn transient_jfet_gate_source_capacitance_slows_gate_step() {
 }
 
 #[test]
+fn transient_jfet_junction_potential_shapes_gate_charge() {
+    fn final_gate_voltage(junction_potential: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
+            "Vstep",
+            "in",
+            "0",
+            0.0,
+            Waveform::Pwl(PwlWaveform::new(vec![
+                (0.0, 0.0),
+                (2.0e-7, 0.4),
+                (2.0e-6, 0.4),
+            ])),
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "gate", 1_000.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rdrain", "drain", "0", 1_000.0,
+        )));
+        let mut jfet = Jfet::with_model_and_capacitance(
+            "J1",
+            "drain",
+            "gate",
+            "0",
+            JfetPolarity::Njf,
+            1.0e-12,
+            -2.0,
+            0.0,
+            1.0e-9,
+            0.0,
+        );
+        jfet.junction_potential = junction_potential;
+        circuit.add(Element::Jfet(jfet));
+        transient_with_method(&circuit, 2.0e-7, 2.0e-6, TransientMethod::Euler)
+            .unwrap()
+            .last()
+            .unwrap()
+            .voltage("gate")
+            .unwrap()
+    }
+
+    assert!(final_gate_voltage(0.5) < final_gate_voltage(2.0));
+}
+
+#[test]
 fn transient_mosfet_overlap_capacitance_slows_gate_step() {
     fn run(gate_source_overlap_capacitance: f64) -> Vec<TransientPoint> {
         let mut circuit = Circuit::new();

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add JFET model-card `PB` gate-junction-potential support with `VJ` as an
+  alias, bias-dependent `CGS`/`CGD` depletion capacitance in AC and transient
+  analysis, hierarchy preservation, and finite-positive validation.
 - Add JFET model-card `AF` flicker-noise current-exponent support, defaulting
   to `1` and applying `KF * abs(Id)^AF / frequency` across noise analysis.
 - Add JFET model-card `KF` flicker-noise support with a distinct drain-current

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1697,6 +1697,7 @@ export interface Jfet {
   readonly gateDrainCapacitance: number;
   readonly flickerNoiseCoefficient: number;
   readonly flickerNoiseExponent: number;
+  readonly junctionPotential: number;
 }
 
 export type BjtPolarity = "NPN" | "PNP";
@@ -2026,8 +2027,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   D: [15, 21, 5, 3],
   NPN: [41, 58, 13, 4],
   PNP: [41, 58, 13, 4],
-  NJF: [7, 13, 5, 3],
-  PJF: [7, 13, 5, 3],
+  NJF: [8, 15, 6, 3],
+  PJF: [8, 15, 6, 3],
   NMOS: [18, 25, 6, 3],
   PMOS: [18, 25, 6, 3],
 };
@@ -3613,7 +3614,7 @@ function cloneSubcktElement(
     case "diode":
       return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient, element.breakdownVoltage, element.breakdownCurrent, element.junctionCapacitance, element.transitTime, element.junctionPotential, element.gradingCoefficient, element.forwardBiasDepletionCoefficient, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.seriesResistance, element.flickerNoiseCoefficient, element.flickerNoiseExponent);
     case "jfet":
-      return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance, element.flickerNoiseCoefficient, element.flickerNoiseExponent);
+      return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.junctionPotential);
     case "bjt":
       return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees, element.forwardTransitTimeBiasCoefficient, element.forwardTransitTimeCurrent, element.forwardTransitTimeVoltage, element.emitterResistance, element.collectorResistance, element.baseResistance, element.minimumBaseResistance, element.baseResistanceHalfCurrent, element.baseCollectorCapacitanceFraction);
     case "mosfet":
@@ -7760,6 +7761,7 @@ export function jfet(
   gateDrainCapacitance = 0.0,
   flickerNoiseCoefficient = 0.0,
   flickerNoiseExponent = 1.0,
+  junctionPotential = 1.0,
 ): Jfet {
   return {
     kind: "jfet",
@@ -7775,6 +7777,7 @@ export function jfet(
     gateDrainCapacitance,
     flickerNoiseCoefficient,
     flickerNoiseExponent,
+    junctionPotential,
   };
 }
 
@@ -8033,6 +8036,8 @@ const JFET_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   CGD0: "CGD",
   KF: "KF",
   AF: "AF",
+  PB: "PB",
+  VJ: "PB",
 };
 
 const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -8578,6 +8583,7 @@ export function jfetFromModelCard(
     p.CGD ?? 0.0,
     p.KF ?? 0.0,
     p.AF ?? 1.0,
+    p.PB ?? 1.0,
   );
 }
 
@@ -19528,6 +19534,9 @@ function validateJfet(element: Jfet): void {
       "flicker-noise exponent must be finite and non-negative",
     );
   }
+  if (!Number.isFinite(element.junctionPotential) || element.junctionPotential <= 0.0) {
+    throw invalidElement(element.name, "junction potential must be finite and positive");
+  }
 }
 
 function stampJfet(
@@ -19569,17 +19578,22 @@ function stampJfetCharge(
     if (state === undefined || spec.capacitance <= 0.0) {
       continue;
     }
+    const capacitance = jfetChargeDynamicCapacitance(
+      element,
+      spec.capacitance,
+      state.previousVoltage,
+    );
     const conductance =
       state.method === "trap"
-        ? (2.0 * spec.capacitance) / state.timeStep
+        ? (2.0 * capacitance) / state.timeStep
         : state.method === "gear2"
-          ? (3.0 * spec.capacitance) / (2.0 * state.timeStep)
-          : spec.capacitance / state.timeStep;
+          ? (3.0 * capacitance) / (2.0 * state.timeStep)
+          : capacitance / state.timeStep;
     const historyCurrent =
       state.method === "trap"
         ? conductance * state.previousVoltage + state.previousCurrent
         : state.method === "gear2"
-          ? (spec.capacitance *
+          ? (capacitance *
               (4.0 * state.previousVoltage - state.previousPreviousVoltage)) /
             (2.0 * state.timeStep)
           : conductance * state.previousVoltage;
@@ -20220,6 +20234,27 @@ function jfetChargeStateVoltage(
   nodeVoltages: ReadonlyMap<string, number>,
 ): number {
   return voltageAt(nodeVoltages, spec.positive) - voltageAt(nodeVoltages, spec.negative);
+}
+
+function jfetChargeDynamicCapacitance(
+  element: Jfet,
+  zeroBiasCapacitance: number,
+  junctionVoltage: number,
+): number {
+  const gradingCoefficient = 0.5;
+  const forwardBiasDepletionCoefficient = 0.5;
+  const orientedVoltage = element.polarity === "PJF" ? -junctionVoltage : junctionVoltage;
+  const normalizedVoltage = orientedVoltage / element.junctionPotential;
+  if (normalizedVoltage < forwardBiasDepletionCoefficient) {
+    return zeroBiasCapacitance / ((1.0 - normalizedVoltage) ** gradingCoefficient);
+  }
+  const transitionScale =
+    (1.0 - forwardBiasDepletionCoefficient) ** (1.0 + gradingCoefficient);
+  const continuation =
+    1.0 -
+    forwardBiasDepletionCoefficient * (1.0 + gradingCoefficient) +
+    gradingCoefficient * normalizedVoltage;
+  return (zeroBiasCapacitance * continuation) / transitionScale;
 }
 
 interface MosfetChargeStateSpec {
@@ -20948,7 +20983,11 @@ function updateCapacitorStates(
                 previousVoltages.get(bjtBaseCollectorChargeStateName(bjtElement!)) ?? 0.0,
               )
             : jfetSpec !== undefined
-              ? jfetSpec.capacitance
+              ? jfetChargeDynamicCapacitance(
+                  jfetElement!,
+                  jfetSpec.capacitance,
+                  state.previousVoltage,
+                )
               : mosfetChargeDynamicCapacitance(
                   mosfetElement!,
                   mosfetSpec!,
@@ -22662,18 +22701,28 @@ function stampAcJfetSmallSignal(
     gateVoltage - sourceVoltage,
     drainVoltage - sourceVoltage,
   );
+  const gateSourceCapacitance = jfetChargeDynamicCapacitance(
+    element,
+    element.gateSourceCapacitance,
+    gateVoltage - sourceVoltage,
+  );
+  const gateDrainCapacitance = jfetChargeDynamicCapacitance(
+    element,
+    element.gateDrainCapacitance,
+    gateVoltage - drainVoltage,
+  );
   stampComplexConductance(matrix, drain, source, complex(result.gds, 0.0));
   stampComplexConductance(
     matrix,
     gate,
     source,
-    complex(0.0, omega * element.gateSourceCapacitance),
+    complex(0.0, omega * gateSourceCapacitance),
   );
   stampComplexConductance(
     matrix,
     gate,
     drain,
-    complex(0.0, omega * element.gateDrainCapacitance),
+    complex(0.0, omega * gateDrainCapacitance),
   );
   stampComplexTransconductance(
     matrix,

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -519,6 +519,22 @@ describe("acSweep", () => {
     expect(withCapacitance).toBeLessThan(withoutCapacitance / 100.0);
   });
 
+  it("uses JFET junction potential to shape reverse-biased gate capacitance", () => {
+    function gateAmplitude(junctionPotential: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "in", "0", -0.5, 1.0));
+      circuit.add(resistor("Rin", "in", "gate", 1_000.0));
+      circuit.add(resistor("Rdrain", "drain", "0", 1_000.0));
+      circuit.add({
+        ...jfet("J1", "drain", "gate", "0", "NJF", 1.0e-12, -2.0, 0.0, 1.0e-9),
+        junctionPotential,
+      });
+      return complexAbs(acSweep(circuit, 100_000.0, 100_000.0, 1)[0].voltage("gate")!);
+    }
+
+    expect(gateAmplitude(0.5)).toBeGreaterThan(gateAmplitude(2.0));
+  });
+
   it("uses MOSFET overlap capacitance in AC analysis", () => {
     function gateAmplitude(CGSO: number): number {
       const circuit = new Circuit();

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -120,7 +120,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(147);
+    expect(coverage).toHaveLength(149);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -140,7 +140,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(147);
+    expect(records).toHaveLength(149);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -205,15 +205,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 147,
-      expectedCanonicalParameterCount: 147,
-      acceptedNameCount: 213,
-      aliasedParameterCount: 53,
+      canonicalParameterCount: 149,
+      expectedCanonicalParameterCount: 149,
+      acceptedNameCount: 217,
+      aliasedParameterCount: 55,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t147\t147\t213\t53\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t149\t149\t217\t55\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -236,9 +236,9 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(146);
-    expect(report.acceptedNameCount).toBe(210);
-    expect(report.aliasedParameterCount).toBe(52);
+    expect(report.canonicalParameterCount).toBe(148);
+    expect(report.acceptedNameCount).toBe(214);
+    expect(report.aliasedParameterCount).toBe(54);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
@@ -252,7 +252,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t146\t147\t210\t52\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t148\t149\t214\t54\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -383,15 +383,16 @@ describe("dcOp", () => {
     expectClose(bjtModel.baseCollectorGradingCoefficient, 0.45);
     expectClose(bjtModel.forwardBiasDepletionCoefficient, 0.4);
 
-    const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02, KF: 1.0e-12, AF: 1.3 });
+    const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02, KF: 1.0e-12, AF: 1.3, VJ: 0.8 });
     const jfetModel = jfetFromModelCard("J1", "d", "g", "s", jfetCard);
-    expect(jfetCard.parameters).toStrictEqual({ BETA: 9.0e-4, VTO: -1.8, LAMBDA: 0.02, KF: 1.0e-12, AF: 1.3 });
+    expect(jfetCard.parameters).toStrictEqual({ BETA: 9.0e-4, VTO: -1.8, LAMBDA: 0.02, KF: 1.0e-12, AF: 1.3, PB: 0.8 });
     expect(jfetModel.polarity).toBe("NJF");
     expectClose(jfetModel.beta, 9.0e-4);
     expectClose(jfetModel.thresholdVoltage, -1.8);
     expectClose(jfetModel.channelLengthModulation, 0.02);
     expectClose(jfetModel.flickerNoiseCoefficient, 1.0e-12);
     expectClose(jfetModel.flickerNoiseExponent, 1.3);
+    expectClose(jfetModel.junctionPotential, 0.8);
 
     const mosCard = normalizeModelCard("Mn", "nmos", {
       LEVEL: 1.0,
@@ -1043,7 +1044,7 @@ describe("dcOp", () => {
     expectClose(expanded.flickerNoiseExponent, 1.3);
   });
 
-  it("preserves JFET flicker-noise parameters through subcircuit expansion", () => {
+  it("preserves the complete JFET model through subcircuit expansion", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("jfet-cell", ["d", "g", "s"], [
@@ -1051,6 +1052,7 @@ describe("dcOp", () => {
           ...jfet("Jcell", "d", "g", "s"),
           flickerNoiseCoefficient: 1.0e-12,
           flickerNoiseExponent: 1.3,
+          junctionPotential: 0.8,
         },
       ]),
     );
@@ -1063,6 +1065,7 @@ describe("dcOp", () => {
     }
     expectClose(expanded.flickerNoiseCoefficient, 1.0e-12);
     expectClose(expanded.flickerNoiseExponent, 1.3);
+    expectClose(expanded.junctionPotential, 0.8);
   });
 
   it("preserves the complete BJT model through subcircuit expansion", () => {

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -59,6 +59,16 @@ describe("noiseAc", () => {
     );
   });
 
+  it("rejects an invalid JFET junction potential", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vgate", "gate", "0", 0.0));
+    circuit.add({ ...jfet("J1", "out", "gate", "0"), junctionPotential: 0.0 });
+
+    expect(() => noiseAc(circuit, "out", "Vgate", [1_000.0])).toThrow(
+      /junction potential must be finite and positive/,
+    );
+  });
+
   it("uses JFET AF as the current exponent", () => {
     function sourcePsd(exponent: number): number {
       const circuit = new Circuit();

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -285,6 +285,33 @@ describe("transient", () => {
     expect(chargedFirst!).toBeLessThan(unchargedFirst!);
   });
 
+  it("uses JFET junction potential to shape transient gate charge", () => {
+    function finalGateVoltage(junctionPotential: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithWaveform(
+        "Vstep",
+        "in",
+        "0",
+        0.0,
+        new PwlWaveform([
+          [0.0, 0.0],
+          [2.0e-7, 0.4],
+          [2.0e-6, 0.4],
+        ]),
+      ));
+      circuit.add(resistor("Rin", "in", "gate", 1_000.0));
+      circuit.add(resistor("Rdrain", "drain", "0", 1_000.0));
+      circuit.add({
+        ...jfet("J1", "drain", "gate", "0", "NJF", 1.0e-12, -2.0, 0.0, 1.0e-9),
+        junctionPotential,
+      });
+      const points = transient(circuit, 2.0e-7, 2.0e-6, "euler");
+      return points.at(-1)!.voltage("gate")!;
+    }
+
+    expect(finalGateVoltage(0.5)).toBeLessThan(finalGateVoltage(2.0));
+  });
+
   it("uses MOSFET overlap capacitance during transient gate steps", () => {
     function run(gateSourceOverlapCapacitance: number): TransientPoint[] {
       const circuit = new Circuit();

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,16 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language JFET flicker-noise current exponent.
+1. Cross-language JFET gate-junction potential.
    - Status: current PR completion candidate.
-   - Add Berkeley JFET `AF` model-card support in Rust, Python, and TypeScript,
-     defaulting to one and applying it to the existing drain-current flicker
-     source as `KF * abs(Id)^AF / frequency`.
-   - Preserve `AF` through hierarchy and cloning while validating finite
-     non-negative values in every engine.
-   - Extend the supported-parameter coverage gate from 145 to 147 canonical
-     rows and lock current-exponent behavior in all engines.
+   - Add Berkeley JFET `PB` model-card support, with `VJ` as an accepted alias,
+     in Rust, Python, and TypeScript.
+   - Default `PB` to one volt and use it to shape the existing zero-bias
+     `CGS`/`CGD` junction capacitances in AC and transient analysis with the
+     Berkeley grading and forward-bias continuation defaults.
+   - Preserve `PB` through hierarchy and cloning, validate finite positive
+     values, and extend the supported-parameter coverage gate from 147 to 149
+     canonical rows.
 
 ## Completed Slices
 
@@ -3252,6 +3253,14 @@ the Rust, Python, and TypeScript surfaces together.
    - Hierarchy and cloning paths preserve `KF`, finite non-negative validation
      is shared across analyses, and the supported-parameter release gate now
      covers 145 canonical rows.
+
+250. Cross-language JFET flicker-noise current exponent.
+   - Status: completed in PR 8914.
+   - Rust, Python, and TypeScript JFET model cards now accept `AF`, default it
+     to one, and apply `KF * abs(Id)^AF / frequency` to JFET flicker noise.
+   - Hierarchy and cloning paths preserve `AF`, finite non-negative validation
+     is shared across analyses, and the supported-parameter release gate now
+     covers 147 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add canonical JFET `PB` model-card support with `VJ` alias in Rust, Python, and TypeScript
- apply Berkeley-default bias-dependent `CGS`/`CGD` depletion capacitance in AC and transient analysis
- preserve and validate junction potential, expand the coverage gate to 149 canonical rows, and reconcile the completion plan

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python Ruff on touched sources/tests
- Python full pytest: 592 passed, 88.77% coverage
- TypeScript build and full test: 350 passed