### PR TITLE
feat(sqlite-file): page-1 sqlite_schema records overflow onto overflow pages (F2)

### DIFF
--- a/code/packages/rust/sqlite-file/CHANGELOG.md
+++ b/code/packages/rust/sqlite-file/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog — sqlite-file
 
+## 0.17.0 - Unreleased
+
+**Phase F (writer): page-1 `sqlite_schema` overflow — completes F2.** A schema
+row (a long CREATE statement) too large to sit inline on page 1 now spills onto
+overflow pages instead of being rejected. `write_multi_table_db` routes the
+page-1 schema leaf through the same overflow-split machinery table data rows
+already use (`build_leaf_cells_with_overflow`, extracted from `encode_single_leaf`
+so both share one code path), building the cells with the **reader's**
+page-agnostic threshold `max_local = usable − 35` (not the old `(page_size−100)−35`
+bound — a smaller inline length there would disagree with what the reader
+recomputes for page 1 and corrupt the round-trip). The schema's overflow pages
+are allocated AFTER every table page, so the page-1 cell's 4-byte pointer targets
+them correctly and each table still roots on page 2; `total_pages` counts them.
+
+What remains a later rung: a schema so large that even its *inline heads* exceed
+one page-1 leaf (which would require turning page 1 into an interior schema
+b-tree) — `pack_leaf_cells` rejects that cleanly with `Unsupported`.
+
+Verified by a round-trip unit test and a cross-check that real bundled-C SQLite
+accepts the file (`PRAGMA integrity_check` → "ok") and reassembles the full DDL
+from the schema overflow chain (`SELECT sql FROM sqlite_master`).
+
 ## 0.16.0 - Unreleased
 
 **Phase F (writer): multi-level b-trees.** The tree builder now handles tables

--- a/code/packages/rust/sqlite-file/Cargo.toml
+++ b/code/packages/rust/sqlite-file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlite-file"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "A small, zero-dependency reader for the SQLite on-disk file format — the read subset the Engram Anki-package importer needs — reimplemented from scratch to keep the Engram stack free of the bundled-C `rusqlite` crate."
 license = "MIT"

