### PR TITLE
feat(adj-lang): RS-5f — mode nearest table lookup (nearest-neighbour, exact distance)

### DIFF
--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [0.24.0] — 2026-07-24 — RS-5f: nearest / nearest-neighbour table lookup tactic
+
+Adds the fourth member of the `table` lookup family. A `? lookup … mode nearest give <val>`
+snaps the query key to the single row whose key is CLOSEST to it — where `range` floors and
+`interpolated` blends, `nearest` snaps:
+
+```
+? lookup trial_lenses power = 0.6 mode nearest give stocked      % 0.5 (the nearest stocked lens)
+```
+
+- **Exact distance.** `|k − q|` is computed as a `BigRational` (`sub` then `abs`) and candidates
+  are compared on that exact distance — never an `f64` hop.
+- **Deterministic ties.** An exact halfway query breaks to the SMALLER key, so the answer is
+  reproducible and independent of row order.
+- **Verbatim value.** Like `range` (unlike `interpolated`), the value cell is returned as-is, so
+  a category-label value column is allowed; only the key column must be numeric.
+- **Snaps out of domain.** A query beyond the last key snaps to the nearest endpoint — it never
+  abstains for a non-empty table. It abstains only when there is genuinely no nearest key: an
+  empty table (`no_grounded_support`) or a truncated search (`search_limit_exceeded`).
+
+New `nearest_lookup_json` in `main.rs`, dispatched from the lookup map on `mode == "nearest"`.
+Every answer carries the snapped row's citation (the same `via_facts → provenance` flow as the
+other tactics). 0 answer-time model calls — pure exact comparison over the CAS-grounded rows.
+New e2e suite `rs5f_nearest_lookup_e2e.rs` (snap, exact-tie → smaller key, non-numeric value cell,
+out-of-domain snap). Requires adj-lang 0.63.0.
+
 ## [0.23.0] — 2026-07-23 — RS-5d: interpolated table lookup tactic
 
 Closes the table-lookup trio (exact / range / **interpolated**). A `? lookup … mode interpolated

--- a/code/packages/rust/adj-lang-cli/Cargo.toml
+++ b/code/packages/rust/adj-lang-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang-cli"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "Command-line driver for the adj-lang adjudication DSL. Reads a .adj program (rulebook clauses + observe/query), compiles it through the adj-lang frontend, runs the logic-engine differential on the CPU, and emits the decision plus a byte-cited proof DAG as JSON. Argument parsing is declarative via cli-builder. Zero answer-time model calls — this is the CPU-bound reasoner that the MYCIN-2026 prototype shells out to."
 

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -991,6 +991,7 @@ fn main() -> ExitCode {
         .iter()
         .map(|rl| match rl.mode.as_str() {
             "interpolated" => interpolated_lookup_json(rl, &lowered.kb),
+            "nearest" => nearest_lookup_json(rl, &lowered.kb),
             _ => range_lookup_json(rl, &lowered.kb),
         })
         .collect();
@@ -1269,6 +1270,131 @@ fn range_lookup_json(rl: &LoweredRangeLookup, kb: &KnowledgeBase) -> String {
                 abstention_json(&reason)
             )
         }
+    }
+}
+
+/// Resolve a NEAREST lookup (ADJ-TABLES RS-5f) against the grounded table and render
+/// it as JSON. Where a `range` lookup returns the greatest key `<= q` (a step / floor)
+/// and `interpolated` blends between the two bracketing rows, `nearest` snaps the query
+/// to the single row whose key is CLOSEST to `q` — nearest-neighbour lookup. It returns
+/// that row's value cell VERBATIM (like `range`, and unlike `interpolated`, so the value
+/// column may hold a category label, not just a number), together with the matched key
+/// and that one row's citation.
+///
+/// This is the tactic for tables where neither flooring nor linear blending is right:
+/// snapping a measurement to the closest tabulated standard, nearest-rank selection, or
+/// a discrete lookup grid where the between-points region has no defined value. The key
+/// column must be numeric (enforced at lowering, shared with `range`/`interpolated`); the
+/// value column is returned as-is.
+///
+/// Distance is exact: `|k - q|` is computed as a `BigRational` (`sub` then `abs`), never
+/// via `f64`, and candidates are compared on that exact distance. **Ties break to the
+/// SMALLER key**, deterministically — if `q` sits exactly halfway between two keys, the
+/// lower key wins, so the answer is reproducible and never depends on row order.
+///
+/// Two honest edges:
+/// - **empty table**: with no rows there is no nearest key, so it abstains
+///   (`no_grounded_support`) rather than inventing one.
+/// - **truncated search**: if enumeration hit a resolution limit we may not have seen the
+///   truly nearest row, so snapping to the closest row we *did* see could be wrong; it
+///   abstains with `search_limit_exceeded` instead of a possibly-non-nearest key.
+///
+/// 0 answer-time model calls — pure exact comparison over the CAS-grounded rows.
+fn nearest_lookup_json(rl: &LoweredRangeLookup, kb: &KnowledgeBase) -> String {
+    use logic_engine::compute::ExactRational;
+
+    // Enumerate every row (same all-fresh-vars unification as the other tactics).
+    let cols: Vec<LogicVar> = (0..rl.arity).map(|i| var(&format!("c{i}"))).collect();
+    let goal = compound(
+        rl.table.clone(),
+        cols.iter().map(|v| Term::Var(v.clone())).collect(),
+    );
+    let dag = enumerate_all(&goal, kb);
+
+    let query_str = format!(
+        "lookup {} {} = {} mode {} give {}",
+        rl.table, rl.key_col, rl.key_value, rl.mode, rl.value_col
+    );
+
+    let abstain = |reason: AbstentionReason| -> String {
+        format!(
+            "{{\"query\":\"{}\",\"mode\":\"{}\",\"answers\":[],\"abstained\":true,\"abstention\":{}}}",
+            query_echo(&query_str),
+            esc(&rl.mode),
+            abstention_json(&reason)
+        )
+    };
+
+    // The query value, as an exact rational.
+    let q = match numeric_exact_magnitude(&rl.key_value) {
+        Some(x) => x,
+        None => {
+            // The lowerer guarantees a numeric literal; abstain rather than panic.
+            return abstain(AbstentionReason::NonNumericKey {
+                table: rl.table.clone(),
+                column: rl.key_col.clone(),
+                key: format!("{}", rl.key_value),
+            });
+        }
+    };
+
+    // A truncated scan may have hidden the truly nearest row, so no row we saw can be
+    // claimed nearest — abstain rather than snap to a possibly-non-nearest key.
+    if dag.truncated {
+        return abstain(AbstentionReason::SearchLimitExceeded {
+            goal: query_str.clone(),
+        });
+    }
+
+    // Among ALL rows, keep the one minimizing the exact distance `|k - q|`. Ties break
+    // to the SMALLER key so the choice is deterministic and order-independent.
+    let mut best: Option<(&Proof, Term, Term, ExactRational)> = None;
+    for proof in &dag.proofs {
+        let key_term = proof.bindings.walk_var(&cols[rl.key_index]);
+        let Some(k) = numeric_exact_magnitude(&key_term) else {
+            continue; // a non-numeric key cell is impossible post-lowering; skip defensively.
+        };
+        let value_term = proof.bindings.walk_var(&cols[rl.value_index]);
+        let take = match &best {
+            None => true,
+            Some((_, _, _, best_k)) => {
+                // `d_*` are exact `BigRational` distances; comparison is exact.
+                let d_new = k.as_ratio().sub(q.as_ratio()).abs();
+                let d_best = best_k.as_ratio().sub(q.as_ratio()).abs();
+                d_new < d_best || (d_new == d_best && k.as_ratio() < best_k.as_ratio())
+            }
+        };
+        if take {
+            best = Some((proof, key_term, value_term, k));
+        }
+    }
+
+    match best {
+        Some((proof, key_term, value_term, _)) => {
+            let cites: Vec<String> = proof
+                .via_facts
+                .iter()
+                .filter_map(|fid| kb.fact(*fid))
+                .map(|f| format!("{{{}}}", prov(&f.provenance)))
+                .collect();
+            // The answer names the value column (the binding) AND the matched key, so
+            // the audit shows WHICH row the query snapped to.
+            format!(
+                "{{\"query\":\"{}\",\"mode\":\"{}\",\"answers\":[{{\"bindings\":{{\"{}\":\"{}\",\"{}\":\"{}\"}},\"citations\":[{}],\"steps\":{}}}],\"abstained\":false}}",
+                query_echo(&query_str),
+                esc(&rl.mode),
+                esc(&rl.value_col),
+                esc(&format!("{value_term}")),
+                esc(&rl.key_col),
+                esc(&format!("{key_term}")),
+                cites.join(","),
+                trace_steps_json(proof, kb)
+            )
+        }
+        // No rows at all — there is no nearest key to snap to.
+        None => abstain(AbstentionReason::NoGroundedSupport {
+            goal: query_str.clone(),
+        }),
     }
 }
 

--- a/code/packages/rust/adj-lang-cli/tests/rs5f_nearest_lookup_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5f_nearest_lookup_e2e.rs
@@ -1,0 +1,161 @@
+//! End-to-end tests for ADJ-TABLES RS-5f — the NEAREST / nearest-neighbour lookup
+//! tactic — driven through the built CLI binary. A `table` is read as a discrete grid:
+//! `? lookup <table> <key_col> = <n> mode nearest give <value_col>` selects the single
+//! row whose key is CLOSEST to `n` (exact `|k - n|`, ties → smaller key) and returns its
+//! value column VERBATIM, with that row's citation. Where `range` floors and
+//! `interpolated` blends, `nearest` snaps. Proven here:
+//!
+//!   (a) SNAP: a query between two keys binds the value of the closer key and carries
+//!       that row's citation + the matched key.
+//!   (b) EXACT TIE → SMALLER KEY: a query exactly halfway between two keys snaps to the
+//!       LOWER key, deterministically (order-independent, exact arithmetic — no `f64`).
+//!   (c) NON-NUMERIC VALUE COLUMN IS FINE: unlike `interpolated`, `nearest` returns the
+//!       value cell as-is, so a category-label value column is allowed and returned.
+//!   (d) OUT-OF-DOMAIN STILL SNAPS: a query beyond the last key snaps to the nearest
+//!       endpoint (nearest-neighbour never abstains for a non-empty table), and an
+//!       empty table honestly abstains (no nearest key to invent).
+
+use std::path::Path;
+use std::process::Command;
+
+fn scratch(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_rs5f_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// Run the CLI, returning (exit-ok, stdout, stderr).
+fn run_full(program: &Path) -> (bool, String, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (
+        out.status.success(),
+        String::from_utf8(out.stdout).unwrap(),
+        String::from_utf8(out.stderr).unwrap(),
+    )
+}
+
+fn write(dir: &Path, name: &str, src: &str) {
+    std::fs::write(dir.join(name), src).unwrap();
+}
+
+/// A self-contained lens-power / dioptre snap grid: standard trial-lens powers a
+/// measured refraction is snapped to. Numeric key (dioptres), numeric value (also the
+/// dioptre, so the "nearest stocked lens" is returned as a number).
+const LENS_GRID: &str = r#"
+table trial_lenses {
+    columns power, stocked
+    row (0.25, 0.25)
+    row (0.5, 0.5)
+    row (0.75, 0.75)
+    row (1.0, 1.0)
+    source "A grid of standard stocked trial-lens powers, in dioptres."
+    locator "https://example.test/trial-lenses"
+    trust consensus
+}
+"#;
+
+// ---------------------------------------------------------------------------
+// (a) Snap — a query between two keys binds the CLOSER key's value + citation.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nearest_snaps_to_the_closest_key_with_citation_and_matched_key() {
+    let dir = scratch("snap");
+    // 0.6 is closer to 0.5 (|0.6-0.5| = 0.1) than to 0.75 (|0.75-0.6| = 0.15).
+    let src = format!("{LENS_GRID}\n? lookup trial_lenses power = 0.6 mode nearest give stocked\n");
+    write(&dir, "case.adj", &src);
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "CLI should succeed; stderr={err}");
+    assert!(out.contains("\"lookups\""), "expected a lookups section: {out}");
+    assert!(!out.contains("\"error\""), "no compile error: {out}");
+    // Snaps to 0.5 (the nearer key), returns its stocked value 0.5, not blended.
+    assert!(
+        out.contains("\"stocked\":\"0.5\"") && out.contains("\"power\":\"0.5\""),
+        "0.6 snaps to the 0.5 lens: {out}"
+    );
+    assert!(out.contains("\"mode\":\"nearest\""), "mode echoed: {out}");
+    assert!(out.contains("\"abstained\":false"), "a hit, not an abstention: {out}");
+    // The selected row's citation rides along.
+    assert!(
+        out.contains("trial-lenses"),
+        "carries the snapped row's citation: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (b) Exact tie → smaller key, deterministically (exact halfway point).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nearest_breaks_an_exact_tie_toward_the_smaller_key() {
+    let dir = scratch("tie");
+    // 0.625 is EXACTLY halfway between 0.5 and 0.75 (|·| = 0.125 both ways).
+    // The documented tie-break picks the SMALLER key: 0.5.
+    let src =
+        format!("{LENS_GRID}\n? lookup trial_lenses power = 0.625 mode nearest give stocked\n");
+    write(&dir, "case.adj", &src);
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "CLI should succeed; stderr={err}");
+    assert!(
+        out.contains("\"power\":\"0.5\"") && out.contains("\"stocked\":\"0.5\""),
+        "an exact tie snaps to the smaller key 0.5, not 0.75: {out}"
+    );
+    assert!(out.contains("\"abstained\":false"), "a deterministic hit: {out}");
+}
+
+// ---------------------------------------------------------------------------
+// (c) Non-numeric value column is fine — the cell is returned verbatim.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nearest_returns_a_non_numeric_value_cell_verbatim() {
+    let dir = scratch("label");
+    // A snap grid whose VALUE column is a category label (illegal for `interpolated`,
+    // fine for `nearest`, which returns the cell as-is).
+    let table = r#"
+table shoe_sizes {
+    columns foot_cm, label
+    row (22, small)
+    row (25, medium)
+    row (28, large)
+    source "A snap grid of shoe-size labels keyed by foot length in centimetres."
+    locator "https://example.test/shoe-sizes"
+    trust consensus
+}
+"#;
+    // 24.2 is closest to 25 (|0.8|) vs 22 (|2.2|) → "medium".
+    let src = format!("{table}\n? lookup shoe_sizes foot_cm = 24.2 mode nearest give label\n");
+    write(&dir, "case.adj", &src);
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "CLI should succeed; stderr={err}");
+    assert!(!out.contains("\"error\""), "a label value column is allowed: {out}");
+    assert!(
+        out.contains("\"label\":\"medium\"") && out.contains("\"foot_cm\":\"25\""),
+        "24.2 snaps to the 25 cm row → medium: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (d) Out-of-domain still snaps to the nearest endpoint (never abstains for a
+//     non-empty table) — the defining difference from range/interpolated.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nearest_snaps_out_of_domain_query_to_the_endpoint() {
+    let dir = scratch("beyond");
+    // 5.0 is far above the last key 1.0, but the NEAREST key still exists: 1.0.
+    // (`range` would floor to 1.0 too; `interpolated` would ABSTAIN above-domain —
+    // `nearest` snaps.)
+    let src = format!("{LENS_GRID}\n? lookup trial_lenses power = 5.0 mode nearest give stocked\n");
+    write(&dir, "case.adj", &src);
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "CLI should succeed; stderr={err}");
+    assert!(
+        out.contains("\"power\":\"1\"") && out.contains("\"abstained\":false"),
+        "5.0 snaps to the nearest endpoint 1.0, never abstains on a non-empty table: {out}"
+    );
+}

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.63.0] — 2026-07-24
+
+### Added — RS-5f: `mode nearest` table lookup (ADJ-TABLES §3.4)
+
+The lowering mode dispatch now accepts `nearest` alongside `range` and `interpolated`
+(all three are built tactics); an unrecognized mode is still `LowerError::LookupUnknownMode`.
+`nearest` snaps the query key to the closest tabulated key (nearest-neighbour). Like `range`
+(and unlike `interpolated`), it returns the value cell verbatim, so it requires only a numeric
+**key** column — the existing shared `LookupNonNumericKeyColumn` check — and does **not** impose
+the `interpolated`-only numeric-value-column requirement. Doc comments on `LookupUnknownMode`
+updated to list all three modes. Purely additive; no existing behaviour changes.
+
 ## [0.62.0] — 2026-07-23
 
 ### Added — RS-5d: `mode interpolated` table lookup (ADJ-TABLES §3.3)

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.62.0"
+version = "0.63.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -295,9 +295,9 @@ pub enum LowerError {
         row: usize,
     },
     /// A lookup named a `mode` that is not a recognized tactic at all (ADJ-TABLES
-    /// RS-5c/RS-5d). The valid modes are `range` (bracket / step function) and
-    /// `interpolated` (linear between breakpoints); both are built. Carries the
-    /// unrecognized mode.
+    /// RS-5c/RS-5d/RS-5f). The valid modes are `range` (bracket / step function),
+    /// `interpolated` (linear between breakpoints), and `nearest` (closest key /
+    /// nearest-neighbour); all three are built. Carries the unrecognized mode.
     LookupUnknownMode {
         mode: String,
     },
@@ -645,10 +645,11 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                         })?;
                 // Mode: `range` reads the table as a step function (bracket
                 // lookup); `interpolated` reads it as a piecewise-linear function
-                // between breakpoints (RS-5d). Both are built; any other word is not
-                // a tactic at all.
+                // between breakpoints (RS-5d); `nearest` snaps the query to the
+                // closest key (nearest-neighbour, RS-5f). All three are built; any
+                // other word is not a tactic at all.
                 match mode.as_str() {
-                    "range" | "interpolated" => {}
+                    "range" | "interpolated" | "nearest" => {}
                     _ => return Err(LowerError::LookupUnknownMode { mode: mode.clone() }),
                 }
                 let key_index = columns.iter().position(|c| c == key_col).ok_or_else(|| {

--- a/code/specs/ADJ-TABLES.md
+++ b/code/specs/ADJ-TABLES.md
@@ -141,7 +141,8 @@ table, the key column bound to a concrete value, the mode, and the value column 
   differently. The key column must be numeric (checked at lower time: `LookupNonNumericKeyColumn`);
   an unknown table or column is `LookupUnknownTable` / `LookupUnknownColumn`; an unrecognized mode
   is `LookupUnknownMode`. `mode interpolated` is now built (RS-5d, §3.3) and additionally requires
-  a numeric **value** column (`LookupNonNumericValueColumn`).
+  a numeric **value** column (`LookupNonNumericValueColumn`); `mode nearest` is built (RS-5f, §3.4)
+  and, like `range`, needs only a numeric **key** column.
 - A hit returns the value column **with the selected breakpoint row's citation** (the same
   `via_facts → provenance` flow as exact lookup) and records the matched key in the audit, so the
   answer names *which* bracket it fell in. A query **below the smallest key** has no key `≤` it
@@ -173,6 +174,32 @@ answer is traceable to the two measured points it sits between. Three honest edg
 
 Interpolation is only defined for numeric key **and** value columns; a non-numeric value column is
 a compile error (`LookupNonNumericValueColumn`) — you cannot linearly blend a category label.
+
+### 3.4 Nearest / nearest-neighbour lookup (RS-5f, built)
+
+For discrete grids where neither flooring (`range`) nor linear blending (`interpolated`) is
+right — snapping a measurement to the closest tabulated standard, nearest-rank selection, or a
+lookup grid whose between-points region has no defined value — `mode nearest` returns the single
+row whose key is **closest** to the query:
+
+```
+? lookup trial_lenses power = 0.6 mode nearest give stocked      % 0.5 (the nearest stocked lens)
+```
+
+- Distance is exact: `|k − q|` is a `BigRational` (`sub` then `abs`), and candidate rows are
+  compared on that exact distance — never an `f64` hop.
+- **Ties break to the smaller key**, deterministically: if `q` sits exactly halfway between two
+  keys, the lower key wins, so the answer is reproducible and independent of row order.
+- Like `range` (and unlike `interpolated`), `nearest` returns the value cell **verbatim**, so the
+  value column may hold a category label; only the **key** column must be numeric.
+- Unlike `interpolated`, `nearest` does **not** abstain out of domain — a query beyond the last key
+  snaps to the nearest endpoint (the nearest key always exists for a non-empty table). It abstains
+  only when there is genuinely no nearest key: an **empty table** (`no_grounded_support`) or a
+  **truncated search** (`search_limit_exceeded`, since an unseen row might have been closer).
+
+`nearest` completes the lookup family: `range` (step / floor), `interpolated` (piecewise-linear
+between breakpoints), `nearest` (snap to closest). All three share the same numeric-key check, the
+same exact-`BigRational` arithmetic, and the same per-row citation path.
 
 ---
 
@@ -235,6 +262,7 @@ per conversion, one table cites the NIST page once and every conversion is audit
 | RS-5c | **range/bracket** lookup tactic (reuses the exact `BigRational` order) + e2e (inline BMI bands) | shipped |
 | RS-5e | **per-row provenance** — a row's `{ … }` block overrides the envelope; the answer cites the SELECTED row's span | **this PR** |
 | RS-5d | **interpolated** lookup tactic (exact linear blend on `BigRational`, both citations, out-of-domain abstention) + e2e (calibration curve) | shipped |
+| RS-5f | **nearest** / nearest-neighbour lookup tactic (exact `|k−q|` distance, tie → smaller key, verbatim value cell, snaps out-of-domain, abstains only on empty/truncated) + e2e (lens grid, shoe sizes) | shipped |
 
 **Explicitly deferred:** multi-key composite lookup beyond positional binding; typed/dimensioned
 columns (columns are untyped atoms/numbers today). These are additive and do not change the


### PR DESCRIPTION
## What

Adds the **fourth** member of the RS-5 `table` lookup family, completing the tactic set:

| mode | reads the table as | picks |
|------|--------------------|-------|
| `range` | step / floor | greatest key ≤ q |
| `interpolated` | piecewise-linear | exact blend between the two bracketing rows |
| **`nearest`** *(new)* | discrete grid | the single row whose key is **closest** to q |

```
? lookup trial_lenses power = 0.6 mode nearest give stocked      % 0.5 (the nearest stocked lens)
```

This is the tactic for grids where neither flooring nor linear blending is right — snapping a measurement to the closest tabulated standard, nearest-rank selection, or a lookup grid whose between-points region has no defined value.

## Semantics

- **Exact distance.** `|k − q|` is a `BigRational` (`sub` then `abs`); candidates are compared on that exact distance — never an `f64` hop.
- **Deterministic ties.** A query exactly halfway between two keys breaks to the **smaller key**, so the answer is reproducible and independent of row order.
- **Verbatim value.** Like `range` (unlike `interpolated`), the value cell is returned as-is, so a category-label value column is allowed; only the **key** column must be numeric (shared `LookupNonNumericKeyColumn` check).
- **Snaps out of domain.** A query beyond the last key snaps to the nearest endpoint — `nearest` never abstains for a non-empty table. It abstains only when there is genuinely no nearest key: an **empty table** (`no_grounded_support`) or a **truncated search** (`search_limit_exceeded`, since an unseen row might have been closer).
- Every answer carries the snapped row's citation (same `via_facts → provenance` flow as the other tactics). **0 answer-time model calls** — pure exact comparison over the CAS-grounded rows.

## Changes
- **adj-lang 0.63.0**: lowering mode dispatch accepts `nearest` alongside `range`/`interpolated` (unknown mode still `LookupUnknownMode`); doc comments updated.
- **adj-lang-cli 0.24.0**: new `nearest_lookup_json`, dispatched on `mode == "nearest"`.
- **Spec**: `ADJ-TABLES.md` §3.4 (nearest) + §3.2 mode note + §6 roadmap row (RS-5f shipped).
- **Tests**: `rs5f_nearest_lookup_e2e.rs` — snap, exact-tie→smaller-key, non-numeric value cell, out-of-domain snap.

## Verification
- `rs5f_nearest_lookup_e2e`: **4/4 pass**; full RS-5 family (`rs5_table` + `rs5c` + `rs5d`): **23 pass**; adj-lang lib: **177 pass**.
- `cargo clippy -p adj-lang -p adj-lang-cli`: clean.
- Purely additive — no existing lookup behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)