### PR TITLE
feat(hl03): introduce Dravidian syllables slowly, one consonant at a time (HL03 syllabary PR2)

### DIFF
--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.18.0 — introduce syllables slowly, one consonant at a time (syllabary, PR 2)
+
+- **The Dravidian drill no longer dumps 350 syllables at once.** Practice on
+  Telugu / Kannada / Malayalam now opens with a *single consonant's vowel row*
+  (ka kā ki kī ku kū ke kē ko kō) and unlocks the next consonant only once the
+  current row is mastered — the "ka, ki, ku … kha, khi, khu" build-up the app is
+  meant to teach. This is recognition pattern-building, done the slow way.
+- **New pure module `src/syllabary.ts`** is the gate: `consonantGroups` segments
+  the consonant-major syllabary at each bare consonant (a grounded boundary — a
+  base syllable has one component, a signed one has two), `unlockedConsonantCount`
+  counts how many rows are open given the SRS state (a Leitner box ≥ 3 marks a
+  syllable mastered; a gap holds everything after it locked), and
+  `unlockedLetterIndices` returns the currently drillable subset. No DOM, no
+  globals; unit-tested with a control that keeps the 2nd consonant locked until
+  the 1st row is fully mastered, plus a check against the real generated Telugu
+  data (35 consonants, a 10-syllable first row).
+- **Practice wiring** (`main.ts`): on a syllabary in single-script scope, the
+  scheduler picks the next question *only from unlocked syllables*, distractors
+  are drawn *only from unlocked syllables* (a not-yet-introduced consonant never
+  appears as a decoy), the mastery read-out is scoped to the unlocked rows
+  (`mastered 0 / 10`, not `0 / 350`), and a cue reads **"Learning consonant N of
+  M — master this vowel row to unlock the next."** The alphabets and Mixed mode
+  are untouched (the gate is null for them).
+
 ## 0.17.0 — Telugu, Kannada & Malayalam letters (syllabary, PR 1)
 
 - **The three Dravidian scripts now have letters.** Browse and Practice covered

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -138,6 +138,18 @@ only** — `strokeOrder` is empty, since the handwriting ductus is a separate,
 source-gated effort; the Browse detail hides the stroke-order section when it's
 absent rather than showing an empty one.
 
