### PR TITLE
feat(spice): add JFET gate saturation current

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add JFET model-card `IS` gate-junction saturation-current support,
+  defaulting to `1e-14`, stamping `IGS`/`IGD` leakage in DC, transient, AC,
+  and transfer-function analyses, and emitting distinct shot-noise sources.
 - Add JFET model-card `FC` forward-bias depletion coefficient support,
   defaulting to `0.5` and shaping `CGS`/`CGD` depletion capacitance in AC and
   transient analysis with hierarchy preservation and range validation.

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -516,6 +516,7 @@ class JFET:
     Af: float = 1.0
     Pb: float = 1.0
     Fc: float = 0.5
+    Is: float = 1.0e-14
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -9082,12 +9082,53 @@ def _eval_jfet(el: JFET, vgs: float, vds: float) -> tuple[float, float, float]:
         raise ValueError(f"JFET '{el.name}' PB must be finite and positive")
     if not math.isfinite(el.Fc) or el.Fc < 0.0 or el.Fc >= 1.0:
         raise ValueError(f"JFET '{el.name}' FC must be finite and in [0, 1)")
+    if not math.isfinite(el.Is) or el.Is < 0.0:
+        raise ValueError(
+            f"JFET '{el.name}' gate saturation current must be finite and non-negative"
+        )
     if el.polarity == "PJF":
         ids, gm, gds = _eval_njf(-vgs, -vds, -el.vto, el.beta, el.lambda_)
         return -ids, gm, gds
     if el.polarity != "NJF":
         raise ValueError(f"JFET '{el.name}' polarity must be 'NJF' or 'PJF'")
     return _eval_njf(vgs, vds, el.vto, el.beta, el.lambda_)
