### PR TITLE
feat(adj-formula-stdlib): frequency-period — LibreTexts reciprocal f = 1/T definition library (physics track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_frequency_period_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_frequency_period_e2e.rs
@@ -1,0 +1,107 @@
+//! End-to-end tests for the `physics/frequency-period.adj` library — the reciprocal
+//! relation between frequency and period (f = 1/T) and its single exact rearrangement
+//! (T = 1/f) — driven through the built CLI binary against the SHIPPED stdlib. Each
+//! proves the same invariant as the other formula libraries: a consumer states NO
+//! arithmetic; it imports the grounded library, binds the measured quantity with
+//! `observe`, and the engine applies the cited definition on the CPU — computing the
+//! EXACT reciprocal and rendering the definition's citation + trust tier in the
+//! `derived` section (the auditable answer). Unlike the two-input rate libraries this is
+//! a one-input reciprocal, so the two formulas form a clean 2-way inverter:
+//! 1 / 4 = 0.25 and 1 / 0.5 = 2.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped frequency-period library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_frequency_period_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/physics/frequency-period.adj")
+        .canonicalize()
+        .expect("shipped frequency-period.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_freqper_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_frequency_period_lib()).unwrap();
+    std::fs::write(dir.join("frequency-period.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// frequency — the definition: one divided by the period (f = 1/T).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_frequency_period_library_and_computes_frequency_with_citation() {
+    let dir = scratch("f");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"frequency-period.adj\"\n\
+         observe period(4)\n\
+         ? frequency(period)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied definition's result: 1 / 4 = 0.25.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"frequency\"") && s.contains("\"value\":0.25"),
+        "frequency(4) = 0.25: {s}"
+    );
+    // … AND the LibreTexts citation + trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("phys.libretexts.org"),
+        "applied definition carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// period — the same reciprocal relation solved for T: one divided by the frequency,
+// which INVERTS the frequency direction.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_period_as_reciprocal_of_frequency_with_citation() {
+    let dir = scratch("t");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"frequency-period.adj\"\n\
+         observe frequency(0.5)\n\
+         ? period(frequency)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 1 / 0.5 = 2, computed on the CPU as an exact rational.
+    assert!(
+        s.contains("\"name\":\"period\"") && s.contains("\"value\":2"),
+        "period(0.5) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("phys.libretexts.org"),
+        "period carries its LibreTexts citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/physics/frequency-period.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/frequency-period.adj
@@ -1,0 +1,80 @@
+% ============================================================================
+% frequency-period.adj — frequency is the reciprocal of period (f = 1/T) in the
+% ADJ standard library.
+% ============================================================================
+% The frequency/period entry of the *physics* track, a sibling of `wave-speed.adj`,
+% `power.adj` and `electric-charge.adj`: the foundational oscillations definition a
+% first course states as THE RELATIONSHIP BETWEEN FREQUENCY AND PERIOD — i.e. the
+% reciprocal relation f = 1/T (the frequency is one divided by the period, the time for
+% one cycle) — as an importable, byte-provenanced, PARAMETERIZED `formula`, together
+% with its single exact rearrangement (the period is one divided by the frequency,
+% T = 1/f). Unlike the two-input rate definitions (v = f·λ, P = W/t, I = Q/t), this is a
+% ONE-input RECIPROCAL: each quantity is exactly one over the other, so the two formulas
+% are a clean 2-way inverter rather than a 3-way one. As with every compute library, a
+% consumer states NO arithmetic: it `import`s this file, binds the measured quantity
+% from its own byte-provenance decomposition, and asks the engine to APPLY the cited
+% definition on the CPU. Zero math is performed by the model; the engine computes the
+% value EXACTLY, carrying the definition's citation.
+%
+%     import "frequency-period.adj"
+%     observe period(4)              % "…a period of 4 s…"  (span cited by the model)
+%     ? frequency(period)            % engine → 0.25, carrying f = 1/T
+%
+% Both formulas are EXACT over their parameter — each a reciprocal of a measured
+% quantity, computed as an exact rational (so 1/4 is exactly 0.25, 1/8 exactly 0.125).
+% There is no *separately grounded* physical constant here, so every value the engine
+% returns is exact. The two COMPOSE and invert cleanly: the `frequency` a consumer
+% computes from a period is exactly the `frequency` whose reciprocal the `period`
+% formula returns to recover the period.
+%
+%   frequency(period) = 1 / period      %  f = 1/T   (frequency is one over the period)
+%   period(frequency) = 1 / frequency     %  T = 1/f   (same relation, solved for T)
+%
+% Both formulas are defended by the SAME sentence — "The relationship between frequency
+% and period is:" — the sentence Physics LibreTexts uses to introduce the displayed
+% equation f = 1/T, exactly the lead-in-to-equation form `wave-speed.adj` already cites
+% ("The relationship of the speed of sound, its frequency, and wavelength is the same as
+% for all waves:"). Because the relation is a pure reciprocal, that one sentence
+% sanctions it read either way (f from T, or T from f). The quote is transcribed verbatim
+% from Physics LibreTexts (OpenStax College Physics — a primary educational reference,
+% the same publisher `wave-speed.adj`, `power.adj`, `electric-charge.adj` and
+% `hookes-law.adj` cite), so each `formula` carries the provenance envelope every shipped
+% grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the sentence is a verbatim span of the cited page,
+% not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each quantity is an observable the relation ranges over, and each is BOTH
+% a derived result and the input of the other formula, so each is a single dictionary
+% term used in both roles. The `surface` lists are the everyday names a decomposer maps
+% onto the canonical term; the trailing comment records the intended SI unit.
+% ----------------------------------------------------------------------------
+dictionary frequency_period_vocab {
+    define period    : finding  surface "period", "T"                % period, e.g. s (seconds per cycle)
+    define frequency : finding  surface "frequency", "f"            % frequency, e.g. Hz (cycles per second)
+}
+
+% ----------------------------------------------------------------------------
+% The relation, both ways. Each is a named, importable, reusable `let` over its formal
+% parameter, bound at apply time, and each carries the definitional quote from LibreTexts
+% (a quote is required on a shipped formula). Each is a reciprocal, computed as an exact
+% rational, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook frequency_period_laws {
+    use frequency_period_vocab
+
+    % Frequency — one divided by the period. LibreTexts introduces this as the
+    % relationship between frequency and period, f = 1/T.
+    formula frequency(period) = 1 / period
+        source "The relationship between frequency and period is:"
+        locator "https://phys.libretexts.org/Bookshelves/College_Physics/College_Physics_1e_(OpenStax)/16:_Oscillatory_Motion_and_Waves/16.02:_Period_and_Frequency_in_Oscillations"
+        trust authoritative
+
+    % Period — the same reciprocal relation solved for the period, T = 1/f. Defended by
+    % the SAME sentence, read the other way.
+    formula period(frequency) = 1 / frequency
+        source "The relationship between frequency and period is:"
+        locator "https://phys.libretexts.org/Bookshelves/College_Physics/College_Physics_1e_(OpenStax)/16:_Oscillatory_Motion_and_Waves/16.02:_Period_and_Frequency_in_Oscillations"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/physics/frequency-period.query.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/frequency-period.query.adj
@@ -1,0 +1,27 @@
+% ============================================================================
+% frequency-period.query.adj — worked examples over the physics frequency-period library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a frequency/period
+% question: it states NO arithmetic and NO definition — it only `import`s the grounded
+% library, `observe`s the measured quantity it decomposed from the prompt (a
+% byte-provenanced span, elided here), and asks the engine to APPLY the cited relation.
+% The native adj-lang engine binds the parameter, computes the reciprocal EXACTLY on the
+% CPU, and returns it with the definition's source/locator/trust.
+%
+% The two questions INVERT: an oscillation with a period of 4 s has a frequency of
+% 0.25 Hz; an oscillation with a frequency of 0.5 Hz has a period of 2 s — each the exact
+% reciprocal of the other.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli frequency-period.query.adj
+% ============================================================================
+
+import "frequency-period.adj"
+
+% A period of 4 s: frequency = 1 / 4.
+observe period(4)
+? frequency(period)      % expect 0.25   (definition: f = 1/T)
+
+% A frequency of 0.5 Hz: period = 1 / 0.5.
+observe frequency(0.5)
+? period(frequency)      % expect 2      (same relation, solved for T = 1/f)


### PR DESCRIPTION
## What

Adds the **frequency/period** entry of the physics track: the foundational oscillations relation a first course states as **the relationship between frequency and period** — the reciprocal **f = 1/T** — as an importable, byte-provenanced, parameterized `formula`, plus its single exact rearrangement. Both readings are defended by the **same** verbatim lead-in sentence, transcribed from Physics LibreTexts (OpenStax College Physics 16.2: Period and Frequency in Oscillations):

> "The relationship between frequency and period is:"

| formula | reading |
|---------|---------|
| `frequency(period) = 1 / period` | f = 1/T (frequency is one over the period) |
| `period(frequency) = 1 / frequency` | T = 1/f (same relation, solved for T) |

This is the **same lead-in-to-equation grounding form** the already-merged `wave-speed.adj` cites (*"The relationship of the speed of sound, its frequency, and wavelength is the same as for all waves:"*).

## Why

Unlike the two-input rate definitions (`v = f·λ`, `P = W/t`, `I = Q/t`), this is a **one-input reciprocal** — so the two formulas form a clean **2-way inverter**, a distinct new shape in the library, and it rounds out the oscillations/waves basics alongside `wave-speed.adj`.

## How it works

Data + test only — **no engine/version change**. A consumer states **no arithmetic**: it imports the grounded library, binds the measured quantity with `observe`, and the engine applies the cited relation on the CPU — computing the reciprocal **exactly** (as a rational, so 1/4 is exactly 0.25) and rendering the definition's `source`/`locator`/`trust` in the `derived` section. The two formulas invert cleanly (1/4 = 0.25, 1/0.5 = 2).

## Files
- `physics/frequency-period.adj` — the grounded reciprocal library (2-way inverter)
- `physics/frequency-period.query.adj` — worked examples (f=0.25, T=2)
- `formula_frequency_period_e2e.rs` — 2 e2e tests through the built CLI vs the shipped stdlib

## Verification
- `cargo test -p adj-lang-cli --test formula_frequency_period_e2e` → 2 passed
- Ran the shipped `.query.adj` through the built CLI: frequency=0.25, period=2, each carrying the LibreTexts citation + `authoritative` trust
- Lead-in sentence (incl. trailing colon) byte-verified against the cited LibreTexts page
- Security review passed (data + test only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)