### PR TITLE
feat(idl-parser): MA-12c idl.grammar + idl-parser crate

### DIFF
--- a/code/grammars/idl/idl.grammar
+++ b/code/grammars/idl/idl.grammar
@@ -1,0 +1,572 @@
+# IDL (Interactive Data Language) Parser Grammar
+# ============================================================================
+#
+# Parses the token stream from `idl-lexer` (code/grammars/idl/idl.tokens,
+# MA-12b, already merged) into a CST a future `idl-runtime` (MA-12d) will
+# walk. See code/specs/MA12-idl-language.md (MA-12c, this file).
+#
+# MA12 §5 makes the one decision this file is structured around: unlike
+# every array-family grammar already in this repo (apl/j/q/scilab/matlab),
+# IDL's *surface* is an Algol/Fortran-family imperative grammar --
+# statements, PRO/FUNCTION definitions, IF/FOR/WHILE/REPEAT blocks, an infix
+# operator-precedence cascade with WORD operators (EQ/AND/...) -- closer in
+# shape to this repo's algol.grammar/dartmouth_basic.grammar than to any
+# array-family grammar. This file is therefore written to IDL's own shape,
+# not forked from an array sibling (contrast scilab.grammar, forked from
+# matlab.grammar at the text level).
+#
+# ============================================================================
+# THE TWO GENUINELY NEW DISAMBIGUATIONS (MA12 §3) -- BOTH RESOLVED BY
+# PRODUCTION CONTEXT, NOT BY LOOKAHEAD TRICKS
+# ----------------------------------------------------------------------------
+#
+# idl-lexer (MA-12b) deliberately left two glyphs lexically unconditional --
+# SLASH is always plain division, EQUALS is always one plain "=" -- because
+# neither ambiguity can be resolved from raw characters or a flat token list
+# (idl.tokens' own header comment explains why at length). MA12 §3 frames
+# both as "parser-level, grammar-position concerns", to be resolved by which
+# PRODUCTION is currently being parsed, not by any lexer-level or
+# lookahead-predicate hack. Here is exactly how this grammar resolves each:
+#
+# 1. `/BOOLEAN` keyword shorthand vs. division (MA12 §3 item 3).
+#
+#    `arg` (below) is the ONLY production in this whole grammar that ever
+#    references a bare, argument-leading SLASH:
+#
+#        arg = keyword_arg | bool_keyword_arg | expr ;
+#        bool_keyword_arg = SLASH NAME ;
+#
+#    This works with NO lookahead predicate at all, for a simple structural
+#    reason: nowhere in `expr`'s own precedence cascade (see SECTION on
+#    expressions below) does SLASH ever appear as anything other than a
+#    BINARY operator consumed by `multiplicative`'s own `{ ( STAR | SLASH |
+#    ... ) power }` repetition -- i.e. only AFTER a left operand has already
+#    been parsed. IDL has no unary "/" (there is no such thing as a
+#    division-prefix operator), so `expr` can structurally never SUCCEED
+#    starting exactly at a SLASH token. That means, at an `arg` position:
+#
+#      - `PLOT, x, /YLOG`    -- at the second arg's position, the current
+#        token IS a SLASH. `expr` cannot match here (nothing in the
+#        cascade can start on SLASH), so the ONLY alternative that can ever
+#        succeed is `bool_keyword_arg = SLASH NAME`, unambiguously the
+#        boolean-keyword shorthand -- exactly IDL's own `/YLOG` == `YLOG=1`
+#        rule (MA12 §3 item 3).
+#      - `x = a/YLOG`        -- this is `assignment_stmt`'s RHS `expr`, NOT
+#        an `arg` position at all. `expr` parses `a` as a `primary`, then
+#        `multiplicative` sees the SLASH sitting AFTER an already-parsed
+#        left operand and consumes it as ordinary division, exactly the
+#        same production path `x = a + b` or `x = a * b` takes. `arg`'s own
+#        `bool_keyword_arg` alternative is never even reached here, because
+#        we are not inside an argument list at all.
+#      - `PLOT, x, a/YLOG`   -- a positional arg that is ITSELF a division
+#        expression: at this arg's position the current token is NAME `a`,
+#        not SLASH, so `arg`'s third alternative (`expr`) matches -- and,
+#        exactly as above, `multiplicative` consumes the SLASH as division
+#        once `a` is already parsed as the left operand. `bool_keyword_arg`
+#        is never attempted here either (its own first token, SLASH, is not
+#        the current token), so there is no false-positive risk of this
+#        being misread as a boolean keyword.
+#
+#    So the disambiguation is a genuine, structural fact about this
+#    grammar's shape (a leading SLASH can only ever mean the boolean
+#    shorthand, because `expr` cannot start with one), not a lookahead
+#    predicate bolted on top -- precisely the "know which production you are
+#    inside" resolution MA12 §3 calls for, and precisely why `arg` (an
+#    explicit, dedicated argument-list alternative production, distinct from
+#    a bare `expr`) is the one new production that makes the whole
+#    disambiguation possible at all.
+#
+# 2. `=` as assignment vs. keyword-bind (MA12 §3 item 2).
+#
+#    Exactly the same "which production" resolution, requiring no special
+#    machinery either:
+#
+#        assignment_stmt = NAME [ index_suffix ] EQUALS expr ;   -- statement
+#        keyword_arg     = NAME EQUALS expr ;                    -- inside arg_list
+#
+#    Both productions have the identical `NAME EQUALS expr` shape (modulo
+#    `assignment_stmt`'s optional subscript target) -- the token sequence
+#    around the `=` is genuinely indistinguishable in isolation, exactly as
+#    MA12 §3 says. What tells them apart is which rule the parser is
+#    CURRENTLY inside when it reaches that shape: `assignment_stmt` is only
+#    ever attempted from `statement` (never from inside an `arg_list`), and
+#    `keyword_arg` is only ever attempted from `arg` (only ever inside an
+#    `arg_list`, i.e. immediately after a `PROC_NAME,` or inside a call's
+#    `( ... )`). A caller can never reach `keyword_arg` while parsing a
+#    top-level statement, and can never reach `assignment_stmt` while
+#    parsing an argument -- the grammar's own call graph is the
+#    disambiguation, with no shared "read `=` and decide later" production
+#    and no predicate of any kind.
+#
+# Both resolutions match MA12 §3's own framing ("a parse-context signal...
+# resolved the same 'know which production you are inside' way") to the
+# letter: the argument-list production (`arg_list`/`arg`) is written once,
+# explicitly, as its own distinct home for `KEYWORD=value` and `/KEYWORD`,
+# never folded into how a bare `expr` is parsed anywhere else in this file.
+#
+# ============================================================================
+# WHY THE PROCEDURE-CALL STATEMENT NEEDS NO SPECIAL LOOKAHEAD EITHER
+# ----------------------------------------------------------------------------
+# `statement`'s three NAME-led alternatives -- `procedure_call_stmt`,
+# `assignment_stmt`, `expr_stmt` -- are tried in that order (see `statement`
+# below). This is safe, ordinary PEG ordered choice (`parser::grammar_parser`
+# backtracks via its packrat memo on a failed alternative, restoring
+# position, per that module's own `Alternation` handling), not a hand-rolled
+# disambiguation: `procedure_call_stmt = NAME COMMA arg_list` fails cleanly
+# and backtracks whenever the token after NAME isn't COMMA, `assignment_stmt
+# = NAME [ index_suffix ] EQUALS expr` fails and backtracks whenever no
+# EQUALS follows the (optionally subscripted) NAME, and `expr_stmt = expr`
+# is the catch-all that always succeeds on a bare NAME, a function call
+# `NAME ( ... )`, an indexing expression `NAME [ ... ]`, or any arithmetic
+# expression. COMMA is not used as a statement-level separator anywhere else
+# in this cut's in-scope surface (unlike Scilab, whose `stmt_sep` accepts a
+# bare COMMA as a statement terminator) -- idl.tokens' own SECTION 7 comment
+# confirms IDL's statement separator is `&` (STMT_SEP), not COMMA -- so
+# `NAME COMMA` at the START of a statement is UNAMBIGUOUSLY the
+# procedure-call-statement shape; no other production can ever produce that
+# exact two-token prefix at a statement boundary.
+#
+# A DISCLOSED, SPEC-CONSISTENT SCOPE NOTE: a procedure called with ZERO
+# arguments (real IDL: e.g. a bare `STOP` or `PRINT` with nothing after it)
+# is syntactically IDENTICAL, at the CST level, to a bare-variable-reference
+# expression statement (real IDL: auto-display a variable's value) -- both
+# are just a lone NAME token. MA12 §3 item 1 itself frames the
+# procedure-call-statement production as "a bare identifier ... FOLLOWED BY
+# a comma-separated argument list" (emphasis reflects the quoted text
+# itself), i.e. the comma+arglist IS the defining shape; a zero-arg call has
+# no comma and so has no distinguishing syntax at all versus a bare name
+# read. This mirrors MA12 §1's own finding for pre-5.0 IDL's `fish(5)`
+# ambiguity: some "is this a call or a value" questions in IDL are only
+# answerable by a symbol table, not by grammar alone. This grammar does not
+# invent a zero-arg `procedure_call_stmt` alternative to paper over that --
+# a bare NAME statement parses via `expr_stmt` either way, and a future
+# `idl-runtime` (MA-12d) is where "is this NAME a known zero-arg procedure or
+# a variable to auto-display" gets resolved, by symbol-table lookup, exactly
+# as real IDL's own compiler does it -- not a gap this parser's CST needs to
+# paper over.
+#
+# ============================================================================
+# BLOCK TERMINATORS, BODY FORMS, AND REPEAT'S ENDREP-BEFORE-UNTIL ORDER
+# ----------------------------------------------------------------------------
+# Every conditional/loop header has TWO body forms (MA12 §3): a
+# single-`statement` form with NO closing keyword at all (`IF x THEN y = 1`),
+# and a `BEGIN ... ENDxxx`/`END` block form. The matched terminator
+# (`ENDIF`/`ENDELSE`/`ENDFOR`/`ENDWHILE`/`ENDREP`) is preferred; a bare `END`
+# is always also accepted as the generic fallback (MA12 §3: "the optional
+# compiler-side 'does ENDFOR match a FOR?' check is a nicety the parser can
+# carry, not a semantic requirement") -- this grammar does not attempt that
+# compiler-side cross-check (it would require passing the opener's identity
+# down into a parameterized production family this shared EBNF has no way to
+# express), so `IF x THEN BEGIN y = 1 ENDFOR` would parse -- a deliberately
+# NOT-caught mismatch, left to a later semantic pass exactly as MA12 §3
+# itself says is acceptable.
+#
+# `DO` sits in the IDENTICAL relative position for both FOR and WHILE (MA12
+# §4: "FOR v = init, limit[, step] DO ..." / "WHILE expr DO ..." -- `DO`
+# immediately follows the range/condition, immediately before the body, in
+# both), so `for_stmt`/`while_stmt` share the same "condition/range DO body"
+# shape with no divergence to encode -- confirmed by direct comparison of
+# both bullets, not assumed.
+#
+# `REPEAT`'s own terminator order was double-checked against real IDL
+# documentation (not guessed): the closing `ENDREP` comes BEFORE `UNTIL`, not
+# after -- `REPEAT BEGIN ... ENDREP UNTIL expr` (single-statement form:
+# `REPEAT statement UNTIL expr`, no ENDREP at all, the same "no closer for
+# the single-statement form" shape every other construct here has). This
+# reads naturally once `ENDREP` is understood as `BEGIN`'s OWN closer (the
+# same role `ENDIF`/`ENDFOR`/`ENDWHILE` each play for their own `BEGIN`),
+# with `UNTIL expr` as REPEAT's trailing loop-condition clause coming after
+# the body is fully closed -- not a terminator for the whole `REPEAT`
+# construct in its own right.
+#
+# ============================================================================
+# NO `$` (CONTINUATION) HANDLING IN THIS GRAMMAR -- A DELIBERATE, DISCLOSED
+# SCOPE BOUNDARY, NOT AN OVERSIGHT
+# ----------------------------------------------------------------------------
+# idl-lexer emits CONTINUATION (`$`) as an ordinary, un-suppressed token and
+# explicitly does NOT swallow the NEWLINE that follows it (idl-lexer's own
+# doc comment: "what 'continuation' means operationally is entirely
+# idl-repl's concern, not this lexer's"). MA12 §5 assigns exactly that
+# responsibility to `idl-repl`'s own "continuation scanner", which tracks
+# paren/bracket balance and `$` at the RAW TEXT level to decide when a
+# chunk of source is complete BEFORE it is ever handed to `tokenize_idl` --
+# a text-joining step that happens strictly before lexing, not something a
+# grammar operating on an already-tokenized stream could express or should
+# try to. Consistently, `CONTINUATION` is not referenced ANYWHERE in this
+# file: a bare `$` reaching `idl-parser` is a syntax error by construction,
+# exactly mirroring `idl-lexer`'s own explicit disclaiming of `$`'s meaning.
+# This is MA-12d's (`idl-repl`) job, not this crate's -- consistent with this
+# task's own scope boundary (MA-12c only).
+#
+# ============================================================================
+# OPERATOR PRECEDENCE -- VERIFIED AGAINST THE OFFICIAL NV5/L3HARRIS
+# "OPERATOR PRECEDENCE" REFERENCE PAGE, NOT GUESSED
+# ----------------------------------------------------------------------------
+# IDL's own documented precedence table (highest to lowest; the untranslated
+# tiers -- pointer-deref/`++`/`--`/`MOD`/`<`-min/`>`-max/`&&`/`||`/`?:` -- are
+# all out of scope per MA12 §4 and have no token in idl.tokens to reference):
+#
+#   1. ( ) grouping; [ ] array-literal/concatenation       -- `group`/`array_literal`
+#   2. [ ] subscripting; ( ) call                          -- `postfix` suffixes
+#   3. ^ (exponentiation)                                  -- `power`
+#   4. * / # ## (multiplicative, incl. matrix product)     -- `multiplicative`
+#   5. binary + -; UNARY + - NOT                           -- `additive`/`unary`
+#   6. EQ NE LE LT GE GT (comparison -- ALL SIX, one tier) -- `comparison`
+#   7. AND OR XOR (logical/bitwise -- all three, one tier) -- `logical`
+#
+# TWO GENUINELY NON-OBVIOUS FACTS THIS CASCADE ENCODES, CONFIRMED AGAINST THE
+# OFFICIAL REFERENCE RATHER THAN ASSUMED FROM SCILAB/MATLAB'S OWN SHAPE:
+#
+#   a. Unary `+`/`-`/`NOT` sit at the SAME documented tier (tier 5) as
+#      BINARY `+`/`-`, not at a tighter tier above `multiplicative` the way
+#      Scilab's/MATLAB's own `unary` production sits (between
+#      `multiplicative` and `power`). This is why `unary` here recurses
+#      ABOVE `multiplicative` (i.e. a unary prefix wraps the entire
+#      `multiplicative` term that follows it): `-a*b` is `-(a*b)`, and
+#      `-a^b` is `-(a^b)` -- a real, documented IDL divergence from the
+#      "unary binds tighter than `*`" convention most C-family/MATLAB-family
+#      languages use.
+#   b. `^` (exponentiation) is LEFT-associative in IDL, not right-associative
+#      the way Scilab's/MATLAB's/Python's own `^`/`**` is. The official
+#      precedence page states the general rule "operators with equal
+#      precedence are evaluated from left to right" and gives a worked
+#      example (`6 / 2 * 3` = 9, left-to-right) for tier 4; since `^` sits
+#      ALONE at its own tier with no competing binary operator, that same
+#      general rule is what governs a `^` CHAIN against itself, and
+#      secondary sources confirm this directly: `2^3^2` evaluates to
+#      `(2^3)^2 = 64` in real IDL, not `2^(3^2) = 512`. `power` below is
+#      therefore written with LEFT-recursive `{ }` repetition (like every
+#      other tier in this cascade), NOT the right-recursive `[ CARET power
+#      ]` shape Scilab's own `power` production uses.
+#
+# `NOT` is placed in `unary` (tier 5, per the table above), not in
+# `logical`'s own tier 7 alongside `AND`/`OR`/`XOR` -- despite idl.tokens'
+# own SECTION 6 comment grouping all four together under one descriptive
+# "logical/bitwise" heading, that comment is about the LEXER's keyword list,
+# not this grammar's precedence tiers; NV5's own precedence table is
+# unambiguous that `NOT` (a UNARY operator) sits at tier 5 while
+# `AND`/`OR`/`XOR` (BINARY operators) sit at tier 7 -- two different tiers,
+# confirmed directly against the official reference rather than assumed
+# from the lexer's own grouping.
+#
+# Assignment (`=`) is NOT part of this expression cascade at all -- unlike
+# Scilab's/MATLAB's own `assignment = logical_or [ EQ assignment ]`
+# (chainable, expression-level `x = y = z`), real IDL has no
+# assignment-as-expression and no assignment chaining; `=` is purely a
+# STATEMENT-level construct here (`assignment_stmt`), confirmed by the
+# absence of any documented IDL "compound/chained assignment expression"
+# construct and consistent with MA12 §4's own "Assignment & statements:
+# `x = expr`" bullet treating it as a statement, not an expression form.
+# ============================================================================
+
+# ============================================================================
+# Program and statements
+# ============================================================================
+
+# The entry rule (first in the file) -- a program is top-level PRO/FUNCTION
+# definitions interleaved with ordinary executable statements, covering both
+# a library-file cut (all PRO/FUNCTION defs) and a batch/REPL-style cut (a
+# plain sequence of statements with no routine definitions at all), per MA12
+# §5's own "the crate layout mirrors ... the REPL & binary" framing and this
+# task's own brief ("A program is a sequence of statements (procedure/
+# function definitions at top level, or a sequence of executable statements
+# for the REPL case)"). Real IDL disallows NESTING a PRO/FUNCTION definition
+# inside a block body (a `.pro` file defines exactly one routine, or is a
+# main-level batch of statements with none) -- so, unlike scilab.grammar's
+# own `statement` (which includes `func_def` as an ordinary nestable
+# statement alternative), `pro_def`/`func_def` are reachable ONLY from
+# `top_level_item`, never from `statement` (used inside `block_body`).
+program = { top_level_item } ;
+
+top_level_item = pro_def
+               | func_def
+               | statement_line ;
+
+# A statement-bearing line: one or more statements joined by the `&`
+# statement separator (idl.tokens SECTION 4 / MA12 §3's "lexer trivia"
+# bullet), then an optional terminating NEWLINE (optional so the final line
+# of a file need not end with one) -- or a bare blank line (just a NEWLINE,
+# nothing else). Mirrors scilab.grammar's own `statement_line` shape,
+# adapted to IDL's own separator/terminator pair (`&`/NEWLINE) instead of
+# Scilab's (COMMA/NEWLINE/SEMICOLON).
+statement_line = statement { STMT_SEP statement } [ NEWLINE ]
+               | NEWLINE ;
+
+# A run of statement lines; stops at whatever keyword closes the enclosing
+# construct (`ENDIF`/`ENDELSE`/`ENDFOR`/`ENDWHILE`/`ENDREP`/`END`/`UNTIL`),
+# none of which can begin a `statement`. Also consumes the header's own
+# trailing NEWLINE as a leading blank `statement_line` -- so `pro_def`/
+# `func_def`/every block-form header below needs no dedicated
+# header-terminator production of its own; the ordinary newline right after
+# a header line is just the first (blank) `statement_line` in the body.
+block_body = { statement_line } ;
+
+statement = if_stmt
+          | for_stmt
+          | while_stmt
+          | repeat_stmt
+          | begin_block
+          | break_stmt
+          | continue_stmt
+          | return_stmt
+          | procedure_call_stmt
+          | assignment_stmt
+          | expr_stmt ;
+
+# ============================================================================
+# Control flow
+# ============================================================================
+
+# `IF expr THEN <then-branch> [ ELSE <else-branch> ]`. `THEN`/`ELSE` are
+# MANDATORY linker keywords (MA12 §3/§4 -- simpler than Scilab's
+# optional-elidable `then`, no elision rule needed at all). Each branch is
+# either the single-statement form or a `BEGIN ... ENDxxx|END` block.
+if_stmt = "IF" expr "THEN" then_branch [ "ELSE" else_branch ] ;
+
+then_branch = "BEGIN" block_body ( "ENDIF" | "END" )
+            | statement ;
+
+else_branch = "BEGIN" block_body ( "ENDELSE" | "END" )
+            | statement ;
+
+# `FOR v = init, limit[, step] DO <body>` (MA12 §4's own exact spelling,
+# COMMA-separated -- not Scilab/MATLAB's colon-range `for i = 1:10`; IDL has
+# no colon-range FOR form in scope here).
+for_stmt = "FOR" NAME EQUALS expr COMMA expr [ COMMA expr ] "DO" for_body ;
+
+for_body = "BEGIN" block_body ( "ENDFOR" | "END" )
+         | statement ;
+
+# `WHILE expr DO <body>` -- `DO` in the identical relative position to
+# `for_stmt`'s own (see this file's header comment).
+while_stmt = "WHILE" expr "DO" while_body ;
+
+while_body = "BEGIN" block_body ( "ENDWHILE" | "END" )
+           | statement ;
+
+# `REPEAT <body> UNTIL expr` -- single-statement form has no closer at all;
+# the block form's `ENDREP`/`END` closes `BEGIN`'s own block BEFORE `UNTIL
+# expr` (this file's header comment explains why ENDREP precedes UNTIL,
+# confirmed against real IDL documentation rather than guessed).
+repeat_stmt = "REPEAT" repeat_body "UNTIL" expr ;
+
+repeat_body = "BEGIN" block_body ( "ENDREP" | "END" )
+            | statement ;
+
+# A generic `BEGIN ... END` block used as an ordinary statement (MA12 §4's
+# own "a generic BEGIN…ENDxxx block" bullet) -- plain grouping, not attached
+# to any header keyword. Always closes with a bare `END` here (there is no
+# more-specific matched terminator for a block with no header to match
+# against).
+begin_block = "BEGIN" block_body "END" ;
+
+break_stmt = "BREAK" ;
+continue_stmt = "CONTINUE" ;
+
+# `RETURN` alone (procedure context, early exit) or `RETURN, expr` (function
+# context, the returned value) -- MA12 §3/§4's "with or without an
+# expression, function vs. procedure context". Both forms are accepted
+# everywhere by this CST-only grammar; which context is semantically valid
+# is a future `idl-runtime` (MA-12d) concern, not this parser's. The comma
+# before the returned expression mirrors the same command-style
+# "NAME, arg" shape `procedure_call_stmt` itself uses -- RETURN just cannot
+# fall through to that generic production because it is a reserved KEYWORD,
+# never a NAME.
+return_stmt = "RETURN" [ COMMA expr ] ;
+
+# ============================================================================
+# The procedure-call statement and assignment -- the two NAME-led,
+# comma/equals-disambiguated statement forms (see this file's header
+# comment for the full disambiguation design). Order matters here only in
+# the sense that each alternative must be tried before the more permissive
+# ones that could otherwise also match a bare NAME -- ordinary PEG ordered
+# choice with packrat backtracking, not a hand-rolled lookahead.
+# ============================================================================
+
+# `PROC_NAME, arg, arg, KEYWORD=value, /BOOLEAN_KEYWORD ...` -- MA12 §3's
+# headline new production. Requires the COMMA (see this file's header
+# comment on the disclosed zero-arg-call scope note); `arg_list` (below) is
+# the SAME production a function call's parenthesised argument list uses
+# (`call_suffix`), so keyword arguments and the `/BOOLEAN` shorthand work
+# identically in both procedure and function calls, exactly as MA12 §3
+# item 2 requires.
+procedure_call_stmt = NAME COMMA arg_list ;
+
+# `x = expr` or `a[i] = expr` / `a[i,j] = expr` (subscripted assignment,
+# MA12 §4). `index_suffix` is the SAME production `postfix` uses for
+# ordinary indexing (see the expression cascade below) -- reused, not
+# duplicated. Only ONE subscript group is permitted on an assignment target
+# (real IDL assignment targets are `var` or `var[subscripts]`, never a
+# chained `f(x)[i] = ...` or `a[i][j] = ...`), unlike `postfix`'s own
+# `{ index_suffix | call_suffix }` repetition used for general expressions.
+assignment_stmt = NAME [ index_suffix ] EQUALS expr ;
+
+# The catch-all: a bare NAME (variable read / zero-arg procedure-call
+# shape, see this file's header comment), a function call `NAME(...)`, an
+# indexing expression `NAME[...]`, or any arithmetic/comparison/logical
+# expression used for its side effect or auto-display value.
+expr_stmt = expr ;
+
+# ============================================================================
+# Procedure and function definitions (MA12 §3/§4/§6)
+#
+#   PRO name, p1, p2, KW=kw ... & ... & END
+#   FUNCTION name, p1, p2, KW=kw ... & ... & RETURN, value & END
+#
+# Both terminated by the generic `END` (there is no `ENDPRO`/`ENDFUNCTION`
+# in idl.tokens' keyword list -- confirmed directly, unlike Scilab's own
+# dedicated `endfunction`). Parameter lists mix plain positional parameter
+# names with keyword-parameter declarations of the shape
+# `KEYWORD=local_var_name` (MA12 §4's own literal "KW=kw" spelling) -- in
+# real IDL this binds the call-site keyword name KEYWORD to a LOCAL
+# VARIABLE NAME inside the body, which may differ from KEYWORD itself; the
+# right-hand side of a parameter declaration's `=` is therefore always a
+# bare NAME (the local binding), never an arbitrary expression -- a real
+# default value is instead assigned inside the body via IDL's own
+# `N_ELEMENTS(kw) EQ 0` idiom (MA12 §3), not declared in the header.
+# ============================================================================
+
+pro_def = "PRO" NAME [ COMMA params ] block_body "END" ;
+func_def = "FUNCTION" NAME [ COMMA params ] block_body "END" ;
+
+params = param { COMMA param } ;
+param = NAME EQUALS NAME
+      | NAME ;
+
+# ============================================================================
+# Expression precedence cascade (loosest -> tightest). See this file's
+# header comment for the full precedence-table verification and the two
+# non-obvious divergences from Scilab/MATLAB's own cascade shape (unary
+# binding looser than multiplicative, and left- rather than
+# right-associative `^`).
+# ============================================================================
+
+expr = logical ;
+
+logical = comparison { ( "AND" | "OR" | "XOR" ) comparison } ;
+
+comparison = additive { ( "EQ" | "NE" | "LE" | "LT" | "GE" | "GT" ) additive } ;
+
+# Binary `+`/`-`. The left operand is `unary` (not `multiplicative`
+# directly), so a leading unary prefix correctly wraps the entire
+# multiplicative term that follows it (`-a*b` = `-(a*b)`, per this file's
+# header comment).
+additive = unary { ( PLUS | MINUS ) unary } ;
+
+# Unary `+`/`-`/`NOT`, self-recursive so a chain (`- - -5`, `NOT NOT x`)
+# parses; the base case dives into `multiplicative`. This production sits
+# ABOVE `multiplicative` in the call graph (looser), matching IDL's
+# documented tier-5 unary placement -- NOT the tighter-than-multiplicative
+# position Scilab's/MATLAB's own `unary` production occupies.
+unary = ( PLUS | MINUS | "NOT" ) unary
+      | multiplicative ;
+
+# `*` `/` and BOTH matrix-product operators `#`/`##` share one precedence
+# tier (MA12 §4's own "matrix multiply # and ##" bullet grouped alongside
+# "+ - * /"; confirmed against the official precedence table's own tier 4,
+# which lists `*`, `#`/`##`, `/`, and `MOD` together -- MOD is out of scope,
+# no token exists for it). Left-associative repetition, like every other
+# tier here except the two documented left-associative/loosest-unary
+# divergences already called out above (which are ALSO left-associative,
+# just structured differently for the wrapping reason explained there).
+multiplicative = power { ( STAR | SLASH | HASH_HASH | HASH ) power } ;
+
+# Exponentiation -- LEFT-associative (see this file's header comment for
+# the verification against the official reference and the worked
+# `2^3^2 = 64` confirmation), so plain `{ }` repetition, NOT the
+# right-recursive `[ CARET power ]` shape a right-associative power
+# operator would need (contrast Scilab's own `power`).
+power = postfix { CARET postfix } ;
+
+# Postfix (tightest, tier 1/2 combined): subscripting and function-call
+# argument lists. `index_suffix`/`call_suffix` may repeat and interleave
+# (`f(x)[i]`, `a[i](x)`, ...) -- real IDL rarely nests these, but nothing in
+# MA12 §4 forbids it structurally, and the repetition costs nothing extra
+# to express here (mirrors scilab.grammar's own generously-repeating
+# `postfix`).
+postfix = primary { index_suffix | call_suffix } ;
+
+index_suffix = LBRACKET subscript_list RBRACKET ;
+call_suffix = LPAREN [ arg_list ] RPAREN ;
+
+# ============================================================================
+# Subscripts -- the full surface MA12 §4 lists: plain (`a[i]`), 2-D
+# (`a[i,j]`), ranged (`a[s0:s1]`), strided (`a[s0:s1:n]`), `*`-wildcard
+# (`a[*]`, `a[s0:*]`, `a[s0:*:n]`), and negative-from-end (`a[-1]`, handled
+# for free by `expr`'s own `unary` MINUS -- no dedicated production needed).
+# ============================================================================
+
+subscript_list = subscript { COMMA subscript } ;
+
+# Order: `STAR` first, since a bare `a[*]` cannot be matched by
+# `range_subscript` (which requires a leading `expr`, and `expr` cannot
+# start with STAR any more than it can start with SLASH) or by `expr`
+# itself -- `STAR` is the only alternative that can ever succeed on a bare
+# leading STAR token, so the ordering is not load-bearing for correctness,
+# only for avoiding two guaranteed-to-fail attempts first.
+subscript = STAR
+          | range_subscript
+          | expr ;
+
+# `s0:s1` / `s0:s1:n` / `s0:*` / `s0:*:n` -- the stride slot (third,
+# optional) is always a concrete `expr`; MA12 §2/§4 document `*` only as
+# the RANGE-END position, never the stride, so no `STAR` alternative is
+# offered there.
+range_subscript = expr COLON range_end [ COLON expr ] ;
+range_end = STAR
+          | expr ;
+
+# ============================================================================
+# Argument lists -- the headline new production (MA12 §3). Shared,
+# unmodified, between `procedure_call_stmt`'s command-style comma list and
+# `call_suffix`'s parenthesised function-call list, so keyword arguments and
+# the `/BOOLEAN` shorthand behave identically in both (MA12 §3 item 2).
+# See this file's header comment for the full disambiguation design.
+# ============================================================================
+
+arg_list = arg { COMMA arg } ;
+
+# Order matters here for efficiency (packrat memoization makes it harmless
+# for correctness either way, since each alternative fails cleanly and
+# backtracks): try the two argument-list-specific shapes before falling
+# through to a bare `expr`, so an ordinary positional argument that happens
+# to start with a NAME (the overwhelmingly common case) only pays for one
+# extra failed `NAME EQUALS` attempt before matching as `expr`.
+arg = keyword_arg
+    | bool_keyword_arg
+    | expr ;
+
+# `KEYWORD=value` -- a keyword binding, MA12 §3 item 2. Structurally
+# identical in shape to `assignment_stmt`, but reachable only from `arg`,
+# inside an argument list -- see this file's header comment.
+keyword_arg = NAME EQUALS expr ;
+
+# `/KEYWORD` -- the boolean shorthand, MA12 §3 item 3, `== KEYWORD=1` at the
+# semantic level (a future `idl-runtime` concern). See this file's header
+# comment for why this alternative can never be confused with SLASH-as
+# -division: `expr` structurally cannot start on a SLASH token, so this is
+# the only alternative that can ever succeed here.
+bool_keyword_arg = SLASH NAME ;
+
+# ============================================================================
+# Primary expressions
+# ============================================================================
+
+primary = NUMBER
+        | STRING
+        | array_literal
+        | group
+        | NAME ;
+
+group = LPAREN expr RPAREN ;
+
+# `[1, 2, 3]` -- array literal / concatenation (MA12 §4), tier 1 in the
+# precedence table (same tier as grouping parens) -- a PRIMARY alternative,
+# structurally distinct from `index_suffix`'s OWN `LBRACKET` (a postfix
+# SUFFIX on an already-parsed primary): a leading `[` at a primary position
+# (nothing parsed yet) is unambiguously a literal; a `[` immediately after
+# an existing `postfix` value is unambiguously a subscript. No lookahead
+# needed -- the same "which production position" resolution used
+# throughout this file.
+array_literal = LBRACKET [ array_elements ] RBRACKET ;
+array_elements = expr { COMMA expr } ;

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -281,6 +281,7 @@ members = [
     "q-repl",
     "q-to-semantic-ir",
     "idl-lexer",
+    "idl-parser",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/idl-parser/BUILD
+++ b/code/packages/rust/idl-parser/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-idl-parser -- --nocapture

--- a/code/packages/rust/idl-parser/BUILD_windows
+++ b/code/packages/rust/idl-parser/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-idl-parser -- --nocapture

--- a/code/packages/rust/idl-parser/CHANGELOG.md
+++ b/code/packages/rust/idl-parser/CHANGELOG.md
@@ -1,0 +1,156 @@
+# Changelog
+
+## [0.1.0] - 2026-07-23
+
+### Added
+
+- Initial grammar-driven Rust IDL parser (MA12 §6, task MA-12c).
+- `code/grammars/idl/idl.grammar` (47 rules), written to IDL's own
+  Algol/Fortran-family imperative shape (MA12 §5) — statements,
+  `PRO`/`FUNCTION` definitions, `IF`/`FOR`/`WHILE`/`REPEAT` blocks, an infix
+  operator-precedence cascade with word operators — rather than forked from
+  any array-family grammar (contrast `scilab.grammar`'s fork of
+  `matlab.grammar`).
+- The two genuinely new disambiguations MA12 §3 fixed as design problems,
+  now resolved entirely through grammar structure (no lookahead predicate of
+  any kind):
+  1. `/BOOLEAN` keyword shorthand vs. division — `arg = keyword_arg |
+     bool_keyword_arg | expr ;` with `bool_keyword_arg = SLASH NAME`. Safe
+     because `expr`'s own cascade never lets `SLASH` appear except as a
+     binary operator consumed after a left operand (IDL has no unary `/`),
+     so a leading `SLASH` at an argument position can only ever be the
+     boolean shorthand.
+  2. `=` as assignment vs. keyword-bind — `assignment_stmt = NAME
+     [ index_suffix ] EQUALS expr` (statement-level, reachable only from
+     `statement`) vs. `keyword_arg = NAME EQUALS expr` (reachable only from
+     `arg`, inside an argument list). Identical token shape, disambiguated
+     purely by which production the parser is inside.
+  Both productions (`arg_list`/`arg`) are shared, unmodified, between
+  `procedure_call_stmt`'s command-style comma list and a function call's
+  parenthesised `call_suffix`, so keyword arguments and the `/BOOLEAN`
+  shorthand behave identically in both call styles (MA12 §3 item 2).
+- `procedure_call_stmt = NAME COMMA arg_list` — the headline new production,
+  disambiguated from `assignment_stmt`/`expr_stmt` by ordinary PEG ordered
+  choice (COMMA is not used as a statement separator anywhere else in this
+  cut's in-scope surface; IDL's own separator is `&`). A disclosed,
+  spec-consistent scope note: a zero-argument call is syntactically
+  identical, at the CST level, to a bare-variable-reference expression
+  statement (both are a lone NAME with no comma) — MA12 §3 itself frames the
+  call-statement production as requiring the comma+arg-list shape, so no
+  synthetic zero-arg alternative was added; resolving "call or read" for a
+  bare NAME is left to a future `idl-runtime`'s symbol table (MA-12d),
+  mirroring MA12 §1's own pre-5.0 `fish(5)` finding.
+- Full control-flow surface: `IF...THEN...ELSE` (single-statement and
+  `BEGIN...ENDIF/ENDELSE/END` block forms), `FOR v=lo,hi[,step] DO` (`DO` in
+  the identical relative position to `WHILE`'s own, confirmed by direct
+  comparison, not assumed), `WHILE expr DO`, `REPEAT...UNTIL` (with the
+  block form's `ENDREP` confirmed, against real IDL documentation, to
+  precede `UNTIL` rather than follow it — a regression test
+  (`repeat_until_reversed_order_is_a_syntax_error`) proves the reversed
+  order is rejected), `BREAK`/`CONTINUE`, a generic `BEGIN...END` block, and
+  `RETURN`/`RETURN, expr` (both forms accepted everywhere by this CST-only
+  grammar; which is semantically valid in a given routine kind is deferred
+  to MA-12d).
+- `pro_def`/`func_def` — both terminated by the generic `END` (no
+  `ENDPRO`/`ENDFUNCTION` exists in `idl.tokens`' keyword list). Parameter
+  lists mix plain positional names with `KEYWORD=local_var` keyword-
+  parameter declarations (MA12 §4's own literal spelling) — the RHS of a
+  parameter declaration's `=` is always a bare NAME (the internal binding
+  variable), never an arbitrary expression, since real IDL default values
+  are assigned inside the body, not declared in the header.
+- The full expression precedence cascade, verified against the official
+  NV5/L3Harris *Operator Precedence* reference (and a verbatim IRYA/UNAM
+  mirror of the same table) rather than assumed from Scilab's/MATLAB's own
+  cascade shape. Two confirmed, non-obvious divergences:
+  1. Unary `+`/`-`/`NOT` sit at the SAME documented tier as binary `+`/`-`,
+     not tighter than `multiplicative` the way Scilab/MATLAB's own `unary`
+     sits — `unary` here recurses *above* `multiplicative`, so `-a*b`
+     parses as `-(a*b)`.
+  2. `^` is LEFT-associative in IDL (`2^3^2` = `(2^3)^2` = 64), not
+     right-associative like Scilab/MATLAB/Python's own `^`/`**` — `power`
+     uses left-recursive `{ }` repetition, not the right-recursive
+     `[ CARET power ]` shape a right-associative operator would need.
+  `NOT` (unary, tier 5) and `AND`/`OR`/`XOR` (binary, tier 7) sit at
+  different precedence tiers despite `idl.tokens`' own lexer-layer comment
+  grouping all four under one descriptive "logical/bitwise" heading.
+  Assignment (`=`) is deliberately NOT part of the expression cascade at
+  all — unlike Scilab's/MATLAB's chainable `assignment = logical_or
+  [ EQ assignment ]`, real IDL has no assignment-as-expression.
+- Both matrix-product operators `#`/`##` at the same precedence tier as
+  `*`/`/` (confirmed against the official table's own tier grouping, not
+  assumed to be a separate tier).
+- The full subscript surface (MA12 §4): plain (`a[i]`), 2-D (`a[i,j]`),
+  ranged (`a[s0:s1]`), strided (`a[s0:s1:n]`), `*`-wildcard (`a[*]`,
+  `a[s0:*]`, `a[s0:*:n]`), and negative-from-end (`a[-1]`, handled for free
+  by the ordinary `unary` MINUS — no dedicated production needed). Array
+  literals (`[1, 2, 3]`) as a `primary` alternative, structurally distinct
+  from `index_suffix`'s postfix-position `LBRACKET`.
+- A deliberate, disclosed scope boundary: `CONTINUATION` (`$`) is not
+  referenced anywhere in `idl.grammar` — `idl-lexer` emits it unconditionally
+  and does not suppress the following NEWLINE, and MA12 §5 assigns
+  continuation-tracking to `idl-repl`'s own raw-text-level scanner (MA-12d),
+  not to this parser. `grammar-tools cross_validate` reports the resulting
+  "Token 'CONTINUATION' defined but never used" warning — expected and
+  documented, not a bug.
+- A bespoke `MAX_RULE_DEPTH = 148` recursion-depth cap — the FIRST IDL crate
+  with actual recursive descent (`idl-lexer` only tokenizes; no cap existed
+  before this crate). Six structurally distinct self-referential shapes were
+  measured independently (binary search, uncapped parser, default-stack
+  worker thread, debug build, one fresh subprocess per data point):
+  parenthesised nesting (27 safe / 28 crash nesting-count, 291/292
+  rule-frame), nested `IF`/`ENDIF` (47/48 nesting, 249/250 rule-frame —
+  `FOR`/`WHILE`/`REPEAT`/generic `BEGIN` share the identical
+  `statement -> ... -> block_body -> statement_line -> statement`
+  reachability, confirmed by rule-graph inspection, so not separately
+  measured), nested function-call arguments (22/23 nesting, 266/267
+  rule-frame), nested subscript indexing (21/22 nesting, 273/274
+  rule-frame — measured independently despite an apparently-identical
+  three-wrapper-frame shape to call-argument nesting, to confirm the
+  rule-graph symmetry actually holds at the native-stack level), a unary
+  prefix chain (199/200 nesting, 212/213 rule-frame), and nested array
+  literals (24/25 nesting, 282/283 rule-frame). Every "flat chain of one
+  operator" production written with EBNF `{ x }` repetition costs zero
+  native stack regardless of width, confirmed by reading
+  `parser::grammar_parser`'s own `Repetition`/`SeparatedRepetition`
+  implementation directly.
+- The genuine surprise (mirroring `scilab-parser`'s own): the unary prefix
+  chain tolerates by far the *most* nesting levels (199) of any measured
+  shape, yet has the *lowest* rule-frame floor (212) — its persisting
+  per-level cost is exactly one rule-frame (`unary` itself, confirmed by the
+  near-1:1 nesting-to-frame ratio, 212/199 ≈ 1.07), cheap enough per level to
+  reach 199 levels, yet its own call path costs more native-stack bytes per
+  crossing than the other shapes' higher per-level rule-frame counts would
+  suggest. `148` sits about 30.2% below the binding 212 floor (comparable to
+  `reduce-parser`'s own ~28.5%, `apl-parser`'s ~26.5%, `j-parser`'s ~30%,
+  `derive-parser`'s ~33%, `maple-parser`'s ~31.2%, `scilab-parser`'s
+  ~30.2%), and therefore safely below all five other rule-frame floors (291,
+  249, 266, 273, 282) too. Full measurement tables and reasoning in
+  `MAX_RULE_DEPTH`'s own doc comment (`src/lib.rs`).
+- 59 tests + 1 doctest covering: every statement/control-flow production
+  (one test per construct, both body forms where applicable); the two
+  headline disambiguations in both directions (`/BOOLEAN` shorthand vs.
+  division in an assignment RHS vs. division as a positional call argument;
+  `=` as keyword-bind vs. assignment); the procedure-call-statement's
+  zero-arg scope note; `REPEAT`'s `ENDREP`-before-`UNTIL` order (plus a
+  regression proving the reversed order is rejected); every subscript form;
+  `PRO`/`FUNCTION` definitions (positional and keyword parameters) and
+  `RETURN`'s two forms; the full precedence cascade (one test per tier
+  boundary, including the two confirmed divergences — unary binding looser
+  than multiplicative, and left-associative `^`); both matrix-product
+  operators; array literals (including immediate re-subscripting); and 4
+  depth-guard tests exercising all six measured shapes at once.
+- `code/grammars/idl/idl.grammar` validated with
+  `grammar_tools::parser_grammar::validate_parser_grammar` (47 rules, clean)
+  and cross-validated against `code/grammars/idl/idl.tokens` with
+  `grammar_tools::cross_validator::cross_validate` (one expected, documented
+  warning: `CONTINUATION` defined but unused — see above).
+- Registered `idl-parser` in `code/packages/rust/Cargo.toml`'s workspace
+  `members`.
+
+### Not touched
+
+- `idl-lexer` (MA-12b, already merged) — `code/grammars/idl/idl.tokens` and
+  `code/packages/rust/idl-lexer/` are untouched; this crate consumes
+  `idl-lexer`'s public `tokenize_idl`/`try_tokenize_idl` API as-is.
+- `idl-runtime`/`idl-repl` (MA-12d) and `idl-to-semantic-ir` (MA-12e) — not
+  started; out of scope for this item (MA-12c is parser-only).

--- a/code/packages/rust/idl-parser/Cargo.toml
+++ b/code/packages/rust/idl-parser/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "coding-adventures-idl-parser"
+version = "0.1.0"
+edition = "2021"
+description = "Parser for IDL (Interactive Data Language), the science/astronomy array frontend (MA12 MA-12c)"
+license = "MIT"
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }
+parser = { path = "../parser" }
+coding-adventures-idl-lexer = { path = "../idl-lexer" }