+
+
+_JFET_THERMAL_VOLTAGE = 0.02585
+
+
+def _jfet_gate_junction_current_conductance(
+    el: JFET, gate_voltage: float
+) -> tuple[float, float]:
+    junction_voltage = gate_voltage if el.polarity == "NJF" else -gate_voltage
+    exp_value = math.exp(
+        max(-40.0, min(40.0, junction_voltage / _JFET_THERMAL_VOLTAGE))
+    )
+    return (
+        el.Is * (exp_value - 1.0),
+        el.Is / _JFET_THERMAL_VOLTAGE * exp_value,
+    )
+
+
+def _stamp_jfet_gate_junction(
+    G: list[list[float]],
+    b: list[float],
+    node_to_idx: dict[str, int],
+    el: JFET,
+    terminal: str,
+    gate_voltage: float,
+) -> None:
+    current, conductance = _jfet_gate_junction_current_conductance(el, gate_voltage)
+    junction_voltage = gate_voltage if el.polarity == "NJF" else -gate_voltage
+    equivalent_current = current - conductance * junction_voltage
+    positive, negative = (
+        (el.gate, terminal) if el.polarity == "NJF" else (terminal, el.gate)
+    )
+    _stamp_g(G, node_to_idx, positive, negative, conductance)
+    if not _is_ground(positive):
+        b[node_to_idx[positive]] -= equivalent_current
+    if not _is_ground(negative):
+        b[node_to_idx[negative]] += equivalent_current
 
 
 def _eval_njf(
@@ -9141,6 +9182,8 @@ def _stamp_jfet(
         b[node_to_idx[el.drain]] -= Ieq
     if not _is_ground(el.source):
         b[node_to_idx[el.source]] += Ieq
+    _stamp_jfet_gate_junction(G, b, node_to_idx, el, el.source, Vg - Vs)
+    _stamp_jfet_gate_junction(G, b, node_to_idx, el, el.drain, Vg - Vd)
 
 
 def _bjt_early_factor(el: BJT, junction_voltage: float, output_voltage: float) -> float:
@@ -12758,7 +12801,11 @@ def _stamp_ac(
         Vg = 0.0 if _is_ground(el.gate) else dc_x[node_to_idx[el.gate]]
         Vs = 0.0 if _is_ground(el.source) else dc_x[node_to_idx[el.source]]
         _, gm_j, gds_j = _eval_jfet(el, Vg - Vs, Vd - Vs)
+        _, ggs = _jfet_gate_junction_current_conductance(el, Vg - Vs)
+        _, ggd = _jfet_gate_junction_current_conductance(el, Vg - Vd)
         _stamp_g_c(G, node_to_idx, el.drain, el.source, gds_j + 0j)
+        _stamp_g_c(G, node_to_idx, el.gate, el.source, ggs + 0j)
+        _stamp_g_c(G, node_to_idx, el.gate, el.drain, ggd + 0j)
         if el.Cgs > 0.0:
             cgs = _jfet_charge_dynamic_capacitance(el, el.Cgs, Vg - Vs)
             _stamp_g_c(G, node_to_idx, el.gate, el.source, 1j * omega * cgs)
@@ -13473,7 +13520,11 @@ def _build_ss_matrix(
             Vg = 0.0 if _is_ground(el.gate) else dc_x[node_to_idx[el.gate]]
             Vs = 0.0 if _is_ground(el.source) else dc_x[node_to_idx[el.source]]
             _, gm_j, gds_j = _eval_jfet(el, Vg - Vs, Vd - Vs)
+            _, ggs = _jfet_gate_junction_current_conductance(el, Vg - Vs)
+            _, ggd = _jfet_gate_junction_current_conductance(el, Vg - Vd)
             _stamp_g(G, node_to_idx, el.drain, el.source, gds_j)
+            _stamp_g(G, node_to_idx, el.gate, el.source, ggs)
+            _stamp_g(G, node_to_idx, el.gate, el.drain, ggd)
             if not _is_ground(el.drain):
                 d = node_to_idx[el.drain]
                 if not _is_ground(el.gate):
@@ -15357,6 +15408,21 @@ def _collect_noise_sources(
                 n_d = None if _is_ground(el.drain) else node_to_idx[el.drain]
                 n_s = None if _is_ground(el.source) else node_to_idx[el.source]
                 sources.append((el.name, "thermal", n_d, n_s, psd, 0.0))
+            n_g = None if _is_ground(el.gate) else node_to_idx[el.gate]
+            n_s = None if _is_ground(el.source) else node_to_idx[el.source]
+            n_d = None if _is_ground(el.drain) else node_to_idx[el.drain]
+            gate_source_current, _ = _jfet_gate_junction_current_conductance(
+                el, Vg - Vs
+            )
+            gate_drain_current, _ = _jfet_gate_junction_current_conductance(
+                el, Vg - Vd
+            )
+            sources.append(
+                (f"{el.name}:IGS", "shot", n_g, n_s, q2 * abs(gate_source_current), 0.0)
+            )
+            sources.append(
+                (f"{el.name}:IGD", "shot", n_g, n_d, q2 * abs(gate_drain_current), 0.0)
+            )
             if el.Kf > 0.0:
                 n_d = None if _is_ground(el.drain) else node_to_idx[el.drain]
                 n_s = None if _is_ground(el.source) else node_to_idx[el.source]

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -309,8 +309,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (15, 21, 5, 3),
     "NPN": (41, 58, 13, 4),
     "PNP": (41, 58, 13, 4),
-    "NJF": (9, 16, 6, 3),
-    "PJF": (9, 16, 6, 3),
+    "NJF": (10, 17, 6, 3),
+    "PJF": (10, 17, 6, 3),
     "NMOS": (18, 25, 6, 3),
     "PMOS": (18, 25, 6, 3),
 }
@@ -435,6 +435,7 @@ _JFET_PARAMETER_ALIASES: dict[str, str] = {
     "PB": "PB",
     "VJ": "PB",
     "FC": "FC",
+    "IS": "IS",
 }
 
 _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
@@ -1011,6 +1012,7 @@ def jfet_from_model_card(
         Af=p.get("AF", 1.0),
         Pb=p.get("PB", 1.0),
         Fc=p.get("FC", 0.5),
+        Is=p.get("IS", 1.0e-14),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -407,7 +407,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 151
+    assert len(coverage) == 153
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -422,7 +422,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 151
+    assert len(records) == 153
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -496,9 +496,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 151
-    assert report.expected_canonical_parameter_count == 151
-    assert report.accepted_name_count == 219
+    assert report.canonical_parameter_count == 153
+    assert report.expected_canonical_parameter_count == 153
+    assert report.accepted_name_count == 221
     assert report.aliased_parameter_count == 55
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -506,7 +506,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t151\t151\t219\t55\t4\t0"
+        "true\t7\t7\t153\t153\t221\t55\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -534,8 +534,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 150
-    assert report.accepted_name_count == 216
+    assert report.canonical_parameter_count == 152
+    assert report.accepted_name_count == 218
     assert report.aliased_parameter_count == 54
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -550,7 +550,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t150\t151\t216\t54\t4\t4\n"
+        "false\t7\t7\t152\t153\t218\t54\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -674,6 +674,7 @@ def test_model_card_aliases_build_device_instances() -> None:
             "AF": 1.3,
             "VJ": 0.8,
             "FC": 0.35,
+            "IS": 2.0e-13,
         },
     )
     jfet_model = jfet_from_model_card("J1", "d", "g", "s", jfet_card)
@@ -685,6 +686,7 @@ def test_model_card_aliases_build_device_instances() -> None:
         "AF": 1.3,
         "PB": 0.8,
         "FC": 0.35,
+        "IS": 2.0e-13,
     }
     assert jfet_model.polarity == "NJF"
     assert jfet_model.beta == pytest.approx(9.0e-4)
@@ -694,6 +696,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert jfet_model.Af == pytest.approx(1.3)
     assert jfet_model.Pb == pytest.approx(0.8)
     assert jfet_model.Fc == pytest.approx(0.35)
+    assert jfet_model.Is == pytest.approx(2.0e-13)
 
     mos_card = normalize_model_card(
         "Mn",
@@ -765,6 +768,41 @@ def test_dc_rejects_invalid_jfet_forward_bias_depletion_coefficient() -> None:
 
     with pytest.raises(ValueError, match=r"FC must be finite and in \[0, 1\)"):
         dc_op(circuit)
+
+
+def test_dc_rejects_invalid_jfet_gate_saturation_current() -> None:
+    circuit = Circuit()
+    circuit.add(JFET("J1", "drain", "gate", "0", Is=-1.0))
+
+    with pytest.raises(
+        ValueError,
+        match="gate saturation current must be finite and non-negative",
+    ):
+        dc_op(circuit)
+
+
+def test_jfet_gate_saturation_current_loads_a_forward_biased_gate() -> None:
+    def gate_voltage(
+        polarity: str, bias_voltage: float, gate_saturation_current: float
+    ) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vbias", "bias", "0", bias_voltage))
+        circuit.add(Resistor("Rgate", "bias", "gate", 1.0e6))
+        circuit.add(
+            JFET(
+                "J1",
+                "0",
+                "gate",
+                "0",
+                polarity=polarity,
+                vto=-2.0 if polarity == "NJF" else 2.0,
+                Is=gate_saturation_current,
+            )
+        )
+        return dc_op(circuit).node_voltages["gate"]
+
+    assert gate_voltage("NJF", 0.3, 1.0e-9) < gate_voltage("NJF", 0.3, 1.0e-14)
+    assert gate_voltage("PJF", -0.3, 1.0e-9) > gate_voltage("PJF", -0.3, 1.0e-14)
 
 
 def test_bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() -> None:
@@ -2525,7 +2563,7 @@ def test_subcircuit_expansion_preserves_complete_jfet_model():
     cell = SubcircuitDefinition(
         "jfet-cell",
         ("d", "g", "s"),
-        (JFET("Jcell", "d", "g", "s", Kf=1.0e-12, Af=1.3, Pb=0.8, Fc=0.35),),
+        (JFET("Jcell", "d", "g", "s", Kf=1.0e-12, Af=1.3, Pb=0.8, Fc=0.35, Is=2.0e-13),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2536,6 +2574,7 @@ def test_subcircuit_expansion_preserves_complete_jfet_model():
     assert expanded.Af == pytest.approx(1.3)
     assert expanded.Pb == pytest.approx(0.8)
     assert expanded.Fc == pytest.approx(0.35)
+    assert expanded.Is == pytest.approx(2.0e-13)
 
 
 def test_subcircuit_expansion_preserves_complete_bjt_model():
@@ -7550,6 +7589,24 @@ def test_noise_jfet_kf_adds_inverse_frequency_flicker_noise() -> None:
 
     assert flicker_psds[0] > 0.0
     assert flicker_psds[0] / flicker_psds[1] == pytest.approx(100.0)
+
+
+def test_noise_jfet_gate_junctions_emit_distinct_shot_sources() -> None:
+    circuit = Circuit()
+    circuit.add(VoltageSource("Vdd", "out", "0", 1.0))
+    circuit.add(VoltageSource("Vgate", "gate", "0", 0.3))
+    circuit.add(JFET("J1", "out", "gate", "0", Is=1.0e-12))
+
+    entries = noise_ac(
+        circuit, "gate", "Vgate", freqs=[1_000.0], temperature=300.0
+    ).points[0].entries
+    for name in ("J1:IGS", "J1:IGD"):
+        entry = next(
+            entry
+            for entry in entries
+            if entry.element_name == name and entry.noise_type == "shot"
+        )
+        assert entry.source_psd > 0.0
 
 
 def test_noise_jfet_af_is_the_current_exponent() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add JFET model-card `IS` gate-junction saturation-current support,
+  defaulting to `1e-14`, stamping `IGS`/`IGD` leakage in DC, transient, AC,
+  and transfer-function analyses, and emitting distinct shot-noise sources.
 - Add JFET model-card `FC` forward-bias depletion coefficient support,
   defaulting to `0.5` and shaping `CGS`/`CGD` depletion capacitance in AC and
   transient analysis with hierarchy preservation and range validation.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -430,6 +430,7 @@ fn clone_subckt_element(
             mapped.flicker_noise_exponent = element.flicker_noise_exponent;
             mapped.junction_potential = element.junction_potential;
             mapped.forward_bias_depletion_coefficient = element.forward_bias_depletion_coefficient;
+            mapped.gate_saturation_current = element.gate_saturation_current;
             Element::Jfet(mapped)
         }
         Element::Bjt(element) => {
@@ -2821,6 +2822,7 @@ pub struct Jfet {
     pub flicker_noise_exponent: f64,
     pub junction_potential: f64,
     pub forward_bias_depletion_coefficient: f64,
+    pub gate_saturation_current: f64,
 }
 
 impl Jfet {
@@ -2893,6 +2895,7 @@ impl Jfet {
             flicker_noise_exponent: 1.0,
             junction_potential: 1.0,
             forward_bias_depletion_coefficient: 0.5,
+            gate_saturation_current: 1.0e-14,
         }
     }
 }
@@ -3816,8 +3819,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     (ModelCardKind::Diode, 15, 21, 5, 3),
     (ModelCardKind::Npn, 41, 58, 13, 4),
     (ModelCardKind::Pnp, 41, 58, 13, 4),
-    (ModelCardKind::Njf, 9, 16, 6, 3),
-    (ModelCardKind::Pjf, 9, 16, 6, 3),
+    (ModelCardKind::Njf, 10, 17, 6, 3),
+    (ModelCardKind::Pjf, 10, 17, 6, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
     (ModelCardKind::Pmos, 18, 25, 6, 3),
 ];
@@ -3921,6 +3924,7 @@ const JFET_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("PB", "PB"),
     ("VJ", "PB"),
     ("FC", "FC"),
+    ("IS", "IS"),
 ];
 const MOS_LEVEL1_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("LEVEL", "LEVEL"),
@@ -4651,6 +4655,7 @@ pub fn jfet_from_model_card(
     jfet.flicker_noise_exponent = model_card_value(model, "AF", 1.0);
     jfet.junction_potential = model_card_value(model, "PB", 1.0);
     jfet.forward_bias_depletion_coefficient = model_card_value(model, "FC", 0.5);
+    jfet.gate_saturation_current = model_card_value(model, "IS", 1.0e-14);
     Ok(jfet)
 }
 
@@ -22471,6 +22476,26 @@ fn collect_noise_sources(
                         frequency_exponent: 0.0,
                     });
                 }
+                let (gate_source_current, _) =
+                    jfet_gate_junction_current_conductance(jfet, gate_voltage - source_voltage);
+                let (gate_drain_current, _) =
+                    jfet_gate_junction_current_conductance(jfet, gate_voltage - drain_voltage);
+                sources.push(NoiseSource {
+                    element_name: format!("{}:IGS", jfet.name),
+                    noise_type: NoiseType::Shot,
+                    positive: gate,
+                    negative: source,
+                    source_psd: 2.0 * ELECTRON_CHARGE * gate_source_current.abs(),
+                    frequency_exponent: 0.0,
+                });
+                sources.push(NoiseSource {
+                    element_name: format!("{}:IGD", jfet.name),
+                    noise_type: NoiseType::Shot,
+                    positive: gate,
+                    negative: drain,
+                    source_psd: 2.0 * ELECTRON_CHARGE * gate_drain_current.abs(),
+                    frequency_exponent: 0.0,
+                });
                 if jfet.flicker_noise_coefficient > 0.0 {
                     sources.push(NoiseSource {
                         element_name: jfet.name.clone(),
@@ -23607,8 +23632,59 @@ fn stamp_jfet(
     stamp_conductance(matrix, drain, source, result.gds);
     stamp_transconductance(matrix, drain, source, gate, source, result.gm);
     stamp_equivalent_current_source(rhs, drain, source, equivalent_current);
+    stamp_jfet_gate_junction(
+        jfet,
+        gate,
+        source,
+        gate_voltage - source_voltage,
+        matrix,
+        rhs,
+    );
+    stamp_jfet_gate_junction(jfet, gate, drain, gate_voltage - drain_voltage, matrix, rhs);
     stamp_jfet_charge(jfet, capacitor_states, node_indices, matrix, rhs)?;
     Ok(())
+}
+
+const JFET_THERMAL_VOLTAGE: f64 = 0.02585;
+
+fn jfet_gate_junction_current_conductance(jfet: &Jfet, gate_voltage: f64) -> (f64, f64) {
+    let junction_voltage = match jfet.polarity {
+        JfetPolarity::Njf => gate_voltage,
+        JfetPolarity::Pjf => -gate_voltage,
+    };
+    let exp_value = (junction_voltage / JFET_THERMAL_VOLTAGE)
+        .clamp(-40.0, 40.0)
+        .exp();
+    (
+        jfet.gate_saturation_current * (exp_value - 1.0),
+        jfet.gate_saturation_current / JFET_THERMAL_VOLTAGE * exp_value,
+    )
+}
+
+fn stamp_jfet_gate_junction(
+    jfet: &Jfet,
+    gate: Option<usize>,
+    terminal: Option<usize>,
+    gate_voltage: f64,
+    matrix: &mut [Vec<f64>],
+    rhs: &mut [f64],
+) {
+    let (current, conductance) = jfet_gate_junction_current_conductance(jfet, gate_voltage);
+    let junction_voltage = match jfet.polarity {
+        JfetPolarity::Njf => gate_voltage,
+        JfetPolarity::Pjf => -gate_voltage,
+    };
+    let equivalent_current = current - conductance * junction_voltage;
+    match jfet.polarity {
+        JfetPolarity::Njf => {
+            stamp_conductance(matrix, gate, terminal, conductance);
+            stamp_equivalent_current_source(rhs, gate, terminal, equivalent_current);
+        }
+        JfetPolarity::Pjf => {
+            stamp_conductance(matrix, terminal, gate, conductance);
+            stamp_equivalent_current_source(rhs, terminal, gate, equivalent_current);
+        }
+    }
 }
 
 fn stamp_jfet_charge(
@@ -23937,7 +24013,13 @@ fn stamp_jfet_small_signal(
         gate_voltage - source_voltage,
         drain_voltage - source_voltage,
     );
+    let (_, gate_source_conductance) =
+        jfet_gate_junction_current_conductance(jfet, gate_voltage - source_voltage);
+    let (_, gate_drain_conductance) =
+        jfet_gate_junction_current_conductance(jfet, gate_voltage - drain_voltage);
     stamp_conductance(matrix, drain, source, result.gds);
+    stamp_conductance(matrix, gate, source, gate_source_conductance);
+    stamp_conductance(matrix, gate, drain, gate_drain_conductance);
     stamp_transconductance(matrix, drain, source, gate, source, result.gm);
     Ok(())
 }
@@ -24017,17 +24099,21 @@ fn stamp_ac_jfet_small_signal(
         gate_voltage - drain_voltage,
     );
     stamp_complex_conductance(matrix, drain, source, Complex::new(result.gds, 0.0));
+    let (_, gate_source_conductance) =
+        jfet_gate_junction_current_conductance(jfet, gate_voltage - source_voltage);
+    let (_, gate_drain_conductance) =
+        jfet_gate_junction_current_conductance(jfet, gate_voltage - drain_voltage);
     stamp_complex_conductance(
         matrix,
         gate,
         source,
-        Complex::new(0.0, omega * gate_source_capacitance),
+        Complex::new(gate_source_conductance, omega * gate_source_capacitance),
     );
     stamp_complex_conductance(
         matrix,
         gate,
         drain,
-        Complex::new(0.0, omega * gate_drain_capacitance),
+        Complex::new(gate_drain_conductance, omega * gate_drain_capacitance),
     );
     stamp_complex_transconductance(
         matrix,
@@ -24927,6 +25013,12 @@ fn validate_jfet(jfet: &Jfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: jfet.name.clone(),
             reason: "forward-bias depletion coefficient must be finite and in [0, 1)".to_string(),
+        });
+    }
+    if !jfet.gate_saturation_current.is_finite() || jfet.gate_saturation_current < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: jfet.name.clone(),
+            reason: "gate saturation current must be finite and non-negative".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -95,7 +95,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 151);
+    assert_eq!(coverage.len(), 153);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -114,7 +114,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 151);
+    assert_eq!(records.len(), 153);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -195,15 +195,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 151);
-    assert_eq!(report.expected_canonical_parameter_count, 151);
-    assert_eq!(report.accepted_name_count, 219);
+    assert_eq!(report.canonical_parameter_count, 153);
+    assert_eq!(report.expected_canonical_parameter_count, 153);
+    assert_eq!(report.accepted_name_count, 221);
     assert_eq!(report.aliased_parameter_count, 55);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t151\t151\t219\t55\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t153\t153\t221\t55\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -230,8 +230,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 150);
