### PR TITLE
feat(spice): add JFET forward depletion coefficient

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add JFET model-card `FC` forward-bias depletion coefficient support,
+  defaulting to `0.5` and shaping `CGS`/`CGD` depletion capacitance in AC and
+  transient analysis with hierarchy preservation and range validation.
 - Add JFET model-card `PB` gate-junction-potential support with `VJ` as an
   alias, bias-dependent `CGS`/`CGD` depletion capacitance in AC and transient
   analysis, hierarchy preservation, and finite-positive validation.

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -515,6 +515,7 @@ class JFET:
     Kf: float = 0.0
     Af: float = 1.0
     Pb: float = 1.0
+    Fc: float = 0.5
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -604,7 +604,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
             element.Af,
         )
     if isinstance(element, JFET):
-        return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_, element.Cgs, element.Cgd, element.Kf, element.Af, element.Pb)
+        return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_, element.Cgs, element.Cgd, element.Kf, element.Af, element.Pb, element.Fc)
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
@@ -8923,17 +8923,16 @@ def _jfet_charge_dynamic_capacitance(
     el: JFET, zero_bias_capacitance: float, junction_voltage: float
 ) -> float:
     grading_coefficient = 0.5
-    forward_bias_depletion_coefficient = 0.5
     oriented_voltage = -junction_voltage if el.polarity == "PJF" else junction_voltage
     normalized_voltage = oriented_voltage / el.Pb
-    if normalized_voltage < forward_bias_depletion_coefficient:
+    if normalized_voltage < el.Fc:
         return zero_bias_capacitance / ((1.0 - normalized_voltage) ** grading_coefficient)
-    transition_scale = (1.0 - forward_bias_depletion_coefficient) ** (
+    transition_scale = (1.0 - el.Fc) ** (
         1.0 + grading_coefficient
     )
     continuation = (
         1.0
-        - forward_bias_depletion_coefficient * (1.0 + grading_coefficient)
+        - el.Fc * (1.0 + grading_coefficient)
         + grading_coefficient * normalized_voltage
     )
     return zero_bias_capacitance * continuation / transition_scale
@@ -9081,6 +9080,8 @@ def _eval_jfet(el: JFET, vgs: float, vds: float) -> tuple[float, float, float]:
         raise ValueError(f"JFET '{el.name}' flicker-noise exponent must be finite and non-negative")
     if not math.isfinite(el.Pb) or el.Pb <= 0.0:
         raise ValueError(f"JFET '{el.name}' PB must be finite and positive")
+    if not math.isfinite(el.Fc) or el.Fc < 0.0 or el.Fc >= 1.0:
+        raise ValueError(f"JFET '{el.name}' FC must be finite and in [0, 1)")
     if el.polarity == "PJF":
         ids, gm, gds = _eval_njf(-vgs, -vds, -el.vto, el.beta, el.lambda_)
         return -ids, gm, gds

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -309,8 +309,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (15, 21, 5, 3),
     "NPN": (41, 58, 13, 4),
     "PNP": (41, 58, 13, 4),
-    "NJF": (8, 15, 6, 3),
-    "PJF": (8, 15, 6, 3),
+    "NJF": (9, 16, 6, 3),
+    "PJF": (9, 16, 6, 3),
     "NMOS": (18, 25, 6, 3),
     "PMOS": (18, 25, 6, 3),
 }
@@ -434,6 +434,7 @@ _JFET_PARAMETER_ALIASES: dict[str, str] = {
     "AF": "AF",
     "PB": "PB",
     "VJ": "PB",
+    "FC": "FC",
 }
 
 _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
@@ -1009,6 +1010,7 @@ def jfet_from_model_card(
         Kf=p.get("KF", 0.0),
         Af=p.get("AF", 1.0),
         Pb=p.get("PB", 1.0),
+        Fc=p.get("FC", 0.5),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -407,7 +407,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 149
+    assert len(coverage) == 151
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -422,7 +422,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 149
+    assert len(records) == 151
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -496,9 +496,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 149
-    assert report.expected_canonical_parameter_count == 149
-    assert report.accepted_name_count == 217
+    assert report.canonical_parameter_count == 151
+    assert report.expected_canonical_parameter_count == 151
+    assert report.accepted_name_count == 219
     assert report.aliased_parameter_count == 55
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -506,7 +506,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t149\t149\t217\t55\t4\t0"
+        "true\t7\t7\t151\t151\t219\t55\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -534,8 +534,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 148
-    assert report.accepted_name_count == 214
+    assert report.canonical_parameter_count == 150
+    assert report.accepted_name_count == 216
     assert report.aliased_parameter_count == 54
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -550,7 +550,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t148\t149\t214\t54\t4\t4\n"
+        "false\t7\t7\t150\t151\t216\t54\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -673,6 +673,7 @@ def test_model_card_aliases_build_device_instances() -> None:
             "KF": 1.0e-12,
             "AF": 1.3,
             "VJ": 0.8,
+            "FC": 0.35,
         },
     )
     jfet_model = jfet_from_model_card("J1", "d", "g", "s", jfet_card)
