### PR TITLE
feat(spice): add JFET drain resistance

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add JFET model-card `RD` drain-resistance support with an intrinsic drain
+  node across DC, transient, AC, transfer-function, and noise analysis, plus
+  hierarchy preservation, validation, and a distinct thermal-noise source.
 - Add JFET model-card `IS` gate-junction saturation-current support,
   defaulting to `1e-14`, stamping `IGS`/`IGD` leakage in DC, transient, AC,
   and transfer-function analyses, and emitting distinct shot-noise sources.

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -517,6 +517,7 @@ class JFET:
     Pb: float = 1.0
     Fc: float = 0.5
     Is: float = 1.0e-14
+    Rd: float = 0.0
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -604,7 +604,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
             element.Af,
         )
     if isinstance(element, JFET):
-        return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_, element.Cgs, element.Cgd, element.Kf, element.Af, element.Pb, element.Fc)
+        return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_, element.Cgs, element.Cgd, element.Kf, element.Af, element.Pb, element.Fc, element.Is, element.Rd)
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
@@ -7262,7 +7262,10 @@ def _element_nodes(el: Element) -> list[str]:
             nodes.append(_diode_intrinsic_anode_node(el))
         return nodes
     if isinstance(el, JFET):
-        return [el.drain, el.gate, el.source]
+        nodes = [el.drain, el.gate, el.source]
+        if el.Rd > 0.0:
+            nodes.append(_jfet_intrinsic_drain_node(el))
+        return nodes
     if isinstance(el, Mosfet):
         return [el.drain, el.gate, el.source, el.body]
     if isinstance(el, BJT):
@@ -8911,8 +8914,23 @@ def _jfet_charge_state_specs(el: JFET) -> list[tuple[str, str, str, float]]:
     if el.Cgs > 0.0:
         specs.append((_jfet_gate_source_charge_state_name(el), el.gate, el.source, el.Cgs))
     if el.Cgd > 0.0:
-        specs.append((_jfet_gate_drain_charge_state_name(el), el.gate, el.drain, el.Cgd))
+        specs.append(
+            (
+                _jfet_gate_drain_charge_state_name(el),
+                el.gate,
+                _jfet_intrinsic_drain_node(el),
+                el.Cgd,
+            )
+        )
     return specs
+
+
+def _jfet_intrinsic_drain_node(el: JFET) -> str:
+    return (
+        el.drain
+        if not math.isfinite(el.Rd) or el.Rd <= 0.0
+        else f"__spice_{el.name}_drain"
+    )
 
 
 def _jfet_charge_state_voltage(n_plus: str, n_minus: str, node_voltages: dict[str, float]) -> float:
@@ -9086,6 +9104,8 @@ def _eval_jfet(el: JFET, vgs: float, vds: float) -> tuple[float, float, float]:
         raise ValueError(
             f"JFET '{el.name}' gate saturation current must be finite and non-negative"
         )
+    if not math.isfinite(el.Rd) or el.Rd < 0.0:
+        raise ValueError(f"JFET '{el.name}' drain resistance must be finite and non-negative")
     if el.polarity == "PJF":
         ids, gm, gds = _eval_njf(-vgs, -vds, -el.vto, el.beta, el.lambda_)
         return -ids, gm, gds
@@ -9157,16 +9177,17 @@ def _stamp_jfet(
     node_to_idx: dict[str, int],
     el: JFET,
 ) -> None:
-    Vd = 0.0 if _is_ground(el.drain) else x[node_to_idx[el.drain]]
+    intrinsic_drain = _jfet_intrinsic_drain_node(el)
+    Vd = 0.0 if _is_ground(intrinsic_drain) else x[node_to_idx[intrinsic_drain]]
     Vg = 0.0 if _is_ground(el.gate) else x[node_to_idx[el.gate]]
     Vs = 0.0 if _is_ground(el.source) else x[node_to_idx[el.source]]
     vgs = Vg - Vs
     vds = Vd - Vs
     ids, gm, gds = _eval_jfet(el, vgs, vds)
 
-    _stamp_g(G, node_to_idx, el.drain, el.source, gds)
-    if not _is_ground(el.drain):
-        d = node_to_idx[el.drain]
+    _stamp_g(G, node_to_idx, intrinsic_drain, el.source, gds)
+    if not _is_ground(intrinsic_drain):
+        d = node_to_idx[intrinsic_drain]
         if not _is_ground(el.gate):
             G[d][node_to_idx[el.gate]] += gm
         if not _is_ground(el.source):
