### PR TITLE
feat(spice): add JFET source resistance

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add JFET model-card `RS` source-resistance support with an intrinsic source
+  node across DC, transient, AC, transfer-function, and noise analysis, plus
+  hierarchy preservation, validation, and a distinct thermal-noise source.
 - Add JFET model-card `RD` drain-resistance support with an intrinsic drain
   node across DC, transient, AC, transfer-function, and noise analysis, plus
   hierarchy preservation, validation, and a distinct thermal-noise source.

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -518,6 +518,7 @@ class JFET:
     Fc: float = 0.5
     Is: float = 1.0e-14
     Rd: float = 0.0
+    Rs: float = 0.0
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -604,7 +604,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
             element.Af,
         )
     if isinstance(element, JFET):
-        return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_, element.Cgs, element.Cgd, element.Kf, element.Af, element.Pb, element.Fc, element.Is, element.Rd)
+        return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_, element.Cgs, element.Cgd, element.Kf, element.Af, element.Pb, element.Fc, element.Is, element.Rd, element.Rs)
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
@@ -7265,6 +7265,8 @@ def _element_nodes(el: Element) -> list[str]:
         nodes = [el.drain, el.gate, el.source]
         if el.Rd > 0.0:
             nodes.append(_jfet_intrinsic_drain_node(el))
+        if el.Rs > 0.0:
+            nodes.append(_jfet_intrinsic_source_node(el))
         return nodes
     if isinstance(el, Mosfet):
         return [el.drain, el.gate, el.source, el.body]
@@ -8912,7 +8914,14 @@ def _jfet_gate_drain_charge_state_name(el: JFET) -> str:
 def _jfet_charge_state_specs(el: JFET) -> list[tuple[str, str, str, float]]:
     specs: list[tuple[str, str, str, float]] = []
     if el.Cgs > 0.0:
-        specs.append((_jfet_gate_source_charge_state_name(el), el.gate, el.source, el.Cgs))
+        specs.append(
+            (
+                _jfet_gate_source_charge_state_name(el),
+                el.gate,
+                _jfet_intrinsic_source_node(el),
+                el.Cgs,
+            )
+        )
     if el.Cgd > 0.0:
         specs.append(
             (
@@ -8930,6 +8939,14 @@ def _jfet_intrinsic_drain_node(el: JFET) -> str:
         el.drain
         if not math.isfinite(el.Rd) or el.Rd <= 0.0
         else f"__spice_{el.name}_drain"
+    )
+
+
+def _jfet_intrinsic_source_node(el: JFET) -> str:
+    return (
+        el.source
+        if not math.isfinite(el.Rs) or el.Rs <= 0.0
+        else f"__spice_{el.name}_source"
     )
 
 
@@ -9106,6 +9123,8 @@ def _eval_jfet(el: JFET, vgs: float, vds: float) -> tuple[float, float, float]:
         )
     if not math.isfinite(el.Rd) or el.Rd < 0.0:
         raise ValueError(f"JFET '{el.name}' drain resistance must be finite and non-negative")
+    if not math.isfinite(el.Rs) or el.Rs < 0.0:
+        raise ValueError(f"JFET '{el.name}' source resistance must be finite and non-negative")
     if el.polarity == "PJF":
         ids, gm, gds = _eval_njf(-vgs, -vds, -el.vto, el.beta, el.lambda_)
         return -ids, gm, gds
@@ -9178,35 +9197,38 @@ def _stamp_jfet(
     el: JFET,
 ) -> None:
     intrinsic_drain = _jfet_intrinsic_drain_node(el)
+    intrinsic_source = _jfet_intrinsic_source_node(el)
     Vd = 0.0 if _is_ground(intrinsic_drain) else x[node_to_idx[intrinsic_drain]]
     Vg = 0.0 if _is_ground(el.gate) else x[node_to_idx[el.gate]]
-    Vs = 0.0 if _is_ground(el.source) else x[node_to_idx[el.source]]
+    Vs = 0.0 if _is_ground(intrinsic_source) else x[node_to_idx[intrinsic_source]]
     vgs = Vg - Vs
     vds = Vd - Vs
     ids, gm, gds = _eval_jfet(el, vgs, vds)
 
-    _stamp_g(G, node_to_idx, intrinsic_drain, el.source, gds)
+    _stamp_g(G, node_to_idx, intrinsic_drain, intrinsic_source, gds)
     if not _is_ground(intrinsic_drain):
         d = node_to_idx[intrinsic_drain]
         if not _is_ground(el.gate):
             G[d][node_to_idx[el.gate]] += gm
-        if not _is_ground(el.source):
-            G[d][node_to_idx[el.source]] -= gm
-    if not _is_ground(el.source):
-        s = node_to_idx[el.source]
+        if not _is_ground(intrinsic_source):
+            G[d][node_to_idx[intrinsic_source]] -= gm
+    if not _is_ground(intrinsic_source):
+        s = node_to_idx[intrinsic_source]
         if not _is_ground(el.gate):
             G[s][node_to_idx[el.gate]] -= gm
-        if not _is_ground(el.source):
-            G[s][node_to_idx[el.source]] += gm
+        if not _is_ground(intrinsic_source):
+            G[s][node_to_idx[intrinsic_source]] += gm
     Ieq = ids - gm * vgs - gds * vds
     if not _is_ground(intrinsic_drain):
         b[node_to_idx[intrinsic_drain]] -= Ieq
-    if not _is_ground(el.source):
-        b[node_to_idx[el.source]] += Ieq
-    _stamp_jfet_gate_junction(G, b, node_to_idx, el, el.source, Vg - Vs)
+    if not _is_ground(intrinsic_source):
+        b[node_to_idx[intrinsic_source]] += Ieq
+    _stamp_jfet_gate_junction(G, b, node_to_idx, el, intrinsic_source, Vg - Vs)
     _stamp_jfet_gate_junction(G, b, node_to_idx, el, intrinsic_drain, Vg - Vd)
     if el.Rd > 0.0:
         _stamp_g(G, node_to_idx, el.drain, intrinsic_drain, 1.0 / el.Rd)
+    if el.Rs > 0.0:
+        _stamp_g(G, node_to_idx, el.source, intrinsic_source, 1.0 / el.Rs)
 
 
 def _bjt_early_factor(el: BJT, junction_voltage: float, output_voltage: float) -> float:
