### PR TITLE
feat(adj-formula-stdlib): dilution — LibreTexts M₁V₁=M₂V₂ conservation library (chemistry track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_dilution_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_dilution_e2e.rs
@@ -1,0 +1,175 @@
+//! End-to-end tests for the `chemistry/dilution.adj` library — the dilution
+//! equation (M₁V₁ = M₂V₂) and its four exact rearrangements (solve for the final
+//! concentration, the final volume, the initial concentration, or the initial
+//! volume) — driven through the built CLI binary against the SHIPPED stdlib. Each
+//! proves the same invariant as the other formula libraries: a consumer states NO
+//! arithmetic; it imports the grounded library, binds the measured quantities with
+//! `observe`, and the engine applies the cited conservation law on the CPU —
+//! computing the EXACT value and rendering the relation's citation + trust tier in
+//! the `derived` section (the auditable answer). The four readings invert around one
+//! conserved product M₁V₁ = M₂V₂ = 12: with M₁=4, V₁=3, M₂=2, V₂=6, each of the four
+//! recovers the fourth quantity from the other three.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped dilution library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_dilution_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/chemistry/dilution.adj")
+        .canonicalize()
+        .expect("shipped dilution.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_dilut_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_dilution_lib()).unwrap();
+    std::fs::write(dir.join("dilution.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// final concentration — M₂ = M₁V₁ / V₂: the conserved product over the new volume.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_dilution_library_and_computes_final_concentration_with_citation() {
+    let dir = scratch("m2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"dilution.adj\"\n\
+         observe initial_concentration(4)\n\
+         observe initial_volume(3)\n\
+         observe final_volume(6)\n\
+         ? final_concentration(initial_concentration, initial_volume, final_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 4 * 3 / 6 = 2.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"final_concentration\"") && s.contains("\"value\":2"),
+        "final_concentration(4, 3, 6) = 2: {s}"
+    );
+    // … AND the LibreTexts citation + trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// final volume — V₂ = M₁V₁ / M₂: the volume needed to hit a target concentration.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_final_volume_with_citation() {
+    let dir = scratch("v2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"dilution.adj\"\n\
+         observe initial_concentration(4)\n\
+         observe initial_volume(3)\n\
+         observe final_concentration(2)\n\
+         ? final_volume(initial_concentration, initial_volume, final_concentration)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 4 * 3 / 2 = 6, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"final_volume\"") && s.contains("\"value\":6"),
+        "final_volume(4, 3, 2) = 6: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "final_volume carries its LibreTexts citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// initial concentration — M₁ = M₂V₂ / V₁: the stock a known dilution came from.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_initial_concentration_with_citation() {
+    let dir = scratch("m1");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"dilution.adj\"\n\
+         observe final_concentration(2)\n\
+         observe final_volume(6)\n\
+         observe initial_volume(3)\n\
+         ? initial_concentration(final_concentration, final_volume, initial_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 2 * 6 / 3 = 4, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"initial_concentration\"") && s.contains("\"value\":4"),
+        "initial_concentration(2, 6, 3) = 4: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "initial_concentration carries its LibreTexts citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// initial volume — V₁ = M₂V₂ / M₁: the amount of stock a target dilution needs.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_initial_volume_with_citation() {
+    let dir = scratch("v1");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"dilution.adj\"\n\
+         observe final_concentration(2)\n\
+         observe final_volume(6)\n\
+         observe initial_concentration(4)\n\
+         ? initial_volume(final_concentration, final_volume, initial_concentration)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 2 * 6 / 4 = 3, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"initial_volume\"") && s.contains("\"value\":3"),
+        "initial_volume(2, 6, 4) = 3: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "initial_volume carries its LibreTexts citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/chemistry/dilution.adj
+++ b/code/specs/data/adj-formula-stdlib/chemistry/dilution.adj
@@ -1,0 +1,109 @@
+% ============================================================================
+% dilution.adj — the dilution equation (M₁V₁ = M₂V₂) in the ADJ standard library.
+% ============================================================================
+% The dilution entry of the *chemistry* track, a sibling of `molarity.adj` and
+% `ideal-gas-law.adj`: the foundational solution-chemistry relation a first course
+% states as THE PRODUCT OF CONCENTRATION AND VOLUME IS CONSERVED WHEN A SOLUTION IS
+% DILUTED, as an importable, byte-provenanced, PARAMETERIZED `formula` — together
+% with the FOUR exact readings that one conservation law sanctions (solve for any one
+% of the initial concentration, initial volume, final concentration or final volume
+% from the other three). As with every compute library, a consumer states NO
+% arithmetic: it `import`s this file, binds the measured quantities from its own
+% byte-provenance decomposition, and asks the engine to APPLY the cited relation on
+% the CPU. Zero math is performed by the model; the engine computes each value
+% EXACTLY, carrying the relation's citation.
+%
+%     import "dilution.adj"
+%     observe initial_concentration(4)   % "…4 M stock…"   (span cited by the model)
+%     observe initial_volume(3)          % "…3 L of it…"   (span cited by the model)
+%     observe final_volume(6)            % "…diluted to 6 L…"
+%     ? final_concentration(initial_concentration, initial_volume, final_volume)
+%                                          % engine → 2, carrying M₁V₁ = M₂V₂
+%
+% It pairs directly with `molarity.adj`: molarity (M = n/V) DEFINES the concentration
+% of a single solution, and this dilution relation says that concentration times
+% volume — the amount of solute — is CONSERVED across a dilution, so the two libraries
+% compose (a molarity feeds a dilution, and a diluted concentration can feed a
+% molarity back to moles). One grounded artifact building on another
+% (write-once-use-many).
+%
+% All four formulas are EXACT over their parameters — each is a product divided by a
+% measured quantity — so every value the engine returns is exact; there is no
+% *separately grounded* constant here. The four COMPOSE and invert cleanly around the
+% worked case M₁ = 4, V₁ = 3, M₂ = 2, V₂ = 6 (note 4·3 = 12 = 2·6):
+%
+%   final_concentration(initial_concentration, initial_volume, final_volume)
+%       = initial_concentration * initial_volume / final_volume     % M₂ = M₁V₁ / V₂ = 4·3/6 = 2
+%   final_volume(initial_concentration, initial_volume, final_concentration)
+%       = initial_concentration * initial_volume / final_concentration % V₂ = M₁V₁ / M₂ = 4·3/2 = 6
+%   initial_concentration(final_concentration, final_volume, initial_volume)
+%       = final_concentration * final_volume / initial_volume        % M₁ = M₂V₂ / V₁ = 2·6/3 = 4
+%   initial_volume(final_concentration, final_volume, initial_concentration)
+%       = final_concentration * final_volume / initial_concentration % V₁ = M₂V₂ / M₁ = 2·6/4 = 3
+%
+% All four formulas are defended by the SAME sentence — "Because this quantity does
+% not change before and after the change in concentration, the product MV must be the
+% same before and after the concentration change." — because that one conservation
+% statement (the product of concentration and volume is unchanged by a dilution) is
+% exactly M₁V₁ = M₂V₂, and so sanctions the relation solved for any single variable.
+% The quote is transcribed verbatim from Chemistry LibreTexts (the same primary
+% reference `molarity.adj` cites), so each `formula` carries the provenance envelope
+% every shipped grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the sentence is a verbatim span of the cited
+% page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. The dilution relation ranges over four observable quantities: the
+% concentration and volume of the solution BEFORE dilution and the concentration and
+% volume AFTER. Each appears BOTH as a derived result (of one formula) and as an
+% input (of the others), so each is a single dictionary term used in both roles. The
+% `surface` lists are the everyday names a decomposer maps onto the canonical term;
+% the trailing comment records the intended unit (a concentration in mol/L and a
+% volume in L, though the relation holds for ANY consistent concentration and volume
+% units, since only the products are compared).
+% ----------------------------------------------------------------------------
+dictionary dilution_vocab {
+    define initial_concentration : finding  surface "initial concentration", "stock concentration", "M1", "C1"   % before, e.g. mol/L
+    define initial_volume        : finding  surface "initial volume", "stock volume", "V1"                       % before, e.g. L
+    define final_concentration   : finding  surface "final concentration", "diluted concentration", "M2", "C2"   % after, e.g. mol/L
+    define final_volume          : finding  surface "final volume", "diluted volume", "V2"                       % after, e.g. L
+}
+
+% ----------------------------------------------------------------------------
+% The dilution equation, all four ways. Each is a named, importable, reusable `let`
+% over its formal parameters, bound at apply time, and each carries the conservation
+% sentence from LibreTexts (a quote is required on a shipped formula). Each body is a
+% product divided by a measured quantity, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook dilution_laws {
+    use dilution_vocab
+
+    % Final concentration — the concentration after diluting a stock to a larger
+    % volume (M₂ = M₁V₁ / V₂). The conserved product M₁V₁ divided by the new volume.
+    formula final_concentration(initial_concentration, initial_volume, final_volume) = initial_concentration * initial_volume / final_volume
+        source "Because this quantity does not change before and after the change in concentration, the product MV must be the same before and after the concentration change."
+        locator "https://chem.libretexts.org/Courses/Nassau_Community_College/Principles_of_Chemistry/11:_Solutions/11.04:_Dilutions_and_Concentrations"
+        trust authoritative
+
+    % Final volume — the volume the stock must reach to hit a target concentration
+    % (V₂ = M₁V₁ / M₂). Defended by the SAME conservation sentence, read another way.
+    formula final_volume(initial_concentration, initial_volume, final_concentration) = initial_concentration * initial_volume / final_concentration
+        source "Because this quantity does not change before and after the change in concentration, the product MV must be the same before and after the concentration change."
+        locator "https://chem.libretexts.org/Courses/Nassau_Community_College/Principles_of_Chemistry/11:_Solutions/11.04:_Dilutions_and_Concentrations"
+        trust authoritative
+
+    % Initial concentration — the stock concentration a known dilution came from
+    % (M₁ = M₂V₂ / V₁). Again the SAME conservation sentence, solved for M₁.
+    formula initial_concentration(final_concentration, final_volume, initial_volume) = final_concentration * final_volume / initial_volume
+        source "Because this quantity does not change before and after the change in concentration, the product MV must be the same before and after the concentration change."
+        locator "https://chem.libretexts.org/Courses/Nassau_Community_College/Principles_of_Chemistry/11:_Solutions/11.04:_Dilutions_and_Concentrations"
+        trust authoritative
+
+    % Initial volume — the amount of stock needed for a target dilution
+    % (V₁ = M₂V₂ / M₁). The fourth exact reading of the one conservation law.
+    formula initial_volume(final_concentration, final_volume, initial_concentration) = final_concentration * final_volume / initial_concentration
+        source "Because this quantity does not change before and after the change in concentration, the product MV must be the same before and after the concentration change."
+        locator "https://chem.libretexts.org/Courses/Nassau_Community_College/Principles_of_Chemistry/11:_Solutions/11.04:_Dilutions_and_Concentrations"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/chemistry/dilution.query.adj
+++ b/code/specs/data/adj-formula-stdlib/chemistry/dilution.query.adj
@@ -1,0 +1,36 @@
+% ============================================================================
+% dilution.query.adj — worked examples over the chemistry dilution library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a dilution question:
+% it states NO arithmetic and NO relation — it only `import`s the grounded library,
+% `observe`s the measured quantities it decomposed from the prompt (each a
+% byte-provenanced span, elided here), and asks the engine to APPLY the cited
+% conservation law. The native adj-lang engine binds the parameters, computes each
+% value EXACTLY on the CPU, and returns it with the relation's source/locator/trust.
+%
+% The four questions INVERT around one conserved product (M₁V₁ = M₂V₂ = 12): a 4 M
+% stock in 3 L, diluted to 6 L, gives 2 M; that same 4 M stock reaches a 2 M target
+% at exactly 6 L; a 2 M/6 L dilution came from a 4 M stock when 3 L was taken; and
+% reaching 2 M in 6 L from that 4 M stock needs exactly 3 L of it.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli dilution.query.adj
+% ============================================================================
+
+import "dilution.adj"
+
+% A 4 M stock, 3 L of it, diluted to a total of 6 L: M₂ = 4·3 / 6.
+observe initial_concentration(4)
+observe initial_volume(3)
+observe final_volume(6)
+? final_concentration(initial_concentration, initial_volume, final_volume)   % expect 2   (M₂ = M₁V₁/V₂)
+
+% That same 4 M stock in 3 L, to reach a 2 M target: V₂ = 4·3 / 2.
+observe final_concentration(2)
+? final_volume(initial_concentration, initial_volume, final_concentration)    % expect 6   (V₂ = M₁V₁/M₂)
+
+% A 2 M solution in 6 L known to have come from 3 L of stock: M₁ = 2·6 / 3.
+? initial_concentration(final_concentration, final_volume, initial_volume)    % expect 4   (M₁ = M₂V₂/V₁)
+
+% Reaching that 2 M in 6 L from the 4 M stock: V₁ = 2·6 / 4.
+? initial_volume(final_concentration, final_volume, initial_concentration)     % expect 3   (V₁ = M₂V₂/M₁)


### PR DESCRIPTION
## What

A new **Libraries** entry: the **dilution equation (M₁V₁ = M₂V₂)** as an importable, byte-provenanced formula library, with the **four** exact readings that one conservation law sanctions — solve for the final concentration, final volume, initial concentration, or initial volume from the other three. Sibling of `molarity.adj` / `ideal-gas-law.adj` in the thin chemistry track.

Pairs directly with `molarity.adj`: molarity (M = n/V) *defines* a single solution's concentration; this relation says concentration × volume (the amount of solute) is **conserved** across a dilution — so the two libraries compose (write-once-use-many).

## The four readings (one conserved product M₁V₁ = M₂V₂ = 12)

| solve for | body | worked (M₁=4, V₁=3, M₂=2, V₂=6) |
|---|---|---|
| final_concentration | M₁·V₁ / V₂ | 4·3/6 = **2** |
| final_volume | M₁·V₁ / M₂ | 4·3/2 = **6** |
| initial_concentration | M₂·V₂ / V₁ | 2·6/3 = **4** |
| initial_volume | M₂·V₂ / M₁ | 2·6/4 = **3** |

Each is a product over a measured quantity (no separately grounded constant), so every value the engine returns is **exact**.

## Grounding

All four formulas are defended by the **same** sentence, transcribed verbatim from Chemistry LibreTexts (the same primary reference `molarity.adj` cites):

> "Because this quantity does not change before and after the change in concentration, the product MV must be the same before and after the concentration change."

That one conservation statement *is* M₁V₁ = M₂V₂, so it sanctions the relation solved for any single variable. (Prose, no subscript-rendering fragility.) Locator: the [LibreTexts Dilutions and Concentrations page](https://chem.libretexts.org/Courses/Nassau_Community_College/Principles_of_Chemistry/11:_Solutions/11.04:_Dilutions_and_Concentrations).

## How it answers

A consumer states **no arithmetic**: it imports the library, `observe`s the measured quantities, and the engine applies the cited relation on the CPU, exactly, carrying the citation into the `derived` section (the auditable answer). Zero model math.

## Changes

- **New:** `chemistry/dilution.adj` + `dilution.query.adj` (worked 4-way inverting example).
- **Test:** `formula_dilution_e2e.rs` — 4 tests, one per rearrangement, each asserting the exact value (2/6/4/3) + the `chem.libretexts.org` citation + `authoritative` trust. All pass. Shipped query verified through the CLI.

Data + test only — **no version bump** (no adj-lang crate source changed). Security review passed (no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)