### PR TITLE
feat(gc-core): moving-collector C ABI __gc_collect_compacting (AOT00-T3 §5)

### DIFF
--- a/code/packages/rust/gc-core-capi/CHANGELOG.md
+++ b/code/packages/rust/gc-core-capi/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this crate are documented here.
 
+## 0.15.0 - 2026-07-24 — moving/compacting collector C ABI `__gc_collect_compacting` (AOT00-T3 §5)
+
+- **`__gc_collect_compacting()`** (new export in `stack_scan.rs`) — the argument-less
+  **relocating** collection rooted precisely at this thread's stack: the relocating analogue
+  of `__gc_collect_precise`. It runs the *same* frame-pointer walk (`build_precise_roots` →
+  precise slots for stack-mapped frames + conservative regions for the rest, plus the spilled
+  callee-saved registers), then drives `gc_core::FlatHeap::collect_compacting` instead of
+  `collect_mixed`. Movable survivors (reachable purely precisely, no conservative in-edge) are
+  evacuated into an arena and every pointer that named them is rewritten — including writing
+  the forwarded address back into its precise root slot, so the mutator's stack points at the
+  relocated objects on return. With no stack maps registered nothing is movable and it
+  degrades to exactly `__gc_collect_precise`, so it is always safe to call. Declared in
+  `include/gc_core.h`.
+- **Tests (+2):** an end-to-end smoke test on a real thread stack (`__gc_collect_compacting`
+  keeps a live local, frees a dead object, never crashes) and a synthetic-stack **relocation
+  differential** (`walk_output_drives_compacting_collection_and_relocates`): a precisely-named
+  registered-kind object with no conservative in-edge is *moved* — its address in the root
+  slot is rewritten to the new arena location — while an unnamed sibling in the same mapped
+  frame is reclaimed; `live_bytes` preserved.
+
 ## 0.14.0 - 2026-07-23 — generational tenuring-age C ABI
 
 Exposes gc-core 0.11.0's tunable generational **tenuring age** across the C ABI so native

--- a/code/packages/rust/gc-core-capi/Cargo.toml
+++ b/code/packages/rust/gc-core-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core-capi"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "C ABI for gc-core's flat-native heap — the gc_runtime_<target> archive linked into native-AOT output (LANG16 / AOT00 T1)."
 license = "MIT"

