### PR TITLE
feat(sql): add the TOTAL(x) aggregate

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.67 — `TOTAL()` aggregate
+
+`SELECT total(v) FROM t` is now supported — SQLite's NULL-free companion to
+`SUM`: it always returns a REAL and yields `0.0` (not NULL) for an empty or
+all-NULL group, and returns REAL even when every input is an integer. Previously
+`total(...)` errored with "unknown built-in function". Verified against bundled
+real SQLite (empty→0.0, all-int→REAL, mixed int/real→REAL, per-group). Spans
+sql-planner 0.2.33, sql-codegen 0.6.13, sql-vm 0.4.37.
+
 ## 0.5.66 — DISTINCT applies before ORDER BY (representative selection)
 
 `SELECT DISTINCT x COLLATE NOCASE FROM t ORDER BY x` now keeps SQLite's

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.66"
+version = "0.5.67"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -2280,6 +2280,35 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT k, sum(v) FROM g GROUP BY k ORDER BY 2",
     },
+    // `TOTAL(x)` is SQLite's NULL-free companion to SUM: always REAL, and 0.0
+    // (not NULL) for an empty or all-NULL group. Here the mixed int/real values
+    // sum to a REAL, and the all-NULL / empty groups return 0.0.
+    Case {
+        id: "total_aggregate",
+        setup: &[
+            "CREATE TABLE t (g TEXT, v)",
+            "INSERT INTO t VALUES ('a',1),('a',2),('b',NULL),('c',2.5)",
+        ],
+        query: "SELECT g, total(v), sum(v) FROM t GROUP BY g ORDER BY g",
+    },
+    // TOTAL over an empty table is 0.0 (a single grouped-less aggregate row),
+    // where SUM would be NULL — the defining difference (Real(0.0) vs Null in the
+    // value comparison).
+    Case {
+        id: "total_empty_is_zero",
+        setup: &["CREATE TABLE e (v INTEGER)"],
+        query: "SELECT total(v), sum(v) FROM e",
+    },
+    // TOTAL of all integers still returns a REAL (unlike SUM, which stays
+    // INTEGER) — `Real(6.0)` vs `Int(6)` in the value comparison proves the type.
+    Case {
+        id: "total_ints_returns_real",
+        setup: &[
+            "CREATE TABLE t (v INTEGER)",
+            "INSERT INTO t VALUES (1),(2),(3)",
+        ],
+        query: "SELECT total(v), sum(v) FROM t",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-codegen/CHANGELOG.md
+++ b/code/packages/rust/sql-codegen/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.6.13] - Unreleased
+
+### Added
+
+- **`TOTAL(x)` aggregate** — new `AggFn::Total`, wired through the `AggFunc→AggFn`
+  mapping and the aggregate name renderer (`TOTAL`). Accumulates like `SUM`; the
+  VM finalizes it as an always-REAL, `0.0`-default value.
+
 ## [0.6.12] - Unreleased
 
 ### Changed

--- a/code/packages/rust/sql-codegen/Cargo.toml
+++ b/code/packages/rust/sql-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-codegen"
-version = "0.6.12"
+version = "0.6.13"
 edition = "2021"
 description = "Bytecode code generator for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-codegen/src/lib.rs
