### PR TITLE
feat(adj-formula-stdlib): pressure-conversions — NIST SP 811 B.9 pressure-unit→pascal factors (RS-5 table)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -419,6 +419,47 @@ fn shipped_energy_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b8) Shipped table — reference/pressure-conversions.adj resolves via import
+//      (pressure/stress unit → pascals, EXACT SP 811 B.9 boldface factors), and a
+//      non-exact unit (`torr`) — a rounded measured factor with no row — abstains.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_pressure_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_pressure");
+    let src = stdlib().join("reference/pressure-conversions.adj");
+    std::fs::copy(&src, dir.join("pressure-conversions.adj"))
+        .expect("copy shipped pressure-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"pressure-conversions.adj\"\n\
+         ? pressure_to_pascals(atmosphere_standard, $Pa)\n\
+         ? pressure_to_pascals(bar, $Pa)\n\
+         ? pressure_to_pascals(kilogram_force_per_square_meter, $Pa)\n\
+         ? pressure_to_pascals(torr, $Pa)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 "Pressure or stress" exact factors resolve, character-for-
+    // character from the table (boldface = exact; scientific notation to plain decimal).
+    assert!(out.contains("\"Pa\":\"101325\""), "standard atmosphere = 101325 Pa: {out}");
+    assert!(out.contains("\"Pa\":\"100000\""), "bar = 100000 Pa: {out}");
+    assert!(out.contains("\"Pa\":\"9.80665\""), "kgf/m² = 9.80665 Pa: {out}");
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `torr` is NOT a single exact factor (SP 811 lists it as a rounded measured
+    // value, not boldface) — no row, so the engine abstains rather than commit.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a non-exact unit abstains, never a fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/pressure-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/pressure-conversions.adj
@@ -1,0 +1,65 @@
+% ============================================================================
+% pressure-conversions — pressure-unit → pascal factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of `energy-conversions.adj` / `time-conversions.adj`: a native
+% tabular relation ingested VERBATIM from a published NIST conversion table. Each
+% row states the factor converting one pressure (or stress) unit to the SI unit of
+% pressure, the pascal (Pa = N/m²):
+%
+%     ? pressure_to_pascals(atmosphere_standard, $Pa)   % 101325   (the standard atmosphere)
+%     ? pressure_to_pascals(bar, $Pa)                   % 100000   (a bar)
+%
+% Why a `table` and not several hand-written `relate` clauses: this is exactly the
+% shape reference data comes in — a published table, not prose. The citable
+% artifact IS the NIST conversion-factors table at the `locator` below; every
+% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors
+% for units listed alphabetically"), and the whole table is defended by one
+% provenance envelope rather than repeating `source`/`locator`/`trust` on every
+% row. Each `row` lowers to a ground relation `pressure_to_pascals(unit, pascals)`,
+% so the exact lookup above is the ordinary SLD binding query — the engine returns
+% the factor WITH this table's citation as its proof, on the CPU, with zero model
+% calls. A looked-up factor is a number, so it can feed a `let`/`formula`
+% downstream (e.g. multiply a pressure quantity by it) through the existing slot path.
+%
+% HONESTY NOTE (like energy-conversions, these are EXACT defined factors, not
+% rounded ones): NIST SP 811 B.9 prints these six "Pressure or stress" factors in
+% BOLDFACE, its convention for factors that are EXACT by definition, transcribed
+% here as the plain decimal number of pascals each unit names:
+%
+%     atmosphere, standard (atm)                  1.013 25 E+05   →  101325
+%     bar                                         1.0     E+05   →  100000
+%     millibar (mbar)                             1.0     E+02   →  100
+%     dyne per square centimeter (dyn/cm²)        1.0     E-01   →  0.1
+%     kilogram-force per square centimeter        9.806 65 E+04   →  98066.5
+%     kilogram-force per square meter (kgf/m²)    9.806 65 E+00   →  9.80665
+%
+% These six are exact: the standard atmosphere IS defined as exactly 101325 Pa, a
+% bar as exactly 100000 Pa, and the kilogram-force factors derive from the exact
+% standard gravity 9.80665 m/s². (NIST also lists the technical atmosphere, at =
+% kgf/cm² = 9.80665 E+04 Pa — the SAME value as the kilogram_force_per_square_centimeter
+% row here — so it is not repeated under a second name.) Deliberately OMITTED: the
+% torr and the conventional millimeter of mercury (both 1.333224 E+02, rounded
+% seven-figure measured factors, NOT boldface) and the pound-force per square inch
+% / psi (6.894757 E+03, likewise rounded) — none is a single EXACT defined factor,
+% so a `? pressure_to_pascals(torr, $Pa)` (etc.) ABSTAINS rather than committing to
+% a rounded value. The only claim this table makes is "these are the exact factors
+% NIST SP 811 B.9 prints" — which is exactly what a byte-check against the cited
+% table verifies. `trust authoritative` — a primary, re-fetchable standards
+% reference. (See ADJ-TABLES.md; and feedback_nothing_human_authored — every factor
+% is a verbatim cell of the cited table, nothing asserted from memory.)
+% ============================================================================
+
+table pressure_to_pascals {
+    columns unit, pascals
+
+    row (atmosphere_standard, 101325)
+    row (bar, 100000)
+    row (millibar, 100)
+    row (dyne_per_square_centimeter, 0.1)
+    row (kilogram_force_per_square_centimeter, 98066.5)
+    row (kilogram_force_per_square_meter, 9.80665)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/pressure-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/pressure-conversions.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% pressure-conversions.query.adj — a worked lookup over the pressure-conversions table.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a "how many pascals
+% in a bar?" question: it states no conversion fact — it only `import`s the grounded
+% table and asks binding queries. The native adj-lang engine resolves each `?`
+% against the table's rows (lowered to `pressure_to_pascals` relations) and returns
+% the binding + the table's source/locator/trust. A unit not in the table abstains
+% honestly — the engine never invents a factor (notably the torr and the psi, which
+% have no single EXACT factor and so have no row).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli pressure-conversions.query.adj
+% ============================================================================
+
+import "pressure-conversions.adj"
+
+? pressure_to_pascals(atmosphere_standard, $Pa)   % expect 101325
+? pressure_to_pascals(bar, $Pa)                   % expect 100000
+? pressure_to_pascals(kilogram_force_per_square_meter, $Pa)  % expect 9.80665
+? pressure_to_pascals(torr, $Pa)                  % expect abstain — rounded factor, not a row


### PR DESCRIPTION
New **Facts** entry: a native RS-5 `table` grounding the EXACT (boldface) pressure/stress conversion factors from **NIST Special Publication 811, Appendix B.9**, to the SI unit of pressure, the pascal. Sibling of `energy-conversions.adj` / `time-conversions.adj`.

**Six exact factors**, byte-verified against the cited NIST page (boldface = exact by definition; scientific notation transcribed to plain decimal):

| unit | NIST factor | → pascals |
|---|---|---|
| atmosphere, standard | 1.01325 E+05 | `101325` |
| bar | 1.0 E+05 | `100000` |
| millibar | 1.0 E+02 | `100` |
| dyne per square centimeter | 1.0 E-01 | `0.1` |
| kilogram-force per square cm | 9.80665 E+04 | `98066.5` |
| kilogram-force per square meter | 9.80665 E+00 | `9.80665` |

The standard atmosphere IS defined as exactly 101325 Pa and a bar as exactly 100000 Pa; the kgf factors derive from the exact standard gravity 9.80665 m/s². (NIST's technical atmosphere `at` = kgf/cm² = 9.80665 E+04 Pa is the *same* value as the `kilogram_force_per_square_centimeter` row, so it isn't repeated under a second name.)

**Honest abstention.** Deliberately OMITTED: torr and conventional mmHg (both 1.333224 E+02, rounded measured factors, NOT boldface) and psi (6.894757 E+03, likewise rounded) — none is a single exact defined factor, so `? pressure_to_pascals(torr, $Pa)` **ABSTAINS** rather than commit to a rounded value.

Each `row` lowers to a ground relation `pressure_to_pascals(unit, pascals)`, so a lookup is the ordinary SLD binding query — the engine returns the factor WITH the table's citation as its proof, on the CPU, zero model calls. A looked-up factor is a number, so it can feed a `let`/`formula` downstream through the existing slot path.

**Files (data + test only — no version bump, mirrors the energy/time-conversions PRs):**
- New: `reference/pressure-conversions.adj` + `pressure-conversions.query.adj` (worked lookup: atm/bar/kgf-m² resolve, torr abstains).
- Test: `rs5_table_e2e::shipped_pressure_conversions_table_resolves_and_abstains` — asserts 101325/100000/9.80665 resolve with the NIST locator, and torr abstains. **Suite now 13 tests, all pass.** Shipped query verified through the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)