--- a/code/packages/rust/sqlite-file/src/page_writer.rs
+++ b/code/packages/rust/sqlite-file/src/page_writer.rs
@@ -345,6 +345,9 @@ pub type TableSpec<'a> = (&'a str, &'a str, &'a [(i64, Vec<crate::record::SqlVal
 ///   followed immediately by that table's overflow pages (for rows too large to
 ///   sit inline), then the next table's leaf, and so on. A table's root page is
 ///   therefore wherever its leaf lands after the previous tables' pages.
+/// - **Schema overflow pages** (for a `sqlite_schema` row — a long CREATE
+///   statement — too large to sit inline on page 1) come LAST, after every table
+///   page, so the page-1 leaf's cell points at the first of them.
 ///
 /// The result reads back through [`crate::schema::read_table`]`(&db, name)` for
 /// each table and is accepted by real SQLite (it passes `PRAGMA
@@ -353,9 +356,10 @@ pub type TableSpec<'a> = (&'a str, &'a str, &'a [(i64, Vec<crate::record::SqlVal
 /// # Errors
 /// [`SqliteError::BadPageSize`] for a `page_size` outside the power-of-two
 /// `512..=65536` range; [`SqliteError::Unsupported`] if a duplicate rowid
-/// appears within a table, if the combined `sqlite_schema` rows do not fit on
-/// page 1's single leaf (page-1 schema overflow is a later rung), or if the
-/// database would exceed the 2³²-page limit.
+/// appears within a table, if the database would exceed the 2³²-page limit, or if
+/// the `sqlite_schema` rows' *inline heads* still do not fit on page 1's single
+/// leaf even after overflow (a schema large enough to need page 1 to become an
+/// interior b-tree is a later rung).
 pub fn write_multi_table_db(page_size: usize, tables: &[TableSpec]) -> Result<Vec<u8>, SqliteError> {
     if !(512..=65536).contains(&page_size) || !page_size.is_power_of_two() {
         return Err(SqliteError::BadPageSize(page_size as u32));
@@ -390,8 +394,25 @@ pub fn write_multi_table_db(page_size: usize, tables: &[TableSpec]) -> Result<Ve
         table_pages.extend(pages);
     }
 
-    // Total pages: page 1 (schema) + every table/overflow page.
-    let total_pages = u32::try_from(1 + table_pages.len())
+    // --- Page-1 sqlite_schema leaf. Build its cells with overflow support, using
+    // the SAME threshold as any leaf (`data_max_local` = usable - 35): the reader
+    // recomputes the overflow split page-agnostically for page 1 too, so a smaller
+    // (page_size - 100) bound would emit an inline length it disagrees with and
+    // corrupt the round-trip. A schema row too large to sit inline spills onto
+    // overflow pages, which are allocated AFTER every table page (so they take the
+    // next free page numbers); the page-1 leaf's cell then points at the first.
+    let ordered_schema = order_cells(&schema_rows)?;
+    let first_schema_overflow = next_page;
+    let (schema_cells, schema_overflow) = build_leaf_cells_with_overflow(
+        page_size,
+        usable,
+        data_max_local,
+        &ordered_schema,
+        first_schema_overflow,
+    );
+
+    // Total pages: page 1 + every table/overflow page + the schema's overflow pages.
+    let total_pages = u32::try_from(1 + table_pages.len() + schema_overflow.len())
         .map_err(|_| SqliteError::Unsupported("database exceeds the 2^32-page limit"))?;
 
     // --- Page 1: DB header (offset 0..100) + sqlite_schema leaf (offset 100). -
@@ -409,16 +430,23 @@ pub fn write_multi_table_db(page_size: usize, tables: &[TableSpec]) -> Result<Ve
     let mut page1 = vec![0u8; page_size];
     page1[0..100].copy_from_slice(&header.encode());
 
-    // The schema b-tree leaf sits at offset 100 (after the DB header). Its inline
-    // limit is the usable area minus that 100-byte prefix and the 35-byte cell
-    // overhead; schema rows that would overflow it are rejected (a later rung).
-    let ordered_schema = order_cells(&schema_rows)?;
-    let schema_max_local = (page_size - 100).saturating_sub(LEAF_PAYLOAD_OVERHEAD);
-    fill_table_leaf_page(&mut page1, 100, page_size, schema_max_local, &ordered_schema)?;
+    // Frame the schema cells onto page 1's leaf at offset 100. `pack_leaf_cells`
+    // enforces that the cells' inline heads physically fit page 1's reduced
+    // content area (`page_size - 100 - 8 - 2·N`). Overflow beyond that has already
+    // been peeled off into `schema_overflow`; what remains unsupported is a schema
+    // whose inline heads alone exceed one page-1 leaf (turning page 1 into an
+    // interior schema b-tree is a later rung), which surfaces here as an error.
+    pack_leaf_cells(&mut page1, 100, page_size, &schema_cells)?;
 
-    // --- Assemble: page 1, then every table's pages in allocation order. ------
+    // --- Assemble: page 1, every table's pages, then the schema's overflow pages.
+    // The schema overflow pages come last, so their page numbers are exactly
+    // `first_schema_overflow …` — matching the pointers baked into the page-1
+    // cells above.
     let mut file = page1;
     for page in &table_pages {
+        file.extend_from_slice(page);
+    }
+    for page in &schema_overflow {
         file.extend_from_slice(page);
     }
     Ok(file)
@@ -620,27 +648,51 @@ fn encode_single_leaf(
     ordered: &[&(i64, Vec<u8>)],
     indices: &[usize],
 ) -> Result<(Vec<u8>, Vec<Vec<u8>>), SqliteError> {
-    let mut next_overflow_page = leaf_page + 1;
+    let selected: Vec<&(i64, Vec<u8>)> = indices.iter().map(|&i| ordered[i]).collect();
+    let (leaf_cells, overflow_pages) =
+        build_leaf_cells_with_overflow(page_size, usable, data_max_local, &selected, leaf_page + 1);
+    let mut leaf = vec![0u8; page_size];
+    pack_leaf_cells(&mut leaf, 0, page_size, &leaf_cells)?;
+    Ok((leaf, overflow_pages))
+}
+
+/// Build the table-leaf **cell bytes** for every `(rowid, record)` in `ordered`,
+/// spilling oversized records into overflow pages. Returns `(cells, overflow)`:
+/// `cells` are the inline cell bytes (still to be framed onto a leaf page by
+/// [`pack_leaf_cells`], at offset 0 for an ordinary page or 100 on page 1), and
+/// `overflow` is the flat list of overflow pages the records produced, numbered
+/// consecutively from `first_overflow_page`.
+///
+/// The split is page-position-agnostic — it uses `max_local` and `usable`
+/// directly — so the SAME routine serves both ordinary data leaves and the
+/// page-1 `sqlite_schema` leaf. In particular the schema leaf must pass
+/// `max_local = usable - 35` (NOT a `usable - 100 - 35` bound), because the
+/// reader recomputes the overflow threshold page-agnostically for page 1 too;
+/// emitting a different inline length would corrupt the round-trip.
+fn build_leaf_cells_with_overflow(
+    page_size: usize,
+    usable: usize,
+    max_local: usize,
+    ordered: &[&(i64, Vec<u8>)],
+    first_overflow_page: u32,
+) -> (Vec<Vec<u8>>, Vec<Vec<u8>>) {
+    let mut next_overflow_page = first_overflow_page;
     let mut overflow_pages: Vec<Vec<u8>> = Vec::new();
-    let mut leaf_cells: Vec<Vec<u8>> = Vec::with_capacity(indices.len());
-    for &i in indices {
-        let (rowid, record) = ordered[i];
+    let mut cells: Vec<Vec<u8>> = Vec::with_capacity(ordered.len());
+    for entry in ordered {
         let (cell, spilled) = build_leaf_cell(
-            *rowid,
-            record,
+            entry.0,
+            &entry.1,
             page_size,
             usable,
-            data_max_local,
+            max_local,
             next_overflow_page,
         );
         next_overflow_page += spilled.len() as u32;
         overflow_pages.extend(spilled);
-        leaf_cells.push(cell);
+        cells.push(cell);
     }
-
-    let mut leaf = vec![0u8; page_size];
-    pack_leaf_cells(&mut leaf, 0, page_size, &leaf_cells)?;
-    Ok((leaf, overflow_pages))
+    (cells, overflow_pages)
 }
 
 /// Pack an **interior table b-tree page** (type `0x05`) from its divider cells
@@ -796,6 +848,45 @@ mod tests {
         // docs' leaf + its overflow pages.
         assert_eq!(schema[1].root_page, Some(3));
         assert!(schema[2].root_page.unwrap() > 3);
+    }
+
+    /// A `sqlite_schema` row (a long CREATE statement) too large to sit inline on
+    /// page 1 spills onto overflow pages — the same overflow path data rows use,
+    /// but for the schema leaf at offset 100. The overflow pages are allocated
+    /// AFTER the table's data pages, so the table still roots on page 2, and the
+    /// reader reassembles the full DDL from the chain.
+    #[test]
+    fn write_page1_schema_row_spills_into_overflow() {
+        // ~580-byte CREATE statement ≫ the 512-byte page's inline limit
+        // (max_local = 512 − 35 = 477), so the schema record must overflow.
+        let cols = (0..80).map(|i| format!("col{i}")).collect::<Vec<_>>().join(", ");
+        let create_sql = format!("CREATE TABLE big({cols})");
+        assert!(create_sql.len() > 477, "test needs an overflowing schema row");
+
+        let rows = vec![
+            (1i64, vec![SqlValue::Int(1), SqlValue::Text("a".into())]),
+            (2, vec![SqlValue::Int(2), SqlValue::Text("b".into())]),
+        ];
+        let db = write_single_table_db(512, "big", &create_sql, &rows).unwrap();
+
+        // Page 1 (schema leaf, spilling) + page 2 (data leaf) + ≥1 schema overflow
+        // page. The header's page count must equal the actual file length.
+        assert_eq!(db.len() % 512, 0);
+        let pages = db.len() / 512;
+        assert!(pages > 2, "schema overflow page must exist, got {pages} pages");
+        let header = crate::header::Header::parse(&db).unwrap();
+        assert_eq!(header.page_count as usize, pages);
+        assert_eq!(&db[0..16], MAGIC);
+
+        // The reader reassembles the full DDL from the schema overflow chain, and
+        // the table (rooted on page 2, before the schema's overflow pages) reads
+        // back by name.
+        let schema = crate::schema::read_schema(&db).unwrap();
+        assert_eq!(schema.len(), 1);
+        assert_eq!(schema[0].name, "big");
+        assert_eq!(schema[0].root_page, Some(2));
+        assert_eq!(schema[0].sql.as_deref(), Some(create_sql.as_str()));
+        assert_eq!(crate::schema::read_table(&db, "big").unwrap(), rows);
     }
 
     /// A table with more rows than fit on one leaf grows a b-tree: several data

--- a/code/packages/rust/sqlite-file/tests/cross_check_reader.rs
+++ b/code/packages/rust/sqlite-file/tests/cross_check_reader.rs
@@ -474,6 +474,75 @@ fn our_writer_output_reads_in_real_sqlite_with_overflow() {
     );
 }
 
+/// Page-1 `sqlite_schema` overflow cross-check: a database whose CREATE
+/// statement is too long to sit inline on page 1 spills onto overflow pages, and
+/// real bundled-C SQLite both validates it (`PRAGMA integrity_check` → "ok") and
+/// reassembles the full DDL from the schema overflow chain (`SELECT sql FROM
+/// sqlite_master`). This is the strongest gate that the writer's page-1 overflow
+/// framing — offset-100 leaf, overflow pointer, and chained pages — is
+/// byte-correct.
+#[test]
+fn our_writer_page1_schema_overflow_reads_in_real_sqlite() {
+    use sqlite_file::page_writer::write_single_table_db;
+    use sqlite_file::SqlValue;
+
+    // A CREATE with hundreds of columns → several KiB of DDL, well past the
+    // 4096-byte page's inline limit (max_local = 4096 − 35 = 4061), so the
+    // sqlite_schema row must overflow off page 1.
+    let cols = (0..600)
+        .map(|i| format!("column_{i}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let create_sql = format!("CREATE TABLE big({cols})");
+    assert!(
+        create_sql.len() > 4061,
+        "test needs a schema row that overflows page 1"
+    );
+    let rows = vec![
+        (1i64, vec![SqlValue::Int(10), SqlValue::Int(11)]),
+        (2, vec![SqlValue::Int(20), SqlValue::Int(21)]),
+    ];
+    let db = write_single_table_db(4096, "big", &create_sql, &rows).unwrap();
+    assert!(
+        db.len() / 4096 > 2,
+        "the schema row must have spilled into overflow pages"
+    );
+
+    static COUNTER_S: AtomicU64 = AtomicU64::new(9_500_000);
+    let unique = COUNTER_S.fetch_add(1, Ordering::Relaxed);
+    let mut dir = std::env::temp_dir();
+    dir.push(format!("sqlite_file_schemaovf_{}_{}", std::process::id(), unique));
+    std::fs::create_dir(&dir).expect("create fresh fixture dir");
+    let path = dir.join("ours.db");
+    std::fs::write(&path, &db).unwrap();
+
+    let conn = rusqlite::Connection::open(&path).unwrap();
+    let integrity: String = conn
+        .query_row("PRAGMA integrity_check", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(
+        integrity, "ok",
+        "real SQLite's integrity_check must pass on a page-1 schema-overflow file"
+    );
+    // Real SQLite reassembles the full DDL from the overflow chain.
+    let sql: String = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE name = 'big'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(sql, create_sql, "the overflowed DDL must round-trip in full");
+    // And the table itself is queryable (its root page precedes the schema
+    // overflow pages, so nothing shifted).
+    let count: i64 = conn
+        .query_row("SELECT count(*) FROM big", [], |r| r.get(0))
+        .unwrap();
+    drop(conn);
+    let _ = std::fs::remove_dir_all(&dir);
+    assert_eq!(count, 2, "real SQLite must read the table's rows");
+}
+
 /// Multi-table write-path cross-check: a database our writer assembles with
 /// several tables — one carrying an overflow row — is accepted by real
 /// bundled-C SQLite (`PRAGMA integrity_check` → "ok") and every table reads

--- a/code/specs/engram-zero-dep-plan.md
+++ b/code/specs/engram-zero-dep-plan.md
@@ -198,7 +198,13 @@ test-fixture work for Phase F.
 ### Phase F — sqlite-file writer (**removes rusqlite**) — L (PRs A6–A8)
 - F1: record/header/b-tree **write** — smallest-serial-type rule, leaf-insert,
   page splits → interior pages, overflow-write for large `col` JSON. L
-- F2: sqlite_schema writer + `build(tables)` API. M
+- F2: sqlite_schema writer + `build(tables)` API. M — **DONE.**
+  `write_multi_table_db(page_size, tables)` (with `write_single_table_db` as the
+  one-table case) emits a full multi-table database — page-1 `sqlite_schema` leaf
+  + per-table data b-trees — accepted by real SQLite (`PRAGMA integrity_check`).
+  Page-1 `sqlite_schema` records that overflow now spill onto overflow pages
+  (sqlite-file 0.17.0). Remaining later rung: a schema so large its inline heads
+  need page 1 to become an interior b-tree.
 - F3: cut anki-pkg **writer** over (`write_v11_collection_bytes_from_engram_state`),
   **delete `rusqlite`** from Cargo.toml; port engram-capi's test-only sqlite
   fixture builder to the new writer, drop its dev-dep. **rusqlite gone from repo.**


### PR DESCRIPTION
## What

Completes **Phase F2** of the zero-dep SQLite writer: a `sqlite_schema` row — a long `CREATE` statement — too large to sit inline on page 1 now **spills onto overflow pages** instead of being rejected. This is the last writer rung before F3 (cutting the anki-pkg writer over and deleting `rusqlite`).

Previously `write_multi_table_db` assumed every schema record fit inline on page 1 and errored otherwise.

## How

Reuses the exact overflow-split machinery table *data* rows already use, now applied to the page-1 schema leaf (at offset 100):

- The old `encode_single_leaf` cell-building loop is extracted into **`build_leaf_cells_with_overflow`**; `encode_single_leaf` delegates to it (byte-identical data leaves — same overflow page numbering, same cell order), and the page-1 schema leaf calls it too.
- **The load-bearing correctness point:** the schema cells use the reader's page-agnostic threshold `max_local = usable − 35`, *not* the old `(page_size − 100) − 35` bound. The reader recomputes the overflow split page-agnostically for page 1, so a smaller inline length there would disagree with what it reassembles and corrupt the round-trip.
- The schema's overflow pages are allocated **after** every table page (taking the next free page numbers), so the page-1 cell's 4-byte pointer targets them and each table still roots on page 2. `total_pages` counts them.
- `pack_leaf_cells` frames the cells at offset 100 and already guards physical fit: a schema whose *inline heads* still exceed page 1's reduced content area (which would require turning page 1 into an interior schema b-tree) is rejected with a clean `Unsupported` — the documented next rung.

## Verification

- **Round-trip unit test** (`write_page1_schema_row_spills_into_overflow`): a ~580-byte CREATE on a 512-byte page overflows, and `read_schema`/`read_table` reassemble the full DDL and rows.
- **Cross-check vs real bundled-C SQLite** (`our_writer_page1_schema_overflow_reads_in_real_sqlite`): a ~7 KB CREATE on a 4096-byte page → real SQLite `PRAGMA integrity_check` = "ok", `SELECT sql FROM sqlite_master` returns the full DDL, and the table is queryable. This is the strongest gate that the page-1 overflow framing is byte-correct.
- Full `sqlite-file` suite + downstream consumers (`storage-sqlite`, `engram-anki-package`) green; clippy clean.
- Inline security review **CLEAN**: page numbers, thresholds, and the fit-guard all line up with the reader; the `encode_single_leaf` refactor is byte-identical.

Spec F2 in `engram-zero-dep-plan.md` marked **DONE**. Version: `sqlite-file` 0.17.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
