### PR TITLE
feat(spice): add JFET beta temperature coefficient

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add JFET model-card `BETATCE` support, applying the alternative
+  `BETA(T) = BETA * 1.01^(BETATCE * (T - TNOM))` rule with precedence over
+  `BEX` when explicitly present.
 - Add JFET model-card `BEX` support, applying
   `BETA(T) = BETA * (T / TNOM)^BEX` with a temperature-invariant zero default.
 - Add JFET model-card `TNOM` / `T_NOM` and `TCV` support, converting nominal

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -78,8 +78,9 @@ print(result.diagnostics.solver)   # "dense_real" or "sparse_real"
 operating-temperature footholds for diode, BJT, JFET, and Level-1 MOSFET
 models before running an analysis.
 JFET model cards use `TCV` for threshold-voltage scaling and `BEX` for
-`BETA(T) = BETA * (T / TNOM)^BEX`; both default to temperature-invariant
-behavior and honor model-card `TNOM` / `T_NOM`.
+`BETA(T) = BETA * (T / TNOM)^BEX`. When explicitly present, `BETATCE`
+overrides `BEX` with `BETA(T) = BETA * 1.01^(BETATCE * (T - TNOM))`.
+All temperature coefficients honor model-card `TNOM` / `T_NOM`.
 `dc_temperature_sweep()` and `dc_temperature_sweep_corners()` run
 `.temp`-style DC operating-point snapshots across explicit analysis
 temperatures, with stable nominal and named-corner table helpers for

--- a/code/packages/python/spice-engine/src/spice_engine/elements.py
+++ b/code/packages/python/spice-engine/src/spice_engine/elements.py
@@ -522,6 +522,7 @@ class JFET:
     Tcv: float = 0.0
     Tnom: float | None = None
     Bex: float = 0.0
+    Betatce: float | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -421,11 +421,18 @@ def jfet_at_temperature(
         raise ValueError(f"{jfet.name}: JFET TCV must be finite")
     if not math.isfinite(jfet.Bex):
         raise ValueError(f"{jfet.name}: JFET BEX must be finite")
+    if jfet.Betatce is not None and not math.isfinite(jfet.Betatce):
+        raise ValueError(f"{jfet.name}: JFET BETATCE must be finite")
     temperature_ratio = temperature_kelvin / nominal_temperature
+    beta_scale = (
+        1.01 ** (jfet.Betatce * (temperature_kelvin - nominal_temperature))
+        if jfet.Betatce is not None
+        else temperature_ratio**jfet.Bex
+    )
     return replace(
         jfet,
         vto=jfet.vto - jfet.Tcv * (temperature_kelvin - nominal_temperature),
-        beta=jfet.beta * temperature_ratio**jfet.Bex,
+        beta=jfet.beta * beta_scale,
     )
 
 
@@ -637,7 +644,7 @@ def _clone_subckt_element(element: Element, instance_name: str, node_map: dict[s
             element.Af,
         )
     if isinstance(element, JFET):
-        return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_, element.Cgs, element.Cgd, element.Kf, element.Af, element.Pb, element.Fc, element.Is, element.Rd, element.Rs, element.Tcv, element.Tnom, element.Bex)
+        return JFET(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), element.polarity, element.beta, element.vto, element.lambda_, element.Cgs, element.Cgd, element.Kf, element.Af, element.Pb, element.Fc, element.Is, element.Rd, element.Rs, element.Tcv, element.Tnom, element.Bex, element.Betatce)
     if isinstance(element, Mosfet):
         return Mosfet(name, _map_subckt_node(element.drain, instance_name, node_map), _map_subckt_node(element.gate, instance_name, node_map), _map_subckt_node(element.source, instance_name, node_map), _map_subckt_node(element.body, instance_name, node_map), element.model)
     if isinstance(element, BJT):
@@ -9164,6 +9171,8 @@ def _eval_jfet(el: JFET, vgs: float, vds: float) -> tuple[float, float, float]:
         raise ValueError(f"JFET '{el.name}' TNOM must be finite and positive")
     if not math.isfinite(el.Bex):
         raise ValueError(f"JFET '{el.name}' BEX must be finite")
+    if el.Betatce is not None and not math.isfinite(el.Betatce):
+        raise ValueError(f"JFET '{el.name}' BETATCE must be finite")
     if el.polarity == "PJF":
         ids, gm, gds = _eval_njf(-vgs, -vds, -el.vto, el.beta, el.lambda_)
         return -ids, gm, gds

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -309,8 +309,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "D": (15, 21, 5, 3),
     "NPN": (41, 58, 13, 4),
     "PNP": (41, 58, 13, 4),
-    "NJF": (15, 23, 7, 3),
-    "PJF": (15, 23, 7, 3),
+    "NJF": (16, 24, 7, 3),
+    "PJF": (16, 24, 7, 3),
     "NMOS": (18, 25, 6, 3),
     "PMOS": (18, 25, 6, 3),
 }
@@ -442,6 +442,7 @@ _JFET_PARAMETER_ALIASES: dict[str, str] = {
     "T_NOM": "TNOM",
     "TCV": "TCV",
     "BEX": "BEX",
+    "BETATCE": "BETATCE",
 }
 
 _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
@@ -1024,6 +1025,7 @@ def jfet_from_model_card(
         Tcv=p.get("TCV", 0.0),
         Tnom=p["TNOM"] + 273.15 if "TNOM" in p else None,
         Bex=p.get("BEX", 0.0),
+        Betatce=p.get("BETATCE"),
     )
 
 