@@ -12821,18 +12843,19 @@ def _stamp_ac(
 
     elif isinstance(el, JFET):
         intrinsic_drain = _jfet_intrinsic_drain_node(el)
+        intrinsic_source = _jfet_intrinsic_source_node(el)
         Vd = 0.0 if _is_ground(intrinsic_drain) else dc_x[node_to_idx[intrinsic_drain]]
         Vg = 0.0 if _is_ground(el.gate) else dc_x[node_to_idx[el.gate]]
-        Vs = 0.0 if _is_ground(el.source) else dc_x[node_to_idx[el.source]]
+        Vs = 0.0 if _is_ground(intrinsic_source) else dc_x[node_to_idx[intrinsic_source]]
         _, gm_j, gds_j = _eval_jfet(el, Vg - Vs, Vd - Vs)
         _, ggs = _jfet_gate_junction_current_conductance(el, Vg - Vs)
         _, ggd = _jfet_gate_junction_current_conductance(el, Vg - Vd)
-        _stamp_g_c(G, node_to_idx, intrinsic_drain, el.source, gds_j + 0j)
-        _stamp_g_c(G, node_to_idx, el.gate, el.source, ggs + 0j)
+        _stamp_g_c(G, node_to_idx, intrinsic_drain, intrinsic_source, gds_j + 0j)
+        _stamp_g_c(G, node_to_idx, el.gate, intrinsic_source, ggs + 0j)
         _stamp_g_c(G, node_to_idx, el.gate, intrinsic_drain, ggd + 0j)
         if el.Cgs > 0.0:
             cgs = _jfet_charge_dynamic_capacitance(el, el.Cgs, Vg - Vs)
-            _stamp_g_c(G, node_to_idx, el.gate, el.source, 1j * omega * cgs)
+            _stamp_g_c(G, node_to_idx, el.gate, intrinsic_source, 1j * omega * cgs)
         if el.Cgd > 0.0:
             cgd = _jfet_charge_dynamic_capacitance(el, el.Cgd, Vg - Vd)
             _stamp_g_c(G, node_to_idx, el.gate, intrinsic_drain, 1j * omega * cgd)
@@ -12840,16 +12863,18 @@ def _stamp_ac(
             d = node_to_idx[intrinsic_drain]
             if not _is_ground(el.gate):
                 G[d][node_to_idx[el.gate]] += gm_j + 0j
-            if not _is_ground(el.source):
-                G[d][node_to_idx[el.source]] -= gm_j + 0j
-        if not _is_ground(el.source):
-            s = node_to_idx[el.source]
+            if not _is_ground(intrinsic_source):
+                G[d][node_to_idx[intrinsic_source]] -= gm_j + 0j
+        if not _is_ground(intrinsic_source):
+            s = node_to_idx[intrinsic_source]
             if not _is_ground(el.gate):
                 G[s][node_to_idx[el.gate]] -= gm_j + 0j
-            if not _is_ground(el.source):
-                G[s][node_to_idx[el.source]] += gm_j + 0j
+            if not _is_ground(intrinsic_source):
+                G[s][node_to_idx[intrinsic_source]] += gm_j + 0j
         if el.Rd > 0.0:
             _stamp_g_c(G, node_to_idx, el.drain, intrinsic_drain, 1.0 / el.Rd)
+        if el.Rs > 0.0:
+            _stamp_g_c(G, node_to_idx, el.source, intrinsic_source, 1.0 / el.Rs)
 
     elif isinstance(el, Mosfet):
         # Small-signal model: gds (output conductance) + gm (transconductance).
@@ -13543,33 +13568,40 @@ def _build_ss_matrix(
 
         elif isinstance(el, JFET):
             intrinsic_drain = _jfet_intrinsic_drain_node(el)
+            intrinsic_source = _jfet_intrinsic_source_node(el)
             Vd = (
                 0.0
                 if _is_ground(intrinsic_drain)
                 else dc_x[node_to_idx[intrinsic_drain]]
             )
             Vg = 0.0 if _is_ground(el.gate) else dc_x[node_to_idx[el.gate]]
-            Vs = 0.0 if _is_ground(el.source) else dc_x[node_to_idx[el.source]]
+            Vs = (
+                0.0
+                if _is_ground(intrinsic_source)
+                else dc_x[node_to_idx[intrinsic_source]]
+            )
             _, gm_j, gds_j = _eval_jfet(el, Vg - Vs, Vd - Vs)
             _, ggs = _jfet_gate_junction_current_conductance(el, Vg - Vs)
             _, ggd = _jfet_gate_junction_current_conductance(el, Vg - Vd)
-            _stamp_g(G, node_to_idx, intrinsic_drain, el.source, gds_j)
-            _stamp_g(G, node_to_idx, el.gate, el.source, ggs)
+            _stamp_g(G, node_to_idx, intrinsic_drain, intrinsic_source, gds_j)
+            _stamp_g(G, node_to_idx, el.gate, intrinsic_source, ggs)
             _stamp_g(G, node_to_idx, el.gate, intrinsic_drain, ggd)
             if not _is_ground(intrinsic_drain):
                 d = node_to_idx[intrinsic_drain]
                 if not _is_ground(el.gate):
                     G[d][node_to_idx[el.gate]] += gm_j
-                if not _is_ground(el.source):
-                    G[d][node_to_idx[el.source]] -= gm_j
-            if not _is_ground(el.source):
-                s = node_to_idx[el.source]
+                if not _is_ground(intrinsic_source):
+                    G[d][node_to_idx[intrinsic_source]] -= gm_j
+            if not _is_ground(intrinsic_source):
+                s = node_to_idx[intrinsic_source]
                 if not _is_ground(el.gate):
                     G[s][node_to_idx[el.gate]] -= gm_j
-                if not _is_ground(el.source):
-                    G[s][node_to_idx[el.source]] += gm_j
+                if not _is_ground(intrinsic_source):
+                    G[s][node_to_idx[intrinsic_source]] += gm_j
             if el.Rd > 0.0:
                 _stamp_g(G, node_to_idx, el.drain, intrinsic_drain, 1.0 / el.Rd)
+            if el.Rs > 0.0:
+                _stamp_g(G, node_to_idx, el.source, intrinsic_source, 1.0 / el.Rs)
 
         elif isinstance(el, Mosfet):
             # Small-signal model: gds (drain–source) + gm VCCS (gate–source
@@ -15432,13 +15464,18 @@ def _collect_noise_sources(
 
         elif isinstance(el, JFET):
             intrinsic_drain = _jfet_intrinsic_drain_node(el)
+            intrinsic_source = _jfet_intrinsic_source_node(el)
             Vd = (
                 0.0
                 if _is_ground(intrinsic_drain)
                 else dc_x[node_to_idx[intrinsic_drain]]
             )
             Vg = 0.0 if _is_ground(el.gate) else dc_x[node_to_idx[el.gate]]
-            Vs = 0.0 if _is_ground(el.source) else dc_x[node_to_idx[el.source]]
+            Vs = (
+                0.0
+                if _is_ground(intrinsic_source)
+                else dc_x[node_to_idx[intrinsic_source]]
+            )
             drain_current, gm, _ = _eval_jfet(el, Vg - Vs, Vd - Vs)
             gm = max(0.0, float(gm))
             if gm > 0.0:
@@ -15448,10 +15485,18 @@ def _collect_noise_sources(
                     if _is_ground(intrinsic_drain)
                     else node_to_idx[intrinsic_drain]
                 )
-                n_s = None if _is_ground(el.source) else node_to_idx[el.source]
+                n_s = (
+                    None
+                    if _is_ground(intrinsic_source)
+                    else node_to_idx[intrinsic_source]
+                )
                 sources.append((el.name, "thermal", n_d, n_s, psd, 0.0))
             n_g = None if _is_ground(el.gate) else node_to_idx[el.gate]
-            n_s = None if _is_ground(el.source) else node_to_idx[el.source]
+            n_s = (
+                None
+                if _is_ground(intrinsic_source)
+                else node_to_idx[intrinsic_source]
+            )
             n_d = (
                 None
                 if _is_ground(intrinsic_drain)
@@ -15475,7 +15520,11 @@ def _collect_noise_sources(
                     if _is_ground(intrinsic_drain)
                     else node_to_idx[intrinsic_drain]
                 )
-                n_s = None if _is_ground(el.source) else node_to_idx[el.source]
+                n_s = (
+                    None
+                    if _is_ground(intrinsic_source)
+                    else node_to_idx[intrinsic_source]
+                )
                 sources.append(
                     (el.name, "flicker", n_d, n_s, el.Kf * abs(drain_current) ** el.Af, 1.0)
                 )
@@ -15487,6 +15536,17 @@ def _collect_noise_sources(
                         node_to_idx.get(el.drain),
                         node_to_idx.get(intrinsic_drain),
                         kT4 / el.Rd,
+                        0.0,
+                    )
+                )
+            if el.Rs > 0.0:
+                sources.append(
+                    (
+                        f"{el.name}:RS",
+                        "thermal",
+                        node_to_idx.get(el.source),
+                        node_to_idx.get(intrinsic_source),
+                        kT4 / el.Rs,
                         0.0,
                     )
                 )

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -309,8 +309,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (15, 21, 5, 3),
     "NPN": (41, 58, 13, 4),
     "PNP": (41, 58, 13, 4),
-    "NJF": (11, 18, 6, 3),
-    "PJF": (11, 18, 6, 3),
+    "NJF": (12, 19, 6, 3),
+    "PJF": (12, 19, 6, 3),
     "NMOS": (18, 25, 6, 3),
     "PMOS": (18, 25, 6, 3),
 }
@@ -437,6 +437,7 @@ _JFET_PARAMETER_ALIASES: dict[str, str] = {
     "FC": "FC",
     "IS": "IS",
     "RD": "RD",
+    "RS": "RS",
 }
 
 _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
@@ -1015,6 +1016,7 @@ def jfet_from_model_card(
         Fc=p.get("FC", 0.5),
         Is=p.get("IS", 1.0e-14),
         Rd=p.get("RD", 0.0),
+        Rs=p.get("RS", 0.0),
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -407,7 +407,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 155
+    assert len(coverage) == 157
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -422,7 +422,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 155
+    assert len(records) == 157
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -496,9 +496,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 155
-    assert report.expected_canonical_parameter_count == 155
-    assert report.accepted_name_count == 223
+    assert report.canonical_parameter_count == 157
+    assert report.expected_canonical_parameter_count == 157
+    assert report.accepted_name_count == 225
     assert report.aliased_parameter_count == 55
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -506,7 +506,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t155\t155\t223\t55\t4\t0"
+        "true\t7\t7\t157\t157\t225\t55\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -534,8 +534,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 154
-    assert report.accepted_name_count == 220
+    assert report.canonical_parameter_count == 156
+    assert report.accepted_name_count == 222
     assert report.aliased_parameter_count == 54
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -550,7 +550,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t154\t155\t220\t54\t4\t4\n"
+        "false\t7\t7\t156\t157\t222\t54\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -676,6 +676,7 @@ def test_model_card_aliases_build_device_instances() -> None:
             "FC": 0.35,
             "IS": 2.0e-13,
             "RD": 125.0,
+            "RS": 75.0,
         },
     )
     jfet_model = jfet_from_model_card("J1", "d", "g", "s", jfet_card)
@@ -689,6 +690,7 @@ def test_model_card_aliases_build_device_instances() -> None:
         "FC": 0.35,
         "IS": 2.0e-13,
         "RD": 125.0,
+        "RS": 75.0,
     }
     assert jfet_model.polarity == "NJF"
     assert jfet_model.beta == pytest.approx(9.0e-4)
@@ -700,6 +702,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert jfet_model.Fc == pytest.approx(0.35)
     assert jfet_model.Is == pytest.approx(2.0e-13)
     assert jfet_model.Rd == pytest.approx(125.0)
+    assert jfet_model.Rs == pytest.approx(75.0)
 
     mos_card = normalize_model_card(
         "Mn",
@@ -795,6 +798,17 @@ def test_dc_rejects_invalid_jfet_drain_resistance() -> None:
         dc_op(circuit)
 
 
+def test_dc_rejects_invalid_jfet_source_resistance() -> None:
+    circuit = Circuit()
+    circuit.add(JFET("J1", "drain", "gate", "0", Rs=-1.0))
+
+    with pytest.raises(
+        ValueError,
+        match="source resistance must be finite and non-negative",
+    ):
+        dc_op(circuit)
+
+
 def test_dc_jfet_drain_resistance_drops_intrinsic_drain_voltage() -> None:
     circuit = Circuit()
     circuit.add(VoltageSource("Vdrain", "drain", "0", 5.0))
@@ -804,6 +818,16 @@ def test_dc_jfet_drain_resistance_drops_intrinsic_drain_voltage() -> None:
     result = dc_op(circuit)
     assert result.node_voltages["drain"] == pytest.approx(5.0)
     assert result.node_voltages["__spice_J1_drain"] < 5.0
+
+
+def test_dc_jfet_source_resistance_raises_intrinsic_source_voltage() -> None:
+    circuit = Circuit()
+    circuit.add(VoltageSource("Vdrain", "drain", "0", 5.0))
+    circuit.add(VoltageSource("Vgate", "gate", "0", 3.0))
+    circuit.add(JFET("J1", "drain", "gate", "0", beta=1.0e-3, Rs=1_000.0))
+
+    result = dc_op(circuit)
+    assert result.node_voltages["__spice_J1_source"] > 0.0
 
 
 def test_jfet_gate_saturation_current_loads_a_forward_biased_gate() -> None:
@@ -2588,7 +2612,7 @@ def test_subcircuit_expansion_preserves_complete_jfet_model():
     cell = SubcircuitDefinition(
         "jfet-cell",
         ("d", "g", "s"),
-        (JFET("Jcell", "d", "g", "s", Kf=1.0e-12, Af=1.3, Pb=0.8, Fc=0.35, Is=2.0e-13, Rd=125.0),),
+        (JFET("Jcell", "d", "g", "s", Kf=1.0e-12, Af=1.3, Pb=0.8, Fc=0.35, Is=2.0e-13, Rd=125.0, Rs=75.0),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2601,6 +2625,7 @@ def test_subcircuit_expansion_preserves_complete_jfet_model():
     assert expanded.Fc == pytest.approx(0.35)
     assert expanded.Is == pytest.approx(2.0e-13)
     assert expanded.Rd == pytest.approx(125.0)
+    assert expanded.Rs == pytest.approx(75.0)
 
 
 def test_subcircuit_expansion_preserves_complete_bjt_model():
@@ -7631,6 +7656,22 @@ def test_noise_jfet_rd_adds_thermal_noise() -> None:
         if entry.element_name == "J1:RD" and entry.noise_type == "thermal"
     )
     assert rd.source_psd == pytest.approx(4.0 * 1.380_649e-23 * 300.0 / 250.0)
+
+
+def test_noise_jfet_rs_adds_thermal_noise() -> None:
+    circuit = Circuit()
+    circuit.add(VoltageSource("Vdd", "vdd", "0", 5.0))
+    circuit.add(VoltageSource("Vgate", "gate", "0", 0.0))
+    circuit.add(Resistor("Rload", "vdd", "out", 1_000.0))
+    circuit.add(JFET("J1", "out", "gate", "0", Rs=250.0))
+
+    entries = noise_ac(circuit, "out", "Vgate", freqs=[1_000.0]).points[0].entries
+    rs = next(
+        entry
+        for entry in entries
+        if entry.element_name == "J1:RS" and entry.noise_type == "thermal"
+    )
+    assert rs.source_psd == pytest.approx(4.0 * 1.380_649e-23 * 300.0 / 250.0)
 
 
 def test_noise_jfet_gate_junctions_emit_distinct_shot_sources() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add JFET model-card `RS` source-resistance support with an intrinsic source
+  node across DC, transient, AC, transfer-function, and noise analysis, plus
+  hierarchy preservation, validation, and a distinct thermal-noise source.
 - Add JFET model-card `RD` drain-resistance support with an intrinsic drain
   node across DC, transient, AC, transfer-function, and noise analysis, plus
   hierarchy preservation, validation, and a distinct thermal-noise source.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -432,6 +432,7 @@ fn clone_subckt_element(
             mapped.forward_bias_depletion_coefficient = element.forward_bias_depletion_coefficient;
             mapped.gate_saturation_current = element.gate_saturation_current;
             mapped.drain_resistance = element.drain_resistance;
+            mapped.source_resistance = element.source_resistance;
             Element::Jfet(mapped)
         }
         Element::Bjt(element) => {
@@ -2825,6 +2826,7 @@ pub struct Jfet {
     pub forward_bias_depletion_coefficient: f64,
     pub gate_saturation_current: f64,
     pub drain_resistance: f64,
+    pub source_resistance: f64,
 }
 
 impl Jfet {
@@ -2899,6 +2901,7 @@ impl Jfet {
             forward_bias_depletion_coefficient: 0.5,
             gate_saturation_current: 1.0e-14,
             drain_resistance: 0.0,
+            source_resistance: 0.0,
         }
     }
 }
@@ -3822,8 +3825,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     (ModelCardKind::Diode, 15, 21, 5, 3),
     (ModelCardKind::Npn, 41, 58, 13, 4),
     (ModelCardKind::Pnp, 41, 58, 13, 4),
-    (ModelCardKind::Njf, 11, 18, 6, 3),
-    (ModelCardKind::Pjf, 11, 18, 6, 3),
+    (ModelCardKind::Njf, 12, 19, 6, 3),
+    (ModelCardKind::Pjf, 12, 19, 6, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
     (ModelCardKind::Pmos, 18, 25, 6, 3),
 ];
@@ -3929,6 +3932,7 @@ const JFET_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("FC", "FC"),
     ("IS", "IS"),
     ("RD", "RD"),
+    ("RS", "RS"),
 ];
 const MOS_LEVEL1_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("LEVEL", "LEVEL"),
@@ -4661,6 +4665,7 @@ pub fn jfet_from_model_card(
     jfet.forward_bias_depletion_coefficient = model_card_value(model, "FC", 0.5);
     jfet.gate_saturation_current = model_card_value(model, "IS", 1.0e-14);
     jfet.drain_resistance = model_card_value(model, "RD", 0.0);
+    jfet.source_resistance = model_card_value(model, "RS", 0.0);
     Ok(jfet)
 }
 
@@ -22082,6 +22087,9 @@ fn collect_node_indices(circuit: &Circuit) -> HashMap<String, usize> {
                 if jfet.drain_resistance > 0.0 {
                     insert_node(&mut names, &jfet_intrinsic_drain_node(jfet));
                 }
+                if jfet.source_resistance > 0.0 {
+                    insert_node(&mut names, &jfet_intrinsic_source_node(jfet));
+                }
             }
             Element::Bjt(bjt) => {
                 insert_node(&mut names, &bjt.collector);
@@ -22459,9 +22467,10 @@ fn collect_noise_sources(
             Element::Jfet(jfet) => {
                 validate_jfet(jfet)?;
                 let intrinsic_drain = jfet_intrinsic_drain_node(jfet);
+                let intrinsic_source = jfet_intrinsic_source_node(jfet);
                 let drain = node_index(node_indices, &intrinsic_drain);
                 let gate = node_index(node_indices, &jfet.gate);
-                let source = node_index(node_indices, &jfet.source);
+                let source = node_index(node_indices, &intrinsic_source);
                 let drain_voltage = vector_voltage(operating_point, drain);
                 let gate_voltage = vector_voltage(operating_point, gate);
                 let source_voltage = vector_voltage(operating_point, source);
@@ -22523,6 +22532,16 @@ fn collect_noise_sources(
                         positive: node_index(node_indices, &jfet.drain),
                         negative: drain,
                         source_psd: 4.0 * BOLTZMANN * temperature_kelvin / jfet.drain_resistance,
+                        frequency_exponent: 0.0,
+                    });
+                }
+                if jfet.source_resistance > 0.0 {
+                    sources.push(NoiseSource {
+                        element_name: format!("{}:RS", jfet.name),
+                        noise_type: NoiseType::Thermal,
+                        positive: node_index(node_indices, &jfet.source),
+                        negative: source,
+                        source_psd: 4.0 * BOLTZMANN * temperature_kelvin / jfet.source_resistance,
                         frequency_exponent: 0.0,
                     });
                 }
@@ -23638,9 +23657,10 @@ fn stamp_jfet(
 ) -> Result<(), SpiceError> {
     validate_jfet(jfet)?;
     let intrinsic_drain = jfet_intrinsic_drain_node(jfet);
+    let intrinsic_source = jfet_intrinsic_source_node(jfet);
     let drain = node_index(node_indices, &intrinsic_drain);
     let gate = node_index(node_indices, &jfet.gate);
-    let source = node_index(node_indices, &jfet.source);
+    let source = node_index(node_indices, &intrinsic_source);
     let drain_voltage = vector_voltage(operating_point, drain);
     let gate_voltage = vector_voltage(operating_point, gate);
     let source_voltage = vector_voltage(operating_point, source);
@@ -23668,6 +23688,14 @@ fn stamp_jfet(
             node_index(node_indices, &jfet.drain),
             drain,
             1.0 / jfet.drain_resistance,
+        );
+    }
+    if jfet.source_resistance > 0.0 {
+        stamp_conductance(
+            matrix,
+            node_index(node_indices, &jfet.source),
+            source,
+            1.0 / jfet.source_resistance,
         );
     }
     Ok(())
@@ -24031,9 +24059,10 @@ fn stamp_jfet_small_signal(
 ) -> Result<(), SpiceError> {
     validate_jfet(jfet)?;
     let intrinsic_drain = jfet_intrinsic_drain_node(jfet);
+    let intrinsic_source = jfet_intrinsic_source_node(jfet);
     let drain = node_index(node_indices, &intrinsic_drain);
     let gate = node_index(node_indices, &jfet.gate);
-    let source = node_index(node_indices, &jfet.source);
+    let source = node_index(node_indices, &intrinsic_source);
     let drain_voltage = vector_voltage(operating_point, drain);
     let gate_voltage = vector_voltage(operating_point, gate);
     let source_voltage = vector_voltage(operating_point, source);
@@ -24056,6 +24085,14 @@ fn stamp_jfet_small_signal(
             node_index(node_indices, &jfet.drain),
             drain,
             1.0 / jfet.drain_resistance,
+        );
+    }
+    if jfet.source_resistance > 0.0 {
+        stamp_conductance(
+            matrix,
+            node_index(node_indices, &jfet.source),
+            source,
+            1.0 / jfet.source_resistance,
         );
     }
     Ok(())
@@ -24115,9 +24152,10 @@ fn stamp_ac_jfet_small_signal(
 ) -> Result<(), SpiceError> {
     validate_jfet(jfet)?;
     let intrinsic_drain = jfet_intrinsic_drain_node(jfet);
+    let intrinsic_source = jfet_intrinsic_source_node(jfet);
     let drain = node_index(node_indices, &intrinsic_drain);
     let gate = node_index(node_indices, &jfet.gate);
-    let source = node_index(node_indices, &jfet.source);
+    let source = node_index(node_indices, &intrinsic_source);
     let drain_voltage = vector_voltage(operating_point, drain);
     let gate_voltage = vector_voltage(operating_point, gate);
     let source_voltage = vector_voltage(operating_point, source);
@@ -24167,6 +24205,14 @@ fn stamp_ac_jfet_small_signal(
             node_index(node_indices, &jfet.drain),
             drain,
             Complex::new(1.0 / jfet.drain_resistance, 0.0),
+        );
+    }
+    if jfet.source_resistance > 0.0 {
+        stamp_complex_conductance(
+            matrix,
+            node_index(node_indices, &jfet.source),
+            source,
+            Complex::new(1.0 / jfet.source_resistance, 0.0),
         );
     }
     Ok(())
@@ -24470,7 +24516,7 @@ fn jfet_charge_state_specs(jfet: &Jfet) -> Vec<JfetChargeStateSpec> {
         specs.push(JfetChargeStateSpec {
             name: jfet_gate_source_charge_state_name(jfet),
             positive: jfet.gate.clone(),
-            negative: jfet.source.clone(),
+            negative: jfet_intrinsic_source_node(jfet),
             capacitance: jfet.gate_source_capacitance,
         });
     }
@@ -24497,6 +24543,14 @@ fn jfet_intrinsic_drain_node(jfet: &Jfet) -> String {
         jfet.drain.clone()
     } else {
         format!("__spice_{}_drain", jfet.name)
+    }
+}
+
+fn jfet_intrinsic_source_node(jfet: &Jfet) -> String {
+    if jfet.source_resistance == 0.0 {
+        jfet.source.clone()
+    } else {
+        format!("__spice_{}_source", jfet.name)
     }
 }
 
@@ -25079,6 +25133,12 @@ fn validate_jfet(jfet: &Jfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: jfet.name.clone(),
             reason: "drain resistance must be finite and non-negative".to_string(),
+        });
+    }
+    if !jfet.source_resistance.is_finite() || jfet.source_resistance < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: jfet.name.clone(),
+            reason: "source resistance must be finite and non-negative".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -95,7 +95,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 155);
+    assert_eq!(coverage.len(), 157);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -114,7 +114,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 155);
+    assert_eq!(records.len(), 157);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -195,15 +195,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 155);
-    assert_eq!(report.expected_canonical_parameter_count, 155);
-    assert_eq!(report.accepted_name_count, 223);
+    assert_eq!(report.canonical_parameter_count, 157);
+    assert_eq!(report.expected_canonical_parameter_count, 157);
+    assert_eq!(report.accepted_name_count, 225);
     assert_eq!(report.aliased_parameter_count, 55);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t155\t155\t223\t55\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t157\t157\t225\t55\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -230,8 +230,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 154);
