### PR TITLE
feat(adj-formula-stdlib): speed-conversions — NIST SP 811 B.9 speed-unit→metre-per-second factors (RS-5 table)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -460,6 +460,47 @@ fn shipped_pressure_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b9) Shipped table — reference/speed-conversions.adj resolves via import (speed
+//      unit → metres per second, EXACT SP 811 B.9 boldface factors), and a non-exact
+//      unit (`kilometer_per_hour`) — a rounded factor with no row — abstains.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_speed_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_speed");
+    let src = stdlib().join("reference/speed-conversions.adj");
+    std::fs::copy(&src, dir.join("speed-conversions.adj"))
+        .expect("copy shipped speed-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"speed-conversions.adj\"\n\
+         ? speed_to_metres_per_second(mile_per_hour, $mps)\n\
+         ? speed_to_metres_per_second(foot_per_second, $mps)\n\
+         ? speed_to_metres_per_second(mile_per_second, $mps)\n\
+         ? speed_to_metres_per_second(kilometer_per_hour, $mps)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 "Speed or velocity" exact factors resolve, character-for-
+    // character from the table (boldface = exact; scientific notation to plain decimal).
+    assert!(out.contains("\"mps\":\"0.44704\""), "mile/hour = 0.44704 m/s: {out}");
+    assert!(out.contains("\"mps\":\"0.3048\""), "foot/second = 0.3048 m/s: {out}");
+    assert!(out.contains("\"mps\":\"1609.344\""), "mile/second = 1609.344 m/s: {out}");
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `kilometer_per_hour` is NOT a single exact factor (SP 811 lists 1000/3600 as a
+    // rounded value, not boldface) — no row, so the engine abstains rather than commit.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a non-exact unit abstains, never a fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/speed-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/speed-conversions.adj
@@ -1,0 +1,65 @@
+% ============================================================================
+% speed-conversions — speed-unit → metre-per-second factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of `pressure-conversions.adj` / `energy-conversions.adj`: a
+% native tabular relation ingested VERBATIM from a published NIST conversion table.
+% Each row states the factor converting one speed (velocity) unit to the SI unit of
+% speed, the metre per second (m/s):
+%
+%     ? speed_to_metres_per_second(mile_per_hour, $mps)    % 0.44704   (a mph)
+%     ? speed_to_metres_per_second(foot_per_second, $mps)  % 0.3048    (a ft/s)
+%
+% It also pairs with the `arithmetic/speed.adj` formula (v = d/t): that formula
+% COMPUTES a speed from a distance and a time, and this table NORMALISES a speed
+% given in customary units to the SI unit — one grounded artifact feeding another
+% (write-once-use-many). Why a `table` and not several hand-written `relate` clauses:
+% this is exactly the shape reference data comes in — a published table, not prose.
+% The citable artifact IS the NIST conversion-factors table at the `locator` below;
+% every factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors
+% for units listed alphabetically"), and the whole table is defended by one provenance
+% envelope rather than repeating `source`/`locator`/`trust` on every row. Each `row`
+% lowers to a ground relation `speed_to_metres_per_second(unit, mps)`, so the exact
+% lookup above is the ordinary SLD binding query — the engine returns the factor WITH
+% this table's citation as its proof, on the CPU, with zero model calls.
+%
+% HONESTY NOTE (like pressure-conversions, these are EXACT defined factors, not
+% rounded ones): NIST SP 811 B.9 prints these six "Speed or velocity" factors in
+% BOLDFACE, its convention for factors that are EXACT by definition, transcribed here
+% as the plain decimal number of metres per second each unit names:
+%
+%     foot per second (ft/s)     3.048    E-01   →  0.3048
+%     foot per minute (ft/min)   5.08     E-03   →  0.00508
+%     inch per second (in/s)     2.54     E-02   →  0.0254
+%     mile per hour (mi/h)       4.4704   E-01   →  0.44704
+%     mile per minute (mi/min)   2.682 24 E+01   →  26.8224
+%     mile per second (mi/s)     1.609344 E+03   →  1609.344
+%
+% These six are exact because the foot, inch and international mile are exact by
+% definition (0.3048 m, 0.0254 m, 1609.344 m) and the minute and hour are exactly 60
+% and 3600 s, so each ratio terminates: e.g. mile/hour = 1609.344 / 3600 = 0.44704
+% exactly. Deliberately OMITTED: the foot per hour (8.466667 E-05, a repeating
+% ratio), the kilometre per hour (2.777778 E-01 = 1000/3600, repeating) and the knot
+% (5.144444 E-01), each of which NIST prints NOT in boldface (a rounded value, not a
+% single exact factor), so a `? speed_to_metres_per_second(kilometer_per_hour, $mps)`
+% (etc.) ABSTAINS rather than committing to a rounded value. The only claim this table
+% makes is "these are the exact factors NIST SP 811 B.9 prints" — which is exactly
+% what a byte-check against the cited table verifies. `trust authoritative` — a
+% primary, re-fetchable standards reference. (See ADJ-TABLES.md; and
+% feedback_nothing_human_authored — every factor is a verbatim cell of the cited
+% table, nothing asserted from memory.)
+% ============================================================================
+
+table speed_to_metres_per_second {
+    columns unit, mps
+
+    row (foot_per_second, 0.3048)
+    row (foot_per_minute, 0.00508)
+    row (inch_per_second, 0.0254)
+    row (mile_per_hour, 0.44704)
+    row (mile_per_minute, 26.8224)
+    row (mile_per_second, 1609.344)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/speed-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/speed-conversions.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% speed-conversions.query.adj — a worked lookup over the speed-conversions table.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a "how many metres
+% per second in a mile per hour?" question: it states no conversion fact — it only
+% `import`s the grounded table and asks binding queries. The native adj-lang engine
+% resolves each `?` against the table's rows (lowered to `speed_to_metres_per_second`
+% relations) and returns the binding + the table's source/locator/trust. A unit not
+% in the table abstains honestly — the engine never invents a factor (notably the
+% kilometre per hour and the knot, which NIST prints as rounded values, not exact
+% factors, and so have no row).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli speed-conversions.query.adj
+% ============================================================================
+
+import "speed-conversions.adj"
+
+? speed_to_metres_per_second(mile_per_hour, $mps)      % expect 0.44704
+? speed_to_metres_per_second(foot_per_second, $mps)    % expect 0.3048
+? speed_to_metres_per_second(mile_per_second, $mps)    % expect 1609.344
+? speed_to_metres_per_second(kilometer_per_hour, $mps) % expect abstain — rounded factor, not a row


### PR DESCRIPTION
## What

A new **Facts** entry: a native RS-5 `table` grounding the **exact** speed/velocity conversion factors from **NIST Special Publication 811, Appendix B.9** to the SI unit of speed, the metre per second. Sibling of `pressure-conversions.adj` / `energy-conversions.adj`, and a companion to `arithmetic/speed.adj` (v = d/t): that formula *computes* a speed, this table *normalises* a customary-unit speed to SI (write-once-use-many).

## The six factors (byte-verified against the cited NIST page)

NIST prints exact-by-definition factors in **boldface**; transcribed here as plain decimal m/s:

| unit | NIST (sci. notation) | m/s |
|---|---|---|
| foot per second | 3.048 E-01 | 0.3048 |
| foot per minute | 5.08 E-03 | 0.00508 |
| inch per second | 2.54 E-02 | 0.0254 |
| mile per hour | 4.4704 E-01 | 0.44704 |
| mile per minute | 2.682 24 E+01 | 26.8224 |
| mile per second | 1.609 344 E+03 | 1609.344 |

Exact because the foot/inch/international mile are exact by definition and the minute/hour are exactly 60/3600 s, so each ratio terminates (e.g. mile/hour = 1609.344 / 3600 = 0.44704 exactly).

## Honest abstention

Deliberately **omitted** — each printed by NIST **not** in boldface (a rounded value, not a single exact factor): foot per hour (8.466667 E-05, repeating), kilometre per hour (1000/3600, repeating), knot (5.144444 E-01). A `? speed_to_metres_per_second(kilometer_per_hour, $mps)` therefore **abstains** rather than commit to a rounded value.

## How it answers

Each `row` lowers to a ground relation `speed_to_metres_per_second(unit, mps)`, so a lookup is the ordinary SLD binding query — the engine returns the factor **with the table's citation as its proof**, on the CPU, zero model calls.

## Changes

- **New:** `reference/speed-conversions.adj` + `speed-conversions.query.adj` (worked lookup: mph/ft-s/mi-s resolve; km/h abstains).
- **Test:** `rs5_table_e2e::shipped_speed_conversions_table_resolves_and_abstains` — asserts 0.44704 / 0.3048 / 1609.344 resolve carrying the NIST locator, and km/h abstains. Suite now 14 tests, all green. Shipped query verified through the CLI.

Data + test only — **no version bump** (no adj-lang crate source changed). Security review passed (no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)