+**Practice introduces them slowly** (`src/syllabary.ts`). Rather than drill all
+350 syllables at once, the recall drill opens with a *single consonant's vowel
+row* — ka kā ki kī ku kū ke kē ko kō — and unlocks the next consonant only once
+the current row is mastered (a Leitner box ≥ 3). So recognition is built one
+consonant at a time, the "ka, ki, ku … kha, khi, khu" way. On these scripts the
+drill's target and its distractors are both confined to the unlocked syllables
+(a consonant you haven't met never appears, even as a wrong option), the mastery
+read-out is scoped to the open rows, and a cue shows *"Learning consonant N of M
+— master this vowel row to unlock the next."* The gate is a pure, unit-tested
+helper (with a control that keeps the 2nd consonant locked until row 1 is done);
+the alphabets and Mixed mode are unaffected.
+
 ## Design
 
 - **`src/core.ts`** — the pure, unit-tested heart: `buildScriptView`,

--- a/code/programs/typescript/language-ladder/package.json
+++ b/code/programs/typescript/language-ladder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ladder",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "private": true,
   "description": "The unified curriculum learning app (HL03): walk the language chain concept by concept, seeing the threads back to what you already know, then review it all with a randomised SRS quiz. (Was the HL02 script-writing-visualizer, whose Browse/Practice/Lessons/Concepts modes it now subsumes.)",
   "type": "module",

--- a/code/programs/typescript/language-ladder/src/main.ts
+++ b/code/programs/typescript/language-ladder/src/main.ts
@@ -31,6 +31,12 @@ import {
   type ItemState,
 } from "./scheduler.ts";
 import { buildPool, type PoolEntry } from "./interleave.ts";
+import {
+  isSyllabary,
+  consonantGroups,
+  unlockedConsonantCount,
+  unlockedLetterIndices,
+} from "./syllabary.ts";
 import { loadLessons, indicesByLanguage, nextDue } from "./lessons.ts";
 import {
   planSession,
@@ -228,6 +234,29 @@ function resolve(idx: number): PoolEntry {
   return { scriptIndex: currentScript, letterIndex: idx };
 }
 
+// The slow-unlock gate for the Dravidian syllabaries. Drilling 350 syllables at
+// once is the opposite of learning to read; instead the drill opens ONE
+// consonant's vowel row (ka kā ki … kō) and unlocks the next consonant only once
+// the current row is mastered — the "ka, ki, ku … kha, khi, khu" build-up. Only
+// active in "script" scope on a syllabary; null (no gating) everywhere else, so
+// the alphabets and Mixed mode are untouched. In script scope the schedule index
+// IS the letter index, so `schedule` lines up 1:1 with `letters`.
+interface SyllabaryGate {
+  indices: number[]; // the letter indices currently drillable
+  set: Set<number>; // same, for O(1) distractor filtering
+  unlocked: number; // how many consonants are open
+  total: number; // how many consonants in all
+}
+function syllabaryGate(): SyllabaryGate | null {
+  if (scope !== "script") return null;
+  const letters = SCRIPTS[currentScript]!.letters;
+  if (!isSyllabary(letters)) return null;
+  const groups = consonantGroups(letters);
+  const unlocked = unlockedConsonantCount(groups, schedule);
+  const indices = unlockedLetterIndices(groups, unlocked);
+  return { indices, set: new Set(indices), unlocked, total: groups.length };
+}
+
 // --- shared chrome ----------------------------------------------------------
 
 const SUBTITLES: Record<Mode, string> = {
@@ -412,15 +441,36 @@ function startPractice(): void {
 function nextQuestion(): void {
   // The scheduler decides WHICH item (spaced repetition, interleaved in mixed
   // scope); randomness is only for the distractors + answer position.
-  const idx = pickNext(schedule, sessionTick);
-  scheduleIndex = idx < 0 ? 0 : idx;
+  const gate = syllabaryGate();
+  let idx: number;
+  if (gate) {
+    // Only ask about UNLOCKED syllables: run the scheduler over just that slice.
+    // pickNext returns the picked item's real `letterIndex` (initStates seeds it
+    // to the schedule position and reviewIn preserves it), and every item in the
+    // slice is an unlocked letter — so the return value is already a real index
+    // into the full letters/views, no re-mapping needed.
+    const picked = pickNext(
+      gate.indices.map((i) => schedule[i]!),
+      sessionTick,
+    );
+    idx = picked < 0 ? gate.indices[0]! : picked;
+  } else {
+    idx = pickNext(schedule, sessionTick);
+    if (idx < 0) idx = 0;
+  }
+  scheduleIndex = idx;
   const { scriptIndex, letterIndex } = resolve(scheduleIndex);
   questionScript = scriptIndex;
   const views = buildScriptView(SCRIPTS[scriptIndex]!);
   const placeAt = randInt(Math.min(OPTION_COUNT, views.length));
   // Distractors come from the target's OWN script, so a Cyrillic prompt never
-  // offers a Hebrew decoy.
-  question = buildDrillQuestion(views, letterIndex, OPTION_COUNT, chooseConfusableShuffled, placeAt);
+  // offers a Hebrew decoy — and on a gated syllabary, only from UNLOCKED
+  // syllables, so a not-yet-introduced consonant never appears as a decoy.
+  const chooser = gate
+    ? (ranked: number[], count: number) =>
+        chooseConfusableShuffled(ranked.filter((i) => gate.set.has(i)), count)
+    : chooseConfusableShuffled;
+  question = buildDrillQuestion(views, letterIndex, OPTION_COUNT, chooser, placeAt);
   chosen = null;
 }
 
@@ -433,14 +483,25 @@ function renderPractice(): HTMLElement {
 
   wrap.appendChild(renderScopeToggle());
 
-  // Score line + a spaced-repetition mastery read-out (across the whole pool in
-  // mixed scope).
+  // Score line + a spaced-repetition mastery read-out. On a gated syllabary the
+  // read-out is over the UNLOCKED syllables, not all 350 — otherwise "mastered
+  // 10 / 350" would read as no progress when you've in fact finished the first
+  // row.
+  const gate = syllabaryGate();
   const acc = accuracy(score);
-  const mastered = masteredCount(schedule);
+  const scoreState = gate ? gate.indices.map((i) => schedule[i]!) : schedule;
+  const mastered = masteredCount(scoreState);
   const scoreLine = el("div", "score");
   const scoreText = acc === null ? "Score: 0 / 0" : `Score: ${score.correct} / ${score.total}  ·  ${acc}%`;
-  scoreLine.textContent = `${scoreText}   ·   mastered ${mastered} / ${schedule.length}`;
+  scoreLine.textContent = `${scoreText}   ·   mastered ${mastered} / ${scoreState.length}`;
   wrap.appendChild(scoreLine);
+
+  // The slow-unlock cue: which consonant you're on, and how to open the next.
+  if (gate) {
+    const cue = el("div", "syllabary-cue");
+    cue.textContent = `Learning consonant ${gate.unlocked} of ${gate.total} — master this vowel row to unlock the next.`;
+    wrap.appendChild(cue);
+  }
 
   // Prompt
   const prompt = el("div", "prompt");

--- a/code/programs/typescript/language-ladder/src/styles.css
+++ b/code/programs/typescript/language-ladder/src/styles.css
@@ -121,6 +121,15 @@ body {
 
 .practice { max-width: 560px; }
 .score { color: var(--muted); font-size: 0.9rem; margin-bottom: 14px; }
+.syllabary-cue {
+  color: var(--accent);
+  font-size: 0.9rem;
+  margin: -6px 0 16px;
+  padding: 8px 12px;
+  border-left: 3px solid var(--accent);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  border-radius: 4px;
+}
 
 .prompt {
   background: var(--card);

--- a/code/programs/typescript/language-ladder/src/syllabary.ts
+++ b/code/programs/typescript/language-ladder/src/syllabary.ts
@@ -1,0 +1,86 @@
+// ---------------------------------------------------------------------------
+// syllabary.ts — introducing an abugida's syllables SLOWLY, one consonant at a time.
+//
+// The Dravidian syllabaries (Telugu / Kannada / Malayalam) carry ~350 syllables
+// each: 35 consonants, each across ten vowels (ka kā ki kī ku kū ke kē ko kō).
+// Dropping all 350 on a beginner is the opposite of learning to read — the whole
+// point (the user's words) is to "build pattern recognition slowly … ka, ki, ku …
+// kha, khi, khu". So the drill starts with ONE consonant's vowel row and unlocks
+// the next consonant only once the current row is mastered.
+//
+// This module is the pure gate. It knows nothing about the DOM or the drill; it
+// takes the script's syllables (in the generated consonant-major order) plus the
+// SRS state, and answers "which syllables are unlocked right now?". Deterministic
+// and unit-tested, with a control that keeps a later consonant locked until the
+// current row is mastered.
+// ---------------------------------------------------------------------------
+
+import { MAX_BOX } from "./scheduler.ts";
+
+/** The minimal syllable shape this module needs — a base syllable has ONE piece
+ *  (the bare consonant), a signed syllable has two (consonant + vowel sign). */
+interface Syllable {
+  role: string;
+  components: string[];
+}
+
+/** The minimal SRS shape — the Leitner box is all that "mastered" depends on. */
+interface Boxed {
+  box: number;
+}
+
+/** How mastered a row must be before the next consonant unlocks (Leitner box). */
+export const ROW_MASTERY_BOX = 3;
+
+/** Is this script one of the generated syllabaries (every letter a syllable)? */
+export function isSyllabary(letters: { role: string }[]): boolean {
+  return letters.length > 0 && letters.every((l) => l.role === "syllable");
+}
+
+/**
+ * Segment a consonant-major syllabary into one index-group per consonant.
+ *
+ * The generator emits, for each consonant, its bare form (inherent “a”, a single
+ * component) followed by its signed syllables (two components). So a new group
+ * begins at every single-component syllable — a grounded boundary that needs no
+ * separate marker. `[[0,1,2,…], [10,11,…], …]`.
+ */
+export function consonantGroups(letters: Syllable[]): number[][] {
+  const groups: number[][] = [];
+  letters.forEach((l, i) => {
+    if (l.components.length <= 1 || groups.length === 0) groups.push([i]);
+    else groups[groups.length - 1]!.push(i);
+  });
+  return groups;
+}
+
+/** Is every syllable in this group's index list mastered (box ≥ ROW_MASTERY_BOX)? */
+function rowMastered(group: number[], states: Boxed[]): boolean {
+  return group.every((i) => {
+    const s = states[i];
+    return s !== undefined && s.box >= Math.min(ROW_MASTERY_BOX, MAX_BOX);
+  });
+}
+
+/**
+ * How many consonants are unlocked given the current SRS state.
+ *
+ * Always at least one (you start on `ka`). Each additional consonant unlocks only
+ * when EVERY earlier consonant's row is mastered — so a gap (an un-mastered early
+ * row) holds the rest locked, exactly the "don't run ahead" the slow build wants.
+ * Capped at the number of consonants.
+ */
+export function unlockedConsonantCount(groups: number[][], states: Boxed[]): number {
+  let unlocked = 1;
+  for (let g = 0; g < groups.length; g++) {
+    if (!rowMastered(groups[g]!, states)) break;
+    unlocked = g + 2; // this row is done → the next consonant is open
+  }
+  return Math.min(unlocked, groups.length);
+}
+
+/** The flat list of syllable indices the learner may currently be drilled on. */
+export function unlockedLetterIndices(groups: number[][], unlockedCount: number): number[] {
+  const n = Math.max(1, Math.min(unlockedCount, groups.length));
+  return groups.slice(0, n).flat();
+}

--- a/code/programs/typescript/language-ladder/tests/syllabary.test.ts
+++ b/code/programs/typescript/language-ladder/tests/syllabary.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import {
+  isSyllabary,
+  consonantGroups,
+  unlockedConsonantCount,
+  unlockedLetterIndices,
+  ROW_MASTERY_BOX,
+} from "../src/syllabary";
+import { SCRIPTS } from "../src/data";
+
+// A tiny fixture: 3 consonants × 3 vowels. A base syllable has ONE component (the
+// bare consonant); a signed one has two — the boundary consonantGroups() reads.
+function syl(base: boolean) {
+  return { role: "syllable", components: base ? ["k"] : ["k", "i"] };
+}
+const LETTERS = [
+  syl(true), syl(false), syl(false), // consonant 1: ka ki ku  (indices 0,1,2)
+  syl(true), syl(false), syl(false), // consonant 2: ga gi gu  (3,4,5)
+  syl(true), syl(false), syl(false), // consonant 3: ca ci cu  (6,7,8)
+];
+const boxes = (arr: number[]) => arr.map((box) => ({ box }));
+const mastered = boxes(Array(9).fill(ROW_MASTERY_BOX));
+
+describe("isSyllabary", () => {
+  it("true only when every letter is a syllable", () => {
+    expect(isSyllabary(LETTERS)).toBe(true);
+    expect(isSyllabary([{ role: "consonant" }, { role: "syllable" }])).toBe(false);
+    expect(isSyllabary([])).toBe(false);
+  });
+});
+
+describe("consonantGroups", () => {
+  it("segments a consonant-major syllabary at each bare consonant", () => {
+    expect(consonantGroups(LETTERS)).toEqual([[0, 1, 2], [3, 4, 5], [6, 7, 8]]);
+  });
+});
+
+describe("unlockedConsonantCount — the slow unlock", () => {
+  const groups = consonantGroups(LETTERS);
+
+  it("starts at 1 consonant (only ka's row) on a fresh, unmastered state", () => {
+    expect(unlockedConsonantCount(groups, boxes([0, 0, 0, 0, 0, 0, 0, 0, 0]))).toBe(1);
+  });
+
+  it("CONTROL: the 2nd consonant stays LOCKED until the 1st row is fully mastered", () => {
+    // Row 1 partially mastered (ku still at box 0) → still only 1 unlocked.
+    const partial = boxes([ROW_MASTERY_BOX, ROW_MASTERY_BOX, 0, 0, 0, 0, 0, 0, 0]);
+    expect(unlockedConsonantCount(groups, partial)).toBe(1);
+    // Master the whole first row → the 2nd consonant unlocks.
+    const rowOneDone = boxes([ROW_MASTERY_BOX, ROW_MASTERY_BOX, ROW_MASTERY_BOX, 0, 0, 0, 0, 0, 0]);
+    expect(unlockedConsonantCount(groups, rowOneDone)).toBe(2);
+  });
+
+  it("a gap holds the rest locked — mastering row 3 without row 2 unlocks nothing extra", () => {
+    const gap = boxes([ROW_MASTERY_BOX, ROW_MASTERY_BOX, ROW_MASTERY_BOX, 0, 0, 0, ROW_MASTERY_BOX, ROW_MASTERY_BOX, ROW_MASTERY_BOX]);
+    expect(unlockedConsonantCount(groups, gap)).toBe(2); // row 2 not done → capped at 2
+  });
+
+  it("all rows mastered unlocks every consonant, capped at the count", () => {
+    expect(unlockedConsonantCount(groups, mastered)).toBe(3);
+  });
+});
+
+describe("unlockedLetterIndices", () => {
+  const groups = consonantGroups(LETTERS);
+  it("returns exactly the syllables of the unlocked consonants", () => {
+    expect(unlockedLetterIndices(groups, 1)).toEqual([0, 1, 2]);
+    expect(unlockedLetterIndices(groups, 2)).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(unlockedLetterIndices(groups, 99)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]); // clamped
+    expect(unlockedLetterIndices(groups, 0)).toEqual([0, 1, 2]); // floored to 1
+  });
+});
+
+describe("against the real generated Telugu syllabary", () => {
+  const telugu = SCRIPTS.find((s) => s.script === "telugu")!;
+
+  it("is recognised as a syllabary and starts with a single-row unlock", () => {
+    expect(isSyllabary(telugu.letters)).toBe(true);
+    const groups = consonantGroups(telugu.letters);
+    expect(groups.length).toBe(35); // 35 consonants
+    expect(groups[0]!.length).toBe(10); // ka's row = 10 core vowels
+    // Fresh learner: only the first consonant's 10 syllables are drillable.
+    const fresh = telugu.letters.map(() => ({ box: 0 }));
+    expect(unlockedConsonantCount(groups, fresh)).toBe(1);
+    expect(unlockedLetterIndices(groups, 1)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+});


### PR DESCRIPTION
## What & why

PR1 (#8949) gave Telugu / Kannada / Malayalam their letters — but dropped all **~350 syllables** into Practice at once, which is the opposite of learning to read. This PR makes the drill build **pattern recognition slowly**, exactly as asked: start with **one consonant's vowel row** and unlock the next consonant only once the current row is mastered — the *"ka, ki, ku … kha, khi, khu"* progression.

## The gate — `src/syllabary.ts` (pure, unit-tested)

- **`consonantGroups`** — segments the consonant-major syllabary at each *bare* consonant. A base syllable has one component (కా→ one piece), a signed one has two (కి = క + ి), so the boundary is grounded in the data — no separate marker.
- **`unlockedConsonantCount`** — opens the next row only when **every earlier row** is mastered (Leitner box ≥ 3). A gap holds everything after it locked.
- **`unlockedLetterIndices`** — the currently drillable subset.

Tested with a **control** that keeps the 2nd consonant locked until the 1st row is fully mastered, and a check against the **real generated Telugu data** (35 consonants, a 10-syllable first row).

## Practice wiring (`main.ts`)

On a syllabary in single-script scope only (alphabets & Mixed mode untouched — the gate is `null` for them):
- the scheduler picks the next question **only from unlocked syllables**;
- **distractors are drawn only from unlocked syllables** — a not-yet-introduced consonant never appears, even as a wrong option;
- the mastery read-out is scoped to the open rows: **`mastered 0 / 10`**, not `0 / 350`;
- a cue reads **"Learning consonant N of M — master this vowel row to unlock the next."**

## Verified in-browser (Practice → Telugu)

Only **ka**'s row is drilled; cue shows **"Learning consonant 1 of 35"**; picking a wrong option reveals the grounded decomposition (**క ka — base consonant (inherent "a")**); score advances; **no empty stroke-order section** (recognition only — the handwriting ductus stays paused, still awaiting sources).

## Notes

- **Still recognition-only.** No stroke order is added or fabricated for these scripts.
- **20/20 test files, 246 tests pass**; `vite build` clean.
- Correctness + security reviewed (subagent): gate boundaries correct, index mapping sound, `textContent`-only (no XSS), alphabets/Mixed provably unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)