-    assert_eq!(report.accepted_name_count, 216);
+    assert_eq!(report.canonical_parameter_count, 152);
+    assert_eq!(report.accepted_name_count, 218);
     assert_eq!(report.aliased_parameter_count, 54);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -248,7 +248,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t150\t151\t216\t54\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t152\t153\t218\t54\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -517,6 +517,7 @@ fn model_card_aliases_build_device_instances() {
             ("AF", 1.3),
             ("VJ", 0.8),
             ("FC", 0.35),
+            ("IS", 2.0e-13),
         ],
     )
     .unwrap();
@@ -528,6 +529,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*jfet_card.parameters.get("AF").unwrap(), 1.3);
     assert_close(*jfet_card.parameters.get("PB").unwrap(), 0.8);
     assert_close(*jfet_card.parameters.get("FC").unwrap(), 0.35);
+    assert_close(*jfet_card.parameters.get("IS").unwrap(), 2.0e-13);
     assert_eq!(jfet_model.polarity, JfetPolarity::Njf);
     assert_close(jfet_model.beta, 9.0e-4);
     assert_close(jfet_model.threshold_voltage, -1.8);
@@ -536,6 +538,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(jfet_model.flicker_noise_exponent, 1.3);
     assert_close(jfet_model.junction_potential, 0.8);
     assert_close(jfet_model.forward_bias_depletion_coefficient, 0.35);
