### PR TITLE
feat(task-app): warm visual system on the app shell (UI design, step 1)

### DIFF
--- a/code/programs/mosaic/task-app/CHANGELOG.md
+++ b/code/programs/mosaic/task-app/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to the `task-app` web program are documented here.
 
 ## [0.1.0] - Unreleased
 
+### Changed - warm visual system on the app shell (UI design, step 1)
+
+- **`TaskApp.light.msl` restyled to the "warm & approachable" identity** from
+  [`code/specs/task-app-ui-design.md`](../../../specs/task-app-ui-design.md): warm paper
+  ground (`#f0ebe3`), crisp warm-white surfaces, warm-charcoal ink, and a single honey
+  accent (`#e0942a`) spent only on the primary Add action and active affordances.
+  Semantic red stays a separate axis, used only for the destructive Delete. Adds
+  `state focused` (honey ring on inputs) and `state hover` (honey-tinted rows, deeper
+  honey on the Add button) — the first hover/focus affordances the app has had.
+  Verified end-to-end: the sources compile (`cargo test -p task-app`), and the palette
+  and the hover/focus selectors flow through `mosaic-compile --backend react` into the
+  generated component's inline styles and CSS lattice.
+- This is the first increment of the design spec's Phase-5 work (design tokens + app
+  shell). Richer rows (checkbox, chips, progressive-disclosure detail), the timeline and
+  board views, and a matching **dark theme** — which needs host-level theme switching —
+  are the follow-on increments; the prototype at
+  `design/ui-prototype.html` remains the visual target.
+
 ### Changed
 
 - **The web host is now a committed npm package** (`host/web/`) instead of files

--- a/code/programs/mosaic/task-app/CHANGELOG.md
+++ b/code/programs/mosaic/task-app/CHANGELOG.md
@@ -16,10 +16,17 @@ All notable changes to the `task-app` web program are documented here.
   Verified end-to-end: the sources compile (`cargo test -p task-app`), and the palette
   and the hover/focus selectors flow through `mosaic-compile --backend react` into the
   generated component's inline styles and CSS lattice.
+- **`TaskApp.dark.msl` added** — the dark half of the same identity, authored not
+  inverted: a warm near-black ground (`#1a1714`), warm-ivory ink, and the honey accent
+  lifted to `#eaa63f` so it stays legible on the dark ground. Resolved by
+  `mosaic-compile --theme dark`; verified the dark palette + states flow through to the
+  generated React (inline styles + CSS lattice) and that `--theme light` still resolves
+  the light theme. The compile test now compiles both themes against the layout parts.
+  Host-level theme *switching* (wiring `prefers-color-scheme` / a toggle in the web host
+  to select the emitted theme) is the remaining follow-on.
 - This is the first increment of the design spec's Phase-5 work (design tokens + app
-  shell). Richer rows (checkbox, chips, progressive-disclosure detail), the timeline and
-  board views, and a matching **dark theme** — which needs host-level theme switching —
-  are the follow-on increments; the prototype at
+  shell). Richer rows (checkbox, chips, progressive-disclosure detail) and the timeline
+  and board views are the follow-on increments; the prototype at
   `design/ui-prototype.html` remains the visual target.
 
 ### Changed