@@ -1259,7 +1261,7 @@ def device_model_temperature_audit_fixtures() -> tuple[DeviceModelTemperatureBeh
         "bjt-emitter-follower": "BJT saturation current and thermal voltage scale with temperature",
         "jfet-source-bias": (
             "JFET temperature scaling defaults to invariant; TCV/TNOM enable "
-            "threshold-voltage scaling and BEX enables beta scaling"
+            "threshold-voltage scaling; BETATCE overrides BEX for beta scaling"
         ),
         "mos-level1-common-source": "Level-1 MOS threshold and transconductance scale with temperature",
     }

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -408,7 +408,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 163
+    assert len(coverage) == 165
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -423,7 +423,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 163
+    assert len(records) == 165
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -497,9 +497,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 163
-    assert report.expected_canonical_parameter_count == 163
-    assert report.accepted_name_count == 233
+    assert report.canonical_parameter_count == 165
+    assert report.expected_canonical_parameter_count == 165
+    assert report.accepted_name_count == 235
     assert report.aliased_parameter_count == 57
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -507,7 +507,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t163\t163\t233\t57\t4\t0"
+        "true\t7\t7\t165\t165\t235\t57\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -535,8 +535,8 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 162
-    assert report.accepted_name_count == 230
+    assert report.canonical_parameter_count == 164
+    assert report.accepted_name_count == 232
     assert report.aliased_parameter_count == 56
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
@@ -551,7 +551,7 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t162\t163\t230\t56\t4\t4\n"
+        "false\t7\t7\t164\t165\t232\t56\t4\t4\n"
         "kind\tfield\tmessage\n"
         "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
         "supported parameters, found 17\n"
@@ -681,6 +681,7 @@ def test_model_card_aliases_build_device_instances() -> None:
             "T_NOM": 50.0,
             "TCV": 0.01,
             "BEX": 1.5,
+            "BETATCE": -0.5,
         },
     )
     jfet_model = jfet_from_model_card("J1", "d", "g", "s", jfet_card)
@@ -698,6 +699,7 @@ def test_model_card_aliases_build_device_instances() -> None:
         "TNOM": 50.0,
         "TCV": 0.01,
         "BEX": 1.5,
+        "BETATCE": -0.5,
     }
     assert jfet_model.polarity == "NJF"
     assert jfet_model.beta == pytest.approx(9.0e-4)
@@ -713,6 +715,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert jfet_model.Tnom == pytest.approx(323.15)
     assert jfet_model.Tcv == pytest.approx(0.01)
     assert jfet_model.Bex == pytest.approx(1.5)