@@ -9178,12 +9199,14 @@ def _stamp_jfet(
         if not _is_ground(el.source):
             G[s][node_to_idx[el.source]] += gm
     Ieq = ids - gm * vgs - gds * vds
-    if not _is_ground(el.drain):
-        b[node_to_idx[el.drain]] -= Ieq
+    if not _is_ground(intrinsic_drain):
+        b[node_to_idx[intrinsic_drain]] -= Ieq
     if not _is_ground(el.source):
         b[node_to_idx[el.source]] += Ieq
     _stamp_jfet_gate_junction(G, b, node_to_idx, el, el.source, Vg - Vs)
-    _stamp_jfet_gate_junction(G, b, node_to_idx, el, el.drain, Vg - Vd)
+    _stamp_jfet_gate_junction(G, b, node_to_idx, el, intrinsic_drain, Vg - Vd)
+    if el.Rd > 0.0:
+        _stamp_g(G, node_to_idx, el.drain, intrinsic_drain, 1.0 / el.Rd)
 
 
 def _bjt_early_factor(el: BJT, junction_voltage: float, output_voltage: float) -> float:
@@ -12797,23 +12820,24 @@ def _stamp_ac(
             _stamp_g_c(G, node_to_idx, el.anode, intrinsic_anode, 1.0 / el.Rs)
 
     elif isinstance(el, JFET):
-        Vd = 0.0 if _is_ground(el.drain) else dc_x[node_to_idx[el.drain]]
+        intrinsic_drain = _jfet_intrinsic_drain_node(el)
+        Vd = 0.0 if _is_ground(intrinsic_drain) else dc_x[node_to_idx[intrinsic_drain]]
         Vg = 0.0 if _is_ground(el.gate) else dc_x[node_to_idx[el.gate]]
         Vs = 0.0 if _is_ground(el.source) else dc_x[node_to_idx[el.source]]
         _, gm_j, gds_j = _eval_jfet(el, Vg - Vs, Vd - Vs)
         _, ggs = _jfet_gate_junction_current_conductance(el, Vg - Vs)
         _, ggd = _jfet_gate_junction_current_conductance(el, Vg - Vd)
-        _stamp_g_c(G, node_to_idx, el.drain, el.source, gds_j + 0j)
+        _stamp_g_c(G, node_to_idx, intrinsic_drain, el.source, gds_j + 0j)
         _stamp_g_c(G, node_to_idx, el.gate, el.source, ggs + 0j)
-        _stamp_g_c(G, node_to_idx, el.gate, el.drain, ggd + 0j)
+        _stamp_g_c(G, node_to_idx, el.gate, intrinsic_drain, ggd + 0j)
         if el.Cgs > 0.0:
             cgs = _jfet_charge_dynamic_capacitance(el, el.Cgs, Vg - Vs)
             _stamp_g_c(G, node_to_idx, el.gate, el.source, 1j * omega * cgs)
         if el.Cgd > 0.0:
             cgd = _jfet_charge_dynamic_capacitance(el, el.Cgd, Vg - Vd)
-            _stamp_g_c(G, node_to_idx, el.gate, el.drain, 1j * omega * cgd)
-        if not _is_ground(el.drain):
-            d = node_to_idx[el.drain]
+            _stamp_g_c(G, node_to_idx, el.gate, intrinsic_drain, 1j * omega * cgd)
+        if not _is_ground(intrinsic_drain):
+            d = node_to_idx[intrinsic_drain]
             if not _is_ground(el.gate):
                 G[d][node_to_idx[el.gate]] += gm_j + 0j
             if not _is_ground(el.source):
@@ -12824,6 +12848,8 @@ def _stamp_ac(
                 G[s][node_to_idx[el.gate]] -= gm_j + 0j
             if not _is_ground(el.source):
                 G[s][node_to_idx[el.source]] += gm_j + 0j
+        if el.Rd > 0.0:
+            _stamp_g_c(G, node_to_idx, el.drain, intrinsic_drain, 1.0 / el.Rd)
 
     elif isinstance(el, Mosfet):
         # Small-signal model: gds (output conductance) + gm (transconductance).
@@ -13516,17 +13542,22 @@ def _build_ss_matrix(
                 _stamp_g(G, node_to_idx, el.anode, intrinsic_anode, 1.0 / el.Rs)
 
         elif isinstance(el, JFET):
-            Vd = 0.0 if _is_ground(el.drain) else dc_x[node_to_idx[el.drain]]
+            intrinsic_drain = _jfet_intrinsic_drain_node(el)
+            Vd = (
+                0.0
+                if _is_ground(intrinsic_drain)
+                else dc_x[node_to_idx[intrinsic_drain]]
+            )
             Vg = 0.0 if _is_ground(el.gate) else dc_x[node_to_idx[el.gate]]
             Vs = 0.0 if _is_ground(el.source) else dc_x[node_to_idx[el.source]]
             _, gm_j, gds_j = _eval_jfet(el, Vg - Vs, Vd - Vs)
             _, ggs = _jfet_gate_junction_current_conductance(el, Vg - Vs)
             _, ggd = _jfet_gate_junction_current_conductance(el, Vg - Vd)
-            _stamp_g(G, node_to_idx, el.drain, el.source, gds_j)
+            _stamp_g(G, node_to_idx, intrinsic_drain, el.source, gds_j)
             _stamp_g(G, node_to_idx, el.gate, el.source, ggs)
-            _stamp_g(G, node_to_idx, el.gate, el.drain, ggd)
-            if not _is_ground(el.drain):
-                d = node_to_idx[el.drain]
+            _stamp_g(G, node_to_idx, el.gate, intrinsic_drain, ggd)
+            if not _is_ground(intrinsic_drain):
+                d = node_to_idx[intrinsic_drain]
                 if not _is_ground(el.gate):
                     G[d][node_to_idx[el.gate]] += gm_j
                 if not _is_ground(el.source):
@@ -13537,6 +13568,8 @@ def _build_ss_matrix(
                     G[s][node_to_idx[el.gate]] -= gm_j
                 if not _is_ground(el.source):
                     G[s][node_to_idx[el.source]] += gm_j
+            if el.Rd > 0.0:
+                _stamp_g(G, node_to_idx, el.drain, intrinsic_drain, 1.0 / el.Rd)
 
         elif isinstance(el, Mosfet):
             # Small-signal model: gds (drain–source) + gm VCCS (gate–source
@@ -15398,19 +15431,32 @@ def _collect_noise_sources(
                 sources.append((el.name, "thermal", n_d, n_s, psd, 0.0))
 
         elif isinstance(el, JFET):
-            Vd = 0.0 if _is_ground(el.drain) else dc_x[node_to_idx[el.drain]]
+            intrinsic_drain = _jfet_intrinsic_drain_node(el)
+            Vd = (
+                0.0
+                if _is_ground(intrinsic_drain)
+                else dc_x[node_to_idx[intrinsic_drain]]
+            )
             Vg = 0.0 if _is_ground(el.gate) else dc_x[node_to_idx[el.gate]]
             Vs = 0.0 if _is_ground(el.source) else dc_x[node_to_idx[el.source]]
             drain_current, gm, _ = _eval_jfet(el, Vg - Vs, Vd - Vs)
             gm = max(0.0, float(gm))
             if gm > 0.0:
                 psd = kT4 * _MOSFET_CHANNEL_NOISE_GAMMA * gm
-                n_d = None if _is_ground(el.drain) else node_to_idx[el.drain]
+                n_d = (
+                    None
+                    if _is_ground(intrinsic_drain)
+                    else node_to_idx[intrinsic_drain]
+                )
                 n_s = None if _is_ground(el.source) else node_to_idx[el.source]
                 sources.append((el.name, "thermal", n_d, n_s, psd, 0.0))
             n_g = None if _is_ground(el.gate) else node_to_idx[el.gate]
             n_s = None if _is_ground(el.source) else node_to_idx[el.source]
-            n_d = None if _is_ground(el.drain) else node_to_idx[el.drain]
+            n_d = (
+                None
+                if _is_ground(intrinsic_drain)
+                else node_to_idx[intrinsic_drain]
+            )
             gate_source_current, _ = _jfet_gate_junction_current_conductance(
                 el, Vg - Vs
             )
@@ -15424,10 +15470,25 @@ def _collect_noise_sources(
                 (f"{el.name}:IGD", "shot", n_g, n_d, q2 * abs(gate_drain_current), 0.0)
             )
             if el.Kf > 0.0:
-                n_d = None if _is_ground(el.drain) else node_to_idx[el.drain]
+                n_d = (
+                    None
+                    if _is_ground(intrinsic_drain)
+                    else node_to_idx[intrinsic_drain]
+                )
                 n_s = None if _is_ground(el.source) else node_to_idx[el.source]
                 sources.append(
                     (el.name, "flicker", n_d, n_s, el.Kf * abs(drain_current) ** el.Af, 1.0)
+                )
+            if el.Rd > 0.0:
+                sources.append(
+                    (
+                        f"{el.name}:RD",
+                        "thermal",
+                        node_to_idx.get(el.drain),
+                        node_to_idx.get(intrinsic_drain),
+                        kT4 / el.Rd,
+                        0.0,
+                    )
                 )
 
         # Capacitors, Inductors, VoltageSources, CurrentSources: noiseless in

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -309,8 +309,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (15, 21, 5, 3),
     "NPN": (41, 58, 13, 4),
     "PNP": (41, 58, 13, 4),
-    "NJF": (10, 17, 6, 3),
-    "PJF": (10, 17, 6, 3),
+    "NJF": (11, 18, 6, 3),
+    "PJF": (11, 18, 6, 3),
     "NMOS": (18, 25, 6, 3),
     "PMOS": (18, 25, 6, 3),
 }
@@ -436,6 +436,7 @@ _JFET_PARAMETER_ALIASES: dict[str, str] = {
     "VJ": "PB",
     "FC": "FC",
     "IS": "IS",
+    "RD": "RD",
 }
 
 _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
@@ -1013,6 +1014,7 @@ def jfet_from_model_card(
         Pb=p.get("PB", 1.0),
         Fc=p.get("FC", 0.5),
         Is=p.get("IS", 1.0e-14),
+        Rd=p.get("RD", 0.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -407,7 +407,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 153
+    assert len(coverage) == 155
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -422,7 +422,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 153
+    assert len(records) == 155
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -496,9 +496,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 153
-    assert report.expected_canonical_parameter_count == 153
-    assert report.accepted_name_count == 221
+    assert report.canonical_parameter_count == 155
+    assert report.expected_canonical_parameter_count == 155
+    assert report.accepted_name_count == 223
     assert report.aliased_parameter_count == 55
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -506,7 +506,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t153\t153\t221\t55\t4\t0"
+        "true\t7\t7\t155\t155\t223\t55\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -534,8 +534,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 152
-    assert report.accepted_name_count == 218
+    assert report.canonical_parameter_count == 154
+    assert report.accepted_name_count == 220
     assert report.aliased_parameter_count == 54
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -550,7 +550,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t152\t153\t218\t54\t4\t4\n"
+        "false\t7\t7\t154\t155\t220\t54\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -675,6 +675,7 @@ def test_model_card_aliases_build_device_instances() -> None:
             "VJ": 0.8,
             "FC": 0.35,
             "IS": 2.0e-13,
+            "RD": 125.0,
         },
     )
     jfet_model = jfet_from_model_card("J1", "d", "g", "s", jfet_card)
@@ -687,6 +688,7 @@ def test_model_card_aliases_build_device_instances() -> None:
         "PB": 0.8,
         "FC": 0.35,
         "IS": 2.0e-13,
+        "RD": 125.0,
     }
     assert jfet_model.polarity == "NJF"
     assert jfet_model.beta == pytest.approx(9.0e-4)
@@ -697,6 +699,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert jfet_model.Pb == pytest.approx(0.8)
     assert jfet_model.Fc == pytest.approx(0.35)
     assert jfet_model.Is == pytest.approx(2.0e-13)
+    assert jfet_model.Rd == pytest.approx(125.0)
 
     mos_card = normalize_model_card(
         "Mn",
@@ -779,6 +782,28 @@ def test_dc_rejects_invalid_jfet_gate_saturation_current() -> None:
         match="gate saturation current must be finite and non-negative",
     ):
         dc_op(circuit)
+
+
+def test_dc_rejects_invalid_jfet_drain_resistance() -> None:
+    circuit = Circuit()
+    circuit.add(JFET("J1", "drain", "gate", "0", Rd=-1.0))
+
+    with pytest.raises(
+        ValueError,
+        match="drain resistance must be finite and non-negative",
+    ):
+        dc_op(circuit)
+
+
+def test_dc_jfet_drain_resistance_drops_intrinsic_drain_voltage() -> None:
+    circuit = Circuit()
+    circuit.add(VoltageSource("Vdrain", "drain", "0", 5.0))
+    circuit.add(VoltageSource("Vgate", "gate", "0", 0.0))
+    circuit.add(JFET("J1", "drain", "gate", "0", beta=1.0e-3, Rd=1_000.0))
+
+    result = dc_op(circuit)
+    assert result.node_voltages["drain"] == pytest.approx(5.0)
+    assert result.node_voltages["__spice_J1_drain"] < 5.0
 
 
 def test_jfet_gate_saturation_current_loads_a_forward_biased_gate() -> None:
@@ -2563,7 +2588,7 @@ def test_subcircuit_expansion_preserves_complete_jfet_model():
     cell = SubcircuitDefinition(
         "jfet-cell",
         ("d", "g", "s"),
-        (JFET("Jcell", "d", "g", "s", Kf=1.0e-12, Af=1.3, Pb=0.8, Fc=0.35, Is=2.0e-13),),
+        (JFET("Jcell", "d", "g", "s", Kf=1.0e-12, Af=1.3, Pb=0.8, Fc=0.35, Is=2.0e-13, Rd=125.0),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2575,6 +2600,7 @@ def test_subcircuit_expansion_preserves_complete_jfet_model():
     assert expanded.Pb == pytest.approx(0.8)
     assert expanded.Fc == pytest.approx(0.35)
     assert expanded.Is == pytest.approx(2.0e-13)
+    assert expanded.Rd == pytest.approx(125.0)
 
 
 def test_subcircuit_expansion_preserves_complete_bjt_model():
@@ -7589,6 +7615,22 @@ def test_noise_jfet_kf_adds_inverse_frequency_flicker_noise() -> None:
 
     assert flicker_psds[0] > 0.0
     assert flicker_psds[0] / flicker_psds[1] == pytest.approx(100.0)
+
+
+def test_noise_jfet_rd_adds_thermal_noise() -> None:
+    circuit = Circuit()
+    circuit.add(VoltageSource("Vdd", "vdd", "0", 5.0))
+    circuit.add(VoltageSource("Vgate", "gate", "0", 0.0))
+    circuit.add(Resistor("Rload", "vdd", "out", 1_000.0))
+    circuit.add(JFET("J1", "out", "gate", "0", Rd=250.0))
+
+    entries = noise_ac(circuit, "out", "Vgate", freqs=[1_000.0]).points[0].entries
+    rd = next(
+        entry
+        for entry in entries
+        if entry.element_name == "J1:RD" and entry.noise_type == "thermal"
+    )
+    assert rd.source_psd == pytest.approx(4.0 * 1.380_649e-23 * 300.0 / 250.0)
 
 
 def test_noise_jfet_gate_junctions_emit_distinct_shot_sources() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add JFET model-card `RD` drain-resistance support with an intrinsic drain
+  node across DC, transient, AC, transfer-function, and noise analysis, plus
+  hierarchy preservation, validation, and a distinct thermal-noise source.
 - Add JFET model-card `IS` gate-junction saturation-current support,
   defaulting to `1e-14`, stamping `IGS`/`IGD` leakage in DC, transient, AC,
   and transfer-function analyses, and emitting distinct shot-noise sources.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -431,6 +431,7 @@ fn clone_subckt_element(
             mapped.junction_potential = element.junction_potential;
             mapped.forward_bias_depletion_coefficient = element.forward_bias_depletion_coefficient;
             mapped.gate_saturation_current = element.gate_saturation_current;
+            mapped.drain_resistance = element.drain_resistance;
             Element::Jfet(mapped)
         }
         Element::Bjt(element) => {
@@ -2823,6 +2824,7 @@ pub struct Jfet {
     pub junction_potential: f64,
     pub forward_bias_depletion_coefficient: f64,
     pub gate_saturation_current: f64,
+    pub drain_resistance: f64,
 }
 
 impl Jfet {
@@ -2896,6 +2898,7 @@ impl Jfet {
             junction_potential: 1.0,
             forward_bias_depletion_coefficient: 0.5,
             gate_saturation_current: 1.0e-14,
+            drain_resistance: 0.0,
         }
     }
 }
@@ -3819,8 +3822,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     (ModelCardKind::Diode, 15, 21, 5, 3),
     (ModelCardKind::Npn, 41, 58, 13, 4),
     (ModelCardKind::Pnp, 41, 58, 13, 4),
-    (ModelCardKind::Njf, 10, 17, 6, 3),
-    (ModelCardKind::Pjf, 10, 17, 6, 3),
+    (ModelCardKind::Njf, 11, 18, 6, 3),
+    (ModelCardKind::Pjf, 11, 18, 6, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
     (ModelCardKind::Pmos, 18, 25, 6, 3),
 ];
@@ -3925,6 +3928,7 @@ const JFET_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("VJ", "PB"),
     ("FC", "FC"),
     ("IS", "IS"),
+    ("RD", "RD"),
 ];
 const MOS_LEVEL1_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("LEVEL", "LEVEL"),
@@ -4656,6 +4660,7 @@ pub fn jfet_from_model_card(
     jfet.junction_potential = model_card_value(model, "PB", 1.0);
     jfet.forward_bias_depletion_coefficient = model_card_value(model, "FC", 0.5);
     jfet.gate_saturation_current = model_card_value(model, "IS", 1.0e-14);
+    jfet.drain_resistance = model_card_value(model, "RD", 0.0);
     Ok(jfet)
 }
 
@@ -22074,6 +22079,9 @@ fn collect_node_indices(circuit: &Circuit) -> HashMap<String, usize> {
                 insert_node(&mut names, &jfet.drain);
                 insert_node(&mut names, &jfet.gate);
                 insert_node(&mut names, &jfet.source);
+                if jfet.drain_resistance > 0.0 {
+                    insert_node(&mut names, &jfet_intrinsic_drain_node(jfet));
+                }
             }
             Element::Bjt(bjt) => {
                 insert_node(&mut names, &bjt.collector);
@@ -22450,7 +22458,8 @@ fn collect_noise_sources(
             }
             Element::Jfet(jfet) => {
                 validate_jfet(jfet)?;
-                let drain = node_index(node_indices, &jfet.drain);
+                let intrinsic_drain = jfet_intrinsic_drain_node(jfet);
+                let drain = node_index(node_indices, &intrinsic_drain);
                 let gate = node_index(node_indices, &jfet.gate);
                 let source = node_index(node_indices, &jfet.source);
                 let drain_voltage = vector_voltage(operating_point, drain);
@@ -22505,6 +22514,16 @@ fn collect_noise_sources(
                         source_psd: jfet.flicker_noise_coefficient
                             * result.drain_current.abs().powf(jfet.flicker_noise_exponent),
                         frequency_exponent: 1.0,
+                    });
+                }
+                if jfet.drain_resistance > 0.0 {
+                    sources.push(NoiseSource {
+                        element_name: format!("{}:RD", jfet.name),
+                        noise_type: NoiseType::Thermal,
+                        positive: node_index(node_indices, &jfet.drain),
+                        negative: drain,
+                        source_psd: 4.0 * BOLTZMANN * temperature_kelvin / jfet.drain_resistance,
+                        frequency_exponent: 0.0,
                     });
                 }
             }
@@ -23618,7 +23637,8 @@ fn stamp_jfet(
     operating_point: &[f64],
 ) -> Result<(), SpiceError> {
     validate_jfet(jfet)?;
-    let drain = node_index(node_indices, &jfet.drain);
+    let intrinsic_drain = jfet_intrinsic_drain_node(jfet);
+    let drain = node_index(node_indices, &intrinsic_drain);
     let gate = node_index(node_indices, &jfet.gate);
     let source = node_index(node_indices, &jfet.source);
     let drain_voltage = vector_voltage(operating_point, drain);
@@ -23642,6 +23662,14 @@ fn stamp_jfet(
     );
     stamp_jfet_gate_junction(jfet, gate, drain, gate_voltage - drain_voltage, matrix, rhs);
     stamp_jfet_charge(jfet, capacitor_states, node_indices, matrix, rhs)?;
+    if jfet.drain_resistance > 0.0 {
+        stamp_conductance(
+            matrix,
+            node_index(node_indices, &jfet.drain),
+            drain,
+            1.0 / jfet.drain_resistance,
+        );
+    }
     Ok(())
 }
 
@@ -23719,8 +23747,8 @@ fn stamp_jfet_charge(
             }
             TransientMethod::Euler => conductance * state.previous_voltage,
         };
-        let positive = node_index(node_indices, spec.positive);
-        let negative = node_index(node_indices, spec.negative);
+        let positive = node_index(node_indices, &spec.positive);
+        let negative = node_index(node_indices, &spec.negative);
         stamp_conductance(matrix, positive, negative, conductance);
         if let Some(index) = positive {
             rhs[index] += history_current;
@@ -24002,7 +24030,8 @@ fn stamp_jfet_small_signal(
     operating_point: &[f64],
 ) -> Result<(), SpiceError> {
     validate_jfet(jfet)?;
-    let drain = node_index(node_indices, &jfet.drain);
+    let intrinsic_drain = jfet_intrinsic_drain_node(jfet);
+    let drain = node_index(node_indices, &intrinsic_drain);
     let gate = node_index(node_indices, &jfet.gate);
     let source = node_index(node_indices, &jfet.source);
     let drain_voltage = vector_voltage(operating_point, drain);
@@ -24021,6 +24050,14 @@ fn stamp_jfet_small_signal(
     stamp_conductance(matrix, gate, source, gate_source_conductance);
     stamp_conductance(matrix, gate, drain, gate_drain_conductance);
     stamp_transconductance(matrix, drain, source, gate, source, result.gm);
+    if jfet.drain_resistance > 0.0 {
+        stamp_conductance(
+            matrix,
+            node_index(node_indices, &jfet.drain),
+            drain,
+            1.0 / jfet.drain_resistance,
+        );
+    }
     Ok(())
 }
 
@@ -24077,7 +24114,8 @@ fn stamp_ac_jfet_small_signal(
     omega: f64,
 ) -> Result<(), SpiceError> {
     validate_jfet(jfet)?;
-    let drain = node_index(node_indices, &jfet.drain);
+    let intrinsic_drain = jfet_intrinsic_drain_node(jfet);
+    let drain = node_index(node_indices, &intrinsic_drain);
     let gate = node_index(node_indices, &jfet.gate);
     let source = node_index(node_indices, &jfet.source);
     let drain_voltage = vector_voltage(operating_point, drain);
@@ -24123,6 +24161,14 @@ fn stamp_ac_jfet_small_signal(
         source,
         Complex::new(result.gm, 0.0),
     );
+    if jfet.drain_resistance > 0.0 {
+        stamp_complex_conductance(
+            matrix,
+            node_index(node_indices, &jfet.drain),
+            drain,
+            Complex::new(1.0 / jfet.drain_resistance, 0.0),
+        );
+    }
     Ok(())
 }
 
@@ -24403,10 +24449,10 @@ fn bjt_charge_state_voltage(
     voltage_at(node_voltages, &spec.positive) - voltage_at(node_voltages, &spec.negative)
 }
 
-struct JfetChargeStateSpec<'a> {
+struct JfetChargeStateSpec {
     name: String,
-    positive: &'a str,
-    negative: &'a str,
+    positive: String,
+    negative: String,
     capacitance: f64,
 }
 
@@ -24418,21 +24464,21 @@ fn jfet_gate_drain_charge_state_name(jfet: &Jfet) -> String {
     format!("_J_{}_gd_charge", jfet.name)
 }
 
-fn jfet_charge_state_specs(jfet: &Jfet) -> Vec<JfetChargeStateSpec<'_>> {
+fn jfet_charge_state_specs(jfet: &Jfet) -> Vec<JfetChargeStateSpec> {
     let mut specs = Vec::new();
     if jfet.gate_source_capacitance > 0.0 {
         specs.push(JfetChargeStateSpec {
             name: jfet_gate_source_charge_state_name(jfet),
-            positive: jfet.gate.as_str(),
-            negative: jfet.source.as_str(),
+            positive: jfet.gate.clone(),
+            negative: jfet.source.clone(),
             capacitance: jfet.gate_source_capacitance,
         });
     }
     if jfet.gate_drain_capacitance > 0.0 {
         specs.push(JfetChargeStateSpec {
             name: jfet_gate_drain_charge_state_name(jfet),
-            positive: jfet.gate.as_str(),
-            negative: jfet.drain.as_str(),
+            positive: jfet.gate.clone(),
+            negative: jfet_intrinsic_drain_node(jfet),
             capacitance: jfet.gate_drain_capacitance,
         });
     }
@@ -24440,10 +24486,18 @@ fn jfet_charge_state_specs(jfet: &Jfet) -> Vec<JfetChargeStateSpec<'_>> {
 }
 
 fn jfet_charge_state_voltage(
-    spec: &JfetChargeStateSpec<'_>,
+    spec: &JfetChargeStateSpec,
     node_voltages: &BTreeMap<String, f64>,
 ) -> f64 {
-    voltage_at(node_voltages, spec.positive) - voltage_at(node_voltages, spec.negative)
+    voltage_at(node_voltages, &spec.positive) - voltage_at(node_voltages, &spec.negative)
+}
+
+fn jfet_intrinsic_drain_node(jfet: &Jfet) -> String {
+    if jfet.drain_resistance == 0.0 {
+        jfet.drain.clone()
+    } else {
+        format!("__spice_{}_drain", jfet.name)
+    }
 }
 
 fn jfet_charge_dynamic_capacitance(
@@ -25019,6 +25073,12 @@ fn validate_jfet(jfet: &Jfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: jfet.name.clone(),
             reason: "gate saturation current must be finite and non-negative".to_string(),
+        });
+    }
+    if !jfet.drain_resistance.is_finite() || jfet.drain_resistance < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: jfet.name.clone(),
+            reason: "drain resistance must be finite and non-negative".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -95,7 +95,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 153);
+    assert_eq!(coverage.len(), 155);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -114,7 +114,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 153);
+    assert_eq!(records.len(), 155);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -195,15 +195,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 153);
-    assert_eq!(report.expected_canonical_parameter_count, 153);
-    assert_eq!(report.accepted_name_count, 221);
+    assert_eq!(report.canonical_parameter_count, 155);
+    assert_eq!(report.expected_canonical_parameter_count, 155);
+    assert_eq!(report.accepted_name_count, 223);
     assert_eq!(report.aliased_parameter_count, 55);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t153\t153\t221\t55\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t155\t155\t223\t55\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -230,8 +230,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 152);