-    assert_eq!(report.accepted_name_count, 220);
+    assert_eq!(report.canonical_parameter_count, 156);
+    assert_eq!(report.accepted_name_count, 222);
     assert_eq!(report.aliased_parameter_count, 54);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -248,7 +248,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t154\t155\t220\t54\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t156\t157\t222\t54\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -519,6 +519,7 @@ fn model_card_aliases_build_device_instances() {
             ("FC", 0.35),
             ("IS", 2.0e-13),
             ("RD", 125.0),
+            ("RS", 75.0),
         ],
     )
     .unwrap();
@@ -532,6 +533,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*jfet_card.parameters.get("FC").unwrap(), 0.35);
     assert_close(*jfet_card.parameters.get("IS").unwrap(), 2.0e-13);
     assert_close(*jfet_card.parameters.get("RD").unwrap(), 125.0);
+    assert_close(*jfet_card.parameters.get("RS").unwrap(), 75.0);
     assert_eq!(jfet_model.polarity, JfetPolarity::Njf);
     assert_close(jfet_model.beta, 9.0e-4);
     assert_close(jfet_model.threshold_voltage, -1.8);
@@ -542,6 +544,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(jfet_model.forward_bias_depletion_coefficient, 0.35);
     assert_close(jfet_model.gate_saturation_current, 2.0e-13);
     assert_close(jfet_model.drain_resistance, 125.0);