+    assert jfet_model.Betatce == pytest.approx(-0.5)
 
     mos_card = normalize_model_card(
         "Mn",
@@ -2622,7 +2625,7 @@ def test_subcircuit_expansion_preserves_complete_jfet_model():
     cell = SubcircuitDefinition(
         "jfet-cell",
         ("d", "g", "s"),
-        (JFET("Jcell", "d", "g", "s", Kf=1.0e-12, Af=1.3, Pb=0.8, Fc=0.35, Is=2.0e-13, Rd=125.0, Rs=75.0, Tcv=0.01, Tnom=323.15, Bex=1.5),),
+        (JFET("Jcell", "d", "g", "s", Kf=1.0e-12, Af=1.3, Pb=0.8, Fc=0.35, Is=2.0e-13, Rd=125.0, Rs=75.0, Tcv=0.01, Tnom=323.15, Bex=1.5, Betatce=-0.5),),
     )
     circuit = Circuit()
     circuit.define_subcircuit(cell)
@@ -2638,6 +2641,7 @@ def test_subcircuit_expansion_preserves_complete_jfet_model():
     assert expanded.Rs == pytest.approx(75.0)
     assert expanded.Tcv == pytest.approx(0.01)
     assert expanded.Bex == pytest.approx(1.5)
+    assert expanded.Betatce == pytest.approx(-0.5)
     assert expanded.Tnom == pytest.approx(323.15)
 
 
@@ -2918,7 +2922,7 @@ def test_bjt_temperature_scaling_uses_model_temperature_exponent():
     assert high.Is > low.Is
 
 
-def test_jfet_temperature_scaling_uses_tcv_bex_and_model_nominal_temperature():
+def test_jfet_temperature_scaling_uses_tcv_betatce_and_model_nominal_temperature():
     transistor = JFET(
         "J1",
         "d",
@@ -2928,21 +2932,27 @@ def test_jfet_temperature_scaling_uses_tcv_bex_and_model_nominal_temperature():
         vto=-2.0,
         Tcv=0.01,
         Tnom=310.0,
-        Bex=1.0,
+        Bex=-5.0,
+        Betatce=1.0,
     )
     at_model_nominal = jfet_at_temperature(transistor, 310.0)
     hot = jfet_at_temperature(transistor, 320.0)
     cold = jfet_at_temperature(transistor, 300.0)
     invariant = jfet_at_temperature(JFET("Jflat", "d", "g", "s"), 350.0)
+    bex_fallback = jfet_at_temperature(
+        JFET("Jbex", "d", "g", "s", beta=1.0e-4, Tnom=310.0, Bex=1.0),
+        320.0,
+    )
 
     assert at_model_nominal.vto == pytest.approx(-2.0)
     assert at_model_nominal.beta == pytest.approx(1.0e-4)
     assert hot.vto == pytest.approx(-2.1)
-    assert hot.beta == pytest.approx(1.0e-4 * 320.0 / 310.0)
+    assert hot.beta == pytest.approx(1.0e-4 * 1.01**10.0)
     assert cold.vto == pytest.approx(-1.9)
-    assert cold.beta == pytest.approx(1.0e-4 * 300.0 / 310.0)
+    assert cold.beta == pytest.approx(1.0e-4 * 1.01**-10.0)
     assert invariant.vto == pytest.approx(-2.0)
     assert invariant.beta == pytest.approx(1.0e-4)
+    assert bex_fallback.beta == pytest.approx(1.0e-4 * 320.0 / 310.0)
 
 
 def test_dc_rejects_invalid_jfet_temperature_parameters():
@@ -2959,6 +2969,11 @@ def test_dc_rejects_invalid_jfet_temperature_parameters():
     circuit = Circuit()
     circuit.add(JFET("Jbad", "d", "g", "0", Bex=float("nan")))
     with pytest.raises(ValueError, match="BEX must be finite"):
+        dc_op(circuit)
+
+    circuit = Circuit()
+    circuit.add(JFET("Jbad", "d", "g", "0", Betatce=float("nan")))
+    with pytest.raises(ValueError, match="BETATCE must be finite"):
         dc_op(circuit)
 
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add JFET model-card `BETATCE` support, applying the alternative
+  `BETA(T) = BETA * 1.01^(BETATCE * (T - TNOM))` rule with precedence over
+  `BEX` when explicitly present.
 - Add JFET model-card `BEX` support, applying
   `BETA(T) = BETA * (T / TNOM)^BEX` with a temperature-invariant zero default.
 - Add JFET model-card `TNOM` / `T_NOM` and `TCV` support, converting nominal

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -119,8 +119,9 @@ let result = transient_adaptive(
 operating-temperature footholds for diode, BJT, JFET, and Level-1 MOSFET
 models before running an analysis.
 JFET model cards use `TCV` for threshold-voltage scaling and `BEX` for
-`BETA(T) = BETA * (T / TNOM)^BEX`; both default to temperature-invariant
-behavior and honor model-card `TNOM` / `T_NOM`.
+`BETA(T) = BETA * (T / TNOM)^BEX`. When explicitly present, `BETATCE`
+overrides `BEX` with `BETA(T) = BETA * 1.01^(BETATCE * (T - TNOM))`.
+All temperature coefficients honor model-card `TNOM` / `T_NOM`.
 
 `normalize_model_card`, `diode_from_model_card`, `bjt_from_model_card`,
 `jfet_from_model_card`, and `mosfet_from_model_card` provide the shared

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -437,6 +437,7 @@ fn clone_subckt_element(
                 element.threshold_voltage_temperature_coefficient;
             mapped.nominal_temperature_kelvin = element.nominal_temperature_kelvin;
             mapped.mobility_temperature_exponent = element.mobility_temperature_exponent;
+            mapped.mobility_temperature_coefficient = element.mobility_temperature_coefficient;
             Element::Jfet(mapped)
         }
         Element::Bjt(element) => {
@@ -2803,11 +2804,24 @@ pub fn jfet_at_temperature(
             reason: "mobility temperature exponent must be finite".to_string(),
         });
     }
+    if jfet
+        .mobility_temperature_coefficient
+        .is_some_and(|coefficient| !coefficient.is_finite())
+    {
+        return Err(SpiceError::InvalidElement {
+            name: jfet.name.clone(),
+            reason: "mobility temperature coefficient must be finite".to_string(),
+        });
+    }
     let temperature_ratio = temperature_kelvin / nominal_temperature;
+    let beta_scale = jfet.mobility_temperature_coefficient.map_or_else(
+        || temperature_ratio.powf(jfet.mobility_temperature_exponent),
+        |coefficient| 1.01_f64.powf(coefficient * (temperature_kelvin - nominal_temperature)),
+    );
     let mut adjusted = jfet.clone();
     adjusted.threshold_voltage -=
         jfet.threshold_voltage_temperature_coefficient * (temperature_kelvin - nominal_temperature);
-    adjusted.beta *= temperature_ratio.powf(jfet.mobility_temperature_exponent);
+    adjusted.beta *= beta_scale;
     Ok(adjusted)
 }
 
@@ -2879,6 +2893,7 @@ pub struct Jfet {
     pub threshold_voltage_temperature_coefficient: f64,
     pub nominal_temperature_kelvin: Option<f64>,
     pub mobility_temperature_exponent: f64,
+    pub mobility_temperature_coefficient: Option<f64>,
 }
 
 impl Jfet {
@@ -2957,6 +2972,7 @@ impl Jfet {
             threshold_voltage_temperature_coefficient: 0.0,
             nominal_temperature_kelvin: None,
             mobility_temperature_exponent: 0.0,
+            mobility_temperature_coefficient: None,
         }
     }
 }
@@ -3880,8 +3896,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     (ModelCardKind::Diode, 15, 21, 5, 3),
     (ModelCardKind::Npn, 41, 58, 13, 4),
     (ModelCardKind::Pnp, 41, 58, 13, 4),