-    assert_eq!(report.accepted_name_count, 218);
+    assert_eq!(report.canonical_parameter_count, 154);
+    assert_eq!(report.accepted_name_count, 220);
     assert_eq!(report.aliased_parameter_count, 54);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -248,7 +248,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t152\t153\t218\t54\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t154\t155\t220\t54\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -518,6 +518,7 @@ fn model_card_aliases_build_device_instances() {
             ("VJ", 0.8),
             ("FC", 0.35),
             ("IS", 2.0e-13),
+            ("RD", 125.0),
         ],
     )
     .unwrap();
@@ -530,6 +531,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*jfet_card.parameters.get("PB").unwrap(), 0.8);
     assert_close(*jfet_card.parameters.get("FC").unwrap(), 0.35);
     assert_close(*jfet_card.parameters.get("IS").unwrap(), 2.0e-13);
+    assert_close(*jfet_card.parameters.get("RD").unwrap(), 125.0);
     assert_eq!(jfet_model.polarity, JfetPolarity::Njf);
     assert_close(jfet_model.beta, 9.0e-4);
     assert_close(jfet_model.threshold_voltage, -1.8);
@@ -539,6 +541,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(jfet_model.junction_potential, 0.8);
     assert_close(jfet_model.forward_bias_depletion_coefficient, 0.35);
     assert_close(jfet_model.gate_saturation_current, 2.0e-13);
