### PR TITLE
feat(hl03): Telugu, Kannada & Malayalam letters as Unicode-grounded syllabaries (PR 1)

### DIFF
--- a/code/learning/human-languages/data/scripts/generate_syllabary.py
+++ b/code/learning/human-languages/data/scripts/generate_syllabary.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# ---------------------------------------------------------------------------
+# generate_syllabary.py — Telugu / Kannada / Malayalam syllabaries, from Unicode.
+#
+# WHY THIS EXISTS (and why it is a generator, not a hand-authored table).
+# These three Dravidian scripts are abugidas: a base consonant carries an
+# inherent /a/, and a vowel sign turns it into a syllable — క = ka, కి = ki,
+# కు = ku; ఖ = kha, ఖి = khi, ఖు = khu. The study app teaches them as pattern
+# recognition, one consonant across its vowel row. That is hundreds of syllables
+# per script, and they are scripts many maintainers cannot proofread by eye — so
+# hand-typing the glyphs would be both tedious and unverifiable.
+#
+# GROUNDING. Every glyph here is COMPOSED FROM UNICODE CODE POINTS, never typed
+# from memory. The identity and romanization of each base consonant / vowel sign
+# come from its official Unicode character NAME (e.g. "TELUGU LETTER KA",
+# "KANNADA VOWEL SIGN II"), mapped to ISO-15919 transliteration. A base consonant
+# whose Unicode name we do not have a transliteration for is SKIPPED rather than
+# guessed — the output only ever contains letters we can name from the standard.
+# So the Unicode Character Database is the single source of truth, and the file
+# is regenerable: `python3 generate_syllabary.py`.
+#
+# NOT INCLUDED: stroke order / how to hand-write ("ductus"). That is a separate,
+# source-gated effort and stays paused — these entries carry `strokeOrder: []`.
+# This file is for READING (recognition), which the glyph + romanization + the
+# consonant⊕vowel-sign decomposition fully support.
+# ---------------------------------------------------------------------------
+
+import json
+import os
+import unicodedata
+
+# ISO-15919 romanization keyed on the Unicode consonant token (the "<X>" in
+# "<SCRIPT> LETTER <X>"). The order here IS the traditional varga order the
+# scripts are taught in, so iterating it yields a pedagogical, consonant-major
+# sequence. A script that lacks one of these simply won't have that code point.
+CONSONANTS = [
+    ("KA", "ka"), ("KHA", "kha"), ("GA", "ga"), ("GHA", "gha"), ("NGA", "ṅa"),
+    ("CA", "ca"), ("CHA", "cha"), ("JA", "ja"), ("JHA", "jha"), ("NYA", "ña"),
+    ("TTA", "ṭa"), ("TTHA", "ṭha"), ("DDA", "ḍa"), ("DDHA", "ḍha"), ("NNA", "ṇa"),
+    ("TA", "ta"), ("THA", "tha"), ("DA", "da"), ("DHA", "dha"), ("NA", "na"),
+    ("PA", "pa"), ("PHA", "pha"), ("BA", "ba"), ("BHA", "bha"), ("MA", "ma"),
+    ("YA", "ya"), ("RA", "ra"), ("LA", "la"), ("VA", "va"),
+    ("SHA", "śa"), ("SSA", "ṣa"), ("SA", "sa"), ("HA", "ha"),
+    ("LLA", "ḷa"), ("RRA", "ṟa"), ("NNNA", "ṉa"),
+]
+
+# The Dravidian core vowel set (short + long e/o — the distinction is phonemic in
+# these languages). The empty key is the inherent /a/ (the bare consonant).
+# Keyed on the Unicode vowel-sign token ("<SCRIPT> VOWEL SIGN <V>"); the roman is
+# the vowel added AFTER the consonant root. `ai/au/ṛ` etc. are left for later.
+VOWELS = [
+    ("", "a"),      # inherent — no sign
+    ("AA", "ā"), ("I", "i"), ("II", "ī"), ("U", "u"), ("UU", "ū"),
+    ("E", "e"), ("EE", "ē"), ("O", "o"), ("OO", "ō"),
+]
+
+# The three scripts: (script id, display name, Unicode block base, the Noto face
+# the glyphs were verified against — metadata only; the app renders with system
+# fonts). `signature` is a factual "how to spot it" cue, verified by rendering.
+SCRIPTS = [
+    ("telugu", "Telugu", 0x0C00, "_fonts/NotoSansTelugu-Static.ttf",
+     "Rounded, curvy letters, most crowned with a small tick or check-mark headstroke; no continuous top line."),
+    ("kannada", "Kannada", 0x0C80, "_fonts/NotoSansKannada-Static.ttf",
+     "Rounded and looping like Telugu (its sister script), most letters topped by a small curved headstroke; no continuous top line."),
+    ("malayalam", "Malayalam", 0x0D00, "_fonts/NotoSansMalayalam-Static.ttf",
+     "Highly rounded and loopy — full circles, hooks and curls, with almost no straight lines."),
+]
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def codepoint_by_name(target_name: str, block_base: int) -> int | None:
+    """Find the code point in a 128-slot block whose Unicode name matches."""
+    for cp in range(block_base, block_base + 0x80):
+        ch = chr(cp)
+        try:
+            if unicodedata.name(ch) == target_name:
+                return cp
+        except ValueError:
+            continue  # unassigned code point
+    return None
+
+
+def build_script(script_id: str, name: str, base: int, font: str, signature: str) -> dict:
+    up = name.upper()
+    letters = []
+    for con_tok, con_rom in CONSONANTS:
+        con_cp = codepoint_by_name(f"{up} LETTER {con_tok}", base)
+        if con_cp is None:
+            continue  # this script doesn't have this consonant — skip, never invent
+        con_ch = chr(con_cp)
+        root = con_rom[:-1]  # drop the inherent 'a': "kha" -> "kh"
+        for vow_tok, vow_rom in VOWELS:
+            if vow_tok == "":
+                glyph = con_ch
+                sound = con_rom
+                components = [f"{con_ch}  {con_rom} — base consonant (inherent “a”)"]
+            else:
+                sign_cp = codepoint_by_name(f"{up} VOWEL SIGN {vow_tok}", base)
+                if sign_cp is None:
+                    continue  # this script lacks this vowel sign — skip
+                sign_ch = chr(sign_cp)
+                glyph = con_ch + sign_ch
+                sound = root + vow_rom
+                components = [
+                    f"{con_ch}  {con_rom} — base consonant",
+                    f"{sign_ch}  “{vow_rom}” vowel sign",
+                ]
+            letters.append({
+                "glyph": glyph,
+                "sound": sound,
+                "role": "syllable",
+                "inherentVowel": "a",
+                "components": components,
+                "strokeOrder": [],       # recognition only — ductus is a separate, paused effort
+                "strokeOrderNote": "",
+            })
+    return {
+        "script": script_id,
+        "name": name,
+        "font": font,
+        "direction": "ltr",
+        "system": "abugida",
+        "signature": signature,
+        "complete": False,  # the core varga × core vowels — not the full script yet
+        "notes": (
+            "Syllabary generated from Unicode by generate_syllabary.py: each syllable is a base "
+            "consonant (varga order) composed with a core vowel sign. Romanization is ISO-15919. "
+            "Recognition only — stroke order is a separate, source-gated effort and is omitted."
+        ),
+        "letters": letters,
+    }
+
+
+def main() -> None:
+    for script_id, name, base, font, signature in SCRIPTS:
+        data = build_script(script_id, name, base, font, signature)
+        path = os.path.join(HERE, f"{script_id}.json")
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, ensure_ascii=False, indent=2)
+            fh.write("\n")
+        print(f"wrote {path}: {len(data['letters'])} syllables "
+              f"({sum(1 for l in data['letters'] if len(l['components']) == 1)} base consonants)")
+
+
+if __name__ == "__main__":
+    main()

