### PR TITLE
feat(adj-formula-stdlib): wave-speed — LibreTexts v=f·λ wave-relation library (physics track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_wave_speed_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_wave_speed_e2e.rs
@@ -1,0 +1,139 @@
+//! End-to-end tests for the `physics/wave-speed.adj` library — the wave relation
+//! (v = f·λ) and its two exact rearrangements (f = v/λ, λ = v/f) — driven through
+//! the built CLI binary against the SHIPPED stdlib. Each proves the same invariant
+//! as the other formula libraries: a consumer states NO arithmetic; it imports the
+//! grounded library, binds the measured quantities with `observe`, and the engine
+//! applies the cited relation on the CPU — computing the EXACT value and rendering
+//! the relation's citation + trust tier in the `derived` section (the auditable
+//! answer). The three formulas INVERT: 2 * 3 = 6, 6 / 3 = 2, 6 / 2 = 3.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped wave-speed library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_wave_speed_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/physics/wave-speed.adj")
+        .canonicalize()
+        .expect("shipped wave-speed.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_wave_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_wave_speed_lib()).unwrap();
+    std::fs::write(dir.join("wave-speed.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// wave speed — the relation: the frequency times the wavelength (v = f·λ).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_wave_speed_library_and_computes_relation_with_citation() {
+    let dir = scratch("v");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"wave-speed.adj\"\n\
+         observe frequency(2)\n\
+         observe wavelength(3)\n\
+         ? wave_speed(frequency, wavelength)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 2 * 3 = 6.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"wave_speed\"") && s.contains("\"value\":6"),
+        "wave_speed(2, 3) = 6: {s}"
+    );
+    // … AND the LibreTexts citation + trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("phys.libretexts.org"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// frequency — the same relation solved for f: the speed over the wavelength, which
+// INVERTS the wave speed just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_frequency_as_speed_over_wavelength_with_citation() {
+    let dir = scratch("f");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"wave-speed.adj\"\n\
+         observe wave_speed(6)\n\
+         observe wavelength(3)\n\
+         ? frequency(wave_speed, wavelength)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 6 / 3 = 2, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"frequency\"") && s.contains("\"value\":2"),
+        "frequency(6, 3) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("phys.libretexts.org"),
+        "frequency carries its LibreTexts citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// wavelength — the same relation solved for λ: the speed over the frequency, the
+// third exact reading of the one relation.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_wavelength_as_speed_over_frequency_with_citation() {
+    let dir = scratch("lambda");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"wave-speed.adj\"\n\
+         observe wave_speed(6)\n\
+         observe frequency(2)\n\
+         ? wavelength(wave_speed, frequency)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 6 / 2 = 3, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"wavelength\"") && s.contains("\"value\":3"),
+        "wavelength(6, 2) = 3: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("phys.libretexts.org"),
+        "wavelength carries its LibreTexts citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/physics/wave-speed.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/wave-speed.adj
@@ -1,0 +1,88 @@
+% ============================================================================
+% wave-speed.adj — the wave relation (v = f·λ) in the ADJ standard library.
+% ============================================================================
+% The wave-speed entry of the *physics* track, a sibling of `kinematics.adj`,
+% `momentum.adj` and `energy-work.adj`: the foundational wave relation a first course
+% states as THE SPEED OF A WAVE IS THE PRODUCT OF ITS FREQUENCY AND WAVELENGTH, as an
+% importable, byte-provenanced, PARAMETERIZED `formula`, together with its two exact
+% rearrangements (the frequency a speed implies for a wavelength, and the wavelength
+% it implies for a frequency). As with every compute library, a consumer states NO
+% arithmetic: it `import`s this file, binds the physical quantities from its own
+% byte-provenance decomposition, and asks the engine to APPLY the cited relation on
+% the CPU. Zero math is performed by the model; the engine computes each value
+% EXACTLY, carrying the relation's citation.
+%
+%     import "wave-speed.adj"
+%     observe frequency(2)             % "…2 Hz…"    (span cited by the model)
+%     observe wavelength(3)            % "…3 m…"     (span cited by the model)
+%     ? wave_speed(frequency, wavelength)   % engine → 6, carrying v = f·λ
+%
+% All three formulas are EXACT over their parameters — one a product, two quotients
+% of measured quantities. There is no *separately grounded* physical constant here,
+% so every value the engine returns is exact. The three COMPOSE and invert cleanly:
+% the `wave_speed` a consumer computes from a frequency and a wavelength is exactly
+% the `wave_speed` the `frequency` formula divides by that wavelength to recover the
+% frequency, and exactly the `wave_speed` the `wavelength` formula divides by that
+% frequency to recover the wavelength.
+%
+%   wave_speed(frequency, wavelength) = frequency * wavelength   %  v = f·λ  (the wave relation)
+%   frequency(wave_speed, wavelength) = wave_speed / wavelength   %  f = v/λ  (same relation, solved for f)
+%   wavelength(wave_speed, frequency) = wave_speed / frequency    %  λ = v/f  (same relation, solved for λ)
+%
+% All three formulas are defended by the SAME sentence — "The relationship of the
+% speed of sound, its frequency, and wavelength is the same as for all waves:" —
+% because that one statement (which the page immediately writes as v = fλ, and which
+% it explicitly generalises to EVERY wave, not just sound) sanctions the relation read
+% every way (v from f and λ, f from v and λ, or λ from v and f). The quote is
+% transcribed verbatim from Physics LibreTexts (OpenStax College Physics — a primary
+% educational reference, the same publisher `molarity.adj` and `dilution.adj` cite for
+% chemistry), so each `formula` carries the provenance envelope every shipped grounded
+% clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the sentence is a verbatim span of the cited page,
+% not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable physical quantity the relation ranges
+% over, and each result is the derived quantity. `wave_speed`, `frequency` and
+% `wavelength` each appear BOTH as a derived result and as an input (of the other
+% formulas), so each is a single dictionary term used in both roles. The `surface`
+% lists are the everyday names a decomposer maps onto the canonical term; the
+% trailing comment records the intended SI unit.
+% ----------------------------------------------------------------------------
+dictionary wave_speed_vocab {
+    define frequency  : finding  surface "frequency", "f"                        % frequency, e.g. Hz
+    define wavelength : finding  surface "wavelength", "lambda"                  % wavelength, e.g. m
+    define wave_speed : finding  surface "wave speed", "speed", "wave velocity"  % speed, e.g. m/s
+}
+
+% ----------------------------------------------------------------------------
+% The wave relation, all three ways. Each is a named, importable, reusable `let` over
+% its formal parameters, bound at apply time, and each carries the definitional quote
+% from Physics LibreTexts (a quote is required on a shipped formula). One is a product
+% and two are quotients, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook wave_speed_laws {
+    use wave_speed_vocab
+
+    % Wave speed — the product of frequency and wavelength. LibreTexts gives the speed
+    % of a wave as its frequency multiplied by its wavelength, i.e. v = f·λ.
+    formula wave_speed(frequency, wavelength) = frequency * wavelength
+        source "The relationship of the speed of sound, its frequency, and wavelength is the same as for all waves:"
+        locator "https://phys.libretexts.org/Bookshelves/College_Physics/College_Physics_1e_(OpenStax)/17:_Physics_of_Hearing/17.02:_Speed_of_Sound_Frequency_and_Wavelength"
+        trust authoritative
+
+    % Frequency — the same relation solved for the frequency a speed implies for a
+    % wavelength (f = v/λ). Defended by the SAME sentence, read the other way.
+    formula frequency(wave_speed, wavelength) = wave_speed / wavelength
+        source "The relationship of the speed of sound, its frequency, and wavelength is the same as for all waves:"
+        locator "https://phys.libretexts.org/Bookshelves/College_Physics/College_Physics_1e_(OpenStax)/17:_Physics_of_Hearing/17.02:_Speed_of_Sound_Frequency_and_Wavelength"
+        trust authoritative
+
+    % Wavelength — the same relation solved for the wavelength a speed implies for a
+    % frequency (λ = v/f). Again the SAME sentence, read the third way.
+    formula wavelength(wave_speed, frequency) = wave_speed / frequency
+        source "The relationship of the speed of sound, its frequency, and wavelength is the same as for all waves:"
+        locator "https://phys.libretexts.org/Bookshelves/College_Physics/College_Physics_1e_(OpenStax)/17:_Physics_of_Hearing/17.02:_Speed_of_Sound_Frequency_and_Wavelength"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/physics/wave-speed.query.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/wave-speed.query.adj
@@ -1,0 +1,32 @@
+% ============================================================================
+% wave-speed.query.adj — worked examples over the physics wave-speed library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a wave question: it
+% states NO arithmetic and NO relation — it only `import`s the grounded library,
+% `observe`s the measured quantities it decomposed from the prompt (each a
+% byte-provenanced span, elided here), and asks the engine to APPLY the cited wave
+% relation. The native adj-lang engine binds the parameters, computes each value
+% EXACTLY on the CPU, and returns it with the relation's source/locator/trust.
+%
+% The three questions INVERT: a 2 Hz wave with a 3 m wavelength travels at 6 m/s;
+% that 6 m/s speed is exactly what the frequency formula divides by the 3 m to
+% recover the 2 Hz, and exactly what the wavelength formula divides by the 2 Hz to
+% recover the 3 m.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli wave-speed.query.adj
+% ============================================================================
+
+import "wave-speed.adj"
+
+% A 2 Hz wave with a 3 m wavelength: speed = 2 * 3.
+observe frequency(2)
+observe wavelength(3)
+? wave_speed(frequency, wavelength)      % expect 6   (relation: v = f·λ)
+
+% That 6 m/s wave at the same 3 m wavelength: frequency = 6 / 3.
+observe wave_speed(6)
+? frequency(wave_speed, wavelength)       % expect 2   (same relation, solved for f = v/λ)
+
+% That 6 m/s wave at the same 2 Hz frequency: wavelength = 6 / 2.
+? wavelength(wave_speed, frequency)       % expect 3   (same relation, solved for λ = v/f)


### PR DESCRIPTION
## What

A new **Libraries** entry: the **wave relation (v = f·λ)** as an importable, byte-provenanced formula library, with its two exact rearrangements (f = v/λ, λ = v/f). Sibling of `kinematics.adj` / `momentum.adj` / `energy-work.adj` in the physics track.

A consumer states **no arithmetic**: it imports the library, `observe`s the measured quantities, and the engine applies the cited relation on the CPU, exactly, carrying the citation into the `derived` section (the auditable answer).

## The three readings (one relation, inverted)

| solve for | body | worked (f=2, λ=3) |
|---|---|---|
| wave_speed | f · λ | 2·3 = **6** |
| frequency | v / λ | 6/3 = **2** |
| wavelength | v / f | 6/2 = **3** |

Each is a product or quotient of measured quantities (no separately grounded constant), so every value is **exact**.

## Grounding

All three formulas are defended by the **same** sentence, transcribed verbatim from Physics LibreTexts (OpenStax College Physics):

> "The relationship of the speed of sound, its frequency, and wavelength is the same as for all waves:"

The page writes this as v = fλ and explicitly generalises it to **every** wave, so the one sentence sanctions the relation read all three ways. Deliberately grounded from **quotable prose** — not the image-only HyperPhysics wave-relations page. Locator: the [LibreTexts Speed of Sound, Frequency, and Wavelength page](https://phys.libretexts.org/Bookshelves/College_Physics/College_Physics_1e_(OpenStax)/17:_Physics_of_Hearing/17.02:_Speed_of_Sound_Frequency_and_Wavelength).

## Changes

- **New:** `physics/wave-speed.adj` + `wave-speed.query.adj` (worked 3-way inverting example).
- **Test:** `formula_wave_speed_e2e.rs` — 3 tests, one per rearrangement, each asserting the exact value (6/2/3) + the `phys.libretexts.org` citation + `authoritative` trust. All pass. Shipped query verified through the CLI.

Data + test only — **no version bump** (no adj-lang crate source changed). Security review passed (no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)