### PR TITLE
feat(adj-formula-stdlib): time-conversions — NIST SP 811 B.9 time-unit→second factors (RS-5 table)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -336,6 +336,48 @@ fn shipped_si_prefixes_table_resolves_signed_exponents_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b6) Shipped table — reference/time-conversions.adj resolves via import (time
+//      unit → seconds, EXACT defined factors), and `year` — which has no single
+//      exact factor and therefore no row — abstains honestly.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_time_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_time");
+    let src = stdlib().join("reference/time-conversions.adj");
+    std::fs::copy(&src, dir.join("time-conversions.adj"))
+        .expect("copy shipped time-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"time-conversions.adj\"\n\
+         ? time_to_seconds(minute, $S)\n\
+         ? time_to_seconds(hour, $S)\n\
+         ? time_to_seconds(day, $S)\n\
+         ? time_to_seconds(year, $S)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 "Time" exact factors resolve, character-for-character
+    // from the table (boldface = exact; scientific notation to plain integer).
+    assert!(out.contains("\"S\":\"60\""), "minute = 60 s: {out}");
+    assert!(out.contains("\"S\":\"3600\""), "hour = 3600 s: {out}");
+    assert!(out.contains("\"S\":\"86400\""), "day = 86400 s: {out}");
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `year` is NOT a single exact factor (SP 811 lists only non-exact,
+    // inequivalent variants) — no row, so the engine abstains rather than
+    // committing to one of several lengths.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "year abstains, never a fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/time-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/time-conversions.adj
@@ -1,0 +1,57 @@
+% ============================================================================
+% time-conversions — customary time-unit → second factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of `length-conversions.adj` / `mass-conversions.adj`: a native
+% tabular relation ingested VERBATIM from a published NIST conversion table. Each
+% row states the factor converting one everyday time unit to the SI base unit, the
+% second:
+%
+%     ? time_to_seconds(minute, $S)     % 60      (a minute is 60 s)
+%     ? time_to_seconds(hour, $S)       % 3600    (an hour is 3600 s)
+%     ? time_to_seconds(day, $S)        % 86400   (a day is 86400 s)
+%
+% Why a `table` and not three hand-written `relate` clauses: this is exactly the
+% shape reference data comes in — a published table, not prose. The citable
+% artifact IS the NIST conversion-factors table at the `locator` below; every
+% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors
+% for units listed alphabetically"), and the whole table is defended by one
+% provenance envelope rather than repeating `source`/`locator`/`trust` on every
+% row. Each `row` lowers to a ground relation `time_to_seconds(unit, seconds)`, so
+% the exact lookup above is the ordinary SLD binding query — the engine returns
+% the factor WITH this table's citation as its proof, on the CPU, with zero model
+% calls. A looked-up factor is a number, so it can feed a `let`/`formula`
+% downstream (e.g. multiply a duration by it) through the existing slot path.
+%
+% HONESTY NOTE (like length-conversions, these are EXACT defined factors, not
+% rounded 7-figure ones): NIST SP 811 B.9 prints the "Time" factors in BOLDFACE,
+% its convention for factors that are EXACT by definition, transcribed here as the
+% plain integer number of seconds each unit names:
+%
+%     minute (min)   6.0  E+01   →  60
+%     hour   (h)     3.6  E+03   →  3600
+%     day    (d)     8.64 E+04   →  86400
+%
+% These three are exact: a minute IS exactly 60 seconds, an hour exactly 3600, a
+% day exactly 86400 — definitional, not measured. Deliberately OMITTED: the year,
+% which SP 811 lists only as a non-exact multiple (365 d → 3.1536 E+07 s, plus
+% distinct sidereal/tropical variants), so it is NOT a single exact factor and has
+% no honest row here; a `? time_to_seconds(year, $S)` therefore ABSTAINS rather
+% than committing to one of several inequivalent lengths. The only claim this table
+% makes is "these are the exact factors NIST SP 811 B.9 prints" — which is exactly
+% what a byte-check against the cited table verifies. `trust authoritative` — a
+% primary, re-fetchable standards reference. (See ADJ-TABLES.md; and
+% feedback_nothing_human_authored — nothing here is asserted "from memory": every
+% factor is a verbatim cell of the cited table.)
+% ============================================================================
+
+table time_to_seconds {
+    columns unit, seconds
+
+    row (minute, 60)
+    row (hour, 3600)
+    row (day, 86400)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/time-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/time-conversions.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% time-conversions.query.adj — a worked lookup over the time-conversions table.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a "how many
+% seconds in an hour?" question: it states no conversion fact — it only `import`s
+% the grounded table and asks binding queries. The native adj-lang engine resolves
+% each `?` against the table's rows (lowered to `time_to_seconds` relations) and
+% returns the binding + the table's source/locator/trust. A unit not in the table
+% abstains honestly — the engine never invents a factor (notably `year`, which has
+% no single exact factor and so has no row).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli time-conversions.query.adj
+% ============================================================================
+
+import "time-conversions.adj"
+
+? time_to_seconds(minute, $S)    % expect 60
+? time_to_seconds(hour, $S)      % expect 3600
+? time_to_seconds(day, $S)       % expect 86400
+? time_to_seconds(year, $S)      % expect abstain — no single exact factor, not a row


### PR DESCRIPTION
## What

Adds a new grounded RS-5 `table` to the ADJ formula stdlib: **time-unit → seconds**, a sibling of the existing length/mass/area/volume conversion references and `si-prefixes`.

```
? time_to_seconds(minute, $S)    % 60
? time_to_seconds(hour, $S)      % 3600
? time_to_seconds(day, $S)       % 86400
? time_to_seconds(year, $S)      % abstain — no single exact factor
```

## Grounding

Every value is a verbatim cell of **NIST Special Publication 811, Appendix B.9** ("Factors for units listed alphabetically"), "Time" section, which prints these three factors in **boldface** — its convention for factors that are *exact by definition*:

| unit | SP 811 | seconds |
|------|--------|---------|
| minute (min) | 6.0 E+01 | 60 |
| hour (h) | 3.6 E+03 | 3600 |
| day (d) | 8.64 E+04 | 86400 |

**`year` is deliberately omitted.** SP 811 lists the year only as a *non-exact*, inequivalent multiple (365 d → 3.1536 E+07 s, plus distinct sidereal/tropical variants), so there is no single honest exact factor — a `? time_to_seconds(year, $S)` **abstains** rather than committing to one of several lengths. This is the honest-abstention discipline the `table` construct is built around.

The whole table is defended by one provenance envelope (`source`/`locator`/`trust authoritative`, re-fetchable at the NIST URL); each `row` lowers to a ground `time_to_seconds(unit, seconds)` relation, so exact lookup is the ordinary SLD binding query — the engine returns the factor **with the table's citation** as its proof, on the CPU, 0 model calls.

## Files
- `reference/time-conversions.adj` + `.query.adj` — new shipped grounded table + worked lookup
- `rs5_table_e2e.rs` — `shipped_time_conversions_table_resolves_and_abstains` (minute/hour/day resolve carrying the NIST locator; `year` abstains)

## Verification
- New e2e test + full `rs5_table_e2e` suite: **11 passed**
- Shipped `.query.adj` run through the built CLI: binds 60/3600/86400 each with the NIST SP 811 B.9 citation; `year` abstains
- Data + test only — no crate code touched, no version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)