+    assert_close(jfet_model.source_resistance, 75.0);
 
     let mos_card = normalize_model_card(
         "Mn",
@@ -1468,6 +1471,7 @@ fn subcircuit_expansion_preserves_complete_jfet_model() {
     jfet.forward_bias_depletion_coefficient = 0.35;
     jfet.gate_saturation_current = 2.0e-13;
     jfet.drain_resistance = 125.0;
+    jfet.source_resistance = 75.0;
     let mut circuit = Circuit::new();
     circuit
         .define_subcircuit(SubcircuitDefinition::new(
@@ -1498,6 +1502,7 @@ fn subcircuit_expansion_preserves_complete_jfet_model() {
     assert_close(expanded.forward_bias_depletion_coefficient, 0.35);
     assert_close(expanded.gate_saturation_current, 2.0e-13);
     assert_close(expanded.drain_resistance, 125.0);
+    assert_close(expanded.source_resistance, 75.0);
 }
 
 #[test]
@@ -1517,6 +1522,24 @@ fn dc_jfet_drain_resistance_drops_intrinsic_drain_voltage() {
     let result = dc_op(&circuit).unwrap();
     assert_close(result.node_voltages["drain"], 5.0);
     assert!(result.node_voltages["__spice_J1_drain"] < 5.0);
+}
+
+#[test]
+fn dc_jfet_source_resistance_raises_intrinsic_source_voltage() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vdrain", "drain", "0", 5.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 3.0,
+    )));
+    let mut jfet = Jfet::new("J1", "drain", "gate", "0");
+    jfet.beta = 1.0e-3;
+    jfet.source_resistance = 1_000.0;
+    circuit.add(Element::Jfet(jfet));
+
+    let result = dc_op(&circuit).unwrap();
+    assert!(result.node_voltages["__spice_J1_source"] > 0.0);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -420,6 +420,24 @@ fn jfet_rejects_invalid_drain_resistance() {
 }
 
 #[test]
+fn jfet_rejects_invalid_source_resistance() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 0.0,
+    )));
+    let mut jfet = Jfet::new("J1", "out", "gate", "0");
+    jfet.source_resistance = -1.0;
+    circuit.add(Element::Jfet(jfet));
+
+    let error = noise_ac(&circuit, "out", "Vgate", &[1_000.0], 300.0).unwrap_err();
+    assert!(matches!(
+        error,
+        SpiceError::InvalidElement { reason, .. }
+            if reason == "source resistance must be finite and non-negative"
+    ));
+}
+
+#[test]
 fn jfet_drain_resistance_emits_thermal_noise() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(
@@ -440,6 +458,35 @@ fn jfet_drain_resistance_emits_thermal_noise() {
         .entries
         .iter()
         .find(|entry| entry.element_name == "J1:RD" && entry.noise_type == NoiseType::Thermal)
+        .unwrap();
+    assert_close(
+        entry.source_psd,
+        4.0 * 1.380_649e-23 * 300.0 / 250.0,
+        1.0e-30,
+    );
+}
+
+#[test]
+fn jfet_source_resistance_emits_thermal_noise() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vdd", "vdd", "0", 5.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 0.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "vdd", "out", 1_000.0,
+    )));
+    let mut jfet = Jfet::new("J1", "out", "gate", "0");
+    jfet.source_resistance = 250.0;
+    circuit.add(Element::Jfet(jfet));
+
+    let result = noise_ac(&circuit, "out", "Vgate", &[1_000.0], 300.0).unwrap();
+    let entry = result.points[0]
+        .entries
+        .iter()
+        .find(|entry| entry.element_name == "J1:RS" && entry.noise_type == NoiseType::Thermal)
         .unwrap();
     assert_close(
         entry.source_psd,

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add JFET model-card `RS` source-resistance support with an intrinsic source
+  node across DC, transient, AC, transfer-function, and noise analysis, plus
+  hierarchy preservation, validation, and a distinct thermal-noise source.
 - Add JFET model-card `RD` drain-resistance support with an intrinsic drain
   node across DC, transient, AC, transfer-function, and noise analysis, plus
   hierarchy preservation, validation, and a distinct thermal-noise source.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1701,6 +1701,7 @@ export interface Jfet {
   readonly forwardBiasDepletionCoefficient: number;
   readonly gateSaturationCurrent: number;
   readonly drainResistance: number;
+  readonly sourceResistance: number;
 }
 
 export type BjtPolarity = "NPN" | "PNP";
@@ -2030,8 +2031,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   D: [15, 21, 5, 3],
   NPN: [41, 58, 13, 4],
   PNP: [41, 58, 13, 4],
-  NJF: [11, 18, 6, 3],
-  PJF: [11, 18, 6, 3],
+  NJF: [12, 19, 6, 3],
+  PJF: [12, 19, 6, 3],
   NMOS: [18, 25, 6, 3],
   PMOS: [18, 25, 6, 3],
 };