--- a/code/learning/human-languages/data/scripts/kannada.json
+++ b/code/learning/human-languages/data/scripts/kannada.json
@@ -1,0 +1,4177 @@
+{
+  "script": "kannada",
+  "name": "Kannada",
+  "font": "_fonts/NotoSansKannada-Static.ttf",
+  "direction": "ltr",
+  "system": "abugida",
+  "signature": "Rounded and looping like Telugu (its sister script), most letters topped by a small curved headstroke; no continuous top line.",
+  "complete": false,
+  "notes": "Syllabary generated from Unicode by generate_syllabary.py: each syllable is a base consonant (varga order) composed with a core vowel sign. Romanization is ISO-15919. Recognition only — stroke order is a separate, source-gated effort and is omitted.",
+  "letters": [
+    {
+      "glyph": "ಕ",
+      "sound": "ka",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಕ  ka — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಕಾ",
+      "sound": "kā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಕ  ka — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಕಿ",
+      "sound": "ki",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಕ  ka — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಕೀ",
+      "sound": "kī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಕ  ka — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಕು",
+      "sound": "ku",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಕ  ka — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಕೂ",
+      "sound": "kū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಕ  ka — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಕೆ",
+      "sound": "ke",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಕ  ka — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಕೇ",
+      "sound": "kē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಕ  ka — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಕೊ",
+      "sound": "ko",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಕ  ka — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಕೋ",
+      "sound": "kō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಕ  ka — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಖ",
+      "sound": "kha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಖ  kha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಖಾ",
+      "sound": "khā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಖ  kha — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಖಿ",
+      "sound": "khi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಖ  kha — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಖೀ",
+      "sound": "khī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಖ  kha — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಖು",
+      "sound": "khu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಖ  kha — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಖೂ",
+      "sound": "khū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಖ  kha — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಖೆ",
+      "sound": "khe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಖ  kha — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಖೇ",
+      "sound": "khē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಖ  kha — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಖೊ",
+      "sound": "kho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಖ  kha — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಖೋ",
+      "sound": "khō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಖ  kha — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಗ",
+      "sound": "ga",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಗ  ga — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಗಾ",
+      "sound": "gā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಗ  ga — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಗಿ",
+      "sound": "gi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಗ  ga — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಗೀ",
+      "sound": "gī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಗ  ga — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಗು",
+      "sound": "gu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಗ  ga — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಗೂ",
+      "sound": "gū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಗ  ga — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಗೆ",
+      "sound": "ge",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಗ  ga — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಗೇ",
+      "sound": "gē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಗ  ga — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಗೊ",
+      "sound": "go",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಗ  ga — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಗೋ",
+      "sound": "gō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಗ  ga — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಘ",
+      "sound": "gha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಘ  gha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಘಾ",
+      "sound": "ghā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಘ  gha — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಘಿ",
+      "sound": "ghi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಘ  gha — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಘೀ",
+      "sound": "ghī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಘ  gha — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಘು",
+      "sound": "ghu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಘ  gha — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಘೂ",
+      "sound": "ghū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಘ  gha — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಘೆ",
+      "sound": "ghe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಘ  gha — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಘೇ",
+      "sound": "ghē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಘ  gha — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಘೊ",
+      "sound": "gho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಘ  gha — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಘೋ",
+      "sound": "ghō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಘ  gha — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಙ",
+      "sound": "ṅa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಙ  ṅa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಙಾ",
+      "sound": "ṅā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಙ  ṅa — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಙಿ",
+      "sound": "ṅi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಙ  ṅa — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಙೀ",
+      "sound": "ṅī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಙ  ṅa — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಙು",
+      "sound": "ṅu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಙ  ṅa — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಙೂ",
+      "sound": "ṅū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಙ  ṅa — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಙೆ",
+      "sound": "ṅe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಙ  ṅa — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಙೇ",
+      "sound": "ṅē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಙ  ṅa — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಙೊ",
+      "sound": "ṅo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಙ  ṅa — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಙೋ",
+      "sound": "ṅō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಙ  ṅa — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಚ",
+      "sound": "ca",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಚ  ca — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಚಾ",
+      "sound": "cā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಚ  ca — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಚಿ",
+      "sound": "ci",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಚ  ca — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಚೀ",
+      "sound": "cī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಚ  ca — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಚು",
+      "sound": "cu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಚ  ca — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಚೂ",
+      "sound": "cū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಚ  ca — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಚೆ",
+      "sound": "ce",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಚ  ca — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಚೇ",
+      "sound": "cē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಚ  ca — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಚೊ",
+      "sound": "co",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಚ  ca — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಚೋ",
+      "sound": "cō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಚ  ca — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಛ",
+      "sound": "cha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಛ  cha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಛಾ",
+      "sound": "chā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಛ  cha — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಛಿ",
+      "sound": "chi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಛ  cha — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಛೀ",
+      "sound": "chī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಛ  cha — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಛು",
+      "sound": "chu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಛ  cha — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಛೂ",
+      "sound": "chū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಛ  cha — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಛೆ",
+      "sound": "che",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಛ  cha — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಛೇ",
+      "sound": "chē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಛ  cha — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಛೊ",
+      "sound": "cho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಛ  cha — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಛೋ",
+      "sound": "chō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಛ  cha — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಜ",
+      "sound": "ja",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಜ  ja — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಜಾ",
+      "sound": "jā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಜ  ja — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಜಿ",
+      "sound": "ji",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಜ  ja — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಜೀ",
+      "sound": "jī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಜ  ja — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಜು",
+      "sound": "ju",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಜ  ja — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಜೂ",
+      "sound": "jū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಜ  ja — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಜೆ",
+      "sound": "je",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಜ  ja — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಜೇ",
+      "sound": "jē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಜ  ja — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಜೊ",
+      "sound": "jo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಜ  ja — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಜೋ",
+      "sound": "jō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಜ  ja — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಝ",
+      "sound": "jha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಝ  jha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಝಾ",
+      "sound": "jhā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಝ  jha — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಝಿ",
+      "sound": "jhi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಝ  jha — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಝೀ",
+      "sound": "jhī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಝ  jha — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಝು",
+      "sound": "jhu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಝ  jha — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಝೂ",
+      "sound": "jhū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಝ  jha — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಝೆ",
+      "sound": "jhe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಝ  jha — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಝೇ",
+      "sound": "jhē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಝ  jha — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಝೊ",
+      "sound": "jho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಝ  jha — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಝೋ",
+      "sound": "jhō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಝ  jha — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಞ",
+      "sound": "ña",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಞ  ña — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಞಾ",
+      "sound": "ñā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಞ  ña — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಞಿ",
+      "sound": "ñi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಞ  ña — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಞೀ",
+      "sound": "ñī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಞ  ña — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಞು",
+      "sound": "ñu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಞ  ña — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಞೂ",
+      "sound": "ñū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಞ  ña — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಞೆ",
+      "sound": "ñe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಞ  ña — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಞೇ",
+      "sound": "ñē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಞ  ña — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಞೊ",
+      "sound": "ño",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಞ  ña — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಞೋ",
+      "sound": "ñō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಞ  ña — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಟ",
+      "sound": "ṭa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಟ  ṭa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಟಾ",
+      "sound": "ṭā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಟ  ṭa — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಟಿ",
+      "sound": "ṭi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಟ  ṭa — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಟೀ",
+      "sound": "ṭī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಟ  ṭa — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಟು",
+      "sound": "ṭu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಟ  ṭa — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಟೂ",
+      "sound": "ṭū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಟ  ṭa — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಟೆ",
+      "sound": "ṭe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಟ  ṭa — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಟೇ",
+      "sound": "ṭē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಟ  ṭa — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಟೊ",
+      "sound": "ṭo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಟ  ṭa — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಟೋ",
+      "sound": "ṭō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಟ  ṭa — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಠ",
+      "sound": "ṭha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಠ  ṭha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಠಾ",
+      "sound": "ṭhā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಠ  ṭha — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಠಿ",
+      "sound": "ṭhi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಠ  ṭha — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಠೀ",
+      "sound": "ṭhī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಠ  ṭha — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಠು",
+      "sound": "ṭhu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಠ  ṭha — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಠೂ",
+      "sound": "ṭhū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಠ  ṭha — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಠೆ",
+      "sound": "ṭhe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಠ  ṭha — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಠೇ",
+      "sound": "ṭhē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಠ  ṭha — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಠೊ",
+      "sound": "ṭho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಠ  ṭha — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಠೋ",
+      "sound": "ṭhō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಠ  ṭha — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಡ",
+      "sound": "ḍa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಡ  ḍa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಡಾ",
+      "sound": "ḍā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಡ  ḍa — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಡಿ",
+      "sound": "ḍi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಡ  ḍa — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಡೀ",
+      "sound": "ḍī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಡ  ḍa — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಡು",
+      "sound": "ḍu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಡ  ḍa — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಡೂ",
+      "sound": "ḍū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಡ  ḍa — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಡೆ",
+      "sound": "ḍe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಡ  ḍa — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಡೇ",
+      "sound": "ḍē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಡ  ḍa — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಡೊ",
+      "sound": "ḍo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಡ  ḍa — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಡೋ",
+      "sound": "ḍō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಡ  ḍa — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಢ",
+      "sound": "ḍha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಢ  ḍha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಢಾ",
+      "sound": "ḍhā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಢ  ḍha — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಢಿ",
+      "sound": "ḍhi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಢ  ḍha — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಢೀ",
+      "sound": "ḍhī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಢ  ḍha — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಢು",
+      "sound": "ḍhu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಢ  ḍha — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಢೂ",
+      "sound": "ḍhū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಢ  ḍha — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಢೆ",
+      "sound": "ḍhe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಢ  ḍha — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಢೇ",
+      "sound": "ḍhē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಢ  ḍha — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಢೊ",
+      "sound": "ḍho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಢ  ḍha — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಢೋ",
+      "sound": "ḍhō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಢ  ḍha — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಣ",
+      "sound": "ṇa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಣ  ṇa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಣಾ",
+      "sound": "ṇā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಣ  ṇa — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಣಿ",
+      "sound": "ṇi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಣ  ṇa — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಣೀ",
+      "sound": "ṇī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಣ  ṇa — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಣು",
+      "sound": "ṇu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಣ  ṇa — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಣೂ",
+      "sound": "ṇū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಣ  ṇa — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಣೆ",
+      "sound": "ṇe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಣ  ṇa — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಣೇ",
+      "sound": "ṇē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಣ  ṇa — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಣೊ",
+      "sound": "ṇo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಣ  ṇa — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಣೋ",
+      "sound": "ṇō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಣ  ṇa — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ತ",
+      "sound": "ta",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ತ  ta — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ತಾ",
+      "sound": "tā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ತ  ta — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ತಿ",
+      "sound": "ti",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ತ  ta — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ತೀ",
+      "sound": "tī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ತ  ta — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ತು",
+      "sound": "tu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ತ  ta — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ತೂ",
+      "sound": "tū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ತ  ta — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ತೆ",
+      "sound": "te",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ತ  ta — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ತೇ",
+      "sound": "tē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ತ  ta — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ತೊ",
+      "sound": "to",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ತ  ta — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ತೋ",
+      "sound": "tō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ತ  ta — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಥ",
+      "sound": "tha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಥ  tha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಥಾ",
+      "sound": "thā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಥ  tha — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಥಿ",
+      "sound": "thi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಥ  tha — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಥೀ",
+      "sound": "thī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಥ  tha — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಥು",
+      "sound": "thu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಥ  tha — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಥೂ",
+      "sound": "thū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಥ  tha — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಥೆ",
+      "sound": "the",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಥ  tha — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಥೇ",
+      "sound": "thē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಥ  tha — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಥೊ",
+      "sound": "tho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಥ  tha — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಥೋ",
+      "sound": "thō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಥ  tha — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ದ",
+      "sound": "da",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ದ  da — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ದಾ",
+      "sound": "dā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ದ  da — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ದಿ",
+      "sound": "di",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ದ  da — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ದೀ",
+      "sound": "dī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ದ  da — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ದು",
+      "sound": "du",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ದ  da — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ದೂ",
+      "sound": "dū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ದ  da — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ದೆ",
+      "sound": "de",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ದ  da — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ದೇ",
+      "sound": "dē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ದ  da — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ದೊ",
+      "sound": "do",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ದ  da — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ದೋ",
+      "sound": "dō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ದ  da — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಧ",
+      "sound": "dha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಧ  dha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಧಾ",
+      "sound": "dhā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಧ  dha — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಧಿ",
+      "sound": "dhi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಧ  dha — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಧೀ",
+      "sound": "dhī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಧ  dha — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಧು",
+      "sound": "dhu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಧ  dha — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಧೂ",
+      "sound": "dhū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಧ  dha — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಧೆ",
+      "sound": "dhe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಧ  dha — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಧೇ",
+      "sound": "dhē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಧ  dha — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಧೊ",
+      "sound": "dho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಧ  dha — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಧೋ",
+      "sound": "dhō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಧ  dha — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ನ",
+      "sound": "na",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ನ  na — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ನಾ",
+      "sound": "nā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ನ  na — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ನಿ",
+      "sound": "ni",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ನ  na — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ನೀ",
+      "sound": "nī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ನ  na — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ನು",
+      "sound": "nu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ನ  na — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ನೂ",
+      "sound": "nū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ನ  na — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ನೆ",
+      "sound": "ne",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ನ  na — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ನೇ",
+      "sound": "nē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ನ  na — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ನೊ",
+      "sound": "no",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ನ  na — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ನೋ",
+      "sound": "nō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ನ  na — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಪ",
+      "sound": "pa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಪ  pa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಪಾ",
+      "sound": "pā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಪ  pa — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಪಿ",
+      "sound": "pi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಪ  pa — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಪೀ",
+      "sound": "pī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಪ  pa — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಪು",
+      "sound": "pu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಪ  pa — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಪೂ",
+      "sound": "pū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಪ  pa — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಪೆ",
+      "sound": "pe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಪ  pa — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಪೇ",
+      "sound": "pē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಪ  pa — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಪೊ",
+      "sound": "po",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಪ  pa — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಪೋ",
+      "sound": "pō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಪ  pa — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಫ",
+      "sound": "pha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಫ  pha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಫಾ",
+      "sound": "phā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಫ  pha — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಫಿ",
+      "sound": "phi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಫ  pha — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಫೀ",
+      "sound": "phī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಫ  pha — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಫು",
+      "sound": "phu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಫ  pha — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಫೂ",
+      "sound": "phū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಫ  pha — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಫೆ",
+      "sound": "phe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಫ  pha — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಫೇ",
+      "sound": "phē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಫ  pha — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಫೊ",
+      "sound": "pho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಫ  pha — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಫೋ",
+      "sound": "phō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಫ  pha — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಬ",
+      "sound": "ba",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಬ  ba — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಬಾ",
+      "sound": "bā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಬ  ba — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಬಿ",
+      "sound": "bi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಬ  ba — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಬೀ",
+      "sound": "bī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಬ  ba — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಬು",
+      "sound": "bu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಬ  ba — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಬೂ",
+      "sound": "bū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಬ  ba — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಬೆ",
+      "sound": "be",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಬ  ba — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಬೇ",
+      "sound": "bē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಬ  ba — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಬೊ",
+      "sound": "bo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಬ  ba — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಬೋ",
+      "sound": "bō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಬ  ba — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಭ",
+      "sound": "bha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಭ  bha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಭಾ",
+      "sound": "bhā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಭ  bha — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಭಿ",
+      "sound": "bhi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಭ  bha — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಭೀ",
+      "sound": "bhī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಭ  bha — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಭು",
+      "sound": "bhu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಭ  bha — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಭೂ",
+      "sound": "bhū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಭ  bha — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಭೆ",
+      "sound": "bhe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಭ  bha — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಭೇ",
+      "sound": "bhē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಭ  bha — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಭೊ",
+      "sound": "bho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಭ  bha — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಭೋ",
+      "sound": "bhō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಭ  bha — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಮ",
+      "sound": "ma",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಮ  ma — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಮಾ",
+      "sound": "mā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಮ  ma — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಮಿ",
+      "sound": "mi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಮ  ma — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಮೀ",
+      "sound": "mī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಮ  ma — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಮು",
+      "sound": "mu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಮ  ma — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಮೂ",
+      "sound": "mū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಮ  ma — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಮೆ",
+      "sound": "me",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಮ  ma — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಮೇ",
+      "sound": "mē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಮ  ma — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಮೊ",
+      "sound": "mo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಮ  ma — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಮೋ",
+      "sound": "mō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಮ  ma — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಯ",
+      "sound": "ya",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಯ  ya — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಯಾ",
+      "sound": "yā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಯ  ya — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಯಿ",
+      "sound": "yi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಯ  ya — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಯೀ",
+      "sound": "yī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಯ  ya — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಯು",
+      "sound": "yu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಯ  ya — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಯೂ",
+      "sound": "yū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಯ  ya — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಯೆ",
+      "sound": "ye",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಯ  ya — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಯೇ",
+      "sound": "yē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಯ  ya — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಯೊ",
+      "sound": "yo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಯ  ya — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಯೋ",
+      "sound": "yō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಯ  ya — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ರ",
+      "sound": "ra",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ರ  ra — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ರಾ",
+      "sound": "rā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ರ  ra — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ರಿ",
+      "sound": "ri",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ರ  ra — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ರೀ",
+      "sound": "rī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ರ  ra — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ರು",
+      "sound": "ru",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ರ  ra — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ರೂ",
+      "sound": "rū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ರ  ra — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ರೆ",
+      "sound": "re",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ರ  ra — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ರೇ",
+      "sound": "rē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ರ  ra — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ರೊ",
+      "sound": "ro",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ರ  ra — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ರೋ",
+      "sound": "rō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ರ  ra — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಲ",
+      "sound": "la",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಲ  la — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಲಾ",
+      "sound": "lā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಲ  la — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಲಿ",
+      "sound": "li",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಲ  la — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಲೀ",
+      "sound": "lī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಲ  la — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಲು",
+      "sound": "lu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಲ  la — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಲೂ",
+      "sound": "lū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಲ  la — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಲೆ",
+      "sound": "le",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಲ  la — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಲೇ",
+      "sound": "lē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಲ  la — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಲೊ",
+      "sound": "lo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಲ  la — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಲೋ",
+      "sound": "lō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಲ  la — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ವ",
+      "sound": "va",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ವ  va — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ವಾ",
+      "sound": "vā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ವ  va — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ವಿ",
+      "sound": "vi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ವ  va — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ವೀ",
+      "sound": "vī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ವ  va — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ವು",
+      "sound": "vu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ವ  va — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ವೂ",
+      "sound": "vū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ವ  va — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ವೆ",
+      "sound": "ve",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ವ  va — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ವೇ",
+      "sound": "vē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ವ  va — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ವೊ",
+      "sound": "vo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ವ  va — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ವೋ",
+      "sound": "vō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ವ  va — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಶ",
+      "sound": "śa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಶ  śa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಶಾ",
+      "sound": "śā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಶ  śa — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಶಿ",
+      "sound": "śi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಶ  śa — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಶೀ",
+      "sound": "śī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಶ  śa — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಶು",
+      "sound": "śu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಶ  śa — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಶೂ",
+      "sound": "śū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಶ  śa — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಶೆ",
+      "sound": "śe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಶ  śa — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಶೇ",
+      "sound": "śē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಶ  śa — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಶೊ",
+      "sound": "śo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಶ  śa — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಶೋ",
+      "sound": "śō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಶ  śa — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಷ",
+      "sound": "ṣa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಷ  ṣa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಷಾ",
+      "sound": "ṣā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಷ  ṣa — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಷಿ",
+      "sound": "ṣi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಷ  ṣa — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಷೀ",
+      "sound": "ṣī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಷ  ṣa — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಷು",
+      "sound": "ṣu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಷ  ṣa — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಷೂ",
+      "sound": "ṣū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಷ  ṣa — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಷೆ",
+      "sound": "ṣe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಷ  ṣa — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಷೇ",
+      "sound": "ṣē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಷ  ṣa — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಷೊ",
+      "sound": "ṣo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಷ  ṣa — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಷೋ",
+      "sound": "ṣō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಷ  ṣa — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಸ",
+      "sound": "sa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಸ  sa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಸಾ",
+      "sound": "sā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಸ  sa — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಸಿ",
+      "sound": "si",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಸ  sa — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಸೀ",
+      "sound": "sī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಸ  sa — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಸು",
+      "sound": "su",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಸ  sa — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಸೂ",
+      "sound": "sū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಸ  sa — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಸೆ",
+      "sound": "se",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಸ  sa — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಸೇ",
+      "sound": "sē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಸ  sa — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಸೊ",
+      "sound": "so",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಸ  sa — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಸೋ",
+      "sound": "sō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಸ  sa — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಹ",
+      "sound": "ha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಹ  ha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಹಾ",
+      "sound": "hā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಹ  ha — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಹಿ",
+      "sound": "hi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಹ  ha — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಹೀ",
+      "sound": "hī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಹ  ha — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಹು",
+      "sound": "hu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಹ  ha — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಹೂ",
+      "sound": "hū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಹ  ha — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಹೆ",
+      "sound": "he",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಹ  ha — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಹೇ",
+      "sound": "hē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಹ  ha — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಹೊ",
+      "sound": "ho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಹ  ha — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಹೋ",
+      "sound": "hō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಹ  ha — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಳ",
+      "sound": "ḷa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಳ  ḷa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಳಾ",
+      "sound": "ḷā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಳ  ḷa — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಳಿ",
+      "sound": "ḷi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಳ  ḷa — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಳೀ",
+      "sound": "ḷī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಳ  ḷa — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಳು",
+      "sound": "ḷu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಳ  ḷa — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಳೂ",
+      "sound": "ḷū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಳ  ḷa — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಳೆ",
+      "sound": "ḷe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಳ  ḷa — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಳೇ",
+      "sound": "ḷē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಳ  ḷa — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಳೊ",
+      "sound": "ḷo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಳ  ḷa — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಳೋ",
+      "sound": "ḷō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಳ  ḷa — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಱ",
+      "sound": "ṟa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಱ  ṟa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಱಾ",
+      "sound": "ṟā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಱ  ṟa — base consonant",
+        "ಾ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಱಿ",
+      "sound": "ṟi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಱ  ṟa — base consonant",
+        "ಿ  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಱೀ",
+      "sound": "ṟī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಱ  ṟa — base consonant",
+        "ೀ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಱು",
+      "sound": "ṟu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಱ  ṟa — base consonant",
+        "ು  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಱೂ",
+      "sound": "ṟū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಱ  ṟa — base consonant",
+        "ೂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಱೆ",
+      "sound": "ṟe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಱ  ṟa — base consonant",
+        "ೆ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಱೇ",
+      "sound": "ṟē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಱ  ṟa — base consonant",
+        "ೇ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಱೊ",
+      "sound": "ṟo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಱ  ṟa — base consonant",
+        "ೊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಱೋ",
+      "sound": "ṟō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಱ  ṟa — base consonant",
+        "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    }
+  ]
+}

--- a/code/learning/human-languages/data/scripts/malayalam.json
+++ b/code/learning/human-languages/data/scripts/malayalam.json
@@ -1,0 +1,4296 @@
+{
+  "script": "malayalam",
+  "name": "Malayalam",
+  "font": "_fonts/NotoSansMalayalam-Static.ttf",
+  "direction": "ltr",
+  "system": "abugida",
+  "signature": "Highly rounded and loopy — full circles, hooks and curls, with almost no straight lines.",
+  "complete": false,
+  "notes": "Syllabary generated from Unicode by generate_syllabary.py: each syllable is a base consonant (varga order) composed with a core vowel sign. Romanization is ISO-15919. Recognition only — stroke order is a separate, source-gated effort and is omitted.",
+  "letters": [
+    {
+      "glyph": "ക",
+      "sound": "ka",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ക  ka — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "കാ",
+      "sound": "kā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ക  ka — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "കി",
+      "sound": "ki",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ക  ka — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "കീ",
+      "sound": "kī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ക  ka — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "കു",
+      "sound": "ku",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ക  ka — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "കൂ",
+      "sound": "kū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ക  ka — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "കെ",
+      "sound": "ke",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ക  ka — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "കേ",
+      "sound": "kē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ക  ka — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "കൊ",
+      "sound": "ko",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ക  ka — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "കോ",
+      "sound": "kō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ക  ka — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഖ",
+      "sound": "kha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഖ  kha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഖാ",
+      "sound": "khā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഖ  kha — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഖി",
+      "sound": "khi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഖ  kha — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഖീ",
+      "sound": "khī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഖ  kha — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഖു",
+      "sound": "khu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഖ  kha — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഖൂ",
+      "sound": "khū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഖ  kha — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഖെ",
+      "sound": "khe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഖ  kha — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഖേ",
+      "sound": "khē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഖ  kha — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഖൊ",
+      "sound": "kho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഖ  kha — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഖോ",
+      "sound": "khō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഖ  kha — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഗ",
+      "sound": "ga",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഗ  ga — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഗാ",
+      "sound": "gā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഗ  ga — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഗി",
+      "sound": "gi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഗ  ga — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഗീ",
+      "sound": "gī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഗ  ga — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഗു",
+      "sound": "gu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഗ  ga — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഗൂ",
+      "sound": "gū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഗ  ga — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഗെ",
+      "sound": "ge",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഗ  ga — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഗേ",
+      "sound": "gē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഗ  ga — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഗൊ",
+      "sound": "go",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഗ  ga — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഗോ",
+      "sound": "gō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഗ  ga — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഘ",
+      "sound": "gha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഘ  gha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഘാ",
+      "sound": "ghā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഘ  gha — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഘി",
+      "sound": "ghi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഘ  gha — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഘീ",
+      "sound": "ghī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഘ  gha — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഘു",
+      "sound": "ghu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഘ  gha — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഘൂ",
+      "sound": "ghū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഘ  gha — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഘെ",
+      "sound": "ghe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഘ  gha — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഘേ",
+      "sound": "ghē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഘ  gha — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഘൊ",
+      "sound": "gho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഘ  gha — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഘോ",
+      "sound": "ghō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഘ  gha — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ങ",
+      "sound": "ṅa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ങ  ṅa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ങാ",
+      "sound": "ṅā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ങ  ṅa — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ങി",
+      "sound": "ṅi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ങ  ṅa — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ങീ",
+      "sound": "ṅī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ങ  ṅa — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ങു",
+      "sound": "ṅu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ങ  ṅa — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ങൂ",
+      "sound": "ṅū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ങ  ṅa — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ങെ",
+      "sound": "ṅe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ങ  ṅa — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ങേ",
+      "sound": "ṅē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ങ  ṅa — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ങൊ",
+      "sound": "ṅo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ങ  ṅa — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ങോ",
+      "sound": "ṅō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ങ  ṅa — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ച",
+      "sound": "ca",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ച  ca — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ചാ",
+      "sound": "cā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ച  ca — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ചി",
+      "sound": "ci",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ച  ca — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ചീ",
+      "sound": "cī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ച  ca — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ചു",
+      "sound": "cu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ച  ca — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ചൂ",
+      "sound": "cū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ച  ca — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ചെ",
+      "sound": "ce",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ച  ca — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ചേ",
+      "sound": "cē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ച  ca — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ചൊ",
+      "sound": "co",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ച  ca — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ചോ",
+      "sound": "cō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ച  ca — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഛ",
+      "sound": "cha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഛ  cha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഛാ",
+      "sound": "chā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഛ  cha — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഛി",
+      "sound": "chi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഛ  cha — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഛീ",
+      "sound": "chī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഛ  cha — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഛു",
+      "sound": "chu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഛ  cha — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഛൂ",
+      "sound": "chū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഛ  cha — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഛെ",
+      "sound": "che",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഛ  cha — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഛേ",
+      "sound": "chē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഛ  cha — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഛൊ",
+      "sound": "cho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഛ  cha — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഛോ",
+      "sound": "chō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഛ  cha — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ജ",
+      "sound": "ja",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ജ  ja — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ജാ",
+      "sound": "jā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ജ  ja — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ജി",
+      "sound": "ji",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ജ  ja — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ജീ",
+      "sound": "jī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ജ  ja — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ജു",
+      "sound": "ju",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ജ  ja — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ജൂ",
+      "sound": "jū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ജ  ja — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ജെ",
+      "sound": "je",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ജ  ja — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ജേ",
+      "sound": "jē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ജ  ja — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ജൊ",
+      "sound": "jo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ജ  ja — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ജോ",
+      "sound": "jō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ജ  ja — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഝ",
+      "sound": "jha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഝ  jha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഝാ",
+      "sound": "jhā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഝ  jha — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഝി",
+      "sound": "jhi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഝ  jha — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഝീ",
+      "sound": "jhī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഝ  jha — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഝു",
+      "sound": "jhu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഝ  jha — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഝൂ",
+      "sound": "jhū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഝ  jha — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഝെ",
+      "sound": "jhe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഝ  jha — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഝേ",
+      "sound": "jhē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഝ  jha — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഝൊ",
+      "sound": "jho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഝ  jha — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഝോ",
+      "sound": "jhō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഝ  jha — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഞ",
+      "sound": "ña",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഞ  ña — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഞാ",
+      "sound": "ñā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഞ  ña — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഞി",
+      "sound": "ñi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഞ  ña — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഞീ",
+      "sound": "ñī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഞ  ña — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഞു",
+      "sound": "ñu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഞ  ña — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഞൂ",
+      "sound": "ñū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഞ  ña — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഞെ",
+      "sound": "ñe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഞ  ña — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഞേ",
+      "sound": "ñē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഞ  ña — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഞൊ",
+      "sound": "ño",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഞ  ña — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഞോ",
+      "sound": "ñō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഞ  ña — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ട",
+      "sound": "ṭa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ട  ṭa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ടാ",
+      "sound": "ṭā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ട  ṭa — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ടി",
+      "sound": "ṭi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ട  ṭa — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ടീ",
+      "sound": "ṭī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ട  ṭa — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ടു",
+      "sound": "ṭu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ട  ṭa — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ടൂ",
+      "sound": "ṭū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ട  ṭa — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ടെ",
+      "sound": "ṭe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ട  ṭa — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ടേ",
+      "sound": "ṭē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ട  ṭa — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ടൊ",
+      "sound": "ṭo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ട  ṭa — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ടോ",
+      "sound": "ṭō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ട  ṭa — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഠ",
+      "sound": "ṭha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഠ  ṭha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഠാ",
+      "sound": "ṭhā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഠ  ṭha — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഠി",
+      "sound": "ṭhi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഠ  ṭha — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഠീ",
+      "sound": "ṭhī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഠ  ṭha — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഠു",
+      "sound": "ṭhu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഠ  ṭha — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഠൂ",
+      "sound": "ṭhū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഠ  ṭha — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഠെ",
+      "sound": "ṭhe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഠ  ṭha — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഠേ",
+      "sound": "ṭhē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഠ  ṭha — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഠൊ",
+      "sound": "ṭho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഠ  ṭha — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഠോ",
+      "sound": "ṭhō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഠ  ṭha — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഡ",
+      "sound": "ḍa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഡ  ḍa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഡാ",
+      "sound": "ḍā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഡ  ḍa — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഡി",
+      "sound": "ḍi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഡ  ḍa — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഡീ",
+      "sound": "ḍī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഡ  ḍa — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഡു",
+      "sound": "ḍu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഡ  ḍa — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഡൂ",
+      "sound": "ḍū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഡ  ḍa — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഡെ",
+      "sound": "ḍe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഡ  ḍa — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഡേ",
+      "sound": "ḍē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഡ  ḍa — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഡൊ",
+      "sound": "ḍo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഡ  ḍa — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഡോ",
+      "sound": "ḍō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഡ  ḍa — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഢ",
+      "sound": "ḍha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഢ  ḍha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഢാ",
+      "sound": "ḍhā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഢ  ḍha — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഢി",
+      "sound": "ḍhi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഢ  ḍha — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഢീ",
+      "sound": "ḍhī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഢ  ḍha — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഢു",
+      "sound": "ḍhu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഢ  ḍha — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഢൂ",
+      "sound": "ḍhū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഢ  ḍha — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഢെ",
+      "sound": "ḍhe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഢ  ḍha — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഢേ",
+      "sound": "ḍhē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഢ  ḍha — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഢൊ",
+      "sound": "ḍho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഢ  ḍha — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഢോ",
+      "sound": "ḍhō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഢ  ḍha — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ണ",
+      "sound": "ṇa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ണ  ṇa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ണാ",
+      "sound": "ṇā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ണ  ṇa — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ണി",
+      "sound": "ṇi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ണ  ṇa — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ണീ",
+      "sound": "ṇī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ണ  ṇa — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ണു",
+      "sound": "ṇu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ണ  ṇa — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ണൂ",
+      "sound": "ṇū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ണ  ṇa — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ണെ",
+      "sound": "ṇe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ണ  ṇa — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ണേ",
+      "sound": "ṇē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ണ  ṇa — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ണൊ",
+      "sound": "ṇo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ണ  ṇa — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ണോ",
+      "sound": "ṇō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ണ  ṇa — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ത",
+      "sound": "ta",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ത  ta — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "താ",
+      "sound": "tā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ത  ta — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "തി",
+      "sound": "ti",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ത  ta — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "തീ",
+      "sound": "tī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ത  ta — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "തു",
+      "sound": "tu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ത  ta — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "തൂ",
+      "sound": "tū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ത  ta — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "തെ",
+      "sound": "te",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ത  ta — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "തേ",
+      "sound": "tē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ത  ta — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "തൊ",
+      "sound": "to",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ത  ta — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "തോ",
+      "sound": "tō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ത  ta — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഥ",
+      "sound": "tha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഥ  tha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഥാ",
+      "sound": "thā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഥ  tha — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഥി",
+      "sound": "thi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഥ  tha — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഥീ",
+      "sound": "thī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഥ  tha — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഥു",
+      "sound": "thu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഥ  tha — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഥൂ",
+      "sound": "thū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഥ  tha — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഥെ",
+      "sound": "the",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഥ  tha — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഥേ",
+      "sound": "thē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഥ  tha — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഥൊ",
+      "sound": "tho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഥ  tha — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഥോ",
+      "sound": "thō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഥ  tha — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ദ",
+      "sound": "da",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ദ  da — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ദാ",
+      "sound": "dā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ദ  da — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ദി",
+      "sound": "di",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ദ  da — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ദീ",
+      "sound": "dī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ദ  da — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ദു",
+      "sound": "du",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ദ  da — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ദൂ",
+      "sound": "dū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ദ  da — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ദെ",
+      "sound": "de",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ദ  da — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ദേ",
+      "sound": "dē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ദ  da — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ദൊ",
+      "sound": "do",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ദ  da — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ദോ",
+      "sound": "dō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ദ  da — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ധ",
+      "sound": "dha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ധ  dha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ധാ",
+      "sound": "dhā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ധ  dha — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ധി",
+      "sound": "dhi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ധ  dha — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ധീ",
+      "sound": "dhī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ധ  dha — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ധു",
+      "sound": "dhu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ധ  dha — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ധൂ",
+      "sound": "dhū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ധ  dha — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ധെ",
+      "sound": "dhe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ധ  dha — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ധേ",
+      "sound": "dhē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ധ  dha — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ധൊ",
+      "sound": "dho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ധ  dha — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ധോ",
+      "sound": "dhō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ധ  dha — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ന",
+      "sound": "na",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ന  na — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "നാ",
+      "sound": "nā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ന  na — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "നി",
+      "sound": "ni",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ന  na — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "നീ",
+      "sound": "nī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ന  na — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "നു",
+      "sound": "nu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ന  na — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "നൂ",
+      "sound": "nū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ന  na — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "നെ",
+      "sound": "ne",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ന  na — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "നേ",
+      "sound": "nē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ന  na — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "നൊ",
+      "sound": "no",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ന  na — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "നോ",
+      "sound": "nō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ന  na — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "പ",
+      "sound": "pa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "പ  pa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "പാ",
+      "sound": "pā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "പ  pa — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "പി",
+      "sound": "pi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "പ  pa — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "പീ",
+      "sound": "pī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "പ  pa — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "പു",
+      "sound": "pu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "പ  pa — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "പൂ",
+      "sound": "pū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "പ  pa — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "പെ",
+      "sound": "pe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "പ  pa — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "പേ",
+      "sound": "pē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "പ  pa — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "പൊ",
+      "sound": "po",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "പ  pa — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "പോ",
+      "sound": "pō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "പ  pa — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഫ",
+      "sound": "pha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഫ  pha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഫാ",
+      "sound": "phā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഫ  pha — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഫി",
+      "sound": "phi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഫ  pha — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഫീ",
+      "sound": "phī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഫ  pha — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഫു",
+      "sound": "phu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഫ  pha — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഫൂ",
+      "sound": "phū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഫ  pha — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഫെ",
+      "sound": "phe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഫ  pha — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഫേ",
+      "sound": "phē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഫ  pha — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഫൊ",
+      "sound": "pho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഫ  pha — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഫോ",
+      "sound": "phō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഫ  pha — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ബ",
+      "sound": "ba",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ബ  ba — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ബാ",
+      "sound": "bā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ബ  ba — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ബി",
+      "sound": "bi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ബ  ba — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ബീ",
+      "sound": "bī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ബ  ba — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ബു",
+      "sound": "bu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ബ  ba — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ബൂ",
+      "sound": "bū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ബ  ba — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ബെ",
+      "sound": "be",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ബ  ba — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ബേ",
+      "sound": "bē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ബ  ba — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ബൊ",
+      "sound": "bo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ബ  ba — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ബോ",
+      "sound": "bō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ബ  ba — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഭ",
+      "sound": "bha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഭ  bha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഭാ",
+      "sound": "bhā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഭ  bha — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഭി",
+      "sound": "bhi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഭ  bha — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഭീ",
+      "sound": "bhī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഭ  bha — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഭു",
+      "sound": "bhu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഭ  bha — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഭൂ",
+      "sound": "bhū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഭ  bha — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഭെ",
+      "sound": "bhe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഭ  bha — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഭേ",
+      "sound": "bhē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഭ  bha — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഭൊ",
+      "sound": "bho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഭ  bha — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഭോ",
+      "sound": "bhō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഭ  bha — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "മ",
+      "sound": "ma",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "മ  ma — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "മാ",
+      "sound": "mā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "മ  ma — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "മി",
+      "sound": "mi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "മ  ma — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "മീ",
+      "sound": "mī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "മ  ma — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "മു",
+      "sound": "mu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "മ  ma — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "മൂ",
+      "sound": "mū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "മ  ma — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "മെ",
+      "sound": "me",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "മ  ma — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "മേ",
+      "sound": "mē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "മ  ma — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "മൊ",
+      "sound": "mo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "മ  ma — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "മോ",
+      "sound": "mō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "മ  ma — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "യ",
+      "sound": "ya",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "യ  ya — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "യാ",
+      "sound": "yā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "യ  ya — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "യി",
+      "sound": "yi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "യ  ya — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "യീ",
+      "sound": "yī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "യ  ya — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "യു",
+      "sound": "yu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "യ  ya — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "യൂ",
+      "sound": "yū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "യ  ya — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "യെ",
+      "sound": "ye",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "യ  ya — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "യേ",
+      "sound": "yē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "യ  ya — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "യൊ",
+      "sound": "yo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "യ  ya — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "യോ",
+      "sound": "yō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "യ  ya — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ര",
+      "sound": "ra",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ര  ra — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "രാ",
+      "sound": "rā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ര  ra — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "രി",
+      "sound": "ri",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ര  ra — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "രീ",
+      "sound": "rī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ര  ra — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "രു",
+      "sound": "ru",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ര  ra — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "രൂ",
+      "sound": "rū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ര  ra — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "രെ",
+      "sound": "re",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ര  ra — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "രേ",
+      "sound": "rē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ര  ra — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "രൊ",
+      "sound": "ro",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ര  ra — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "രോ",
+      "sound": "rō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ര  ra — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ല",
+      "sound": "la",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ല  la — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ലാ",
+      "sound": "lā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ല  la — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ലി",
+      "sound": "li",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ല  la — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ലീ",
+      "sound": "lī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ല  la — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ലു",
+      "sound": "lu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ല  la — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ലൂ",
+      "sound": "lū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ല  la — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ലെ",
+      "sound": "le",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ല  la — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ലേ",
+      "sound": "lē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ല  la — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ലൊ",
+      "sound": "lo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ല  la — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ലോ",
+      "sound": "lō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ല  la — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "വ",
+      "sound": "va",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "വ  va — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "വാ",
+      "sound": "vā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "വ  va — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "വി",
+      "sound": "vi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "വ  va — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "വീ",
+      "sound": "vī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "വ  va — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "വു",
+      "sound": "vu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "വ  va — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "വൂ",
+      "sound": "vū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "വ  va — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "വെ",
+      "sound": "ve",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "വ  va — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "വേ",
+      "sound": "vē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "വ  va — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "വൊ",
+      "sound": "vo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "വ  va — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "വോ",
+      "sound": "vō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "വ  va — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ശ",
+      "sound": "śa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ശ  śa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ശാ",
+      "sound": "śā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ശ  śa — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ശി",
+      "sound": "śi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ശ  śa — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ശീ",
+      "sound": "śī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ശ  śa — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ശു",
+      "sound": "śu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ശ  śa — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ശൂ",
+      "sound": "śū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ശ  śa — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ശെ",
+      "sound": "śe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ശ  śa — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ശേ",
+      "sound": "śē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ശ  śa — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ശൊ",
+      "sound": "śo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ശ  śa — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ശോ",
+      "sound": "śō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ശ  śa — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഷ",
+      "sound": "ṣa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഷ  ṣa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഷാ",
+      "sound": "ṣā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഷ  ṣa — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഷി",
+      "sound": "ṣi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഷ  ṣa — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഷീ",
+      "sound": "ṣī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഷ  ṣa — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഷു",
+      "sound": "ṣu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഷ  ṣa — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഷൂ",
+      "sound": "ṣū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഷ  ṣa — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഷെ",
+      "sound": "ṣe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഷ  ṣa — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഷേ",
+      "sound": "ṣē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഷ  ṣa — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഷൊ",
+      "sound": "ṣo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഷ  ṣa — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഷോ",
+      "sound": "ṣō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഷ  ṣa — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "സ",
+      "sound": "sa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "സ  sa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "സാ",
+      "sound": "sā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "സ  sa — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "സി",
+      "sound": "si",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "സ  sa — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "സീ",
+      "sound": "sī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "സ  sa — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "സു",
+      "sound": "su",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "സ  sa — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "സൂ",
+      "sound": "sū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "സ  sa — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "സെ",
+      "sound": "se",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "സ  sa — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "സേ",
+      "sound": "sē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "സ  sa — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "സൊ",
+      "sound": "so",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "സ  sa — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "സോ",
+      "sound": "sō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "സ  sa — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഹ",
+      "sound": "ha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഹ  ha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഹാ",
+      "sound": "hā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഹ  ha — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഹി",
+      "sound": "hi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഹ  ha — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഹീ",
+      "sound": "hī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഹ  ha — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഹു",
+      "sound": "hu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഹ  ha — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഹൂ",
+      "sound": "hū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഹ  ha — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഹെ",
+      "sound": "he",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഹ  ha — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഹേ",
+      "sound": "hē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഹ  ha — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഹൊ",
+      "sound": "ho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഹ  ha — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഹോ",
+      "sound": "hō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഹ  ha — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ള",
+      "sound": "ḷa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ള  ḷa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ളാ",
+      "sound": "ḷā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ള  ḷa — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ളി",
+      "sound": "ḷi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ള  ḷa — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ളീ",
+      "sound": "ḷī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ള  ḷa — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ളു",
+      "sound": "ḷu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ള  ḷa — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ളൂ",
+      "sound": "ḷū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ള  ḷa — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ളെ",
+      "sound": "ḷe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ള  ḷa — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ളേ",
+      "sound": "ḷē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ള  ḷa — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ളൊ",
+      "sound": "ḷo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ള  ḷa — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ളോ",
+      "sound": "ḷō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ള  ḷa — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "റ",
+      "sound": "ṟa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "റ  ṟa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "റാ",
+      "sound": "ṟā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "റ  ṟa — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "റി",
+      "sound": "ṟi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "റ  ṟa — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "റീ",
+      "sound": "ṟī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "റ  ṟa — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "റു",
+      "sound": "ṟu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "റ  ṟa — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "റൂ",
+      "sound": "ṟū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "റ  ṟa — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "റെ",
+      "sound": "ṟe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "റ  ṟa — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "റേ",
+      "sound": "ṟē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "റ  ṟa — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "റൊ",
+      "sound": "ṟo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "റ  ṟa — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "റോ",
+      "sound": "ṟō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "റ  ṟa — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഩ",
+      "sound": "ṉa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഩ  ṉa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഩാ",
+      "sound": "ṉā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഩ  ṉa — base consonant",
+        "ാ  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഩി",
+      "sound": "ṉi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഩ  ṉa — base consonant",
+        "ി  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഩീ",
+      "sound": "ṉī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഩ  ṉa — base consonant",
+        "ീ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഩു",
+      "sound": "ṉu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഩ  ṉa — base consonant",
+        "ു  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഩൂ",
+      "sound": "ṉū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഩ  ṉa — base consonant",
+        "ൂ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഩെ",
+      "sound": "ṉe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഩ  ṉa — base consonant",
+        "െ  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഩേ",
+      "sound": "ṉē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഩ  ṉa — base consonant",
+        "േ  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഩൊ",
+      "sound": "ṉo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഩ  ṉa — base consonant",
+        "ൊ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഩോ",
+      "sound": "ṉō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഩ  ṉa — base consonant",
+        "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    }
+  ]
+}

--- a/code/learning/human-languages/data/scripts/telugu.json
+++ b/code/learning/human-languages/data/scripts/telugu.json
@@ -1,0 +1,4177 @@
+{
+  "script": "telugu",
+  "name": "Telugu",
+  "font": "_fonts/NotoSansTelugu-Static.ttf",
+  "direction": "ltr",
+  "system": "abugida",
+  "signature": "Rounded, curvy letters, most crowned with a small tick or check-mark headstroke; no continuous top line.",
+  "complete": false,
+  "notes": "Syllabary generated from Unicode by generate_syllabary.py: each syllable is a base consonant (varga order) composed with a core vowel sign. Romanization is ISO-15919. Recognition only — stroke order is a separate, source-gated effort and is omitted.",
+  "letters": [
+    {
+      "glyph": "క",
+      "sound": "ka",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "క  ka — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "కా",
+      "sound": "kā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "క  ka — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "కి",
+      "sound": "ki",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "క  ka — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "కీ",
+      "sound": "kī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "క  ka — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "కు",
+      "sound": "ku",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "క  ka — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "కూ",
+      "sound": "kū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "క  ka — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "కె",
+      "sound": "ke",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "క  ka — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "కే",
+      "sound": "kē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "క  ka — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "కొ",
+      "sound": "ko",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "క  ka — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "కో",
+      "sound": "kō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "క  ka — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఖ",
+      "sound": "kha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఖ  kha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఖా",
+      "sound": "khā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఖ  kha — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఖి",
+      "sound": "khi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఖ  kha — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఖీ",
+      "sound": "khī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఖ  kha — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఖు",
+      "sound": "khu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఖ  kha — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఖూ",
+      "sound": "khū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఖ  kha — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఖె",
+      "sound": "khe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఖ  kha — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఖే",
+      "sound": "khē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఖ  kha — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఖొ",
+      "sound": "kho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఖ  kha — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఖో",
+      "sound": "khō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఖ  kha — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "గ",
+      "sound": "ga",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "గ  ga — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "గా",
+      "sound": "gā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "గ  ga — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "గి",
+      "sound": "gi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "గ  ga — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "గీ",
+      "sound": "gī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "గ  ga — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "గు",
+      "sound": "gu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "గ  ga — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "గూ",
+      "sound": "gū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "గ  ga — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "గె",
+      "sound": "ge",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "గ  ga — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "గే",
+      "sound": "gē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "గ  ga — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "గొ",
+      "sound": "go",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "గ  ga — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "గో",
+      "sound": "gō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "గ  ga — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఘ",
+      "sound": "gha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఘ  gha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఘా",
+      "sound": "ghā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఘ  gha — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఘి",
+      "sound": "ghi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఘ  gha — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఘీ",
+      "sound": "ghī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఘ  gha — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఘు",
+      "sound": "ghu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఘ  gha — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఘూ",
+      "sound": "ghū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఘ  gha — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఘె",
+      "sound": "ghe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఘ  gha — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఘే",
+      "sound": "ghē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఘ  gha — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఘొ",
+      "sound": "gho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఘ  gha — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఘో",
+      "sound": "ghō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఘ  gha — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఙ",
+      "sound": "ṅa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఙ  ṅa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఙా",
+      "sound": "ṅā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఙ  ṅa — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఙి",
+      "sound": "ṅi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఙ  ṅa — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఙీ",
+      "sound": "ṅī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఙ  ṅa — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఙు",
+      "sound": "ṅu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఙ  ṅa — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఙూ",
+      "sound": "ṅū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఙ  ṅa — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఙె",
+      "sound": "ṅe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఙ  ṅa — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఙే",
+      "sound": "ṅē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఙ  ṅa — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఙొ",
+      "sound": "ṅo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఙ  ṅa — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఙో",
+      "sound": "ṅō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఙ  ṅa — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "చ",
+      "sound": "ca",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "చ  ca — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "చా",
+      "sound": "cā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "చ  ca — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "చి",
+      "sound": "ci",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "చ  ca — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "చీ",
+      "sound": "cī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "చ  ca — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "చు",
+      "sound": "cu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "చ  ca — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "చూ",
+      "sound": "cū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "చ  ca — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "చె",
+      "sound": "ce",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "చ  ca — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "చే",
+      "sound": "cē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "చ  ca — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "చొ",
+      "sound": "co",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "చ  ca — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "చో",
+      "sound": "cō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "చ  ca — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఛ",
+      "sound": "cha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఛ  cha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఛా",
+      "sound": "chā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఛ  cha — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఛి",
+      "sound": "chi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఛ  cha — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఛీ",
+      "sound": "chī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఛ  cha — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఛు",
+      "sound": "chu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఛ  cha — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఛూ",
+      "sound": "chū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఛ  cha — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఛె",
+      "sound": "che",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఛ  cha — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఛే",
+      "sound": "chē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఛ  cha — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఛొ",
+      "sound": "cho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఛ  cha — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఛో",
+      "sound": "chō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఛ  cha — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "జ",
+      "sound": "ja",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "జ  ja — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "జా",
+      "sound": "jā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "జ  ja — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "జి",
+      "sound": "ji",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "జ  ja — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "జీ",
+      "sound": "jī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "జ  ja — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "జు",
+      "sound": "ju",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "జ  ja — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "జూ",
+      "sound": "jū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "జ  ja — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "జె",
+      "sound": "je",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "జ  ja — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "జే",
+      "sound": "jē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "జ  ja — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "జొ",
+      "sound": "jo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "జ  ja — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "జో",
+      "sound": "jō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "జ  ja — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఝ",
+      "sound": "jha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఝ  jha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఝా",
+      "sound": "jhā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఝ  jha — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఝి",
+      "sound": "jhi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఝ  jha — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఝీ",
+      "sound": "jhī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఝ  jha — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఝు",
+      "sound": "jhu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఝ  jha — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఝూ",
+      "sound": "jhū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఝ  jha — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఝె",
+      "sound": "jhe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఝ  jha — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఝే",
+      "sound": "jhē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఝ  jha — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఝొ",
+      "sound": "jho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఝ  jha — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఝో",
+      "sound": "jhō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఝ  jha — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఞ",
+      "sound": "ña",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఞ  ña — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఞా",
+      "sound": "ñā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఞ  ña — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఞి",
+      "sound": "ñi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఞ  ña — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఞీ",
+      "sound": "ñī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఞ  ña — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఞు",
+      "sound": "ñu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఞ  ña — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఞూ",
+      "sound": "ñū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఞ  ña — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఞె",
+      "sound": "ñe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఞ  ña — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఞే",
+      "sound": "ñē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఞ  ña — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఞొ",
+      "sound": "ño",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఞ  ña — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఞో",
+      "sound": "ñō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఞ  ña — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ట",
+      "sound": "ṭa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ట  ṭa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "టా",
+      "sound": "ṭā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ట  ṭa — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "టి",
+      "sound": "ṭi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ట  ṭa — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "టీ",
+      "sound": "ṭī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ట  ṭa — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "టు",
+      "sound": "ṭu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ట  ṭa — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "టూ",
+      "sound": "ṭū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ట  ṭa — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "టె",
+      "sound": "ṭe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ట  ṭa — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "టే",
+      "sound": "ṭē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ట  ṭa — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "టొ",
+      "sound": "ṭo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ట  ṭa — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "టో",
+      "sound": "ṭō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ట  ṭa — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఠ",
+      "sound": "ṭha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఠ  ṭha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఠా",
+      "sound": "ṭhā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఠ  ṭha — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఠి",
+      "sound": "ṭhi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఠ  ṭha — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఠీ",
+      "sound": "ṭhī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఠ  ṭha — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఠు",
+      "sound": "ṭhu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఠ  ṭha — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఠూ",
+      "sound": "ṭhū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఠ  ṭha — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఠె",
+      "sound": "ṭhe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఠ  ṭha — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఠే",
+      "sound": "ṭhē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఠ  ṭha — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఠొ",
+      "sound": "ṭho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఠ  ṭha — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఠో",
+      "sound": "ṭhō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఠ  ṭha — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "డ",
+      "sound": "ḍa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "డ  ḍa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "డా",
+      "sound": "ḍā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "డ  ḍa — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "డి",
+      "sound": "ḍi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "డ  ḍa — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "డీ",
+      "sound": "ḍī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "డ  ḍa — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "డు",
+      "sound": "ḍu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "డ  ḍa — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "డూ",
+      "sound": "ḍū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "డ  ḍa — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "డె",
+      "sound": "ḍe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "డ  ḍa — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "డే",
+      "sound": "ḍē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "డ  ḍa — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "డొ",
+      "sound": "ḍo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "డ  ḍa — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "డో",
+      "sound": "ḍō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "డ  ḍa — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఢ",
+      "sound": "ḍha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఢ  ḍha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఢా",
+      "sound": "ḍhā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఢ  ḍha — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఢి",
+      "sound": "ḍhi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఢ  ḍha — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఢీ",
+      "sound": "ḍhī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఢ  ḍha — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఢు",
+      "sound": "ḍhu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఢ  ḍha — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఢూ",
+      "sound": "ḍhū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఢ  ḍha — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఢె",
+      "sound": "ḍhe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఢ  ḍha — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఢే",
+      "sound": "ḍhē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఢ  ḍha — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఢొ",
+      "sound": "ḍho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఢ  ḍha — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఢో",
+      "sound": "ḍhō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఢ  ḍha — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ణ",
+      "sound": "ṇa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ణ  ṇa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ణా",
+      "sound": "ṇā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ణ  ṇa — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ణి",
+      "sound": "ṇi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ణ  ṇa — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ణీ",
+      "sound": "ṇī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ణ  ṇa — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ణు",
+      "sound": "ṇu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ణ  ṇa — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ణూ",
+      "sound": "ṇū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ణ  ṇa — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ణె",
+      "sound": "ṇe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ణ  ṇa — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ణే",
+      "sound": "ṇē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ణ  ṇa — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ణొ",
+      "sound": "ṇo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ణ  ṇa — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ణో",
+      "sound": "ṇō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ణ  ṇa — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "త",
+      "sound": "ta",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "త  ta — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "తా",
+      "sound": "tā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "త  ta — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "తి",
+      "sound": "ti",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "త  ta — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "తీ",
+      "sound": "tī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "త  ta — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "తు",
+      "sound": "tu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "త  ta — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "తూ",
+      "sound": "tū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "త  ta — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "తె",
+      "sound": "te",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "త  ta — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "తే",
+      "sound": "tē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "త  ta — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "తొ",
+      "sound": "to",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "త  ta — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "తో",
+      "sound": "tō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "త  ta — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "థ",
+      "sound": "tha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "థ  tha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "థా",
+      "sound": "thā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "థ  tha — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "థి",
+      "sound": "thi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "థ  tha — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "థీ",
+      "sound": "thī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "థ  tha — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "థు",
+      "sound": "thu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "థ  tha — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "థూ",
+      "sound": "thū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "థ  tha — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "థె",
+      "sound": "the",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "థ  tha — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "థే",
+      "sound": "thē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "థ  tha — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "థొ",
+      "sound": "tho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "థ  tha — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "థో",
+      "sound": "thō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "థ  tha — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ద",
+      "sound": "da",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ద  da — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "దా",
+      "sound": "dā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ద  da — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ది",
+      "sound": "di",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ద  da — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "దీ",
+      "sound": "dī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ద  da — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "దు",
+      "sound": "du",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ద  da — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "దూ",
+      "sound": "dū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ద  da — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "దె",
+      "sound": "de",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ద  da — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "దే",
+      "sound": "dē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ద  da — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "దొ",
+      "sound": "do",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ద  da — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "దో",
+      "sound": "dō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ద  da — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ధ",
+      "sound": "dha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ధ  dha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ధా",
+      "sound": "dhā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ధ  dha — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ధి",
+      "sound": "dhi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ధ  dha — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ధీ",
+      "sound": "dhī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ధ  dha — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ధు",
+      "sound": "dhu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ధ  dha — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ధూ",
+      "sound": "dhū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ధ  dha — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ధె",
+      "sound": "dhe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ధ  dha — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ధే",
+      "sound": "dhē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ధ  dha — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ధొ",
+      "sound": "dho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ధ  dha — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ధో",
+      "sound": "dhō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ధ  dha — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "న",
+      "sound": "na",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "న  na — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "నా",
+      "sound": "nā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "న  na — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ని",
+      "sound": "ni",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "న  na — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "నీ",
+      "sound": "nī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "న  na — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ను",
+      "sound": "nu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "న  na — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "నూ",
+      "sound": "nū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "న  na — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "నె",
+      "sound": "ne",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "న  na — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "నే",
+      "sound": "nē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "న  na — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "నొ",
+      "sound": "no",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "న  na — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "నో",
+      "sound": "nō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "న  na — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ప",
+      "sound": "pa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ప  pa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "పా",
+      "sound": "pā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ప  pa — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "పి",
+      "sound": "pi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ప  pa — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "పీ",
+      "sound": "pī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ప  pa — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "పు",
+      "sound": "pu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ప  pa — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "పూ",
+      "sound": "pū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ప  pa — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "పె",
+      "sound": "pe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ప  pa — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "పే",
+      "sound": "pē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ప  pa — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "పొ",
+      "sound": "po",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ప  pa — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "పో",
+      "sound": "pō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ప  pa — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఫ",
+      "sound": "pha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఫ  pha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఫా",
+      "sound": "phā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఫ  pha — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఫి",
+      "sound": "phi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఫ  pha — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఫీ",
+      "sound": "phī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఫ  pha — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఫు",
+      "sound": "phu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఫ  pha — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఫూ",
+      "sound": "phū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఫ  pha — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఫె",
+      "sound": "phe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఫ  pha — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఫే",
+      "sound": "phē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఫ  pha — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఫొ",
+      "sound": "pho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఫ  pha — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఫో",
+      "sound": "phō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఫ  pha — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "బ",
+      "sound": "ba",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "బ  ba — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "బా",
+      "sound": "bā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "బ  ba — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "బి",
+      "sound": "bi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "బ  ba — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "బీ",
+      "sound": "bī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "బ  ba — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "బు",
+      "sound": "bu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "బ  ba — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "బూ",
+      "sound": "bū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "బ  ba — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "బె",
+      "sound": "be",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "బ  ba — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "బే",
+      "sound": "bē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "బ  ba — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "బొ",
+      "sound": "bo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "బ  ba — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "బో",
+      "sound": "bō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "బ  ba — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "భ",
+      "sound": "bha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "భ  bha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "భా",
+      "sound": "bhā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "భ  bha — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "భి",
+      "sound": "bhi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "భ  bha — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "భీ",
+      "sound": "bhī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "భ  bha — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "భు",
+      "sound": "bhu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "భ  bha — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "భూ",
+      "sound": "bhū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "భ  bha — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "భె",
+      "sound": "bhe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "భ  bha — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "భే",
+      "sound": "bhē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "భ  bha — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "భొ",
+      "sound": "bho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "భ  bha — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "భో",
+      "sound": "bhō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "భ  bha — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "మ",
+      "sound": "ma",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "మ  ma — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "మా",
+      "sound": "mā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "మ  ma — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "మి",
+      "sound": "mi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "మ  ma — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "మీ",
+      "sound": "mī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "మ  ma — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ము",
+      "sound": "mu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "మ  ma — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "మూ",
+      "sound": "mū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "మ  ma — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "మె",
+      "sound": "me",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "మ  ma — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "మే",
+      "sound": "mē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "మ  ma — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "మొ",
+      "sound": "mo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "మ  ma — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "మో",
+      "sound": "mō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "మ  ma — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "య",
+      "sound": "ya",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "య  ya — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "యా",
+      "sound": "yā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "య  ya — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "యి",
+      "sound": "yi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "య  ya — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "యీ",
+      "sound": "yī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "య  ya — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "యు",
+      "sound": "yu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "య  ya — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "యూ",
+      "sound": "yū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "య  ya — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "యె",
+      "sound": "ye",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "య  ya — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "యే",
+      "sound": "yē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "య  ya — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "యొ",
+      "sound": "yo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "య  ya — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "యో",
+      "sound": "yō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "య  ya — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ర",
+      "sound": "ra",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ర  ra — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "రా",
+      "sound": "rā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ర  ra — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "రి",
+      "sound": "ri",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ర  ra — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "రీ",
+      "sound": "rī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ర  ra — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "రు",
+      "sound": "ru",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ర  ra — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "రూ",
+      "sound": "rū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ర  ra — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "రె",
+      "sound": "re",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ర  ra — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "రే",
+      "sound": "rē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ర  ra — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "రొ",
+      "sound": "ro",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ర  ra — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "రో",
+      "sound": "rō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ర  ra — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ల",
+      "sound": "la",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ల  la — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "లా",
+      "sound": "lā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ల  la — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "లి",
+      "sound": "li",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ల  la — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "లీ",
+      "sound": "lī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ల  la — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "లు",
+      "sound": "lu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ల  la — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "లూ",
+      "sound": "lū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ల  la — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "లె",
+      "sound": "le",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ల  la — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "లే",
+      "sound": "lē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ల  la — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "లొ",
+      "sound": "lo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ల  la — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "లో",
+      "sound": "lō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ల  la — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "వ",
+      "sound": "va",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "వ  va — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "వా",
+      "sound": "vā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "వ  va — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "వి",
+      "sound": "vi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "వ  va — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "వీ",
+      "sound": "vī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "వ  va — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "వు",
+      "sound": "vu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "వ  va — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "వూ",
+      "sound": "vū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "వ  va — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "వె",
+      "sound": "ve",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "వ  va — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "వే",
+      "sound": "vē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "వ  va — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "వొ",
+      "sound": "vo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "వ  va — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "వో",
+      "sound": "vō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "వ  va — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "శ",
+      "sound": "śa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "శ  śa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "శా",
+      "sound": "śā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "శ  śa — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "శి",
+      "sound": "śi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "శ  śa — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "శీ",
+      "sound": "śī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "శ  śa — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "శు",
+      "sound": "śu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "శ  śa — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "శూ",
+      "sound": "śū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "శ  śa — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "శె",
+      "sound": "śe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "శ  śa — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "శే",
+      "sound": "śē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "శ  śa — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "శొ",
+      "sound": "śo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "శ  śa — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "శో",
+      "sound": "śō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "శ  śa — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ష",
+      "sound": "ṣa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ష  ṣa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "షా",
+      "sound": "ṣā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ష  ṣa — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "షి",
+      "sound": "ṣi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ష  ṣa — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "షీ",
+      "sound": "ṣī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ష  ṣa — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "షు",
+      "sound": "ṣu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ష  ṣa — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "షూ",
+      "sound": "ṣū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ష  ṣa — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "షె",
+      "sound": "ṣe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ష  ṣa — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "షే",
+      "sound": "ṣē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ష  ṣa — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "షొ",
+      "sound": "ṣo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ష  ṣa — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "షో",
+      "sound": "ṣō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ష  ṣa — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "స",
+      "sound": "sa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "స  sa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "సా",
+      "sound": "sā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "స  sa — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "సి",
+      "sound": "si",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "స  sa — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "సీ",
+      "sound": "sī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "స  sa — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "సు",
+      "sound": "su",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "స  sa — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "సూ",
+      "sound": "sū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "స  sa — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "సె",
+      "sound": "se",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "స  sa — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "సే",
+      "sound": "sē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "స  sa — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "సొ",
+      "sound": "so",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "స  sa — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "సో",
+      "sound": "sō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "స  sa — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "హ",
+      "sound": "ha",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "హ  ha — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "హా",
+      "sound": "hā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "హ  ha — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "హి",
+      "sound": "hi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "హ  ha — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "హీ",
+      "sound": "hī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "హ  ha — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "హు",
+      "sound": "hu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "హ  ha — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "హూ",
+      "sound": "hū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "హ  ha — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "హె",
+      "sound": "he",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "హ  ha — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "హే",
+      "sound": "hē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "హ  ha — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "హొ",
+      "sound": "ho",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "హ  ha — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "హో",
+      "sound": "hō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "హ  ha — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ళ",
+      "sound": "ḷa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ళ  ḷa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ళా",
+      "sound": "ḷā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ళ  ḷa — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ళి",
+      "sound": "ḷi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ళ  ḷa — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ళీ",
+      "sound": "ḷī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ళ  ḷa — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ళు",
+      "sound": "ḷu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ళ  ḷa — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ళూ",
+      "sound": "ḷū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ళ  ḷa — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ళె",
+      "sound": "ḷe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ళ  ḷa — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ళే",
+      "sound": "ḷē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ళ  ḷa — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ళొ",
+      "sound": "ḷo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ళ  ḷa — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ళో",
+      "sound": "ḷō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ళ  ḷa — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఱ",
+      "sound": "ṟa",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఱ  ṟa — base consonant (inherent “a”)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఱా",
+      "sound": "ṟā",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఱ  ṟa — base consonant",
+        "ా  “ā” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఱి",
+      "sound": "ṟi",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఱ  ṟa — base consonant",
+        "ి  “i” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఱీ",
+      "sound": "ṟī",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఱ  ṟa — base consonant",
+        "ీ  “ī” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఱు",
+      "sound": "ṟu",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఱ  ṟa — base consonant",
+        "ు  “u” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఱూ",
+      "sound": "ṟū",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఱ  ṟa — base consonant",
+        "ూ  “ū” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఱె",
+      "sound": "ṟe",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఱ  ṟa — base consonant",
+        "ె  “e” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఱే",
+      "sound": "ṟē",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఱ  ṟa — base consonant",
+        "ే  “ē” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఱొ",
+      "sound": "ṟo",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఱ  ṟa — base consonant",
+        "ొ  “o” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఱో",
+      "sound": "ṟō",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఱ  ṟa — base consonant",
+        "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    }
+  ]
+}

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.17.0 — Telugu, Kannada & Malayalam letters (syllabary, PR 1)
+
+- **The three Dravidian scripts now have letters.** Browse and Practice covered
+  only Arabic / Devanagari / Tamil; Telugu, Kannada, and Malayalam — the tail of
+  the language chain — had none. They're **abugidas**, so each "letter" is a
+  syllable: a base consonant carries an inherent *a*, and a vowel sign turns it
+  into ka → ki → ku, kha → khi → khu. All three now appear as Browse tabs (350
+  Telugu / 350 Kannada / 360 Malayalam syllables) and drill in Practice, reusing
+  the existing letter engine unchanged (a syllable is just a `Letter`).
+- **Generated from Unicode, not hand-typed.** New
+  `data/scripts/generate_syllabary.py` composes every syllable from Unicode code
+  points, taking each base consonant / vowel-sign's identity and ISO-15919
+  romanization from its official Unicode character name (`TELUGU LETTER KA`, …) —
+  a letter it can't name from the standard is skipped, never guessed. The three
+  `*.json` files are its regenerable output; the generator is the provenance.
+- **Recognition only — no fabricated stroke order.** These carry `strokeOrder:
+  []` (their ductus is a separate, source-gated effort, still paused). The Browse
+  detail now **hides the "Write it — stroke order" section when there is none**,
+  rather than showing an empty one — so we never imply data we don't have. The
+  grounded consonant⊕vowel-sign decomposition (`క ka + ి "i" sign`) still shows.
+- 10 new tests (238 total) grounding the glyphs to code points, with controls
+  that bite: `ka` must equal the block's KA code point, `ki` must be KA + the
+  i-sign, and every syllable's `strokeOrder` must be `[]`. Verified in a real
+  browser — Telugu and Malayalam grids render real glyphs, no tofu. Slowly
+  unlocking the syllables one consonant at a time is the next slice (PR 2).
+
 ## 0.16.0 — a spine progress bar (HL03 polish)
 
 - **A slim progress bar under the "Concept N of 186" line**, showing how far

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -123,8 +123,20 @@ language-ladder                                     ← this app renders it (HL0
 
 The app imports those JSON files **directly**, so it can never drift from the
 curriculum. Adding a script to the curriculum surfaces it here with a one-line
-edit in `src/data.ts`. Ships today with **Cyrillic, Hebrew, Chinese, Arabic, and
-Devanagari**.
+edit in `src/data.ts`. Ships today with **Cyrillic, Hebrew, Chinese, Arabic,
+Devanagari, Gujarati, Tamil**, and the three **Dravidian syllabaries** below.
+
+### Dravidian syllabaries (Telugu / Kannada / Malayalam)
+
+These three are **abugidas** — a base consonant carries an inherent *a*, and a
+vowel sign turns it into a syllable (క = *ka*, కి = *ki*, కు = *ku*; ఖ = *kha*).
+So each "letter" is a syllable, and `data/scripts/{telugu,kannada,malayalam}.json`
+are **generated from Unicode** by `data/scripts/generate_syllabary.py`: every
+glyph is composed from code points and its romanization taken from the official
+Unicode character name (ISO-15919), never hand-typed. They are **recognition
+only** — `strokeOrder` is empty, since the handwriting ductus is a separate,
+source-gated effort; the Browse detail hides the stroke-order section when it's
+absent rather than showing an empty one.
 
 ## Design
 

--- a/code/programs/typescript/language-ladder/package.json
+++ b/code/programs/typescript/language-ladder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ladder",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "description": "The unified curriculum learning app (HL03): walk the language chain concept by concept, seeing the threads back to what you already know, then review it all with a randomised SRS quiz. (Was the HL02 script-writing-visualizer, whose Browse/Practice/Lessons/Concepts modes it now subsumes.)",
   "type": "module",

--- a/code/programs/typescript/language-ladder/src/data.ts
+++ b/code/programs/typescript/language-ladder/src/data.ts
@@ -15,6 +15,12 @@ import arabic from "../../../../learning/human-languages/data/scripts/arabic.jso
 import devanagari from "../../../../learning/human-languages/data/scripts/devanagari.json";
 import gujarati from "../../../../learning/human-languages/data/scripts/gujarati.json";
 import tamil from "../../../../learning/human-languages/data/scripts/tamil.json";
+// The Dravidian syllabaries (Telugu/Kannada/Malayalam) are GENERATED from Unicode
+// by data/scripts/generate_syllabary.py — each "letter" is a base consonant
+// composed with a vowel sign (ka, ki, ku, kha, …), for reading-recognition.
+import kannada from "../../../../learning/human-languages/data/scripts/kannada.json";
+import telugu from "../../../../learning/human-languages/data/scripts/telugu.json";
+import malayalam from "../../../../learning/human-languages/data/scripts/malayalam.json";
 
 // The JSON files are authored to the ScriptData shape; assert it once here.
 export const SCRIPTS: ScriptData[] = [
@@ -25,4 +31,8 @@ export const SCRIPTS: ScriptData[] = [
   devanagari as ScriptData,
   gujarati as ScriptData,
   tamil as ScriptData,
+  // The Dravidian trio, in chain order (Tamil → Kannada → Telugu → Malayalam).
+  kannada as ScriptData,
+  telugu as ScriptData,
+  malayalam as ScriptData,
 ];

--- a/code/programs/typescript/language-ladder/src/main.ts
+++ b/code/programs/typescript/language-ladder/src/main.ts
@@ -378,7 +378,12 @@ function renderDetail(v: LetterView): HTMLElement {
   head.append(big, meta);
   d.appendChild(head);
   d.appendChild(section("Break it apart — the pieces", listOf(v.components, "pieces")));
-  d.appendChild(section(`Write it — stroke order (${v.strokeOrderNote})`, orderedListOf(v.strokeOrder)));
+  // Only offer stroke order when we actually have it. The Dravidian syllabaries
+  // are recognition-only (their ductus is a separate, paused effort), so showing
+  // an empty "Write it" section would imply data we don't have.
+  if (v.strokeOrder.length > 0) {
+    d.appendChild(section(`Write it — stroke order (${v.strokeOrderNote})`, orderedListOf(v.strokeOrder)));
+  }
   if (v.notes) {
     const note = el("p", "detail__notes");
     note.textContent = v.notes;

--- a/code/programs/typescript/language-ladder/tests/syllabary_data.test.ts
+++ b/code/programs/typescript/language-ladder/tests/syllabary_data.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { SCRIPTS } from "../src/data";
+import type { ScriptData } from "../src/types";
+
+// The three Dravidian syllabaries generated from Unicode by
+// data/scripts/generate_syllabary.py. These tests ground the GLYPHS against the
+// exact Unicode code points (not pasted glyph literals — those would risk the
+// very mistyping the generator exists to avoid): a syllable must be the base
+// consonant composed with the vowel sign, or it fails here rather than reaching
+// a native reader.
+
+function byId(id: string): ScriptData {
+  const s = SCRIPTS.find((x) => x.script === id);
+  if (!s) throw new Error(`script ${id} not registered in data.ts`);
+  return s;
+}
+
+// KA and the "i" vowel-sign code points, per script's Unicode block.
+const cp = String.fromCodePoint;
+const BLOCKS = {
+  telugu: { ka: 0x0c15, iSign: 0x0c3f },
+  kannada: { ka: 0x0c95, iSign: 0x0cbf },
+  malayalam: { ka: 0x0d15, iSign: 0x0d3f },
+} as const;
+const IDS = ["telugu", "kannada", "malayalam"] as const;
+
+describe("Dravidian syllabaries are registered and abugida-shaped", () => {
+  for (const id of IDS) {
+    it(`${id} is present, an abugida, with a full core grid`, () => {
+      const s = byId(id);
+      expect(s.system).toBe("abugida");
+      expect(s.direction).toBe("ltr");
+      expect(s.letters.length).toBeGreaterThanOrEqual(340); // ~35 consonants × 10 vowels
+      expect((s.signature ?? "").length).toBeGreaterThan(20);
+    });
+  }
+});
+
+describe("every syllable is recognition-ready and ductus-free", () => {
+  for (const id of IDS) {
+    it(`${id}: non-empty glyph + sound, role 'syllable', and NO stroke order`, () => {
+      for (const l of byId(id).letters) {
+        expect(l.glyph.length).toBeGreaterThan(0);
+        expect(l.sound.length).toBeGreaterThan(0);
+        expect(l.role).toBe("syllable");
+        // CONTROL: stroke order stays paused (recognition only). If ductus data
+        // ever leaked into the generated syllabary, this fails.
+        expect(l.strokeOrder).toEqual([]);
+        expect(l.components.length).toBeGreaterThan(0);
+      }
+    });
+  }
+});
+
+describe("glyphs are composed from the real Unicode code points (grounding control)", () => {
+  for (const id of IDS) {
+    it(`${id}: 'ka' is the block's KA, and 'ki' is KA + the i-sign`, () => {
+      const letters = byId(id).letters;
+      const ka = letters.find((l) => l.sound === "ka")!;
+      const ki = letters.find((l) => l.sound === "ki")!;
+      const { ka: kaCp, iSign } = BLOCKS[id];
+      // CONTROL: a hand-typed or mis-composed glyph — or a look-alike KA from the
+      // wrong Dravidian block — would not equal these exact code points.
+      expect(ka.glyph).toBe(cp(kaCp));
+      expect(ki.glyph).toBe(cp(kaCp) + cp(iSign));
+    });
+  }
+});
+
+describe("the ka/kha rows read as the user expects (ka ki ku, kha khi khu)", () => {
+  it("telugu composes the ka and kha rows correctly from code points", () => {
+    const t = byId("telugu");
+    const g = (sound: string) => t.letters.find((l) => l.sound === sound)?.glyph;
+    const KA = cp(0x0c15), KHA = cp(0x0c16);
+    const I = cp(0x0c3f), U = cp(0x0c41);
+    expect(g("ka")).toBe(KA);
+    expect(g("ki")).toBe(KA + I);
+    expect(g("ku")).toBe(KA + U);
+    expect(g("kha")).toBe(KHA);
+    expect(g("khi")).toBe(KHA + I);
+    expect(g("khu")).toBe(KHA + U);
+  });
+});


### PR DESCRIPTION
## What

The three Dravidian scripts — the tail of the language chain — had **no letters** in the app (only Arabic/Devanagari/Tamil did). This adds them as **syllabaries**: they're abugidas, so each "letter" is a base consonant + a vowel sign — **ka → ki → ku**, **kha → khi → khu** — exactly the slow pattern-recognition progression requested.

They plug into the **existing** Browse + Practice + script-intro machinery unchanged (a syllable is just a `Letter`): three new Browse tabs (350 Telugu / 350 Kannada / 360 Malayalam syllables), drillable in Practice.

## Grounded in Unicode, not hand-typed

New `data/scripts/generate_syllabary.py` composes **every glyph from Unicode code points** and takes each base consonant / vowel-sign's identity + **ISO-15919** romanization from its official Unicode character name (`TELUGU LETTER KA`, `… VOWEL SIGN II`, …). A letter it can't name from the standard is **skipped, never guessed**. The `*.json` files are its regenerable output; the generator is the provenance. A correctness review independently recomputed the syllables from the Unicode database and confirmed a byte-for-byte match.

## Recognition only — no fabricated stroke order

These carry `strokeOrder: []` (the handwriting **ductus stays paused**, awaiting sources). The Browse detail now **hides the "Write it — stroke order" section when it's empty** rather than showing an empty one, so we never imply data we don't have. The grounded `క ka + ి "i" sign` decomposition still shows.

## Please eyeball these rows (you read these natively)

| | ka | kā | ki | kī | ku | kū | ke | kē | ko | kō | kha | khi | khu |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| **Telugu** | క | కా | కి | కీ | కు | కూ | కె | కే | కొ | కో | ఖ | ఖి | ఖు |
| **Kannada** | ಕ | ಕಾ | ಕಿ | ಕೀ | ಕು | ಕೂ | ಕೆ | ಕೇ | ಕೊ | ಕೋ | ಖ | ಖಿ | ಖು |
| **Malayalam** | ക | കാ | കി | കീ | കു | കൂ | കെ | കേ | കൊ | കോ | ഖ | ഖി | ഖു |

(Retroflex/sibilant romanization follows ISO-15919: ṭa ṇa ṣa ḷa ṟa ṉa, ś, long vowels ā ī ū ē ō.)

## Verification

- **10 new tests (238 total)** with controls that bite: `ka` must equal the block's KA code point, `ki` must be `KA + i-sign`, every syllable's `strokeOrder` must be `[]`.
- **Real browser** (headless screenshots, read back): Telugu and Malayalam grids render real glyphs, no tofu; the ka/ki/ku · kha/khi/khu rows are correct; the detail shows the decomposition and no empty stroke-order section.
- Correctness/grounding review: **clean**.

## Scope

The letters + data (PR 1). **PR 2** introduces them *slowly* — a pure `syllabary.ts` that unlocks one consonant's vowel row at a time (start with *ka*, expand as you master it) so you're not shown 350 syllables at once. Later: the full vowel set (ai/au/ṛ), special letters, a matrix view.

New direction requested in chat; builds on the completed HL03 app (#8924).