+++ b/code/packages/rust/sql-codegen/src/lib.rs
@@ -186,6 +186,9 @@ pub enum AggFn {
     CountDistinct,
     /// `SUM(col)` — sum of all non-NULL values
     Sum,
+    /// `TOTAL(col)` — like SUM but always REAL and `0.0` (never NULL) for an
+    /// empty/all-NULL group.
+    Total,
     /// `AVG(col)` — arithmetic mean of non-NULL values
     Avg,
     /// `MIN(col)` — minimum value
@@ -2442,6 +2445,7 @@ fn render_aggregate_name(func: &AggFunc, arg: Option<&SqlExpr>, distinct: bool) 
     let func_name = match func {
         AggFunc::Count => "COUNT",
         AggFunc::Sum => "SUM",
+        AggFunc::Total => "TOTAL",
         AggFunc::Avg => "AVG",
         AggFunc::Min => "MIN",
         AggFunc::Max => "MAX",
@@ -2620,6 +2624,7 @@ fn plan_agg_to_agg_fn(func: &AggFunc, is_star: bool) -> AggFn {
             }
         }
         AggFunc::Sum => AggFn::Sum,
+        AggFunc::Total => AggFn::Total,
         AggFunc::Avg => AggFn::Avg,
         AggFunc::Min => AggFn::Min,
         AggFunc::Max => AggFn::Max,

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.33] - Unreleased
+
+### Added
+
+- **`TOTAL(x)` aggregate.** Recognized as an aggregate function name (both
+  aggregate-detection sites), lowering to the new `AggFunc::Total`. `TOTAL` is
+  SQLite's NULL-free companion to `SUM`: it accumulates identically but always
+  returns a REAL and yields `0.0` (never NULL) for an empty or all-NULL group.
+
 ## [0.2.32] - Unreleased
 
 ### Changed

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.32"
+version = "0.2.33"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -254,6 +254,10 @@ pub enum CastType {
 pub enum AggFunc {
     Count,
     Sum,
+    /// `TOTAL(x)` — like `SUM(x)` but ALWAYS returns a REAL and yields `0.0`
+    /// (never NULL) for an empty group or an all-NULL column. This is SQLite's
+    /// non-standard, NULL-free companion to SUM.
+    Total,
     Avg,
     Min,
     Max,
@@ -2052,6 +2056,7 @@ fn try_plan_as_aggregate(func_call: &GrammarASTNode) -> Option<AggregateItem> {
     let agg_func = match name.to_uppercase().as_str() {
         "COUNT" => AggFunc::Count,
         "SUM" => AggFunc::Sum,
+        "TOTAL" => AggFunc::Total,
         "AVG" => AggFunc::Avg,
         "MIN" => AggFunc::Min,
         "MAX" => AggFunc::Max,
@@ -3589,6 +3594,7 @@ fn plan_function_call(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
     let agg_func = match name.to_uppercase().as_str() {
         "COUNT" => Some(AggFunc::Count),
         "SUM" => Some(AggFunc::Sum),
+        "TOTAL" => Some(AggFunc::Total),
         "AVG" => Some(AggFunc::Avg),
         "MIN" => Some(AggFunc::Min),
         "MAX" => Some(AggFunc::Max),

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.37] - Unreleased
+
+### Added
+
+- **`TOTAL(x)` aggregate.** Accumulates identically to `SUM` (shared
+  `update_accumulator` arm), but finalizes as `SqlValue::Float(to_f64(sum))` with
+  a `0.0` default — always REAL and never NULL, matching SQLite's `total()`.
+
 ## [0.4.36] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.36"
+version = "0.4.37"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -3303,7 +3303,9 @@ fn update_accumulator(acc: &mut AggAccumulator, fn_tag: &AggFn, v: SqlValue) -> 
                 acc.count += 1;
             }
         }
-        AggFn::Sum => {
+        AggFn::Sum | AggFn::Total => {
+            // TOTAL accumulates exactly like SUM (skip NULLs, add the rest); the
+            // only difference is at finalize time (always REAL, `0.0` default).
             if !matches!(v, SqlValue::Null) {
                 acc.acc = Some(match &acc.acc {
                     None => v,
@@ -3441,6 +3443,17 @@ fn finalize_accumulator(acc: &AggAccumulator, fn_tag: &AggFn) -> SqlValue {
         AggFn::CountStar => SqlValue::Int(acc.count),
         AggFn::Count => SqlValue::Int(acc.count),
         AggFn::Sum => acc.acc.clone().unwrap_or(SqlValue::Null),
+        // TOTAL always returns a REAL and yields 0.0 (never NULL) for an empty or
+        // all-NULL group — SQLite's NULL-free companion to SUM. The running sum is
+        // kept in `acc.acc` exactly as SUM does (i64 while all inputs are
+        // integers, saturating at i64::MAX) and converted to f64 here; SQLite
+        // accumulates in a double throughout, so the two agree for every sum
+        // within i64 range and diverge only past i64::MAX (~9.22e18) — an
+        // astronomical edge we accept.
+        AggFn::Total => SqlValue::Float(match &acc.acc {
+            Some(v) => to_f64(v),
+            None => 0.0,
+        }),
         AggFn::Min => acc.acc.clone().unwrap_or(SqlValue::Null),
         AggFn::Max => acc.acc.clone().unwrap_or(SqlValue::Null),
         // The accumulated Text, or NULL when no non-NULL value was seen (an


### PR DESCRIPTION
## What

Adds the **`TOTAL(x)` aggregate** — SQLite's NULL-free companion to `SUM`. Previously `SELECT total(v) FROM t` errored with *"unknown built-in function: TOTAL"*.

`TOTAL` differs from `SUM` in exactly two ways, both at result time:
- it **always returns a REAL** (even when every input is an integer), and
- it yields **`0.0` (never NULL)** for an empty or all-NULL group.

```sql
SELECT total(v) FROM empty;        -- 0.0   (sum(v) → NULL)
SELECT total(v) FROM ints_1_2_3;   -- 6.0   (sum(v) → 6, integer)
```

## How

Mirrors `SUM` across the pipeline (found by probing real SQLite for unimplemented features):
- **sql-planner** (0.2.33): `"TOTAL"` recognized at both aggregate-detection sites → new `AggFunc::Total`.
- **sql-codegen** (0.6.13): new `AggFn::Total`, wired through the `AggFunc→AggFn` map and the aggregate name renderer.
- **sql-vm** (0.4.37): accumulates identically to `SUM` (shared `update_accumulator` arm), and finalizes as `SqlValue::Float(to_f64(sum))` with a `0.0` default. The sum is kept as `SUM` keeps it (i64 while all inputs are integers) and converted to f64 at finalize — this agrees with SQLite's running double for every sum within i64 range (documented, astronomical edge past i64::MAX aside).

## Verification
- Differential oracle green vs **bundled real SQLite** — new cases: `total` over an empty table is `0.0` where `sum` is NULL; `total` of integers returns REAL where `sum` stays INTEGER; a mixed int/real per-group case.
- Full `sql-planner` / `sql-optimizer` / `sql-codegen` / `sql-vm` / `mini-sqlite` suites pass; clippy clean.
- Inline security review **CLEAN**: all six `AggFunc`/`AggFn` dispatch sites handle `Total`; no panics; `TOTAL(DISTINCT x)` ignores `DISTINCT` exactly as `SUM(DISTINCT x)` does.

Versions: `sql-planner` 0.2.33, `sql-codegen` 0.6.13, `sql-vm` 0.4.37, `mini-sqlite` 0.5.67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