@@ -683,6 +684,7 @@ def test_model_card_aliases_build_device_instances() -> None:
         "KF": 1.0e-12,
         "AF": 1.3,
         "PB": 0.8,
+        "FC": 0.35,
     }
     assert jfet_model.polarity == "NJF"
     assert jfet_model.beta == pytest.approx(9.0e-4)
@@ -691,6 +693,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert jfet_model.Kf == pytest.approx(1.0e-12)
     assert jfet_model.Af == pytest.approx(1.3)
     assert jfet_model.Pb == pytest.approx(0.8)
+    assert jfet_model.Fc == pytest.approx(0.35)
 
     mos_card = normalize_model_card(
         "Mn",
@@ -753,6 +756,14 @@ def test_dc_rejects_invalid_jfet_junction_potential() -> None:
     circuit.add(JFET("J1", "drain", "gate", "0", Pb=0.0))
 
     with pytest.raises(ValueError, match="PB must be finite and positive"):
+        dc_op(circuit)
+
+
+def test_dc_rejects_invalid_jfet_forward_bias_depletion_coefficient() -> None:
+    circuit = Circuit()
+    circuit.add(JFET("J1", "drain", "gate", "0", Fc=1.0))
+
+    with pytest.raises(ValueError, match=r"FC must be finite and in \[0, 1\)"):
         dc_op(circuit)
 
 
@@ -1462,6 +1473,42 @@ def test_transient_jfet_junction_potential_shapes_gate_charge() -> None:
         return result.points[-1].node_voltages["gate"]
 
     assert final_gate_voltage(0.5) < final_gate_voltage(2.0)
+
+
+def test_transient_jfet_forward_bias_depletion_coefficient_shapes_gate_charge() -> None:
+    def final_gate_voltage(fc: float) -> float:
+        circuit = Circuit()
+        circuit.add(
+            VoltageSource(
+                "Vstep",
+                "in",
+                "0",
+                0.0,
+                waveform=PwlWaveform(
+                    ((0.0, 0.0), (2.0e-7, 0.6), (2.0e-6, 0.6))
+                ),
+            )
+        )
+        circuit.add(Resistor("Rin", "in", "gate", 1_000.0))
+        circuit.add(Resistor("Rdrain", "drain", "0", 1_000.0))
+        circuit.add(
+            JFET(
+                "J1",
+                "drain",
+                "gate",
+                "0",
+                beta=1.0e-12,
+                vto=-2.0,
+                Cgs=1.0e-9,
+                Fc=fc,
+            )
+        )
+        result = transient(
+            circuit, t_stop=2.0e-6, t_step=2.0e-7, method="euler"
+        )
+        return result.points[-1].node_voltages["gate"]
+
+    assert final_gate_voltage(0.2) > final_gate_voltage(0.8)
 
 
 def test_transient_mosfet_overlap_capacitance_slows_gate_step() -> None:
@@ -2478,7 +2525,7 @@ def test_subcircuit_expansion_preserves_complete_jfet_model():
     cell = SubcircuitDefinition(
         "jfet-cell",
         ("d", "g", "s"),
-        (JFET("Jcell", "d", "g", "s", Kf=1.0e-12, Af=1.3, Pb=0.8),),
+        (JFET("Jcell", "d", "g", "s", Kf=1.0e-12, Af=1.3, Pb=0.8, Fc=0.35),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2488,6 +2535,7 @@ def test_subcircuit_expansion_preserves_complete_jfet_model():
     assert expanded.Kf == pytest.approx(1.0e-12)
     assert expanded.Af == pytest.approx(1.3)
     assert expanded.Pb == pytest.approx(0.8)
+    assert expanded.Fc == pytest.approx(0.35)
 
 
 def test_subcircuit_expansion_preserves_complete_bjt_model():
@@ -3696,6 +3744,32 @@ def test_ac_jfet_junction_potential_shapes_reverse_biased_gate_capacitance() -> 
         return abs(result.points[0].node_voltages["gate"])
 
     assert gate_amplitude(0.5) > gate_amplitude(2.0)
+
+
+def test_ac_jfet_forward_bias_depletion_coefficient_shapes_gate_capacitance() -> None:
+    def gate_amplitude(fc: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vac", "in", "0", 0.6, ac=AcSource(1.0)))
+        circuit.add(Resistor("Rin", "in", "gate", 1_000.0))
+        circuit.add(Resistor("Rdrain", "drain", "0", 1_000.0))
+        circuit.add(
+            JFET(
+                "J1",
+                "drain",
+                "gate",
+                "0",
+                beta=1.0e-12,
+                vto=-2.0,
+                Cgs=1.0e-9,
+                Fc=fc,
+            )
+        )
+        result = ac_sweep(
+            circuit, f_start=100_000.0, f_stop=100_000.0, n_points=1
+        )
+        return abs(result.points[0].node_voltages["gate"])
+
+    assert gate_amplitude(0.2) > gate_amplitude(0.8)
 
 
 def test_jfet_transient_source_follower_charges_output_capacitor() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add JFET model-card `FC` forward-bias depletion coefficient support,
+  defaulting to `0.5` and shaping `CGS`/`CGD` depletion capacitance in AC and
+  transient analysis with hierarchy preservation and range validation.
 - Add JFET model-card `PB` gate-junction-potential support with `VJ` as an
   alias, bias-dependent `CGS`/`CGD` depletion capacitance in AC and transient
   analysis, hierarchy preservation, and finite-positive validation.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -429,6 +429,7 @@ fn clone_subckt_element(
             mapped.flicker_noise_coefficient = element.flicker_noise_coefficient;
             mapped.flicker_noise_exponent = element.flicker_noise_exponent;
             mapped.junction_potential = element.junction_potential;
+            mapped.forward_bias_depletion_coefficient = element.forward_bias_depletion_coefficient;
             Element::Jfet(mapped)
         }
         Element::Bjt(element) => {
@@ -2819,6 +2820,7 @@ pub struct Jfet {
     pub flicker_noise_coefficient: f64,
     pub flicker_noise_exponent: f64,
     pub junction_potential: f64,
+    pub forward_bias_depletion_coefficient: f64,
 }
 
 impl Jfet {
@@ -2890,6 +2892,7 @@ impl Jfet {
             flicker_noise_coefficient: 0.0,
             flicker_noise_exponent: 1.0,
             junction_potential: 1.0,
+            forward_bias_depletion_coefficient: 0.5,
         }
     }
 }
@@ -3813,8 +3816,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     (ModelCardKind::Diode, 15, 21, 5, 3),
     (ModelCardKind::Npn, 41, 58, 13, 4),
     (ModelCardKind::Pnp, 41, 58, 13, 4),
-    (ModelCardKind::Njf, 8, 15, 6, 3),
-    (ModelCardKind::Pjf, 8, 15, 6, 3),
+    (ModelCardKind::Njf, 9, 16, 6, 3),
+    (ModelCardKind::Pjf, 9, 16, 6, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
     (ModelCardKind::Pmos, 18, 25, 6, 3),
 ];
@@ -3917,6 +3920,7 @@ const JFET_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("AF", "AF"),
     ("PB", "PB"),
     ("VJ", "PB"),
+    ("FC", "FC"),
 ];
 const MOS_LEVEL1_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("LEVEL", "LEVEL"),
@@ -4646,6 +4650,7 @@ pub fn jfet_from_model_card(
     jfet.flicker_noise_coefficient = model_card_value(model, "KF", 0.0);
     jfet.flicker_noise_exponent = model_card_value(model, "AF", 1.0);
     jfet.junction_potential = model_card_value(model, "PB", 1.0);
+    jfet.forward_bias_depletion_coefficient = model_card_value(model, "FC", 0.5);
     Ok(jfet)
 }
 
@@ -24361,19 +24366,17 @@ fn jfet_charge_dynamic_capacitance(
     junction_voltage: f64,
 ) -> f64 {
     const GRADING_COEFFICIENT: f64 = 0.5;
-    const FORWARD_BIAS_DEPLETION_COEFFICIENT: f64 = 0.5;
-
     let oriented_voltage = match jfet.polarity {
         JfetPolarity::Njf => junction_voltage,
         JfetPolarity::Pjf => -junction_voltage,
     };
     let normalized_voltage = oriented_voltage / jfet.junction_potential;
-    if normalized_voltage < FORWARD_BIAS_DEPLETION_COEFFICIENT {
+    if normalized_voltage < jfet.forward_bias_depletion_coefficient {
         return zero_bias_capacitance / (1.0 - normalized_voltage).powf(GRADING_COEFFICIENT);
     }
     let transition_scale =
-        (1.0 - FORWARD_BIAS_DEPLETION_COEFFICIENT).powf(1.0 + GRADING_COEFFICIENT);
-    let continuation = 1.0 - FORWARD_BIAS_DEPLETION_COEFFICIENT * (1.0 + GRADING_COEFFICIENT)
+        (1.0 - jfet.forward_bias_depletion_coefficient).powf(1.0 + GRADING_COEFFICIENT);
+    let continuation = 1.0 - jfet.forward_bias_depletion_coefficient * (1.0 + GRADING_COEFFICIENT)
         + GRADING_COEFFICIENT * normalized_voltage;
     zero_bias_capacitance * continuation / transition_scale
 }
@@ -24915,6 +24918,15 @@ fn validate_jfet(jfet: &Jfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: jfet.name.clone(),
             reason: "junction potential must be finite and positive".to_string(),
+        });
+    }
+    if !jfet.forward_bias_depletion_coefficient.is_finite()
+        || jfet.forward_bias_depletion_coefficient < 0.0
+        || jfet.forward_bias_depletion_coefficient >= 1.0
+    {
+        return Err(SpiceError::InvalidElement {
+            name: jfet.name.clone(),
+            reason: "forward-bias depletion coefficient must be finite and in [0, 1)".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -1461,6 +1461,42 @@ fn ac_jfet_junction_potential_shapes_reverse_biased_gate_capacitance() {
 }
 
 #[test]
+fn ac_jfet_forward_bias_depletion_coefficient_shapes_gate_capacitance() {
+    fn gate_amplitude(coefficient: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "in", "0", 0.6, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "gate", 1_000.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rdrain", "drain", "0", 1_000.0,
+        )));
+        let mut jfet = Jfet::with_model_and_capacitance(
+            "J1",
+            "drain",
+            "gate",
+            "0",
+            JfetPolarity::Njf,
+            1.0e-12,
+            -2.0,
+            0.0,
+            1.0e-9,
+            0.0,
+        );
+        jfet.forward_bias_depletion_coefficient = coefficient;
+        circuit.add(Element::Jfet(jfet));
+        ac_sweep(&circuit, 100_000.0, 100_000.0, 1).unwrap()[0]
+            .voltage("gate")
+            .unwrap()
+            .abs()
+    }
+
+    assert!(gate_amplitude(0.2) > gate_amplitude(0.8));
+}
+
+#[test]
 fn ac_current_source_supports_explicit_magnitude_and_phase() {
     let mut circuit = Circuit::new();
     circuit.add(Element::CurrentSource(CurrentSource::with_ac(

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -95,7 +95,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 149);
+    assert_eq!(coverage.len(), 151);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -114,7 +114,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 149);
+    assert_eq!(records.len(), 151);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -195,15 +195,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 149);
-    assert_eq!(report.expected_canonical_parameter_count, 149);
-    assert_eq!(report.accepted_name_count, 217);
+    assert_eq!(report.canonical_parameter_count, 151);
+    assert_eq!(report.expected_canonical_parameter_count, 151);
+    assert_eq!(report.accepted_name_count, 219);
     assert_eq!(report.aliased_parameter_count, 55);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t149\t149\t217\t55\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t151\t151\t219\t55\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -230,8 +230,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 148);
-    assert_eq!(report.accepted_name_count, 214);
+    assert_eq!(report.canonical_parameter_count, 150);
+    assert_eq!(report.accepted_name_count, 216);
     assert_eq!(report.aliased_parameter_count, 54);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -248,7 +248,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t148\t149\t214\t54\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t150\t151\t216\t54\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -516,6 +516,7 @@ fn model_card_aliases_build_device_instances() {
             ("KF", 1.0e-12),
             ("AF", 1.3),
             ("VJ", 0.8),
+            ("FC", 0.35),
         ],
     )
     .unwrap();
@@ -526,6 +527,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*jfet_card.parameters.get("KF").unwrap(), 1.0e-12);
     assert_close(*jfet_card.parameters.get("AF").unwrap(), 1.3);
     assert_close(*jfet_card.parameters.get("PB").unwrap(), 0.8);
