### PR TITLE
feat(c-to-semantic-ir): logical operators && || ! (SIR27 milestone 4)

### DIFF
--- a/code/packages/rust/c-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/c-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+### Milestone 4 — logical operators (`&&`, `||`, `!`)
+
+- The short-circuiting logical operators lower to SIR's `and`/`or`/`not`
+  builtins, reusing the milestone-2 truthiness bridge.  As a **condition** each
+  operand is lowered *as a condition* (`a && b → and(cond(a), cond(b))`,
+  left-associative — C's evaluation order, and the builtins short-circuit like
+  C); as a **value** the resulting bool is wrapped back to C's int `0`/`1` with
+  `If(bool, 1, 0)`.  So `if (x >= 0 && x < n)`, `return a && b`, and `!(x > 5)`
+  all translate now.
+- Manifest declares `Feature::ShortCircuit`.  Both backends already accept it and
+  render `and`/`or`; the C backend gains a `_sir_not` runtime helper for `!`
+  (Ruby already had `not`).
+- A logical operator chain folds into a tree as deep as it is wide, so its width
+  is charged against the shared depth budget, and `!!!…` recursion is bounded
+  too — a 200-long `&&` chain is a clean positioned error, not a crash.
+- Corpus grows with 8 logical programs (`&&` range checks in/out of range, `||`
+  out-of-band, `&&`/`!` as values, `!` in a condition, a chained `&&`, and mixed
+  `|| / && / !` precedence) — all byte-identical across reference `clang -fwrapv`,
+  emitted Ruby, and emitted C (and clang+gcc+MSVC).
+- Still deferred: bitwise (`& | ^ ~`, `<< >>`) — needs new backend builtins — and
+  division/modulo (`/ %`) — needs the truncate-vs-floor split.
+
 ### Milestone 3 — early `return` (return lifting)
 
 - A returning `if` is now **lifted** into a value-producing `Expr::If`, with the

--- a/code/packages/rust/c-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/c-to-semantic-ir/src/lib.rs
@@ -16,6 +16,8 @@
 //!   `for`, re-assignment), bridging the C-vs-SIR truthiness mismatch.
 //! - **Milestone 3** — early `return`, lifted into value-producing `If`s, which
 //!   is what makes guard clauses and idiomatic recursion translatable.
+//! - **Milestone 4** — the short-circuiting logical operators `&&`, `||`, `!`,
+//!   reusing the truthiness bridge (`and`/`or`/`not` builtins).
 
 mod lower;
 
@@ -122,6 +124,73 @@ mod tests {
         let m = lower("int main(void) { int a = 5; int b = 3; int c = a > b; return 0; }");
         let text = semantic_ir::print_module(&m);
         assert!(text.contains("(if (builtin-call >"), "no if-int:\n{text}");
+    }
+
+    // ── milestone 4: logical operators ──────────────────────────────────────
+
+    #[test]
+    fn logical_and_condition_short_circuits_via_and_builtin() {
+        // `if (a && b)` → `and(cond(a), cond(b))`, each operand a SIR bool.
+        let m = lower("int f(int x) { if (x >= 0 && x < 10) { return 1; } return 0; }");
+        let text = semantic_ir::print_module(&m);
+        assert!(
+            text.contains("(builtin-call and"),
+            "no short-circuit and:\n{text}"
+        );
+        // Its operands are the comparison builtins directly (bools), not `!= 0`.
+        assert!(text.contains("(builtin-call >="), "no >= operand:\n{text}");
+        assert!(text.contains("(builtin-call <"), "no < operand:\n{text}");
+    }
+
+    #[test]
+    fn logical_or_uses_or_builtin() {
+        let m = lower("int f(int x) { if (x < 0 || x > 9) { return 1; } return 0; }");
+        assert!(semantic_ir::print_module(&m).contains("(builtin-call or"));
+    }
+
+    #[test]
+    fn logical_not_condition_uses_not_builtin() {
+        let m = lower("int f(int x) { if (!(x > 5)) { return 1; } return 0; }");
+        assert!(semantic_ir::print_module(&m).contains("(builtin-call not"));
+    }
+
+    #[test]
+    fn bare_variable_operand_is_bridged_via_ne_zero() {
+        // `a && b` with plain int operands: each is `!= 0` (SIR treats 0 truthy).
+        let m = lower("int f(int a, int b) { if (a && b) { return 1; } return 0; }");
+        let text = semantic_ir::print_module(&m);
+        assert!(text.contains("(builtin-call and"), "no and:\n{text}");
+        assert!(
+            text.contains("(builtin-call != (effects pure) (var-ref a param) (int 0))"),
+            "operand a not bridged via != 0:\n{text}"
+        );
+    }
+
+    #[test]
+    fn logical_as_value_is_if_one_else_zero() {
+        // `int r = a && b;` — a logical operator used as a value is int 0/1.
+        let m = lower("int f(int a, int b) { int r = a && b; return r; }");
+        assert!(semantic_ir::print_module(&m).contains("(if (builtin-call and"));
+    }
+
+    #[test]
+    fn long_logical_chain_is_a_clean_error_not_a_crash() {
+        // A `&&` chain folds into a tree as deep as it is wide, so its width is
+        // charged against the shared depth budget.
+        let mut cond = String::from("x > 0");
+        for i in 0..200 {
+            cond.push_str(&format!(" && x != {i}"));
+        }
+        let err = compile_source(
+            &format!("int f(int x) {{ if ({cond}) {{ return 1; }} return 0; }}"),
+            "t",
+        )
+        .unwrap_err();
+        assert!(
+            err.message.contains("limit"),
+            "wrong error: {}",
+            err.message
+        );
     }
 
     // ── milestone 3: early return ───────────────────────────────────────────

