### PR TITLE
feat(adj-formula-stdlib): density — ρ = m/V definition formula library (physics track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_density_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_density_e2e.rs
@@ -1,0 +1,109 @@
+//! End-to-end tests for the `physics/density.adj` library — the definition of
+//! density (ρ = m/V) and its exact rearrangement (m = ρ·V) — driven through the
+//! built CLI binary against the SHIPPED stdlib. Each proves the same invariant as
+//! the other formula libraries: a consumer states NO arithmetic; it imports the
+//! grounded library, binds the physical quantities with `observe`, and the engine
+//! applies the cited definition on the CPU — computing the EXACT value and rendering
+//! the definition's citation + trust tier in the `derived` section (the auditable
+//! answer). The two formulas INVERT: 60 / 3 = 20, and 20 * 3 = 60.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped density library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_density_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/physics/density.adj")
+        .canonicalize()
+        .expect("shipped density.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_dens_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_density_lib()).unwrap();
+    std::fs::write(dir.join("density.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// density — the definition: the mass divided by the volume.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_density_library_and_computes_definition_with_citation() {
+    let dir = scratch("def");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"density.adj\"\n\
+         observe mass(60)\n\
+         observe volume(3)\n\
+         ? density(mass, volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied definition's result: 60 / 3 = 20.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"density\"") && s.contains("\"value\":20"),
+        "density(60, 3) = 20: {s}"
+    );
+    // … AND the HyperPhysics citation + trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"")
+            && s.contains("hyperphysics.gsu.edu/hbase/dens.html"),
+        "applied definition carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// mass — the same definition solved for m: the density times the volume, which
+// INVERTS the density just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_mass_as_density_times_volume_with_citation() {
+    let dir = scratch("mass");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"density.adj\"\n\
+         observe density(20)\n\
+         observe volume(3)\n\
+         ? mass(density, volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 20 * 3 = 60, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"mass\"") && s.contains("\"value\":60"),
+        "mass(20, 3) = 60: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"")
+            && s.contains("hyperphysics.gsu.edu/hbase/dens.html"),
+        "mass carries its HyperPhysics citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/physics/density.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/density.adj
@@ -1,0 +1,74 @@
+% ============================================================================
+% density.adj — the definition of density in the ADJ standard library.
+% ============================================================================
+% The density entry of the *physics* track, a sibling of `pressure.adj` and
+% `electricity.adj`: the foundational material definition a first course opens
+% with — DENSITY IS MASS PER UNIT VOLUME — as an importable, byte-provenanced,
+% PARAMETERIZED `formula`, together with its exact rearrangement (the mass a given
+% density fills a volume with). As with every compute library, a consumer states
+% NO arithmetic: it `import`s this file, binds the physical quantities from its own
+% byte-provenance decomposition, and asks the engine to APPLY the cited definition
+% on the CPU. Zero math is performed by the model; the engine computes each value
+% EXACTLY, carrying the definition's citation.
+%
+%     import "density.adj"
+%     observe mass(60)          % "…60 g…"        (span cited by the model)
+%     observe volume(3)         % "…in 3 cm³…"    (span cited by the model)
+%     ? density(mass, volume)   % engine → 20, carrying the def ρ = m/V
+%
+% Both formulas are EXACT over their parameters — one a quotient, one a product of
+% two measured quantities. There is no *separately grounded* physical constant here,
+% so every value the engine returns is exact. The two COMPOSE and invert cleanly:
+% the `density` a consumer computes from a mass in a volume is exactly the `density`
+% the `mass` formula multiplies back by a volume to recover the mass.
+%
+%   density(mass, volume) = mass / volume    %  ρ = m/V   (definition of density)
+%   mass(density, volume) = density · volume  %  m = ρ·V   (the same definition, solved for m)
+%
+% Both formulas are defended by the SAME definitional sentence — "Density is defined
+% as mass per unit volume." — because that one definition sanctions the relation read
+% either way (ρ from m and V, or m from ρ and V). The quote is transcribed verbatim
+% from Georgia State University's HyperPhysics (a university .edu physics reference —
+% the same primary source `pressure.adj` and `electricity.adj` cite), so each
+% `formula` carries the provenance envelope every shipped grounded clause carries;
+% the linter rejects an unsourced one. (See feedback_nothing_human_authored — the
+% definitional sentence is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable physical quantity the definition
+% ranges over, and each result is the derived quantity. `density` and `mass` each
+% appear BOTH as a derived result and as an input (of the other formula), so each
+% is a single dictionary term used in both roles. The `surface` lists are the
+% everyday names a decomposer maps onto the canonical term; the trailing comment
+% records the intended SI unit.
+% ----------------------------------------------------------------------------
+dictionary density_vocab {
+    define mass    : finding  surface "mass", "m"                        % mass, e.g. kg
+    define volume  : finding  surface "volume", "V"                      % volume, e.g. m³
+    define density : finding  surface "density", "rho"                  % density, e.g. kg/m³
+}
+
+% ----------------------------------------------------------------------------
+% The definition, both ways. Each is a named, importable, reusable `let` over its
+% formal parameters, bound at apply time, and each carries the definitional quote
+% from HyperPhysics (a quote is required on a shipped formula). One is a quotient
+% and one a product, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook density_laws {
+    use density_vocab
+
+    % Density — the mass per unit volume. HyperPhysics defines density as the mass
+    % distributed over the volume it occupies, i.e. ρ = m/V.
+    formula density(mass, volume) = mass / volume
+        source "Density is defined as mass per unit volume."
+        locator "https://hyperphysics.gsu.edu/hbase/dens.html"
+        trust authoritative
+
+    % Mass — the same definition solved for the mass a density fills a volume with
+    % (m = ρ·V). Defended by the SAME definitional sentence, read the other way.
+    formula mass(density, volume) = density * volume
+        source "Density is defined as mass per unit volume."
+        locator "https://hyperphysics.gsu.edu/hbase/dens.html"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/physics/density.query.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/density.query.adj
@@ -1,0 +1,29 @@
+% ============================================================================
+% density.query.adj — worked examples over the physics density library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a density
+% question: it states NO arithmetic and NO definition — it only `import`s the
+% grounded library, `observe`s the physical quantities it decomposed from the
+% prompt (each a byte-provenanced span, elided here), and asks the engine to APPLY
+% the cited definition. The native adj-lang engine binds the parameters, computes
+% each value EXACTLY on the CPU, and returns it with the definition's
+% source/locator/trust.
+%
+% The two questions INVERT: 60 g in 3 cm³ gives a density of 20 g/cm³, which is
+% exactly the density the mass formula multiplies back by the 3 cm³ volume to
+% recover the 60 g mass.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli density.query.adj
+% ============================================================================
+
+import "density.adj"
+
+% A 60 g mass in a 3 cm³ volume: density = 60 / 3.
+observe mass(60)
+observe volume(3)
+? density(mass, volume)     % expect 20   (definition: ρ = m/V)
+
+% That 20 g/cm³ density in the same 3 cm³ volume: mass = 20 * 3.
+observe density(20)
+? mass(density, volume)      % expect 60   (same definition, solved for m = ρ·V)


### PR DESCRIPTION
## What

A `formulabook` sibling of `pressure.adj` / `electricity.adj` (Libraries front): the foundational material definition — **density is mass per unit volume** — as two importable, byte-provenanced, parameterized formulas:

```
density(mass, volume) = mass / volume    % ρ = m/V  (definition)
mass(density, volume) = density * volume  % m = ρ·V  (same definition, solved for m)
```

Both are **exact** over their parameters (a quotient and a product) and **invert** cleanly: 60 / 3 = 20, and 20 · 3 = 60. A consumer states no arithmetic — it imports the library, `observe`s the quantities, and the engine applies the cited definition on the CPU (0 model calls), carrying source/locator/trust.

## Grounding

Both formulas are defended by the **same definitional sentence**, quoted **verbatim** from Georgia State University's HyperPhysics (fetched and byte-verified this session):

> "Density is defined as mass per unit volume."

— that one definition sanctions the relation read either way. `trust authoritative` (a primary university `.edu` physics reference, the same source `pressure.adj`/`electricity.adj` cite). Nothing asserted from memory.

## Changes

- New: `physics/density.adj` + `density.query.adj` (worked inverting example — ρ from m,V then m back from ρ,V).
- Test: `formula_density_e2e` — `density(60,3)=20` with the `dens.html` citation; `mass(20,3)=60` with the same. **2/2 pass.**

## Verification

- `cargo test -p adj-lang-cli --test formula_density_e2e` → 2 passed.
- Shipped `.query.adj` driven through the built CLI: `density=20` and `mass=60`, each rendering the verbatim HyperPhysics citation + `authoritative` trust.
- Security review passed (pure declarative data + static-path test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)