--- a/code/programs/mosaic/task-app/src/TaskApp.dark.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.dark.msl
@@ -1,0 +1,94 @@
+// TaskApp — styling (mosstyle), dark theme. Parts match the [ part-name ] labels
+// in TaskApp.mll, and mirror TaskApp.light.msl part-for-part.
+//
+// The dark half of the "warm & approachable" identity (code/specs/task-app-ui-design.md):
+// a warm near-black ground (#1a1714, not a cold #000), warm-ivory ink, and the same
+// honey accent — lifted to #eaa63f so it stays legible on the dark ground. Both themes
+// are authored, not inverted. Resolved by `mosaic-compile --theme dark`.
+
+style TaskApp {
+  part app-shell {
+    background : "#1a1714" ;
+    color : "#f1ebe1" ;
+    font-family : "-apple-system, Segoe UI, system-ui, sans-serif" ;
+    padding : 28 ;
+    gap : 16 ;
+  }
+  part title {
+    font-size : 22 ;
+    font-weight : bold ;
+    color : "#f1ebe1" ;
+  }
+  part add-row {
+    gap : 8 ;
+    align : center-vertical ;
+  }
+  part name-input {
+    background : "#252019" ;
+    color : "#f1ebe1" ;
+    font-size : 14 ;
+    padding : 10 ;
+    border-width : 1 ;
+    border-color : "#352e25" ;
+    border-radius : 9 ;
+    state focused {
+      border-color : "#eaa63f" ;
+    }
+  }
+  part due-input {
+    background : "#252019" ;
+    color : "#f1ebe1" ;
+    font-size : 14 ;
+    padding : 10 ;
+    border-width : 1 ;
+    border-color : "#352e25" ;
+    border-radius : 9 ;
+    state focused {
+      border-color : "#eaa63f" ;
+    }
+  }
+  part add-btn {
+    background : "#eaa63f" ;
+    color : "#1a1714" ;
+    font-weight : bold ;
+    padding : 10 ;
+    border-radius : 9 ;
+    state hover {
+      background : "#d4922f" ;
+    }
+  }
+  part summary {
+    color : "#b3a99c" ;
+    font-size : 13 ;
+  }
+  part task-list {
+    gap : 8 ;
+  }
+  part task-row {
+    gap : 8 ;
+    align : center-vertical ;
+  }
+  part row-btn {
+    background : "#252019" ;
+    color : "#f1ebe1" ;
+    font-size : 14 ;
+    padding : 12 ;
+    border-width : 1 ;
+    border-color : "#352e25" ;
+    border-radius : 11 ;
+    state hover {
+      border-color : "#eaa63f" ;
+      background : "#3a2c17" ;
+    }
+  }
+  part del-btn {
+    background : "#3a221c" ;
+    color : "#e26a52" ;
+    font-weight : bold ;
+    padding : 10 ;
+    border-radius : 9 ;
+    state hover {
+      background : "#4a2a22" ;
+    }
+  }
+}

--- a/code/programs/mosaic/task-app/src/TaskApp.light.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.light.msl
@@ -1,60 +1,94 @@
 // TaskApp — styling (mosstyle), light theme. Parts match the [ part-name ] labels
 // in TaskApp.mll.
+//
+// The "warm & approachable" identity from code/specs/task-app-ui-design.md: warm
+// paper ground, crisp warm-white surfaces, warm-charcoal ink, and a single honey
+// accent (#e0942a) spent only on the primary action and active affordances.
+// Semantic red (#cf4b34) is a separate axis, used only for the destructive Delete.
 
 style TaskApp {
   part app-shell {
-    background : "#f8fafc" ;
-    color : "#0f172a" ;
-    font-family : "system-ui, sans-serif" ;
-    padding : 24 ;
-    gap : 14 ;
+    background : "#f0ebe3" ;
+    color : "#2b2723" ;
+    font-family : "-apple-system, Segoe UI, system-ui, sans-serif" ;
+    padding : 28 ;
+    gap : 16 ;
   }
   part title {
+    font-size : 22 ;
     font-weight : bold ;
+    color : "#2b2723" ;
   }
   part add-row {
     gap : 8 ;
     align : center-vertical ;
   }
   part name-input {
-    padding : 8 ;
+    background : "#fffdfa" ;
+    color : "#2b2723" ;
+    font-size : 14 ;
+    padding : 10 ;
     border-width : 1 ;
-    border-color : "#cbd5e1" ;
-    border-radius : 6 ;
+    border-color : "#e6ded3" ;
+    border-radius : 9 ;
+    state focused {
+      border-color : "#e0942a" ;
+    }
   }
   part due-input {
-    padding : 8 ;
+    background : "#fffdfa" ;
+    color : "#2b2723" ;
+    font-size : 14 ;
+    padding : 10 ;
     border-width : 1 ;
-    border-color : "#cbd5e1" ;
-    border-radius : 6 ;
+    border-color : "#e6ded3" ;
+    border-radius : 9 ;
+    state focused {
+      border-color : "#e0942a" ;
+    }
   }
   part add-btn {
-    background : "#2563eb" ;
+    background : "#e0942a" ;
     color : "#ffffff" ;
-    padding : 8 ;
-    border-radius : 6 ;
+    font-weight : bold ;
+    padding : 10 ;
+    border-radius : 9 ;
+    state hover {
+      background : "#c67f1e" ;
+    }
   }
   part summary {
-    color : "#64748b" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
   }
   part task-list {
-    gap : 6 ;
+    gap : 8 ;
   }
   part task-row {
     gap : 8 ;
     align : center-vertical ;
   }
   part row-btn {
-    padding : 8 ;
+    background : "#fffdfa" ;
+    color : "#2b2723" ;
+    font-size : 14 ;
+    padding : 12 ;
     border-width : 1 ;
-    border-color : "#e2e8f0" ;
-    border-radius : 6 ;
-    background : "#ffffff" ;
+    border-color : "#e6ded3" ;
+    border-radius : 11 ;
+    state hover {
+      border-color : "#e0942a" ;
+      background : "#faedd6" ;
+    }
   }
   part del-btn {
-    padding : 8 ;
-    border-radius : 6 ;
-    background : "#fee2e2" ;
-    color : "#991b1b" ;
+    background : "#f8e4df" ;
+    color : "#cf4b34" ;
+    font-weight : bold ;
+    padding : 10 ;
+    border-radius : 9 ;
+    state hover {
+      background : "#f1cabf" ;
+    }
   }
 }

