### PR TITLE
feat(adj-formula-stdlib): power — LibreTexts P=W/t mechanical-power library (physics track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_power_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_power_e2e.rs
@@ -1,0 +1,139 @@
+//! End-to-end tests for the `physics/power.adj` library — mechanical power
+//! (P = W/t) and its two exact rearrangements (W = P·t, t = W/P) — driven through the
+//! built CLI binary against the SHIPPED stdlib. Each proves the same invariant as the
+//! other formula libraries: a consumer states NO arithmetic; it imports the grounded
+//! library, binds the measured quantities with `observe`, and the engine applies the
+//! cited definition on the CPU — computing the EXACT value and rendering the
+//! definition's citation + trust tier in the `derived` section (the auditable answer).
+//! The three formulas INVERT: 6 / 2 = 3, 3 * 2 = 6, 6 / 3 = 2.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped power library, resolved from this crate's manifest dir
+/// so the test is location-independent.
+fn shipped_power_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/physics/power.adj")
+        .canonicalize()
+        .expect("shipped power.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_power_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_power_lib()).unwrap();
+    std::fs::write(dir.join("power.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// power — the definition: the work done divided by the time taken (P = W/t).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_power_library_and_computes_definition_with_citation() {
+    let dir = scratch("p");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"power.adj\"\n\
+         observe work(6)\n\
+         observe time(2)\n\
+         ? power(work, time)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied definition's result: 6 / 2 = 3.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"power\"") && s.contains("\"value\":3"),
+        "power(6, 2) = 3: {s}"
+    );
+    // … AND the LibreTexts citation + trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("phys.libretexts.org"),
+        "applied definition carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// work — the same definition solved for W: the power times the time, which INVERTS
+// the power just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_work_as_power_times_time_with_citation() {
+    let dir = scratch("w");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"power.adj\"\n\
+         observe power(3)\n\
+         observe time(2)\n\
+         ? work(power, time)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 3 * 2 = 6, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"work\"") && s.contains("\"value\":6"),
+        "work(3, 2) = 6: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("phys.libretexts.org"),
+        "work carries its LibreTexts citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// time — the same definition solved for t: the work over the power, the third exact
+// reading of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_time_as_work_over_power_with_citation() {
+    let dir = scratch("t");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"power.adj\"\n\
+         observe work(6)\n\
+         observe power(3)\n\
+         ? time(work, power)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 6 / 3 = 2, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"time\"") && s.contains("\"value\":2"),
+        "time(6, 3) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("phys.libretexts.org"),
+        "time carries its LibreTexts citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/physics/power.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/power.adj
@@ -1,0 +1,94 @@
+% ============================================================================
+% power.adj — mechanical power (P = W/t) in the ADJ standard library.
+% ============================================================================
+% The power entry of the *physics* track, a sibling of `energy-work.adj`,
+% `wave-speed.adj` and `hookes-law.adj`: the foundational mechanics definition a first
+% course states as POWER IS THE RATE OF DOING WORK — i.e. the AVERAGE-power relation
+% P = W/t (work done divided by the time taken) — as an importable, byte-provenanced,
+% PARAMETERIZED `formula`, together with its two exact rearrangements (the work a
+% power delivers in a time, and the time a power takes to do a work). This is
+% MECHANICAL power (work per unit time); it is distinct from the electrical power
+% P = V·I in `electricity.adj`, and from `arithmetic/powers.adj` (exponentiation). As
+% with every compute library, a consumer states NO arithmetic: it `import`s this file,
+% binds the physical quantities from its own byte-provenance decomposition, and asks
+% the engine to APPLY the cited definition on the CPU. Zero math is performed by the
+% model; the engine computes each value EXACTLY, carrying the definition's citation.
+%
+%     import "power.adj"
+%     observe work(6)                % "…6 J of work…"  (span cited by the model)
+%     observe time(2)                % "…in 2 s…"       (span cited by the model)
+%     ? power(work, time)            % engine → 3, carrying P = W/t
+%
+% NOTE: this computes the AVERAGE power over the interval, P = W/t — the plain
+% work-over-time rate. (Instantaneous power is the same rate in the limit of a
+% vanishing interval; the exact numeric relation the engine applies over measured W
+% and t is P = W/t.)
+%
+% All three formulas are EXACT over their parameters — one a quotient, one a product,
+% one a quotient of measured quantities. There is no *separately grounded* physical
+% constant here, so every value the engine returns is exact. The three COMPOSE and
+% invert cleanly: the `power` a consumer computes from a work done in a time is exactly
+% the `power` the `work` formula multiplies by that time to recover the work, and
+% exactly the `power` the `time` formula divides that work by to recover the time.
+%
+%   power(work, time) = work / time     %  P = W/t   (definition of power)
+%   work(power, time) = power * time      %  W = P·t   (same definition, solved for W)
+%   time(work, power) = work / power      %  t = W/P   (same definition, solved for t)
+%
+% All three formulas are defended by the SAME definitional sentence — "Power is
+% defined as the rate of doing work, or the limit of the average power for time
+% intervals approaching zero." — because that definition (power IS the rate of doing
+% work, i.e. work per unit time) sanctions the relation read every way (P from W and
+% t, W from P and t, or t from W and P). The quote is transcribed verbatim from
+% Physics LibreTexts (OpenStax University Physics — a primary educational reference,
+% the same publisher `wave-speed.adj`, `hookes-law.adj`, `molarity.adj` and
+% `dilution.adj` cite), so each `formula` carries the provenance envelope every shipped
+% grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the sentence is a verbatim span of the cited page,
+% not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable physical quantity the definition ranges
+% over, and each result is the derived quantity. `power`, `work` and `time` each appear
+% BOTH as a derived result and as an input (of the other formulas), so each is a single
+% dictionary term used in both roles. The `surface` lists are the everyday names a
+% decomposer maps onto the canonical term; the trailing comment records the intended
+% SI unit.
+% ----------------------------------------------------------------------------
+dictionary power_vocab {
+    define work  : finding  surface "work", "energy", "W"       % work/energy, e.g. J
+    define time  : finding  surface "time", "duration", "t"     % time, e.g. s
+    define power : finding  surface "power", "P"                % power, e.g. W (watt)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable `let` over its
+% formal parameters, bound at apply time, and each carries the definitional quote from
+% LibreTexts (a quote is required on a shipped formula). One is a quotient, one a
+% product, one a quotient, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook power_laws {
+    use power_vocab
+
+    % Power — the work done divided by the time taken. LibreTexts defines power as the
+    % rate of doing work, i.e. P = W/t.
+    formula power(work, time) = work / time
+        source "Power is defined as the rate of doing work, or the limit of the average power for time intervals approaching zero."
+        locator "https://phys.libretexts.org/Bookshelves/University_Physics/University_Physics_(OpenStax)/Book:_University_Physics_I_-_Mechanics_Sound_Oscillations_and_Waves_(OpenStax)/07:_Work_and_Kinetic_Energy/7.05:_Power"
+        trust authoritative
+
+    % Work — the same definition solved for the work a power delivers in a time
+    % (W = P·t). Defended by the SAME definitional sentence, read the other way.
+    formula work(power, time) = power * time
+        source "Power is defined as the rate of doing work, or the limit of the average power for time intervals approaching zero."
+        locator "https://phys.libretexts.org/Bookshelves/University_Physics/University_Physics_(OpenStax)/Book:_University_Physics_I_-_Mechanics_Sound_Oscillations_and_Waves_(OpenStax)/07:_Work_and_Kinetic_Energy/7.05:_Power"
+        trust authoritative
+
+    % Time — the same definition solved for the time a power takes to do a work
+    % (t = W/P). Again the SAME definitional sentence, read the third way.
+    formula time(work, power) = work / power
+        source "Power is defined as the rate of doing work, or the limit of the average power for time intervals approaching zero."
+        locator "https://phys.libretexts.org/Bookshelves/University_Physics/University_Physics_(OpenStax)/Book:_University_Physics_I_-_Mechanics_Sound_Oscillations_and_Waves_(OpenStax)/07:_Work_and_Kinetic_Energy/7.05:_Power"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/physics/power.query.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/power.query.adj
@@ -1,0 +1,32 @@
+% ============================================================================
+% power.query.adj — worked examples over the physics power library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a power question: it
+% states NO arithmetic and NO definition — it only `import`s the grounded library,
+% `observe`s the measured quantities it decomposed from the prompt (each a
+% byte-provenanced span, elided here), and asks the engine to APPLY the cited
+% definition. The native adj-lang engine binds the parameters, computes each value
+% EXACTLY on the CPU, and returns it with the definition's source/locator/trust.
+%
+% The three questions INVERT: 6 J of work done in 2 s is a power of 3 W; that 3 W
+% power over the same 2 s is exactly what the work formula multiplies to recover the
+% 6 J, and that 6 J at the same 3 W is exactly what the time formula divides to
+% recover the 2 s.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli power.query.adj
+% ============================================================================
+
+import "power.adj"
+
+% 6 J of work done in 2 s: power = 6 / 2.
+observe work(6)
+observe time(2)
+? power(work, time)      % expect 3   (definition: P = W/t)
+
+% That 3 W power over the same 2 s: work = 3 * 2.
+observe power(3)
+? work(power, time)       % expect 6   (same definition, solved for W = P·t)
+
+% That 6 J of work at the same 3 W: time = 6 / 3.
+? time(work, power)       % expect 2   (same definition, solved for t = W/P)


### PR DESCRIPTION
## What

A new **Libraries** entry: mechanical (average) **power P = W/t** (power = work ÷ time) as an importable, byte-provenanced formula library, with its two exact rearrangements (W = P·t, t = W/P). Sibling of `energy-work.adj` / `wave-speed.adj` / `hookes-law.adj` in the physics track. Distinct from the *electrical* power P=V·I in `electricity.adj` and from `arithmetic/powers.adj` (exponentiation).

A consumer states **no arithmetic**: it imports the library, `observe`s the measured quantities, and the engine applies the cited definition on the CPU, exactly, carrying the citation into the `derived` section.

## The three readings (one definition, inverted)

| solve for | body | worked (W=6, t=2) |
|---|---|---|
| power | W / t | 6/2 = **3** |
| work | P · t | 3·2 = **6** |
| time | W / P | 6/3 = **2** |

Each is a product or quotient of measured quantities (no separately grounded constant), so every value is **exact**.

## Grounding

All three formulas are defended by the **same** definitional sentence, transcribed verbatim from Physics LibreTexts (OpenStax University Physics):

> "Power is defined as the rate of doing work, or the limit of the average power for time intervals approaching zero."

Power *is* the rate of doing work (work per unit time), so the definition sanctions the relation read all three ways. Grounded from **quotable prose**, not an image-only formula page. Locator: the [LibreTexts Power page](https://phys.libretexts.org/Bookshelves/University_Physics/University_Physics_(OpenStax)/Book:_University_Physics_I_-_Mechanics_Sound_Oscillations_and_Waves_(OpenStax)/07:_Work_and_Kinetic_Energy/7.05:_Power). This computes the **average** power over the interval, P = W/t.

## Changes

- **New:** `physics/power.adj` + `power.query.adj` (worked 3-way inverting example).
- **Test:** `formula_power_e2e.rs` — 3 tests, one per rearrangement, each asserting the exact value (3/6/2) + the `phys.libretexts.org` citation + `authoritative` trust. All pass. Shipped query verified through the CLI.

Data + test only — **no version bump** (no adj-lang crate source changed). Security review passed (no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)