### PR TITLE
feat(fold-control-flow): do-while loop-body comma-fusion (0.36.0)

### DIFF
--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.36.0] - 2026-07-24
+
+### Added - do-while loop-body comma-fusion
+
+A `do … while` loop body that is a block of all-plain-expression statements now
+fuses to a single (possibly comma-sequenced) expression statement, dropping the
+braces — matching the reference Closure Compiler at SIMPLE and completing the
+loop-body fusion already done for `for`/`while` (0.32.0):
+
+```text
+  do { a(); b(); } while(c);      ->  do a(), b(); while(c);
+  do { a(); b(); d(); } while(c); ->  do a(), b(), d(); while(c);
+  do { a(); } while(c);           ->  do a(); while(c);         (block unwrapped)
+```
+
+The comma operator runs the operands left-to-right with identical side effects
+and the loop discards the value, so the rewrite is behaviour-preserving. It runs
+after the body's own inner folds, so an `if (x) a();` that folded to `x && a()`
+participates: `do { if (x) a(); b(); } while(c);` -> `do x && a(), b(); while(c);`.
+
+Reuses the existing `stmts_as_sequence_expr` gate, which keeps the block intact
+for any body carrying a declaration (`var`/`let`/`const`), a
+`break`/`continue`/`return`, or a nested statement — none can join a
+comma-sequence. Unlike `while`, a `do`-loop is not rewritten to a `for`, so the
+fusion is applied directly in the `DoWhileStatement` fold arm.
+
+Not handled here (separate reference transforms, tracked as follow-ups): trailing
+`continue` removal in a do-body (`do{a();continue}while(c)` -> `do a();while(c)`),
+trailing `return` -> `break` in a loop, and empty-body `do{}while(c)` ->
+`for(;c;);`.
+
 ## [0.35.0] - 2026-07-22
 
 ### Added - split a comma-sequence expression statement into separate statements

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -396,11 +396,49 @@ fn fold_tagged_statement(stmt: &TaggedStatement, st: &mut FoldState) -> Statemen
         // A `do … while(test)` runs its body at least once, so — unlike
         // `while` — it can NEVER be eliminated as a dead loop even when
         // `test` is statically falsy (the single body run is observable).
-        // We therefore only recurse structurally: fold the body and the test.
+        // We therefore recurse structurally (fold the body and the test) and
+        // then apply the same loop-body comma-fusion as `for`/`while`:
+        //
+        //   do { a(); b(); } while(c);   →   do a(), b(); while(c);
+        //
+        // A `BlockStatement` body whose statements are *all* plain expression
+        // statements collapses to one (possibly comma-sequenced) expression
+        // statement, dropping the braces — the comma operator runs them
+        // left-to-right with identical side effects and the loop discards the
+        // value. `stmts_as_sequence_expr` returns `None` (keeping the block) for
+        // any body carrying a declaration (`var`/`let`/`const`), a
+        // `break`/`continue`/`return`, or a nested statement — none of which can
+        // join a comma-sequence. Unlike `while`, a `do`-loop is not rewritten to
+        // a `for`, so the fusion is applied here rather than inherited from
+        // `fold_for_statement`. It runs *after* the body's own inner folds, so an
+        // `if (x) a();` that folded to `x && a()` participates:
+        // `do { if (x) a(); b(); } while(c);` → `do x && a(), b(); while(c);`.
         TaggedStatement::DoWhileStatement(s) => {
+            let body = fold_statement(&s.body, st);
+            let body = match &body {
+                Statement::Tagged(TaggedStatement::BlockStatement(_)) => {
+                    match stmts_as_sequence_expr(&body) {
+                        Some(expr) => {
+                            let body_cv = statement_cv(&body);
+                            st.record_fold(
+                                &s.cv,
+                                "loop-body-fuse",
+                                "do { s1; s2; … } while(…)",
+                                "do s1, s2, … while(…)",
+                            );
+                            Statement::expression_statement(ExpressionStatement {
+                                cv: body_cv,
+                                expression: expr,
+                            })
+                        }
+                        None => body,
+                    }
+                }
+                _ => body,
+            };
             Statement::Tagged(TaggedStatement::DoWhileStatement(DoWhileStatement {
                 cv: s.cv.clone(),
-                body: Box::new(fold_statement(&s.body, st)),
+                body: Box::new(body),
                 test: fold_expression(&s.test, st),
             }))
         }
@@ -2662,6 +2700,75 @@ mod tests {
                 other => panic!("expected a fused expression-statement body; got {other:?}"),
             },
             other => panic!("expected ForStatement; got {other:?}"),