+    assert_close(jfet_model.drain_resistance, 125.0);
 
     let mos_card = normalize_model_card(
         "Mn",
@@ -1464,6 +1467,7 @@ fn subcircuit_expansion_preserves_complete_jfet_model() {
     jfet.junction_potential = 0.8;
     jfet.forward_bias_depletion_coefficient = 0.35;
     jfet.gate_saturation_current = 2.0e-13;
+    jfet.drain_resistance = 125.0;
     let mut circuit = Circuit::new();
     circuit
         .define_subcircuit(SubcircuitDefinition::new(
@@ -1493,6 +1497,26 @@ fn subcircuit_expansion_preserves_complete_jfet_model() {
     assert_close(expanded.junction_potential, 0.8);
     assert_close(expanded.forward_bias_depletion_coefficient, 0.35);
     assert_close(expanded.gate_saturation_current, 2.0e-13);
+    assert_close(expanded.drain_resistance, 125.0);
+}
+
+#[test]
+fn dc_jfet_drain_resistance_drops_intrinsic_drain_voltage() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vdrain", "drain", "0", 5.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 0.0,
+    )));
+    let mut jfet = Jfet::new("J1", "drain", "gate", "0");
+    jfet.beta = 1.0e-3;
+    jfet.drain_resistance = 1_000.0;
+    circuit.add(Element::Jfet(jfet));
+
+    let result = dc_op(&circuit).unwrap();
+    assert_close(result.node_voltages["drain"], 5.0);
+    assert!(result.node_voltages["__spice_J1_drain"] < 5.0);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -402,6 +402,53 @@ fn jfet_rejects_invalid_gate_saturation_current() {
 }
 
 #[test]
+fn jfet_rejects_invalid_drain_resistance() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 0.0,
+    )));
+    let mut jfet = Jfet::new("J1", "out", "gate", "0");
+    jfet.drain_resistance = -1.0;
+    circuit.add(Element::Jfet(jfet));
+
+    let error = noise_ac(&circuit, "out", "Vgate", &[1_000.0], 300.0).unwrap_err();
+    assert!(matches!(
+        error,
+        SpiceError::InvalidElement { reason, .. }
+            if reason == "drain resistance must be finite and non-negative"
+    ));
+}
+
+#[test]
+fn jfet_drain_resistance_emits_thermal_noise() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vdd", "vdd", "0", 5.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 0.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "vdd", "out", 1_000.0,
+    )));
+    let mut jfet = Jfet::new("J1", "out", "gate", "0");
+    jfet.drain_resistance = 250.0;
+    circuit.add(Element::Jfet(jfet));
+
+    let result = noise_ac(&circuit, "out", "Vgate", &[1_000.0], 300.0).unwrap();
+    let entry = result.points[0]
+        .entries
+        .iter()
+        .find(|entry| entry.element_name == "J1:RD" && entry.noise_type == NoiseType::Thermal)
+        .unwrap();
+    assert_close(
+        entry.source_psd,
+        4.0 * 1.380_649e-23 * 300.0 / 250.0,
+        1.0e-30,
+    );
+}
+
+#[test]
 fn jfet_gate_junctions_emit_distinct_shot_noise_sources() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add JFET model-card `RD` drain-resistance support with an intrinsic drain
