### PR TITLE
feat(hl03): a spine progress bar in Learn mode

### DIFF
--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.16.0 — a spine progress bar (HL03 polish)
+
+- **A slim progress bar under the "Concept N of 186" line**, showing how far
+  along the whole spine the walk has reached — a sense of the journey's scale
+  that the bare count doesn't convey at a glance (a thin sliver at concept 1, a
+  half-full bar at ~93, full at the end).
+- New pure `spineProgress(cursor, length)` in `sequence.ts` returns the fraction
+  reached in `[0, 1]`, counting the current concept (cursor 0 of 10 → 0.1),
+  clamping an out-of-range cursor and returning 0 for an empty spine. 3 new tests
+  (228 total) with a control that bites: a naive `cursor/length` would read 0 at
+  the start, so the test pins 0.1. Width is set via `style.width` (no innerHTML).
+  Verified in a real browser (seeded to concept 93 → the bar sits at ~50%).
+
 ## 0.15.0 — jump to any concept (HL03 polish)
 
 - **A "jump to concept" picker in the Learn nav.** Walking 186 concepts one

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -21,8 +21,9 @@ own script, its etymology hook, and the **connections back** to earlier
 languages that share a root, so the cross-language memory the interleaving is
 meant to build is made visible rather than left implicit. Prev / Next walk the
 spine, and a **jump picker** (a `<select>` of the whole book-ordered spine) leaps
-straight to any concept; consolidation lessons (`practice`/`review`) are left to
-the review quiz, not the teaching sweep.
+straight to any concept; a slim **progress bar** shows how far along the 186-
+concept walk you are. Consolidation lessons (`practice`/`review`) are left to the
+review quiz, not the teaching sweep.
 
 The session **introduces writing systems as-needed** (`scriptintro.ts`): the
 first time the walk reaches a non-Latin script — Arabic, then Devanagari, then

--- a/code/programs/typescript/language-ladder/package.json
+++ b/code/programs/typescript/language-ladder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ladder",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "private": true,
   "description": "The unified curriculum learning app (HL03): walk the language chain concept by concept, seeing the threads back to what you already know, then review it all with a randomised SRS quiz. (Was the HL02 script-writing-visualizer, whose Browse/Practice/Lessons/Concepts modes it now subsumes.)",
   "type": "module",

--- a/code/programs/typescript/language-ladder/src/main.ts
+++ b/code/programs/typescript/language-ladder/src/main.ts
@@ -52,6 +52,7 @@ import {
   sweepableConcepts,
   activeChain,
   LANGUAGE_CHAIN,
+  spineProgress,
 } from "./sequence.ts";
 import type { SessionStep } from "./session.ts";
 import {
@@ -751,6 +752,15 @@ function renderLearn(): HTMLElement {
     `Concept ${conceptCursor + 1} of ${CONCEPT_SPINE.length}` +
     ` · taught in ${plan.teaching.length} language${plan.teaching.length === 1 ? "" : "s"}`;
   wrap.appendChild(progress);
+
+  // A slim bar for how far along the spine you are — a sense of the whole
+  // journey that the bare "N of M" count doesn't convey at a glance.
+  const track = el("div", "progress");
+  const fill = el("div", "progress__fill");
+  const pct = spineProgress(conceptCursor, CONCEPT_SPINE.length) * 100;
+  fill.style.width = `${pct}%`;
+  track.appendChild(fill);
+  wrap.appendChild(track);
 
   const heading = el("h2", "learn__concept");
   heading.textContent = conceptTitle(concept);

--- a/code/programs/typescript/language-ladder/src/sequence.ts
+++ b/code/programs/typescript/language-ladder/src/sequence.ts
@@ -159,3 +159,15 @@ export function sweepableConcepts(
     return a < b ? -1 : a > b ? 1 : 0;
   });
 }
+
+/**
+ * How far along a spine of `length` concepts a 0-based `cursor` has reached, as a
+ * fraction in [0, 1]. Counts the current concept as reached, so cursor 0 of 10 is
+ * 0.1 (one of ten), and the last concept is 1. An empty spine is 0; the cursor is
+ * clamped so an out-of-range value can't push past the ends.
+ */
+export function spineProgress(cursor: number, length: number): number {
+  if (length <= 0) return 0;
+  const reached = Math.max(0, Math.min(cursor, length - 1)) + 1;
+  return reached / length;
+}