--- a/code/programs/mosaic/task-app/tests/package_compiles.rs
+++ b/code/programs/mosaic/task-app/tests/package_compiles.rs
@@ -19,10 +19,15 @@ fn task_app_sources_compile() {
         .expect("TaskApp.mll should compile against the interface");
     let light = mosstyle_compiler::compile(&read("TaskApp.light.msl"), Some(&mll.part_map_json))
         .expect("TaskApp.light.msl should compile against the layout parts");
+    // Both themes are authored and must compile against the same layout parts;
+    // `mosaic-compile --theme dark` resolves TaskApp.dark.msl.
+    let dark = mosstyle_compiler::compile(&read("TaskApp.dark.msl"), Some(&mll.part_map_json))
+        .expect("TaskApp.dark.msl should compile against the layout parts");
 
     assert_eq!(mil.component.component, "TaskApp");
     assert_eq!(mll.def.component_name, "TaskApp");
     assert_eq!(light.def.component_name, "TaskApp");
+    assert_eq!(dark.def.component_name, "TaskApp");
 
     // The interface exposes exactly the slots the web host fills.
     let slots: Vec<&str> = mil.component.slots.iter().map(|s| s.name.as_str()).collect();


### PR DESCRIPTION
First increment of the task-app UI design ([`code/specs/task-app-ui-design.md`](../blob/main/code/specs/task-app-ui-design.md), merged in #8878) landing in the **real app**: the `TaskApp` Mosaic component restyled to the warm & approachable identity — at the correct architectural layer (mosstyle `.msl`), not by hand-editing generated output.

## What changes

- Warm paper ground (`#f0ebe3`), crisp warm-white surfaces (`#fffdfa`), warm-charcoal ink (`#2b2723`), and a single **honey** accent (`#e0942a`) spent only on the primary Add action and active affordances. Semantic red (`#cf4b34`) stays a separate axis, used only for the destructive Delete.
- Adds `state focused` (honey ring on the inputs) and `state hover` (honey-tinted rows, deeper honey on Add) — **the first hover/focus affordances the app has had.**

## Verification (without the browser — the in-app pane is currently unresponsive)

- `cargo test -p task-app` — the `.mil`/`.mll`/`.msl` still compile against each other.
- Regenerated via `mosaic-compile --backend react` and confirmed the change reaches the output: the warm palette lands in the component's inline styles, and the hover/focus states land in the CSS lattice (5 `:hover`/`:focus` selectors; honey `#c67f1e` / `#faedd6` / `#f1cabf` present).

## Scope

This is **Phase-5 step 1** (design tokens + app shell). Deliberately style-only. The follow-on increments — richer rows (checkbox, chips, progressive-disclosure detail), the timeline and board views, and a matching **dark theme** (which needs host-level theme switching) — build on this. The prototype at `code/programs/mosaic/task-app/design/ui-prototype.html` remains the visual target.

Security: style-only change (compiler-validated hex/number values in a `.msl`, no logic, no user input, no injection surface); reviewed inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)