### PR TITLE
feat(adj-formula-stdlib): hookes-law — LibreTexts F=k·x elasticity library (physics track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_hookes_law_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_hookes_law_e2e.rs
@@ -1,0 +1,139 @@
+//! End-to-end tests for the `physics/hookes-law.adj` library — Hooke's law (the
+//! magnitude relation F = k·x) and its two exact rearrangements (k = F/x, x = F/k) —
+//! driven through the built CLI binary against the SHIPPED stdlib. Each proves the
+//! same invariant as the other formula libraries: a consumer states NO arithmetic; it
+//! imports the grounded library, binds the measured quantities with `observe`, and the
+//! engine applies the cited relation on the CPU — computing the EXACT value and
+//! rendering the relation's citation + trust tier in the `derived` section (the
+//! auditable answer). The three formulas INVERT: 3 * 2 = 6, 6 / 2 = 3, 6 / 3 = 2.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped Hooke's-law library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_hookes_law_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/physics/hookes-law.adj")
+        .canonicalize()
+        .expect("shipped hookes-law.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_hooke_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_hookes_law_lib()).unwrap();
+    std::fs::write(dir.join("hookes-law.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// spring force — the relation: the force constant times the displacement (F = k·x).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_hookes_law_library_and_computes_force_with_citation() {
+    let dir = scratch("f");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"hookes-law.adj\"\n\
+         observe spring_constant(3)\n\
+         observe displacement(2)\n\
+         ? spring_force(spring_constant, displacement)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 3 * 2 = 6.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"spring_force\"") && s.contains("\"value\":6"),
+        "spring_force(3, 2) = 6: {s}"
+    );
+    // … AND the LibreTexts citation + trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("phys.libretexts.org"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// force constant — the same relation solved for k: the force over the displacement,
+// which INVERTS the spring force just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_spring_constant_as_force_over_displacement_with_citation() {
+    let dir = scratch("k");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"hookes-law.adj\"\n\
+         observe spring_force(6)\n\
+         observe displacement(2)\n\
+         ? spring_constant(spring_force, displacement)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 6 / 2 = 3, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"spring_constant\"") && s.contains("\"value\":3"),
+        "spring_constant(6, 2) = 3: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("phys.libretexts.org"),
+        "spring_constant carries its LibreTexts citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// displacement — the same relation solved for x: the force over the force constant,
+// the third exact reading of the one relation.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_displacement_as_force_over_spring_constant_with_citation() {
+    let dir = scratch("x");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"hookes-law.adj\"\n\
+         observe spring_force(6)\n\
+         observe spring_constant(3)\n\
+         ? displacement(spring_force, spring_constant)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 6 / 3 = 2, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"displacement\"") && s.contains("\"value\":2"),
+        "displacement(6, 3) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("phys.libretexts.org"),
+        "displacement carries its LibreTexts citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/physics/hookes-law.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/hookes-law.adj
@@ -1,0 +1,99 @@
+% ============================================================================
+% hookes-law.adj — Hooke's law (spring force F = k·x) in the ADJ standard library.
+% ============================================================================
+% The Hooke's-law entry of the *physics* track, a sibling of `wave-speed.adj`,
+% `momentum.adj` and `energy-work.adj`: the foundational elasticity relation a first
+% course states as THE RESTORING FORCE OF A SPRING IS PROPORTIONAL TO ITS
+% DISPLACEMENT, with the force (spring) constant k as the proportionality constant —
+% i.e. the MAGNITUDE relation F = k·x — as an importable, byte-provenanced,
+% PARAMETERIZED `formula`, together with its two exact rearrangements (the force
+% constant a force implies for a displacement, and the displacement a force implies
+% for a force constant). As with every compute library, a consumer states NO
+% arithmetic: it `import`s this file, binds the physical quantities from its own
+% byte-provenance decomposition, and asks the engine to APPLY the cited relation on
+% the CPU. Zero math is performed by the model; the engine computes each value
+% EXACTLY, carrying the relation's citation.
+%
+%     import "hookes-law.adj"
+%     observe spring_constant(3)       % "…k = 3 N/m…"  (span cited by the model)
+%     observe displacement(2)          % "…stretched 2 m…" (span cited by the model)
+%     ? spring_force(spring_constant, displacement)   % engine → 6, carrying F = k·x
+%
+% NOTE ON SIGN: the library computes the MAGNITUDE of the restoring force, F = k·x.
+% Hooke's law is often written F = -k·x, where the minus sign records only that the
+% restoring force points OPPOSITE to the displacement (back toward equilibrium); it is
+% a direction, not part of the magnitude a consumer computes. So the exact numeric
+% relation the engine applies is F = k·x over the measured magnitudes.
+%
+% All three formulas are EXACT over their parameters — one a product, two quotients of
+% measured quantities. There is no *separately grounded* physical constant here (the
+% spring's force constant k is itself one of the measured quantities), so every value
+% the engine returns is exact. The three COMPOSE and invert cleanly: the
+% `spring_force` a consumer computes from a force constant and a displacement is
+% exactly the `spring_force` the `spring_constant` formula divides by that displacement
+% to recover the force constant, and exactly the `spring_force` the `displacement`
+% formula divides by that force constant to recover the displacement.
+%
+%   spring_force(spring_constant, displacement) = spring_constant * displacement  % F = k·x
+%   spring_constant(spring_force, displacement) = spring_force / displacement       % k = F/x
+%   displacement(spring_force, spring_constant) = spring_force / spring_constant    % x = F/k
+%
+% All three formulas are defended by the SAME sentence — "The simplest oscillations
+% occur when the restoring force is directly proportional to displacement." — because
+% that statement of DIRECT PROPORTIONALITY between the restoring force and the
+% displacement IS Hooke's law: a directly-proportional relation is exactly F = k·x for
+% the proportionality (force) constant k the page names, and so sanctions the relation
+% read every way (F from k and x, k from F and x, or x from F and k). The quote is
+% transcribed verbatim from Physics LibreTexts (OpenStax College Physics — a primary
+% educational reference, the same publisher `wave-speed.adj`, `molarity.adj` and
+% `dilution.adj` cite), so each `formula` carries the provenance envelope every shipped
+% grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the sentence is a verbatim span of the cited page,
+% not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable physical quantity the relation ranges
+% over, and each result is the derived quantity. `spring_force`, `spring_constant` and
+% `displacement` each appear BOTH as a derived result and as an input (of the other
+% formulas), so each is a single dictionary term used in both roles. The `surface`
+% lists are the everyday names a decomposer maps onto the canonical term; the trailing
+% comment records the intended SI unit.
+% ----------------------------------------------------------------------------
+dictionary hookes_law_vocab {
+    define spring_constant : finding  surface "spring constant", "force constant", "k"      % stiffness, e.g. N/m
+    define displacement    : finding  surface "displacement", "extension", "stretch", "x"   % displacement, e.g. m
+    define spring_force    : finding  surface "spring force", "restoring force", "force", "F" % force magnitude, e.g. N
+}
+
+% ----------------------------------------------------------------------------
+% Hooke's law, all three ways. Each is a named, importable, reusable `let` over its
+% formal parameters, bound at apply time, and each carries the definitional quote from
+% Physics LibreTexts (a quote is required on a shipped formula). One is a product and
+% two are quotients, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook hookes_law {
+    use hookes_law_vocab
+
+    % Spring force — the product of the force constant and the displacement. LibreTexts
+    % gives the restoring force as directly proportional to the displacement, i.e.
+    % F = k·x (magnitude).
+    formula spring_force(spring_constant, displacement) = spring_constant * displacement
+        source "The simplest oscillations occur when the restoring force is directly proportional to displacement."
+        locator "https://phys.libretexts.org/Bookshelves/College_Physics/College_Physics_1e_(OpenStax)/16:_Oscillatory_Motion_and_Waves/16.01:_Hookes_Law_-_Stress_and_Strain_Revisited"
+        trust authoritative
+
+    % Force constant — the same relation solved for the stiffness a force implies for a
+    % displacement (k = F/x). Defended by the SAME sentence, read the other way.
+    formula spring_constant(spring_force, displacement) = spring_force / displacement
+        source "The simplest oscillations occur when the restoring force is directly proportional to displacement."
+        locator "https://phys.libretexts.org/Bookshelves/College_Physics/College_Physics_1e_(OpenStax)/16:_Oscillatory_Motion_and_Waves/16.01:_Hookes_Law_-_Stress_and_Strain_Revisited"
+        trust authoritative
+
+    % Displacement — the same relation solved for the displacement a force implies for a
+    % force constant (x = F/k). Again the SAME sentence, read the third way.
+    formula displacement(spring_force, spring_constant) = spring_force / spring_constant
+        source "The simplest oscillations occur when the restoring force is directly proportional to displacement."
+        locator "https://phys.libretexts.org/Bookshelves/College_Physics/College_Physics_1e_(OpenStax)/16:_Oscillatory_Motion_and_Waves/16.01:_Hookes_Law_-_Stress_and_Strain_Revisited"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/physics/hookes-law.query.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/hookes-law.query.adj
@@ -1,0 +1,32 @@
+% ============================================================================
+% hookes-law.query.adj — worked examples over the physics Hooke's-law library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a spring question: it
+% states NO arithmetic and NO relation — it only `import`s the grounded library,
+% `observe`s the measured quantities it decomposed from the prompt (each a
+% byte-provenanced span, elided here), and asks the engine to APPLY the cited relation.
+% The native adj-lang engine binds the parameters, computes each value EXACTLY on the
+% CPU, and returns it with the relation's source/locator/trust.
+%
+% The three questions INVERT: a spring with a 3 N/m force constant stretched 2 m
+% exerts a 6 N restoring force; that 6 N restoring force over the same 2 m implies
+% exactly the 3 N/m force constant, and that 6 N force with the same 3 N/m constant
+% implies exactly the 2 m displacement.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli hookes-law.query.adj
+% ============================================================================
+
+import "hookes-law.adj"
+
+% A 3 N/m spring stretched 2 m: force = 3 * 2.
+observe spring_constant(3)
+observe displacement(2)
+? spring_force(spring_constant, displacement)   % expect 6   (relation: F = k·x)
+
+% That 6 N restoring force over the same 2 m: k = 6 / 2.
+observe spring_force(6)
+? spring_constant(spring_force, displacement)    % expect 3   (same relation, solved for k = F/x)
+
+% That 6 N force with the same 3 N/m constant: x = 6 / 3.
+? displacement(spring_force, spring_constant)    % expect 2   (same relation, solved for x = F/k)


### PR DESCRIPTION
## What

A new **Libraries** entry: **Hooke's law** (the magnitude relation **F = k·x**, spring force = force constant × displacement) as an importable, byte-provenanced formula library, with its two exact rearrangements (k = F/x, x = F/k). Sibling of `wave-speed.adj` / `momentum.adj` / `energy-work.adj` in the physics track.

A consumer states **no arithmetic**: it imports the library, `observe`s the measured quantities, and the engine applies the cited relation on the CPU, exactly, carrying the citation into the `derived` section.

## The three readings (one relation, inverted)

| solve for | body | worked (k=3, x=2) |
|---|---|---|
| spring_force | k · x | 3·2 = **6** |
| spring_constant | F / x | 6/2 = **3** |
| displacement | F / k | 6/3 = **2** |

Each is a product or quotient of measured quantities (the spring's force constant is itself measured — no separately grounded constant), so every value is **exact**.

## Grounding

All three formulas are defended by the **same** sentence, transcribed verbatim from Physics LibreTexts (OpenStax College Physics):

> "The simplest oscillations occur when the restoring force is directly proportional to displacement."

That statement of **direct proportionality** between restoring force and displacement *is* Hooke's law — a directly-proportional relation is exactly F = k·x for the force constant k the page names — so it sanctions the relation read all three ways. Grounded from **quotable prose**, not the image-only HyperPhysics page. Locator: the [LibreTexts Hooke's Law page](https://phys.libretexts.org/Bookshelves/College_Physics/College_Physics_1e_(OpenStax)/16:_Oscillatory_Motion_and_Waves/16.01:_Hookes_Law_-_Stress_and_Strain_Revisited).

**Sign:** the library computes the **magnitude** F = k·x. The minus sign in the common form F = -k·x records only direction (the restoring force opposes the displacement), not part of the magnitude a consumer computes.

## Changes

- **New:** `physics/hookes-law.adj` + `hookes-law.query.adj` (worked 3-way inverting example).
- **Test:** `formula_hookes_law_e2e.rs` — 3 tests, one per rearrangement, each asserting the exact value (6/3/2) + the `phys.libretexts.org` citation + `authoritative` trust. All pass. Shipped query verified through the CLI.

Data + test only — **no version bump** (no adj-lang crate source changed). Security review passed (no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)