+    assert_close(jfet_model.gate_saturation_current, 2.0e-13);
 
     let mos_card = normalize_model_card(
         "Mn",
@@ -1460,6 +1463,7 @@ fn subcircuit_expansion_preserves_complete_jfet_model() {
     jfet.flicker_noise_exponent = 1.3;
     jfet.junction_potential = 0.8;
     jfet.forward_bias_depletion_coefficient = 0.35;
+    jfet.gate_saturation_current = 2.0e-13;
     let mut circuit = Circuit::new();
     circuit
         .define_subcircuit(SubcircuitDefinition::new(
@@ -1488,6 +1492,49 @@ fn subcircuit_expansion_preserves_complete_jfet_model() {
     assert_close(expanded.flicker_noise_exponent, 1.3);
     assert_close(expanded.junction_potential, 0.8);
     assert_close(expanded.forward_bias_depletion_coefficient, 0.35);
+    assert_close(expanded.gate_saturation_current, 2.0e-13);
+}
+
+#[test]
+fn jfet_gate_saturation_current_loads_a_forward_biased_gate() {
+    let gate_voltage = |polarity: JfetPolarity, bias_voltage: f64, gate_saturation_current: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vbias",
+            "bias",
+            "0",
+            bias_voltage,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rgate", "bias", "gate", 1.0e6,
+        )));
+        let mut jfet = Jfet::with_model(
+            "J1",
+            "0",
+            "gate",
+            "0",
+            polarity,
+            1.0e-4,
+            if polarity == JfetPolarity::Njf {
+                -2.0
+            } else {
+                2.0
+            },
+            0.0,
+        );
+        jfet.gate_saturation_current = gate_saturation_current;
+        circuit.add(Element::Jfet(jfet));
+        dc_op(&circuit).unwrap().node_voltages["gate"]
+    };
+
+    assert!(
+        gate_voltage(JfetPolarity::Njf, 0.3, 1.0e-9)
+            < gate_voltage(JfetPolarity::Njf, 0.3, 1.0e-14)
+    );
+    assert!(
+        gate_voltage(JfetPolarity::Pjf, -0.3, 1.0e-9)
+            > gate_voltage(JfetPolarity::Pjf, -0.3, 1.0e-14)
+    );
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -384,6 +384,48 @@ fn jfet_rejects_invalid_forward_bias_depletion_coefficient() {
 }
 
 #[test]
+fn jfet_rejects_invalid_gate_saturation_current() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 0.0,
+    )));
+    let mut jfet = Jfet::new("J1", "out", "gate", "0");
+    jfet.gate_saturation_current = -1.0;
+    circuit.add(Element::Jfet(jfet));
+
+    let error = noise_ac(&circuit, "out", "Vgate", &[1_000.0], 300.0).unwrap_err();
+    assert!(matches!(
+        error,
+        SpiceError::InvalidElement { reason, .. }
+            if reason == "gate saturation current must be finite and non-negative"
+    ));
+}
+
+#[test]
+fn jfet_gate_junctions_emit_distinct_shot_noise_sources() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vdd", "out", "0", 1.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 0.3,
+    )));
+    let mut jfet = Jfet::new("J1", "out", "gate", "0");
+    jfet.gate_saturation_current = 1.0e-12;
+    circuit.add(Element::Jfet(jfet));
+
+    let result = noise_ac(&circuit, "gate", "Vgate", &[1_000.0], 300.0).unwrap();
+    let entries = &result.points[0].entries;
+    for name in ["J1:IGS", "J1:IGD"] {
+        let entry = entries
+            .iter()
+            .find(|entry| entry.element_name == name && entry.noise_type == NoiseType::Shot)
+            .unwrap();
+        assert!(entry.source_psd > 0.0);
+    }
+}
+
+#[test]
 fn jfet_flicker_noise_uses_af_current_exponent() {
     let source_psd = |exponent: f64| {
         let mut circuit = Circuit::new();

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add JFET model-card `IS` gate-junction saturation-current support,
+  defaulting to `1e-14`, stamping `IGS`/`IGD` leakage in DC, transient, AC,
+  and transfer-function analyses, and emitting distinct shot-noise sources.
 - Add JFET model-card `FC` forward-bias depletion coefficient support,
   defaulting to `0.5` and shaping `CGS`/`CGD` depletion capacitance in AC and
   transient analysis with hierarchy preservation and range validation.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1699,6 +1699,7 @@ export interface Jfet {
   readonly flickerNoiseExponent: number;
   readonly junctionPotential: number;
   readonly forwardBiasDepletionCoefficient: number;
+  readonly gateSaturationCurrent: number;
 }
 
 export type BjtPolarity = "NPN" | "PNP";
@@ -2028,8 +2029,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   D: [15, 21, 5, 3],
   NPN: [41, 58, 13, 4],
   PNP: [41, 58, 13, 4],
-  NJF: [9, 16, 6, 3],
-  PJF: [9, 16, 6, 3],
+  NJF: [10, 17, 6, 3],
+  PJF: [10, 17, 6, 3],
   NMOS: [18, 25, 6, 3],
   PMOS: [18, 25, 6, 3],
 };
@@ -3615,7 +3616,7 @@ function cloneSubcktElement(
     case "diode":
       return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient, element.breakdownVoltage, element.breakdownCurrent, element.junctionCapacitance, element.transitTime, element.junctionPotential, element.gradingCoefficient, element.forwardBiasDepletionCoefficient, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.seriesResistance, element.flickerNoiseCoefficient, element.flickerNoiseExponent);
     case "jfet":
-      return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.junctionPotential, element.forwardBiasDepletionCoefficient);
+      return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.junctionPotential, element.forwardBiasDepletionCoefficient, element.gateSaturationCurrent);
     case "bjt":
       return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees, element.forwardTransitTimeBiasCoefficient, element.forwardTransitTimeCurrent, element.forwardTransitTimeVoltage, element.emitterResistance, element.collectorResistance, element.baseResistance, element.minimumBaseResistance, element.baseResistanceHalfCurrent, element.baseCollectorCapacitanceFraction);
     case "mosfet":
