### PR TITLE
fix(sql-vm): apply DISTINCT before ORDER BY (SQL logical order)

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.5.66 — DISTINCT applies before ORDER BY (representative selection)
+
+`SELECT DISTINCT x COLLATE NOCASE FROM t ORDER BY x` now keeps SQLite's
+scan-first row of each fold, not the byte-sort-first one — the VM applies DISTINCT
+before ORDER BY (SQL logical order) instead of after. Only WHICH original text
+survives a collation fold was affected; the folding itself was already correct.
+Retires the `distinct_collate_order_by_representative` ledger entry (and restores
+the `ORDER BY` to the `distinct_explicit_collate` case that had been trimmed to
+sidestep this bug). The oracle ledger is now down to a single entry
+(`order_by_ordinal_over_aggregate`). Verified against bundled real SQLite. Spans
+sql-vm 0.4.36.
+
 ## 0.5.65 — `*` composes in a SELECT comma list (`SELECT a, *`)
 
 `SELECT a, *`, `SELECT *, a` (and any mix) now parse and expand the `*` in place,

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.65"
+version = "0.5.66"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1867,26 +1867,20 @@ const CASES: &[Case] = &[
     // rows; `COLLATE NOCASE` collapses them to two, keeping each fold's FIRST
     // (scan-order) original text — 'a','b'. The output column is named after its
     // source text `b COLLATE NOCASE` (SQLite includes the COLLATE in the name).
-    //
-    // No ORDER BY on purpose: the surviving representative of a fold is only
-    // well-defined once DISTINCT runs, and mini's VM currently applies ORDER BY
-    // BEFORE DISTINCT (post-op order sort→distinct), which would pick the
-    // sort-first row instead — an orthogonal ordering bug tracked separately as
-    // `distinct_collate_order_by_representative`. Compared unordered as a multiset.
+    // Now with an `ORDER BY b`: DISTINCT runs BEFORE the sort (fixed VM post-op
+    // order), so the scan-first 'a'/'b' survive and are then ordered — exactly
+    // SQLite. (Previously the VM sorted first and kept the byte-sort-first 'A'.)
     Case {
         id: "distinct_explicit_collate",
         setup: &[
             "CREATE TABLE t (id INTEGER, c TEXT COLLATE NOCASE, b TEXT)",
             "INSERT INTO t VALUES (1,'a','a'),(2,'A','A'),(3,'b','b'),(4,'B','B')",
         ],
-        query: "SELECT DISTINCT b COLLATE NOCASE FROM t",
+        query: "SELECT DISTINCT b COLLATE NOCASE FROM t ORDER BY b",
     },
-    // Tracks the orthogonal bug the case above sidesteps: with `ORDER BY b` the
-    // VM sorts (post_sort) BEFORE deduping (post_distinct), so the NOCASE fold of
-    // 'a'/'A' keeps the byte-sort-first 'A' rather than SQLite's scan-first 'a'.
-    // The COLLATE *folding* is correct (two rows out); only WHICH original text
-    // survives diverges. Fix is to apply DISTINCT before ORDER BY (SQL semantics),
-    // a VM post-op reordering left to its own increment.
+    // The specific representative-selection regression, now fixed: a NOCASE fold
+    // of 'a'/'A' under `ORDER BY b` keeps SQLite's scan-first 'a', because the VM
+    // applies DISTINCT before ORDER BY. Guards the post-op ordering directly.
     Case {
         id: "distinct_collate_order_by_representative",
         setup: &[
@@ -2322,13 +2316,6 @@ const LEDGER: &[(&str, &str)] = &[
     (
         "order_by_ordinal_over_aggregate",
         "positional ORDER BY over an aggregate output column not yet re-bound to the materialized column",
-    ),
-    // Explicit COLLATE now parses AND folds (DISTINCT / GROUP BY); the only
-    // remaining divergence is which original row a fold keeps when ORDER BY is
-    // present, because the VM runs sort before distinct. Folding is correct.
-    (
-        "distinct_collate_order_by_representative",
-        "`SELECT DISTINCT x COLLATE NOCASE ... ORDER BY x` keeps the sort-first original text, not SQLite's scan-first, because the VM applies ORDER BY (post_sort) before DISTINCT (post_distinct); DISTINCT should precede ORDER BY",
     ),
 ];
 

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.36] - Unreleased
+
+### Fixed
+
+- **DISTINCT is now applied before ORDER BY (SQL logical order).** The
+  post-processing phase ran `sort → strip-hidden-sort-columns → distinct → limit`,
+  so a `DISTINCT` group kept whichever row sorted first instead of SQLite's
+  scan-first row — observable when a collation folds rows with different original
+  text (`SELECT DISTINCT x COLLATE NOCASE … ORDER BY x` kept the byte-sort-first
+  `'A'` rather than `'a'`). It now runs `distinct → sort → truncate → limit`.
+- `apply_distinct` gained a `visible_cols` parameter and dedups on ONLY the first
+  `visible_cols` (SELECT-list) columns, so the trailing hidden `__sort_N__`
+  columns — which must survive until the sort reads them — don't pollute the
+  dedup key, and the collation vector still lines up. `visible_cols =
+  post_truncate.unwrap_or(output_columns.len())`, i.e. the visible-column prefix
+  whether or not hidden sort columns were appended. LIMIT still runs last.
+
 ## [0.4.35] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.35"
+version = "0.4.36"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -1076,21 +1076,32 @@ pub fn execute(program: &Program, backend: &mut dyn Backend) -> Result<QueryResu
 
     // ── Phase 3: post-processing ──────────────────────────────────────────────
 
+    // SQL logical order applies DISTINCT to the projected SELECT-list rows BEFORE
+    // ORDER BY: a deduped group keeps its FIRST row in SCAN order (matching
+    // SQLite), and ORDER BY then sorts the survivors. Running the sort first (the
+    // previous order) instead kept whichever row sorted first — observable when a
+    // collation folds rows with different original text
+    // (`SELECT DISTINCT x COLLATE NOCASE … ORDER BY x` kept the byte-sort-first
+    // 'A' rather than SQLite's scan-first 'a').
+    //
+    // Hidden `__sort_N__` columns (appended for an ORDER BY key that is not itself
+    // an output column) must survive until the sort can read them, so DISTINCT
+    // dedups on only the first `visible_cols` = SELECT-list columns, and the
+    // truncation that strips the hidden columns runs AFTER the sort. When there
+    // are no hidden columns `post_truncate` is `None` and every column is visible.
+    let visible_cols = post_truncate.unwrap_or(output_columns.len());
+    if post_distinct {
+        apply_distinct(&mut output_rows, &post_distinct_colls, visible_cols);
+    }
     if let Some(keys) = post_sort {
         apply_sort(&mut output_rows, &keys, &output_columns);
     }
-    // Strip hidden sort-key columns that were appended during compilation so
-    // that SortResult could find them by name.  This truncation must happen
-    // AFTER sorting and BEFORE distinct/limit so that only the SELECT-list
-    // columns remain in the output.
+    // Strip the hidden sort-key columns so only the SELECT-list columns remain.
     if let Some(n) = post_truncate {
         for row in &mut output_rows {
             row.truncate(n);
         }
         output_columns.truncate(n);
-    }
-    if post_distinct {
-        apply_distinct(&mut output_rows, &post_distinct_colls);
     }
     if let Some((count, offset)) = post_limit {
         apply_limit(&mut output_rows, count, offset);
@@ -3603,15 +3614,26 @@ fn collate_text(s: &str, collation: &str) -> String {
 /// average serialised row width — far better than the previous O(n²) Vec scan.
 /// The Debug output is deterministic for all `SqlValue` variants, so collisions
 /// can only happen between rows that are genuinely equal.
-fn apply_distinct(rows: &mut Vec<Vec<(String, SqlValue)>>, collations: &[Option<String>]) {
-    // The collation slice is indexed by output-column POSITION, so it is only
-    // meaningful when it describes exactly the row being keyed. If the widths
-    // disagree, the planner's view of the output columns and what was actually
-    // emitted have diverged (e.g. an unexpanded `SELECT DISTINCT *`), and
-    // applying it would put a collation on the WRONG column — silently folding
-    // values that must stay distinct, i.e. dropping rows. Fall back to BINARY,
-    // which dedupes strictly and can never merge rows that genuinely differ.
-    let widths_agree = rows.iter().all(|r| r.len() == collations.len());
+fn apply_distinct(
+    rows: &mut Vec<Vec<(String, SqlValue)>>,
+    collations: &[Option<String>],
+    visible_cols: usize,
+) {
+    // Dedup on the first `visible_cols` columns only — the SELECT-list output.
+    // Rows may carry trailing hidden `__sort_N__` columns (appended for an ORDER
+    // BY key that is not itself an output column and stripped after the sort);
+    // SQLite dedups on the visible select-list, NOT those, so they must be
+    // excluded from the key — otherwise two rows equal in the select list but
+    // differing in a hidden sort key would both survive.
+    //
+    // The collation slice is indexed by output-column POSITION and describes
+    // exactly those visible columns. If its width disagrees, the planner's view
+    // of the output columns and what was actually emitted have diverged (e.g. an
+    // unexpanded `SELECT DISTINCT *`), and applying it would put a collation on
+    // the WRONG column — silently folding values that must stay distinct. Fall
+    // back to BINARY, which dedupes strictly and can never merge rows that differ.
+    let widths_agree =
+        collations.len() == visible_cols && rows.iter().all(|r| r.len() >= visible_cols);
     let collations: &[Option<String>] = if widths_agree { collations } else { &[] };
 
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
@@ -3629,6 +3651,7 @@ fn apply_distinct(rows: &mut Vec<Vec<(String, SqlValue)>>, collations: &[Option<
         // BINARY, which is the stricter, fail-safe direction.
         let key: String = row
             .iter()
+            .take(visible_cols)
             .enumerate()
             .map(|(i, (col, val))| match (val, collations.get(i).and_then(|c| c.as_ref())) {
                 (SqlValue::Text(s), Some(coll)) => {


### PR DESCRIPTION
## What

The VM now applies **DISTINCT before ORDER BY** (SQL logical order). Previously it ran `sort → distinct`, so a `DISTINCT` group kept whichever row *sorted* first instead of SQLite's *scan*-first row — visible when a collation folds rows with different original text:

```sql
-- t.b = 'a','A','b','B'
SELECT DISTINCT b COLLATE NOCASE FROM t ORDER BY b;
-- SQLite / now:  a, b      (scan-first survivor of each fold)
-- before:        A, B      (byte-sort-first survivor)
```

This is the second of the two follow-ups I ledgered during the mini-sqlite rotation. With it retired, **the oracle ledger is down to a single entry** (`order_by_ordinal_over_aggregate`).

## How

The post-processing phase went from `sort → strip-hidden-sort-columns → distinct → limit` to `distinct → sort → truncate → limit`.

The one subtlety is **hidden `__sort_N__` columns**: codegen appends them when an ORDER BY key isn't itself an output column (here the output is named `b COLLATE NOCASE`, so `ORDER BY b` needs a hidden `b`), and strips them after the sort. They must survive until the sort reads them, so `apply_distinct` gained a `visible_cols` parameter and dedups on **only the first `visible_cols` (SELECT-list) columns** — hidden sort columns no longer pollute the dedup key, and the collation vector still lines up. `visible_cols = post_truncate.unwrap_or(output_columns.len())` is the true visible-column count whether or not hidden columns were appended. LIMIT still runs last.

Only *which* original text survives a fold changed; folding and all non-collation DISTINCT results are unaffected (byte-identical groups have an order-independent representative, and re-sorting the deduped set equals sorting-then-deduping). The BINARY fallback for an unexpanded `SELECT DISTINCT *` (collation-vector width mismatch) is preserved.

## Verification
- Differential oracle green vs **bundled real SQLite** — retires `distinct_collate_order_by_representative` and restores the `ORDER BY` to the `distinct_explicit_collate` case that had been trimmed to sidestep this bug.
- Full `sql-vm` / `mini-sqlite` / `storage-sqlite` suites pass; clippy clean.
- Inline security review **CLEAN**: cross-checked against codegen — `visible_cols` is always the true visible count (`output_columns` locked from the first emitted row; `post_truncate` is `Some` exactly when hidden columns exist); no new panics; BINARY fallback preserved; LIMIT unmoved relative to sort.

Versions: `sql-vm` 0.4.36, `mini-sqlite` 0.5.66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