+    assert_close(*jfet_card.parameters.get("FC").unwrap(), 0.35);
     assert_eq!(jfet_model.polarity, JfetPolarity::Njf);
     assert_close(jfet_model.beta, 9.0e-4);
     assert_close(jfet_model.threshold_voltage, -1.8);
@@ -533,6 +535,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(jfet_model.flicker_noise_coefficient, 1.0e-12);
     assert_close(jfet_model.flicker_noise_exponent, 1.3);
     assert_close(jfet_model.junction_potential, 0.8);
+    assert_close(jfet_model.forward_bias_depletion_coefficient, 0.35);
 
     let mos_card = normalize_model_card(
         "Mn",
@@ -1456,6 +1459,7 @@ fn subcircuit_expansion_preserves_complete_jfet_model() {
     jfet.flicker_noise_coefficient = 1.0e-12;
     jfet.flicker_noise_exponent = 1.3;
     jfet.junction_potential = 0.8;
+    jfet.forward_bias_depletion_coefficient = 0.35;
     let mut circuit = Circuit::new();
     circuit
         .define_subcircuit(SubcircuitDefinition::new(
@@ -1483,6 +1487,7 @@ fn subcircuit_expansion_preserves_complete_jfet_model() {
     assert_close(expanded.flicker_noise_coefficient, 1.0e-12);
     assert_close(expanded.flicker_noise_exponent, 1.3);
     assert_close(expanded.junction_potential, 0.8);
+    assert_close(expanded.forward_bias_depletion_coefficient, 0.35);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -366,6 +366,24 @@ fn jfet_rejects_invalid_junction_potential() {
 }
 
 #[test]
+fn jfet_rejects_invalid_forward_bias_depletion_coefficient() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 0.0,
+    )));
+    let mut jfet = Jfet::new("J1", "out", "gate", "0");
+    jfet.forward_bias_depletion_coefficient = 1.0;
+    circuit.add(Element::Jfet(jfet));
+
+    let error = noise_ac(&circuit, "out", "Vgate", &[1_000.0], 300.0).unwrap_err();
+    assert!(matches!(
+        error,
+        SpiceError::InvalidElement { reason, .. }
+            if reason == "forward-bias depletion coefficient must be finite and in [0, 1)"
+    ));
+}
+
+#[test]
 fn jfet_flicker_noise_uses_af_current_exponent() {
     let source_psd = |exponent: f64| {
         let mut circuit = Circuit::new();

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -326,6 +326,52 @@ fn transient_jfet_junction_potential_shapes_gate_charge() {
 }
 
 #[test]
+fn transient_jfet_forward_bias_depletion_coefficient_shapes_gate_charge() {
+    fn final_gate_voltage(coefficient: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
+            "Vstep",
+            "in",
+            "0",
+            0.0,
+            Waveform::Pwl(PwlWaveform::new(vec![
+                (0.0, 0.0),
+                (2.0e-7, 0.6),
+                (2.0e-6, 0.6),
+            ])),
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "gate", 1_000.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rdrain", "drain", "0", 1_000.0,
+        )));
+        let mut jfet = Jfet::with_model_and_capacitance(
+            "J1",
+            "drain",
+            "gate",
+            "0",
+            JfetPolarity::Njf,
+            1.0e-12,
+            -2.0,
+            0.0,
+            1.0e-9,
+            0.0,
+        );
+        jfet.forward_bias_depletion_coefficient = coefficient;
+        circuit.add(Element::Jfet(jfet));
+        transient_with_method(&circuit, 2.0e-7, 2.0e-6, TransientMethod::Euler)
+            .unwrap()
+            .last()
+            .unwrap()
+            .voltage("gate")
+            .unwrap()
+    }
+
+    assert!(final_gate_voltage(0.2) > final_gate_voltage(0.8));
+}
+
+#[test]
 fn transient_mosfet_overlap_capacitance_slows_gate_step() {
     fn run(gate_source_overlap_capacitance: f64) -> Vec<TransientPoint> {
         let mut circuit = Circuit::new();

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add JFET model-card `FC` forward-bias depletion coefficient support,
+  defaulting to `0.5` and shaping `CGS`/`CGD` depletion capacitance in AC and
+  transient analysis with hierarchy preservation and range validation.
 - Add JFET model-card `PB` gate-junction-potential support with `VJ` as an
   alias, bias-dependent `CGS`/`CGD` depletion capacitance in AC and transient
   analysis, hierarchy preservation, and finite-positive validation.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1698,6 +1698,7 @@ export interface Jfet {
   readonly flickerNoiseCoefficient: number;
   readonly flickerNoiseExponent: number;
   readonly junctionPotential: number;
+  readonly forwardBiasDepletionCoefficient: number;
 }
 
 export type BjtPolarity = "NPN" | "PNP";
@@ -2027,8 +2028,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   D: [15, 21, 5, 3],
   NPN: [41, 58, 13, 4],
   PNP: [41, 58, 13, 4],
-  NJF: [8, 15, 6, 3],
-  PJF: [8, 15, 6, 3],
+  NJF: [9, 16, 6, 3],
+  PJF: [9, 16, 6, 3],
   NMOS: [18, 25, 6, 3],
   PMOS: [18, 25, 6, 3],
 };
@@ -3614,7 +3615,7 @@ function cloneSubcktElement(
     case "diode":
       return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient, element.breakdownVoltage, element.breakdownCurrent, element.junctionCapacitance, element.transitTime, element.junctionPotential, element.gradingCoefficient, element.forwardBiasDepletionCoefficient, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.seriesResistance, element.flickerNoiseCoefficient, element.flickerNoiseExponent);
     case "jfet":
-      return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.junctionPotential);
+      return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.junctionPotential, element.forwardBiasDepletionCoefficient);
     case "bjt":
       return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees, element.forwardTransitTimeBiasCoefficient, element.forwardTransitTimeCurrent, element.forwardTransitTimeVoltage, element.emitterResistance, element.collectorResistance, element.baseResistance, element.minimumBaseResistance, element.baseResistanceHalfCurrent, element.baseCollectorCapacitanceFraction);
     case "mosfet":