@@ -3617,7 +3618,7 @@ function cloneSubcktElement(
     case "diode":
       return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient, element.breakdownVoltage, element.breakdownCurrent, element.junctionCapacitance, element.transitTime, element.junctionPotential, element.gradingCoefficient, element.forwardBiasDepletionCoefficient, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.seriesResistance, element.flickerNoiseCoefficient, element.flickerNoiseExponent);
     case "jfet":
-      return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.junctionPotential, element.forwardBiasDepletionCoefficient, element.gateSaturationCurrent, element.drainResistance);
+      return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.junctionPotential, element.forwardBiasDepletionCoefficient, element.gateSaturationCurrent, element.drainResistance, element.sourceResistance);
     case "bjt":
       return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees, element.forwardTransitTimeBiasCoefficient, element.forwardTransitTimeCurrent, element.forwardTransitTimeVoltage, element.emitterResistance, element.collectorResistance, element.baseResistance, element.minimumBaseResistance, element.baseResistanceHalfCurrent, element.baseCollectorCapacitanceFraction);
     case "mosfet":
@@ -7768,6 +7769,7 @@ export function jfet(
   forwardBiasDepletionCoefficient = 0.5,
   gateSaturationCurrent = 1.0e-14,
   drainResistance = 0.0,
+  sourceResistance = 0.0,
 ): Jfet {
   return {
     kind: "jfet",
@@ -7787,6 +7789,7 @@ export function jfet(
     forwardBiasDepletionCoefficient,
     gateSaturationCurrent,
     drainResistance,
+    sourceResistance,
   };
 }
 
@@ -8050,6 +8053,7 @@ const JFET_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   FC: "FC",
   IS: "IS",
   RD: "RD",
+  RS: "RS",
 };
 
 const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -8599,6 +8603,7 @@ export function jfetFromModelCard(
     p.FC ?? 0.5,
     p.IS ?? 1.0e-14,
     p.RD ?? 0.0,
+    p.RS ?? 0.0,
   );
 }
 