-    (ModelCardKind::Njf, 15, 23, 7, 3),
-    (ModelCardKind::Pjf, 15, 23, 7, 3),
+    (ModelCardKind::Njf, 16, 24, 7, 3),
+    (ModelCardKind::Pjf, 16, 24, 7, 3),
     (ModelCardKind::Nmos, 18, 25, 6, 3),
     (ModelCardKind::Pmos, 18, 25, 6, 3),
 ];
@@ -3992,6 +4008,7 @@ const JFET_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("T_NOM", "TNOM"),
     ("TCV", "TCV"),
     ("BEX", "BEX"),
+    ("BETATCE", "BETATCE"),
 ];
 const MOS_LEVEL1_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("LEVEL", "LEVEL"),
@@ -4731,6 +4748,7 @@ pub fn jfet_from_model_card(
         .get("TNOM")
         .map(|temperature| temperature + 273.15);
     jfet.mobility_temperature_exponent = model_card_value(model, "BEX", 0.0);
+    jfet.mobility_temperature_coefficient = model.parameters.get("BETATCE").copied();
     Ok(jfet)
 }
 
@@ -5070,7 +5088,7 @@ fn device_model_temperature_behavior(name: &str) -> Result<String, SpiceError> {
             Ok("BJT saturation current and thermal voltage scale with temperature".to_string())
         }
         "jfet-source-bias" => Ok(
-            "JFET temperature scaling defaults to invariant; TCV/TNOM enable threshold-voltage scaling and BEX enables beta scaling".to_string(),
+            "JFET temperature scaling defaults to invariant; TCV/TNOM enable threshold-voltage scaling; BETATCE overrides BEX for beta scaling".to_string(),
         ),
         "mos-level1-common-source" => {
             Ok("Level-1 MOS threshold and transconductance scale with temperature".to_string())
@@ -25225,6 +25243,15 @@ fn validate_jfet(jfet: &Jfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: jfet.name.clone(),
             reason: "mobility temperature exponent must be finite".to_string(),
+        });
+    }
+    if jfet
+        .mobility_temperature_coefficient
+        .is_some_and(|coefficient| !coefficient.is_finite())
+    {
+        return Err(SpiceError::InvalidElement {
+            name: jfet.name.clone(),
+            reason: "mobility temperature coefficient must be finite".to_string(),
         });
     }
     Ok(())

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -95,7 +95,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 163);
+    assert_eq!(coverage.len(), 165);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -114,7 +114,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 163);
+    assert_eq!(records.len(), 165);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -195,15 +195,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 163);
-    assert_eq!(report.expected_canonical_parameter_count, 163);
-    assert_eq!(report.accepted_name_count, 233);
+    assert_eq!(report.canonical_parameter_count, 165);
+    assert_eq!(report.expected_canonical_parameter_count, 165);
+    assert_eq!(report.accepted_name_count, 235);
     assert_eq!(report.aliased_parameter_count, 57);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t163\t163\t233\t57\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t165\t165\t235\t57\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -230,8 +230,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 162);
-    assert_eq!(report.accepted_name_count, 230);
+    assert_eq!(report.canonical_parameter_count, 164);
+    assert_eq!(report.accepted_name_count, 232);
     assert_eq!(report.aliased_parameter_count, 56);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -248,7 +248,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t162\t163\t230\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t164\t165\t232\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
@@ -523,6 +523,7 @@ fn model_card_aliases_build_device_instances() {
             ("T_NOM", 50.0),
             ("TCV", 0.01),
             ("BEX", 1.5),
+            ("BETATCE", -0.5),
         ],
     )
     .unwrap();
@@ -540,6 +541,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*jfet_card.parameters.get("TNOM").unwrap(), 50.0);
     assert_close(*jfet_card.parameters.get("TCV").unwrap(), 0.01);
     assert_close(*jfet_card.parameters.get("BEX").unwrap(), 1.5);
+    assert_close(*jfet_card.parameters.get("BETATCE").unwrap(), -0.5);
     assert_eq!(jfet_model.polarity, JfetPolarity::Njf);
     assert_close(jfet_model.beta, 9.0e-4);
     assert_close(jfet_model.threshold_voltage, -1.8);
@@ -554,6 +556,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(jfet_model.drain_resistance, 125.0);
     assert_close(jfet_model.source_resistance, 75.0);
     assert_close(jfet_model.mobility_temperature_exponent, 1.5);