+  node across DC, transient, AC, transfer-function, and noise analysis, plus
+  hierarchy preservation, validation, and a distinct thermal-noise source.
 - Add JFET model-card `IS` gate-junction saturation-current support,
   defaulting to `1e-14`, stamping `IGS`/`IGD` leakage in DC, transient, AC,
   and transfer-function analyses, and emitting distinct shot-noise sources.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1700,6 +1700,7 @@ export interface Jfet {
   readonly junctionPotential: number;
   readonly forwardBiasDepletionCoefficient: number;
   readonly gateSaturationCurrent: number;
+  readonly drainResistance: number;
 }
 
 export type BjtPolarity = "NPN" | "PNP";
@@ -2029,8 +2030,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   D: [15, 21, 5, 3],
   NPN: [41, 58, 13, 4],
   PNP: [41, 58, 13, 4],
-  NJF: [10, 17, 6, 3],
-  PJF: [10, 17, 6, 3],
+  NJF: [11, 18, 6, 3],
+  PJF: [11, 18, 6, 3],
   NMOS: [18, 25, 6, 3],
   PMOS: [18, 25, 6, 3],
 };
@@ -3616,7 +3617,7 @@ function cloneSubcktElement(
     case "diode":
       return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient, element.breakdownVoltage, element.breakdownCurrent, element.junctionCapacitance, element.transitTime, element.junctionPotential, element.gradingCoefficient, element.forwardBiasDepletionCoefficient, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.seriesResistance, element.flickerNoiseCoefficient, element.flickerNoiseExponent);
     case "jfet":