@@ -18365,6 +18370,9 @@ function collectNodeIndices(circuit: Circuit): Map<string, number> {
         if (element.drainResistance > 0.0) {
           insertNode(names, jfetIntrinsicDrainNode(element));
         }
+        if (element.sourceResistance > 0.0) {
+          insertNode(names, jfetIntrinsicSourceNode(element));
+        }
         break;
       case "bjt":
         insertNode(names, element.collector);
@@ -18660,9 +18668,10 @@ function collectNoiseSources(
     } else if (element.kind === "jfet") {
       validateJfet(element);
       const intrinsicDrain = jfetIntrinsicDrainNode(element);
+      const intrinsicSource = jfetIntrinsicSourceNode(element);
       const drain = nodeIndex(nodeIndices, intrinsicDrain);
       const gate = nodeIndex(nodeIndices, element.gate);
-      const source = nodeIndex(nodeIndices, element.source);
+      const source = nodeIndex(nodeIndices, intrinsicSource);
       const drainVoltage = vectorVoltage(operatingPoint, drain);
       const gateVoltage = vectorVoltage(operatingPoint, gate);
       const sourceVoltage = vectorVoltage(operatingPoint, source);
@@ -18726,6 +18735,17 @@ function collectNoiseSources(
           negative: drain,
           sourcePsd:
             4.0 * BOLTZMANN * temperatureKelvin / element.drainResistance,
+          frequencyExponent: 0.0,
+        });
+      }
+      if (element.sourceResistance > 0.0) {
+        sources.push({
+          elementName: `${element.name}:RS`,
+          noiseType: "thermal",
+          positive: nodeIndex(nodeIndices, element.source),
+          negative: source,
+          sourcePsd:
+            4.0 * BOLTZMANN * temperatureKelvin / element.sourceResistance,
           frequencyExponent: 0.0,
         });
       }