--- a/code/packages/rust/c-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/c-to-semantic-ir/src/lower.rs
@@ -352,6 +352,9 @@ pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, CLowe
         // builtins need no feature of their own (core control flow / intrinsics).
         Feature::Loops,
         Feature::MutableBindings,
+        // Milestone 4: `&&`/`||`/`!` lower to the short-circuiting `and`/`or`/
+        // `not` builtins.
+        Feature::ShortCircuit,
     ]);
 
     let module = Module {
@@ -990,12 +993,72 @@ impl Lowerer {
     /// so the explicit compare is required).
     fn lower_cond(&mut self, node: &GrammarASTNode) -> Result<Expr, CLowerError> {
         let n = peel(node);
-        if matches!(n.rule_name.as_str(), "equality" | "relational") && child_nodes(n).len() >= 2 {
-            self.lower_compare_bool(n)
-        } else {
-            let (e, _t) = self.lower_expr(node)?;
-            Ok(builtin("!=", vec![e, int_lit(0)]))
+        match n.rule_name.as_str() {
+            // Short-circuiting `&&` / `||`: fold the operands *as conditions*
+            // with the matching SIR builtin (left-associative, like C).
+            "logical_and" if child_nodes(n).len() >= 2 => self.lower_logical(n, "and"),
+            "logical_or" if child_nodes(n).len() >= 2 => self.lower_logical(n, "or"),
+            // A comparison already yields a SIR bool.
+            "equality" | "relational" if child_nodes(n).len() >= 2 => self.lower_compare_bool(n),
+            // Unary `!c` → `not(cond(c))`.  Charged against the depth budget:
+            // `!!!…c` recurses here per `!`, and nests the emitted tree the same.
+            "unary" if unary_op(n).as_deref() == Some("!") => {
+                let operand = child_nodes(n)
+                    .into_iter()
+                    .next()
+                    .ok_or_else(|| CLowerError {
+                        message: "`!` without an operand".into(),
+                        line: n.start_line.unwrap_or(0),
+                        column: n.start_column.unwrap_or(0),
+                    })?;
+                self.expr_depth += 1;
+                if self.budget_used() > MAX_EXPR_DEPTH {
+                    self.expr_depth -= 1;
+                    return err(
+                        format!("expression nests deeper than the limit of {MAX_EXPR_DEPTH}"),
+                        n,
+                    );
+                }
+                let inner = self.lower_cond(operand);
+                self.expr_depth -= 1;
+                Ok(builtin("not", vec![inner?]))
+            }
+            // Any other integer expression `e` is true iff `e != 0` (C treats 0
+            // as false; SIR treats it as truthy).
+            _ => {
+                let (e, _t) = self.lower_expr(node)?;
+                Ok(builtin("!=", vec![e, int_lit(0)]))
+            }
         }
+    }
+
+    /// Fold a `logical_and`/`logical_or` node into left-associative short-circuit
+    /// builtins, lowering each operand *as a condition*.  Its width is charged
+    /// against the depth budget (the fold nests as deep as the chain is wide).
+    fn lower_logical(&mut self, n: &GrammarASTNode, op: &str) -> Result<Expr, CLowerError> {
+        let width = self.charge_chain(n)?;
+        self.expr_depth += width;
+        let result = self.lower_logical_inner(n, op);
+        self.expr_depth -= width;
+        result
+    }
+
+    fn lower_logical_inner(&mut self, n: &GrammarASTNode, op: &str) -> Result<Expr, CLowerError> {
+        let mut acc: Option<Expr> = None;
+        for c in &n.children {
+            if let ASTNodeOrToken::Node(operand) = c {
+                let cond = self.lower_cond(operand)?;
+                acc = Some(match acc {
+                    None => cond,
+                    Some(a) => builtin(op, vec![a, cond]),
+                });
+            }
+        }
+        acc.ok_or_else(|| CLowerError {
+            message: "empty logical expression".into(),
+            line: n.start_line.unwrap_or(0),
+            column: n.start_column.unwrap_or(0),
+        })
     }
 
     /// Lower an `equality`/`relational` node to a SIR bool.  Left-associative:
@@ -1186,18 +1249,23 @@ impl Lowerer {
             "additive" | "multiplicative" | "shift" | "bit_and" | "bit_or" | "bit_xor" => {
                 self.lower_binary(n)
             }
-            // A comparison used as a *value* has type `int` in C (0 or 1), so it
-            // lowers to `If(cmp, 1, 0)` — restoring the integer from the bool.
+            // A comparison or logical operator used as a *value* has type `int`
+            // in C (0 or 1), so it lowers to `If(bool, 1, 0)` — restoring the
+            // integer from the SIR bool.
             "equality" | "relational" if child_nodes(n).len() >= 2 => {
                 let b = self.lower_compare_bool(n)?;
+                Ok((if_int(b), i32_spec()))
+            }
+            "logical_and" | "logical_or" if child_nodes(n).len() >= 2 => {
+                let b = self.lower_cond(n)?;
                 Ok((if_int(b), i32_spec()))
             }
             "cast" => self.lower_cast(n),
             "unary" => self.lower_unary(n),
             "postfix" => self.lower_postfix(n),
             "primary" => self.lower_primary(n),
-            // Logical `&& ||`, unary `!`, and assignment-as-subexpression remain
-            // deferred (assignment is handled in statement position).
+            // Assignment-as-subexpression remains deferred (assignment is handled
+            // in statement position).
             other => err(format!("expression `{other}` not yet supported"), n),
         }
     }
@@ -1293,6 +1361,14 @@ impl Lowerer {
         // unary = (PLUS|MINUS|TILDE|BANG) unary
         let op = child_tokens(n).first().map(|t| t.value.clone()).unwrap();
         let operand = child_nodes(n).into_iter().next().unwrap();
+
+        // `!c` used as a *value* has type `int` (0/1), so lower its operand as a
+        // condition and wrap the resulting bool: `If(not(cond(c)), 1, 0)`.
+        if op == "!" {
+            let cond = builtin("not", vec![self.lower_cond(operand)?]);
+            return Ok((if_int(cond), i32_spec()));
+        }
+
         let (e, t) = self.lower_expr(operand)?;
         let tp = promote(t); // unary applies integer promotion
         let e = convert_to(e, t, tp);
@@ -1301,8 +1377,8 @@ impl Lowerer {
             // Unary minus as `0 - x` (both backends render binary `-`); the
             // subtract happens at the promoted type and its result is wrapped.
             "-" => Ok((convert(builtin("-", vec![int_lit(0), e]), tp), tp)),
-            // `~` (bitnot) and `!` (logical not / truthiness) are deferred.
-            other => err(format!("unary `{other}` not supported in milestone 1"), n),
+            // `~` (bitnot) is deferred to the bitwise milestone.
+            other => err(format!("unary `{other}` not yet supported"), n),
         }
     }
 
@@ -1429,6 +1505,11 @@ impl Lowerer {
 
 fn peel_block_item(item: &GrammarASTNode) -> &GrammarASTNode {
     child_nodes(item).into_iter().next().unwrap_or(item)
+}
+
+/// The leading operator token of a `unary` node (`!`, `~`, `-`, `+`), if any.
+fn unary_op(n: &GrammarASTNode) -> Option<String> {
+    child_tokens(n).first().map(|t| t.value.clone())
 }
 
 // ── sequence / control-flow shape analysis (milestone 3) ────────────────────

--- a/code/packages/rust/c-to-semantic-ir/tests/three_way_conformance.rs
+++ b/code/packages/rust/c-to-semantic-ir/tests/three_way_conformance.rs
@@ -362,6 +362,55 @@ fn corpus() -> Vec<Case> {
                    if (go > 0) { return s; } return 0; }\n\
                    int main(void) { printf(\"%u\\n\", total(1)); return 0; }",
         },
+        // ── milestone 4: logical operators (&& || !) ─────────────────────────
+        Case {
+            label: "&& range check in-range in_range(5) → 1",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int in_range(int x) { if (x >= 0 && x < 10) { return 1; } return 0; }\n\
+                   int main(void) { printf(\"%d\\n\", in_range(5)); return 0; }",
+        },
+        Case {
+            label: "&& range check out-of-range in_range(15) → 0",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int in_range(int x) { if (x >= 0 && x < 10) { return 1; } return 0; }\n\
+                   int main(void) { printf(\"%d\\n\", in_range(15)); return 0; }",
+        },
+        Case {
+            label: "|| out-of-band far(-3) → 1",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int far(int x) { if (x < 0 || x > 100) { return 1; } return 0; }\n\
+                   int main(void) { printf(\"%d\\n\", far(-3)); return 0; }",
+        },
+        Case {
+            label: "&& as a value both(3,0) → 0",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int both(int a, int b) { return a && b; }\n\
+                   int main(void) { printf(\"%d\\n\", both(3, 0)); return 0; }",
+        },
+        Case {
+            label: "! as a value negate(0) → 1",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int negate(int x) { return !x; }\n\
+                   int main(void) { printf(\"%d\\n\", negate(0)); return 0; }",
+        },
+        Case {
+            label: "! in a condition not_big(3) → 100",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int not_big(int x) { if (!(x > 5)) { return 100; } return 200; }\n\
+                   int main(void) { printf(\"%d\\n\", not_big(3)); return 0; }",
+        },
+        Case {
+            label: "chained && excludes 50 band(50) → 0",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int band(int x) { if (x > 0 && x < 100 && x != 50) { return 1; } return 0; }\n\
+                   int main(void) { printf(\"%d\\n\", band(50)); return 0; }",
+        },
+        Case {
+            label: "mixed || / && / ! precedence classify(4) → 1",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int classify(int x, int y) { if ((x > 0 || y > 0) && !(x == y)) { return 1; } return 0; }\n\
+                   int main(void) { printf(\"%d\\n\", classify(4, 4)); return 0; }",
+        },
     ]
 }
 

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -1487,6 +1487,8 @@ fn fixed_helper(name: &str) -> Option<(&'static str, usize)> {
         ">=" => ("_sir_ge", 2),
         "==" => ("_sir_eq", 2),
         "!=" => ("_sir_ne", 2),
+        // Milestone 4 logical negation (`&&`/`||` short-circuit via emit_assign).
+        "not" => ("_sir_not", 1),
         "cons" => ("_sir_cons", 2),
         "car" => ("_sir_car", 1),
         "cdr" => ("_sir_cdr", 1),

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -417,6 +417,9 @@ int _sir_value_eq(SirValue a, SirValue b) { return _sir_value_eq_d(a, b, 0); }
 SirValue _sir_eq(SirValue a, SirValue b) { return _sir_bool(_sir_value_eq(a, b)); }
 SirValue _sir_ne(SirValue a, SirValue b) { return _sir_bool(!_sir_value_eq(a, b)); }
 
+/* Logical negation: `!v` under SIR truthiness (only nil/false are falsy). */
+SirValue _sir_not(SirValue v) { return _sir_bool(!_sir_truthy(v)); }
+
 /* Ruby `===` (case subsumption).  For the v0 value set — no classes, ranges, or
  * regexps yet — `pattern === value` reduces to structural equality, so `case`
  * / `when` over literals behaves correctly.  Later batches extend this for
@@ -928,6 +931,7 @@ SirValue _sir_builtin_dispatch(SirValue *caps, SirValue *args, int argc) {
     if (strcmp(name, ">=") == 0)       return _sir_ge(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
     if (strcmp(name, "==") == 0)       return _sir_eq(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
     if (strcmp(name, "!=") == 0)       return _sir_ne(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
+    if (strcmp(name, "not") == 0)      return _sir_not(_sir_arg(args, argc, 0));
     if (strcmp(name, "cons") == 0)     return _sir_cons(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
     if (strcmp(name, "car") == 0)      return _sir_car(_sir_arg(args, argc, 0));
     if (strcmp(name, "cdr") == 0)      return _sir_cdr(_sir_arg(args, argc, 0));

--- a/code/specs/SIR27-c-to-semantic-ir.md
+++ b/code/specs/SIR27-c-to-semantic-ir.md
@@ -272,6 +272,35 @@ guard bounds.
    a positioned error.  Lifting the cap means making those consumers iterative —
    a cross-cutting change well beyond this frontend.
 
+## Logical operators (milestone 4)
+
+`&&`, `||`, and unary `!` — the short-circuiting logical operators — reuse the
+same C-vs-SIR truthiness bridge as milestone 2.  In C each operand is tested for
+truthiness (`!= 0`) and the result is an `int` `0`/`1`; SIR has short-circuiting
+`and`/`or` builtins (and `not`) whose operands are evaluated under SIR
+truthiness.  So the two directions mirror the comparison handling:
+
+- **As a condition** (`if (a && b)`), each operand is lowered *as a condition*
+  (`lower_cond`, which already yields the right SIR bool for a comparison or an
+  `!= 0`), and the operator becomes the matching short-circuiting builtin:
+  `a && b → and(cond(a), cond(b))`, `a || b → or(cond(a), cond(b))`,
+  `!a → not(cond(a))`.  Left-associative, so `a && b && c` is `and(and(a,b),c)` —
+  exactly C's evaluation order, and the SIR builtins short-circuit just as C
+  does (the backends render `and`/`or` as `&&`/`||` in Ruby and as a
+  short-circuiting `if` chain in C).
+- **As a value** (`int r = a && b;`), the bool is wrapped back to C's `int`
+  `0`/`1` with `If(bool, 1, 0)` — the same `if_int` used for a bare comparison.
+
+A logical operator chain folds into a tree as deep as it is wide, so — like an
+arithmetic chain — its width is charged against the shared depth budget.
+
+`Feature::ShortCircuit` is added to the module manifest (both backends already
+accept it and render `and`/`or`; the C backend gains a `_sir_not` for `!`).
+
+Bitwise (`& | ^ ~`, `<< >>`) and division/modulo (`/ %`) remain deferred:
+bitwise needs new builtins in both backends, and `/`/`%` need the truncate-vs-
+floor split (C truncates toward zero; SIR/Ruby floor), which is its own slice.
+
 ## Pipeline
 
 ```text


### PR DESCRIPTION
## Milestone 4 of the C → SIR → Ruby initiative — logical operators

The short-circuiting `&&`, `||`, and `!` now translate, reusing the milestone-2 truthiness bridge. This unlocks the single most common gap in real C conditions — `if (x >= 0 && x < n)`.

**As a condition**, each operand is lowered *as a condition* (a SIR bool), and the operator becomes the matching short-circuiting builtin, left-associative to match C's order:
- `a && b` → `and(cond(a), cond(b))`
- `a || b` → `or(cond(a), cond(b))`
- `!a` → `not(cond(a))`

**As a value** (`int r = a && b;`), the bool is wrapped back to C's int `0`/`1` with `If(b, 1, 0)`.

### Backends
`Feature::ShortCircuit` is declared; both backends already accept it and render `and`/`or` (Ruby native `&&`/`||`, C a short-circuiting `if` chain). The C backend gains a `_sir_not` runtime helper for `!` (Ruby already had `not`).

### DoS-safe
A logical chain folds into a tree as deep as it is wide, so its width is charged against the shared depth budget, and `!!!…` recursion is bounded too — a 200-long `&&` chain is a clean positioned error, not a crash.

### Verified locally
- **35-program three-way conformance corpus** byte-identical across reference `clang -fwrapv`, emitted Ruby (`ruby` 3.4), and emitted C.
- Eight logical programs also compile+run identically on **clang + gcc + MSVC** (`&&` range checks, `||` out-of-band, `&&`/`!` as values, `!` in a condition, chained `&&`, mixed `|| / && / !` precedence).
- **Security review passed first round** — 27 differential cases including De Morgan equivalence over all inputs, short-circuit confirmed via a self-recursive RHS, depth budget covers logical chains + `!` nesting, no `expr_depth` leak, no miscompile.

Still deferred (future milestones): bitwise (`& | ^ ~`, `<< >>`) — needs new backend builtins — and division/modulo (`/ %`) — needs the truncate-vs-floor split (C truncates toward zero; SIR/Ruby floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)