+    assert_close(jfet_model.mobility_temperature_coefficient.unwrap(), -0.5);
 
     let mos_card = normalize_model_card(
         "Mn",
@@ -1484,6 +1487,7 @@ fn subcircuit_expansion_preserves_complete_jfet_model() {
     jfet.threshold_voltage_temperature_coefficient = 0.01;
     jfet.nominal_temperature_kelvin = Some(323.15);
     jfet.mobility_temperature_exponent = 1.5;
+    jfet.mobility_temperature_coefficient = Some(-0.5);
     let mut circuit = Circuit::new();
     circuit
         .define_subcircuit(SubcircuitDefinition::new(
@@ -1518,6 +1522,7 @@ fn subcircuit_expansion_preserves_complete_jfet_model() {
     assert_close(expanded.threshold_voltage_temperature_coefficient, 0.01);
     assert_close(expanded.nominal_temperature_kelvin.unwrap(), 323.15);
     assert_close(expanded.mobility_temperature_exponent, 1.5);
+    assert_close(expanded.mobility_temperature_coefficient.unwrap(), -0.5);
 }
 
 #[test]
@@ -2223,26 +2228,32 @@ fn bjt_temperature_scaling_uses_beta_temperature_exponent() {
 }
 
 #[test]
-fn jfet_temperature_scaling_uses_tcv_bex_and_model_nominal_temperature() {
+fn jfet_temperature_scaling_uses_tcv_betatce_and_model_nominal_temperature() {
     let mut transistor = Jfet::new("J1", "d", "g", "s");
     transistor.threshold_voltage = -2.0;
     transistor.threshold_voltage_temperature_coefficient = 0.01;
     transistor.nominal_temperature_kelvin = Some(310.0);
-    transistor.mobility_temperature_exponent = 1.0;
+    transistor.mobility_temperature_exponent = -5.0;
+    transistor.mobility_temperature_coefficient = Some(1.0);
 
     let at_model_nominal = jfet_at_temperature(&transistor, 310.0, 300.15).unwrap();
     let hot = jfet_at_temperature(&transistor, 320.0, 300.15).unwrap();
     let cold = jfet_at_temperature(&transistor, 300.0, 300.15).unwrap();
     let invariant = jfet_at_temperature(&Jfet::new("Jflat", "d", "g", "s"), 350.0, 300.15).unwrap();
+    let mut bex_transistor = Jfet::new("Jbex", "d", "g", "s");
+    bex_transistor.nominal_temperature_kelvin = Some(310.0);
+    bex_transistor.mobility_temperature_exponent = 1.0;
+    let bex_fallback = jfet_at_temperature(&bex_transistor, 320.0, 300.15).unwrap();
 
     assert_close(at_model_nominal.threshold_voltage, -2.0);
     assert_close(at_model_nominal.beta, transistor.beta);
     assert_close(hot.threshold_voltage, -2.1);
-    assert_close(hot.beta, transistor.beta * 320.0 / 310.0);
+    assert_close(hot.beta, transistor.beta * 1.01_f64.powf(10.0));
     assert_close(cold.threshold_voltage, -1.9);
-    assert_close(cold.beta, transistor.beta * 300.0 / 310.0);
+    assert_close(cold.beta, transistor.beta * 1.01_f64.powf(-10.0));
     assert_close(invariant.threshold_voltage, -2.0);
     assert_close(invariant.beta, 1.0e-4);
+    assert_close(bex_fallback.beta, bex_transistor.beta * 320.0 / 310.0);
 }
 
 #[test]
@@ -2273,6 +2284,15 @@ fn dc_rejects_invalid_jfet_temperature_parameters() {
     assert!(error
         .to_string()
         .contains("mobility temperature exponent must be finite"));
+
+    let mut transistor = Jfet::new("Jbad", "d", "g", "0");
+    transistor.mobility_temperature_coefficient = Some(f64::NAN);
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Jfet(transistor));
+    let error = dc_op(&circuit).unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("mobility temperature coefficient must be finite"));
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add JFET model-card `BETATCE` support, applying the alternative
+  `BETA(T) = BETA * 1.01^(BETATCE * (T - TNOM))` rule with precedence over
+  `BEX` when explicitly present.
 - Add JFET model-card `BEX` support, applying
   `BETA(T) = BETA * (T / TNOM)^BEX` with a temperature-invariant zero default.
 - Add JFET model-card `TNOM` / `T_NOM` and `TCV` support, converting nominal

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -70,8 +70,9 @@ steps were clipped, and the minimum damping factor; pass
 operating-temperature footholds for diode, BJT, JFET, and Level-1 MOSFET
 models before running an analysis.
 JFET model cards use `TCV` for threshold-voltage scaling and `BEX` for
-`BETA(T) = BETA * (T / TNOM)^BEX`; both default to temperature-invariant
-behavior and honor model-card `TNOM` / `T_NOM`.
+`BETA(T) = BETA * (T / TNOM)^BEX`. When explicitly present, `BETATCE`
+overrides `BEX` with `BETA(T) = BETA * 1.01^(BETATCE * (T - TNOM))`.
+All temperature coefficients honor model-card `TNOM` / `T_NOM`.
 `dcTemperatureSweep` and `dcTemperatureSweepCorners` run `.temp`-style DC
 operating-point snapshots across explicit analysis temperatures, with stable
 nominal and named-corner table helpers for cross-language comparison.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1705,6 +1705,7 @@ export interface Jfet {
   readonly thresholdVoltageTemperatureCoefficient: number;
   readonly nominalTemperatureKelvin?: number;
   readonly mobilityTemperatureExponent: number;
+  readonly mobilityTemperatureCoefficient?: number;
 }
 
 export type BjtPolarity = "NPN" | "PNP";
@@ -2034,8 +2035,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   D: [15, 21, 5, 3],
   NPN: [41, 58, 13, 4],
   PNP: [41, 58, 13, 4],
-  NJF: [15, 23, 7, 3],
-  PJF: [15, 23, 7, 3],
+  NJF: [16, 24, 7, 3],
+  PJF: [16, 24, 7, 3],
   NMOS: [18, 25, 6, 3],
   PMOS: [18, 25, 6, 3],
 };
@@ -3621,7 +3622,7 @@ function cloneSubcktElement(
     case "diode":
       return diode(name, mapSubcktNode(element.anode, instanceName, nodeMap), mapSubcktNode(element.cathode, instanceName, nodeMap), element.saturationCurrent, element.thermalVoltage, element.emissionCoefficient, element.breakdownVoltage, element.breakdownCurrent, element.junctionCapacitance, element.transitTime, element.junctionPotential, element.gradingCoefficient, element.forwardBiasDepletionCoefficient, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.seriesResistance, element.flickerNoiseCoefficient, element.flickerNoiseExponent);
     case "jfet":
-      return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.junctionPotential, element.forwardBiasDepletionCoefficient, element.gateSaturationCurrent, element.drainResistance, element.sourceResistance, element.thresholdVoltageTemperatureCoefficient, element.nominalTemperatureKelvin, element.mobilityTemperatureExponent);
+      return jfet(name, mapSubcktNode(element.drain, instanceName, nodeMap), mapSubcktNode(element.gate, instanceName, nodeMap), mapSubcktNode(element.source, instanceName, nodeMap), element.polarity, element.beta, element.thresholdVoltage, element.channelLengthModulation, element.gateSourceCapacitance, element.gateDrainCapacitance, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.junctionPotential, element.forwardBiasDepletionCoefficient, element.gateSaturationCurrent, element.drainResistance, element.sourceResistance, element.thresholdVoltageTemperatureCoefficient, element.nominalTemperatureKelvin, element.mobilityTemperatureExponent, element.mobilityTemperatureCoefficient);
     case "bjt":
       return bjt(name, mapSubcktNode(element.collector, instanceName, nodeMap), mapSubcktNode(element.base, instanceName, nodeMap), mapSubcktNode(element.emitter, instanceName, nodeMap), element.polarity, element.saturationCurrent, element.forwardBeta, element.thermalVoltage, element.baseEmitterCapacitance, element.baseCollectorCapacitance, element.forwardTransitTime, element.reverseTransitTime, element.saturationCurrentTemperatureExponent, element.energyGapElectronVolts, element.forwardEarlyVoltage, element.forwardEmissionCoefficient, element.reverseEmissionCoefficient, element.baseEmitterJunctionPotential, element.baseEmitterGradingCoefficient, element.baseCollectorJunctionPotential, element.baseCollectorGradingCoefficient, element.forwardBiasDepletionCoefficient, element.reverseEarlyVoltage, element.forwardBetaRolloffCurrent, element.baseEmitterLeakageSaturationCurrent, element.baseEmitterLeakageEmissionCoefficient, element.baseCollectorLeakageSaturationCurrent, element.baseCollectorLeakageEmissionCoefficient, element.forwardBetaTemperatureExponent, element.reverseBeta, element.reverseBetaRolloffCurrent, element.nominalTemperatureKelvin, element.flickerNoiseCoefficient, element.flickerNoiseExponent, element.forwardExcessPhaseDegrees, element.forwardTransitTimeBiasCoefficient, element.forwardTransitTimeCurrent, element.forwardTransitTimeVoltage, element.emitterResistance, element.collectorResistance, element.baseResistance, element.minimumBaseResistance, element.baseResistanceHalfCurrent, element.baseCollectorCapacitanceFraction);
     case "mosfet":
@@ -7739,10 +7740,22 @@ export function jfetAtTemperature(
   if (!Number.isFinite(element.mobilityTemperatureExponent)) {
     throw invalidElement(element.name, "mobility temperature exponent must be finite");
   }
+  if (
+    element.mobilityTemperatureCoefficient !== undefined &&
+    !Number.isFinite(element.mobilityTemperatureCoefficient)
+  ) {
+    throw invalidElement(element.name, "mobility temperature coefficient must be finite");
+  }
   const temperatureRatio = temperatureKelvin / nominalTemperature;
+  const betaScale =
+    element.mobilityTemperatureCoefficient !== undefined
+      ? 1.01 **
+        (element.mobilityTemperatureCoefficient *
+          (temperatureKelvin - nominalTemperature))
+      : temperatureRatio ** element.mobilityTemperatureExponent;
   return {
     ...element,
-    beta: element.beta * temperatureRatio ** element.mobilityTemperatureExponent,
+    beta: element.beta * betaScale,
     thresholdVoltage:
       element.thresholdVoltage -
       element.thresholdVoltageTemperatureCoefficient *
@@ -7811,6 +7824,7 @@ export function jfet(
   thresholdVoltageTemperatureCoefficient = 0.0,
   nominalTemperatureKelvin: number | undefined = undefined,
   mobilityTemperatureExponent = 0.0,
+  mobilityTemperatureCoefficient: number | undefined = undefined,
 ): Jfet {
   return {
     kind: "jfet",
@@ -7834,6 +7848,7 @@ export function jfet(
     thresholdVoltageTemperatureCoefficient,
     nominalTemperatureKelvin,
     mobilityTemperatureExponent,
+    mobilityTemperatureCoefficient,
   };
 }
 
@@ -8102,6 +8117,7 @@ const JFET_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   T_NOM: "TNOM",
   TCV: "TCV",
   BEX: "BEX",
+  BETATCE: "BETATCE",
 };
 
 const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
@@ -8655,6 +8671,7 @@ export function jfetFromModelCard(
     p.TCV ?? 0.0,
     p.TNOM !== undefined ? p.TNOM + 273.15 : undefined,
     p.BEX ?? 0.0,
+    p.BETATCE,
   );
 }
 
@@ -8876,7 +8893,7 @@ function deviceModelTemperatureBehavior(name: string): string {
   const behaviors: Record<string, string> = {
     "diode-forward-bias": "diode saturation current and thermal voltage scale with temperature",
     "bjt-emitter-follower": "BJT saturation current and thermal voltage scale with temperature",
-    "jfet-source-bias": "JFET temperature scaling defaults to invariant; TCV/TNOM enable threshold-voltage scaling and BEX enables beta scaling",
+    "jfet-source-bias": "JFET temperature scaling defaults to invariant; TCV/TNOM enable threshold-voltage scaling; BETATCE overrides BEX for beta scaling",
     "mos-level1-common-source": "Level-1 MOS threshold and transconductance scale with temperature",
   };
   const behavior = behaviors[name];
@@ -19702,6 +19719,12 @@ function validateJfet(element: Jfet): void {
   }
   if (!Number.isFinite(element.mobilityTemperatureExponent)) {
     throw invalidElement(element.name, "mobility temperature exponent must be finite");
+  }
+  if (
+    element.mobilityTemperatureCoefficient !== undefined &&
+    !Number.isFinite(element.mobilityTemperatureCoefficient)
+  ) {
+    throw invalidElement(element.name, "mobility temperature coefficient must be finite");
   }
 }
 

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -121,7 +121,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(163);
+    expect(coverage).toHaveLength(165);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -141,7 +141,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(163);
+    expect(records).toHaveLength(165);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -206,15 +206,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 163,
-      expectedCanonicalParameterCount: 163,
-      acceptedNameCount: 233,
+      canonicalParameterCount: 165,
+      expectedCanonicalParameterCount: 165,
+      acceptedNameCount: 235,
       aliasedParameterCount: 57,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t163\t163\t233\t57\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t165\t165\t235\t57\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -237,8 +237,8 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(162);
-    expect(report.acceptedNameCount).toBe(230);
+    expect(report.canonicalParameterCount).toBe(164);
+    expect(report.acceptedNameCount).toBe(232);
     expect(report.aliasedParameterCount).toBe(56);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
@@ -253,7 +253,7 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t162\t163\t230\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t164\t165\t232\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
@@ -384,9 +384,9 @@ describe("dcOp", () => {
     expectClose(bjtModel.baseCollectorGradingCoefficient, 0.45);
     expectClose(bjtModel.forwardBiasDepletionCoefficient, 0.4);
 
-    const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02, KF: 1.0e-12, AF: 1.3, VJ: 0.8, FC: 0.35, IS: 2.0e-13, RD: 125.0, RS: 75.0, T_NOM: 50.0, TCV: 0.01, BEX: 1.5 });
+    const jfetCard = normalizeModelCard("Jn", "njfet", { BET: 9.0e-4, VT0: -1.8, LAM: 0.02, KF: 1.0e-12, AF: 1.3, VJ: 0.8, FC: 0.35, IS: 2.0e-13, RD: 125.0, RS: 75.0, T_NOM: 50.0, TCV: 0.01, BEX: 1.5, BETATCE: -0.5 });
     const jfetModel = jfetFromModelCard("J1", "d", "g", "s", jfetCard);
-    expect(jfetCard.parameters).toStrictEqual({ BETA: 9.0e-4, VTO: -1.8, LAMBDA: 0.02, KF: 1.0e-12, AF: 1.3, PB: 0.8, FC: 0.35, IS: 2.0e-13, RD: 125.0, RS: 75.0, TNOM: 50.0, TCV: 0.01, BEX: 1.5 });
+    expect(jfetCard.parameters).toStrictEqual({ BETA: 9.0e-4, VTO: -1.8, LAMBDA: 0.02, KF: 1.0e-12, AF: 1.3, PB: 0.8, FC: 0.35, IS: 2.0e-13, RD: 125.0, RS: 75.0, TNOM: 50.0, TCV: 0.01, BEX: 1.5, BETATCE: -0.5 });
     expect(jfetModel.polarity).toBe("NJF");
     expectClose(jfetModel.beta, 9.0e-4);
     expectClose(jfetModel.thresholdVoltage, -1.8);
@@ -401,6 +401,7 @@ describe("dcOp", () => {
     expectClose(jfetModel.nominalTemperatureKelvin, 323.15);
     expectClose(jfetModel.thresholdVoltageTemperatureCoefficient, 0.01);
     expectClose(jfetModel.mobilityTemperatureExponent, 1.5);
+    expectClose(jfetModel.mobilityTemperatureCoefficient, -0.5);
 
     const mosCard = normalizeModelCard("Mn", "nmos", {
       LEVEL: 1.0,
@@ -1068,6 +1069,7 @@ describe("dcOp", () => {
           thresholdVoltageTemperatureCoefficient: 0.01,
           nominalTemperatureKelvin: 323.15,
           mobilityTemperatureExponent: 1.5,
+          mobilityTemperatureCoefficient: -0.5,
         },
       ]),
     );
@@ -1088,6 +1090,7 @@ describe("dcOp", () => {
     expectClose(expanded.thresholdVoltageTemperatureCoefficient, 0.01);
     expectClose(expanded.nominalTemperatureKelvin, 323.15);
     expectClose(expanded.mobilityTemperatureExponent, 1.5);
+    expectClose(expanded.mobilityTemperatureCoefficient, -0.5);
   });
 
   it("drops the intrinsic JFET drain voltage across RD", () => {
@@ -1543,28 +1546,38 @@ describe("dcOp", () => {
     expect(high.saturationCurrent).toBeGreaterThan(low.saturationCurrent);
   });
 
-  it("uses JFET TCV, BEX, and model nominal temperature", () => {
+  it("uses JFET TCV, BETATCE, and model nominal temperature", () => {
     const transistor = {
       ...jfet("J1", "d", "g", "s"),
       thresholdVoltage: -2.0,
       beta: 1.0e-4,
       thresholdVoltageTemperatureCoefficient: 0.01,
       nominalTemperatureKelvin: 310.0,
-      mobilityTemperatureExponent: 1.0,
+      mobilityTemperatureExponent: -5.0,
+      mobilityTemperatureCoefficient: 1.0,
     };
     const atModelNominal = jfetAtTemperature(transistor, 310.0);
     const hot = jfetAtTemperature(transistor, 320.0);
     const cold = jfetAtTemperature(transistor, 300.0);
     const invariant = jfetAtTemperature(jfet("Jflat", "d", "g", "s"), 350.0);
+    const bexFallback = jfetAtTemperature(
+      {
+        ...jfet("Jbex", "d", "g", "s"),
+        nominalTemperatureKelvin: 310.0,
+        mobilityTemperatureExponent: 1.0,
+      },
+      320.0,
+    );
 
     expectClose(atModelNominal.thresholdVoltage, -2.0);
     expectClose(atModelNominal.beta, 1.0e-4);
     expectClose(hot.thresholdVoltage, -2.1);
-    expectClose(hot.beta, 1.0e-4 * 320.0 / 310.0);
+    expectClose(hot.beta, 1.0e-4 * 1.01 ** 10.0);
     expectClose(cold.thresholdVoltage, -1.9);
-    expectClose(cold.beta, 1.0e-4 * 300.0 / 310.0);
+    expectClose(cold.beta, 1.0e-4 * 1.01 ** -10.0);
     expectClose(invariant.thresholdVoltage, -2.0);
     expectClose(invariant.beta, 1.0e-4);
+    expectClose(bexFallback.beta, 1.0e-4 * 320.0 / 310.0);
   });
 
   it("rejects invalid JFET temperature parameters", () => {
@@ -1593,6 +1606,15 @@ describe("dcOp", () => {
     });
     expect(() => dcOp(invalidExponent)).toThrowError(
       "mobility temperature exponent must be finite",
+    );
+
+    const invalidCoefficient = new Circuit();
+    invalidCoefficient.add({
+      ...jfet("Jbad", "d", "g", "0"),
+      mobilityTemperatureCoefficient: Number.NaN,
+    });
+    expect(() => dcOp(invalidCoefficient)).toThrowError(
+      "mobility temperature coefficient must be finite",
     );
   });
 

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,14 +33,16 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language JFET beta temperature scaling.
+1. Cross-language JFET alternative beta temperature scaling.
    - Status: current PR completion candidate.
-   - Add Berkeley JFET `BEX` model-card support in Rust, Python, and TypeScript.
-   - Apply `BETA(T) = BETA * (T / TNOM)^BEX`, with model `TNOM` overriding the
-     circuit nominal temperature.
-   - Preserve the exponent through hierarchy and cloning, validate finite
-     coefficients, keep the default temperature-invariant when `BEX` is zero,
-     and extend the supported-parameter coverage gate from 161 to 163
+   - Add Berkeley JFET `BETATCE` model-card support in Rust, Python, and
+     TypeScript.
+   - When explicitly present, apply
+     `BETA(T) = BETA * 1.01^(BETATCE * (T - TNOM))` with precedence over
+     `BEX`; otherwise retain the existing `BEX` rule.
+   - Preserve parameter presence through hierarchy and cloning, validate
+     finite coefficients, and extend the supported-parameter coverage gate
+     from 163 to 165
      canonical rows.
 
 ## Completed Slices
@@ -3321,6 +3323,15 @@ the Rust, Python, and TypeScript surfaces together.
      and finite-positive nominal temperatures are validated, the zero default
      remains temperature-invariant, and the supported-parameter release gate
      now covers 161 canonical rows.
+
+257. Cross-language JFET beta temperature scaling.
+   - Status: completed in PR 8944.
+   - Rust, Python, and TypeScript JFET model cards now accept `BEX` and apply
+     `BETA(T) = BETA * (T / TNOM)^BEX`, with model `TNOM` overriding the
+     circuit nominal temperature.
+   - Hierarchy and cloning paths preserve the exponent, finite validation is
+     shared across analyses, the zero default remains temperature-invariant,
+     and the supported-parameter release gate now covers 163 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley JFET `BETATCE` model-card support across Rust, Python, and TypeScript
- apply `BETA(T) = BETA * 1.01^(BETATCE * (T - TNOM))` when explicitly present, with precedence over `BEX`
- preserve parameter presence through hierarchy, validate finite values, extend coverage gates to 165 rows, and reconcile the SPICE plan

## Verification
- `cargo test -p spice-engine`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo fmt -p spice-engine -- --check`
- Python: `python -m pytest -q` (606 passed, 88.76% coverage)
- Python: `ruff check` on touched source and test files
- TypeScript: `npm run build`
- TypeScript: `npx vitest run --pool=forks --maxWorkers=1 --no-file-parallelism` (364 passed)
- `git diff --check`