+        }
+    }
+
+    /// `do { a(); b(); } while(c);` → `do a(), b(); while(c);` — a do-while
+    /// block body of plain expression statements fuses to a comma-sequenced
+    /// single statement, exactly like `for`/`while`.
+    #[test]
+    fn do_while_body_multi_expr_fuses_to_sequence() {
+        let body = block(
+            Some("blk.1"),
+            vec![
+                expr_stmt(call_expr("a"), None),
+                expr_stmt(call_expr("b"), None),
+            ],
+        );
+        let dw = Statement::Tagged(TaggedStatement::DoWhileStatement(DoWhileStatement {
+            cv: Some("dw.1".to_string()),
+            body: Box::new(body),
+            test: ident("c"),
+        }));
+        let (out, contribs, changed, _) =
+            run_pass(program().with_body(vec![ProgramItem::Statement(dw)]));
+        assert!(changed);
+        assert!(contribs.iter().any(|c| c.tag == "loop-body-fuse"));
+        match first_stmt(&out) {
+            Statement::Tagged(TaggedStatement::DoWhileStatement(d)) => match d.body.as_ref() {
+                Statement::Tagged(TaggedStatement::ExpressionStatement(es)) => {
+                    match &es.expression {
+                        Expression::SequenceExpression(s) => assert_eq!(s.expressions.len(), 2),
+                        other => panic!("expected a 2-element sequence; got {other:?}"),
+                    }
+                }
+                other => panic!("expected a fused expression-statement body; got {other:?}"),
+            },
+            other => panic!("expected DoWhileStatement; got {other:?}"),
+        }
+    }
+
+    /// `do { var x = 1; a(); } while(c);` — a do-while body carrying a `var`
+    /// declaration is NOT fused (a declaration can't join a comma-sequence);
+    /// the block is kept intact.
+    #[test]
+    fn do_while_body_with_var_decl_not_fused() {
+        use coding_adventures_javascript_ast::{
+            BindingTarget, VariableDeclaration, VariableDeclarator,
+        };
+        let var_x = Statement::Declaration(Declaration::VariableDeclaration(VariableDeclaration {
+            cv: None,
+            kind: VarKind::Var,
+            declarations: vec![VariableDeclarator {
+                cv: None,
+                id: BindingTarget::Identifier(Identifier { cv: None, name: "x".to_string() }),
+                init: Some(num(1.0, None)),
+            }],
+        }));
+        let body = block(Some("blk.1"), vec![var_x, expr_stmt(call_expr("a"), None)]);
+        let dw = Statement::Tagged(TaggedStatement::DoWhileStatement(DoWhileStatement {
+            cv: None,
+            body: Box::new(body),
+            test: ident("c"),
+        }));
+        let (out, _, _, _) = run_pass(program().with_body(vec![ProgramItem::Statement(dw)]));
+        match first_stmt(&out) {
+            Statement::Tagged(TaggedStatement::DoWhileStatement(d)) => assert!(
+                matches!(d.body.as_ref(), Statement::Tagged(TaggedStatement::BlockStatement(_))),
+                "var-carrying do-while body must stay a block; got {:?}",
+                d.body
+            ),
+            other => panic!("expected DoWhileStatement; got {other:?}"),
         }
     }
 

--- a/code/programs/rust/closurec/tests/diff/simple-do-while-body-fuse/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-do-while-body-fuse/README.md
@@ -1,0 +1,19 @@
+# simple-do-while-body-fuse
+
+End-to-end oracle for **do-while loop-body comma-fusion** in
+`closure-pass-fold-control-flow` (fcf 0.36.0) — the do-while counterpart of the
+`for`/`while` fusion (0.32.0).
+
+A do-while body that is a block of all-plain-expression statements fuses to a
+single (possibly comma-sequenced) expression statement, dropping the braces. It
+runs after the body's inner folds (so a folded `if` participates), and declines
+on any body carrying a declaration or a control-flow statement.
+
+## Expected output
+
+```text
+do a(),b();while(c);do x&&g(),h();while(d);do{var v=1;k(v)}while(e);
+```
+
+Byte-identical to the reference Closure Compiler (`v20260712`,
+`SIMPLE_OPTIMIZATIONS`, `ECMASCRIPT_2020`, `NO_TRANSPILE`), verified with `xxd`.

--- a/code/programs/rust/closurec/tests/diff/simple-do-while-body-fuse/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-do-while-body-fuse/expected.stdout
@@ -1,0 +1,1 @@
+do a(),b();while(c);do x&&g(),h();while(d);do{var v=1;k(v)}while(e);