@@ -7764,6 +7765,7 @@ export function jfet(
   flickerNoiseExponent = 1.0,
   junctionPotential = 1.0,
   forwardBiasDepletionCoefficient = 0.5,
+  gateSaturationCurrent = 1.0e-14,
 ): Jfet {
   return {
     kind: "jfet",
@@ -7781,6 +7783,7 @@ export function jfet(
     flickerNoiseExponent,
     junctionPotential,
     forwardBiasDepletionCoefficient,
+    gateSaturationCurrent,
   };
 }
 
@@ -8042,6 +8045,7 @@ const JFET_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   PB: "PB",
   VJ: "PB",
   FC: "FC",
+  IS: "IS",
 };
 
 const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -8589,6 +8593,7 @@ export function jfetFromModelCard(
     p.AF ?? 1.0,
     p.PB ?? 1.0,
     p.FC ?? 0.5,
+    p.IS ?? 1.0e-14,
   );
 }
 
@@ -18668,6 +18673,30 @@ function collectNoiseSources(
           frequencyExponent: 0.0,
         });
       }
+      const [gateSourceCurrent] = jfetGateJunctionCurrentConductance(
+        element,
+        gateVoltage - sourceVoltage,
+      );
+      const [gateDrainCurrent] = jfetGateJunctionCurrentConductance(
+        element,
+        gateVoltage - drainVoltage,
+      );
+      sources.push({
+        elementName: `${element.name}:IGS`,
+        noiseType: "shot",
+        positive: gate,
+        negative: source,
+        sourcePsd: 2.0 * ELECTRON_CHARGE * Math.abs(gateSourceCurrent),
+        frequencyExponent: 0.0,
+      });
+      sources.push({
+        elementName: `${element.name}:IGD`,
+        noiseType: "shot",
+        positive: gate,
+        negative: drain,
+        sourcePsd: 2.0 * ELECTRON_CHARGE * Math.abs(gateDrainCurrent),
+        frequencyExponent: 0.0,
+      });
       if (element.flickerNoiseCoefficient > 0.0) {
         sources.push({
           elementName: element.name,
@@ -19550,6 +19579,52 @@ function validateJfet(element: Jfet): void {
       "forward-bias depletion coefficient must be finite and in [0, 1)",
     );
   }
+  if (!Number.isFinite(element.gateSaturationCurrent) ||
+      element.gateSaturationCurrent < 0.0) {
+    throw invalidElement(
+      element.name,
+      "gate saturation current must be finite and non-negative",
+    );
+  }
+}
+
+const JFET_THERMAL_VOLTAGE = 0.02585;
+
+function jfetGateJunctionCurrentConductance(
+  element: Jfet,
+  gateVoltage: number,
+): readonly [number, number] {
+  const junctionVoltage = element.polarity === "NJF" ? gateVoltage : -gateVoltage;
+  const exponent = Math.max(
+    -40.0,
+    Math.min(40.0, junctionVoltage / JFET_THERMAL_VOLTAGE),
+  );
+  const expValue = Math.exp(exponent);
+  return [
+    element.gateSaturationCurrent * (expValue - 1.0),
+    element.gateSaturationCurrent / JFET_THERMAL_VOLTAGE * expValue,
+  ];
+}
+
+function stampJfetGateJunction(
+  element: Jfet,
+  gate: number | undefined,
+  terminal: number | undefined,
+  gateVoltage: number,
+  matrix: number[][],
+  rhs: number[],
+): void {
+  const [current, conductance] =
+    jfetGateJunctionCurrentConductance(element, gateVoltage);
+  const junctionVoltage = element.polarity === "NJF" ? gateVoltage : -gateVoltage;
+  const equivalentCurrent = current - conductance * junctionVoltage;
+  if (element.polarity === "NJF") {
+    stampConductance(matrix, gate, terminal, conductance);
+    stampCurrentSourceEquivalent(rhs, gate, terminal, equivalentCurrent);
+  } else {
+    stampConductance(matrix, terminal, gate, conductance);
+    stampCurrentSourceEquivalent(rhs, terminal, gate, equivalentCurrent);
+  }
 }
 
 function stampJfet(
@@ -19576,6 +19651,22 @@ function stampJfet(
   stampConductance(matrix, drain, source, result.gds);
   stampTransconductance(matrix, drain, source, gate, source, result.gm);
   stampCurrentSourceEquivalent(rhs, drain, source, equivalentCurrent);
+  stampJfetGateJunction(
+    element,
+    gate,
+    source,
+    gateVoltage - sourceVoltage,
+    matrix,
+    rhs,
+  );
+  stampJfetGateJunction(
+    element,
+    gate,
+    drain,
+    gateVoltage - drainVoltage,
+    matrix,
+    rhs,
+  );
   stampJfetCharge(element, capacitorStates, nodeIndices, matrix, rhs);
 }
 
@@ -21977,7 +22068,13 @@ function stampJfetSmallSignal(
     gateVoltage - sourceVoltage,
     drainVoltage - sourceVoltage,
   );
+  const [, gateSourceConductance] =
+    jfetGateJunctionCurrentConductance(element, gateVoltage - sourceVoltage);
+  const [, gateDrainConductance] =
+    jfetGateJunctionCurrentConductance(element, gateVoltage - drainVoltage);
   stampConductance(matrix, drain, source, result.gds);
+  stampConductance(matrix, gate, source, gateSourceConductance);
+  stampConductance(matrix, gate, drain, gateDrainConductance);
   stampTransconductance(matrix, drain, source, gate, source, result.gm);
 }
 
@@ -22723,18 +22820,22 @@ function stampAcJfetSmallSignal(
     element.gateDrainCapacitance,
     gateVoltage - drainVoltage,
   );
+  const [, gateSourceConductance] =
+    jfetGateJunctionCurrentConductance(element, gateVoltage - sourceVoltage);
+  const [, gateDrainConductance] =
+    jfetGateJunctionCurrentConductance(element, gateVoltage - drainVoltage);
   stampComplexConductance(matrix, drain, source, complex(result.gds, 0.0));
   stampComplexConductance(
     matrix,
     gate,
     source,
-    complex(0.0, omega * gateSourceCapacitance),
+    complex(gateSourceConductance, omega * gateSourceCapacitance),
   );
   stampComplexConductance(
     matrix,
     gate,
     drain,
-    complex(0.0, omega * gateDrainCapacitance),
+    complex(gateDrainConductance, omega * gateDrainCapacitance),
   );
   stampComplexTransconductance(
     matrix,

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -120,7 +120,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(151);
+    expect(coverage).toHaveLength(153);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -140,7 +140,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(151);
+    expect(records).toHaveLength(153);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -205,15 +205,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 151,
-      expectedCanonicalParameterCount: 151,
-      acceptedNameCount: 219,
+      canonicalParameterCount: 153,
+      expectedCanonicalParameterCount: 153,
+      acceptedNameCount: 221,
       aliasedParameterCount: 55,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t151\t151\t219\t55\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t153\t153\t221\t55\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -236,8 +236,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(150);
-    expect(report.acceptedNameCount).toBe(216);
+    expect(report.canonicalParameterCount).toBe(152);
+    expect(report.acceptedNameCount).toBe(218);
     expect(report.aliasedParameterCount).toBe(54);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -252,7 +252,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t150\t151\t216\t54\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t152\t153\t218\t54\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -383,9 +383,9 @@ describe("dcOp", () => {
     expectClose(bjtModel.baseCollectorGradingCoefficient, 0.45);
     expectClose(bjtModel.forwardBiasDepletionCoefficient, 0.4);
 
-    const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02, KF: 1.0e-12, AF: 1.3, VJ: 0.8, FC: 0.35 });
+    const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02, KF: 1.0e-12, AF: 1.3, VJ: 0.8, FC: 0.35, IS: 2.0e-13 });
     const jfetModel = jfetFromModelCard("J1", "d", "g", "s", jfetCard);
