### PR TITLE
feat(adj-formula-stdlib): acceleration-conversions — NIST SP 811 B.9 acceleration→m/s² exact factors (RS-5 table)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -541,6 +541,54 @@ fn shipped_force_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b11) Shipped table — reference/acceleration-conversions.adj resolves via import
+//       (acceleration unit → metres per second squared, EXACT SP 811 B.9 boldface
+//       factors, incl. the conventional standard gravity gₙ), and the SI unit itself
+//       (`metre_per_second_squared`) — which has no customary-conversion row — abstains.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_acceleration_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_accel");
+    let src = stdlib().join("reference/acceleration-conversions.adj");
+    std::fs::copy(&src, dir.join("acceleration-conversions.adj"))
+        .expect("copy shipped acceleration-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"acceleration-conversions.adj\"\n\
+         ? acceleration_to_metres_per_second_squared(free_fall_standard, $a)\n\
+         ? acceleration_to_metres_per_second_squared(foot_per_second_squared, $a)\n\
+         ? acceleration_to_metres_per_second_squared(gal, $a)\n\
+         ? acceleration_to_metres_per_second_squared(metre_per_second_squared, $a)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 "Acceleration" exact factors resolve, character-for-
+    // character from the table (boldface = exact; scientific notation to plain decimal).
+    assert!(
+        out.contains("\"a\":\"9.80665\""),
+        "standard acceleration of free fall gₙ = 9.80665 m/s²: {out}"
+    );
+    assert!(
+        out.contains("\"a\":\"0.3048\""),
+        "foot/second² = 0.3048 m/s²: {out}"
+    );
+    assert!(out.contains("\"a\":\"0.01\""), "gal = 0.01 m/s²: {out}");
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `metre_per_second_squared` is the SI unit itself, not a customary-conversion row
+    // — the engine abstains rather than fabricating a factor.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "the SI unit itself abstains, never a fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/acceleration-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/acceleration-conversions.adj
@@ -1,0 +1,65 @@
+% ============================================================================
+% acceleration-conversions — acceleration-unit → metre-per-second-squared factors
+% (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of `speed-conversions.adj` / `pressure-conversions.adj`: a
+% native tabular relation ingested VERBATIM from a published NIST conversion table.
+% Each row states the factor converting one acceleration unit to the SI unit of
+% acceleration, the metre per second squared (m/s²):
+%
+%     ? acceleration_to_metres_per_second_squared(free_fall_standard, $a) % 9.80665
+%     ? acceleration_to_metres_per_second_squared(gal, $a)                % 0.01  (a Gal)
+%
+% This is the next dimension after `speed-conversions.adj` (the time-derivative of
+% speed): where that table normalises a velocity given in customary units, this one
+% normalises an ACCELERATION. It pairs naturally with the mechanics libraries —
+% Newton's second law reads a force from a mass and an acceleration, and this table
+% puts that acceleration into SI first (write-once-use-many). Why a `table` and not
+% several hand-written `relate` clauses: this is exactly the shape reference data
+% comes in — a published table, not prose. The citable artifact IS the NIST
+% conversion-factors table at the `locator` below; every factor here is a CELL of NIST
+% Special Publication 811, Appendix B.9 ("Factors for units listed alphabetically"),
+% and the whole table is defended by one provenance envelope rather than repeating
+% `source`/`locator`/`trust` on every row. Each `row` lowers to a ground relation
+% `acceleration_to_metres_per_second_squared(unit, mpss)`, so the exact lookup above is
+% the ordinary SLD binding query — the engine returns the factor WITH this table's
+% citation as its proof, on the CPU, with zero model calls.
+%
+% HONESTY NOTE (like speed-conversions, these are EXACT defined factors, not rounded
+% ones): NIST SP 811 B.9 prints these four "Acceleration" factors in BOLDFACE, its
+% convention for factors that are EXACT by definition, transcribed here as the plain
+% decimal number of metres per second squared each unit names:
+%
+%     foot per second squared (ft/s²)             3.048    E-01  →  0.3048
+%     inch per second squared (in/s²)             2.54     E-02  →  0.0254
+%     gal (Gal)                                    1.0      E-02  →  0.01
+%     standard acceleration of free fall (gₙ)      9.806 65 E+00  →  9.80665
+%
+% These four are exact because the foot and inch are exact by definition (0.3048 m,
+% 0.0254 m) and the second is the SI base unit, so each ft/s² and in/s² factor is just
+% that exact length in metres; the gal is defined as exactly 10⁻² m/s² (1 cm/s²); and
+% the standard acceleration of free fall gₙ is FIXED by convention at exactly
+% 9.806 65 m/s² (the CGPM-adopted conventional value). Every factor therefore
+% terminates — nothing here is a rounded measurement. A unit NIST does NOT list among
+% these acceleration rows — e.g. the SI unit itself, the metre per second squared —
+% has no row, so a `? acceleration_to_metres_per_second_squared(metre_per_second_squared,
+% $a)` ABSTAINS rather than fabricating a factor. The only claim this table makes is
+% "these are the exact factors NIST SP 811 B.9 prints" — which is exactly what a
+% byte-check against the cited table verifies. `trust authoritative` — a primary,
+% re-fetchable standards reference. (See ADJ-TABLES.md; and
+% feedback_nothing_human_authored — every factor is a verbatim cell of the cited
+% table, nothing asserted from memory.)
+% ============================================================================
+
+table acceleration_to_metres_per_second_squared {
+    columns unit, mpss
+
+    row (foot_per_second_squared, 0.3048)
+    row (inch_per_second_squared, 0.0254)
+    row (gal, 0.01)
+    row (free_fall_standard, 9.80665)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/acceleration-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/acceleration-conversions.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% acceleration-conversions.query.adj — a worked lookup over the acceleration table.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a "how many metres per
+% second squared is one g?" question: it states no conversion fact — it only `import`s
+% the grounded table and asks binding queries. The native adj-lang engine resolves each
+% `?` against the table's rows (lowered to
+% `acceleration_to_metres_per_second_squared` relations) and returns the binding + the
+% table's source/locator/trust. A unit not in the table abstains honestly — the engine
+% never invents a factor (notably the SI unit itself, the metre per second squared,
+% which has no customary-conversion row).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli acceleration-conversions.query.adj
+% ============================================================================
+
+import "acceleration-conversions.adj"
+
+? acceleration_to_metres_per_second_squared(free_fall_standard, $a)         % expect 9.80665
+? acceleration_to_metres_per_second_squared(foot_per_second_squared, $a)    % expect 0.3048
+? acceleration_to_metres_per_second_squared(gal, $a)                        % expect 0.01
+? acceleration_to_metres_per_second_squared(metre_per_second_squared, $a)   % expect abstain — SI unit, not a row


### PR DESCRIPTION
## What

Adds a `table` (ADJ-TABLES RS-5) of the **acceleration-unit → metre-per-second-squared** conversion factors, ingested verbatim from **NIST Special Publication 811, Appendix B.9** ("Factors for units listed alphabetically"). Ships only the factors NIST prints in **boldface** — its convention for factors that are **exact by definition**:

| unit | NIST factor | m/s² |
|------|-------------|------|
| foot per second squared (ft/s²) | 3.048 E-01 | `0.3048` |
| inch per second squared (in/s²) | 2.54 E-02 | `0.0254` |
| gal (Gal) | 1.0 E-02 | `0.01` |
| standard acceleration of free fall (gₙ) | 9.806 65 E+00 | `9.80665` |

Each is exact: ft/s² and in/s² are the exact defined length (0.3048 m, 0.0254 m) per second squared; the gal is defined as exactly 10⁻² m/s²; and gₙ is the CGPM-adopted conventional value, fixed at exactly 9.806 65 m/s². The SI unit itself (`metre_per_second_squared`) has **no customary-conversion row**, so a lookup for it **abstains** rather than fabricating a factor.

## Why

This is the next dimension after `speed-conversions` (the time-derivative of speed) and rounds out the kinematic-unit conversion set alongside length/time/speed. It pairs with the mechanics libraries — a force read from a mass and an acceleration first normalises that acceleration to SI via this table (write-once-use-many).

## How it works

Data + test only — **no engine/version change**. Each `row` lowers to the ground relation `acceleration_to_metres_per_second_squared(unit, mpss)`, so exact lookup is the existing SLD binding query; the engine returns the factor **with the table's NIST citation** as its proof, on the CPU, with zero model calls. The whole table is defended by one provenance envelope (`source`/`locator`/`trust authoritative`).

## Files
- `reference/acceleration-conversions.adj` — the grounded NIST table (4 exact rows)
- `reference/acceleration-conversions.query.adj` — worked lookup (3 hits + 1 honest abstain)
- `rs5_table_e2e.rs` — `shipped_acceleration_conversions_table_resolves_and_abstains` (b10)

## Verification
- `cargo test -p adj-lang-cli --test rs5_table_e2e shipped_acceleration` → 1 passed
- Ran the shipped `.query.adj` through the built CLI: 9.80665 / 0.3048 / 0.01 resolve exactly; the SI unit abstains (`"abstained":true`)
- Every factor byte-verified against the cited NIST SP 811 B.9 page
- Security review passed (data + test only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)