--- a/code/programs/typescript/language-ladder/src/styles.css
+++ b/code/programs/typescript/language-ladder/src/styles.css
@@ -236,6 +236,21 @@ body {
 
 /* --- learn mode — the curriculum session -------------------------------- */
 .learn { max-width: 640px; }
+/* Spine progress — how far along the 186-concept walk you are. */
+.progress {
+  height: 6px;
+  background: var(--line);
+  border-radius: 999px;
+  overflow: hidden;
+  margin: 2px 0 14px;
+}
+.progress__fill {
+  height: 100%;
+  min-width: 2px;
+  background: var(--accent);
+  border-radius: 999px;
+  transition: width 0.2s ease;
+}
 .learn__concept {
   font-size: 1.5rem;
   margin: 2px 0 2px;

--- a/code/programs/typescript/language-ladder/tests/sequence.test.ts
+++ b/code/programs/typescript/language-ladder/tests/sequence.test.ts
@@ -8,6 +8,7 @@ import {
   activeChain,
   teachingSweep,
   sweepableConcepts,
+  spineProgress,
   type ChainLanguage,
 } from "../src/sequence";
 
@@ -152,5 +153,25 @@ describe("sweepableConcepts", () => {
     const hello = concepts.indexOf("GREETING-HELLO");
     expect(hello).toBeGreaterThanOrEqual(0);
     expect(hello).toBeLessThan(concepts.length - 1);
+  });
+});
+
+describe("spineProgress", () => {
+  it("counts the current concept as reached: cursor 0 of 10 is 0.1, last is 1", () => {
+    // CONTROL: a naive cursor/length would give 0 at the start (0/10). Counting
+    // the current concept (cursor+1)/length gives 0.1 — this asserts that.
+    expect(spineProgress(0, 10)).toBeCloseTo(0.1, 5);
+    expect(spineProgress(4, 10)).toBeCloseTo(0.5, 5);
+    expect(spineProgress(9, 10)).toBe(1);
+  });
+
+  it("an empty spine is 0, never NaN or Infinity", () => {
+    expect(spineProgress(3, 0)).toBe(0);
+    expect(spineProgress(0, 0)).toBe(0);
+  });
+
+  it("clamps an out-of-range cursor to the ends", () => {
+    expect(spineProgress(-5, 10)).toBeCloseTo(0.1, 5); // clamped up to 0 → 1/10
+    expect(spineProgress(999, 10)).toBe(1); // clamped down to 9 → 10/10
   });
 });


### PR DESCRIPTION
## What

Under the **"Concept N of 186"** line, a slim bar now shows how far along the whole 186-concept walk you are — a sense of the journey's scale that the bare count doesn't convey at a glance (a thin sliver at concept 1, half-full at ~93, full at the end). It updates on every Prev / Next / jump.

- New pure **`spineProgress(cursor, length)`** in `sequence.ts`: the fraction reached in `[0, 1]`, **counting the current concept** (cursor 0 of 10 → 0.1), clamping an out-of-range cursor and returning 0 for an empty spine (no NaN / div-by-zero).
- Width is set via `style.width` (no `innerHTML`).

## Verification

- **3 new tests (228 total)** with a control that bites: a naive `cursor/length` reads 0 at the start, so the test pins **0.1**; clamp and empty-spine cases covered.
- **Real browser** (headless screenshot, read back): seeded to concept 93 → the bar sits at **~50%**, a blue accent fill on a muted track, right under the count line.
- Correctness review (subagent): **clean** — bounded fraction, no injection, correct placement, control bites, no leftovers, no regressions.

## Status

This is honest, small orientation polish. With it, the HL03 unified app is **feature-complete**; remaining candidates (richer confusions view, keyboard shortcuts) are marginal and will only be built if they clear a real-value bar.

Builds on #8916 (jump-to-concept, merged).