--- a/code/packages/rust/idl-parser/README.md
+++ b/code/packages/rust/idl-parser/README.md
@@ -1,0 +1,251 @@
+# coding-adventures-idl-parser
+
+IDL (Interactive Data Language) parser backed by
+`code/grammars/idl/idl.grammar`, compiled to Rust and statically linked into
+the crate.
+
+The runtime path does not read grammar files from disk, which keeps it
+suitable for a future WASM facade.
+
+## Where this fits
+
+This is the second crate of IDL's frontend — MA-12c from
+[`MA12-idl-language.md`](../../../specs/MA12-idl-language.md), the spec that
+fixed IDL's one genuinely new grammar/evaluator problem (a keyword-argument
+calling convention over a procedure/function split, §3) before any lexer or
+parser code existed. The crate layout mirrors MA12 §6's rollout:
+`idl-lexer` (MA-12b, merged) → `idl-parser` (this crate, MA-12c) →
+`idl-runtime`/`idl-repl` (MA-12d) → `idl-to-semantic-ir` (MA-12e).
+
+Unlike every array-family frontend already in this repo (APL/J/Q/Scilab/
+MATLAB), IDL's *surface* is an Algol/Fortran-family imperative grammar —
+statements, `PRO`/`FUNCTION` definitions, `IF`/`FOR`/`WHILE`/`REPEAT` blocks,
+an infix operator-precedence cascade with word operators (`EQ`/`AND`/...) —
+closer in shape to this repo's `algol-parser`/`dartmouth-basic-parser` than
+to any array-family parser (MA12 §5). So `idl.grammar` is written to IDL's
+own imperative shape, not forked from an array sibling (contrast
+`scilab-parser`, forked from `matlab.grammar` at the grammar-source level).
+
+## Scope
+
+Covers the MA12 §4-scoped first cut: `PRO`/`FUNCTION` definitions (both
+terminated by the generic `END`), the procedure-call statement and
+parenthesised function calls with positional, keyword (`KEYWORD=value`), and
+boolean-shorthand (`/KEYWORD`) arguments, `IF...THEN...ELSE` (single-
+statement and `BEGIN...ENDIF/ENDELSE/END` block forms), `FOR v=lo,hi[,step]
+DO`, `WHILE expr DO`, `REPEAT...UNTIL`, `BREAK`/`CONTINUE`, a generic
+`BEGIN...END` block, `RETURN`/`RETURN, expr`, assignment (including
+subscripted targets), the full expression precedence cascade (arithmetic,
+matrix product `#`/`##`, word comparison/logical operators), array literals,
+and the full subscript surface (plain, 2-D, ranged, strided, `*`-wildcard,
+negative-from-end).
+
+## The two genuinely new disambiguations (MA12 §3)
+
+`idl-lexer` (MA-12b) deliberately left two glyphs lexically unconditional —
+`SLASH` is always plain division, `EQUALS` is always one plain `=` — because
+MA12 §3 frames both as parser-level, grammar-position concerns: telling them
+apart requires knowing which *production* is currently being parsed, not
+anything visible in raw characters or a flat token list. This crate resolves
+both entirely through grammar structure, with **no lookahead predicate of
+any kind**.
+
+### 1. `/BOOLEAN` keyword shorthand vs. division
+
+```
+arg = keyword_arg | bool_keyword_arg | expr ;
+bool_keyword_arg = SLASH NAME ;
+```
+
+`arg` is the only production anywhere in this grammar that references a
+bare, argument-leading `SLASH`. This works with no predicate at all, for a
+structural reason: nowhere in `expr`'s own precedence cascade does `SLASH`
+ever appear as anything but a **binary** operator (`multiplicative`'s own
+repetition), consumed only *after* a left operand is already parsed — IDL
+has no unary `/`. So `expr` can never itself succeed starting exactly on a
+`SLASH` token. At an argument position:
+
+- `PLOT, x, /YLOG` — the current token at that arg's slot IS a `SLASH`.
+  `expr` cannot match here at all, so the only alternative that can ever
+  succeed is `bool_keyword_arg`, unambiguously the boolean-keyword shorthand.
+- `x = a/YLOG` — this is `assignment_stmt`'s RHS `expr`, not an argument
+  position at all; `multiplicative` consumes the `SLASH` as ordinary
+  division after `a` is already parsed, exactly like `a + b`.
+- `PLOT, x, a/YLOG` — a positional argument that is *itself* a division: the
+  current token at that arg's slot is NAME `a`, not `SLASH`, so `arg`'s
+  `expr` alternative matches and `multiplicative` handles the division the
+  same way. `bool_keyword_arg` is never even attempted (its own leading
+  token isn't present).
+
+Confirmed by this crate's own tests: `slash_boolean_keyword_shorthand_inside_a_procedure_call`,
+`slash_is_ordinary_division_in_an_assignment_rhs`,
+`slash_is_ordinary_division_as_a_positional_call_argument`, and
+`boolean_keyword_shorthand_in_a_function_call_too` (the same `arg`/`arg_list`
+production is shared, unmodified, between the command-style procedure call
+and a function call's parenthesised argument list — MA12 §3 item 2's "mixed
+freely...in both").
+
+### 2. `=` as assignment vs. keyword-bind
+
+```
+assignment_stmt = NAME [ index_suffix ] EQUALS expr ;   -- statement-level
+keyword_arg     = NAME EQUALS expr ;                     -- inside arg_list
+```
+
+Both productions have the identical `NAME EQUALS expr` shape around the
+`=` — genuinely indistinguishable in isolation, exactly as MA12 §3 says.
+What tells them apart is which rule the parser is *currently inside*:
+`assignment_stmt` is only ever reached from `statement` (never from inside
+an argument list), and `keyword_arg` is only ever reached from `arg` (only
+ever inside an argument list). No shared "read `=` and decide later"
+production exists — the grammar's own call graph is the disambiguation.
+
+Confirmed by `equals_is_keyword_bind_inside_a_call_argument_list` and
+`equals_is_ordinary_assignment_at_statement_level`.
+
+### The procedure-call statement needs no special lookahead either
+
+`statement`'s three NAME-led alternatives — `procedure_call_stmt`
+(`NAME COMMA arg_list`), `assignment_stmt` (`NAME [index_suffix] EQUALS
+expr`), `expr_stmt` (`expr`) — are ordinary PEG ordered choice with packrat
+backtracking. `COMMA` is not used as a statement-level separator anywhere
+else in this cut (IDL's own separator is `&`, per `idl.tokens`), so
+`NAME COMMA` at a statement boundary is unambiguously the procedure-call
+shape.
+
+**A disclosed, spec-consistent scope note**: a zero-argument procedure call
+(real IDL: a bare `STOP`) is syntactically identical, at the CST level, to a
+bare-variable-reference expression statement — both are just a lone `NAME`.
+MA12 §3 itself frames the procedure-call-statement production as requiring
+the comma+arg-list shape, so this grammar does not invent a zero-arg
+`procedure_call_stmt` alternative to paper over the gap; a bare `NAME`
+statement parses via `expr_stmt` either way, and resolving "is this a known
+zero-arg procedure or a variable to auto-display" is deferred to a future
+`idl-runtime`'s symbol table (MA-12d) — mirroring MA12 §1's own finding that
+some "is this a call or a value" questions in IDL are answerable only with a
+symbol table, not grammar alone (pre-5.0 IDL's `fish(5)` ambiguity).
+Confirmed by `bare_name_with_no_comma_is_an_expr_statement_not_a_call`.
+
+## Operator precedence — verified against the official reference, not guessed
+
+`idl.grammar`'s expression cascade was checked against the NV5/L3Harris
+*Operator Precedence* reference page (and a verbatim IRYA/UNAM mirror of the
+same table) rather than assumed from Scilab's/MATLAB's own cascade shape.
+Two genuinely non-obvious, confirmed facts it encodes:
+
+1. **Unary `+`/`-`/`NOT` sit at the SAME documented precedence tier as
+   BINARY `+`/`-`**, not at a tighter tier above `multiplicative` the way
+   Scilab's/MATLAB's own `unary` sits. `unary` in this grammar therefore
+   recurses *above* `multiplicative` (looser), so a unary prefix wraps the
+   entire multiplicative term that follows it: `-a*b` parses as `-(a*b)`,
+   confirmed by `unary_minus_binds_looser_than_multiplicative_and_power`.
+2. **`^` (exponentiation) is LEFT-associative in IDL**, not right-
+   associative like Scilab's/MATLAB's/Python's own `^`/`**`. The official
+   reference states the general rule "operators with equal precedence are
+   evaluated from left to right," and — since `^` sits alone at its own tier
+   with no competing operator — that rule governs a `^` chain against
+   itself: `2^3^2` evaluates to `(2^3)^2 = 64` in real IDL, not
+   `2^(3^2) = 512`. `power` is written with left-recursive `{ }` repetition,
+   confirmed by `power_is_left_associative`.
+
+`NOT` sits in `unary` (tier 5), not alongside `AND`/`OR`/`XOR` in `logical`
+(tier 7) — despite `idl.tokens`' own lexer-layer comment grouping all four
+under one "logical/bitwise" keyword-list heading, the official precedence
+table places the *unary* `NOT` and the *binary* `AND`/`OR`/`XOR` at two
+different tiers.
+
+Assignment (`=`) is **not** part of the expression cascade at all — unlike
+Scilab's/MATLAB's own chainable `assignment = logical_or [ EQ assignment ]`,
+real IDL has no assignment-as-expression and no chained assignment; `=` is
+purely a statement-level construct here.
+
+## `REPEAT`'s `ENDREP`-before-`UNTIL` order — confirmed, not guessed
+
+`REPEAT BEGIN ... ENDREP UNTIL expr` — the block form's `ENDREP` closes
+`BEGIN`'s own block **before** the trailing `UNTIL expr` loop-condition
+clause, confirmed against real IDL documentation rather than assumed from
+the task brief's own paraphrase. Confirmed by
+`repeat_until_block_form_endrep_precedes_until` and the regression
+`repeat_until_reversed_order_is_a_syntax_error` (proving the reversed order
+is rejected, not silently accepted either way).
+
+## No `$` (continuation) handling in this grammar — a disclosed scope boundary
+
+`idl-lexer` emits `CONTINUATION` (`$`) as an ordinary, un-suppressed token
+and does not swallow the following `NEWLINE`. MA12 §5 assigns tracking `$`
+(and paren/bracket balance) to `idl-repl`'s own "continuation scanner" — a
+raw-text-level, pre-tokenization step that joins physical lines before
+`tokenize_idl` ever runs. Consistently, `CONTINUATION` is not referenced
+anywhere in `idl.grammar`; a bare `$` reaching this parser is a syntax error
+by construction. This is MA-12d's job, not this crate's — `grammar-tools
+cross_validate` reports the resulting "Token 'CONTINUATION' defined but
+never used" warning, which is expected and documented, not a bug.
+
+## Recursion-depth guard: six shapes, measured independently
+
+`idl.grammar` has six structurally distinct self-referential recursion
+shapes — parenthesised nesting, nested `IF`/`ENDIF` blocks (the other four
+block constructs — `FOR`/`WHILE`/`REPEAT`/generic `BEGIN`/`END` — share the
+identical `statement -> ... -> block_body -> statement_line -> statement`
+reachability, confirmed by direct rule-graph inspection, so none of the
+other four was separately measured), nested function-call arguments
+(`f(f(f(...)))`), nested subscript indexing (`a[a[a[...]]]`, measured
+independently despite an apparently-identical three-wrapper-frame shape to
+call-argument nesting, to confirm the rule-graph symmetry actually holds at
+the native-stack level too), a unary prefix chain (`- - - ... 5` /
+`NOT NOT ... x`), and nested array literals (`[[[...]]]`) — each measured
+independently (binary search, uncapped parser, default-stack worker thread,
+debug build, one fresh subprocess per data point), per MA12 §6's own
+directive and the "measure, don't assume one shape's floor bounds the
+others" methodology `apl-parser`/`j-parser`/`scilab-parser`/`maple-parser`
+each independently established.
+
+The genuine surprise (mirroring `scilab-parser`'s own): the unary prefix
+chain tolerates by far the *most* nesting levels (199) of any measured
+shape, yet has the *lowest* rule-frame floor (212) — its persisting
+per-level cost is exactly one rule-frame (`unary` itself, confirmed by the
+near-1:1 nesting-to-frame ratio), cheap enough per level to reach 199
+levels, yet its own call path costs more native-stack bytes per crossing
+than the other shapes' higher per-level rule-frame counts would suggest.
+`MAX_RULE_DEPTH = 148` sits about 30.2% below the binding 212 floor, safely
+below all five other rule-frame floors (291, 249, 266, 273, 282) too. Full
+measurement tables and reasoning in `MAX_RULE_DEPTH`'s own doc comment
+(`src/lib.rs`).
+
+## Usage
+
+```rust
+use coding_adventures_idl_parser::parse_idl;
+
+let ast = parse_idl("PRO plot_it, x, y, COLOR=color\n  PRINT, x, /QUIET\nEND\n");
+assert_eq!(ast.rule_name, "program");
+```
+
+`parse_idl` panics on a malformed source string; use `try_parse_idl` for the
+`Result`-returning form, or `create_idl_parser` directly if you need the raw
+`GrammarParser`.
+
+## What this crate does NOT do
+
+- No `idl-runtime`/`idl-repl` (MA-12d) evaluation — this crate only produces
+  a `GrammarASTNode` CST.
+- No `idl-to-semantic-ir` (MA-12e) lowering.
+- No `$`-continuation joining (see above — that's `idl-repl`'s job).
+- No changes to `idl-lexer` (MA-12b, already merged) — `idl.tokens` is
+  untouched; this crate consumes its token stream as-is.
+- No structures, pointers, objects, `LIST`/`HASH`, `COMMON` blocks,
+  `CASE`/`SWITCH`/`FOREACH`, `_EXTRA`/`_REF_EXTRA` keyword inheritance, or
+  the legacy pre-5.0 `( )` subscript form — all explicitly deferred by
+  MA12 §4, unchanged here.
+
+## Where this fits next
+
+`idl-parser` is MA-12c of IDL's frontend crates, consuming the token stream
+from `idl-lexer` (MA-12b) against `code/grammars/idl/idl.grammar` to build
+the `GrammarASTNode` CST a future `idl-runtime` (MA-12d, not yet started)
+will walk to evaluate over `array-runtime`'s `Array` value model plus a new
+`IdlValue::{Num, Str}` enum and an `IdlCallable` procedure/function
+representation with keyword-aware argument binding (MA12 §3), and a future
+`idl-to-semantic-ir` (MA-12e) will lower into
+[`SIR22`](../../../specs/SIR22-array-matrix-semantic-ir.md)'s array/matrix
+domain.

--- a/code/packages/rust/idl-parser/required_capabilities.json
+++ b/code/packages/rust/idl-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/idl-parser",
+  "capabilities": [],
+  "justification": "Pure computation. The IDL grammar is embedded as generated Rust code; tokenizing and parsing need no filesystem, network, or process access."
+}

--- a/code/packages/rust/idl-parser/src/_grammar.rs
+++ b/code/packages/rust/idl-parser/src/_grammar.rs
@@ -1,0 +1,1126 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: idl.grammar
+// Regenerate with: grammar-tools compile-grammar idl.grammar
+//
+// This file embeds a ParserGrammar as native Rust data structures.
+// Call `parser_grammar()` instead of reading and parsing the .grammar file.
+
+use grammar_tools::parser_grammar::{GrammarElement, GrammarRule, ParserGrammar};
+
+pub fn parser_grammar() -> ParserGrammar {
+    ParserGrammar {
+        rules: vec![
+            GrammarRule {
+                name: r#"program"#.to_string(),
+                body: GrammarElement::Repetition {
+                    element: Box::new(GrammarElement::RuleReference {
+                        name: r#"top_level_item"#.to_string(),
+                    }),
+                },
+                line_number: 279,
+            },
+            GrammarRule {
+                name: r#"top_level_item"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"pro_def"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"func_def"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"statement_line"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 281,
+            },
+            GrammarRule {
+                name: r#"statement_line"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::RuleReference {
+                                    name: r#"statement"#.to_string(),
+                                },
+                                GrammarElement::Repetition {
+                                    element: Box::new(GrammarElement::Sequence {
+                                        elements: vec![
+                                            GrammarElement::TokenReference {
+                                                name: r#"STMT_SEP"#.to_string(),
+                                            },
+                                            GrammarElement::RuleReference {
+                                                name: r#"statement"#.to_string(),
+                                            },
+                                        ],
+                                    }),
+                                },
+                                GrammarElement::Optional {
+                                    element: Box::new(GrammarElement::TokenReference {
+                                        name: r#"NEWLINE"#.to_string(),
+                                    }),
+                                },
+                            ],
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NEWLINE"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 292,
+            },
+            GrammarRule {
+                name: r#"block_body"#.to_string(),
+                body: GrammarElement::Repetition {
+                    element: Box::new(GrammarElement::RuleReference {
+                        name: r#"statement_line"#.to_string(),
+                    }),
+                },
+                line_number: 302,
+            },
+            GrammarRule {
+                name: r#"statement"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"if_stmt"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"for_stmt"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"while_stmt"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"repeat_stmt"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"begin_block"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"break_stmt"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"continue_stmt"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"return_stmt"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"procedure_call_stmt"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"assignment_stmt"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr_stmt"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 304,
+            },
+            GrammarRule {
+                name: r#"if_stmt"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"IF"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"THEN"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"then_branch"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::Literal {
+                                        value: r#"ELSE"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"else_branch"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 324,
+            },
+            GrammarRule {
+                name: r#"then_branch"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::Literal {
+                                    value: r#"BEGIN"#.to_string(),
+                                },
+                                GrammarElement::RuleReference {
+                                    name: r#"block_body"#.to_string(),
+                                },
+                                GrammarElement::Group {
+                                    element: Box::new(GrammarElement::Alternation {
+                                        choices: vec![
+                                            GrammarElement::Literal {
+                                                value: r#"ENDIF"#.to_string(),
+                                            },
+                                            GrammarElement::Literal {
+                                                value: r#"END"#.to_string(),
+                                            },
+                                        ],
+                                    }),
+                                },
+                            ],
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"statement"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 326,
+            },
+            GrammarRule {
+                name: r#"else_branch"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::Literal {
+                                    value: r#"BEGIN"#.to_string(),
+                                },
+                                GrammarElement::RuleReference {
+                                    name: r#"block_body"#.to_string(),
+                                },
+                                GrammarElement::Group {
+                                    element: Box::new(GrammarElement::Alternation {
+                                        choices: vec![
+                                            GrammarElement::Literal {
+                                                value: r#"ENDELSE"#.to_string(),
+                                            },
+                                            GrammarElement::Literal {
+                                                value: r#"END"#.to_string(),
+                                            },
+                                        ],
+                                    }),
+                                },
+                            ],
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"statement"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 329,
+            },
+            GrammarRule {
+                name: r#"for_stmt"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"FOR"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NAME"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"EQUALS"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"COMMA"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"COMMA"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"expr"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"DO"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"for_body"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 335,
+            },
+            GrammarRule {
+                name: r#"for_body"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::Literal {
+                                    value: r#"BEGIN"#.to_string(),
+                                },
+                                GrammarElement::RuleReference {
+                                    name: r#"block_body"#.to_string(),
+                                },
+                                GrammarElement::Group {
+                                    element: Box::new(GrammarElement::Alternation {
+                                        choices: vec![
+                                            GrammarElement::Literal {
+                                                value: r#"ENDFOR"#.to_string(),
+                                            },
+                                            GrammarElement::Literal {
+                                                value: r#"END"#.to_string(),
+                                            },
+                                        ],
+                                    }),
+                                },
+                            ],
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"statement"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 337,
+            },
+            GrammarRule {
+                name: r#"while_stmt"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"WHILE"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"DO"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"while_body"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 342,
+            },
+            GrammarRule {
+                name: r#"while_body"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::Literal {
+                                    value: r#"BEGIN"#.to_string(),
+                                },
+                                GrammarElement::RuleReference {
+                                    name: r#"block_body"#.to_string(),
+                                },
+                                GrammarElement::Group {
+                                    element: Box::new(GrammarElement::Alternation {
+                                        choices: vec![
+                                            GrammarElement::Literal {
+                                                value: r#"ENDWHILE"#.to_string(),
+                                            },
+                                            GrammarElement::Literal {
+                                                value: r#"END"#.to_string(),
+                                            },
+                                        ],
+                                    }),
+                                },
+                            ],
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"statement"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 344,
+            },
+            GrammarRule {
+                name: r#"repeat_stmt"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"REPEAT"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"repeat_body"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"UNTIL"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 351,
+            },
+            GrammarRule {
+                name: r#"repeat_body"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::Literal {
+                                    value: r#"BEGIN"#.to_string(),
+                                },
+                                GrammarElement::RuleReference {
+                                    name: r#"block_body"#.to_string(),
+                                },
+                                GrammarElement::Group {
+                                    element: Box::new(GrammarElement::Alternation {
+                                        choices: vec![
+                                            GrammarElement::Literal {
+                                                value: r#"ENDREP"#.to_string(),
+                                            },
+                                            GrammarElement::Literal {
+                                                value: r#"END"#.to_string(),
+                                            },
+                                        ],
+                                    }),
+                                },
+                            ],
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"statement"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 353,
+            },
+            GrammarRule {
+                name: r#"begin_block"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"BEGIN"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"block_body"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"END"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 361,
+            },
+            GrammarRule {
+                name: r#"break_stmt"#.to_string(),
+                body: GrammarElement::Literal {
+                    value: r#"BREAK"#.to_string(),
+                },
+                line_number: 363,
+            },
+            GrammarRule {
+                name: r#"continue_stmt"#.to_string(),
+                body: GrammarElement::Literal {
+                    value: r#"CONTINUE"#.to_string(),
+                },
+                line_number: 364,
+            },
+            GrammarRule {
+                name: r#"return_stmt"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"RETURN"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"COMMA"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"expr"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 375,
+            },
+            GrammarRule {
+                name: r#"procedure_call_stmt"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"NAME"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"COMMA"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"arg_list"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 393,
+            },
+            GrammarRule {
+                name: r#"assignment_stmt"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"NAME"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::RuleReference {
+                                name: r#"index_suffix"#.to_string(),
+                            }),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"EQUALS"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 402,
+            },
+            GrammarRule {
+                name: r#"expr_stmt"#.to_string(),
+                body: GrammarElement::RuleReference {
+                    name: r#"expr"#.to_string(),
+                },
+                line_number: 408,
+            },
+            GrammarRule {
+                name: r#"pro_def"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"PRO"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NAME"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"COMMA"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"params"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"block_body"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"END"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 429,
+            },
+            GrammarRule {
+                name: r#"func_def"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::Literal {
+                            value: r#"FUNCTION"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NAME"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"COMMA"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"params"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"block_body"#.to_string(),
+                        },
+                        GrammarElement::Literal {
+                            value: r#"END"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 430,
+            },
+            GrammarRule {
+                name: r#"params"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"param"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"COMMA"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"param"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 432,
+            },
+            GrammarRule {
+                name: r#"param"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::TokenReference {
+                                    name: r#"NAME"#.to_string(),
+                                },
+                                GrammarElement::TokenReference {
+                                    name: r#"EQUALS"#.to_string(),
+                                },
+                                GrammarElement::TokenReference {
+                                    name: r#"NAME"#.to_string(),
+                                },
+                            ],
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NAME"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 433,
+            },
+            GrammarRule {
+                name: r#"expr"#.to_string(),
+                body: GrammarElement::RuleReference {
+                    name: r#"logical"#.to_string(),
+                },
+                line_number: 444,
+            },
+            GrammarRule {
+                name: r#"logical"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"comparison"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::Group {
+                                        element: Box::new(GrammarElement::Alternation {
+                                            choices: vec![
+                                                GrammarElement::Literal {
+                                                    value: r#"AND"#.to_string(),
+                                                },
+                                                GrammarElement::Literal {
+                                                    value: r#"OR"#.to_string(),
+                                                },
+                                                GrammarElement::Literal {
+                                                    value: r#"XOR"#.to_string(),
+                                                },
+                                            ],
+                                        }),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"comparison"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 446,
+            },
+            GrammarRule {
+                name: r#"comparison"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"additive"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::Group {
+                                        element: Box::new(GrammarElement::Alternation {
+                                            choices: vec![
+                                                GrammarElement::Literal {
+                                                    value: r#"EQ"#.to_string(),
+                                                },
+                                                GrammarElement::Literal {
+                                                    value: r#"NE"#.to_string(),
+                                                },
+                                                GrammarElement::Literal {
+                                                    value: r#"LE"#.to_string(),
+                                                },
+                                                GrammarElement::Literal {
+                                                    value: r#"LT"#.to_string(),
+                                                },
+                                                GrammarElement::Literal {
+                                                    value: r#"GE"#.to_string(),
+                                                },
+                                                GrammarElement::Literal {
+                                                    value: r#"GT"#.to_string(),
+                                                },
+                                            ],
+                                        }),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"additive"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 448,
+            },
+            GrammarRule {
+                name: r#"additive"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"unary"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::Group {
+                                        element: Box::new(GrammarElement::Alternation {
+                                            choices: vec![
+                                                GrammarElement::TokenReference {
+                                                    name: r#"PLUS"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"MINUS"#.to_string(),
+                                                },
+                                            ],
+                                        }),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"unary"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 454,
+            },
+            GrammarRule {
+                name: r#"unary"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::Sequence {
+                            elements: vec![
+                                GrammarElement::Group {
+                                    element: Box::new(GrammarElement::Alternation {
+                                        choices: vec![
+                                            GrammarElement::TokenReference {
+                                                name: r#"PLUS"#.to_string(),
+                                            },
+                                            GrammarElement::TokenReference {
+                                                name: r#"MINUS"#.to_string(),
+                                            },
+                                            GrammarElement::Literal {
+                                                value: r#"NOT"#.to_string(),
+                                            },
+                                        ],
+                                    }),
+                                },
+                                GrammarElement::RuleReference {
+                                    name: r#"unary"#.to_string(),
+                                },
+                            ],
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"multiplicative"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 461,
+            },
+            GrammarRule {
+                name: r#"multiplicative"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"power"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::Group {
+                                        element: Box::new(GrammarElement::Alternation {
+                                            choices: vec![
+                                                GrammarElement::TokenReference {
+                                                    name: r#"STAR"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"SLASH"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"HASH_HASH"#.to_string(),
+                                                },
+                                                GrammarElement::TokenReference {
+                                                    name: r#"HASH"#.to_string(),
+                                                },
+                                            ],
+                                        }),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"power"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 472,
+            },
+            GrammarRule {
+                name: r#"power"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"postfix"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"CARET"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"postfix"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 479,
+            },
+            GrammarRule {
+                name: r#"postfix"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"primary"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Alternation {
+                                choices: vec![
+                                    GrammarElement::RuleReference {
+                                        name: r#"index_suffix"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"call_suffix"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 487,
+            },
+            GrammarRule {
+                name: r#"index_suffix"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"LBRACKET"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"subscript_list"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RBRACKET"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 489,
+            },
+            GrammarRule {
+                name: r#"call_suffix"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"LPAREN"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::RuleReference {
+                                name: r#"arg_list"#.to_string(),
+                            }),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RPAREN"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 490,
+            },
+            GrammarRule {
+                name: r#"subscript_list"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"subscript"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"COMMA"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"subscript"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 499,
+            },
+            GrammarRule {
+                name: r#"subscript"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"STAR"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"range_subscript"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 507,
+            },
+            GrammarRule {
+                name: r#"range_subscript"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"COLON"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"range_end"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"COLON"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"expr"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 515,
+            },
+            GrammarRule {
+                name: r#"range_end"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"STAR"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 516,
+            },
+            GrammarRule {
+                name: r#"arg_list"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"arg"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"COMMA"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"arg"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 527,
+            },
+            GrammarRule {
+                name: r#"arg"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"keyword_arg"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"bool_keyword_arg"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 535,
+            },
+            GrammarRule {
+                name: r#"keyword_arg"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"NAME"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"EQUALS"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 542,
+            },
+            GrammarRule {
+                name: r#"bool_keyword_arg"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"SLASH"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NAME"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 549,
+            },
+            GrammarRule {
+                name: r#"primary"#.to_string(),
+                body: GrammarElement::Alternation {
+                    choices: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"NUMBER"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"STRING"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"array_literal"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"group"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"NAME"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 555,
+            },
+            GrammarRule {
+                name: r#"group"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"LPAREN"#.to_string(),
+                        },
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RPAREN"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 561,
+            },
+            GrammarRule {
+                name: r#"array_literal"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::TokenReference {
+                            name: r#"LBRACKET"#.to_string(),
+                        },
+                        GrammarElement::Optional {
+                            element: Box::new(GrammarElement::RuleReference {
+                                name: r#"array_elements"#.to_string(),
+                            }),
+                        },
+                        GrammarElement::TokenReference {
+                            name: r#"RBRACKET"#.to_string(),
+                        },
+                    ],
+                },
+                line_number: 571,
+            },
+            GrammarRule {
+                name: r#"array_elements"#.to_string(),
+                body: GrammarElement::Sequence {
+                    elements: vec![
+                        GrammarElement::RuleReference {
+                            name: r#"expr"#.to_string(),
+                        },
+                        GrammarElement::Repetition {
+                            element: Box::new(GrammarElement::Sequence {
+                                elements: vec![
+                                    GrammarElement::TokenReference {
+                                        name: r#"COMMA"#.to_string(),
+                                    },
+                                    GrammarElement::RuleReference {
+                                        name: r#"expr"#.to_string(),
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
+                },
+                line_number: 572,
+            },
+        ],
+        version: 0,
+    }
+}

--- a/code/packages/rust/idl-parser/src/lib.rs
+++ b/code/packages/rust/idl-parser/src/lib.rs
@@ -1,0 +1,876 @@
+//! # IDL Parser — building a syntax tree for IDL (Interactive Data Language).
+//!
+//! Turns the token stream from [`coding_adventures_idl_lexer`] into a parse
+//! tree using the generic [`GrammarParser`](parser::grammar_parser::GrammarParser),
+//! driven by the embedded `idl.grammar` (`src/_grammar.rs`). It hand-writes
+//! no parsing logic — a sibling of `scilab-parser`/`q-parser`. See
+//! `code/specs/MA12-idl-language.md` (MA-12c).
+//!
+//! Unlike every array-family frontend already in this repo (APL/J/Q/Scilab/
+//! MATLAB), IDL's *surface* is an Algol/Fortran-family imperative grammar —
+//! statements, `PRO`/`FUNCTION` definitions, `IF`/`FOR`/`WHILE`/`REPEAT`
+//! blocks, an infix operator-precedence cascade with word operators
+//! (`EQ`/`AND`/...) — closer in shape to this repo's `algol-parser`/
+//! `dartmouth-basic-parser` than to any array-family parser (MA12 §5). So
+//! `idl.grammar` is written to IDL's own shape, not forked from an array
+//! sibling (contrast `scilab-parser`, forked from `matlab.grammar` at the
+//! grammar-source level).
+//!
+//! ```text
+//! IDL source
+//!    |
+//!    v
+//! coding_adventures_idl_lexer::tokenize_idl  ->  Vec<Token>
+//!    |
+//!    v
+//! parser::GrammarParser  (driven by the embedded idl.grammar)
+//!    |
+//!    v
+//! GrammarASTNode  <- the tree a future idl-runtime (MA-12d) walks
+//! ```
+//!
+//! ## The two genuinely new disambiguations (MA12 §3)
+//!
+//! `idl-lexer` (MA-12b) deliberately left two glyphs lexically unconditional
+//! — `SLASH` is always plain division, `EQUALS` is always one plain `=` —
+//! because neither ambiguity can be resolved from raw characters or a flat
+//! token list (see that crate's own doc comment). This crate resolves both,
+//! entirely through grammar *structure*, with no lookahead predicate of any
+//! kind:
+//!
+//! 1. **`/BOOLEAN` keyword shorthand vs. division.** `arg` is the only
+//!    production that ever references a bare, argument-leading `SLASH`
+//!    (`bool_keyword_arg = SLASH NAME`). This works because `expr`'s own
+//!    precedence cascade never lets `SLASH` appear except as a *binary*
+//!    operator consumed after a left operand is already parsed
+//!    (`multiplicative`'s own repetition) — IDL has no unary `/`. So at an
+//!    argument position, `expr` can never itself succeed starting exactly on
+//!    a `SLASH` token, which means a leading `SLASH` there can *only* ever be
+//!    the boolean-keyword shorthand. `PLOT, x, /YLOG` hits this production;
+//!    `x = a/YLOG` never even reaches `arg` at all (it's an ordinary
+//!    `assignment_stmt` RHS), and `a`'s `SLASH` is consumed by
+//!    `multiplicative` as ordinary division, exactly like `a + b`.
+//! 2. **`=` as assignment vs. keyword-bind.** `assignment_stmt = NAME
+//!    [ index_suffix ] EQUALS expr` (statement-level) and `keyword_arg = NAME
+//!    EQUALS expr` (inside `arg_list`) have the identical token shape around
+//!    `=`, deliberately — what tells them apart is which rule the parser is
+//!    *currently inside*: `assignment_stmt` is only ever reached from
+//!    `statement`, `keyword_arg` only ever from `arg` (only ever inside an
+//!    argument list). No shared production reads `=` and decides later.
+//!
+//! See `code/grammars/idl/idl.grammar`'s own header comment for the full
+//! design writeup, including the procedure-call-statement's own
+//! `NAME COMMA arg_list` disambiguation (safe ordinary PEG ordered choice,
+//! since `COMMA` is not used as a statement separator anywhere else in this
+//! cut) and the disclosed, spec-consistent zero-argument-call scope note.
+
+use coding_adventures_idl_lexer::{tokenize_idl, try_tokenize_idl};
+use parser::grammar_parser::{GrammarASTNode, GrammarParser};
+mod _grammar;
+
+/// Recursion-depth cap for the IDL [`GrammarParser`] — see
+/// [`GrammarParser::with_max_depth`] and
+/// [`parser::grammar_parser::DEFAULT_MAX_RULE_DEPTH`] for why the underlying
+/// guard exists at all (deep recursion through `parse_rule` can overflow the
+/// *native* thread stack — an uncatchable process abort — before this
+/// crate's own `Result`-returning entry points ever get a chance to report
+/// anything). `idl-lexer` (MA-12b) has no recursion at all (it only
+/// tokenizes); this is the FIRST IDL crate with actual recursive descent, so
+/// this cap is added fresh here, not inherited from a sibling.
+///
+/// # Six recursion shapes, measured independently, per MA12 §6's directive
+///
+/// MA12 §6 (task MA-12c) requires measuring **this** grammar's own actual
+/// native-stack crash floor rather than assuming a sibling `*-parser`
+/// crate's numbers transfer — the "measure, don't assume one shape's floor
+/// bounds the others" methodology `apl-parser`/`j-parser`/`scilab-parser`'s
+/// own `CHANGELOG.md`s document. `idl.grammar` has six structurally distinct
+/// self-referential shapes:
+///
+/// 1. **Parenthesised nesting**, `((((…5…))))` — `group -> expr -> logical ->
+///    comparison -> additive -> unary -> multiplicative -> power -> postfix
+///    -> primary -> group -> …` — cycles through the entire nine-rule
+///    expression cascade every nesting level.
+/// 2. **Nested `IF`/`ENDIF`**, `if 1 then begin ... 5 ... endif` — `if_stmt ->
+///    then_branch -> block_body -> statement_line -> statement -> if_stmt ->
+///    …`. `for_stmt`/`while_stmt`/`repeat_stmt`/`begin_block` each reach
+///    `block_body` the identical way (`statement -> {for_stmt|while_stmt|
+///    repeat_stmt|begin_block} -> {for_body|while_body|repeat_body|
+///    block_body} -> block_body -> statement_line -> statement -> …`,
+///    confirmed by direct inspection of the rule graph — every one of these
+///    five productions reaches `statement` through the same number of
+///    wrapper frames as `if_stmt` does), so none of the other four was
+///    separately measured — a provable rule-graph identity, not an assumed
+///    shape resemblance, mirroring `scilab-parser`'s identical treatment of
+///    `select_stmt` relative to `if_stmt`.
+/// 3. **Nested function-call arguments**, `f(f(f(…5…)))` — `postfix ->
+///    call_suffix -> arg_list -> arg -> expr -> … -> postfix`, interposing
+///    two wrapper rule-frames (`call_suffix`, `arg_list`/`arg`) per level
+///    on top of `postfix`'s own re-entry, structurally distinct from
+///    parenthesised nesting (`group` interposes none).
+/// 4. **Nested subscript indexing**, `a[a[a[…5…]]]` — `postfix ->
+///    index_suffix -> subscript_list -> subscript -> expr -> … -> postfix`.
+///    Confirmed by direct inspection to interpose the SAME number of wrapper
+///    rule-frames per level as call-argument nesting (`index_suffix ->
+///    subscript_list -> subscript`, three frames, vs. `call_suffix ->
+///    arg_list -> arg`, also three) — not merely similar-looking, but
+///    reaching `expr` through an identical frame count either way — so this
+///    shape was independently measured rather than assumed identical, to
+///    confirm the rule-graph symmetry actually holds at the native-stack
+///    level too (see the table below: it does, within measurement
+///    granularity).
+/// 5. **A unary prefix chain**, `- - - … 5` (or `NOT NOT … x`) — `unary`'s
+///    own `( PLUS | MINUS | "NOT" ) unary` self-reference. Chosen as its own
+///    shape (not assumed to share `power`'s floor) because — unlike
+///    Scilab's/MATLAB's own cascade, where `unary` sits BETWEEN
+///    `multiplicative` and `power` — this grammar's `unary` sits ABOVE
+///    `multiplicative` (looser, per IDL's own documented precedence table,
+///    see `idl.grammar`'s header comment), so its base-case dive
+///    (`unary -> multiplicative -> power -> postfix -> primary`, four
+///    frames) is structurally different from every sibling `*-parser`'s own
+///    unary-chain shape.
+/// 6. **Nested array literals**, `[[[[…5…]]]]` — structurally distinct from
+///    parenthesised nesting: `group = LPAREN expr RPAREN` wraps `expr`
+///    directly (zero extra frames), but `array_literal = LBRACKET
+///    [ array_elements ] RBRACKET` reaches `expr` through ONE extra
+///    rule-frame (`array_elements`) — the same "one extra wrapper frame"
+///    gap `maple-parser`'s own `list_literal` has relative to its `group`.
+///
+/// Every "flat chain of one operator" production written with EBNF `{ x }`
+/// repetition (`logical`, `comparison`, `additive`, `multiplicative`,
+/// `power`, `postfix`'s own suffix loop, `arg_list`, `subscript_list`,
+/// `array_elements`, `params`, `statement_line`'s own `{ STMT_SEP statement
+/// }`, `block_body`) costs *zero* native stack regardless of width —
+/// confirmed directly by reading [`parser::grammar_parser`]'s own
+/// `match_element` implementation (the `Repetition`/`SeparatedRepetition`
+/// arms are plain `loop { ... }` where each iteration's `match_element` call
+/// returns before the next iteration begins, so the *native* call stack
+/// never grows with iteration count) — the same engine-level fact every
+/// sibling `*-parser` crate's own `MAX_RULE_DEPTH` doc comment already
+/// establishes, not re-measured by a throwaway probe here.
+///
+/// Measured with the same methodology every sibling `*-parser` crate uses:
+/// binary search, an *uncapped* `GrammarParser` (`max_depth = usize::MAX`,
+/// [`GrammarParser::new`]'s own default), a `std::thread::spawn` worker with
+/// the **default ~2 MiB stack** (no `stack_size` override), one fresh
+/// **subprocess per data point** (a real native-stack overflow calls
+/// `process::abort()`, which kills the whole process, not just the
+/// offending thread — an in-process loop cannot survive past the first
+/// crash to report a clean number), in a **debug** build (`cargo test`'s own
+/// default, since debug frames are meaningfully larger than release frames).
+///
+/// Nesting-count floors (parses safely up to N, crashes at N+1):
+///
+/// | Shape | Nesting-count floor |
+/// |---|---|
+/// | Parenthesised nesting | 27 safe / 28 crash |
+/// | Nested `IF`/`ENDIF` | 47 safe / 48 crash |
+/// | Nested function-call arguments | 22 safe / 23 crash |
+/// | Nested subscript indexing | 21 safe / 22 crash |
+/// | Unary prefix chain | 199 safe / 200 crash |
+/// | Nested array literals | 24 safe / 25 crash |
+///
+/// # The binding constraint is a rule-frame floor, not a nesting-count one
+///
+/// Exactly as every sibling `*-parser` crate's own doc comment warns, the
+/// *nesting-count* floors above do not by themselves say which shape binds
+/// `MAX_RULE_DEPTH` — `self.depth` counts *named-rule* invocations, and
+/// different shapes cost a different number of rule-frames per nesting
+/// level. Converting each measured nesting-count floor into rule-frame terms
+/// (binary search over `with_max_depth` against a fixed 5000-level input —
+/// 2000 for nested `IF`, since each level costs more source text — of each
+/// shape, so the *cap itself* is always what triggers first; same default
+/// ~2 MiB stack, same debug build):
+///
+/// | Shape | Nesting-count floor | Rule-frame floor |
+/// |---|---|---|
+/// | Parenthesised nesting | 27 safe / 28 crash | 291 safe / 292 crash |
+/// | Nested `IF`/`ENDIF` | 47 safe / 48 crash | 249 safe / 250 crash |
+/// | Nested function-call arguments | 22 safe / 23 crash | 266 safe / 267 crash |
+/// | Nested subscript indexing | 21 safe / 22 crash | 273 safe / 274 crash |
+/// | Unary prefix chain | 199 safe / 200 crash | 212 safe / 213 crash |
+/// | Nested array literals | 24 safe / 25 crash | 282 safe / 283 crash |
+///
+/// The genuine surprise here (mirroring `scilab-parser`'s/`maple-parser`'s
+/// own): the unary prefix chain tolerates by far the MOST nesting levels
+/// (199) of any measured shape, yet has the LOWEST rule-frame floor (212) —
+/// its persisting per-level cost is exactly ONE rule-frame (`unary` itself,
+/// confirmed by the near-1:1 nesting-to-frame ratio, 212/199 ≈ 1.07), cheap
+/// enough per level to reach 199 nesting levels before the native stack
+/// gives out, yet its own call path evidently costs more native-stack bytes
+/// per crossing than the other shapes' own higher per-level rule-frame
+/// counts would suggest. Confirms, again, that "the shape tolerating the
+/// fewest levels must bind" (subscript indexing, wrong here) and
+/// "parenthesised nesting binds, since it does for nearly every sibling
+/// crate in this repo" (also wrong — parens has a HIGHER rule-frame floor,
+/// 291, than the unary chain here) both fail for this grammar too, the same
+/// lesson every sibling `*-parser` crate's own doc comment already
+/// documents from its own measurements.
+///
+/// The per-level rule-frame costs are independently consistent with the raw
+/// floor ratios, a useful sanity check that the measurement behaves as the
+/// rule-graph analysis predicts rather than as noise: 291/27 ≈ 10.8 for
+/// parens (`group` interposes zero extra frames before cycling the
+/// nine-rule expression cascade back to `primary`); 266/22 ≈ 12.1 for
+/// nested calls (`call_suffix`/`arg_list`/`arg` interpose three frames on
+/// top of the same cascade); 273/21 ≈ 13.0 for nested subscripts
+/// (`index_suffix`/`subscript_list`/`subscript` interpose the same three);
+/// 282/24 ≈ 11.75 for nested array literals (`array_literal`/
+/// `array_elements` interpose two); 249/47 ≈ 5.3 for nested `IF` (`if_stmt`
+/// -> `then_branch` -> `block_body` -> `statement_line` -> `statement`, five
+/// frames before the next `if_stmt`); 212/199 ≈ 1.07 for the unary chain
+/// (`unary`'s own one-frame self-reference).
+///
+/// The lowest rule-frame floor is the unary prefix chain's **212**.
+/// `MAX_RULE_DEPTH` is set to **148** — about 30.2% below 212 (matching
+/// `scilab-parser`'s own ~30.2% margin, and comparable to `reduce-parser`'s
+/// ~28.5%, `apl-parser`'s ~26.5%, `j-parser`'s ~30%, `derive-parser`'s ~33%,
+/// `maple-parser`'s ~31.2%), and therefore safely below the other five
+/// rule-frame floors (291, 249, 266, 273, 282) too.
+///
+/// Measured real-input headroom at `148` (using the CAPPED parser, i.e.
+/// [`create_idl_parser`]/[`try_parse_idl`], so no crash risk at all):
+/// parenthesised nesting parses cleanly up to 13 levels (14 trips the cap);
+/// a unary prefix chain parses cleanly up to 134 levels (135 trips); nested
+/// `IF`s parse cleanly up to 26 levels (27 trips); nested array literals
+/// parse cleanly up to 12 levels (13 trips); nested function-call arguments
+/// parse cleanly up to 12 levels (13 trips); nested subscript indexing
+/// parses cleanly up to 11 levels (12 trips) — all comfortably beyond
+/// anything a hand-written IDL program needs, and all six independently
+/// confirmed not to crash a default-stack thread even thousands of levels
+/// past the cap (see this crate's tests).
+const MAX_RULE_DEPTH: usize = 148;
+
+/// Build a [`GrammarParser`] wired to the IDL grammar for the already-
+/// tokenized `tokens`, with the recursion-depth guard ([`MAX_RULE_DEPTH`])
+/// enabled. The ONE place that constructs a capped IDL [`GrammarParser`] —
+/// [`create_idl_parser`] and [`try_parse_idl`] both funnel through this, so
+/// a future change to the cap (or to how the parser is wired up) can never
+/// miss one of the two call sites.
+fn capped_idl_parser(tokens: Vec<lexer::token::Token>) -> GrammarParser {
+    GrammarParser::new(tokens, _grammar::parser_grammar()).with_max_depth(MAX_RULE_DEPTH)
+}
+
+/// Create a [`GrammarParser`] wired to the IDL grammar and the tokens of
+/// `source`, with the recursion-depth guard ([`MAX_RULE_DEPTH`]) enabled so
+/// pathologically deep nesting fails cleanly instead of overflowing the
+/// native stack.
+pub fn create_idl_parser(source: &str) -> GrammarParser {
+    capped_idl_parser(tokenize_idl(source))
+}
+
+/// Parse IDL source text into a [`GrammarASTNode`] rooted at `program`.
+///
+/// # Panics
+///
+/// Panics on a lexical or syntax error. Use [`try_parse_idl`] to handle
+/// errors.
+///
+/// # Example
+///
+/// ```
+/// use coding_adventures_idl_parser::parse_idl;
+/// let ast = parse_idl("x = 5\n");
+/// assert_eq!(ast.rule_name, "program");
+/// ```
+pub fn parse_idl(source: &str) -> GrammarASTNode {
+    create_idl_parser(source)
+        .parse()
+        .unwrap_or_else(|e| panic!("IDL parse failed: {e}"))
+}
+
+/// Parse IDL source text, returning a `Result` instead of panicking.
+pub fn try_parse_idl(source: &str) -> Result<GrammarASTNode, String> {
+    let tokens = try_tokenize_idl(source)?;
+    capped_idl_parser(tokens).parse().map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parser::grammar_parser::ASTNodeOrToken;
+
+    fn contains_rule(node: &GrammarASTNode, name: &str) -> bool {
+        node.rule_name == name
+            || node.children.iter().any(|c| match c {
+                ASTNodeOrToken::Node(n) => contains_rule(n, name),
+                ASTNodeOrToken::Token(_) => false,
+            })
+    }
+
+    /// Find the first descendant node (or self) with the given rule name.
+    fn find_rule<'a>(node: &'a GrammarASTNode, name: &str) -> Option<&'a GrammarASTNode> {
+        if node.rule_name == name {
+            return Some(node);
+        }
+        for c in &node.children {
+            if let ASTNodeOrToken::Node(n) = c {
+                if let Some(found) = find_rule(n, name) {
+                    return Some(found);
+                }
+            }
+        }
+        None
+    }
+
+    /// Collect every descendant node (or self) with the given rule name.
+    fn find_rules<'a>(node: &'a GrammarASTNode, name: &str) -> Vec<&'a GrammarASTNode> {
+        let mut out = Vec::new();
+        if node.rule_name == name {
+            out.push(node);
+        }
+        for c in &node.children {
+            if let ASTNodeOrToken::Node(n) = c {
+                out.extend(find_rules(n, name));
+            }
+        }
+        out
+    }
+
+    /// Collect every token value under a node (in order), for shape assertions.
+    fn token_values(node: &GrammarASTNode) -> Vec<String> {
+        let mut out = Vec::new();
+        for c in &node.children {
+            match c {
+                ASTNodeOrToken::Token(t) => out.push(t.value.clone()),
+                ASTNodeOrToken::Node(n) => out.extend(token_values(n)),
+            }
+        }
+        out
+    }
+
+    fn parses(src: &str) -> bool {
+        try_parse_idl(src).is_ok()
+    }
+
+    #[test]
+    fn program_is_the_root() {
+        assert_eq!(parse_idl("x = 5\n").rule_name, "program");
+    }
+
+    // --- The headline disambiguation: /BOOLEAN vs. division -------------
+
+    #[test]
+    fn slash_boolean_keyword_shorthand_inside_a_procedure_call() {
+        let ast = parse_idl("PLOT, x, /YLOG\n");
+        let call = find_rule(&ast, "procedure_call_stmt").expect("procedure_call_stmt");
+        assert!(contains_rule(call, "bool_keyword_arg"));
+        let bka = find_rule(call, "bool_keyword_arg").unwrap();
+        assert_eq!(token_values(bka), vec!["/", "YLOG"]);
+        // The SLASH was consumed by `bool_keyword_arg`, not by a division —
+        // no `multiplicative` node anywhere contains a "/" token value.
+        assert!(!find_rules(call, "multiplicative")
+            .iter()
+            .any(|n| token_values(n).contains(&"/".to_string())));
+    }
+
+    #[test]
+    fn slash_is_ordinary_division_in_an_assignment_rhs() {
+        let ast = parse_idl("x = a/YLOG\n");
+        let assign = find_rule(&ast, "assignment_stmt").expect("assignment_stmt");
+        let mult = find_rule(assign, "multiplicative").expect("multiplicative — division tier");
+        assert_eq!(token_values(mult), vec!["a", "/", "YLOG"]);
+        // No bool_keyword_arg anywhere — this statement has no argument list at all.
+        assert!(!contains_rule(&ast, "bool_keyword_arg"));
+    }
+
+    #[test]
+    fn slash_is_ordinary_division_as_a_positional_call_argument() {
+        // PLOT, a/YLOG -- a positional argument that is itself a division,
+        // not a boolean keyword (the SLASH is not argument-leading here).
+        let ast = parse_idl("PLOT, a/YLOG\n");
+        let call = find_rule(&ast, "procedure_call_stmt").expect("procedure_call_stmt");
+        assert!(!contains_rule(call, "bool_keyword_arg"));
+        let mult = find_rule(call, "multiplicative").expect("multiplicative");
+        assert_eq!(token_values(mult), vec!["a", "/", "YLOG"]);
+    }
+
+    #[test]
+    fn boolean_keyword_shorthand_in_a_function_call_too() {
+        // MA12 §3 item 2: keyword args (and by the same production, the
+        // /BOOLEAN shorthand) work identically in procedure AND function calls.
+        let ast = parse_idl("y = HISTOGRAM(a, /NAN)\n");
+        assert!(contains_rule(&ast, "bool_keyword_arg"));
+    }
+
+    // --- The other headline disambiguation: = assignment vs. keyword-bind -
+
+    #[test]
+    fn equals_is_keyword_bind_inside_a_call_argument_list() {
+        let ast = parse_idl("PLOT, x, TITLE='flux'\n");
+        let call = find_rule(&ast, "procedure_call_stmt").expect("procedure_call_stmt");
+        assert!(contains_rule(call, "keyword_arg"));
+        assert!(!contains_rule(call, "assignment_stmt"));
+    }
+
+    #[test]
+    fn equals_is_ordinary_assignment_at_statement_level() {
+        let ast = parse_idl("x = 5\n");
+        assert!(contains_rule(&ast, "assignment_stmt"));
+        assert!(!contains_rule(&ast, "keyword_arg"));
+    }
+
+    #[test]
+    fn keyword_arg_and_positional_and_boolean_shorthand_mix_freely() {
+        let ast = parse_idl("PLOT, x, y, TITLE='flux', COLOR=255, /YLOG\n");
+        let call = find_rule(&ast, "procedure_call_stmt").expect("procedure_call_stmt");
+        assert!(contains_rule(call, "keyword_arg"));
+        assert!(contains_rule(call, "bool_keyword_arg"));
+    }
+
+    // --- Procedure-call statement vs. plain expression statement --------
+
+    #[test]
+    fn bare_name_with_no_comma_is_an_expr_statement_not_a_call() {
+        // Disclosed scope note (see idl.grammar's header comment): a
+        // zero-arg call is syntactically identical to a bare variable read.
+        let ast = parse_idl("STOP\n");
+        assert!(contains_rule(&ast, "expr_stmt"));
+        assert!(!contains_rule(&ast, "procedure_call_stmt"));
+    }
+
+    #[test]
+    fn function_call_as_an_expression_statement() {
+        let ast = parse_idl("SIN(x)\n");
+        assert!(contains_rule(&ast, "expr_stmt"));
+        assert!(contains_rule(&ast, "call_suffix"));
+    }
+
+    #[test]
+    fn procedure_call_with_only_positional_arguments() {
+        let ast = parse_idl("PRINT, x, y\n");
+        assert!(contains_rule(&ast, "procedure_call_stmt"));
+    }
+
+    // --- Assignment, including subscripted targets -----------------------
+
+    #[test]
+    fn plain_assignment() {
+        assert!(parses("x = 5\n"));
+    }
+
+    #[test]
+    fn subscripted_assignment_1d() {
+        let ast = parse_idl("a[0] = 5\n");
+        let assign = find_rule(&ast, "assignment_stmt").unwrap();
+        assert!(contains_rule(assign, "index_suffix"));
+    }
+
+    #[test]
+    fn subscripted_assignment_2d() {
+        assert!(parses("a[0, 1] = 5\n"));
+    }
+
+    // --- Every subscript form (MA12 §4) -----------------------------------
+
+    #[test]
+    fn subscript_plain_index() {
+        assert!(parses("y = a[0]\n"));
+    }
+
+    #[test]
+    fn subscript_two_d() {
+        assert!(parses("y = a[0, 1]\n"));
+    }
+
+    #[test]
+    fn subscript_negative_from_end() {
+        let ast = parse_idl("y = a[-1]\n");
+        assert!(contains_rule(&ast, "index_suffix"));
+        assert!(contains_rule(&ast, "unary"));
+    }
+
+    #[test]
+    fn subscript_range() {
+        let ast = parse_idl("y = a[0:5]\n");
+        assert!(contains_rule(&ast, "range_subscript"));
+    }
+
+    #[test]
+    fn subscript_strided_range() {
+        let ast = parse_idl("y = a[0:10:2]\n");
+        assert!(contains_rule(&ast, "range_subscript"));
+    }
+
+    #[test]
+    fn subscript_whole_wildcard() {
+        assert!(parses("y = a[*]\n"));
+    }
+
+    #[test]
+    fn subscript_from_start_to_wildcard() {
+        let ast = parse_idl("y = a[2:*]\n");
+        assert!(contains_rule(&ast, "range_subscript"));
+        assert!(contains_rule(&ast, "range_end"));
+    }
+
+    #[test]
+    fn subscript_from_start_to_wildcard_strided() {
+        assert!(parses("y = a[2:*:3]\n"));
+    }
+
+    // --- Array literals ----------------------------------------------------
+
+    #[test]
+    fn array_literal_basic() {
+        let ast = parse_idl("a = [1, 2, 3]\n");
+        assert!(contains_rule(&ast, "array_literal"));
+    }
+
+    #[test]
+    fn array_literal_immediately_subscripted() {
+        assert!(parses("y = [1, 2, 3][0]\n"));
+    }
+
+    // --- Control flow: IF/THEN/ELSE, both body forms ----------------------
+
+    #[test]
+    fn if_then_single_statement_no_terminator_needed() {
+        assert!(parses("IF x GT 0 THEN y = 1\n"));
+    }
+
+    #[test]
+    fn if_then_else_single_statement_forms() {
+        let ast = parse_idl("IF x GT 0 THEN y = 1 ELSE y = 2\n");
+        assert!(contains_rule(&ast, "if_stmt"));
+    }
+
+    #[test]
+    fn if_then_block_form_with_endif() {
+        assert!(parses("IF x GT 0 THEN BEGIN\n y = 1\nENDIF\n"));
+    }
+
+    #[test]
+    fn if_then_block_form_with_generic_end() {
+        assert!(parses("IF x GT 0 THEN BEGIN\n y = 1\nEND\n"));
+    }
+
+    #[test]
+    fn if_then_else_block_form_with_endelse() {
+        assert!(parses(
+            "IF x GT 0 THEN BEGIN\n y = 1\nENDIF ELSE BEGIN\n y = 2\nENDELSE\n"
+        ));
+    }
+
+    // --- FOR ----------------------------------------------------------------
+
+    #[test]
+    fn for_loop_two_arg_range() {
+        assert!(parses("FOR i = 0, 10 DO y = i\n"));
+    }
+
+    #[test]
+    fn for_loop_three_arg_range_with_step() {
+        assert!(parses("FOR i = 0, 10, 2 DO y = i\n"));
+    }
+
+    #[test]
+    fn for_loop_block_form() {
+        assert!(parses("FOR i = 0, 10 DO BEGIN\n y = i\nENDFOR\n"));
+    }
+
+    // --- WHILE ---------------------------------------------------------------
+
+    #[test]
+    fn while_loop_single_statement() {
+        assert!(parses("WHILE x GT 0 DO x = x - 1\n"));
+    }
+
+    #[test]
+    fn while_loop_block_form() {
+        assert!(parses("WHILE x GT 0 DO BEGIN\n x = x - 1\nENDWHILE\n"));
+    }
+
+    // --- REPEAT/UNTIL, including ENDREP-before-UNTIL order ------------------
+
+    #[test]
+    fn repeat_until_single_statement() {
+        assert!(parses("REPEAT x = x - 1 UNTIL x LE 0\n"));
+    }
+
+    #[test]
+    fn repeat_until_block_form_endrep_precedes_until() {
+        let ast = parse_idl("REPEAT BEGIN\n x = x - 1\nENDREP UNTIL x LE 0\n");
+        assert!(contains_rule(&ast, "repeat_stmt"));
+    }
+
+    #[test]
+    fn repeat_until_reversed_order_is_a_syntax_error() {
+        // UNTIL cannot precede ENDREP -- confirms the order is load-bearing,
+        // not accidentally accepted either way.
+        assert!(try_parse_idl("REPEAT BEGIN\n x = x - 1\nUNTIL x LE 0 ENDREP\n").is_err());
+    }
+
+    // --- BREAK / CONTINUE ---------------------------------------------------
+
+    #[test]
+    fn break_and_continue_inside_loops() {
+        assert!(parses("WHILE x GT 0 DO BEGIN\n BREAK\nENDWHILE\n"));
+        assert!(parses("FOR i = 0, 10 DO BEGIN\n CONTINUE\nENDFOR\n"));
+    }
+
+    // --- Generic BEGIN...END block ------------------------------------------
+
+    #[test]
+    fn generic_begin_end_block_as_a_statement() {
+        assert!(parses("BEGIN\n x = 1\n y = 2\nEND\n"));
+    }
+
+    // --- PRO / FUNCTION definitions, including RETURN's two forms ----------
+
+    #[test]
+    fn pro_def_with_no_params() {
+        let ast = parse_idl("PRO simple\n PRINT, 1\nEND\n");
+        assert!(contains_rule(&ast, "pro_def"));
+    }
+
+    #[test]
+    fn pro_def_with_positional_and_keyword_params() {
+        let ast = parse_idl("PRO plot_it, x, y, COLOR=color\n PRINT, x\nEND\n");
+        assert!(contains_rule(&ast, "pro_def"));
+        assert!(contains_rule(&ast, "params"));
+    }
+
+    #[test]
+    fn pro_def_return_with_no_expression() {
+        let ast = parse_idl("PRO early_out, x\n IF x GT 0 THEN RETURN\n PRINT, x\nEND\n");
+        assert!(contains_rule(&ast, "return_stmt"));
+    }
+
+    #[test]
+    fn func_def_with_return_value() {
+        let ast = parse_idl("FUNCTION square, x\n RETURN, x * x\nEND\n");
+        assert!(contains_rule(&ast, "func_def"));
+        let ret = find_rule(&ast, "return_stmt").unwrap();
+        assert!(token_values(ret).contains(&"*".to_string()));
+    }
+
+    #[test]
+    fn func_def_with_keyword_param() {
+        assert!(parses(
+            "FUNCTION scaled, x, FACTOR=factor\n RETURN, x * factor\nEND\n"
+        ));
+    }
+
+    // --- Expression precedence cascade: one test per tier boundary --------
+
+    #[test]
+    fn logical_is_loosest() {
+        let ast = parse_idl("y = a EQ b AND c EQ d\n");
+        assert!(contains_rule(&ast, "logical"));
+        assert!(contains_rule(&ast, "comparison"));
+    }
+
+    #[test]
+    fn comparison_binds_looser_than_additive() {
+        let ast = parse_idl("y = a + 1 EQ b - 1\n");
+        assert!(contains_rule(&ast, "comparison"));
+        assert!(contains_rule(&ast, "additive"));
+    }
+
+    #[test]
+    fn all_six_comparison_operators_parse_at_the_same_tier() {
+        for op in ["EQ", "NE", "LE", "LT", "GE", "GT"] {
+            let src = format!("y = a {op} b\n");
+            assert!(parses(&src), "`{src}` should parse");
+        }
+    }
+
+    #[test]
+    fn all_three_logical_operators_parse() {
+        for op in ["AND", "OR", "XOR"] {
+            let src = format!("y = a {op} b\n");
+            assert!(parses(&src), "`{src}` should parse");
+        }
+    }
+
+    #[test]
+    fn unary_minus_binds_looser_than_multiplicative_and_power() {
+        // -a*b == -(a*b): the unary MINUS must wrap the whole multiplicative
+        // term, per IDL's own documented precedence (tier 5, same as binary
+        // +/-, NOT tighter than * the way Scilab/MATLAB's own unary sits).
+        let ast = parse_idl("y = -a*b\n");
+        let unary = find_rule(&ast, "unary").expect("unary");
+        assert_eq!(token_values(unary), vec!["-", "a", "*", "b"]);
+    }
+
+    #[test]
+    fn unary_not_parses_at_the_same_tier_as_unary_minus() {
+        assert!(parses("y = NOT a\n"));
+        let ast = parse_idl("y = NOT a EQ b\n");
+        // NOT binds tighter than EQ (tier 5 vs tier 6): `(NOT a) EQ b`.
+        assert!(contains_rule(&ast, "comparison"));
+        assert!(contains_rule(&ast, "unary"));
+    }
+
+    #[test]
+    fn power_is_left_associative() {
+        // 2^3^2 == (2^3)^2 in real IDL (left-to-right, per the official
+        // precedence table), NOT right-associative like Scilab/MATLAB's `^`.
+        let ast = parse_idl("y = 2^3^2\n");
+        let power = find_rule(&ast, "power").expect("power");
+        assert_eq!(token_values(power), vec!["2", "^", "3", "^", "2"]);
+    }
+
+    #[test]
+    fn multiplicative_includes_both_matrix_product_operators() {
+        assert!(parses("y = a # b\n"));
+        assert!(parses("y = a ## b\n"));
+    }
+
+    #[test]
+    fn grouping_parens_parse() {
+        assert!(parses("y = (1 + 2) * 3\n"));
+        assert!(contains_rule(&parse_idl("y = (1 + 2) * 3\n"), "group"));
+    }
+
+    #[test]
+    fn syntax_error_is_reported() {
+        assert!(try_parse_idl("y = 1 +\n").is_err());
+        assert!(try_parse_idl("y = (1 + 2\n").is_err());
+    }
+
+    #[test]
+    fn strings_single_and_double_quoted() {
+        assert!(parses("s = 'hello'\n"));
+        assert!(parses("s = \"hello\"\n"));
+    }
+
+    // -------------------------------------------------------------------
+    // Recursion-depth guard (DoS hardening) -- exercises all six
+    // independently-measured shapes documented on `MAX_RULE_DEPTH`.
+    // -------------------------------------------------------------------
+
+    fn nested_paren_source(n: usize) -> String {
+        format!("y = {}5{}\n", "(".repeat(n), ")".repeat(n))
+    }
+
+    fn nested_if_source(n: usize) -> String {
+        let mut s = String::new();
+        for _ in 0..n {
+            s.push_str("IF 1 THEN BEGIN ");
+        }
+        s.push_str("y = 5");
+        for _ in 0..n {
+            s.push_str(" ENDIF");
+        }
+        s.push('\n');
+        s
+    }
+
+    fn nested_call_source(n: usize) -> String {
+        format!("y = {}5{}\n", "f(".repeat(n), ")".repeat(n))
+    }
+
+    fn nested_subscript_source(n: usize) -> String {
+        format!("y = {}5{}\n", "a[".repeat(n), "]".repeat(n))
+    }
+
+    fn unary_prefix_chain_source(n: usize) -> String {
+        format!("y = {}5\n", "-".repeat(n))
+    }
+
+    fn nested_array_literal_source(n: usize) -> String {
+        format!("y = {}5{}\n", "[".repeat(n), "]".repeat(n))
+    }
+
+    fn all_shape_sources(n_small: usize, n_if: usize) -> Vec<String> {
+        vec![
+            nested_paren_source(n_small),
+            nested_if_source(n_if),
+            nested_call_source(n_small),
+            nested_subscript_source(n_small),
+            unary_prefix_chain_source(n_small),
+            nested_array_literal_source(n_small),
+        ]
+    }
+
+    /// Deeply-nested input, for every measured shape, must produce a
+    /// recoverable error, not overflow the native stack. Parses 5000
+    /// levels -- far past `MAX_RULE_DEPTH` -- on a worker thread with a
+    /// generous 32 MiB stack, so the *guard* is what stops the recursion,
+    /// not the stack running out.
+    #[test]
+    fn test_deeply_nested_input_returns_error_not_overflow_for_every_shape() {
+        let sources = all_shape_sources(5000, 2000);
+        let handle = std::thread::Builder::new()
+            .name("idl-parser-depth-guard-regression".to_string())
+            .stack_size(32 * 1024 * 1024)
+            .spawn(move || {
+                for src in sources {
+                    let result = try_parse_idl(&src);
+                    assert!(
+                        result.is_err(),
+                        "deeply-nested input must fail with an error, not parse or crash"
+                    );
+                }
+            })
+            .expect("failed to spawn worker thread");
+        handle
+            .join()
+            .expect("depth guard must keep the worker thread from crashing");
+    }
+
+    /// A caller relying on `MAX_RULE_DEPTH` must have the guard trip
+    /// *before* the native stack overflows on a default-stack thread --
+    /// otherwise a production caller (or `cargo test`'s own per-test
+    /// thread) would still crash. Parses far-too-deep input, for every
+    /// shape, on a worker thread with **no** `stack_size` override (the
+    /// same ~2 MiB a default thread gets).
+    #[test]
+    fn test_cap_trips_before_overflow_on_default_stack_for_every_shape() {
+        let sources = all_shape_sources(5000, 2000);
+        let handle = std::thread::spawn(move || {
+            for src in sources {
+                let result = try_parse_idl(&src);
+                assert!(result.is_err(), "deeply-nested input must error, not crash");
+            }
+        });
+        handle
+            .join()
+            .expect("MAX_RULE_DEPTH must trip BEFORE native overflow on the default stack");
+    }
+
+    /// Reasonable, hand-writable nesting for every shape stays well under
+    /// the cap.
+    #[test]
+    fn test_reasonable_nesting_stays_under_the_cap_for_every_shape() {
+        assert!(try_parse_idl(&nested_paren_source(3)).is_ok());
+        assert!(try_parse_idl(&nested_if_source(3)).is_ok());
+        assert!(try_parse_idl(&nested_call_source(3)).is_ok());
+        assert!(try_parse_idl(&nested_subscript_source(3)).is_ok());
+        assert!(try_parse_idl(&unary_prefix_chain_source(5)).is_ok());
+        assert!(try_parse_idl(&nested_array_literal_source(3)).is_ok());
+    }
+
+    /// Input that nests *exactly up to* `MAX_RULE_DEPTH`'s measured
+    /// real-input headroom for every shape still parses cleanly, and one
+    /// level deeper cleanly trips the cap. These exact boundary counts were
+    /// found empirically by binary-searching `try_parse_idl` (the CAPPED
+    /// public API, `MAX_RULE_DEPTH = 148`) against increasing nesting counts
+    /// for each shape -- see `MAX_RULE_DEPTH`'s own doc comment ("Measured
+    /// real-input headroom at `148`"). Without this test, a future change to
+    /// the constant could silently move these boundaries without anyone
+    /// noticing, mirroring `scilab-parser`/`maple-parser`/`j-parser`'s own
+    /// per-shape boundary tests.
+    #[test]
+    fn test_headroom_boundary_for_every_shape() {
+        assert!(try_parse_idl(&nested_paren_source(13)).is_ok());
+        assert!(try_parse_idl(&nested_paren_source(14)).is_err());
+
+        assert!(try_parse_idl(&nested_if_source(26)).is_ok());
+        assert!(try_parse_idl(&nested_if_source(27)).is_err());
+
+        assert!(try_parse_idl(&nested_call_source(12)).is_ok());
+        assert!(try_parse_idl(&nested_call_source(13)).is_err());
+
+        assert!(try_parse_idl(&nested_subscript_source(11)).is_ok());
+        assert!(try_parse_idl(&nested_subscript_source(12)).is_err());
+
+        assert!(try_parse_idl(&unary_prefix_chain_source(134)).is_ok());
+        assert!(try_parse_idl(&unary_prefix_chain_source(135)).is_err());
+
+        assert!(try_parse_idl(&nested_array_literal_source(12)).is_ok());
+        assert!(try_parse_idl(&nested_array_literal_source(13)).is_err());
+    }
+}