-      return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.junctionPotential, element.forwardBiasDepletionCoefficient, element.gateSaturationCurrent);
+      return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.junctionPotential, element.forwardBiasDepletionCoefficient, element.gateSaturationCurrent, element.drainResistance);
     case "bjt":
       return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees, element.forwardTransitTimeBiasCoefficient, element.forwardTransitTimeCurrent, element.forwardTransitTimeVoltage, element.emitterResistance, element.collectorResistance, element.baseResistance, element.minimumBaseResistance, element.baseResistanceHalfCurrent, element.baseCollectorCapacitanceFraction);
     case "mosfet":
@@ -7766,6 +7767,7 @@ export function jfet(
   junctionPotential = 1.0,
   forwardBiasDepletionCoefficient = 0.5,
   gateSaturationCurrent = 1.0e-14,
+  drainResistance = 0.0,
 ): Jfet {
   return {
     kind: "jfet",
@@ -7784,6 +7786,7 @@ export function jfet(
     junctionPotential,
     forwardBiasDepletionCoefficient,
     gateSaturationCurrent,
+    drainResistance,
   };
 }
 
@@ -8046,6 +8049,7 @@ const JFET_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   VJ: "PB",
   FC: "FC",
   IS: "IS",
+  RD: "RD",
 };
 
 const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -8594,6 +8598,7 @@ export function jfetFromModelCard(
     p.PB ?? 1.0,
     p.FC ?? 0.5,
     p.IS ?? 1.0e-14,
+    p.RD ?? 0.0,
   );
 }
 
