### PR TITLE
feat(sql): a bare * composes in a SELECT comma list (SELECT a, *)

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.5.65 — `*` composes in a SELECT comma list (`SELECT a, *`)
+
+`SELECT a, *`, `SELECT *, a` (and any mix) now parse and expand the `*` in place,
+matching SQLite — `SELECT a, *` yields `a, a, b` (the leading column, then the
+whole row). Previously `*` parsed only as the entire select list, so a mixed list
+was a parse error. The grammar now treats a bare `*` as a `select_item`
+alternative rather than a whole-list alternative; the planner already expanded a
+`*` placeholder in place (from the round-2 star-expansion work), so this only
+needed the parser to produce the mixed shape. Retires the `select_star_in_place`
+ledger entry. Verified against bundled real SQLite. Spans sql-parser 0.1.23 and
+sql-planner 0.2.32.
+
 ## 0.5.64 — explicit `COLLATE` on DISTINCT select-items and GROUP BY keys
 
 `SELECT DISTINCT b COLLATE NOCASE FROM t` and `SELECT b, COUNT(*) FROM t GROUP BY

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.64"
+version = "0.5.65"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1640,10 +1640,9 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT * FROM t ORDER BY 1 DESC",
     },
-    // Still ledgered: `*` mixed with another select item (`SELECT a, *`) does
-    // not PARSE — the grammar's select_list has no bare-`*` alternative in a
-    // comma-separated list. The planner's star expansion handles this shape once
-    // the parser produces it (a grammar follow-up).
+    // `*` mixed with another select item: `*` is now a `select_item` alternative,
+    // so it parses in a comma list and expands IN PLACE. `SELECT a, *` yields
+    // `a, a, b` (the leading `a`, then the whole row) — matching SQLite.
     Case {
         id: "select_star_in_place",
         setup: &[
@@ -1651,6 +1650,16 @@ const CASES: &[Case] = &[
             "INSERT INTO t VALUES (1,'x'),(2,'y')",
         ],
         query: "SELECT a, * FROM t ORDER BY a",
+    },
+    // `*` as the FIRST item, then another column: expands in place to the whole
+    // row followed by the trailing item — `SELECT *, a` → `a, b, a`.
+    Case {
+        id: "select_star_then_column",
+        setup: &[
+            "CREATE TABLE t (a INTEGER, b TEXT)",
+            "INSERT INTO t VALUES (1,'x'),(2,'y')",
+        ],
+        query: "SELECT *, a FROM t ORDER BY a",
     },
     // `SELECT DISTINCT *` now expands AND folds: `*` becomes the bare column
     // references, each contributing its own declared collation, so a NOCASE
@@ -2313,10 +2322,6 @@ const LEDGER: &[(&str, &str)] = &[
     (
         "order_by_ordinal_over_aggregate",
         "positional ORDER BY over an aggregate output column not yet re-bound to the materialized column",
-    ),
-    (
-        "select_star_in_place",
-        "`*` mixed with other select items (`SELECT a, *`) does not parse (grammar: select_list lacks a bare `*` alternative in a comma list)",
     ),
     // Explicit COLLATE now parses AND folds (DISTINCT / GROUP BY); the only
     // remaining divergence is which original row a fold keeps when ORDER BY is

--- a/code/packages/rust/sql-parser/CHANGELOG.md
+++ b/code/packages/rust/sql-parser/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.23] - Unreleased
+
+### Changed
+
+- **A bare `*` is now a `select_item` alternative, so it composes in a comma
+  list.** `select_list` was `STAR | select_item { "," select_item }` — `*` was
+  only accepted as the ENTIRE list, so `SELECT a, *` and `SELECT *, a` failed to
+  parse. `select_list` is now simply `select_item { "," select_item }` and
+  `select_item` is `STAR | ( expr [ COLLATE name ] [ [ "AS" ] NAME ] )` (STAR
+  tried first by ordered choice). Bare `SELECT *` still parses (via the STAR
+  alternative); `SELECT a`, `count(*)`, and `a * b` fall through to the expr form
+  because their first token is not a bare `*`. The planner emits a `*` placeholder
+  per wildcard item, which `expand_star_columns` expands in place.
+
 ## [0.1.22] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-parser/Cargo.toml
+++ b/code/packages/rust/sql-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-parser"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2021"
 description = "SQL parser — parses SQL source text into an AST using the grammar-driven parser and the sql.grammar file"
 

--- a/code/packages/rust/sql-parser/src/_grammar.rs
+++ b/code/packages/rust/sql-parser/src/_grammar.rs
@@ -58,21 +58,32 @@ pub fn parser_grammar() -> ParserGrammar {
         },
         GrammarRule {
             name: r#"select_list"#.to_string(),
-            body: GrammarElement::Alternation { choices: vec![
-                GrammarElement::TokenReference { name: r#"STAR"#.to_string() },
-                GrammarElement::Sequence { elements: vec![
-                    GrammarElement::RuleReference { name: r#"select_item"#.to_string() },
-                    GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
-                            GrammarElement::Literal { value: r#","#.to_string() },
-                            GrammarElement::RuleReference { name: r#"select_item"#.to_string() },
-                        ] }) },
-                ] },
+            // `select_list = select_item { "," select_item }`. A bare `*` is now a
+            // `select_item` alternative (see below), NOT a top-level whole-list
+            // alternative, so `*` can appear as ONE item in a comma list
+            // (`SELECT a, *`, `SELECT *, a`) — SQLite expands each `*` in place.
+            // Previously `*` was only accepted as the entire list, so a mixed list
+            // failed to parse.
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"select_item"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#","#.to_string() },
+                        GrammarElement::RuleReference { name: r#"select_item"#.to_string() },
+                    ] }) },
             ] },
             line_number: 22,
         },
         GrammarRule {
             name: r#"select_item"#.to_string(),
-            body: GrammarElement::Sequence { elements: vec![
+            // `select_item = STAR | ( expr [ COLLATE name ] [ [ "AS" ] NAME ] )`.
+            // A bare `*` is the wildcard item — the planner emits a `*` placeholder
+            // that `expand_star_columns` turns into the table's columns in place,
+            // so `*` composes with other items in a comma list. STAR is tried
+            // first (ordered choice); `SELECT a` / `count(*)` fall through to the
+            // expr form because their first token is not a bare `*`.
+            body: GrammarElement::Alternation { choices: vec![
+              GrammarElement::TokenReference { name: r#"STAR"#.to_string() },
+              GrammarElement::Sequence { elements: vec![
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
                 // Optional `COLLATE name` suffix on a select-list expression, e.g.
                 // `SELECT DISTINCT b COLLATE NOCASE`. Same shape as ORDER BY's
@@ -97,6 +108,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"AS"#.to_string() }) },
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
+              ] },
             ] },
             line_number: 23,
         },

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.32] - Unreleased
+
+### Changed
+
+- **`SELECT` items are all `select_item` nodes now, including a bare `*`.**
+  `plan_select_list` dropped its special-case shortcut (which returned a single
+  `*` column whenever any `*` token appeared) and simply maps `plan_select_item`
+  over the items. `plan_select_item` detects a bare-`*` item (no child expr node
+  + a `*` token) and emits the `*` placeholder (new `star_output_column` helper);
+  `expand_star_columns` then expands each placeholder in place. This is what lets
+  `SELECT a, *` / `SELECT *, a` expand correctly (`a, *` → `a` then the whole
+  row), matching SQLite, now that the grammar produces the mixed shape.
+
 ## [0.2.31] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.31"
+version = "0.2.32"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -1816,43 +1816,48 @@ fn plan_limit(limit_clause: &GrammarASTNode) -> Result<(Option<i64>, Option<i64>
 
 /// Plan the `select_list` into a list of `OutputColumn`s.
 ///
-/// Grammar: `select_list = STAR | select_item { "," select_item }`
-/// Grammar: `select_item = expr [ AS NAME ]`
+/// Grammar: `select_list = select_item { "," select_item }`
+/// Grammar: `select_item = STAR | ( expr [ COLLATE name ] [ [ "AS" ] NAME ] )`
 fn plan_select_list(select_list: &GrammarASTNode) -> Result<Vec<OutputColumn>, PlanError> {
-    // Check for SELECT * (STAR token).
-    if has_token(select_list, "*") {
-        return Ok(vec![OutputColumn {
-            expr: SqlExpr::Column {
-                table: None,
-                name: "*".to_string(),
-            },
-            alias: None,
-        }]);
-    }
-
-    // Plan each select_item.
+    // Every item — including a bare `*` — is a `select_item` now, so `*` can be
+    // one item among others (`SELECT a, *`). `plan_select_item` emits a `*`
+    // placeholder for the wildcard, which `expand_star_columns` expands in place.
     find_nodes(select_list, "select_item")
         .iter()
         .map(|item| plan_select_item(item))
         .collect()
 }
 
+/// The `*` placeholder output column. `expand_star_columns` replaces it with the
+/// base table's columns (in place, so it composes with other select items).
+fn star_output_column() -> OutputColumn {
+    OutputColumn {
+        expr: SqlExpr::Column {
+            table: None,
+            name: "*".to_string(),
+        },
+        alias: None,
+    }
+}
+
 /// Plan a single `select_item` node.
 ///
-/// Grammar: `select_item = expr [ "AS" NAME ]`
+/// Grammar: `select_item = STAR | ( expr [ COLLATE name ] [ [ "AS" ] NAME ] )`
 fn plan_select_item(item: &GrammarASTNode) -> Result<OutputColumn, PlanError> {
-    // The first child node is the expression.
-    let expr_node = item
-        .children
-        .iter()
-        .find_map(|c| {
-            if let ASTNodeOrToken::Node(n) = c {
-                Some(n)
-            } else {
-                None
-            }
-        })
-        .ok_or_else(|| PlanError::UnsupportedStatement("empty select_item".to_string()))?;
+    // The first child node is the expression. A bare `*` item (the STAR
+    // alternative) has NO child expr node — just a `*` token — so it is the
+    // wildcard placeholder.
+    let expr_node = match item.children.iter().find_map(|c| {
+        if let ASTNodeOrToken::Node(n) = c {
+            Some(n)
+        } else {
+            None
+        }
+    }) {
+        Some(n) => n,
+        None if has_token(item, "*") => return Ok(star_output_column()),
+        None => return Err(PlanError::UnsupportedStatement("empty select_item".to_string())),
+    };
 
     let expr = plan_expression(expr_node)?;
 


### PR DESCRIPTION
## What

A bare `*` can now appear as **one item in a SELECT comma list** — `SELECT a, *`, `SELECT *, a`, and any mix — expanding in place to match SQLite:

```sql
SELECT a, * FROM t;   -- a, then the whole row  →  a, a, b
SELECT *, a FROM t;   -- the whole row, then a  →  a, b, a
```

Previously `*` parsed only as the *entire* select list, so a mixed list was a parse error. Retires the `select_star_in_place` oracle ledger entry (one of the two follow-ups flagged during the recent mini-sqlite rotation).

## How

The planner already expanded a `*` placeholder in place (from the round-2 star-expansion work), so this is essentially a **grammar-only** fix plus routing the placeholder through the normal per-item path:

- **Grammar** (`sql-parser`, hand-edited `_grammar.rs`): `select_list` drops its top-level `STAR` alternative → `select_item { "," select_item }`; `select_item` becomes `STAR | ( expr [COLLATE name] [[AS] alias] )` (STAR first by ordered choice). This also fixes the old dangling-comma bug where the whole-list STAR greedily matched `*` and then choked on `, a`.
- **Planner** (`sql-planner`): `plan_select_list` drops the "any `*` token → single `*` column" shortcut and maps `plan_select_item` over the items; `plan_select_item` detects a bare-`*` item (no child expr node + a `*` token) and emits the `*` placeholder, which `expand_star_columns` expands in place.

`count(*)`, `a * b`, and `a` are unaffected — a `TokenReference` STAR only matches when the current token is a bare `*`, and no SQL expression starts with one, so they fall through to the expr form.

## Verification
- Differential oracle green vs **bundled real SQLite** — new `select_star_in_place` (`SELECT a, *`) and `select_star_then_column` (`SELECT *, a`) cases; ledger entry retired.
- Full `sql-parser` / `sql-planner` / `sql-optimizer` / `sql-codegen` / `sql-vm` / `mini-sqlite` suites pass; clippy clean.
- Inline security review **CLEAN**: committed-choice PEG means STAR never steals a real expression; no false-positive wildcard detection; expansion is linear and order-preserving; `SELECT *` and `SELECT DISTINCT *` unregressed.

Versions: `sql-parser` 0.1.23, `sql-planner` 0.2.32, `mini-sqlite` 0.5.65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