@@ -19612,6 +19632,12 @@ function validateJfet(element: Jfet): void {
       "drain resistance must be finite and non-negative",
     );
   }
+  if (!Number.isFinite(element.sourceResistance) || element.sourceResistance < 0.0) {
+    throw invalidElement(
+      element.name,
+      "source resistance must be finite and non-negative",
+    );
+  }
 }
 
 const JFET_THERMAL_VOLTAGE = 0.02585;
@@ -19663,9 +19689,10 @@ function stampJfet(
 ): void {
   validateJfet(element);
   const intrinsicDrain = jfetIntrinsicDrainNode(element);
+  const intrinsicSource = jfetIntrinsicSourceNode(element);
   const drain = nodeIndex(nodeIndices, intrinsicDrain);
   const gate = nodeIndex(nodeIndices, element.gate);
-  const source = nodeIndex(nodeIndices, element.source);
+  const source = nodeIndex(nodeIndices, intrinsicSource);
   const drainVoltage = vectorVoltage(operatingPoint, drain);
   const gateVoltage = vectorVoltage(operatingPoint, gate);
   const sourceVoltage = vectorVoltage(operatingPoint, source);
@@ -19701,6 +19728,14 @@ function stampJfet(
       nodeIndex(nodeIndices, element.drain),
       drain,
       1.0 / element.drainResistance,
+    );
+  }
+  if (element.sourceResistance > 0.0) {
+    stampConductance(
+      matrix,
+      nodeIndex(nodeIndices, element.source),
+      source,
+      1.0 / element.sourceResistance,
     );
   }
 }
@@ -20353,7 +20388,7 @@ function jfetChargeStateSpecs(element: Jfet): JfetChargeStateSpec[] {
     specs.push({
       name: jfetGateSourceChargeStateName(element),
       positive: element.gate,
-      negative: element.source,
+      negative: jfetIntrinsicSourceNode(element),
       capacitance: element.gateSourceCapacitance,
     });
   }
@@ -20372,6 +20407,12 @@ function jfetIntrinsicDrainNode(element: Jfet): string {
   return element.drainResistance === 0.0
     ? element.drain
     : `__spice_${element.name}_drain`;
+}
+
+function jfetIntrinsicSourceNode(element: Jfet): string {
+  return element.sourceResistance === 0.0
+    ? element.source
+    : `__spice_${element.name}_source`;
 }
 
 function jfetChargeStateVoltage(
@@ -22099,9 +22140,10 @@ function stampJfetSmallSignal(
 ): void {
   validateJfet(element);
   const intrinsicDrain = jfetIntrinsicDrainNode(element);
+  const intrinsicSource = jfetIntrinsicSourceNode(element);
   const drain = nodeIndex(nodeIndices, intrinsicDrain);
   const gate = nodeIndex(nodeIndices, element.gate);
-  const source = nodeIndex(nodeIndices, element.source);
+  const source = nodeIndex(nodeIndices, intrinsicSource);
   const drainVoltage = vectorVoltage(operatingPoint, drain);
   const gateVoltage = vectorVoltage(operatingPoint, gate);
   const sourceVoltage = vectorVoltage(operatingPoint, source);
@@ -22124,6 +22166,14 @@ function stampJfetSmallSignal(
       nodeIndex(nodeIndices, element.drain),
       drain,
       1.0 / element.drainResistance,
+    );
+  }
+  if (element.sourceResistance > 0.0) {
+    stampConductance(
+      matrix,
+      nodeIndex(nodeIndices, element.source),
+      source,
+      1.0 / element.sourceResistance,
     );
   }
 }
@@ -22850,9 +22900,10 @@ function stampAcJfetSmallSignal(
 ): void {
   validateJfet(element);
   const intrinsicDrain = jfetIntrinsicDrainNode(element);
+  const intrinsicSource = jfetIntrinsicSourceNode(element);
   const drain = nodeIndex(nodeIndices, intrinsicDrain);
   const gate = nodeIndex(nodeIndices, element.gate);
-  const source = nodeIndex(nodeIndices, element.source);
+  const source = nodeIndex(nodeIndices, intrinsicSource);
   const drainVoltage = vectorVoltage(operatingPoint, drain);
   const gateVoltage = vectorVoltage(operatingPoint, gate);
   const sourceVoltage = vectorVoltage(operatingPoint, source);
@@ -22902,6 +22953,14 @@ function stampAcJfetSmallSignal(
       nodeIndex(nodeIndices, element.drain),
       drain,
       complex(1.0 / element.drainResistance, 0.0),
+    );
+  }
+  if (element.sourceResistance > 0.0) {
+    stampComplexConductance(
+      matrix,
+      nodeIndex(nodeIndices, element.source),
+      source,
+      complex(1.0 / element.sourceResistance, 0.0),
     );
   }
 }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -120,7 +120,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(155);
+    expect(coverage).toHaveLength(157);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -140,7 +140,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(155);
+    expect(records).toHaveLength(157);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -205,15 +205,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 155,
-      expectedCanonicalParameterCount: 155,
-      acceptedNameCount: 223,
+      canonicalParameterCount: 157,
+      expectedCanonicalParameterCount: 157,
+      acceptedNameCount: 225,
       aliasedParameterCount: 55,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t155\t155\t223\t55\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t157\t157\t225\t55\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -236,8 +236,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(154);
-    expect(report.acceptedNameCount).toBe(220);
+    expect(report.canonicalParameterCount).toBe(156);
+    expect(report.acceptedNameCount).toBe(222);
     expect(report.aliasedParameterCount).toBe(54);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -252,7 +252,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t154\t155\t220\t54\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t156\t157\t222\t54\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -383,9 +383,9 @@ describe("dcOp", () => {
     expectClose(bjtModel.baseCollectorGradingCoefficient, 0.45);
     expectClose(bjtModel.forwardBiasDepletionCoefficient, 0.4);
 
-    const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02, KF: 1.0e-12, AF: 1.3, VJ: 0.8, FC: 0.35, IS: 2.0e-13, RD: 125.0 });
+    const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02, KF: 1.0e-12, AF: 1.3, VJ: 0.8, FC: 0.35, IS: 2.0e-13, RD: 125.0, RS: 75.0 });
     const jfetModel = jfetFromModelCard("J1", "d", "g", "s", jfetCard);