--- a/code/programs/rust/closurec/tests/diff/simple-do-while-body-fuse/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-do-while-body-fuse/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-do-while-body-fuse/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-do-while-body-fuse/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-do-while-body-fuse/input/a.js
@@ -1,0 +1,19 @@
+// SIMPLE-level do-while loop-body comma-fusion (fold-control-flow 0.36.0),
+// the do-while counterpart of the for/while fusion (0.32.0).
+//
+// A do-while body that is a block of all-plain-expression statements fuses to a
+// single (possibly comma-sequenced) expression statement, dropping the braces:
+//   do { a(); b(); } while (c);   -> do a(),b();while(c);
+// The comma operator runs the operands left-to-right with identical side effects
+// and the loop discards the value, so the rewrite is behaviour-preserving.
+//
+// It runs AFTER the body's own inner folds, so `if (x) g();` that folded to
+// `x&&g()` participates:
+//   do { if (x) g(); h(); } while (d);  -> do x&&g(),h();while(d);
+//
+// A body carrying a `var` declaration is NOT fused (a declaration can't join a
+// comma-sequence); the block is kept intact:
+//   do { var v = 1; k(v); } while (e);  -> do{var v=1;k(v)}while(e);
+do { a(); b(); } while (c);
+do { if (x) g(); h(); } while (d);
+do { var v = 1; k(v); } while (e);

--- a/code/programs/rust/closurec/tests/diff_simple_do_while_body_fuse.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_do_while_body_fuse.rs
@@ -1,0 +1,53 @@
+//! Integration test for the `tests/diff/simple-do-while-body-fuse/` fixture.
+//!
+//! End-to-end oracle for do-while loop-body comma-fusion in
+//! `closure-pass-fold-control-flow`: a `do … while` body that is a block of
+//! all-plain-expression statements fuses to a single (possibly comma-sequenced)
+//! expression statement, dropping the braces — the do-while counterpart of the
+//! for/while fusion. It runs after the body's inner folds (a folded `if`
+//! participates) and declines on any body carrying a declaration or a
+//! control-flow statement.
+//!
+//! At SIMPLE the fixture optimizes to:
+//!
+//! ```text
+//! do a(),b();while(c);do x&&g(),h();while(d);do{var v=1;k(v)}while(e);
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-do-while-body-fuse/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_do_while_body_fuse_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-do-while-body-fuse/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}


### PR DESCRIPTION
## What

`fold-control-flow` (0.36.0): completes the loop-body comma-fusion family. A
`do … while` body that is a block of all-plain-expression statements now fuses
to a single (possibly comma-sequenced) expression statement, dropping the
braces — matching the reference Closure Compiler at SIMPLE byte-for-byte, and
the do-while counterpart of the for/while fusion (0.32.0).

```text
do { a(); b(); } while(c);        ->  do a(),b();while(c);
do { a(); b(); d(); } while(c);   ->  do a(),b(),d();while(c);
do { a(); } while(c);             ->  do a();while(c);      (block unwrapped)
```

The comma operator runs the operands left-to-right with identical side effects
and the loop discards the value, so the rewrite is behaviour-preserving. It runs
after the body's own inner folds, so an `if (x) g();` that folded to `x&&g()`
participates: `do { if (x) g(); h(); } while(d);` -> `do x&&g(),h();while(d);`.

## How

Reuses the existing `stmts_as_sequence_expr` gate (same helper + `loop-body-fuse`
record tag as the merged for/while fusion), which keeps the block intact for any
body carrying a declaration (`var`/`let`/`const`), a `break`/`continue`/`return`,
or a nested statement — none can join a comma-sequence. Unlike `while`, a
`do`-loop is not rewritten to a `for`, so the fusion is applied directly in the
`DoWhileStatement` fold arm rather than inherited from `fold_for_statement`.

## Not handled (follow-up #226)

Separate reference transforms that this PR correctly declines (body is not
all-plain-expression-statements, so no miscompile): trailing `continue` removal
in a do-body, trailing `return`->`break` in a loop tail, and empty-body
`do{}while(c)` -> `for(;c;);`.

## Verification

- 92 fold-control-flow unit tests (2 new: do-while fuse, do-while var-body
  not-fused) + 13 integration — zero regressions.
- New closurec e2e fixture `simple-do-while-body-fuse`, byte-identical to the
  oracle jar (`v20260712`, `SIMPLE`, `ECMASCRIPT_2020`, `NO_TRANSPILE`),
  verified with `xxd`; covers fuse, if-fold-then-fuse, and var-body decline.
- `cargo clippy -- -D warnings` clean in both workspaces.
- Local closurec suite green through the integration + conformance sets (full
  suite runs in CI).
- Inline security review: **PASSED** — behaviour-preserving, converges in one
  sweep under the pipeline's 100-sweep cap, no panic path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
