### PR TITLE
feat(adj-formula-stdlib): electric-charge — LibreTexts current-as-rate-of-charge-flow I = Q/t definition library (physics track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_electric_charge_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_electric_charge_e2e.rs
@@ -1,0 +1,140 @@
+//! End-to-end tests for the `physics/electric-charge.adj` library — electric current
+//! as the rate of charge flow (I = Q/t) and its two exact rearrangements (Q = I·t,
+//! t = Q/I) — driven through the built CLI binary against the SHIPPED stdlib. Each
+//! proves the same invariant as the other formula libraries: a consumer states NO
+//! arithmetic; it imports the grounded library, binds the measured quantities with
+//! `observe`, and the engine applies the cited definition on the CPU — computing the
+//! EXACT value and rendering the definition's citation + trust tier in the `derived`
+//! section (the auditable answer). The three formulas INVERT: 6 / 2 = 3, 3 * 2 = 6,
+//! 6 / 3 = 2.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped electric-charge library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_electric_charge_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/physics/electric-charge.adj")
+        .canonicalize()
+        .expect("shipped electric-charge.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_echarge_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_electric_charge_lib()).unwrap();
+    std::fs::write(dir.join("electric-charge.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// current — the definition: the charge that flows divided by the time taken (I = Q/t).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_electric_charge_library_and_computes_current_with_citation() {
+    let dir = scratch("i");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"electric-charge.adj\"\n\
+         observe charge(6)\n\
+         observe time(2)\n\
+         ? current(charge, time)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied definition's result: 6 / 2 = 3.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"current\"") && s.contains("\"value\":3"),
+        "current(6, 2) = 3: {s}"
+    );
+    // … AND the LibreTexts citation + trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("phys.libretexts.org"),
+        "applied definition carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// charge — the same definition solved for Q: the current times the time, which INVERTS
+// the current just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_charge_as_current_times_time_with_citation() {
+    let dir = scratch("q");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"electric-charge.adj\"\n\
+         observe current(3)\n\
+         observe time(2)\n\
+         ? charge(current, time)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 3 * 2 = 6, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"charge\"") && s.contains("\"value\":6"),
+        "charge(3, 2) = 6: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("phys.libretexts.org"),
+        "charge carries its LibreTexts citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// time — the same definition solved for t: the charge over the current, the third exact
+// reading of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_time_as_charge_over_current_with_citation() {
+    let dir = scratch("t");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"electric-charge.adj\"\n\
+         observe charge(6)\n\
+         observe current(3)\n\
+         ? time(charge, current)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 6 / 3 = 2, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"time\"") && s.contains("\"value\":2"),
+        "time(6, 3) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("phys.libretexts.org"),
+        "time carries its LibreTexts citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/physics/electric-charge.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/electric-charge.adj
@@ -1,0 +1,97 @@
+% ============================================================================
+% electric-charge.adj — electric current as rate of charge flow (I = Q/t) in the
+% ADJ standard library.
+% ============================================================================
+% The charge/current/time entry of the *physics* track, a sibling of `power.adj`,
+% `electricity.adj` and `wave-speed.adj`: the foundational definition a first course
+% states as ELECTRIC CURRENT IS THE RATE AT WHICH CHARGE FLOWS — i.e. the relation
+% I = Q/t (the charge passing a point divided by the time taken) — as an importable,
+% byte-provenanced, PARAMETERIZED `formula`, together with its two exact
+% rearrangements (the charge delivered by a current in a time, and the time a current
+% takes to deliver a charge). This is distinct from Ohm's law V = I·R and the electric
+% power P = V·I in `electricity.adj`; it is the definition that RELATES the current to
+% the charge and the time. As with every compute library, a consumer states NO
+% arithmetic: it `import`s this file, binds the electrical quantities from its own
+% byte-provenance decomposition, and asks the engine to APPLY the cited definition on
+% the CPU. Zero math is performed by the model; the engine computes each value EXACTLY,
+% carrying the definition's citation.
+%
+%     import "electric-charge.adj"
+%     observe charge(6)               % "…6 C of charge…"  (span cited by the model)
+%     observe time(2)                 % "…in 2 s…"         (span cited by the model)
+%     ? current(charge, time)         % engine → 3, carrying I = Q/t
+%
+% NOTE: this is the AVERAGE current over the interval, I = Q/t — the plain
+% charge-over-time rate. (The instantaneous current is the same rate in the limit of a
+% vanishing interval, I = dQ/dt; the exact numeric relation the engine applies over a
+% measured charge Q and time t is I = Q/t.)
+%
+% All three formulas are EXACT over their parameters — one a quotient, one a product,
+% one a quotient of measured quantities. There is no *separately grounded* physical
+% constant here, so every value the engine returns is exact. The three COMPOSE and
+% invert cleanly: the `current` a consumer computes from a charge delivered in a time
+% is exactly the `current` the `charge` formula multiplies by that time to recover the
+% charge, and exactly the `current` the `time` formula divides that charge by to
+% recover the time.
+%
+%   current(charge, time) = charge / time   %  I = Q/t   (definition: current is the
+%                                           %             rate at which charge flows)
+%   charge(current, time) = current * time    %  Q = I·t   (same definition, solved for Q)
+%   time(charge, current) = charge / current   %  t = Q/I   (same definition, solved for t)
+%
+% All three formulas are defended by the SAME definitional sentence — "Electric current
+% is defined to be the rate at which charge flows." — because that definition (current
+% IS the rate at which charge flows, i.e. charge per unit time) sanctions the relation
+% read every way (I from Q and t, Q from I and t, or t from Q and I). The quote is
+% transcribed verbatim from Physics LibreTexts (OpenStax College Physics — a primary
+% educational reference, the same publisher `power.adj`, `wave-speed.adj`,
+% `hookes-law.adj` and `molarity.adj` cite), so each `formula` carries the provenance
+% envelope every shipped grounded clause carries; the linter rejects an unsourced one.
+% (See feedback_nothing_human_authored — the sentence is a verbatim span of the cited
+% page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable electrical quantity the definition ranges
+% over, and each result is the derived quantity. `current`, `charge` and `time` each
+% appear BOTH as a derived result and as an input (of the other formulas), so each is a
+% single dictionary term used in both roles. The `surface` lists are the everyday names
+% a decomposer maps onto the canonical term; the trailing comment records the intended
+% SI unit.
+% ----------------------------------------------------------------------------
+dictionary electric_charge_vocab {
+    define charge  : finding  surface "charge", "Q"               % electric charge, e.g. C (coulomb)
+    define time    : finding  surface "time", "duration", "t"     % time, e.g. s
+    define current : finding  surface "current", "I"             % electric current, e.g. A (ampere)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable `let` over its
+% formal parameters, bound at apply time, and each carries the definitional quote from
+% LibreTexts (a quote is required on a shipped formula). One is a quotient, one a
+% product, one a quotient, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook electric_charge_laws {
+    use electric_charge_vocab
+
+    % Current — the charge that flows divided by the time it takes. LibreTexts defines
+    % current as the rate at which charge flows, i.e. I = Q/t.
+    formula current(charge, time) = charge / time
+        source "Electric current is defined to be the rate at which charge flows."
+        locator "https://phys.libretexts.org/Bookshelves/College_Physics/College_Physics_1e_(OpenStax)/20:_Electric_Current_Resistance_and_Ohm's_Law/20.01:_Current"
+        trust authoritative
+
+    % Charge — the same definition solved for the charge a current delivers in a time
+    % (Q = I·t). Defended by the SAME definitional sentence, read the other way.
+    formula charge(current, time) = current * time
+        source "Electric current is defined to be the rate at which charge flows."
+        locator "https://phys.libretexts.org/Bookshelves/College_Physics/College_Physics_1e_(OpenStax)/20:_Electric_Current_Resistance_and_Ohm's_Law/20.01:_Current"
+        trust authoritative
+
+    % Time — the same definition solved for the time a current takes to deliver a charge
+    % (t = Q/I). Again the SAME definitional sentence, read the third way.
+    formula time(charge, current) = charge / current
+        source "Electric current is defined to be the rate at which charge flows."
+        locator "https://phys.libretexts.org/Bookshelves/College_Physics/College_Physics_1e_(OpenStax)/20:_Electric_Current_Resistance_and_Ohm's_Law/20.01:_Current"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/physics/electric-charge.query.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/electric-charge.query.adj
@@ -1,0 +1,32 @@
+% ============================================================================
+% electric-charge.query.adj — worked examples over the physics electric-charge library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a charge/current/time
+% question: it states NO arithmetic and NO definition — it only `import`s the grounded
+% library, `observe`s the measured quantities it decomposed from the prompt (each a
+% byte-provenanced span, elided here), and asks the engine to APPLY the cited
+% definition. The native adj-lang engine binds the parameters, computes each value
+% EXACTLY on the CPU, and returns it with the definition's source/locator/trust.
+%
+% The three questions INVERT: 6 C of charge flowing in 2 s is a current of 3 A; that
+% 3 A current over the same 2 s is exactly what the charge formula multiplies to recover
+% the 6 C, and that 6 C at the same 3 A is exactly what the time formula divides to
+% recover the 2 s.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli electric-charge.query.adj
+% ============================================================================
+
+import "electric-charge.adj"
+
+% 6 C of charge flowing in 2 s: current = 6 / 2.
+observe charge(6)
+observe time(2)
+? current(charge, time)      % expect 3   (definition: I = Q/t)
+
+% That 3 A current over the same 2 s: charge = 3 * 2.
+observe current(3)
+? charge(current, time)       % expect 6   (same definition, solved for Q = I·t)
+
+% That 6 C of charge at the same 3 A: time = 6 / 3.
+? time(charge, current)       % expect 2   (same definition, solved for t = Q/I)


### PR DESCRIPTION
## What

Adds the **charge/current/time** entry of the physics track: the foundational definition a first course states as **electric current is the rate at which charge flows** — the relation **I = Q/t** — as an importable, byte-provenanced, parameterized `formula`, together with its two exact rearrangements. All three readings are defended by the **same** verbatim definitional sentence, transcribed from Physics LibreTexts (OpenStax College Physics 20.1: Current):

> "Electric current is defined to be the rate at which charge flows."

| formula | reading |
|---------|---------|
| `current(charge, time) = charge / time` | I = Q/t (the definition) |
| `charge(current, time) = current * time` | Q = I·t (solved for Q) |
| `time(charge, current) = charge / current` | t = Q/I (solved for t) |

## Why

This is the definition that **relates** current, charge and time — distinct from Ohm's law V = I·R and the electric power P = V·I already in `electricity.adj`. It rounds out the electrical basics alongside them and pairs with the other physics rate-definitions (`power.adj`'s P = W/t, `wave-speed.adj`'s v = fλ) — same shape: a rate definition read three ways, each defended by one cited sentence.

## How it works

Data + test only — **no engine/version change**. A consumer states **no arithmetic**: it imports the grounded library, binds the measured quantities with `observe`, and the engine applies the cited definition on the CPU — computing each value **exactly** and rendering the definition's `source`/`locator`/`trust` in the `derived` section (the auditable answer). The model does zero math. The three formulas invert cleanly (6/2=3, 3*2=6, 6/3=2).

## Files
- `physics/electric-charge.adj` — the grounded definition library (3-way inverter)
- `physics/electric-charge.query.adj` — worked examples (I=3, Q=6, t=2)
- `formula_electric_charge_e2e.rs` — 3 e2e tests through the built CLI vs the shipped stdlib

## Verification
- `cargo test -p adj-lang-cli --test formula_electric_charge_e2e` → 3 passed
- Ran the shipped `.query.adj` through the built CLI: current=3, charge=6, time=2, each carrying the LibreTexts citation + `authoritative` trust
- Definitional sentence byte-verified against the cited LibreTexts page
- Security review passed (data + test only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)