### PR TITLE
feat(gc): frontend-triggerable compaction — gc_collect_compacting builtin (AOT00-T3 §5)

### DIFF
--- a/code/packages/rust/aarch64-backend/CHANGELOG.md
+++ b/code/packages/rust/aarch64-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — `aarch64-backend`
 
+## 0.31.0 - 2026-07-24 — `gc_collect_compacting` builtin (frontend GC.compact, AOT00-T3 §5)
+
+- New `V1_BUILTINS` entry `gc_collect_compacting` (0 args, returns the freed count) — the
+  moving/compacting collect. The generic `__twig_<name>` `call_builtin` dispatch auto-emits a
+  `BL __twig_gc_collect_compacting`, so no per-name lowering is needed; it sits beside
+  `gc_collect` / `gc_collect_precise`. A native program can now trigger a compaction. New
+  emission unit test asserts the external reloc symbol.
+
 ## 0.30.0 - 2026-07-21 — V1_BUILTINS: GC collection + observability (AOT00-T1 increment C)
 
 Four `call_builtin` entries the native GC-stress differential drives, resolving to the

--- a/code/packages/rust/aarch64-backend/Cargo.toml
+++ b/code/packages/rust/aarch64-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aarch64-backend"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 description = "ARM64 (AArch64) backend for jit-core / aot-core — lowers CIR to native machine code via aarch64-encoder."
 

