### PR TITLE
feat(adj-formula-stdlib): force-conversions — NIST SP 811 B.9 force-unit→newton factors (RS-5 table)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -501,6 +501,46 @@ fn shipped_speed_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b10) Shipped table — reference/force-conversions.adj resolves via import (force
+//       unit → newtons, EXACT SP 811 B.9 boldface factors), and a non-exact unit
+//       (`pound_force`) — a rounded factor with no row — abstains.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_force_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_force");
+    let src = stdlib().join("reference/force-conversions.adj");
+    std::fs::copy(&src, dir.join("force-conversions.adj"))
+        .expect("copy shipped force-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"force-conversions.adj\"\n\
+         ? force_to_newtons(kilogram_force, $n)\n\
+         ? force_to_newtons(kilopond, $n)\n\
+         ? force_to_newtons(dyne, $n)\n\
+         ? force_to_newtons(pound_force, $n)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 "Force" exact factors resolve, character-for-character from
+    // the table (boldface = exact; scientific notation to plain decimal).
+    assert!(out.contains("\"n\":\"9.80665\""), "kilogram-force = 9.80665 N: {out}");
+    assert!(out.contains("\"n\":\"0.00001\""), "dyne = 0.00001 N: {out}");
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `pound_force` is NOT a single exact factor (SP 811 prints it rounded, not
+    // boldface) — no row, so the engine abstains rather than commit to a rounded value.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a non-exact unit abstains, never a fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/force-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/force-conversions.adj
@@ -1,0 +1,59 @@
+% ============================================================================
+% force-conversions — force-unit → newton factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of `pressure-conversions.adj` / `speed-conversions.adj` /
+% `energy-conversions.adj`: a native tabular relation ingested VERBATIM from a
+% published NIST conversion table. Each row states the factor converting one force
+% unit to the SI unit of force, the newton (N):
+%
+%     ? force_to_newtons(kilogram_force, $n)   % 9.80665   (a kgf)
+%     ? force_to_newtons(dyne, $n)             % 0.00001   (a dyne)
+%
+% It completes the mechanical-unit conversion family already in this directory
+% (length, mass, time, area, volume, speed, pressure, energy — and now force). Why a
+% `table` and not several hand-written `relate` clauses: this is exactly the shape
+% reference data comes in — a published table, not prose. The citable artifact IS the
+% NIST conversion-factors table at the `locator` below; every factor here is a CELL of
+% NIST Special Publication 811, Appendix B.9 ("Factors for units listed
+% alphabetically"), and the whole table is defended by one provenance envelope rather
+% than repeating `source`/`locator`/`trust` on every row. Each `row` lowers to a
+% ground relation `force_to_newtons(unit, newtons)`, so the exact lookup above is the
+% ordinary SLD binding query — the engine returns the factor WITH this table's
+% citation as its proof, on the CPU, with zero model calls.
+%
+% HONESTY NOTE (like pressure-conversions / speed-conversions, these are EXACT defined
+% factors, not rounded ones): NIST SP 811 B.9 prints these three "Force" factors in
+% BOLDFACE, its convention for factors that are EXACT by definition, transcribed here
+% as the plain decimal number of newtons each unit names:
+%
+%     dyne (dyn)                     1.0     E-05   →  0.00001
+%     kilogram-force (kgf)           9.806 65 E+00  →  9.80665
+%     kilopond (kilogram-force) (kp) 9.806 65 E+00  →  9.80665
+%
+% These are exact because the dyne is 10⁻⁵ N by definition (1 g·cm/s² = 10⁻³ kg ·
+% 10⁻² m/s²) and the kilogram-force / kilopond are the weight of one kilogram under
+% the STANDARD acceleration of gravity, defined as exactly 9.80665 m/s² — so each
+% factor terminates. Deliberately OMITTED: the pound-force (4.448222 E+00), the
+% poundal (1.382550 E-01), the ounce-force (2.780139 E-01), the kip (4.448222 E+03)
+% and the ton-force (8.896443 E+03), each of which NIST prints NOT in boldface (a
+% rounded value, not a single exact factor — the international pound-force carries
+% more digits than the printed factor shows), so a
+% `? force_to_newtons(pound_force, $n)` (etc.) ABSTAINS rather than committing to a
+% rounded value. The only claim this table makes is "these are the exact factors NIST
+% SP 811 B.9 prints" — which is exactly what a byte-check against the cited table
+% verifies. `trust authoritative` — a primary, re-fetchable standards reference. (See
+% ADJ-TABLES.md; and feedback_nothing_human_authored — every factor is a verbatim
+% cell of the cited table, nothing asserted from memory.)
+% ============================================================================
+
+table force_to_newtons {
+    columns unit, newtons
+
+    row (dyne, 0.00001)
+    row (kilogram_force, 9.80665)
+    row (kilopond, 9.80665)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/force-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/force-conversions.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% force-conversions.query.adj — a worked lookup over the force-conversions table.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a "how many newtons
+% in a kilogram-force?" question: it states no conversion fact — it only `import`s the
+% grounded table and asks binding queries. The native adj-lang engine resolves each
+% `?` against the table's rows (lowered to `force_to_newtons` relations) and returns
+% the binding + the table's source/locator/trust. A unit not in the table abstains
+% honestly — the engine never invents a factor (notably the pound-force, poundal,
+% ounce-force, kip and ton-force, which NIST prints as rounded values, not exact
+% factors, and so have no row).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli force-conversions.query.adj
+% ============================================================================
+
+import "force-conversions.adj"
+
+? force_to_newtons(kilogram_force, $n)   % expect 9.80665
+? force_to_newtons(kilopond, $n)         % expect 9.80665  (alternate name for kgf)
+? force_to_newtons(dyne, $n)             % expect 0.00001
+? force_to_newtons(pound_force, $n)      % expect abstain — rounded factor, not a row


### PR DESCRIPTION
## What

A new **Facts** entry **completing the mechanical-unit conversion family** (length, mass, time, area, volume, speed, pressure, energy — and now **force**): a native RS-5 `table` grounding the **exact** (boldface) force→newton factors from **NIST Special Publication 811, Appendix B.9**. Sibling of `pressure-conversions.adj` / `speed-conversions.adj`.

## The three exact factors (byte-verified against the cited NIST page)

| unit | NIST (sci. notation) | newtons |
|---|---|---|
| dyne | 1.0 E-05 | 0.00001 |
| kilogram-force (kgf) | 9.806 65 E+00 | 9.80665 |
| kilopond (kgf) | 9.806 65 E+00 | 9.80665 |

Exact because the dyne is 10⁻⁵ N by definition and the kilogram-force / kilopond are the weight of one kilogram under the standard gravity defined as exactly 9.80665 m/s².

## Honest abstention

Deliberately **omitted** — each printed by NIST **not** in boldface (rounded, not exact): pound-force (4.448222 E+00), poundal (1.382550 E-01), ounce-force (2.780139 E-01), kip (4.448222 E+03), ton-force (8.896443 E+03). A `? force_to_newtons(pound_force, $n)` therefore **abstains** rather than commit to a rounded value.

## How it answers

Each `row` lowers to a ground relation `force_to_newtons(unit, newtons)`, so a lookup is the ordinary SLD binding query — the engine returns the factor **with the table's citation as its proof**, on the CPU, zero model calls.

## Changes

- **New:** `reference/force-conversions.adj` + `force-conversions.query.adj` (worked lookup: kgf/kilopond/dyne resolve; pound-force abstains).
- **Test:** `rs5_table_e2e::shipped_force_conversions_table_resolves_and_abstains` — asserts 9.80665 / 0.00001 resolve carrying the NIST locator, and pound-force abstains. Suite now **15 tests, all green**. Shipped query verified through the CLI.

Data + test only — **no version bump** (no adj-lang crate source changed). Security review passed (no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)