-    expect(jfetCard.parameters).toStrictEqual({ BETA: 9.0e-4, VTO: -1.8, LAMBDA: 0.02, KF: 1.0e-12, AF: 1.3, PB: 0.8, FC: 0.35, IS: 2.0e-13, RD: 125.0 });
+    expect(jfetCard.parameters).toStrictEqual({ BETA: 9.0e-4, VTO: -1.8, LAMBDA: 0.02, KF: 1.0e-12, AF: 1.3, PB: 0.8, FC: 0.35, IS: 2.0e-13, RD: 125.0, RS: 75.0 });
     expect(jfetModel.polarity).toBe("NJF");
     expectClose(jfetModel.beta, 9.0e-4);
     expectClose(jfetModel.thresholdVoltage, -1.8);
@@ -396,6 +396,7 @@ describe("dcOp", () => {
     expectClose(jfetModel.forwardBiasDepletionCoefficient, 0.35);
     expectClose(jfetModel.gateSaturationCurrent, 2.0e-13);
     expectClose(jfetModel.drainResistance, 125.0);
+    expectClose(jfetModel.sourceResistance, 75.0);
 
     const mosCard = normalizeModelCard("Mn", "nmos", {
       LEVEL: 1.0,
@@ -1059,6 +1060,7 @@ describe("dcOp", () => {
           forwardBiasDepletionCoefficient: 0.35,
           gateSaturationCurrent: 2.0e-13,
           drainResistance: 125.0,
+          sourceResistance: 75.0,
         },
       ]),
     );
@@ -1075,6 +1077,7 @@ describe("dcOp", () => {
     expectClose(expanded.forwardBiasDepletionCoefficient, 0.35);
     expectClose(expanded.gateSaturationCurrent, 2.0e-13);
     expectClose(expanded.drainResistance, 125.0);
+    expectClose(expanded.sourceResistance, 75.0);
   });
 
   it("drops the intrinsic JFET drain voltage across RD", () => {
@@ -1090,6 +1093,20 @@ describe("dcOp", () => {
     const result = dcOp(circuit);
     expectClose(result.nodeVoltages.get("drain")!, 5.0);
     expect(result.nodeVoltages.get("__spice_J1_drain")!).toBeLessThan(5.0);
+  });
+
+  it("raises the intrinsic JFET source voltage across RS", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vdrain", "drain", "0", 5.0));
+    circuit.add(voltageSource("Vgate", "gate", "0", 3.0));
+    circuit.add({
+      ...jfet("J1", "drain", "gate", "0"),
+      beta: 1.0e-3,
+      sourceResistance: 1_000.0,
+    });
+
+    const result = dcOp(circuit);
+    expect(result.nodeVoltages.get("__spice_J1_source")!).toBeGreaterThan(0.0);
   });
 
   it("loads a forward-biased JFET gate from gate saturation current", () => {

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -99,6 +99,16 @@ describe("noiseAc", () => {
     );
   });
 
+  it("rejects an invalid JFET source resistance", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vgate", "gate", "0", 0.0));
+    circuit.add({ ...jfet("J1", "out", "gate", "0"), sourceResistance: -1.0 });
+
+    expect(() => noiseAc(circuit, "out", "Vgate", [1_000.0])).toThrow(
+      /source resistance must be finite and non-negative/,
+    );
+  });
+
   it("emits JFET drain-resistance thermal noise", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vdd", "vdd", "0", 5.0));
@@ -109,6 +119,23 @@ describe("noiseAc", () => {
     const entry = noiseAc(circuit, "out", "Vgate", [1_000.0], 300.0).points[0]!.entries
       .find((candidate) =>
         candidate.elementName === "J1:RD" && candidate.noiseType === "thermal"
+      );
+    expect(entry?.sourcePsd).toBeCloseTo(
+      4.0 * 1.380_649e-23 * 300.0 / 250.0,
+      30,
+    );
+  });
+
+  it("emits JFET source-resistance thermal noise", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vdd", "vdd", "0", 5.0));
+    circuit.add(voltageSource("Vgate", "gate", "0", 0.0));
+    circuit.add(resistor("Rload", "vdd", "out", 1_000.0));
+    circuit.add({ ...jfet("J1", "out", "gate", "0"), sourceResistance: 250.0 });
+
+    const entry = noiseAc(circuit, "out", "Vgate", [1_000.0], 300.0).points[0]!.entries
+      .find((candidate) =>
+        candidate.elementName === "J1:RS" && candidate.noiseType === "thermal"
       );
     expect(entry?.sourcePsd).toBeCloseTo(
       4.0 * 1.380_649e-23 * 300.0 / 250.0,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language JFET drain resistance.
+1. Cross-language JFET source resistance.
    - Status: current PR completion candidate.
-   - Add Berkeley JFET `RD` model-card support in Rust, Python, and TypeScript.
-   - Default `RD` to zero ohms and, when positive, route channel, gate-drain,
+   - Add Berkeley JFET `RS` model-card support in Rust, Python, and TypeScript.
+   - Default `RS` to zero ohms and, when positive, route channel, gate-source,
      charge, AC, transient, transfer-function, and noise behavior through an
-     intrinsic drain node behind the external drain resistor.
-   - Preserve `RD` through hierarchy and cloning, validate finite non-negative
-     values, emit a distinct `RD` thermal-noise source, and extend the
-     supported-parameter coverage gate from 153 to 155 canonical rows.
+     intrinsic source node behind the external source resistor.
+   - Preserve `RS` through hierarchy and cloning, validate finite non-negative
+     values, emit a distinct `RS` thermal-noise source, and extend the
+     supported-parameter coverage gate from 155 to 157 canonical rows.
 
 ## Completed Slices
 
@@ -3288,6 +3288,17 @@ the Rust, Python, and TypeScript surfaces together.
    - Hierarchy and cloning paths preserve `IS`, finite non-negative validation
      is shared across analyses, distinct `IGS` / `IGD` shot-noise sources are
      emitted, and the supported-parameter release gate now covers 153
+     canonical rows.
+
+254. Cross-language JFET drain resistance.
+   - Status: completed in PR 8934.
+   - Rust, Python, and TypeScript JFET model cards now accept `RD`, default it
+     to zero ohms, and route channel, gate-drain, charge, AC, transient,
+     transfer-function, and noise behavior through an intrinsic drain node
+     behind the external drain resistor when positive.
+   - Hierarchy and cloning paths preserve `RD`, finite non-negative validation
+     is shared across analyses, a distinct `RD` thermal-noise source is
+     emitted, and the supported-parameter release gate now covers 155
      canonical rows.
 
 ## Backlog


### PR DESCRIPTION
## Summary
- add Berkeley JFET `RS` model-card support across Rust, Python, and TypeScript
- route channel, gate-source junction, charge, DC/transient, AC, TF, and noise behavior through an intrinsic source node when `RS > 0`
- preserve and validate `RS`, emit `:RS` thermal noise, and advance the supported-parameter coverage gate to 157 rows

## Verification
- `cargo test -p spice-engine`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo fmt -p spice-engine -- --check`
- Python: 604 tests passed, 88.78% coverage; Ruff passed on touched files
- TypeScript: build passed; 362 tests passed