-    expect(jfetCard.parameters).toStrictEqual({ BETA: 9.0e-4, VTO: -1.8, LAMBDA: 0.02, KF: 1.0e-12, AF: 1.3, PB: 0.8, FC: 0.35 });
+    expect(jfetCard.parameters).toStrictEqual({ BETA: 9.0e-4, VTO: -1.8, LAMBDA: 0.02, KF: 1.0e-12, AF: 1.3, PB: 0.8, FC: 0.35, IS: 2.0e-13 });
     expect(jfetModel.polarity).toBe("NJF");
     expectClose(jfetModel.beta, 9.0e-4);
     expectClose(jfetModel.thresholdVoltage, -1.8);
@@ -394,6 +394,7 @@ describe("dcOp", () => {
     expectClose(jfetModel.flickerNoiseExponent, 1.3);
     expectClose(jfetModel.junctionPotential, 0.8);
     expectClose(jfetModel.forwardBiasDepletionCoefficient, 0.35);
+    expectClose(jfetModel.gateSaturationCurrent, 2.0e-13);
 
     const mosCard = normalizeModelCard("Mn", "nmos", {
       LEVEL: 1.0,
@@ -1055,6 +1056,7 @@ describe("dcOp", () => {
           flickerNoiseExponent: 1.3,
           junctionPotential: 0.8,
           forwardBiasDepletionCoefficient: 0.35,
+          gateSaturationCurrent: 2.0e-13,
         },
       ]),
     );
@@ -1069,6 +1071,31 @@ describe("dcOp", () => {
     expectClose(expanded.flickerNoiseExponent, 1.3);
     expectClose(expanded.junctionPotential, 0.8);
     expectClose(expanded.forwardBiasDepletionCoefficient, 0.35);
+    expectClose(expanded.gateSaturationCurrent, 2.0e-13);
+  });
+
+  it("loads a forward-biased JFET gate from gate saturation current", () => {
+    function gateVoltage(
+      polarity: "NJF" | "PJF",
+      biasVoltage: number,
+      gateSaturationCurrent: number,
+    ): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vbias", "bias", "0", biasVoltage));
+      circuit.add(resistor("Rgate", "bias", "gate", 1.0e6));
+      circuit.add({
+        ...jfet("J1", "0", "gate", "0", polarity),
+        gateSaturationCurrent,
+      });
+      return dcOp(circuit).nodeVoltages.get("gate")!;
+    }
+
+    expect(gateVoltage("NJF", 0.3, 1.0e-9)).toBeLessThan(
+      gateVoltage("NJF", 0.3, 1.0e-14),
+    );
+    expect(gateVoltage("PJF", -0.3, 1.0e-9)).toBeGreaterThan(
+      gateVoltage("PJF", -0.3, 1.0e-14),
+    );
   });
 
   it("preserves the complete BJT model through subcircuit expansion", () => {

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -79,6 +79,31 @@ describe("noiseAc", () => {
     );
   });
 
+  it("rejects an invalid JFET gate saturation current", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vgate", "gate", "0", 0.0));
+    circuit.add({ ...jfet("J1", "out", "gate", "0"), gateSaturationCurrent: -1.0 });
+
+    expect(() => noiseAc(circuit, "out", "Vgate", [1_000.0])).toThrow(
+      /gate saturation current must be finite and non-negative/,
+    );
+  });
+
+  it("emits distinct JFET gate-junction shot-noise sources", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vdd", "out", "0", 1.0));
+    circuit.add(voltageSource("Vgate", "gate", "0", 0.3));
+    circuit.add({ ...jfet("J1", "out", "gate", "0"), gateSaturationCurrent: 1.0e-12 });
+
+    const entries = noiseAc(circuit, "gate", "Vgate", [1_000.0], 300.0).points[0]!.entries;
+    for (const name of ["J1:IGS", "J1:IGD"]) {
+      const entry = entries.find(
+        (candidate) => candidate.elementName === name && candidate.noiseType === "shot",
+      );
+      expect(entry?.sourcePsd).toBeGreaterThan(0.0);
+    }
+  });
+
   it("uses JFET AF as the current exponent", () => {
     function sourcePsd(exponent: number): number {
       const circuit = new Circuit();

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,14 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language JFET forward-bias depletion coefficient.
+1. Cross-language JFET gate-junction saturation current.
    - Status: current PR completion candidate.
-   - Add Berkeley JFET `FC` model-card support in Rust, Python, and TypeScript.
-   - Default `FC` to `0.5` and use it as the forward-bias transition point for
-     the existing `CGS`/`CGD` depletion-capacitance continuation in AC and
-     transient analysis.
-   - Preserve `FC` through hierarchy and cloning, validate finite values in
-     `[0, 1)`, and extend the supported-parameter coverage gate from 149 to 151
-     canonical rows.
+   - Add Berkeley JFET `IS` model-card support in Rust, Python, and TypeScript.
+   - Default `IS` to `1e-14` ampere and stamp both gate-source and gate-drain
+     junction leakage in DC, transient, AC, and transfer-function analyses.
+   - Preserve `IS` through hierarchy and cloning, validate finite non-negative
+     values, emit distinct `IGS` / `IGD` shot-noise sources, and extend the
+     supported-parameter coverage gate from 151 to 153 canonical rows.
 
 ## Completed Slices
 
@@ -3269,6 +3268,16 @@ the Rust, Python, and TypeScript surfaces together.
    - Hierarchy and cloning paths preserve `PB`, finite-positive validation is
      shared across analyses, and the supported-parameter release gate now
      covers 149 canonical rows.
+
+252. Cross-language JFET forward-bias depletion coefficient.
+   - Status: completed in PR 8926.
+   - Rust, Python, and TypeScript JFET model cards now accept `FC`, default it
+     to `0.5`, and use it as the forward-bias transition point for the existing
+     `CGS` / `CGD` depletion-capacitance continuation in AC and transient
+     analysis.
+   - Hierarchy and cloning paths preserve `FC`, finite `[0, 1)` validation is
+     shared across analyses, and the supported-parameter release gate now
+     covers 151 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add JFET model-card `IS` support with a Berkeley-compatible `1e-14` A default across Rust, Python, and TypeScript
- stamp polarity-aware gate-source and gate-drain junction leakage into DC, transient, AC, and transfer-function analyses
- expose distinct gate-junction shot-noise sources and advance the SPICE implementation coverage ledger to 153 canonical rows

## Verification
- `cargo test -p spice-engine`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- Rust formatting check
- Python `pytest -q` (598 passed) and Ruff
- TypeScript `npm run build && npm test` (356 passed)
- targeted NJF/PJF symmetry and noise tests in all three implementations
- `git diff --check`