### PR TITLE
feat(adj-formula-stdlib): boyles-law — LibreTexts P₁V₁ = P₂V₂ conserved-product library (chemistry track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_boyles_law_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_boyles_law_e2e.rs
@@ -1,0 +1,175 @@
+//! End-to-end tests for the `chemistry/boyles-law.adj` library — Boyle's law
+//! (P₁V₁ = P₂V₂) in all FOUR exact readings — driven through the built CLI binary
+//! against the SHIPPED stdlib. Each proves the same invariant as the other formula
+//! libraries: a consumer states NO arithmetic; it imports the grounded library, binds
+//! the measured quantities with `observe`, and the engine applies the cited relation on
+//! the CPU — computing the EXACT value and rendering the relation's citation + trust tier
+//! in the `derived` section (the auditable answer). The four readings all turn on the
+//! same conserved product P₁V₁ = P₂V₂ = 12, around P₁=6, V₁=2, P₂=3, V₂=4.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped Boyle's-law library, resolved from this crate's manifest
+/// dir so the test is location-independent.
+fn shipped_boyles_law_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/chemistry/boyles-law.adj")
+        .canonicalize()
+        .expect("shipped boyles-law.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_boyle_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_boyles_law_lib()).unwrap();
+    std::fs::write(dir.join("boyles-law.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// final_volume — V₂ = P₁V₁ / P₂: a fixed amount of gas reaches this volume at a new
+// pressure. 6*2 / 3 = 4.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_boyles_law_library_and_computes_final_volume_with_citation() {
+    let dir = scratch("v2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"boyles-law.adj\"\n\
+         observe initial_pressure(6)\n\
+         observe initial_volume(2)\n\
+         observe final_pressure(3)\n\
+         ? final_volume(initial_pressure, initial_volume, final_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 6*2 / 3 = 4.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"final_volume\"") && s.contains("\"value\":4"),
+        "final_volume(6, 2, 3) = 4: {s}"
+    );
+    // … AND the LibreTexts citation + trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// final_pressure — P₂ = P₁V₁ / V₂: the pressure after squeezing to a new volume.
+// 6*2 / 4 = 3.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_final_pressure_with_citation() {
+    let dir = scratch("p2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"boyles-law.adj\"\n\
+         observe initial_pressure(6)\n\
+         observe initial_volume(2)\n\
+         observe final_volume(4)\n\
+         ? final_pressure(initial_pressure, initial_volume, final_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 6*2 / 4 = 3, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"final_pressure\"") && s.contains("\"value\":3"),
+        "final_pressure(6, 2, 4) = 3: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "final_pressure carries its LibreTexts citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// initial_pressure — P₁ = P₂V₂ / V₁: recover the starting pressure. 3*4 / 2 = 6.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_initial_pressure_with_citation() {
+    let dir = scratch("p1");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"boyles-law.adj\"\n\
+         observe final_pressure(3)\n\
+         observe final_volume(4)\n\
+         observe initial_volume(2)\n\
+         ? initial_pressure(final_pressure, final_volume, initial_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 3*4 / 2 = 6, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"initial_pressure\"") && s.contains("\"value\":6"),
+        "initial_pressure(3, 4, 2) = 6: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "initial_pressure carries its LibreTexts citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// initial_volume — V₁ = P₂V₂ / P₁: recover the starting volume, the fourth exact
+// reading of the one law. 3*4 / 6 = 2.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_initial_volume_with_citation() {
+    let dir = scratch("v1");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"boyles-law.adj\"\n\
+         observe final_pressure(3)\n\
+         observe final_volume(4)\n\
+         observe initial_pressure(6)\n\
+         ? initial_volume(final_pressure, final_volume, initial_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 3*4 / 6 = 2, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"initial_volume\"") && s.contains("\"value\":2"),
+        "initial_volume(3, 4, 6) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "initial_volume carries its LibreTexts citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/chemistry/boyles-law.adj
+++ b/code/specs/data/adj-formula-stdlib/chemistry/boyles-law.adj
@@ -1,0 +1,108 @@
+% ============================================================================
+% boyles-law.adj — Boyle's law (P₁V₁ = P₂V₂) in the ADJ standard library.
+% ============================================================================
+% The Boyle's-law entry of the *chemistry* track, a sibling of `ideal-gas-law.adj`,
+% `dilution.adj` and `molarity.adj`: the foundational gas relation a first course states
+% as THE VOLUME OF A GAS AT CONSTANT TEMPERATURE IS INVERSELY PROPORTIONAL TO ITS
+% PRESSURE, as an importable, byte-provenanced, PARAMETERIZED `formula` — together with
+% the FOUR exact readings that one proportionality sanctions (solve for any one of the
+% initial pressure, initial volume, final pressure or final volume from the other
+% three). As with every compute library, a consumer states NO arithmetic: it `import`s
+% this file, binds the measured quantities from its own byte-provenance decomposition,
+% and asks the engine to APPLY the cited relation on the CPU. Zero math is performed by
+% the model; the engine computes each value EXACTLY, carrying the relation's citation.
+%
+%     import "boyles-law.adj"
+%     observe initial_pressure(6)    % "…at 6 atm…"          (span cited by the model)
+%     observe initial_volume(2)      % "…occupies 2 L…"      (span cited by the model)
+%     observe final_pressure(3)      % "…compressed to 3 atm…"
+%     ? final_volume(initial_pressure, initial_volume, final_pressure)
+%                                      % engine → 4, carrying P₁V₁ = P₂V₂
+%
+% It is the constant-temperature special case of `ideal-gas-law.adj` (PV = nRT with n
+% and T fixed): the ideal gas law DEFINES the full state, and Boyle's law says that for
+% a fixed amount of gas at fixed temperature the pressure–volume PRODUCT is conserved, so
+% the two libraries compose (an ideal-gas state feeds a Boyle's-law compression). This is
+% the pressure–volume analogue of `dilution.adj`'s M₁V₁ = M₂V₂ — the same conserved-
+% product algebra, a different physical law with its own grounding (write-once-use-many).
+%
+% All four formulas are EXACT over their parameters — each is a product divided by a
+% measured quantity — so every value the engine returns is exact; there is no
+% *separately grounded* constant here. The four COMPOSE and invert cleanly around the
+% worked case P₁ = 6, V₁ = 2, P₂ = 3, V₂ = 4 (note 6·2 = 12 = 3·4):
+%
+%   final_pressure(initial_pressure, initial_volume, final_volume)
+%       = initial_pressure * initial_volume / final_volume       % P₂ = P₁V₁ / V₂ = 6·2/4 = 3
+%   final_volume(initial_pressure, initial_volume, final_pressure)
+%       = initial_pressure * initial_volume / final_pressure     % V₂ = P₁V₁ / P₂ = 6·2/3 = 4
+%   initial_pressure(final_pressure, final_volume, initial_volume)
+%       = final_pressure * final_volume / initial_volume         % P₁ = P₂V₂ / V₁ = 3·4/2 = 6
+%   initial_volume(final_pressure, final_volume, initial_pressure)
+%       = final_pressure * final_volume / initial_pressure       % V₁ = P₂V₂ / P₁ = 3·4/6 = 2
+%
+% All four formulas are defended by the SAME sentence — "The volume of a given amount of
+% gas held at constant temperature is inversely proportional to the pressure under which
+% it is measured." — because inverse proportionality at constant temperature is exactly
+% the statement that the pressure–volume product is constant, P₁V₁ = P₂V₂, and so
+% sanctions the relation solved for any single variable. The quote is transcribed
+% verbatim from Chemistry LibreTexts (OpenStax Chemistry — the same primary reference
+% `molarity.adj`, `dilution.adj` and `ideal-gas-law.adj` cite), so each `formula` carries
+% the provenance envelope every shipped grounded clause carries; the linter rejects an
+% unsourced one. (See feedback_nothing_human_authored — the sentence is a verbatim span
+% of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Boyle's law ranges over four observable quantities: the pressure and
+% volume of the gas BEFORE the change and the pressure and volume AFTER (temperature and
+% amount held constant). Each appears BOTH as a derived result (of one formula) and as
+% an input (of the others), so each is a single dictionary term used in both roles. The
+% `surface` lists are the everyday names a decomposer maps onto the canonical term; the
+% trailing comment records the intended unit (a pressure e.g. in atm and a volume e.g. in
+% L, though the relation holds for ANY consistent pressure and volume units, since only
+% the products are compared).
+% ----------------------------------------------------------------------------
+dictionary boyles_law_vocab {
+    define initial_pressure : finding  surface "initial pressure", "P1"   % before, e.g. atm
+    define initial_volume   : finding  surface "initial volume", "V1"     % before, e.g. L
+    define final_pressure   : finding  surface "final pressure", "P2"     % after, e.g. atm
+    define final_volume     : finding  surface "final volume", "V2"       % after, e.g. L
+}
+
+% ----------------------------------------------------------------------------
+% Boyle's law, all four ways. Each is a named, importable, reusable `let` over its
+% formal parameters, bound at apply time, and each carries the proportionality sentence
+% from LibreTexts (a quote is required on a shipped formula). Each body is a product
+% divided by a measured quantity, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook boyles_law_laws {
+    use boyles_law_vocab
+
+    % Final pressure — the pressure after a fixed amount of gas is squeezed to a new
+    % volume (P₂ = P₁V₁ / V₂). The conserved product P₁V₁ divided by the new volume.
+    formula final_pressure(initial_pressure, initial_volume, final_volume) = initial_pressure * initial_volume / final_volume
+        source "The volume of a given amount of gas held at constant temperature is inversely proportional to the pressure under which it is measured."
+        locator "https://chem.libretexts.org/Bookshelves/General_Chemistry/Chemistry_1e_(OpenSTAX)/09:_Gases/9.2:_Relating_Pressure_Volume_Amount_and_Temperature:_The_Ideal_Gas_Law"
+        trust authoritative
+
+    % Final volume — the volume a fixed amount of gas reaches at a new pressure
+    % (V₂ = P₁V₁ / P₂). Defended by the SAME proportionality sentence, read another way.
+    formula final_volume(initial_pressure, initial_volume, final_pressure) = initial_pressure * initial_volume / final_pressure
+        source "The volume of a given amount of gas held at constant temperature is inversely proportional to the pressure under which it is measured."
+        locator "https://chem.libretexts.org/Bookshelves/General_Chemistry/Chemistry_1e_(OpenSTAX)/09:_Gases/9.2:_Relating_Pressure_Volume_Amount_and_Temperature:_The_Ideal_Gas_Law"
+        trust authoritative
+
+    % Initial pressure — the pressure a known compression started from
+    % (P₁ = P₂V₂ / V₁). Again the SAME proportionality sentence, solved for P₁.
+    formula initial_pressure(final_pressure, final_volume, initial_volume) = final_pressure * final_volume / initial_volume
+        source "The volume of a given amount of gas held at constant temperature is inversely proportional to the pressure under which it is measured."
+        locator "https://chem.libretexts.org/Bookshelves/General_Chemistry/Chemistry_1e_(OpenSTAX)/09:_Gases/9.2:_Relating_Pressure_Volume_Amount_and_Temperature:_The_Ideal_Gas_Law"
+        trust authoritative
+
+    % Initial volume — the volume a fixed amount of gas started at
+    % (V₁ = P₂V₂ / P₁). The fourth exact reading of the one proportionality law.
+    formula initial_volume(final_pressure, final_volume, initial_pressure) = final_pressure * final_volume / initial_pressure
+        source "The volume of a given amount of gas held at constant temperature is inversely proportional to the pressure under which it is measured."
+        locator "https://chem.libretexts.org/Bookshelves/General_Chemistry/Chemistry_1e_(OpenSTAX)/09:_Gases/9.2:_Relating_Pressure_Volume_Amount_and_Temperature:_The_Ideal_Gas_Law"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/chemistry/boyles-law.query.adj
+++ b/code/specs/data/adj-formula-stdlib/chemistry/boyles-law.query.adj
@@ -1,0 +1,35 @@
+% ============================================================================
+% boyles-law.query.adj — worked examples over the chemistry Boyle's-law library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a Boyle's-law question:
+% it states NO arithmetic and NO relation — it only `import`s the grounded library,
+% `observe`s the measured quantities it decomposed from the prompt (each a
+% byte-provenanced span, elided here), and asks the engine to APPLY the cited relation.
+% The native adj-lang engine binds the parameters, computes each value EXACTLY on the
+% CPU, and returns it with the relation's source/locator/trust.
+%
+% The four questions all turn on the SAME conserved product P₁V₁ = P₂V₂ = 12, around the
+% worked case P₁ = 6, V₁ = 2, P₂ = 3, V₂ = 4: given any three, the engine recovers the
+% fourth exactly.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli boyles-law.query.adj
+% ============================================================================
+
+import "boyles-law.adj"
+
+% 6 atm gas occupying 2 L, compressed to 3 atm: final volume = 6*2 / 3.
+observe initial_pressure(6)
+observe initial_volume(2)
+observe final_pressure(3)
+? final_volume(initial_pressure, initial_volume, final_pressure)   % expect 4   (V₂ = P₁V₁/P₂)
+
+% The same gas compressed instead to 4 L: final pressure = 6*2 / 4.
+observe final_volume(4)
+? final_pressure(initial_pressure, initial_volume, final_volume)   % expect 3   (P₂ = P₁V₁/V₂)
+
+% Recover the starting pressure from the 3 atm / 4 L final state and the 2 L start.
+? initial_pressure(final_pressure, final_volume, initial_volume)   % expect 6   (P₁ = P₂V₂/V₁)
+
+% Recover the starting volume from the 3 atm / 4 L final state and the 6 atm start.
+? initial_volume(final_pressure, final_volume, initial_pressure)   % expect 2   (V₁ = P₂V₂/P₁)


### PR DESCRIPTION
## What

Adds the **Boyle's-law** entry of the chemistry track: the foundational gas relation a first course states as **the volume of a gas at constant temperature is inversely proportional to its pressure** — the conserved pressure–volume product **P₁V₁ = P₂V₂** — as an importable, byte-provenanced, parameterized `formula`, in all **four** exact readings. All four are defended by the **same** verbatim sentence, transcribed from Chemistry LibreTexts (OpenStax Chemistry 9.2, "Volume and Pressure: Boyle's Law"):

> "The volume of a given amount of gas held at constant temperature is inversely proportional to the pressure under which it is measured."

| formula | reading |
|---------|---------|
| `final_pressure(P1, V1, V2)` = P1·V1/V2 | P₂ = P₁V₁/V₂ |
| `final_volume(P1, V1, P2)` = P1·V1/P2 | V₂ = P₁V₁/P₂ |
| `initial_pressure(P2, V2, V1)` = P2·V2/V1 | P₁ = P₂V₂/V₁ |
| `initial_volume(P2, V2, P1)` = P2·V2/P1 | V₁ = P₂V₂/P₁ |

## Why

Boyle's law is the **constant-temperature special case** of the ideal gas law (PV = nRT with n, T fixed) already in `ideal-gas-law.adj`, and the pressure–volume **analogue of `dilution.adj`'s M₁V₁ = M₂V₂** — the same conserved-product algebra, a distinct physical law with its own grounding (write-once-use-many). It rounds out the chemistry gas-law basics.

## How it works

Data + test only — **no engine/version change**. A consumer states **no arithmetic**: it imports the grounded library, binds the measured quantities with `observe`, and the engine applies the cited relation on the CPU — computing each value **exactly** and rendering `source`/`locator`/`trust` in the `derived` section. The four readings invert cleanly around P₁=6, V₁=2, P₂=3, V₂=4 (6·2 = 12 = 3·4).

## Files
- `chemistry/boyles-law.adj` — the grounded conserved-product library (4-way inverter)
- `chemistry/boyles-law.query.adj` — worked examples (V₂=4, P₂=3, P₁=6, V₁=2)
- `formula_boyles_law_e2e.rs` — 4 e2e tests through the built CLI vs the shipped stdlib

## Verification
- `cargo test -p adj-lang-cli --test formula_boyles_law_e2e` → 4 passed
- Ran the shipped `.query.adj` through the built CLI: V₂=4, P₂=3, P₁=6, V₁=2, each carrying the LibreTexts citation + `authoritative` trust
- Definitional sentence byte-verified against the cited LibreTexts page
- Security review passed (data + test only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)