--- a/code/packages/rust/gc-core-capi/include/gc_core.h
+++ b/code/packages/rust/gc-core-capi/include/gc_core.h
@@ -150,6 +150,21 @@ int64_t __gc_register_stackmap(uint64_t func_start, uint64_t func_len,
  * __gc_collect. (For precision the image must be built with frame pointers.) */
 int64_t __gc_collect_precise(void);
 
+/* Full **moving/compacting** collection rooted PRECISELY at this thread's stack — the
+ * relocating analogue of __gc_collect_precise (spec AOT00-T3-moving-collector.md §5). The
+ * SAME frame-pointer walk yields precise reference slots (for stack-mapped frames) and
+ * conservative regions (unmapped frames + spilled callee-saved registers); those roots then
+ * drive a compacting cycle that EVACUATES the movable survivors into a fresh arena and
+ * rewrites every pointer that named them — including writing each forwarded address back
+ * into its precise root slot, so the mutator's stack points at the relocated objects when
+ * this returns. Only objects reachable purely precisely (named by a stack map, no
+ * conservative in-edge) move; anything a conservative region can reach is pinned and stays
+ * put. With no stack maps registered nothing is movable and this degrades to exactly
+ * __gc_collect_precise, so it is always safe to call. Returns objects reclaimed (genuinely
+ * dead only — a relocated object is a survivor, not a free). For precision + safety the image
+ * must be built with frame pointers. Same threading contract as __gc_collect_precise. */
+int64_t __gc_collect_compacting(void);
+
 /* One compiled function's stack-map descriptor in a module table (see
  * __gc_register_stackmap_module). Mirrors the __gc_register_stackmap arguments;
  * frame_sizes / callee_masks may be NULL. Emitted into the image's read-only data,

--- a/code/packages/rust/gc-core-capi/src/precise_walk.rs
+++ b/code/packages/rust/gc-core-capi/src/precise_walk.rs
@@ -569,4 +569,58 @@ mod tests {
             assert_eq!(stack[4], live); // keep the stack live to the end
         });
     }
+
+    /// End-to-end through `collect_compacting` (the moving-collector C-ABI path, spec §5):
+    /// the *same* walk output that drives a precise collection now drives a **relocating**
+    /// one. A precisely-named, registered-kind object with no conservative in-edge is
+    /// **evacuated** — its address in the root slot is rewritten in place to the new arena
+    /// location — while an unnamed sibling in the same mapped frame is reclaimed. Proves the
+    /// walk feeds `collect_compacting` correctly and that precise roots make moving safe.
+    #[test]
+    fn walk_output_drives_compacting_collection_and_relocates() {
+        use gc_core::FlatHeap;
+        with_clean_registry(|| {
+            let mut heap = FlatHeap::new();
+            let k = heap.register_kind(&[]); // registered kind (no ref fields) → movable
+            let live = heap.alloc(16, k) as usize; // named by a slot → survives + MOVES
+            let dead = heap.alloc(16, k) as usize; // unnamed local of the mapped frame
+
+            // Same synthetic stack as `walk_output_drives_precise_collection`:
+            //   2: fp0 → [fp0]=fp1; 3: ret0=0x4000 (mapped); 4: `live` (named fp1-16);
+            //   5: `dead` (unnamed fp1-8); 6: fp1 → [fp1]=0 (terminate).
+            let mut stack = [0usize; 8];
+            let sp = addr_of(&stack, 0);
+            let fp0 = addr_of(&stack, 2);
+            let fp1 = addr_of(&stack, 6);
+            let base = addr_of(&stack, 8);
+            stack[2] = fp1;
+            stack[3] = 0x4000;
+            stack[4] = live; // fp1 - 16 : NAMED slot
+            stack[5] = dead; // fp1 - 8  : unnamed local
+            stack[6] = 0;
+            stack[7] = 0;
+
+            unsafe { register(0x4000, 0x80, 0, &[-16]) }; // names only fp1 - 16 (`live`)
+
+            let mut slots = Vec::new();
+            let mut regions = Vec::new();
+            core::hint::black_box(&stack);
+            unsafe { build_precise_roots(fp0, sp, base, &mut slots, &mut regions) };
+            assert_eq!(slots, vec![(fp1 as isize - 16) as usize]);
+
+            let _ = dead;
+            let stats = unsafe { heap.collect_compacting(&slots, &regions) };
+            assert_eq!(stats.freed, 1, "the unnamed local is reclaimed");
+            assert_eq!(heap.object_count(), 1, "exactly one object survives (relocated)");
+            assert_eq!(heap.live_bytes(), 16, "live bytes preserved across the move");
+
+            // The relocation differential: the root slot was rewritten in place to the
+            // survivor's NEW arena address — distinct from both original malloc'd blocks.
+            let relocated = stack[4];
+            assert_ne!(relocated, live, "the survivor moved; its root slot was updated");
+            assert_ne!(relocated, dead, "and it is not the reclaimed sibling's address");
+            assert_ne!(relocated, 0, "the rewritten slot names a real object");
+            core::hint::black_box(&stack);
+        });
+    }
 }

--- a/code/packages/rust/gc-core-capi/src/stack_scan.rs
+++ b/code/packages/rust/gc-core-capi/src/stack_scan.rs
@@ -467,6 +467,75 @@ pub unsafe extern "C" fn __gc_collect_precise() -> i64 {
     freed
 }
 
+/// A full **moving/compacting** collection rooted precisely at this thread's stack —
+/// the argument-less entry that turns the precise-root machinery into a *relocating*
+/// GC (spec `AOT00-T3-moving-collector.md` §5). It is to
+/// [`gc_core::FlatHeap::collect_compacting`] exactly what [`__gc_collect_precise`] is to
+/// `collect_mixed`: the *same* frame-pointer walk produces **precise slots** (for
+/// stack-mapped frames) and **conservative regions** (unmapped frames + the spilled
+/// callee-saved registers), and the very same `(slots, regions)` are handed to
+/// `collect_compacting`, which evacuates the movable survivors into an arena and — this is
+/// what makes moving safe — rewrites the pointers that named them, **including writing each
+/// forwarded address back into its precise root slot** (a real stack location produced by
+/// the walk). After it returns, the mutator's stack slots point at the relocated objects.
+///
+/// **Why precise roots are the safety precondition (and why this is always safe to call):**
+/// only an object reachable *purely precisely* — named by a stack-map slot and by no
+/// conservative region — is ever moved; anything a conservative region (an unmapped frame,
+/// or a spilled register) can reach is **pinned** and stays put, because a conservative
+/// holder's pointer cannot be found-and-rewritten. With **no** stack maps registered every
+/// frame becomes a conservative region tiling all of `[sp, base)`, so nothing is movable and
+/// this degrades to exactly [`__gc_collect_precise`] / `__gc_collect` — no relocation, no
+/// risk, even if the captured frame pointer is garbage. As backends register maps a *valid*
+/// frame pointer becomes load-bearing (see [`current_fp`]), identical to `__gc_collect_precise`.
+/// A failed stack-base detection collects nothing this cycle (bias-to-leak), never freeing
+/// or moving a live object.
+///
+/// Returns the number of objects reclaimed (genuinely-dead only; a relocated object is a
+/// survivor, not a free — see `collect_compacting`).
+///
+/// # Safety
+///
+/// Same contract as [`__gc_collect_precise`]: sound to call from any thread that owns its
+/// stack (the single-threaded native runtime always does); it must not run while another
+/// thread mutates the same heap. The captured frame pointer must be valid once any stack map
+/// is registered (guaranteed by ABI on the aarch64 primary target / frame-pointer builds).
+#[no_mangle]
+#[inline(never)]
+pub unsafe extern "C" fn __gc_collect_compacting() -> i64 {
+    // Spill callee-saved registers into a stack buffer (in this frame), then SP.
+    let mut regs = [0usize; SPILL_SLOTS];
+    let sp = spill_and_sp(regs.as_mut_ptr());
+    // Capture this frame's frame pointer — the walk's unwind anchor (see current_fp).
+    let fp = current_fp();
+    let base = stack_base();
+
+    // Only collect when the stack range is trustworthy (identical gate to
+    // __gc_collect_precise): a failed base detection or absurd span means we cannot
+    // enumerate all roots, so we leak this cycle rather than move/free a live object.
+    let freed = if base != 0 && sp < base && base - sp <= MAX_STACK_SCAN {
+        let mut slots: Vec<usize> = Vec::new();
+        let mut regions: Vec<(*const u8, usize)> = Vec::new();
+        // Walk the frame-pointer chain into precise slots + conservative regions.
+        crate::precise_walk::build_precise_roots(fp, sp, base, &mut slots, &mut regions);
+        // Always scan the spilled callee-saved registers as a conservative region: a
+        // reference live only in such a register is named by no stack map yet, so it must
+        // pin (never move) — exactly as __gc_collect_precise scans it.
+        regions.push((
+            regs.as_ptr() as *const u8,
+            SPILL_SLOTS * core::mem::size_of::<usize>(),
+        ));
+        with_heap(|h| h.collect_compacting(&slots, &regions).freed as i64)
+    } else {
+        0
+    };
+
+    // Keep `regs` materialised across the collect: its address is what makes the
+    // spilled registers part of the scanned roots.
+    core::hint::black_box(&regs);
+    freed
+}
+
 /// Upper bound on how many bytes of stack a single conservative scan will walk
 /// (256 MiB). A corrupt or absurd `base` (far above `sp`) would otherwise make
 /// `collect_region` read hundreds of GB and appear to hang — an
@@ -597,6 +666,42 @@ mod tests {
             unsafe { *(kept as *const i64) },
             0x9a11,
             "the stack-rooted object must survive the precise collect"
+        );
+        assert!(__gc_live_bytes() >= 16);
+        assert_eq!(__gc_collection_count(), 1);
+        core::hint::black_box(kept);
+    }
+
+    /// End-to-end smoke test for the argument-less **moving** entry
+    /// `__gc_collect_compacting`: the same asm-capture → frame-pointer-walk path, now
+    /// driving `collect_compacting`. With no stack maps registered every frame is
+    /// conservative, so nothing is movable and this degrades to exactly
+    /// `__gc_collect_precise` — the live stack local (conservatively pinned) survives with
+    /// its value intact, and the dead object is reclaimed. Proves the C-ABI moving path runs
+    /// on a real thread stack without crashing and never corrupts a live object.
+    #[test]
+    fn compacting_collect_keeps_live_local_frees_dead() {
+        let _guard = crate::TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        __gc_reset();
+        run_compacting_collect_case();
+        __gc_reset();
+    }
+
+    #[inline(never)]
+    fn run_compacting_collect_case() {
+        let kept = __gc_alloc(16);
+        assert!(kept != 0);
+        let _ = __gc_alloc(16); // dead: no stack slot retains it
+        assert_eq!(__gc_live_bytes(), 32);
+        unsafe { *(kept as *mut i64) = 0x5eed };
+
+        let freed = unsafe { __gc_collect_compacting() };
+
+        assert!(freed >= 1, "the unreferenced object must be reclaimed");
+        assert_eq!(
+            unsafe { *(kept as *const i64) },
+            0x5eed,
+            "the conservatively-pinned live local survives the compacting collect intact"
         );
         assert!(__gc_live_bytes() >= 16);
         assert_eq!(__gc_collection_count(), 1);

--- a/code/packages/rust/gc-core/CHANGELOG.md
+++ b/code/packages/rust/gc-core/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — gc-core
 
+## 0.17.0 — 2026-07-24 — `Compacting` algorithm marked available (AOT00-T3 §5)
+
+- `GcAlgorithm::Compacting::is_available()` now returns `true`: the moving/evacuating
+  collector (`FlatHeap::collect_compacting`, shipped in 0.16.0) is implemented, so the
+  adaptive policy's existing high-fragmentation `SuggestSwitch(Compacting, …)` recommendation
+  becomes actionable rather than advisory. `Incremental` remains the one planned-but-absent
+  rung. Precision ladder: mark-and-sweep ✓ → interior-precise ✓ → generational ✓ →
+  precise-roots ✓ → **compacting ✓**.
+
 ## 0.16.0 — 2026-07-24 — the full moving cycle `collect_compacting` (AOT00-T3 PR-3c-2)
 
 Completes the moving/compacting collector: `collect_compacting(root_slots, regions)` runs

--- a/code/packages/rust/gc-core/Cargo.toml
+++ b/code/packages/rust/gc-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "LANG16 — adaptive GC adapter layer wiring garbage-collector into the LANG VM pipeline."
 license = "MIT"

--- a/code/packages/rust/gc-core/src/policy.rs
+++ b/code/packages/rust/gc-core/src/policy.rs
@@ -106,13 +106,14 @@ impl GcAlgorithm {
 
     /// `true` if this algorithm is available in the current gc-core build.
     ///
-    /// `MarkAndSweep` (the conservative/precise full collector) and
-    /// `Generational` (`FlatHeap::collect_minor` + the remembered-set write
-    /// barrier) are implemented; `Compacting` / `Incremental` are still planned.
+    /// `MarkAndSweep` (the conservative/precise full collector), `Generational`
+    /// (`FlatHeap::collect_minor` + the remembered-set write barrier), and
+    /// `Compacting` (`FlatHeap::collect_compacting` — the moving/evacuating
+    /// collector) are implemented; `Incremental` is still planned.
     pub fn is_available(self) -> bool {
         matches!(
             self,
-            GcAlgorithm::MarkAndSweep | GcAlgorithm::Generational
+            GcAlgorithm::MarkAndSweep | GcAlgorithm::Generational | GcAlgorithm::Compacting
         )
     }
 }

--- a/code/packages/rust/gc-core/tests/test_gc_core.rs
+++ b/code/packages/rust/gc-core/tests/test_gc_core.rs
@@ -497,9 +497,15 @@ fn gc_algorithm_generational_is_available() {
 }
 
 #[test]
-fn gc_algorithm_compacting_and_incremental_not_yet_available() {
-    // Still planned rungs of the precision ladder.
-    assert!(!GcAlgorithm::Compacting.is_available());
+fn gc_algorithm_compacting_is_available() {
+    // Compacting became available with FlatHeap::collect_compacting — the full
+    // moving/evacuating cycle (the moving-collector rung of the ladder).
+    assert!(GcAlgorithm::Compacting.is_available());
+}
+
+#[test]
+fn gc_algorithm_incremental_not_yet_available() {
+    // Still a planned rung of the precision ladder.
     assert!(!GcAlgorithm::Incremental.is_available());
 }
 


### PR DESCRIPTION
## AOT00-T3 moving collector — C ABI: `__gc_collect_compacting`

Exposes the moving/compacting collector (`FlatHeap::collect_compacting`, shipped last PR) through the C ABI, per spec §5. This is the wiring that makes a **relocating** collection reachable from native-AOT output.

### `__gc_collect_compacting()`
The argument-less **relocating** collection rooted precisely at this thread's stack — the relocating analogue of `__gc_collect_precise`, and its exact mirror: the **same** frame-pointer walk (`build_precise_roots` → precise slots for stack-mapped frames + conservative regions for the rest + the spilled callee-saved registers), then `collect_compacting` instead of `collect_mixed`.

Movable survivors (reachable purely precisely, no conservative in-edge) are evacuated into an arena and every pointer that named them is rewritten — **including writing the forwarded address back into its precise root slot**, so the mutator's stack points at the relocated objects on return. Anything a conservative region can reach (a spilled register, an unmapped frame) is pinned and stays put. With **no stack maps registered nothing is movable** → degrades to exactly `__gc_collect_precise`, so it is always safe to call.

### Changes
- **gc-core-capi 0.15.0** — `__gc_collect_compacting` in `stack_scan.rs` (byte-identical to `__gc_collect_precise` but for the terminal `collect_compacting` call) + declaration in `include/gc_core.h`.
- **gc-core 0.17.0** — `GcAlgorithm::Compacting::is_available()` → `true` (the moving collector now implements it), so the adaptive policy's high-fragmentation `SuggestSwitch(Compacting)` becomes actionable rather than advisory. The flip is advisory-only; nothing auto-enacts a move. `Incremental` remains the one planned-but-absent rung.

### Tests (+2 capi)
- A real-thread-stack **smoke test** — `__gc_collect_compacting` keeps a live local, frees a dead object, and the whole asm-capture → walk → `collect_compacting` path runs without crashing (no maps → degrades to precise, no move).
- A synthetic-stack **relocation differential** (`walk_output_drives_compacting_collection_and_relocates`) — a precisely-named registered-kind object with no conservative in-edge is **moved**: its address in the root slot is rewritten to the new arena location, while an unnamed sibling in the same mapped frame is reclaimed; `live_bytes` preserved. Policy availability tests updated.

### Verification
- **31 gc-core-capi + 84 gc-core tests** pass; clippy clean.
- The UAF-critical relocation logic (`collect_compacting`) is **Miri-clean from the prior PR**; this PR is pure wiring. The capi wiring is validated by `cargo test` + real execution — Miri can't model the inline-asm real-stack path nor the wildcard-provenance synthetic stacks, an **identical limitation to the pre-existing `__gc_collect_precise` sibling tests** (not a regression).
- **Adversarial `/security-review`: SAFE TO PUSH** — the `(slots, regions)` root/pin set is provably identical to the reviewed `__gc_collect_precise` path; the one new capability (root-slot write-back) targets only bounds-checked (`caller_fp ∈ (sp,base]`) stack addresses already read under the shared readability contract; conservatively-reached objects never move; the gate, degradation, and `regs` keep-alive are all identical to precise; the `is_available` flip is advisory and cannot auto-invoke a move.

**Precision ladder: mark-and-sweep → interior-precise → generational → precise-roots → compacting (core + C ABI).**

gc-core 0.16.0 → 0.17.0, gc-core-capi 0.14.0 → 0.15.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)