### PR DESCRIPTION
## Summary

MA-12c, the third implementation item in IDL's Wave-6 rollout (following the merged MA12 kickoff spec #8890 and idl-lexer #8901): the grammar/parser for IDL, resolving the two genuinely new disambiguations MA12 §3 flagged as deliberately deferred from the lexer layer.

- `code/grammars/idl/idl.grammar` — 47-rule CST grammar covering MA12 §4's full in-scope surface: PRO/FUNCTION definitions, IF/FOR/WHILE/REPEAT control flow (all with both single-statement and BEGIN…END block forms), the procedure-call statement, assignment (including subscripted targets), the full expression precedence cascade, and the full subscript surface (plain/2-D/ranged/strided/wildcard/negative-from-end).
- `code/packages/rust/idl-parser/` — new crate wrapping the shared `GrammarParser` (README, CHANGELOG, generated `_grammar.rs`, 59 tests + 1 doctest).
- Workspace registration in `code/packages/rust/Cargo.toml`.

**The two disambiguations, both resolved by grammar structure alone (no lookahead predicates):**
- **`/BOOLEAN` shorthand vs. division**: `arg = keyword_arg | bool_keyword_arg | expr`, where `bool_keyword_arg = SLASH NAME`. Since IDL has no unary division operator, `expr`'s precedence cascade can never *start* on a SLASH token — so a leading SLASH at an argument position can only ever be the boolean shorthand, and `x = a/YLOG`'s division never reaches the `arg` production at all (it's an ordinary assignment RHS).
- **`=` as assignment vs. keyword-bind**: `assignment_stmt = NAME [subscript] EQUALS expr` (reachable only from `statement`) vs. `keyword_arg = NAME EQUALS expr` (reachable only from `arg`, inside an argument list) — structurally identical shapes, disambiguated purely by which production the parser is inside.

**Design facts independently verified against real IDL documentation** (not guessed): the official NV5/L3Harris operator-precedence table (fetched and cross-checked directly — unary `+`/`-`/`NOT` sit at the *same* tier as binary `+`/`-`, and `^` binds *tighter* than `*`/`/`), and the real `REPEAT BEGIN ... ENDREP UNTIL expr` syntax template (`ENDREP` closes the block *before* `UNTIL`, confirmed via NV5's own REPEAT...UNTIL reference page).

## Test plan

- [x] `cargo test -p coding-adventures-idl-parser` — 59 tests + 1 doctest, all passing (independently re-run, not just agent-reported)
- [x] `cargo clippy -p coding-adventures-idl-parser --all-targets -- -D warnings` — clean
- [x] Independently fetched NV5's official Operator Precedence and REPEAT...UNTIL reference pages and confirmed every claimed precedence-tier/associativity/terminator-ordering fact in the grammar's own header comment against the primary source
- [x] Read the disambiguation tests directly — they inspect the actual CST shape (e.g. asserting no `multiplicative` node contains a `/` token when `bool_keyword_arg` fires, and vice versa), not just that parsing succeeds
- [x] Confirmed a single, centralized `MAX_RULE_DEPTH`-capped parser constructor with no uncapped code path reachable from untrusted input; cap calibrated via the established measure-six-shapes/binary-search/subprocess-per-datapoint methodology (~30% margin below the lowest measured rule-frame floor)
- [x] Confirmed `idl-lexer` untouched (`git status` clean on that crate; its own 53 tests still pass)
- [x] `/security-review` — passed clean, including explicit verification of the depth-cap wiring/calibration and a purity check (no unsafe, no I/O, no external deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)