@@ -18357,6 +18362,9 @@ function collectNodeIndices(circuit: Circuit): Map<string, number> {
         insertNode(names, element.drain);
         insertNode(names, element.gate);
         insertNode(names, element.source);
+        if (element.drainResistance > 0.0) {
+          insertNode(names, jfetIntrinsicDrainNode(element));
+        }
         break;
       case "bjt":
         insertNode(names, element.collector);
@@ -18651,7 +18659,8 @@ function collectNoiseSources(
       }
     } else if (element.kind === "jfet") {
       validateJfet(element);
-      const drain = nodeIndex(nodeIndices, element.drain);
+      const intrinsicDrain = jfetIntrinsicDrainNode(element);
+      const drain = nodeIndex(nodeIndices, intrinsicDrain);
       const gate = nodeIndex(nodeIndices, element.gate);
       const source = nodeIndex(nodeIndices, element.source);
       const drainVoltage = vectorVoltage(operatingPoint, drain);
@@ -18707,6 +18716,17 @@ function collectNoiseSources(
             element.flickerNoiseCoefficient *
             Math.abs(result.drainCurrent) ** element.flickerNoiseExponent,
           frequencyExponent: 1.0,
+        });
+      }
+      if (element.drainResistance > 0.0) {
+        sources.push({
+          elementName: `${element.name}:RD`,
+          noiseType: "thermal",
+          positive: nodeIndex(nodeIndices, element.drain),
+          negative: drain,
+          sourcePsd:
+            4.0 * BOLTZMANN * temperatureKelvin / element.drainResistance,
+          frequencyExponent: 0.0,
         });
       }
     } else if (element.kind === "mosfet") {
@@ -19586,6 +19606,12 @@ function validateJfet(element: Jfet): void {
       "gate saturation current must be finite and non-negative",
     );
   }
+  if (!Number.isFinite(element.drainResistance) || element.drainResistance < 0.0) {
+    throw invalidElement(
+      element.name,
+      "drain resistance must be finite and non-negative",
+    );
+  }
 }
 
 const JFET_THERMAL_VOLTAGE = 0.02585;
