### PR TITLE
feat(adj-formula-stdlib): molarity — LibreTexts M = n/V amount-concentration library (chemistry track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_molarity_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_molarity_e2e.rs
@@ -1,0 +1,139 @@
+//! End-to-end tests for the `chemistry/molarity.adj` library — the definition of
+//! molarity (M = n/V) and its two exact rearrangements (n = M·V, V = n/M) — driven
+//! through the built CLI binary against the SHIPPED stdlib. Each proves the same
+//! invariant as the other formula libraries: a consumer states NO arithmetic; it
+//! imports the grounded library, binds the measured quantities with `observe`, and
+//! the engine applies the cited definition on the CPU — computing the EXACT value
+//! and rendering the definition's citation + trust tier in the `derived` section
+//! (the auditable answer). The three formulas INVERT: 6 / 2 = 3, 3 * 2 = 6, 6 / 3 = 2.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped molarity library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_molarity_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/chemistry/molarity.adj")
+        .canonicalize()
+        .expect("shipped molarity.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_molar_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_molarity_lib()).unwrap();
+    std::fs::write(dir.join("molarity.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// molarity — the definition: the moles of solute divided by the volume.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_molarity_library_and_computes_definition_with_citation() {
+    let dir = scratch("def");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"molarity.adj\"\n\
+         observe moles(6)\n\
+         observe volume(2)\n\
+         ? molarity(moles, volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied definition's result: 6 / 2 = 3.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"molarity\"") && s.contains("\"value\":3"),
+        "molarity(6, 2) = 3: {s}"
+    );
+    // … AND the LibreTexts citation + trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "applied definition carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// moles — the same definition solved for n: the molarity times the volume, which
+// INVERTS the molarity just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_moles_as_molarity_times_volume_with_citation() {
+    let dir = scratch("moles");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"molarity.adj\"\n\
+         observe molarity(3)\n\
+         observe volume(2)\n\
+         ? moles(molarity, volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 3 * 2 = 6, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"moles\"") && s.contains("\"value\":6"),
+        "moles(3, 2) = 6: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "moles carries its LibreTexts citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// volume — the same definition solved for V: the moles divided by the molarity,
+// the third exact reading of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_volume_as_moles_over_molarity_with_citation() {
+    let dir = scratch("vol");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"molarity.adj\"\n\
+         observe moles(6)\n\
+         observe molarity(3)\n\
+         ? volume(moles, molarity)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 6 / 3 = 2, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"volume\"") && s.contains("\"value\":2"),
+        "volume(6, 3) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "volume carries its LibreTexts citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/chemistry/molarity.adj
+++ b/code/specs/data/adj-formula-stdlib/chemistry/molarity.adj
@@ -1,0 +1,91 @@
+% ============================================================================
+% molarity.adj — the definition of molarity (amount concentration) in the ADJ
+% standard library.
+% ============================================================================
+% The molarity entry of the *chemistry* track, a sibling of `ideal-gas-law.adj`:
+% the foundational solution-concentration definition a first course states as
+% MOLARITY IS MOLES OF SOLUTE PER LITER OF SOLUTION, as an importable,
+% byte-provenanced, PARAMETERIZED `formula`, together with its two exact
+% rearrangements (the moles of solute a molarity implies for a volume, and the
+% volume it implies for a given amount of solute). As with every compute library,
+% a consumer states NO arithmetic: it `import`s this file, binds the measured
+% quantities from its own byte-provenance decomposition, and asks the engine to
+% APPLY the cited definition on the CPU. Zero math is performed by the model; the
+% engine computes each value EXACTLY, carrying the definition's citation.
+%
+%     import "molarity.adj"
+%     observe moles(6)               % "…6 mol of solute…"    (span cited by the model)
+%     observe volume(2)              % "…in 2 L of solution…" (span cited by the model)
+%     ? molarity(moles, volume)      % engine → 3, carrying the def M = n/V
+%
+% All three formulas are EXACT over their parameters — one a quotient, one a product,
+% one a quotient — of measured quantities. There is no *separately grounded*
+% physical constant here, so every value the engine returns is exact. The three
+% COMPOSE and invert cleanly: the `molarity` a consumer computes from an amount of
+% solute in a volume is exactly the `molarity` the `moles` formula multiplies back
+% by that volume to recover the amount, and exactly the `molarity` the `volume`
+% formula divides that amount by to recover the volume.
+%
+%   molarity(moles, volume)    = moles / volume        %  M = n/V   (definition of molarity)
+%   moles(molarity, volume)    = molarity * volume       %  n = M·V   (the same definition, solved for n)
+%   volume(moles, molarity)    = moles / molarity        %  V = n/M   (the same definition, solved for V)
+%
+% All three formulas are defended by the SAME definitional sentence — "Molarity is
+% defined as the number of moles of solute in exactly 1 liter (1 L) of the
+% solution:" — because that one definition sanctions the relation read every way (M
+% from n and V, n from M and V, or V from n and M). The quote is transcribed verbatim
+% from Chemistry LibreTexts (the OpenSTAX general-chemistry text — a university-hosted
+% .org educational reference, the chemistry analogue of the HyperPhysics .edu source
+% the physics libraries cite), so each `formula` carries the provenance envelope every
+% shipped grounded clause carries; the linter rejects an unsourced one. (Note: molarity
+% uses the volume of the whole SOLUTION, not of the solvent — the cited page is explicit
+% on this; see feedback_nothing_human_authored — the definitional sentence is a verbatim
+% span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable measured quantity the definition
+% ranges over, and each result is the derived quantity. `molarity`, `moles` and
+% `volume` each appear BOTH as a derived result and as an input (of the other
+% formulas), so each is a single dictionary term used in both roles. The `surface`
+% lists are the everyday names a decomposer maps onto the canonical term; the
+% trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary molarity_vocab {
+    define moles    : finding  surface "moles", "amount", "n"                    % amount of solute, mol
+    define volume   : finding  surface "volume", "V"                             % volume of solution, L
+    define molarity : finding  surface "molarity", "concentration", "M"         % molarity, mol/L
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable `let` over
+% its formal parameters, bound at apply time, and each carries the definitional
+% quote from Chemistry LibreTexts (a quote is required on a shipped formula). Two
+% are quotients and one a product, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook molarity_laws {
+    use molarity_vocab
+
+    % Molarity — moles of solute per liter of solution. LibreTexts defines molarity as
+    % the number of moles of solute in exactly one liter of the solution, i.e. M = n/V.
+    formula molarity(moles, volume) = moles / volume
+        source "Molarity is defined as the number of moles of solute in exactly 1 liter (1 L) of the solution:"
+        locator "https://chem.libretexts.org/Bookshelves/General_Chemistry/Chemistry_1e_(OpenSTAX)/03:_Composition_of_Substances_and_Solutions/3.03:_Molarity"
+        trust authoritative
+
+    % Moles — the same definition solved for the amount of solute a molarity implies
+    % in a volume (n = M·V). Defended by the SAME definitional sentence, read the
+    % other way.
+    formula moles(molarity, volume) = molarity * volume
+        source "Molarity is defined as the number of moles of solute in exactly 1 liter (1 L) of the solution:"
+        locator "https://chem.libretexts.org/Bookshelves/General_Chemistry/Chemistry_1e_(OpenSTAX)/03:_Composition_of_Substances_and_Solutions/3.03:_Molarity"
+        trust authoritative
+
+    % Volume — the same definition solved for the solution volume a given amount of
+    % solute occupies at a molarity (V = n/M). Again the SAME definitional sentence,
+    % read the third way.
+    formula volume(moles, molarity) = moles / molarity
+        source "Molarity is defined as the number of moles of solute in exactly 1 liter (1 L) of the solution:"
+        locator "https://chem.libretexts.org/Bookshelves/General_Chemistry/Chemistry_1e_(OpenSTAX)/03:_Composition_of_Substances_and_Solutions/3.03:_Molarity"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/chemistry/molarity.query.adj
+++ b/code/specs/data/adj-formula-stdlib/chemistry/molarity.query.adj
@@ -1,0 +1,33 @@
+% ============================================================================
+% molarity.query.adj — worked examples over the chemistry molarity library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a molarity
+% question: it states NO arithmetic and NO definition — it only `import`s the
+% grounded library, `observe`s the measured quantities it decomposed from the
+% prompt (each a byte-provenanced span, elided here), and asks the engine to APPLY
+% the cited definition. The native adj-lang engine binds the parameters, computes
+% each value EXACTLY on the CPU, and returns it with the definition's
+% source/locator/trust.
+%
+% The three questions INVERT: 6 mol of solute in 2 L of solution gives a molarity
+% of 3 mol/L; that 3 mol/L molarity is exactly what the moles formula multiplies by
+% the 2 L to recover the 6 mol, and exactly what the volume formula divides the 6
+% mol by to recover the 2 L.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli molarity.query.adj
+% ============================================================================
+
+import "molarity.adj"
+
+% 6 mol of solute in 2 L of solution: molarity = 6 / 2.
+observe moles(6)
+observe volume(2)
+? molarity(moles, volume)      % expect 3   (definition: M = n/V)
+
+% That 3 mol/L molarity in the same 2 L: moles = 3 * 2.
+observe molarity(3)
+? moles(molarity, volume)       % expect 6   (same definition, solved for n = M·V)
+
+% That 6 mol of solute at the same 3 mol/L: volume = 6 / 3.
+? volume(moles, molarity)       % expect 2   (same definition, solved for V = n/M)


### PR DESCRIPTION
New **Libraries (FL)** entry on the **chemistry** track — a sibling of `ideal-gas-law.adj`, filling out a previously near-empty track with a board-relevant Tier-1 concentration definition. Molarity (amount concentration) as an importable, byte-provenanced, parameterized `formula`, with its two exact rearrangements:

- `molarity(moles, volume) = moles / volume`    — M = n/V (the definition)
- `moles(molarity, volume)  = molarity * volume`  — n = M·V (same def, solved for n)
- `volume(moles, molarity)  = moles / molarity`   — V = n/M (same def, solved for V)

**Grounding.** All three formulas are defended by the *same* definitional sentence — "Molarity is defined as the number of moles of solute in exactly 1 liter (1 L) of the solution:" — transcribed verbatim (byte-verified via WebFetch) from **Chemistry LibreTexts** (the OpenSTAX general-chemistry text, `3.3: Molarity`), a university-hosted educational reference — the chemistry analogue of the HyperPhysics source the physics libraries cite. Each `formula` carries the provenance envelope; the linter rejects an unsourced one. The definition uses the volume of the whole **solution**, not the solvent — the cited page is explicit on this.

**Behaviour.** A consumer states NO arithmetic and NO definition: it imports the library, binds the measured quantities with `observe` (byte-provenanced spans), and the engine applies the cited definition on the CPU — computing each value EXACTLY and carrying the citation. No separately-grounded constant, so every value is exact. The three formulas compose and invert cleanly: `6 / 2 = 3`, and both `3 * 2 = 6` and `6 / 3 = 2` recover the inputs.

**Files (data + test only — no version bump, mirrors the density/momentum PRs):**
- New: `chemistry/molarity.adj` + `molarity.query.adj` (worked three-way inverting example).
- Test: `formula_molarity_e2e` — `molarity(6,2)=3`, `moles(3,2)=6`, `volume(6,3)=2`, each carrying the `chem.libretexts.org` citation + `authoritative` trust. **3/3 pass.** Full `formula_*` suite green; shipped query verified through the CLI (derived: molarity=3, moles=6, volume=2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)