### PR TITLE
feat(adj-formula-stdlib): energy-conversions — NIST SP 811 B.9 energy-unit→joule factors (RS-5 table)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -378,6 +378,47 @@ fn shipped_time_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b7) Shipped table — reference/energy-conversions.adj resolves via import (energy
+//      unit → joules, EXACT SP 811 B.9 boldface factors), and a non-exact unit
+//      (`btu`) — which has no single exact factor and therefore no row — abstains.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_energy_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_energy");
+    let src = stdlib().join("reference/energy-conversions.adj");
+    std::fs::copy(&src, dir.join("energy-conversions.adj"))
+        .expect("copy shipped energy-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"energy-conversions.adj\"\n\
+         ? energy_to_joules(calorie_th, $J)\n\
+         ? energy_to_joules(kilowatt_hour, $J)\n\
+         ? energy_to_joules(erg, $J)\n\
+         ? energy_to_joules(btu, $J)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 "Energy" exact factors resolve, character-for-character
+    // from the table (boldface = exact; scientific notation to plain decimal).
+    assert!(out.contains("\"J\":\"4.184\""), "thermochemical calorie = 4.184 J: {out}");
+    assert!(out.contains("\"J\":\"3600000\""), "kilowatt-hour = 3600000 J: {out}");
+    assert!(out.contains("\"J\":\"0.0000001\""), "erg = 1e-7 J: {out}");
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `btu` is NOT a single exact factor (SP 811 lists it as a rounded measured
+    // value) — no row, so the engine abstains rather than commit to a rounded factor.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a non-exact unit abstains, never a fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/energy-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/energy-conversions.adj
@@ -1,0 +1,61 @@
+% ============================================================================
+% energy-conversions — energy-unit → joule factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of the `*-conversions.adj` references: a native tabular
+% relation ingested VERBATIM from a published NIST conversion table. Each row
+% states the factor converting one energy unit to the SI unit of energy, the joule:
+%
+%     ? energy_to_joules(calorie_th, $J)    % 4.184     (a thermochemical calorie)
+%     ? energy_to_joules(kilowatt_hour, $J) % 3600000   (a kW·h)
+%
+% Why a `table` and not several hand-written `relate` clauses: this is exactly the
+% shape reference data comes in — a published table, not prose. The citable
+% artifact IS the NIST conversion-factors table at the `locator` below; every
+% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors
+% for units listed alphabetically"), and the whole table is defended by one
+% provenance envelope rather than repeating `source`/`locator`/`trust` on every
+% row. Each `row` lowers to a ground relation `energy_to_joules(unit, joules)`, so
+% the exact lookup above is the ordinary SLD binding query — the engine returns
+% the factor WITH this table's citation as its proof, on the CPU, with zero model
+% calls. A looked-up factor is a number, so it can feed a `let`/`formula`
+% downstream (e.g. multiply an energy quantity by it) through the existing slot path.
+%
+% HONESTY NOTE (like time-conversions, these are EXACT defined factors, not
+% rounded ones): NIST SP 811 B.9 prints these five "Energy" factors in BOLDFACE,
+% its convention for factors that are EXACT by definition, transcribed here as the
+% plain decimal number of joules each unit names:
+%
+%     calorie (thermochemical)      4.184  E+00   →  4.184
+%     calorie (International Table)  4.1868 E+00   →  4.1868
+%     erg                           1.0    E-07   →  0.0000001
+%     watt hour (W·h)               3.6    E+03   →  3600
+%     kilowatt hour (kW·h)          3.6    E+06   →  3600000
+%
+% The calorie is split into its TWO exact definitions — the thermochemical calorie
+% (`calorie_th`, exactly 4.184 J) and the International Table calorie (`calorie_it`,
+% exactly 4.1868 J) — because a bare "calorie" is ambiguous between them and the
+% engine must never guess which; a caller names the one it means. Deliberately
+% OMITTED: the British thermal unit (1.054350 / 1.055056 E+03, a rounded measured
+% factor, not exact), the electronvolt (1.602177 E-19, tied to a measured constant),
+% and the foot pound-force (1.355818 E+00) — none is a single EXACT defined factor,
+% so a `? energy_to_joules(btu, $J)` (etc.) ABSTAINS rather than committing to a
+% rounded value. The only claim this table makes is "these are the exact factors
+% NIST SP 811 B.9 prints" — which is exactly what a byte-check against the cited
+% table verifies. `trust authoritative` — a primary, re-fetchable standards
+% reference. (See ADJ-TABLES.md; and feedback_nothing_human_authored — every factor
+% is a verbatim cell of the cited table, nothing asserted from memory.)
+% ============================================================================
+
+table energy_to_joules {
+    columns unit, joules
+
+    row (calorie_th, 4.184)
+    row (calorie_it, 4.1868)
+    row (erg, 0.0000001)
+    row (watt_hour, 3600)
+    row (kilowatt_hour, 3600000)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/energy-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/energy-conversions.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% energy-conversions.query.adj — a worked lookup over the energy-conversions table.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a "how many joules
+% in a kilowatt-hour?" question: it states no conversion fact — it only `import`s
+% the grounded table and asks binding queries. The native adj-lang engine resolves
+% each `?` against the table's rows (lowered to `energy_to_joules` relations) and
+% returns the binding + the table's source/locator/trust. A unit not in the table
+% abstains honestly — the engine never invents a factor (notably the Btu and the
+% electronvolt, which have no single EXACT factor and so have no row).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli energy-conversions.query.adj
+% ============================================================================
+
+import "energy-conversions.adj"
+
+? energy_to_joules(calorie_th, $J)     % expect 4.184
+? energy_to_joules(kilowatt_hour, $J)  % expect 3600000
+? energy_to_joules(erg, $J)            % expect 0.0000001
+? energy_to_joules(btu, $J)            % expect abstain — not a single exact factor, not a row


### PR DESCRIPTION
## What

Adds a new grounded RS-5 `table` to the ADJ formula stdlib: **energy-unit → joules**, a sibling of the existing length/mass/area/volume/time conversion references.

```
? energy_to_joules(calorie_th, $J)     % 4.184
? energy_to_joules(kilowatt_hour, $J)  % 3600000
? energy_to_joules(erg, $J)            % 0.0000001
? energy_to_joules(btu, $J)            % abstain — no single exact factor
```

## Grounding

Every value is a verbatim cell of **NIST SP 811, Appendix B.9** ("Factors for units listed alphabetically"), "Energy" section, printed in **boldface** — NIST's convention for factors that are *exact by definition*:

| unit | SP 811 | joules |
|------|--------|--------|
| calorie (thermochemical) | 4.184 E+00 | 4.184 |
| calorie (International Table) | 4.1868 E+00 | 4.1868 |
| erg | 1.0 E-07 | 0.0000001 |
| watt hour | 3.6 E+03 | 3600 |
| kilowatt hour | 3.6 E+06 | 3600000 |

The **calorie is split into its two exact definitions** (`calorie_th` vs `calorie_it`) because a bare "calorie" is ambiguous between them and the engine must never guess which — a caller names the one it means.

**Deliberately omitted:** the British thermal unit, electronvolt, and foot pound-force are rounded/measured factors, not single exact defined ones, so a lookup for them **abstains** rather than committing to a rounded value (mirrors time-conversions omitting the year).

The whole table is defended by one provenance envelope (`trust authoritative`, re-fetchable at the NIST URL); each `row` lowers to a ground `energy_to_joules(unit, joules)` relation, so exact lookup is the ordinary SLD binding query — the engine returns the factor **with the table's citation**, on the CPU, 0 model calls.

## Files
- `reference/energy-conversions.adj` + `.query.adj` — new shipped grounded table + worked lookup
- `rs5_table_e2e.rs` — `shipped_energy_conversions_table_resolves_and_abstains`

## Verification
- New e2e test + full `rs5_table_e2e` suite: **12 passed**
- Shipped `.query.adj` through the built CLI: binds 4.184 / 3600000 / 0.0000001 each with the NIST citation; `btu` abstains
- Data + test only — no crate code touched, no version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)