### PR TITLE
feat(adj-formula-stdlib): momentum — HyperPhysics p = m·v definition library (physics track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_momentum_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_momentum_e2e.rs
@@ -1,0 +1,143 @@
+//! End-to-end tests for the `physics/momentum.adj` library — the definition of
+//! linear momentum (p = m·v) and its two exact rearrangements (v = p/m, m = p/v) —
+//! driven through the built CLI binary against the SHIPPED stdlib. Each proves the
+//! same invariant as the other formula libraries: a consumer states NO arithmetic;
+//! it imports the grounded library, binds the physical quantities with `observe`,
+//! and the engine applies the cited definition on the CPU — computing the EXACT
+//! value and rendering the definition's citation + trust tier in the `derived`
+//! section (the auditable answer). The three formulas INVERT: 2 * 5 = 10, and both
+//! 10 / 2 = 5 and 10 / 5 = 2 recover the inputs.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped momentum library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_momentum_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/physics/momentum.adj")
+        .canonicalize()
+        .expect("shipped momentum.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_mom_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_momentum_lib()).unwrap();
+    std::fs::write(dir.join("momentum.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// momentum — the definition: the mass times the velocity.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_momentum_library_and_computes_definition_with_citation() {
+    let dir = scratch("def");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"momentum.adj\"\n\
+         observe mass(2)\n\
+         observe velocity(5)\n\
+         ? momentum(mass, velocity)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied definition's result: 2 * 5 = 10.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"momentum\"") && s.contains("\"value\":10"),
+        "momentum(2, 5) = 10: {s}"
+    );
+    // … AND the HyperPhysics citation + trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"")
+            && s.contains("hyperphysics.gsu.edu/hbase/mom.html"),
+        "applied definition carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// velocity — the same definition solved for v: the momentum divided by the mass,
+// which INVERTS the momentum just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_velocity_as_momentum_over_mass_with_citation() {
+    let dir = scratch("vel");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"momentum.adj\"\n\
+         observe momentum(10)\n\
+         observe mass(2)\n\
+         ? velocity(momentum, mass)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 10 / 2 = 5, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"velocity\"") && s.contains("\"value\":5"),
+        "velocity(10, 2) = 5: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"")
+            && s.contains("hyperphysics.gsu.edu/hbase/mom.html"),
+        "velocity carries its HyperPhysics citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// mass — the same definition solved for m: the momentum divided by the velocity,
+// the third exact reading of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_mass_as_momentum_over_velocity_with_citation() {
+    let dir = scratch("mass");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"momentum.adj\"\n\
+         observe momentum(10)\n\
+         observe velocity(5)\n\
+         ? mass(momentum, velocity)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 10 / 5 = 2, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"mass\"") && s.contains("\"value\":2"),
+        "mass(10, 5) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"")
+            && s.contains("hyperphysics.gsu.edu/hbase/mom.html"),
+        "mass carries its HyperPhysics citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/physics/momentum.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/momentum.adj
@@ -1,0 +1,86 @@
+% ============================================================================
+% momentum.adj — the definition of linear momentum in the ADJ standard library.
+% ============================================================================
+% The momentum entry of the *physics* track, a sibling of `density.adj`,
+% `pressure.adj` and `electricity.adj`: the foundational mechanics definition a
+% first course states as LINEAR MOMENTUM IS THE PRODUCT OF MASS AND VELOCITY, as an
+% importable, byte-provenanced, PARAMETERIZED `formula`, together with its two exact
+% rearrangements (the velocity a momentum implies for a mass, and the mass it
+% implies for a velocity). As with every compute library, a consumer states NO
+% arithmetic: it `import`s this file, binds the physical quantities from its own
+% byte-provenance decomposition, and asks the engine to APPLY the cited definition
+% on the CPU. Zero math is performed by the model; the engine computes each value
+% EXACTLY, carrying the definition's citation.
+%
+%     import "momentum.adj"
+%     observe mass(2)                % "…2 kg…"     (span cited by the model)
+%     observe velocity(5)            % "…at 5 m/s…" (span cited by the model)
+%     ? momentum(mass, velocity)     % engine → 10, carrying the def p = m·v
+%
+% All three formulas are EXACT over their parameters — one a product, two quotients
+% of measured quantities. There is no *separately grounded* physical constant here,
+% so every value the engine returns is exact. The three COMPOSE and invert cleanly:
+% the `momentum` a consumer computes from a mass moving at a velocity is exactly the
+% `momentum` the `velocity` formula divides by that mass to recover the velocity,
+% and exactly the `momentum` the `mass` formula divides by that velocity to recover
+% the mass.
+%
+%   momentum(mass, velocity)     = mass * velocity        %  p = m·v   (definition of momentum)
+%   velocity(momentum, mass)     = momentum / mass         %  v = p/m   (the same definition, solved for v)
+%   mass(momentum, velocity)     = momentum / velocity     %  m = p/v   (the same definition, solved for m)
+%
+% All three formulas are defended by the SAME definitional sentence — "The momentum
+% of a particle is defined as the product of its mass times its velocity." — because
+% that one definition sanctions the relation read every way (p from m and v, v from
+% p and m, or m from p and v). The quote is transcribed verbatim from Georgia State
+% University's HyperPhysics (a university .edu physics reference — the same primary
+% source `density.adj`, `pressure.adj` and `electricity.adj` cite), so each `formula`
+% carries the provenance envelope every shipped grounded clause carries; the linter
+% rejects an unsourced one. (See feedback_nothing_human_authored — the definitional
+% sentence is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable physical quantity the definition
+% ranges over, and each result is the derived quantity. `momentum`, `mass` and
+% `velocity` each appear BOTH as a derived result and as an input (of the other
+% formulas), so each is a single dictionary term used in both roles. The `surface`
+% lists are the everyday names a decomposer maps onto the canonical term; the
+% trailing comment records the intended SI unit.
+% ----------------------------------------------------------------------------
+dictionary momentum_vocab {
+    define mass     : finding  surface "mass", "m"                  % mass, e.g. kg
+    define velocity : finding  surface "velocity", "speed", "v"    % velocity, e.g. m/s
+    define momentum : finding  surface "momentum", "p"             % momentum, e.g. kg·m/s
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable `let` over
+% its formal parameters, bound at apply time, and each carries the definitional
+% quote from HyperPhysics (a quote is required on a shipped formula). One is a
+% product and two are quotients, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook momentum_laws {
+    use momentum_vocab
+
+    % Momentum — the product of mass and velocity. HyperPhysics defines the momentum
+    % of a particle as its mass multiplied by its velocity, i.e. p = m·v.
+    formula momentum(mass, velocity) = mass * velocity
+        source "The momentum of a particle is defined as the product of its mass times its velocity."
+        locator "https://hyperphysics.gsu.edu/hbase/mom.html"
+        trust authoritative
+
+    % Velocity — the same definition solved for the velocity a momentum implies for a
+    % mass (v = p/m). Defended by the SAME definitional sentence, read the other way.
+    formula velocity(momentum, mass) = momentum / mass
+        source "The momentum of a particle is defined as the product of its mass times its velocity."
+        locator "https://hyperphysics.gsu.edu/hbase/mom.html"
+        trust authoritative
+
+    % Mass — the same definition solved for the mass a momentum implies for a
+    % velocity (m = p/v). Again the SAME definitional sentence, read the third way.
+    formula mass(momentum, velocity) = momentum / velocity
+        source "The momentum of a particle is defined as the product of its mass times its velocity."
+        locator "https://hyperphysics.gsu.edu/hbase/mom.html"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/physics/momentum.query.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/momentum.query.adj
@@ -1,0 +1,33 @@
+% ============================================================================
+% momentum.query.adj — worked examples over the physics momentum library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a momentum
+% question: it states NO arithmetic and NO definition — it only `import`s the
+% grounded library, `observe`s the physical quantities it decomposed from the
+% prompt (each a byte-provenanced span, elided here), and asks the engine to APPLY
+% the cited definition. The native adj-lang engine binds the parameters, computes
+% each value EXACTLY on the CPU, and returns it with the definition's
+% source/locator/trust.
+%
+% The three questions INVERT: a 2 kg mass at 5 m/s carries a momentum of 10
+% kg·m/s; that 10 kg·m/s momentum is exactly what the velocity formula divides by
+% the 2 kg mass to recover the 5 m/s, and exactly what the mass formula divides by
+% the 5 m/s to recover the 2 kg.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli momentum.query.adj
+% ============================================================================
+
+import "momentum.adj"
+
+% A 2 kg mass moving at 5 m/s: momentum = 2 * 5.
+observe mass(2)
+observe velocity(5)
+? momentum(mass, velocity)     % expect 10   (definition: p = m·v)
+
+% That 10 kg·m/s momentum for the same 2 kg mass: velocity = 10 / 2.
+observe momentum(10)
+? velocity(momentum, mass)      % expect 5    (same definition, solved for v = p/m)
+
+% That 10 kg·m/s momentum at the same 5 m/s: mass = 10 / 5.
+? mass(momentum, velocity)      % expect 2    (same definition, solved for m = p/v)


### PR DESCRIPTION
New **Libraries (FL)** entry on the physics track — a sibling of `density.adj` / `pressure.adj` / `electricity.adj`. Linear momentum as an importable, byte-provenanced, parameterized `formula`, with its two exact rearrangements:

- `momentum(mass, velocity) = mass * velocity`   — p = m·v (the definition)
- `velocity(momentum, mass)  = momentum / mass`    — v = p/m (same def, solved for v)
- `mass(momentum, velocity)  = momentum / velocity` — m = p/v (same def, solved for m)

**Grounding.** All three formulas are defended by the *same* definitional sentence — "The momentum of a particle is defined as the product of its mass times its velocity." — transcribed verbatim from Georgia State University's HyperPhysics (`hbase/mom.html`), the same authoritative `.edu` primary source density/pressure/electricity already cite. Each `formula` carries the provenance envelope; the linter rejects an unsourced one (a verbatim span of the cited page, not asserted from memory).

**Behaviour.** A consumer states NO arithmetic and NO definition: it imports the library, binds the physical quantities with `observe` (byte-provenanced spans), and the engine applies the cited definition on the CPU — computing each value EXACTLY and carrying the citation. No separately-grounded constant, so every value is exact. The three formulas compose and invert cleanly: `2 * 5 = 10`, and both `10 / 2 = 5` and `10 / 5 = 2` recover the inputs.

**Files (mirrors the density PR's exact 3-file scope — no version bump, data + test only):**
- New: `physics/momentum.adj` + `momentum.query.adj` (worked three-way inverting example).
- Test: `formula_momentum_e2e` — `momentum(2,5)=10`, `velocity(10,2)=5`, `mass(10,5)=2`, each carrying the `mom.html` citation + `authoritative` trust. **3/3 pass.** Full `formula_*` suite green; shipped query verified through the CLI (derived: momentum=10, velocity=5, mass=2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)