@@ -19636,7 +19662,8 @@ function stampJfet(
   operatingPoint: readonly number[],
 ): void {
   validateJfet(element);
-  const drain = nodeIndex(nodeIndices, element.drain);
+  const intrinsicDrain = jfetIntrinsicDrainNode(element);
+  const drain = nodeIndex(nodeIndices, intrinsicDrain);
   const gate = nodeIndex(nodeIndices, element.gate);
   const source = nodeIndex(nodeIndices, element.source);
   const drainVoltage = vectorVoltage(operatingPoint, drain);
@@ -19668,6 +19695,14 @@ function stampJfet(
     rhs,
   );
   stampJfetCharge(element, capacitorStates, nodeIndices, matrix, rhs);
+  if (element.drainResistance > 0.0) {
+    stampConductance(
+      matrix,
+      nodeIndex(nodeIndices, element.drain),
+      drain,
+      1.0 / element.drainResistance,
+    );
+  }
 }
 
 function stampJfetCharge(
@@ -20326,11 +20361,17 @@ function jfetChargeStateSpecs(element: Jfet): JfetChargeStateSpec[] {
     specs.push({
       name: jfetGateDrainChargeStateName(element),
       positive: element.gate,
-      negative: element.drain,
+      negative: jfetIntrinsicDrainNode(element),
       capacitance: element.gateDrainCapacitance,
     });
   }
   return specs;
+}
+
+function jfetIntrinsicDrainNode(element: Jfet): string {
+  return element.drainResistance === 0.0
+    ? element.drain
+    : `__spice_${element.name}_drain`;
 }
 
 function jfetChargeStateVoltage(
@@ -22057,7 +22098,8 @@ function stampJfetSmallSignal(
   operatingPoint: readonly number[],
 ): void {
   validateJfet(element);
-  const drain = nodeIndex(nodeIndices, element.drain);
+  const intrinsicDrain = jfetIntrinsicDrainNode(element);
+  const drain = nodeIndex(nodeIndices, intrinsicDrain);
   const gate = nodeIndex(nodeIndices, element.gate);
   const source = nodeIndex(nodeIndices, element.source);
   const drainVoltage = vectorVoltage(operatingPoint, drain);
@@ -22076,6 +22118,14 @@ function stampJfetSmallSignal(
   stampConductance(matrix, gate, source, gateSourceConductance);
   stampConductance(matrix, gate, drain, gateDrainConductance);
   stampTransconductance(matrix, drain, source, gate, source, result.gm);
+  if (element.drainResistance > 0.0) {
+    stampConductance(
+      matrix,
+      nodeIndex(nodeIndices, element.drain),
+      drain,
+      1.0 / element.drainResistance,
+    );
+  }
 }
 
 function stampAcResistor(
@@ -22799,7 +22849,8 @@ function stampAcJfetSmallSignal(
   omega: number,
 ): void {
   validateJfet(element);
-  const drain = nodeIndex(nodeIndices, element.drain);
+  const intrinsicDrain = jfetIntrinsicDrainNode(element);
+  const drain = nodeIndex(nodeIndices, intrinsicDrain);
   const gate = nodeIndex(nodeIndices, element.gate);
   const source = nodeIndex(nodeIndices, element.source);
   const drainVoltage = vectorVoltage(operatingPoint, drain);
@@ -22845,6 +22896,14 @@ function stampAcJfetSmallSignal(
     source,
     complex(result.gm, 0.0),
   );
+  if (element.drainResistance > 0.0) {
+    stampComplexConductance(
+      matrix,
+      nodeIndex(nodeIndices, element.drain),
+      drain,
+      complex(1.0 / element.drainResistance, 0.0),
+    );
+  }
 }
 
 function solveLinearSystem(matrix: number[][], rhs: number[]): number[] {

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -120,7 +120,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(153);
+    expect(coverage).toHaveLength(155);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -140,7 +140,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(153);
+    expect(records).toHaveLength(155);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -205,15 +205,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 153,
-      expectedCanonicalParameterCount: 153,
-      acceptedNameCount: 221,
+      canonicalParameterCount: 155,
+      expectedCanonicalParameterCount: 155,
+      acceptedNameCount: 223,
       aliasedParameterCount: 55,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t153\t153\t221\t55\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t155\t155\t223\t55\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -236,8 +236,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(152);
-    expect(report.acceptedNameCount).toBe(218);
+    expect(report.canonicalParameterCount).toBe(154);
+    expect(report.acceptedNameCount).toBe(220);
     expect(report.aliasedParameterCount).toBe(54);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -252,7 +252,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t152\t153\t218\t54\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t154\t155\t220\t54\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -383,9 +383,9 @@ describe("dcOp", () => {
     expectClose(bjtModel.baseCollectorGradingCoefficient, 0.45);
     expectClose(bjtModel.forwardBiasDepletionCoefficient, 0.4);
 
-    const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02, KF: 1.0e-12, AF: 1.3, VJ: 0.8, FC: 0.35, IS: 2.0e-13 });
+    const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02, KF: 1.0e-12, AF: 1.3, VJ: 0.8, FC: 0.35, IS: 2.0e-13, RD: 125.0 });
     const jfetModel = jfetFromModelCard("J1", "d", "g", "s", jfetCard);
-    expect(jfetCard.parameters).toStrictEqual({ BETA: 9.0e-4, VTO: -1.8, LAMBDA: 0.02, KF: 1.0e-12, AF: 1.3, PB: 0.8, FC: 0.35, IS: 2.0e-13 });
+    expect(jfetCard.parameters).toStrictEqual({ BETA: 9.0e-4, VTO: -1.8, LAMBDA: 0.02, KF: 1.0e-12, AF: 1.3, PB: 0.8, FC: 0.35, IS: 2.0e-13, RD: 125.0 });
     expect(jfetModel.polarity).toBe("NJF");
     expectClose(jfetModel.beta, 9.0e-4);
     expectClose(jfetModel.thresholdVoltage, -1.8);
@@ -395,6 +395,7 @@ describe("dcOp", () => {
     expectClose(jfetModel.junctionPotential, 0.8);
     expectClose(jfetModel.forwardBiasDepletionCoefficient, 0.35);
     expectClose(jfetModel.gateSaturationCurrent, 2.0e-13);
+    expectClose(jfetModel.drainResistance, 125.0);
 
     const mosCard = normalizeModelCard("Mn", "nmos", {
       LEVEL: 1.0,
@@ -1057,6 +1058,7 @@ describe("dcOp", () => {
           junctionPotential: 0.8,
           forwardBiasDepletionCoefficient: 0.35,
           gateSaturationCurrent: 2.0e-13,
+          drainResistance: 125.0,
         },
       ]),
     );
@@ -1072,6 +1074,22 @@ describe("dcOp", () => {
     expectClose(expanded.junctionPotential, 0.8);
     expectClose(expanded.forwardBiasDepletionCoefficient, 0.35);
     expectClose(expanded.gateSaturationCurrent, 2.0e-13);
+    expectClose(expanded.drainResistance, 125.0);
+  });
+
+  it("drops the intrinsic JFET drain voltage across RD", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vdrain", "drain", "0", 5.0));
+    circuit.add(voltageSource("Vgate", "gate", "0", 0.0));
+    circuit.add({
+      ...jfet("J1", "drain", "gate", "0"),
+      beta: 1.0e-3,
+      drainResistance: 1_000.0,
+    });
+
+    const result = dcOp(circuit);
+    expectClose(result.nodeVoltages.get("drain")!, 5.0);
+    expect(result.nodeVoltages.get("__spice_J1_drain")!).toBeLessThan(5.0);
   });
 
   it("loads a forward-biased JFET gate from gate saturation current", () => {

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -89,6 +89,33 @@ describe("noiseAc", () => {
     );
   });
 
+  it("rejects an invalid JFET drain resistance", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vgate", "gate", "0", 0.0));
+    circuit.add({ ...jfet("J1", "out", "gate", "0"), drainResistance: -1.0 });
+
+    expect(() => noiseAc(circuit, "out", "Vgate", [1_000.0])).toThrow(
+      /drain resistance must be finite and non-negative/,
+    );
+  });
+
+  it("emits JFET drain-resistance thermal noise", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vdd", "vdd", "0", 5.0));
+    circuit.add(voltageSource("Vgate", "gate", "0", 0.0));
+    circuit.add(resistor("Rload", "vdd", "out", 1_000.0));
+    circuit.add({ ...jfet("J1", "out", "gate", "0"), drainResistance: 250.0 });
+
+    const entry = noiseAc(circuit, "out", "Vgate", [1_000.0], 300.0).points[0]!.entries
+      .find((candidate) =>
+        candidate.elementName === "J1:RD" && candidate.noiseType === "thermal"
+      );
+    expect(entry?.sourcePsd).toBeCloseTo(
+      4.0 * 1.380_649e-23 * 300.0 / 250.0,
+      30,
+    );
+  });
+
   it("emits distinct JFET gate-junction shot-noise sources", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vdd", "out", "0", 1.0));

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,14 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language JFET gate-junction saturation current.
+1. Cross-language JFET drain resistance.
    - Status: current PR completion candidate.
-   - Add Berkeley JFET `IS` model-card support in Rust, Python, and TypeScript.
-   - Default `IS` to `1e-14` ampere and stamp both gate-source and gate-drain
-     junction leakage in DC, transient, AC, and transfer-function analyses.
-   - Preserve `IS` through hierarchy and cloning, validate finite non-negative
-     values, emit distinct `IGS` / `IGD` shot-noise sources, and extend the
-     supported-parameter coverage gate from 151 to 153 canonical rows.
+   - Add Berkeley JFET `RD` model-card support in Rust, Python, and TypeScript.
+   - Default `RD` to zero ohms and, when positive, route channel, gate-drain,
+     charge, AC, transient, transfer-function, and noise behavior through an
+     intrinsic drain node behind the external drain resistor.
+   - Preserve `RD` through hierarchy and cloning, validate finite non-negative
+     values, emit a distinct `RD` thermal-noise source, and extend the
+     supported-parameter coverage gate from 153 to 155 canonical rows.
 
 ## Completed Slices
 
@@ -3278,6 +3279,16 @@ the Rust, Python, and TypeScript surfaces together.
    - Hierarchy and cloning paths preserve `FC`, finite `[0, 1)` validation is
      shared across analyses, and the supported-parameter release gate now
      covers 151 canonical rows.
+
+253. Cross-language JFET gate-junction saturation current.
+   - Status: completed in PR 8930.
+   - Rust, Python, and TypeScript JFET model cards now accept `IS`, default it
+     to `1e-14` ampere, and stamp gate-source and gate-drain junction leakage
+     in DC, transient, AC, and transfer-function analyses.
+   - Hierarchy and cloning paths preserve `IS`, finite non-negative validation
+     is shared across analyses, distinct `IGS` / `IGD` shot-noise sources are
+     emitted, and the supported-parameter release gate now covers 153
+     canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley JFET `RD` model-card support across Rust, Python, and TypeScript
- route channel, gate-drain, charge, AC, transient, transfer-function, and noise behavior through an intrinsic drain node when `RD > 0`
- preserve and validate `RD`, add thermal-noise coverage, and advance the supported-parameter gate from 153 to 155 rows

## Verification
- `cargo test -p spice-engine`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo fmt -p spice-engine -- --check`
- Python: 601 tests passed
- Ruff on touched Python sources and tests
- `npm run build`
- TypeScript: 359 tests passed