@@ -7762,6 +7763,7 @@ export function jfet(
   flickerNoiseCoefficient = 0.0,
   flickerNoiseExponent = 1.0,
   junctionPotential = 1.0,
+  forwardBiasDepletionCoefficient = 0.5,
 ): Jfet {
   return {
     kind: "jfet",
@@ -7778,6 +7780,7 @@ export function jfet(
     flickerNoiseCoefficient,
     flickerNoiseExponent,
     junctionPotential,
+    forwardBiasDepletionCoefficient,
   };
 }
 
@@ -8038,6 +8041,7 @@ const JFET_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   AF: "AF",
   PB: "PB",
   VJ: "PB",
+  FC: "FC",
 };
 
 const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -8584,6 +8588,7 @@ export function jfetFromModelCard(
     p.KF ?? 0.0,
     p.AF ?? 1.0,
     p.PB ?? 1.0,
+    p.FC ?? 0.5,
   );
 }
 
@@ -19537,6 +19542,14 @@ function validateJfet(element: Jfet): void {
   if (!Number.isFinite(element.junctionPotential) || element.junctionPotential <= 0.0) {
     throw invalidElement(element.name, "junction potential must be finite and positive");
   }
+  if (!Number.isFinite(element.forwardBiasDepletionCoefficient) ||
+      element.forwardBiasDepletionCoefficient < 0.0 ||
+      element.forwardBiasDepletionCoefficient >= 1.0) {
+    throw invalidElement(
+      element.name,
+      "forward-bias depletion coefficient must be finite and in [0, 1)",
+    );
+  }
 }
 
 function stampJfet(
@@ -20242,17 +20255,16 @@ function jfetChargeDynamicCapacitance(
   junctionVoltage: number,
 ): number {
   const gradingCoefficient = 0.5;
-  const forwardBiasDepletionCoefficient = 0.5;
   const orientedVoltage = element.polarity === "PJF" ? -junctionVoltage : junctionVoltage;
   const normalizedVoltage = orientedVoltage / element.junctionPotential;
-  if (normalizedVoltage < forwardBiasDepletionCoefficient) {
+  if (normalizedVoltage < element.forwardBiasDepletionCoefficient) {
     return zeroBiasCapacitance / ((1.0 - normalizedVoltage) ** gradingCoefficient);
   }
   const transitionScale =
-    (1.0 - forwardBiasDepletionCoefficient) ** (1.0 + gradingCoefficient);
+    (1.0 - element.forwardBiasDepletionCoefficient) ** (1.0 + gradingCoefficient);
   const continuation =
     1.0 -
-    forwardBiasDepletionCoefficient * (1.0 + gradingCoefficient) +
+    element.forwardBiasDepletionCoefficient * (1.0 + gradingCoefficient) +
     gradingCoefficient * normalizedVoltage;
   return (zeroBiasCapacitance * continuation) / transitionScale;
 }

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -535,6 +535,22 @@ describe("acSweep", () => {
     expect(gateAmplitude(0.5)).toBeGreaterThan(gateAmplitude(2.0));
   });
 
+  it("uses JFET forward-bias depletion coefficient to shape gate capacitance", () => {
+    function gateAmplitude(coefficient: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "in", "0", 0.6, 1.0));
+      circuit.add(resistor("Rin", "in", "gate", 1_000.0));
+      circuit.add(resistor("Rdrain", "drain", "0", 1_000.0));
+      circuit.add({
+        ...jfet("J1", "drain", "gate", "0", "NJF", 1.0e-12, -2.0, 0.0, 1.0e-9),
+        forwardBiasDepletionCoefficient: coefficient,
+      });
+      return complexAbs(acSweep(circuit, 100_000.0, 100_000.0, 1)[0].voltage("gate")!);
+    }
+
+    expect(gateAmplitude(0.2)).toBeGreaterThan(gateAmplitude(0.8));
+  });
+
   it("uses MOSFET overlap capacitance in AC analysis", () => {
     function gateAmplitude(CGSO: number): number {
       const circuit = new Circuit();

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -120,7 +120,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(149);
+    expect(coverage).toHaveLength(151);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -140,7 +140,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(149);
+    expect(records).toHaveLength(151);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -205,15 +205,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 149,
-      expectedCanonicalParameterCount: 149,
-      acceptedNameCount: 217,
+      canonicalParameterCount: 151,
+      expectedCanonicalParameterCount: 151,
+      acceptedNameCount: 219,
       aliasedParameterCount: 55,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t149\t149\t217\t55\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t151\t151\t219\t55\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -236,8 +236,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(148);
-    expect(report.acceptedNameCount).toBe(214);
+    expect(report.canonicalParameterCount).toBe(150);
+    expect(report.acceptedNameCount).toBe(216);
     expect(report.aliasedParameterCount).toBe(54);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -252,7 +252,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t148\t149\t214\t54\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t150\t151\t216\t54\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -383,9 +383,9 @@ describe("dcOp", () => {
     expectClose(bjtModel.baseCollectorGradingCoefficient, 0.45);
     expectClose(bjtModel.forwardBiasDepletionCoefficient, 0.4);
 
-    const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02, KF: 1.0e-12, AF: 1.3, VJ: 0.8 });
+    const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02, KF: 1.0e-12, AF: 1.3, VJ: 0.8, FC: 0.35 });
     const jfetModel = jfetFromModelCard("J1", "d", "g", "s", jfetCard);
-    expect(jfetCard.parameters).toStrictEqual({ BETA: 9.0e-4, VTO: -1.8, LAMBDA: 0.02, KF: 1.0e-12, AF: 1.3, PB: 0.8 });
+    expect(jfetCard.parameters).toStrictEqual({ BETA: 9.0e-4, VTO: -1.8, LAMBDA: 0.02, KF: 1.0e-12, AF: 1.3, PB: 0.8, FC: 0.35 });
     expect(jfetModel.polarity).toBe("NJF");
     expectClose(jfetModel.beta, 9.0e-4);
     expectClose(jfetModel.thresholdVoltage, -1.8);
@@ -393,6 +393,7 @@ describe("dcOp", () => {
     expectClose(jfetModel.flickerNoiseCoefficient, 1.0e-12);
     expectClose(jfetModel.flickerNoiseExponent, 1.3);
     expectClose(jfetModel.junctionPotential, 0.8);
+    expectClose(jfetModel.forwardBiasDepletionCoefficient, 0.35);
 
     const mosCard = normalizeModelCard("Mn", "nmos", {
       LEVEL: 1.0,
@@ -1053,6 +1054,7 @@ describe("dcOp", () => {
           flickerNoiseCoefficient: 1.0e-12,
           flickerNoiseExponent: 1.3,
           junctionPotential: 0.8,
+          forwardBiasDepletionCoefficient: 0.35,
         },
       ]),
     );
@@ -1066,6 +1068,7 @@ describe("dcOp", () => {
     expectClose(expanded.flickerNoiseCoefficient, 1.0e-12);
     expectClose(expanded.flickerNoiseExponent, 1.3);
     expectClose(expanded.junctionPotential, 0.8);
+    expectClose(expanded.forwardBiasDepletionCoefficient, 0.35);
   });
 
   it("preserves the complete BJT model through subcircuit expansion", () => {

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -69,6 +69,16 @@ describe("noiseAc", () => {
     );
   });
 
+  it("rejects an invalid JFET forward-bias depletion coefficient", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vgate", "gate", "0", 0.0));
+    circuit.add({ ...jfet("J1", "out", "gate", "0"), forwardBiasDepletionCoefficient: 1.0 });
+
+    expect(() => noiseAc(circuit, "out", "Vgate", [1_000.0])).toThrow(
+      /forward-bias depletion coefficient must be finite and in \[0, 1\)/,
+    );
+  });
+
   it("uses JFET AF as the current exponent", () => {
     function sourcePsd(exponent: number): number {
       const circuit = new Circuit();

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -312,6 +312,33 @@ describe("transient", () => {
     expect(finalGateVoltage(0.5)).toBeLessThan(finalGateVoltage(2.0));
   });
 
+  it("uses JFET forward-bias depletion coefficient to shape transient gate charge", () => {
+    function finalGateVoltage(coefficient: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithWaveform(
+        "Vstep",
+        "in",
+        "0",
+        0.0,
+        new PwlWaveform([
+          [0.0, 0.0],
+          [2.0e-7, 0.6],
+          [2.0e-6, 0.6],
+        ]),
+      ));
+      circuit.add(resistor("Rin", "in", "gate", 1_000.0));
+      circuit.add(resistor("Rdrain", "drain", "0", 1_000.0));
+      circuit.add({
+        ...jfet("J1", "drain", "gate", "0", "NJF", 1.0e-12, -2.0, 0.0, 1.0e-9),
+        forwardBiasDepletionCoefficient: coefficient,
+      });
+      const points = transient(circuit, 2.0e-7, 2.0e-6, "euler");
+      return points.at(-1)!.voltage("gate")!;
+    }
+
+    expect(finalGateVoltage(0.2)).toBeGreaterThan(finalGateVoltage(0.8));
+  });
+
   it("uses MOSFET overlap capacitance during transient gate steps", () => {
     function run(gateSourceOverlapCapacitance: number): TransientPoint[] {
       const circuit = new Circuit();

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,14 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language JFET gate-junction potential.
+1. Cross-language JFET forward-bias depletion coefficient.
    - Status: current PR completion candidate.
-   - Add Berkeley JFET `PB` model-card support, with `VJ` as an accepted alias,
-     in Rust, Python, and TypeScript.
-   - Default `PB` to one volt and use it to shape the existing zero-bias
-     `CGS`/`CGD` junction capacitances in AC and transient analysis with the
-     Berkeley grading and forward-bias continuation defaults.
-   - Preserve `PB` through hierarchy and cloning, validate finite positive
-     values, and extend the supported-parameter coverage gate from 147 to 149
+   - Add Berkeley JFET `FC` model-card support in Rust, Python, and TypeScript.
+   - Default `FC` to `0.5` and use it as the forward-bias transition point for
+     the existing `CGS`/`CGD` depletion-capacitance continuation in AC and
+     transient analysis.
+   - Preserve `FC` through hierarchy and cloning, validate finite values in
+     `[0, 1)`, and extend the supported-parameter coverage gate from 149 to 151
      canonical rows.
 
 ## Completed Slices
@@ -3261,6 +3260,15 @@ the Rust, Python, and TypeScript surfaces together.
    - Hierarchy and cloning paths preserve `AF`, finite non-negative validation
      is shared across analyses, and the supported-parameter release gate now
      covers 147 canonical rows.
+
+251. Cross-language JFET gate-junction potential.
+   - Status: completed in PR 8919.
+   - Rust, Python, and TypeScript JFET model cards now accept `PB`, with `VJ`
+     as an alias, default it to one volt, and use it to shape `CGS`/`CGD`
+     depletion capacitance in AC and transient analysis.
+   - Hierarchy and cloning paths preserve `PB`, finite-positive validation is
+     shared across analyses, and the supported-parameter release gate now
+     covers 149 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley JFET `FC` model-card support with the default `0.5` transition coefficient in Rust, Python, and TypeScript
- apply `FC` to the shared bias-dependent `CGS`/`CGD` capacitance path used by AC and transient analysis
- preserve and validate the parameter through hierarchy, extend compatibility coverage to 151 canonical rows, and reconcile the SPICE completion plan

## Verification
- `cargo test -p spice-engine`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo fmt --package spice-engine -- --check`
- Python Ruff checks on touched modules and tests
- Python full suite: 595 passed, 88.77% coverage
- TypeScript `npm run build` and `npm test`: 353 passed
- `git diff --check`