--- a/code/packages/rust/aarch64-backend/src/lib.rs
+++ b/code/packages/rust/aarch64-backend/src/lib.rs
@@ -251,13 +251,16 @@ const V1_BUILTINS: &[BuiltinSig] = &[
     // program uses to drive and measure a collection (→ `__twig_gc_*` aliases in
     // gc-core-capi). `gc_collect` is a forced *conservative* full collect;
     // `gc_collect_precise` is the precise-roots walk (returns objects freed);
-    // `gc_live_bytes` reports the live payload. Together they let the GC-stress
-    // differential show precise roots reclaiming a look-alike-pinned object that the
-    // conservative scan retains.
-    BuiltinSig { name: "gc_collect",         n_args: 0, returns: false },
-    BuiltinSig { name: "gc_collect_precise", n_args: 0, returns: true  },
-    BuiltinSig { name: "gc_live_bytes",      n_args: 0, returns: true  },
-    BuiltinSig { name: "gc_stackmap_count",  n_args: 0, returns: true  },
+    // `gc_collect_compacting` is the precise-roots *moving* collect (relocates the movable
+    // survivors, rewriting the caller's root slots — spec AOT00-T3 §5; degrades to
+    // `gc_collect_precise` when nothing is movable); `gc_live_bytes` reports the live
+    // payload. Together they let the GC-stress differential show precise roots reclaiming a
+    // look-alike-pinned object that the conservative scan retains.
+    BuiltinSig { name: "gc_collect",            n_args: 0, returns: false },
+    BuiltinSig { name: "gc_collect_precise",    n_args: 0, returns: true  },
+    BuiltinSig { name: "gc_collect_compacting", n_args: 0, returns: true  },
+    BuiltinSig { name: "gc_live_bytes",         n_args: 0, returns: true  },
+    BuiltinSig { name: "gc_stackmap_count",     n_args: 0, returns: true  },
 ];
 
 fn lookup_builtin(name: &str) -> Option<BuiltinSig> {
@@ -2324,6 +2327,26 @@ mod tests {
         let symbols: Vec<&str> = ext.iter().map(|r| r.symbol.as_str()).collect();
         assert!(symbols.contains(&"__dyn_cons"), "missing cons call: {symbols:?}");
         assert!(symbols.contains(&"__dyn_car"), "missing car call: {symbols:?}");
+    }
+
+    /// `call_builtin "gc_collect_compacting" -> freed` lowers to a `BL` to the linker
+    /// symbol `__twig_gc_collect_compacting` (the moving-collector C-ABI entry, spec
+    /// AOT00-T3 §5), via the generic `__twig_<name>` builtin dispatch — the same path
+    /// `gc_collect_precise` uses. Proves a native frontend can trigger a compaction.
+    #[test]
+    fn gc_collect_compacting_emits_external_twig_call() {
+        let cir = vec![
+            call_builtin(Some("freed"), "gc_collect_compacting", &[]),
+            ret_u64("freed"),
+        ];
+        let (bytes, ext) = compile_with_relocs(&ctx("gc_compact", &[], "u64"), &cir)
+            .unwrap_or_else(|e| panic!("gc_collect_compacting must lower: {e}"));
+        assert!(!bytes.is_empty() && bytes.len() % 4 == 0);
+        let symbols: Vec<&str> = ext.iter().map(|r| r.symbol.as_str()).collect();
+        assert!(
+            symbols.contains(&"__twig_gc_collect_compacting"),
+            "missing compacting-collect call: {symbols:?}",
+        );
     }
 
     #[test]

--- a/code/packages/rust/gc-core-capi/CHANGELOG.md
+++ b/code/packages/rust/gc-core-capi/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this crate are documented here.
 
+## 0.16.0 - 2026-07-24 — twig-compat alias `__twig_gc_collect_compacting` (frontend GC.compact)
+
+- **`__twig_gc_collect_compacting()`** (new `twig_compat` alias → [`__gc_collect_compacting`]) —
+  the `__twig_gc_*` linker symbol a native code generator emits for the `gc_collect_compacting`
+  builtin, so a compiled program can trigger a moving/compacting collection. Mirrors
+  `__twig_gc_collect_precise`. No new `unsafe` beyond the delegated call.
+
 ## 0.15.0 - 2026-07-24 — moving/compacting collector C ABI `__gc_collect_compacting` (AOT00-T3 §5)
 
 - **`__gc_collect_compacting()`** (new export in `stack_scan.rs`) — the argument-less

--- a/code/packages/rust/gc-core-capi/Cargo.toml
+++ b/code/packages/rust/gc-core-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core-capi"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "C ABI for gc-core's flat-native heap — the gc_runtime_<target> archive linked into native-AOT output (LANG16 / AOT00 T1)."
 license = "MIT"

--- a/code/packages/rust/gc-core-capi/src/twig_compat.rs
+++ b/code/packages/rust/gc-core-capi/src/twig_compat.rs
@@ -26,7 +26,7 @@
 //! Once the code generators are migrated to emit the `__gc_*` names directly,
 //! this shim can be deleted.
 
-use crate::stack_scan::{__gc_collect, __gc_collect_precise, __gc_safepoint};
+use crate::stack_scan::{__gc_collect, __gc_collect_compacting, __gc_collect_precise, __gc_safepoint};
 use crate::{__gc_alloc, __gc_collection_count, __gc_live_bytes};
 
 /// `__twig_gc_alloc(n)` → [`__gc_alloc`]. Called by the emitted code and by
@@ -79,6 +79,27 @@ pub unsafe extern "C" fn __twig_gc_safepoint() {
 #[inline(never)]
 pub unsafe extern "C" fn __twig_gc_collect_precise() -> i64 {
     __gc_collect_precise()
+}
+
+/// `__twig_gc_collect_compacting()` → [`__gc_collect_compacting`]. A full **moving**
+/// collection rooted precisely at the caller's stack (spec AOT00-T3 §5): the movable
+/// survivors are evacuated into an arena and every pointer that named them — including the
+/// caller's precise root slots — is rewritten to the new location. Returns the
+/// freed-object count. This is the `__twig_gc_*` name a native code generator emits for the
+/// `gc_collect_compacting` builtin, letting a compiled program trigger a compaction. With
+/// no stack maps registered (or only conservatively-reachable objects, as today's kind-0
+/// frontend allocations) nothing is movable and it degrades to exactly
+/// [`__gc_collect_precise`], so it is always safe to call.
+///
+/// # Safety
+///
+/// Same contract as [`__gc_collect_compacting`]: the calling thread must own its stack.
+/// `#[inline(never)]` keeps it a real frame below the mutator so the walk starts at the
+/// caller.
+#[no_mangle]
+#[inline(never)]
+pub unsafe extern "C" fn __twig_gc_collect_compacting() -> i64 {
+    __gc_collect_compacting()
 }
 
 /// `__twig_gc_live_bytes()` → [`__gc_live_bytes`].

--- a/code/packages/rust/twig-aot/CHANGELOG.md
+++ b/code/packages/rust/twig-aot/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — `twig-aot`
 
+## 0.45.0 - 2026-07-24 — end-to-end frontend-triggered compaction (AOT00-T3 §5)
+
+- New macOS smoke test `end_to_end_gc_compacting_matches_precise`: a compiled native program
+  invokes the `gc_collect_compacting` builtin (→ `__twig_gc_collect_compacting`), keeps its
+  live cons-cell reference, reclaims an `i64` look-alike, and yields the **identical**
+  `live_bytes` to `gc_collect_precise` — proving a native frontend can trigger a compaction
+  that runs safely on a real thread stack. Every frontend heap object is currently allocated
+  **kind 0** (`__dyn_cons` → `__twig_gc_alloc` → `__gc_alloc`), traced conservatively and
+  therefore **pinned**, so nothing is movable yet and the compacting collect degrades to
+  exactly the precise one. A true address-relocation differential is gated on frontend
+  kind-registration (`__gc_alloc_kind` + ref-field maps) — a separate follow-up.
+
 ## 0.44.0 - 2026-07-23 — MsX64 (Windows) precise-roots registration (AOT00-T1 x86_64 PR-x6)
 
 Brings Windows from safe-conservative GC to **real precise-roots registration**, completing

--- a/code/packages/rust/twig-aot/Cargo.toml
+++ b/code/packages/rust/twig-aot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twig-aot"
-version = "0.44.0"
+version = "0.45.0"
 edition = "2021"
 description = "Twig AOT compiler — produces native Mach-O / ELF executables from Twig source. v0.28.0 (E4d-4 fix): strip_dead_aot_string_allocs now keeps EVERY buffer bound to a live string alias — a branch-selected (multi-block) str var aliases several buffers, and the old alias-keyed map dropped all but the last, so a not-last branch read a freed/empty buffer at run time. v0.27.0 (E4-dyn E4d-4): runtime (branch-selected) strings on the native aarch64 + x86_64 columns — a str var assigned by str_const in >1 basic block is kept out of the compile-time literal map so print_str/str_len read the length from the [i64 len][bytes] buffer header at run time (field_load) instead of folding one branch's static length; the var's stack slot already carries the buffer address. v0.26.0 (E4-dyn E4d-1): runtime string helpers __twig_str_concat/_slice/_index/_len/_cmp in twig_runtime.c on the E5 length-prefixed heap block; bounds-trap on slice/index; C-driver unit tests."
 

--- a/code/packages/rust/twig-aot/tests/macos_arm64_smoke.rs
+++ b/code/packages/rust/twig-aot/tests/macos_arm64_smoke.rs
@@ -546,6 +546,93 @@ fn end_to_end_gc_precise_keeps_ref_reclaims_lookalike() {
     );
 }
 
+/// AOT00-T3 §5 — a native frontend triggers a **compacting** collection end to end.
+///
+/// Reuses the keep-ref program but drives `gc_collect_compacting` (the moving-collector
+/// C-ABI entry, via the `__twig_gc_collect_compacting` alias). The compacting collect is a
+/// strict generalisation of the precise collect: it keeps every live reference and reclaims
+/// every look-alike, then *additionally* relocates the objects it can prove movable.
+///
+/// Today every frontend heap object is allocated **kind 0** (`__dyn_cons` → `__twig_gc_alloc`
+/// → `__gc_alloc`), which the collector traces *conservatively* and therefore **pins** — so
+/// nothing is movable yet and the compacting collect degrades to exactly the precise one.
+/// This test pins that guarantee: `gc_collect_compacting` keeps the live cons cell and
+/// reclaims the i64 look-alike, giving the **identical** `live_bytes` to `gc_collect_precise`
+/// — proving the frontend can invoke a compaction, that it runs safely on a real thread
+/// stack, and that it never drops a live reference or pins a look-alike differently. (A true
+/// address-relocation differential is gated on frontend kind-registration — `__gc_alloc_kind`
+/// with a ref-field map — so an object becomes movable; a separate follow-up.)
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[test]
+fn end_to_end_gc_compacting_matches_precise() {
+    use interpreter_ir::instr::{IIRInstr, Operand};
+
+    fn build(collect: &str) -> IIRModule {
+        let body = vec![
+            // A real, live heap reference in an `any` slot (the stack map names it).
+            IIRInstr::new("const", Some("z0".into()), vec![Operand::Int(0)], "i64"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("z".into()),
+                vec![Operand::Var("dyn_box_int".into()), Operand::Var("z0".into())],
+                "any",
+            ),
+            IIRInstr::new(
+                "call_builtin",
+                Some("b".into()),
+                vec![Operand::Var("dyn_cons".into()), Operand::Var("z".into()), Operand::Var("z".into())],
+                "any",
+            ),
+            // A non-reference look-alike (garbage) in an `i64` slot.
+            IIRInstr::new("const", Some("n".into()), vec![Operand::Int(64)], "i64"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("a".into()),
+                vec![Operand::Var("gc_alloc".into()), Operand::Var("n".into())],
+                "i64",
+            ),
+            // The collect under test (both entries return the freed count).
+            IIRInstr::new("call_builtin", Some("freed".into()), vec![Operand::Var(collect.into())], "i64"),
+            IIRInstr::new(
+                "call_builtin",
+                Some("lb".into()),
+                vec![Operand::Var("gc_live_bytes".into())],
+                "i64",
+            ),
+            IIRInstr::new("ret", None, vec![Operand::Var("lb".into())], "i64"),
+        ];
+        let mut m = IIRModule::new("gc_compact", "twig");
+        m.add_or_replace(IIRFunction::new("main", vec![], "i64", body));
+        m.entry_point = Some("main".into());
+        m
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let run = |tag: &str, collect: &str| -> i32 {
+        let m = build(collect);
+        let exe = dir.path().join(tag);
+        twig_aot::compile_module_to_macos_executable(&m, &exe)
+            .unwrap_or_else(|e| panic!("{tag} compiles+links: {e}"));
+        let out = Command::new(&exe).output().unwrap_or_else(|e| panic!("{tag} runs: {e}"));
+        out.status.code().unwrap_or_else(|| panic!("{tag} exited by signal: {out:?}"))
+    };
+
+    let precise = run("gc_compact_prec", "gc_collect_precise");
+    let compacting = run("gc_compact_comp", "gc_collect_compacting");
+
+    // The compacting collect keeps the live cons cell (a UAF would show live_bytes == 0)…
+    assert!(
+        compacting > 0,
+        "compacting collect must KEEP the live cons cell (live_bytes={compacting})",
+    );
+    // …and, with nothing movable yet, matches the precise collect exactly.
+    assert_eq!(
+        compacting, precise,
+        "frontend-triggered compaction must match precise (nothing movable yet): \
+         compacting={compacting}, precise={precise}",
+    );
+}
+
 /// AOT00-T1 (x86_64 PR-x4 / PR-x5) — precise roots reach through a **self-recursive**
 /// frame, not just the entry frame.
 ///

--- a/code/packages/rust/x86_64-backend/CHANGELOG.md
+++ b/code/packages/rust/x86_64-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — `x86_64-backend`
 
+## 0.33.0 - 2026-07-24 — `gc_collect_compacting` builtin (frontend GC.compact, AOT00-T3 §5)
+
+- New `V1_BUILTINS` entry `gc_collect_compacting` (0 args, returns the freed count) — the
+  moving/compacting collect, mirroring the aarch64 backend. The generic `__twig_<name>`
+  `call_builtin` dispatch auto-emits a `call __twig_gc_collect_compacting` (no per-name
+  lowering). A native program can now trigger a compaction. New emission unit test asserts
+  the external reloc symbol.
+
 ## 0.32.0 - 2026-07-23 — GC safepoints at self-recursive calls (AOT00-T1 x86_64 PR-x4)
 
 Closes the recursive-frame precision gap in `compile_function_with_globals_and_stackmap`.

--- a/code/packages/rust/x86_64-backend/Cargo.toml
+++ b/code/packages/rust/x86_64-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86_64-backend"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 description = "x86-64 (AMD64) backend for jit-core / aot-core — lowers CIR to native machine code via x86_64-encoder, with both System V (Linux) and Microsoft x64 (Windows) ABIs."
 

--- a/code/packages/rust/x86_64-backend/src/lib.rs
+++ b/code/packages/rust/x86_64-backend/src/lib.rs
@@ -399,12 +399,16 @@ const V1_BUILTINS: &[BuiltinSig] = &[
     // AOT00-T1 increment C / x86_64 PR-x3 — GC collection + observability entry points
     // a native program uses to drive and measure a collection (→ `__twig_gc_*` aliases
     // in gc-core-capi). `gc_collect` = forced conservative full collect; `gc_collect_precise`
-    // = precise-roots stack walk (returns objects freed); `gc_live_bytes` = live payload
-    // bytes; `gc_stackmap_count` = registered-function count. Mirrors the aarch64 backend.
-    BuiltinSig { name: "gc_collect",         n_args: 0, returns: false },
-    BuiltinSig { name: "gc_collect_precise", n_args: 0, returns: true  },
-    BuiltinSig { name: "gc_live_bytes",      n_args: 0, returns: true  },
-    BuiltinSig { name: "gc_stackmap_count",  n_args: 0, returns: true  },
+    // = precise-roots stack walk (returns objects freed); `gc_collect_compacting` =
+    // precise-roots *moving* collect (relocates movable survivors, rewriting the caller's
+    // root slots — spec AOT00-T3 §5; degrades to `gc_collect_precise` when nothing is
+    // movable); `gc_live_bytes` = live payload bytes; `gc_stackmap_count` = registered-
+    // function count. Mirrors the aarch64 backend.
+    BuiltinSig { name: "gc_collect",            n_args: 0, returns: false },
+    BuiltinSig { name: "gc_collect_precise",    n_args: 0, returns: true  },
+    BuiltinSig { name: "gc_collect_compacting", n_args: 0, returns: true  },
+    BuiltinSig { name: "gc_live_bytes",         n_args: 0, returns: true  },
+    BuiltinSig { name: "gc_stackmap_count",     n_args: 0, returns: true  },
 ];
 
 fn lookup_builtin(name: &str) -> Option<BuiltinSig> {
@@ -2191,6 +2195,27 @@ mod tests {
         let symbols: Vec<&str> = relocs.iter().map(|r| r.symbol.as_str()).collect();
         assert!(symbols.contains(&"__dyn_cons"), "missing cons call: {symbols:?}");
         assert!(symbols.contains(&"__dyn_car"), "missing car call: {symbols:?}");
+    }
+
+    /// `call_builtin "gc_collect_compacting" -> freed` lowers to a `call` to the linker
+    /// symbol `__twig_gc_collect_compacting` (the moving-collector C-ABI entry, spec
+    /// AOT00-T3 §5), via the generic `__twig_<name>` builtin dispatch — the same path
+    /// `gc_collect_precise` uses. Proves a native frontend can trigger a compaction.
+    #[test]
+    fn gc_collect_compacting_emits_external_twig_call() {
+        let ir = vec![
+            call_builtin(Some("freed"), "gc_collect_compacting", &[]),
+            instr("ret_u64", None, vec![Op::Var("freed".into())]),
+        ];
+        let (bytes, relocs) =
+            compile_function_with_relocs(&fn_ctx("gc_compact", &[], "u64"), &ir, X86_64Abi::SysV)
+                .expect("gc_collect_compacting must lower");
+        assert!(!bytes.is_empty());
+        let symbols: Vec<&str> = relocs.iter().map(|r| r.symbol.as_str()).collect();
+        assert!(
+            symbols.contains(&"__twig_gc_collect_compacting"),
+            "missing compacting-collect call: {symbols:?}",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## AOT00-T3 moving collector — frontend `GC.compact` hook

Wires the moving/compacting collector into the native-AOT frontend so a **compiled program can trigger a compaction** — the first end-to-end payoff of the moving-collector arc (which so far had a fully-implemented collector reachable only from Rust/C-ABI test code).

### Changes
- **gc-core-capi 0.16.0** — `__twig_gc_collect_compacting()` twig-compat alias → `__gc_collect_compacting` (mirrors `__twig_gc_collect_precise`): the `__twig_gc_*` linker name a native backend emits.
- **aarch64-backend 0.31.0 + x86_64-backend 0.33.0** — new `gc_collect_compacting` `V1_BUILTINS` row (0 args, returns freed count), beside `gc_collect` / `gc_collect_precise`. The generic `__twig_<name>` `call_builtin` dispatch **auto-emits** `BL`/`call __twig_gc_collect_compacting` — no per-name lowering. An emission unit test in each asserts the external reloc symbol.
- **twig-aot 0.45.0** — end-to-end macOS smoke test: a compiled program invokes `gc_collect_compacting`, keeps its live cons-cell reference, reclaims an `i64` look-alike, and yields the **identical** `live_bytes` to `gc_collect_precise` — proving a native frontend triggers a compaction that runs safely on a real thread stack.

### Grounded limitation (documented in the test + CHANGELOG)
Every frontend heap object is currently allocated **kind 0** (`__dyn_cons` → `__twig_gc_alloc` → `__gc_alloc`), traced conservatively and therefore **pinned** — so nothing is movable yet and the compacting collect provably degrades to *exactly* the precise collect. A true **address-relocation** differential is gated on frontend kind-registration (`__gc_alloc_kind` + ref-field maps so an object becomes movable) — a separate follow-up.

### Verification
- aarch64 + x86_64 backend emission unit tests pass; the twig-aot end-to-end smoke test **compiles → links → RUNS green** on aarch64 macOS; clippy clean.
- **No new `unsafe`** — the alias delegates to the already-Miri-clean `__gc_collect_compacting`; backend rows are data.
- **Adversarial `/security-review`: SAFE TO PUSH** — the compacting collect inherits `gc_collect_precise`'s exact, already-reviewed safepoint + live-ref-spilling machinery through a shared, **un-special-cased** lowering path (a safepoint is recorded at *every* call-return offset, with no per-builtin filter); the change is purely additive with no regression surface; and nothing is movable yet regardless.

**Precision ladder: … → precise-roots → compacting (core + C ABI + frontend-triggerable).**

gc-core-capi 0.15.0→0.16.0, aarch64-backend 0.30.0→0.31.0, x86_64-backend 0.32.0→0.33.0, twig-aot 0.44.0→0.45.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)