### PR TITLE
feat(hl03): full Dravidian vowel row — ai, au & vocalic R (HL03 syllabary PR3)

### DIFF
--- a/code/learning/human-languages/data/scripts/generate_syllabary.py
+++ b/code/learning/human-languages/data/scripts/generate_syllabary.py
@@ -47,11 +47,21 @@ CONSONANTS = [
 # The Dravidian core vowel set (short + long e/o — the distinction is phonemic in
 # these languages). The empty key is the inherent /a/ (the bare consonant).
 # Keyed on the Unicode vowel-sign token ("<SCRIPT> VOWEL SIGN <V>"); the roman is
-# the vowel added AFTER the consonant root. `ai/au/ṛ` etc. are left for later.
+# the vowel added AFTER the consonant root.
+#
+# The first ten are the core row; then the two diphthongs (ai, au) and the vocalic
+# R that Sanskrit-derived words carry (కృ = kr̥, as in కృష్ణ *kr̥ṣṇa* "Krishna").
+# NOTE on the vocalic R romanization: ISO-15919 — which this whole file follows —
+# writes it "r̥", a plain r with a COMBINING RING BELOW (U+0325), NOT the dot-below
+# "ṛ" of IAST (that dot-below form is ISO-15919's *retroflex* ṛ, a different sound,
+# so using it here would be wrong). No precomposed "r-with-ring-below" exists in
+# Unicode, so it is the two code points r + ◌̥ by construction. The rarer vocalic
+# RR / L / LL signs exist too but are archaic; they are left for a later slice.
 VOWELS = [
     ("", "a"),      # inherent — no sign
     ("AA", "ā"), ("I", "i"), ("II", "ī"), ("U", "u"), ("UU", "ū"),
     ("E", "e"), ("EE", "ē"), ("O", "o"), ("OO", "ō"),
+    ("AI", "ai"), ("AU", "au"), ("VOCALIC R", "r̥"),
 ]
 
 # The three scripts: (script id, display name, Unicode block base, the Noto face

--- a/code/learning/human-languages/data/scripts/kannada.json
+++ b/code/learning/human-languages/data/scripts/kannada.json
@@ -128,6 +128,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ಕೈ",
+      "sound": "kai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಕ  ka — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಕೌ",
+      "sound": "kau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಕ  ka — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಕೃ",
+      "sound": "kr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಕ  ka — base consonant",
+        "ೃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ಖ",
       "sound": "kha",
       "role": "syllable",
@@ -242,6 +278,42 @@
       "components": [
         "ಖ  kha — base consonant",
         "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಖೈ",
+      "sound": "khai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಖ  kha — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಖೌ",
+      "sound": "khau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಖ  kha — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಖೃ",
+      "sound": "khr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಖ  kha — base consonant",
+        "ೃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -366,6 +438,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ಗೈ",
+      "sound": "gai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಗ  ga — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಗೌ",
+      "sound": "gau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಗ  ga — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಗೃ",
+      "sound": "gr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಗ  ga — base consonant",
+        "ೃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ಘ",
       "sound": "gha",
       "role": "syllable",
@@ -480,6 +588,42 @@
       "components": [
         "ಘ  gha — base consonant",
         "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಘೈ",
+      "sound": "ghai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಘ  gha — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಘೌ",
+      "sound": "ghau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಘ  gha — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಘೃ",
+      "sound": "ghr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಘ  gha — base consonant",
+        "ೃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -604,6 +748,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ಙೈ",
+      "sound": "ṅai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಙ  ṅa — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಙೌ",
+      "sound": "ṅau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಙ  ṅa — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಙೃ",
+      "sound": "ṅr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಙ  ṅa — base consonant",
+        "ೃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ಚ",
       "sound": "ca",
       "role": "syllable",
@@ -718,6 +898,42 @@
       "components": [
         "ಚ  ca — base consonant",
         "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಚೈ",
+      "sound": "cai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಚ  ca — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಚೌ",
+      "sound": "cau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಚ  ca — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಚೃ",
+      "sound": "cr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಚ  ca — base consonant",
+        "ೃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -842,6 +1058,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ಛೈ",
+      "sound": "chai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಛ  cha — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಛೌ",
+      "sound": "chau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಛ  cha — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಛೃ",
+      "sound": "chr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಛ  cha — base consonant",
+        "ೃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ಜ",
       "sound": "ja",
       "role": "syllable",
@@ -956,6 +1208,42 @@
       "components": [
         "ಜ  ja — base consonant",
         "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಜೈ",
+      "sound": "jai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಜ  ja — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಜೌ",
+      "sound": "jau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಜ  ja — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಜೃ",
+      "sound": "jr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಜ  ja — base consonant",
+        "ೃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -1080,6 +1368,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ಝೈ",
+      "sound": "jhai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಝ  jha — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಝೌ",
+      "sound": "jhau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಝ  jha — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಝೃ",
+      "sound": "jhr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಝ  jha — base consonant",
+        "ೃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ಞ",
       "sound": "ña",
       "role": "syllable",
@@ -1194,6 +1518,42 @@
       "components": [
         "ಞ  ña — base consonant",
         "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಞೈ",
+      "sound": "ñai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಞ  ña — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಞೌ",
+      "sound": "ñau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಞ  ña — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಞೃ",
+      "sound": "ñr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಞ  ña — base consonant",
+        "ೃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -1318,6 +1678,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ಟೈ",
+      "sound": "ṭai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಟ  ṭa — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಟೌ",
+      "sound": "ṭau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಟ  ṭa — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಟೃ",
+      "sound": "ṭr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಟ  ṭa — base consonant",
+        "ೃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ಠ",
       "sound": "ṭha",
       "role": "syllable",
@@ -1432,6 +1828,42 @@
       "components": [
         "ಠ  ṭha — base consonant",
         "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಠೈ",
+      "sound": "ṭhai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಠ  ṭha — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಠೌ",
+      "sound": "ṭhau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಠ  ṭha — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಠೃ",
+      "sound": "ṭhr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಠ  ṭha — base consonant",
+        "ೃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -1556,6 +1988,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ಡೈ",
+      "sound": "ḍai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಡ  ḍa — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಡೌ",
+      "sound": "ḍau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಡ  ḍa — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಡೃ",
+      "sound": "ḍr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಡ  ḍa — base consonant",
+        "ೃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ಢ",
       "sound": "ḍha",
       "role": "syllable",
@@ -1670,6 +2138,42 @@
       "components": [
         "ಢ  ḍha — base consonant",
         "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಢೈ",
+      "sound": "ḍhai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಢ  ḍha — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಢೌ",
+      "sound": "ḍhau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಢ  ḍha — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಢೃ",
+      "sound": "ḍhr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಢ  ḍha — base consonant",
+        "ೃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -1794,6 +2298,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ಣೈ",
+      "sound": "ṇai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಣ  ṇa — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಣೌ",
+      "sound": "ṇau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಣ  ṇa — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಣೃ",
+      "sound": "ṇr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಣ  ṇa — base consonant",
+        "ೃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ತ",
       "sound": "ta",
       "role": "syllable",
@@ -1908,6 +2448,42 @@
       "components": [
         "ತ  ta — base consonant",
         "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ತೈ",
+      "sound": "tai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ತ  ta — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ತೌ",
+      "sound": "tau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ತ  ta — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ತೃ",
+      "sound": "tr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ತ  ta — base consonant",
+        "ೃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -2032,6 +2608,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ಥೈ",
+      "sound": "thai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಥ  tha — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಥೌ",
+      "sound": "thau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಥ  tha — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಥೃ",
+      "sound": "thr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಥ  tha — base consonant",
+        "ೃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ದ",
       "sound": "da",
       "role": "syllable",
@@ -2146,6 +2758,42 @@
       "components": [
         "ದ  da — base consonant",
         "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ದೈ",
+      "sound": "dai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ದ  da — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ದೌ",
+      "sound": "dau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ದ  da — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ದೃ",
+      "sound": "dr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ದ  da — base consonant",
+        "ೃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -2270,6 +2918,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ಧೈ",
+      "sound": "dhai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಧ  dha — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಧೌ",
+      "sound": "dhau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಧ  dha — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಧೃ",
+      "sound": "dhr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಧ  dha — base consonant",
+        "ೃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ನ",
       "sound": "na",
       "role": "syllable",
@@ -2384,6 +3068,42 @@
       "components": [
         "ನ  na — base consonant",
         "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ನೈ",
+      "sound": "nai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ನ  na — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ನೌ",
+      "sound": "nau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ನ  na — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ನೃ",
+      "sound": "nr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ನ  na — base consonant",
+        "ೃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -2508,6 +3228,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ಪೈ",
+      "sound": "pai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಪ  pa — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಪೌ",
+      "sound": "pau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಪ  pa — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಪೃ",
+      "sound": "pr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಪ  pa — base consonant",
+        "ೃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ಫ",
       "sound": "pha",
       "role": "syllable",
@@ -2622,6 +3378,42 @@
       "components": [
         "ಫ  pha — base consonant",
         "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಫೈ",
+      "sound": "phai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಫ  pha — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಫೌ",
+      "sound": "phau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಫ  pha — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಫೃ",
+      "sound": "phr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಫ  pha — base consonant",
+        "ೃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -2746,6 +3538,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ಬೈ",
+      "sound": "bai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಬ  ba — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಬೌ",
+      "sound": "bau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಬ  ba — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಬೃ",
+      "sound": "br̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಬ  ba — base consonant",
+        "ೃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ಭ",
       "sound": "bha",
       "role": "syllable",
@@ -2860,6 +3688,42 @@
       "components": [
         "ಭ  bha — base consonant",
         "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಭೈ",
+      "sound": "bhai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಭ  bha — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಭೌ",
+      "sound": "bhau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಭ  bha — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಭೃ",
+      "sound": "bhr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಭ  bha — base consonant",
+        "ೃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -2984,6 +3848,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ಮೈ",
+      "sound": "mai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಮ  ma — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಮೌ",
+      "sound": "mau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಮ  ma — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಮೃ",
+      "sound": "mr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಮ  ma — base consonant",
+        "ೃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ಯ",
       "sound": "ya",
       "role": "syllable",
@@ -3098,6 +3998,42 @@
       "components": [
         "ಯ  ya — base consonant",
         "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಯೈ",
+      "sound": "yai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಯ  ya — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಯೌ",
+      "sound": "yau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಯ  ya — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಯೃ",
+      "sound": "yr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಯ  ya — base consonant",
+        "ೃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -3222,6 +4158,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ರೈ",
+      "sound": "rai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ರ  ra — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ರೌ",
+      "sound": "rau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ರ  ra — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ರೃ",
+      "sound": "rr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ರ  ra — base consonant",
+        "ೃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ಲ",
       "sound": "la",
       "role": "syllable",
@@ -3336,6 +4308,42 @@
       "components": [
         "ಲ  la — base consonant",
         "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಲೈ",
+      "sound": "lai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಲ  la — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಲೌ",
+      "sound": "lau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಲ  la — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಲೃ",
+      "sound": "lr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಲ  la — base consonant",
+        "ೃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -3460,6 +4468,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ವೈ",
+      "sound": "vai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ವ  va — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ವೌ",
+      "sound": "vau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ವ  va — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ವೃ",
+      "sound": "vr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ವ  va — base consonant",
+        "ೃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ಶ",
       "sound": "śa",
       "role": "syllable",
@@ -3574,6 +4618,42 @@
       "components": [
         "ಶ  śa — base consonant",
         "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಶೈ",
+      "sound": "śai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಶ  śa — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಶೌ",
+      "sound": "śau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಶ  śa — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಶೃ",
+      "sound": "śr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಶ  śa — base consonant",
+        "ೃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -3698,6 +4778,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ಷೈ",
+      "sound": "ṣai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಷ  ṣa — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಷೌ",
+      "sound": "ṣau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಷ  ṣa — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಷೃ",
+      "sound": "ṣr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಷ  ṣa — base consonant",
+        "ೃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ಸ",
       "sound": "sa",
       "role": "syllable",
@@ -3812,6 +4928,42 @@
       "components": [
         "ಸ  sa — base consonant",
         "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಸೈ",
+      "sound": "sai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಸ  sa — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಸೌ",
+      "sound": "sau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಸ  sa — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಸೃ",
+      "sound": "sr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಸ  sa — base consonant",
+        "ೃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -3936,6 +5088,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ಹೈ",
+      "sound": "hai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಹ  ha — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಹೌ",
+      "sound": "hau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಹ  ha — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಹೃ",
+      "sound": "hr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಹ  ha — base consonant",
+        "ೃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ಳ",
       "sound": "ḷa",
       "role": "syllable",
@@ -4055,6 +5243,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ಳೈ",
+      "sound": "ḷai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಳ  ḷa — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಳೌ",
+      "sound": "ḷau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಳ  ḷa — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಳೃ",
+      "sound": "ḷr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಳ  ḷa — base consonant",
+        "ೃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ಱ",
       "sound": "ṟa",
       "role": "syllable",
@@ -4169,6 +5393,42 @@
       "components": [
         "ಱ  ṟa — base consonant",
         "ೋ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಱೈ",
+      "sound": "ṟai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಱ  ṟa — base consonant",
+        "ೈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಱೌ",
+      "sound": "ṟau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಱ  ṟa — base consonant",
+        "ೌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಱೃ",
+      "sound": "ṟr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ಱ  ṟa — base consonant",
+        "ೃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""

--- a/code/learning/human-languages/data/scripts/malayalam.json
+++ b/code/learning/human-languages/data/scripts/malayalam.json
@@ -128,6 +128,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "കൈ",
+      "sound": "kai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ക  ka — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "കൌ",
+      "sound": "kau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ക  ka — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "കൃ",
+      "sound": "kr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ക  ka — base consonant",
+        "ൃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ഖ",
       "sound": "kha",
       "role": "syllable",
@@ -242,6 +278,42 @@
       "components": [
         "ഖ  kha — base consonant",
         "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഖൈ",
+      "sound": "khai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഖ  kha — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഖൌ",
+      "sound": "khau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഖ  kha — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഖൃ",
+      "sound": "khr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഖ  kha — base consonant",
+        "ൃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -366,6 +438,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ഗൈ",
+      "sound": "gai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഗ  ga — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഗൌ",
+      "sound": "gau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഗ  ga — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഗൃ",
+      "sound": "gr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഗ  ga — base consonant",
+        "ൃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ഘ",
       "sound": "gha",
       "role": "syllable",
@@ -480,6 +588,42 @@
       "components": [
         "ഘ  gha — base consonant",
         "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഘൈ",
+      "sound": "ghai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഘ  gha — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഘൌ",
+      "sound": "ghau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഘ  gha — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഘൃ",
+      "sound": "ghr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഘ  gha — base consonant",
+        "ൃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -604,6 +748,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ങൈ",
+      "sound": "ṅai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ങ  ṅa — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ങൌ",
+      "sound": "ṅau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ങ  ṅa — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ങൃ",
+      "sound": "ṅr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ങ  ṅa — base consonant",
+        "ൃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ച",
       "sound": "ca",
       "role": "syllable",
@@ -718,6 +898,42 @@
       "components": [
         "ച  ca — base consonant",
         "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ചൈ",
+      "sound": "cai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ച  ca — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ചൌ",
+      "sound": "cau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ച  ca — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ചൃ",
+      "sound": "cr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ച  ca — base consonant",
+        "ൃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -842,6 +1058,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ഛൈ",
+      "sound": "chai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഛ  cha — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഛൌ",
+      "sound": "chau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഛ  cha — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഛൃ",
+      "sound": "chr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഛ  cha — base consonant",
+        "ൃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ജ",
       "sound": "ja",
       "role": "syllable",
@@ -956,6 +1208,42 @@
       "components": [
         "ജ  ja — base consonant",
         "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ജൈ",
+      "sound": "jai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ജ  ja — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ജൌ",
+      "sound": "jau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ജ  ja — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ജൃ",
+      "sound": "jr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ജ  ja — base consonant",
+        "ൃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -1080,6 +1368,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ഝൈ",
+      "sound": "jhai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഝ  jha — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഝൌ",
+      "sound": "jhau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഝ  jha — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഝൃ",
+      "sound": "jhr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഝ  jha — base consonant",
+        "ൃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ഞ",
       "sound": "ña",
       "role": "syllable",
@@ -1194,6 +1518,42 @@
       "components": [
         "ഞ  ña — base consonant",
         "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഞൈ",
+      "sound": "ñai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഞ  ña — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഞൌ",
+      "sound": "ñau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഞ  ña — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഞൃ",
+      "sound": "ñr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഞ  ña — base consonant",
+        "ൃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -1318,6 +1678,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ടൈ",
+      "sound": "ṭai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ട  ṭa — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ടൌ",
+      "sound": "ṭau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ട  ṭa — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ടൃ",
+      "sound": "ṭr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ട  ṭa — base consonant",
+        "ൃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ഠ",
       "sound": "ṭha",
       "role": "syllable",
@@ -1432,6 +1828,42 @@
       "components": [
         "ഠ  ṭha — base consonant",
         "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഠൈ",
+      "sound": "ṭhai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഠ  ṭha — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഠൌ",
+      "sound": "ṭhau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഠ  ṭha — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഠൃ",
+      "sound": "ṭhr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഠ  ṭha — base consonant",
+        "ൃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -1556,6 +1988,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ഡൈ",
+      "sound": "ḍai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഡ  ḍa — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഡൌ",
+      "sound": "ḍau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഡ  ḍa — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഡൃ",
+      "sound": "ḍr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഡ  ḍa — base consonant",
+        "ൃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ഢ",
       "sound": "ḍha",
       "role": "syllable",
@@ -1670,6 +2138,42 @@
       "components": [
         "ഢ  ḍha — base consonant",
         "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഢൈ",
+      "sound": "ḍhai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഢ  ḍha — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഢൌ",
+      "sound": "ḍhau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഢ  ḍha — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഢൃ",
+      "sound": "ḍhr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഢ  ḍha — base consonant",
+        "ൃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -1794,6 +2298,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ണൈ",
+      "sound": "ṇai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ണ  ṇa — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ണൌ",
+      "sound": "ṇau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ണ  ṇa — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ണൃ",
+      "sound": "ṇr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ണ  ṇa — base consonant",
+        "ൃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ത",
       "sound": "ta",
       "role": "syllable",
@@ -1908,6 +2448,42 @@
       "components": [
         "ത  ta — base consonant",
         "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "തൈ",
+      "sound": "tai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ത  ta — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "തൌ",
+      "sound": "tau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ത  ta — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "തൃ",
+      "sound": "tr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ത  ta — base consonant",
+        "ൃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -2032,6 +2608,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ഥൈ",
+      "sound": "thai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഥ  tha — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഥൌ",
+      "sound": "thau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഥ  tha — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഥൃ",
+      "sound": "thr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഥ  tha — base consonant",
+        "ൃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ദ",
       "sound": "da",
       "role": "syllable",
@@ -2146,6 +2758,42 @@
       "components": [
         "ദ  da — base consonant",
         "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ദൈ",
+      "sound": "dai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ദ  da — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ദൌ",
+      "sound": "dau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ദ  da — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ദൃ",
+      "sound": "dr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ദ  da — base consonant",
+        "ൃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -2270,6 +2918,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ധൈ",
+      "sound": "dhai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ധ  dha — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ധൌ",
+      "sound": "dhau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ധ  dha — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ധൃ",
+      "sound": "dhr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ധ  dha — base consonant",
+        "ൃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ന",
       "sound": "na",
       "role": "syllable",
@@ -2384,6 +3068,42 @@
       "components": [
         "ന  na — base consonant",
         "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "നൈ",
+      "sound": "nai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ന  na — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "നൌ",
+      "sound": "nau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ന  na — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "നൃ",
+      "sound": "nr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ന  na — base consonant",
+        "ൃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -2508,6 +3228,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "പൈ",
+      "sound": "pai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "പ  pa — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "പൌ",
+      "sound": "pau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "പ  pa — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "പൃ",
+      "sound": "pr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "പ  pa — base consonant",
+        "ൃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ഫ",
       "sound": "pha",
       "role": "syllable",
@@ -2622,6 +3378,42 @@
       "components": [
         "ഫ  pha — base consonant",
         "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഫൈ",
+      "sound": "phai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഫ  pha — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഫൌ",
+      "sound": "phau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഫ  pha — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഫൃ",
+      "sound": "phr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഫ  pha — base consonant",
+        "ൃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -2746,6 +3538,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ബൈ",
+      "sound": "bai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ബ  ba — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ബൌ",
+      "sound": "bau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ബ  ba — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ബൃ",
+      "sound": "br̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ബ  ba — base consonant",
+        "ൃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ഭ",
       "sound": "bha",
       "role": "syllable",
@@ -2860,6 +3688,42 @@
       "components": [
         "ഭ  bha — base consonant",
         "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഭൈ",
+      "sound": "bhai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഭ  bha — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഭൌ",
+      "sound": "bhau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഭ  bha — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഭൃ",
+      "sound": "bhr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഭ  bha — base consonant",
+        "ൃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -2984,6 +3848,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "മൈ",
+      "sound": "mai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "മ  ma — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "മൌ",
+      "sound": "mau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "മ  ma — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "മൃ",
+      "sound": "mr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "മ  ma — base consonant",
+        "ൃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "യ",
       "sound": "ya",
       "role": "syllable",
@@ -3098,6 +3998,42 @@
       "components": [
         "യ  ya — base consonant",
         "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "യൈ",
+      "sound": "yai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "യ  ya — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "യൌ",
+      "sound": "yau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "യ  ya — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "യൃ",
+      "sound": "yr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "യ  ya — base consonant",
+        "ൃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -3222,6 +4158,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "രൈ",
+      "sound": "rai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ര  ra — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "രൌ",
+      "sound": "rau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ര  ra — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "രൃ",
+      "sound": "rr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ര  ra — base consonant",
+        "ൃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ല",
       "sound": "la",
       "role": "syllable",
@@ -3336,6 +4308,42 @@
       "components": [
         "ല  la — base consonant",
         "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ലൈ",
+      "sound": "lai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ല  la — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ലൌ",
+      "sound": "lau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ല  la — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ലൃ",
+      "sound": "lr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ല  la — base consonant",
+        "ൃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -3460,6 +4468,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "വൈ",
+      "sound": "vai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "വ  va — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "വൌ",
+      "sound": "vau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "വ  va — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "വൃ",
+      "sound": "vr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "വ  va — base consonant",
+        "ൃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ശ",
       "sound": "śa",
       "role": "syllable",
@@ -3574,6 +4618,42 @@
       "components": [
         "ശ  śa — base consonant",
         "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ശൈ",
+      "sound": "śai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ശ  śa — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ശൌ",
+      "sound": "śau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ശ  śa — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ശൃ",
+      "sound": "śr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ശ  śa — base consonant",
+        "ൃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -3698,6 +4778,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ഷൈ",
+      "sound": "ṣai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഷ  ṣa — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഷൌ",
+      "sound": "ṣau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഷ  ṣa — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഷൃ",
+      "sound": "ṣr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഷ  ṣa — base consonant",
+        "ൃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "സ",
       "sound": "sa",
       "role": "syllable",
@@ -3812,6 +4928,42 @@
       "components": [
         "സ  sa — base consonant",
         "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "സൈ",
+      "sound": "sai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "സ  sa — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "സൌ",
+      "sound": "sau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "സ  sa — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "സൃ",
+      "sound": "sr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "സ  sa — base consonant",
+        "ൃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -3936,6 +5088,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ഹൈ",
+      "sound": "hai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഹ  ha — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഹൌ",
+      "sound": "hau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഹ  ha — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഹൃ",
+      "sound": "hr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഹ  ha — base consonant",
+        "ൃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ള",
       "sound": "ḷa",
       "role": "syllable",
@@ -4050,6 +5238,42 @@
       "components": [
         "ള  ḷa — base consonant",
         "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ളൈ",
+      "sound": "ḷai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ള  ḷa — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ളൌ",
+      "sound": "ḷau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ള  ḷa — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ളൃ",
+      "sound": "ḷr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ള  ḷa — base consonant",
+        "ൃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -4174,6 +5398,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "റൈ",
+      "sound": "ṟai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "റ  ṟa — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "റൌ",
+      "sound": "ṟau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "റ  ṟa — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "റൃ",
+      "sound": "ṟr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "റ  ṟa — base consonant",
+        "ൃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ഩ",
       "sound": "ṉa",
       "role": "syllable",
@@ -4288,6 +5548,42 @@
       "components": [
         "ഩ  ṉa — base consonant",
         "ോ  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഩൈ",
+      "sound": "ṉai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഩ  ṉa — base consonant",
+        "ൈ  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഩൌ",
+      "sound": "ṉau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഩ  ṉa — base consonant",
+        "ൌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഩൃ",
+      "sound": "ṉr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ഩ  ṉa — base consonant",
+        "ൃ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""

--- a/code/learning/human-languages/data/scripts/telugu.json
+++ b/code/learning/human-languages/data/scripts/telugu.json
@@ -128,6 +128,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "కై",
+      "sound": "kai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "క  ka — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "కౌ",
+      "sound": "kau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "క  ka — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "కృ",
+      "sound": "kr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "క  ka — base consonant",
+        "ృ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ఖ",
       "sound": "kha",
       "role": "syllable",
@@ -242,6 +278,42 @@
       "components": [
         "ఖ  kha — base consonant",
         "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఖై",
+      "sound": "khai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఖ  kha — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఖౌ",
+      "sound": "khau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఖ  kha — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఖృ",
+      "sound": "khr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఖ  kha — base consonant",
+        "ృ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -366,6 +438,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "గై",
+      "sound": "gai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "గ  ga — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "గౌ",
+      "sound": "gau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "గ  ga — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "గృ",
+      "sound": "gr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "గ  ga — base consonant",
+        "ృ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ఘ",
       "sound": "gha",
       "role": "syllable",
@@ -480,6 +588,42 @@
       "components": [
         "ఘ  gha — base consonant",
         "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఘై",
+      "sound": "ghai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఘ  gha — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఘౌ",
+      "sound": "ghau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఘ  gha — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఘృ",
+      "sound": "ghr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఘ  gha — base consonant",
+        "ృ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -604,6 +748,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ఙై",
+      "sound": "ṅai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఙ  ṅa — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఙౌ",
+      "sound": "ṅau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఙ  ṅa — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఙృ",
+      "sound": "ṅr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఙ  ṅa — base consonant",
+        "ృ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "చ",
       "sound": "ca",
       "role": "syllable",
@@ -718,6 +898,42 @@
       "components": [
         "చ  ca — base consonant",
         "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "చై",
+      "sound": "cai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "చ  ca — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "చౌ",
+      "sound": "cau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "చ  ca — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "చృ",
+      "sound": "cr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "చ  ca — base consonant",
+        "ృ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -842,6 +1058,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ఛై",
+      "sound": "chai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఛ  cha — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఛౌ",
+      "sound": "chau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఛ  cha — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఛృ",
+      "sound": "chr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఛ  cha — base consonant",
+        "ృ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "జ",
       "sound": "ja",
       "role": "syllable",
@@ -956,6 +1208,42 @@
       "components": [
         "జ  ja — base consonant",
         "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "జై",
+      "sound": "jai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "జ  ja — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "జౌ",
+      "sound": "jau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "జ  ja — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "జృ",
+      "sound": "jr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "జ  ja — base consonant",
+        "ృ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -1080,6 +1368,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ఝై",
+      "sound": "jhai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఝ  jha — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఝౌ",
+      "sound": "jhau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఝ  jha — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఝృ",
+      "sound": "jhr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఝ  jha — base consonant",
+        "ృ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ఞ",
       "sound": "ña",
       "role": "syllable",
@@ -1194,6 +1518,42 @@
       "components": [
         "ఞ  ña — base consonant",
         "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఞై",
+      "sound": "ñai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఞ  ña — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఞౌ",
+      "sound": "ñau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఞ  ña — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఞృ",
+      "sound": "ñr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఞ  ña — base consonant",
+        "ృ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -1318,6 +1678,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "టై",
+      "sound": "ṭai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ట  ṭa — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "టౌ",
+      "sound": "ṭau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ట  ṭa — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "టృ",
+      "sound": "ṭr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ట  ṭa — base consonant",
+        "ృ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ఠ",
       "sound": "ṭha",
       "role": "syllable",
@@ -1432,6 +1828,42 @@
       "components": [
         "ఠ  ṭha — base consonant",
         "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఠై",
+      "sound": "ṭhai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఠ  ṭha — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఠౌ",
+      "sound": "ṭhau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఠ  ṭha — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఠృ",
+      "sound": "ṭhr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఠ  ṭha — base consonant",
+        "ృ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -1556,6 +1988,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "డై",
+      "sound": "ḍai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "డ  ḍa — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "డౌ",
+      "sound": "ḍau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "డ  ḍa — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "డృ",
+      "sound": "ḍr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "డ  ḍa — base consonant",
+        "ృ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ఢ",
       "sound": "ḍha",
       "role": "syllable",
@@ -1670,6 +2138,42 @@
       "components": [
         "ఢ  ḍha — base consonant",
         "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఢై",
+      "sound": "ḍhai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఢ  ḍha — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఢౌ",
+      "sound": "ḍhau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఢ  ḍha — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఢృ",
+      "sound": "ḍhr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఢ  ḍha — base consonant",
+        "ృ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -1794,6 +2298,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ణై",
+      "sound": "ṇai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ణ  ṇa — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ణౌ",
+      "sound": "ṇau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ణ  ṇa — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ణృ",
+      "sound": "ṇr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ణ  ṇa — base consonant",
+        "ృ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "త",
       "sound": "ta",
       "role": "syllable",
@@ -1908,6 +2448,42 @@
       "components": [
         "త  ta — base consonant",
         "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "తై",
+      "sound": "tai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "త  ta — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "తౌ",
+      "sound": "tau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "త  ta — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "తృ",
+      "sound": "tr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "త  ta — base consonant",
+        "ృ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -2032,6 +2608,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "థై",
+      "sound": "thai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "థ  tha — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "థౌ",
+      "sound": "thau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "థ  tha — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "థృ",
+      "sound": "thr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "థ  tha — base consonant",
+        "ృ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ద",
       "sound": "da",
       "role": "syllable",
@@ -2146,6 +2758,42 @@
       "components": [
         "ద  da — base consonant",
         "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "దై",
+      "sound": "dai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ద  da — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "దౌ",
+      "sound": "dau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ద  da — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "దృ",
+      "sound": "dr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ద  da — base consonant",
+        "ృ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -2270,6 +2918,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ధై",
+      "sound": "dhai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ధ  dha — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ధౌ",
+      "sound": "dhau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ధ  dha — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ధృ",
+      "sound": "dhr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ధ  dha — base consonant",
+        "ృ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "న",
       "sound": "na",
       "role": "syllable",
@@ -2384,6 +3068,42 @@
       "components": [
         "న  na — base consonant",
         "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "నై",
+      "sound": "nai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "న  na — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "నౌ",
+      "sound": "nau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "న  na — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "నృ",
+      "sound": "nr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "న  na — base consonant",
+        "ృ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -2508,6 +3228,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "పై",
+      "sound": "pai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ప  pa — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "పౌ",
+      "sound": "pau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ప  pa — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "పృ",
+      "sound": "pr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ప  pa — base consonant",
+        "ృ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ఫ",
       "sound": "pha",
       "role": "syllable",
@@ -2622,6 +3378,42 @@
       "components": [
         "ఫ  pha — base consonant",
         "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఫై",
+      "sound": "phai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఫ  pha — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఫౌ",
+      "sound": "phau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఫ  pha — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఫృ",
+      "sound": "phr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఫ  pha — base consonant",
+        "ృ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -2746,6 +3538,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "బై",
+      "sound": "bai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "బ  ba — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "బౌ",
+      "sound": "bau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "బ  ba — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "బృ",
+      "sound": "br̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "బ  ba — base consonant",
+        "ృ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "భ",
       "sound": "bha",
       "role": "syllable",
@@ -2860,6 +3688,42 @@
       "components": [
         "భ  bha — base consonant",
         "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "భై",
+      "sound": "bhai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "భ  bha — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "భౌ",
+      "sound": "bhau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "భ  bha — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "భృ",
+      "sound": "bhr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "భ  bha — base consonant",
+        "ృ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -2984,6 +3848,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "మై",
+      "sound": "mai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "మ  ma — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "మౌ",
+      "sound": "mau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "మ  ma — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "మృ",
+      "sound": "mr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "మ  ma — base consonant",
+        "ృ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "య",
       "sound": "ya",
       "role": "syllable",
@@ -3098,6 +3998,42 @@
       "components": [
         "య  ya — base consonant",
         "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "యై",
+      "sound": "yai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "య  ya — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "యౌ",
+      "sound": "yau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "య  ya — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "యృ",
+      "sound": "yr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "య  ya — base consonant",
+        "ృ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -3222,6 +4158,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "రై",
+      "sound": "rai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ర  ra — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "రౌ",
+      "sound": "rau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ర  ra — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "రృ",
+      "sound": "rr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ర  ra — base consonant",
+        "ృ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ల",
       "sound": "la",
       "role": "syllable",
@@ -3336,6 +4308,42 @@
       "components": [
         "ల  la — base consonant",
         "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "లై",
+      "sound": "lai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ల  la — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "లౌ",
+      "sound": "lau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ల  la — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "లృ",
+      "sound": "lr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ల  la — base consonant",
+        "ృ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -3460,6 +4468,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "వై",
+      "sound": "vai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "వ  va — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "వౌ",
+      "sound": "vau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "వ  va — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "వృ",
+      "sound": "vr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "వ  va — base consonant",
+        "ృ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "శ",
       "sound": "śa",
       "role": "syllable",
@@ -3574,6 +4618,42 @@
       "components": [
         "శ  śa — base consonant",
         "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "శై",
+      "sound": "śai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "శ  śa — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "శౌ",
+      "sound": "śau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "శ  śa — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "శృ",
+      "sound": "śr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "శ  śa — base consonant",
+        "ృ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -3698,6 +4778,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "షై",
+      "sound": "ṣai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ష  ṣa — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "షౌ",
+      "sound": "ṣau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ష  ṣa — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "షృ",
+      "sound": "ṣr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ష  ṣa — base consonant",
+        "ృ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "స",
       "sound": "sa",
       "role": "syllable",
@@ -3812,6 +4928,42 @@
       "components": [
         "స  sa — base consonant",
         "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "సై",
+      "sound": "sai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "స  sa — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "సౌ",
+      "sound": "sau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "స  sa — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "సృ",
+      "sound": "sr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "స  sa — base consonant",
+        "ృ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""
@@ -3936,6 +5088,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "హై",
+      "sound": "hai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "హ  ha — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "హౌ",
+      "sound": "hau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "హ  ha — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "హృ",
+      "sound": "hr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "హ  ha — base consonant",
+        "ృ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ళ",
       "sound": "ḷa",
       "role": "syllable",
@@ -4055,6 +5243,42 @@
       "strokeOrderNote": ""
     },
     {
+      "glyph": "ళై",
+      "sound": "ḷai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ళ  ḷa — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ళౌ",
+      "sound": "ḷau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ళ  ḷa — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ళృ",
+      "sound": "ḷr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ళ  ḷa — base consonant",
+        "ృ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
       "glyph": "ఱ",
       "sound": "ṟa",
       "role": "syllable",
@@ -4169,6 +5393,42 @@
       "components": [
         "ఱ  ṟa — base consonant",
         "ో  “ō” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఱై",
+      "sound": "ṟai",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఱ  ṟa — base consonant",
+        "ై  “ai” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఱౌ",
+      "sound": "ṟau",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఱ  ṟa — base consonant",
+        "ౌ  “au” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఱృ",
+      "sound": "ṟr̥",
+      "role": "syllable",
+      "inherentVowel": "a",
+      "components": [
+        "ఱ  ṟa — base consonant",
+        "ృ  “r̥” vowel sign"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.19.0 — the full vowel row: ai, au & vocalic R (syllabary, PR 3)
+
+- **Each consonant now carries three more syllables.** The generator's core
+  vowel row was the ten short/long vowels (a ā i ī u ū e ē o ō); it now also
+  composes the two **diphthongs** (ai, au) and the **vocalic R** that
+  Sanskrit-derived words carry — కృ = *kr̥*, as in కృష్ణ *kr̥ṣṇa* "Krishna". So a
+  consonant's row grows from 10 to 13, and the regenerated data goes **Telugu
+  350 → 455, Kannada 350 → 455, Malayalam 360 → 468** syllables.
+- **Still Unicode-grounded.** The three new syllables are composed from the
+  `VOWEL SIGN AI` / `AU` / `VOCALIC R` code points of each block, verified to
+  exist by their official Unicode names before use — nothing hand-typed. The
+  vocalic-R romanization is **ISO-15919 `r̥`** (a plain *r* with a combining ring
+  below), deliberately *not* IAST's dot-below `ṛ` — in ISO-15919 that dot-below
+  form is the *retroflex* ṛ, a different sound, so using it would be wrong.
+- **Flows through the slow-unlock gate unchanged.** The new syllables are signed
+  (two components), so `consonantGroups` keeps them inside their consonant's
+  group automatically: Practice on Telugu now reads *"mastered 0 / 13"* and the
+  first row is `ka kā ki kī ku kū ke kē ko kō kai kau kr̥`. No app code changed —
+  only the generator and the regenerated JSON (plus the one data-dependent test
+  assertion, 10 → 13). Still recognition only (`strokeOrder: []`).
+
 ## 0.18.0 — introduce syllables slowly, one consonant at a time (syllabary, PR 2)
 
 - **The Dravidian drill no longer dumps 350 syllables at once.** Practice on

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -138,9 +138,16 @@ only** — `strokeOrder` is empty, since the handwriting ductus is a separate,
 source-gated effort; the Browse detail hides the stroke-order section when it's
 absent rather than showing an empty one.
 
+Each consonant carries its full vowel row: the ten short/long vowels plus the
+two diphthongs *ai / au* and the **vocalic R** of Sanskrit-derived words (కృ =
+*kr̥*, as in *kr̥ṣṇa* "Krishna") — thirteen syllables per consonant, so **Telugu
+455 / Kannada 455 / Malayalam 468**. The vocalic-R romanization is ISO-15919
+`r̥` (a plain *r* with a ring below), deliberately not IAST's dot-below `ṛ`
+(which in ISO-15919 is the unrelated retroflex ṛ).
+
 **Practice introduces them slowly** (`src/syllabary.ts`). Rather than drill all
-350 syllables at once, the recall drill opens with a *single consonant's vowel
-row* — ka kā ki kī ku kū ke kē ko kō — and unlocks the next consonant only once
+~450 syllables at once, the recall drill opens with a *single consonant's vowel
+row* — ka kā ki kī ku kū ke kē ko kō kai kau kr̥ — and unlocks the next consonant only once
 the current row is mastered (a Leitner box ≥ 3). So recognition is built one
 consonant at a time, the "ka, ki, ku … kha, khi, khu" way. On these scripts the
 drill's target and its distractors are both confined to the unlocked syllables

--- a/code/programs/typescript/language-ladder/package.json
+++ b/code/programs/typescript/language-ladder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ladder",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "private": true,
   "description": "The unified curriculum learning app (HL03): walk the language chain concept by concept, seeing the threads back to what you already know, then review it all with a randomised SRS quiz. (Was the HL02 script-writing-visualizer, whose Browse/Practice/Lessons/Concepts modes it now subsumes.)",
   "type": "module",

--- a/code/programs/typescript/language-ladder/tests/syllabary.test.ts
+++ b/code/programs/typescript/language-ladder/tests/syllabary.test.ts
@@ -78,10 +78,10 @@ describe("against the real generated Telugu syllabary", () => {
     expect(isSyllabary(telugu.letters)).toBe(true);
     const groups = consonantGroups(telugu.letters);
     expect(groups.length).toBe(35); // 35 consonants
-    expect(groups[0]!.length).toBe(10); // ka's row = 10 core vowels
-    // Fresh learner: only the first consonant's 10 syllables are drillable.
+    expect(groups[0]!.length).toBe(13); // ka's row = 10 core vowels + ai, au, vocalic-r
+    // Fresh learner: only the first consonant's 13 syllables are drillable.
     const fresh = telugu.letters.map(() => ({ box: 0 }));
     expect(unlockedConsonantCount(groups, fresh)).toBe(1);
-    expect(unlockedLetterIndices(groups, 1)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(unlockedLetterIndices(groups, 1)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
   });
 });


### PR DESCRIPTION
## What & why

PR2 gave the Dravidian drill its *slow unlock* — one consonant's vowel row at a time. That row was the ten short/long vowels (`a ā i ī u ū e ē o ō`). This PR completes it with the **two diphthongs (ai, au)** and the **vocalic R** that Sanskrit-derived words carry — కృ = *kr̥*, as in కృష్ణ *kr̥ṣṇa* "Krishna".

Thirteen syllables per consonant now, so the regenerated data grows:

| script | before | after |
|---|--:|--:|
| Telugu | 350 | **455** |
| Kannada | 350 | **455** |
| Malayalam | 360 | **468** |

## Grounded, not hand-typed

The three new syllables are composed from each block's `VOWEL SIGN AI` / `AU` / `VOCALIC R` code points, verified to exist by their official Unicode names before use. **Only the generator and its regenerated JSON changed — no app code.**

One deliberate call worth an eyeball: the vocalic-R romanization is **ISO-15919 `r̥`** — a plain *r* with a combining ring below (U+0072 U+0325) — *not* IAST's dot-below `ṛ` (U+1E5B). In ISO-15919 that dot-below form is the **retroflex** ṛ, a different sound, so using it would be wrong. A grounding subagent independently recomputed every code point across all three scripts (incl. non-`ka` consonants), confirmed the ring-below byte sequence, the uniform **+3 per consonant** (no silent desync), and the append-only vowel order.

## Ka's row now (Telugu) — for a native-reader eyeball

```
క ka   కా kā   కి ki   కీ kī   కు ku   కూ kū   కె ke   కే kē   కొ ko   కో kō   కై kai   కౌ kau   కృ kr̥
```

## Flows through the slow-unlock gate unchanged

The new syllables are signed (two components), so `consonantGroups` keeps them inside their consonant's group automatically. No gate code changed; the one data-dependent test assertion moved **10 → 13**.

## Verified in-browser

- **Browse → Telugu:** header reads **Letters: 455**; ka's row shows కై / కౌ / కృ before *ga* begins — no tofu anywhere in the 455-glyph grid.
- **kr̥ detail panel:** sound **kr̥**, decomposition **క ka — base consonant** + **ృ "r̥" vowel sign**, no empty stroke-order section.
- **Practice → Telugu:** reads **"mastered 0 / 13"**, cue still **"Learning consonant 1 of 35"**, distractors drawn from the now-13-syllable unlocked row.

## Checks

- App suite **246 pass**, human-language-data **38 pass**; `vite build` clean; no NUL bytes in new/changed files.
- Recognition only — `strokeOrder: []`, the handwriting ductus stays paused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)