### PR TITLE
feat(adj-formula-stdlib): charles-law — LibreTexts V₁/T₁ = V₂/T₂ conserved-ratio library (chemistry track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_charles_law_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_charles_law_e2e.rs
@@ -1,0 +1,176 @@
+//! End-to-end tests for the `chemistry/charles-law.adj` library — Charles's law
+//! (V₁/T₁ = V₂/T₂, volume directly proportional to absolute temperature at constant
+//! pressure) in all FOUR exact readings — driven through the built CLI binary against
+//! the SHIPPED stdlib. Each proves the same invariant as the other formula libraries: a
+//! consumer states NO arithmetic; it imports the grounded library, binds the measured
+//! quantities with `observe`, and the engine applies the cited relation on the CPU —
+//! computing the EXACT value and rendering the relation's citation + trust tier in the
+//! `derived` section (the auditable answer). The four readings all turn on the same
+//! conserved cross-product V₁T₂ = V₂T₁ = 12, around V₁=2, T₁=4, V₂=3, T₂=6.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped Charles's-law library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_charles_law_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/chemistry/charles-law.adj")
+        .canonicalize()
+        .expect("shipped charles-law.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_charles_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_charles_law_lib()).unwrap();
+    std::fs::write(dir.join("charles-law.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// final_volume — V₂ = V₁T₂ / T₁: a fixed amount of gas reaches this volume at a new
+// absolute temperature. 2*6 / 4 = 3.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_charles_law_library_and_computes_final_volume_with_citation() {
+    let dir = scratch("v2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"charles-law.adj\"\n\
+         observe initial_volume(2)\n\
+         observe initial_temperature(4)\n\
+         observe final_temperature(6)\n\
+         ? final_volume(initial_volume, initial_temperature, final_temperature)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 2*6 / 4 = 3.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"final_volume\"") && s.contains("\"value\":3"),
+        "final_volume(2, 4, 6) = 3: {s}"
+    );
+    // … AND the LibreTexts citation + trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// final_temperature — T₂ = V₂T₁ / V₁: the absolute temperature after expanding to a new
+// volume. 3*4 / 2 = 6.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_final_temperature_with_citation() {
+    let dir = scratch("t2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"charles-law.adj\"\n\
+         observe final_volume(3)\n\
+         observe initial_volume(2)\n\
+         observe initial_temperature(4)\n\
+         ? final_temperature(final_volume, initial_volume, initial_temperature)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 3*4 / 2 = 6, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"final_temperature\"") && s.contains("\"value\":6"),
+        "final_temperature(3, 2, 4) = 6: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "final_temperature carries its LibreTexts citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// initial_volume — V₁ = V₂T₁ / T₂: recover the starting volume. 3*4 / 6 = 2.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_initial_volume_with_citation() {
+    let dir = scratch("v1");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"charles-law.adj\"\n\
+         observe final_volume(3)\n\
+         observe final_temperature(6)\n\
+         observe initial_temperature(4)\n\
+         ? initial_volume(final_volume, final_temperature, initial_temperature)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 3*4 / 6 = 2, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"initial_volume\"") && s.contains("\"value\":2"),
+        "initial_volume(3, 6, 4) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "initial_volume carries its LibreTexts citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// initial_temperature — T₁ = V₁T₂ / V₂: recover the starting absolute temperature, the
+// fourth exact reading of the one law. 2*6 / 3 = 4.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_initial_temperature_with_citation() {
+    let dir = scratch("t1");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"charles-law.adj\"\n\
+         observe initial_volume(2)\n\
+         observe final_temperature(6)\n\
+         observe final_volume(3)\n\
+         ? initial_temperature(initial_volume, final_temperature, final_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 2*6 / 3 = 4, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"initial_temperature\"") && s.contains("\"value\":4"),
+        "initial_temperature(2, 6, 3) = 4: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "initial_temperature carries its LibreTexts citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/chemistry/charles-law.adj
+++ b/code/specs/data/adj-formula-stdlib/chemistry/charles-law.adj
@@ -1,0 +1,115 @@
+% ============================================================================
+% charles-law.adj — Charles's law (V₁/T₁ = V₂/T₂) in the ADJ standard library.
+% ============================================================================
+% The Charles's-law entry of the *chemistry* track, a sibling of `boyles-law.adj`,
+% `ideal-gas-law.adj` and `dilution.adj`: the foundational gas relation a first course
+% states as THE VOLUME OF A GAS AT CONSTANT PRESSURE IS DIRECTLY PROPORTIONAL TO ITS
+% ABSOLUTE (KELVIN) TEMPERATURE, as an importable, byte-provenanced, PARAMETERIZED
+% `formula` — together with the FOUR exact readings that one proportionality sanctions
+% (solve for any one of the initial volume, initial temperature, final volume or final
+% temperature from the other three). As with every compute library, a consumer states NO
+% arithmetic: it `import`s this file, binds the measured quantities from its own
+% byte-provenance decomposition, and asks the engine to APPLY the cited relation on the
+% CPU. Zero math is performed by the model; the engine computes each value EXACTLY,
+% carrying the relation's citation.
+%
+%     import "charles-law.adj"
+%     observe initial_volume(2)         % "…2 L…"        (span cited by the model)
+%     observe initial_temperature(4)    % "…at 4 K…"     (span cited by the model)
+%     observe final_temperature(6)      % "…heated to 6 K…"
+%     ? final_volume(initial_volume, initial_temperature, final_temperature)
+%                                          % engine → 3, carrying V₁/T₁ = V₂/T₂
+%
+% Charles's law is the constant-pressure companion of `boyles-law.adj` (Boyle's holds
+% temperature fixed and conserves the P·V product; Charles's holds pressure fixed and
+% conserves the V/T ratio), and both are special cases of `ideal-gas-law.adj` (PV = nRT):
+% the ideal gas law DEFINES the full state, and Charles's law says that for a fixed amount
+% of gas at fixed pressure the volume-to-temperature RATIO is constant, so the libraries
+% compose (an ideal-gas state feeds a Charles's-law heating). One grounded artifact
+% building on another (write-once-use-many).
+%
+% NOTE: the temperature here MUST be the ABSOLUTE (kelvin) temperature — the direct
+% proportionality holds only on the kelvin scale, since V → 0 as T → 0 K. A decomposer
+% that reads a Celsius temperature from a prompt must convert to kelvin BEFORE binding it;
+% this library computes the exact ratio over whatever absolute temperatures it is given.
+%
+% All four formulas are EXACT over their parameters — each is a product divided by a
+% measured quantity — so every value the engine returns is exact; there is no
+% *separately grounded* constant here. The four COMPOSE and invert cleanly around the
+% worked case V₁ = 2, T₁ = 4, V₂ = 3, T₂ = 6 (note V₁/T₁ = 2/4 = 3/6 = V₂/T₂, i.e. the
+% cross-product V₁T₂ = 2·6 = 12 = 3·4 = V₂T₁):
+%
+%   final_volume(initial_volume, initial_temperature, final_temperature)
+%       = initial_volume * final_temperature / initial_temperature     % V₂ = V₁T₂/T₁ = 2·6/4 = 3
+%   final_temperature(final_volume, initial_volume, initial_temperature)
+%       = final_volume * initial_temperature / initial_volume          % T₂ = V₂T₁/V₁ = 3·4/2 = 6
+%   initial_volume(final_volume, final_temperature, initial_temperature)
+%       = final_volume * initial_temperature / final_temperature       % V₁ = V₂T₁/T₂ = 3·4/6 = 2
+%   initial_temperature(initial_volume, final_temperature, final_volume)
+%       = initial_volume * final_temperature / final_volume            % T₁ = V₁T₂/V₂ = 2·6/3 = 4
+%
+% All four formulas are defended by the SAME sentence — "Charles's law states that the
+% volume of a given amount of gas is directly proportional to its temperature on the
+% kelvin scale when the pressure is held constant." — because direct proportionality of
+% volume to temperature at constant pressure is exactly V/T = constant, i.e.
+% V₁/T₁ = V₂/T₂, and so sanctions the relation solved for any single variable. The quote
+% is transcribed verbatim from Chemistry LibreTexts (OpenStax Chemistry — the same primary
+% reference `boyles-law.adj`, `molarity.adj`, `dilution.adj` and `ideal-gas-law.adj`
+% cite), so each `formula` carries the provenance envelope every shipped grounded clause
+% carries; the linter rejects an unsourced one. (See feedback_nothing_human_authored —
+% the sentence is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Charles's law ranges over four observable quantities: the volume and
+% absolute temperature of the gas BEFORE the change and the volume and absolute
+% temperature AFTER (pressure and amount held constant). Each appears BOTH as a derived
+% result (of one formula) and as an input (of the others), so each is a single dictionary
+% term used in both roles. The `surface` lists are the everyday names a decomposer maps
+% onto the canonical term; the trailing comment records the intended unit (a volume e.g.
+% in L and a temperature in K — the temperature MUST be absolute/kelvin).
+% ----------------------------------------------------------------------------
+dictionary charles_law_vocab {
+    define initial_volume      : finding  surface "initial volume", "V1"        % before, e.g. L
+    define initial_temperature : finding  surface "initial temperature", "T1"   % before, e.g. K (kelvin)
+    define final_volume        : finding  surface "final volume", "V2"          % after, e.g. L
+    define final_temperature   : finding  surface "final temperature", "T2"     % after, e.g. K (kelvin)
+}
+
+% ----------------------------------------------------------------------------
+% Charles's law, all four ways. Each is a named, importable, reusable `let` over its
+% formal parameters, bound at apply time, and each carries the proportionality sentence
+% from LibreTexts (a quote is required on a shipped formula). Each body is a product
+% divided by a measured quantity, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook charles_law_laws {
+    use charles_law_vocab
+
+    % Final volume — the volume a fixed amount of gas reaches at a new absolute
+    % temperature (V₂ = V₁T₂/T₁). The conserved ratio V₁/T₁ scaled up to the new T.
+    formula final_volume(initial_volume, initial_temperature, final_temperature) = initial_volume * final_temperature / initial_temperature
+        source "Charles's law states that the volume of a given amount of gas is directly proportional to its temperature on the kelvin scale when the pressure is held constant."
+        locator "https://chem.libretexts.org/Bookshelves/General_Chemistry/Chemistry_1e_(OpenSTAX)/09:_Gases/9.2:_Relating_Pressure_Volume_Amount_and_Temperature:_The_Ideal_Gas_Law"
+        trust authoritative
+
+    % Final temperature — the absolute temperature a fixed amount of gas reaches at a new
+    % volume (T₂ = V₂T₁/V₁). Defended by the SAME proportionality sentence, read another way.
+    formula final_temperature(final_volume, initial_volume, initial_temperature) = final_volume * initial_temperature / initial_volume
+        source "Charles's law states that the volume of a given amount of gas is directly proportional to its temperature on the kelvin scale when the pressure is held constant."
+        locator "https://chem.libretexts.org/Bookshelves/General_Chemistry/Chemistry_1e_(OpenSTAX)/09:_Gases/9.2:_Relating_Pressure_Volume_Amount_and_Temperature:_The_Ideal_Gas_Law"
+        trust authoritative
+
+    % Initial volume — the volume a fixed amount of gas started at
+    % (V₁ = V₂T₁/T₂). Again the SAME proportionality sentence, solved for V₁.
+    formula initial_volume(final_volume, final_temperature, initial_temperature) = final_volume * initial_temperature / final_temperature
+        source "Charles's law states that the volume of a given amount of gas is directly proportional to its temperature on the kelvin scale when the pressure is held constant."
+        locator "https://chem.libretexts.org/Bookshelves/General_Chemistry/Chemistry_1e_(OpenSTAX)/09:_Gases/9.2:_Relating_Pressure_Volume_Amount_and_Temperature:_The_Ideal_Gas_Law"
+        trust authoritative
+
+    % Initial temperature — the absolute temperature a fixed amount of gas started at
+    % (T₁ = V₁T₂/V₂). The fourth exact reading of the one proportionality law.
+    formula initial_temperature(initial_volume, final_temperature, final_volume) = initial_volume * final_temperature / final_volume
+        source "Charles's law states that the volume of a given amount of gas is directly proportional to its temperature on the kelvin scale when the pressure is held constant."
+        locator "https://chem.libretexts.org/Bookshelves/General_Chemistry/Chemistry_1e_(OpenSTAX)/09:_Gases/9.2:_Relating_Pressure_Volume_Amount_and_Temperature:_The_Ideal_Gas_Law"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/chemistry/charles-law.query.adj
+++ b/code/specs/data/adj-formula-stdlib/chemistry/charles-law.query.adj
@@ -1,0 +1,36 @@
+% ============================================================================
+% charles-law.query.adj — worked examples over the chemistry Charles's-law library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a Charles's-law question:
+% it states NO arithmetic and NO relation — it only `import`s the grounded library,
+% `observe`s the measured quantities it decomposed from the prompt (each a
+% byte-provenanced span, elided here; the temperatures are ABSOLUTE/kelvin), and asks the
+% engine to APPLY the cited relation. The native adj-lang engine binds the parameters,
+% computes each value EXACTLY on the CPU, and returns it with the relation's
+% source/locator/trust.
+%
+% The four questions all turn on the SAME conserved ratio V₁/T₁ = V₂/T₂ (cross-product
+% V₁T₂ = V₂T₁ = 12), around the worked case V₁ = 2 L, T₁ = 4 K, V₂ = 3 L, T₂ = 6 K: given
+% any three, the engine recovers the fourth exactly.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli charles-law.query.adj
+% ============================================================================
+
+import "charles-law.adj"
+
+% 2 L at 4 K, heated to 6 K: final volume = 2 * 6 / 4.
+observe initial_volume(2)
+observe initial_temperature(4)
+observe final_temperature(6)
+? final_volume(initial_volume, initial_temperature, final_temperature)   % expect 3   (V₂ = V₁T₂/T₁)
+
+% The same gas expanded instead to 3 L: final temperature = 3 * 4 / 2.
+observe final_volume(3)
+? final_temperature(final_volume, initial_volume, initial_temperature)   % expect 6   (T₂ = V₂T₁/V₁)
+
+% Recover the starting volume from the 3 L / 6 K final state and the 4 K start.
+? initial_volume(final_volume, final_temperature, initial_temperature)   % expect 2   (V₁ = V₂T₁/T₂)
+
+% Recover the starting temperature from the 3 L / 6 K final state and the 2 L start.
+? initial_temperature(initial_volume, final_temperature, final_volume)   % expect 4   (T₁ = V₁T₂/V₂)


### PR DESCRIPTION
## What

Adds the **Charles's-law** entry of the chemistry track: the foundational gas relation a first course states as **the volume of a gas at constant pressure is directly proportional to its absolute (kelvin) temperature** — the conserved volume/temperature ratio **V₁/T₁ = V₂/T₂** — as an importable, byte-provenanced, parameterized `formula`, in all **four** exact readings. All four are defended by the **same** verbatim sentence, transcribed from Chemistry LibreTexts (OpenStax Chemistry 9.2, "Volume and Temperature: Charles's Law"):

> "Charles's law states that the volume of a given amount of gas is directly proportional to its temperature on the kelvin scale when the pressure is held constant."

| formula | reading |
|---------|---------|
| `final_volume(V1, T1, T2)` = V1·T2/T1 | V₂ = V₁T₂/T₁ |
| `final_temperature(V2, V1, T1)` = V2·T1/V1 | T₂ = V₂T₁/V₁ |
| `initial_volume(V2, T2, T1)` = V2·T1/T2 | V₁ = V₂T₁/T₂ |
| `initial_temperature(V1, T2, V2)` = V1·T2/V2 | T₁ = V₁T₂/V₂ |

## Why

Charles's law is the **constant-pressure companion** of the `boyles-law.adj` I just added (Boyle's fixes T and conserves the P·V product; Charles's fixes P and conserves the V/T ratio), and both are special cases of `ideal-gas-law.adj` (PV = nRT). Together they round out the chemistry gas-law basics.

## How it works

Data + test only — **no engine/version change**. A consumer states **no arithmetic**: it imports the grounded library, binds the measured quantities with `observe` (temperatures **absolute/kelvin** — the proportionality holds only on the kelvin scale, V→0 as T→0 K; a decomposer converts Celsius first), and the engine applies the cited relation on the CPU — computing each value **exactly** and rendering `source`/`locator`/`trust` in the `derived` section. The four readings invert cleanly around V₁=2, T₁=4, V₂=3, T₂=6 (2/4 = 3/6, cross-product 2·6 = 12 = 3·4).

## Files
- `chemistry/charles-law.adj` — the grounded conserved-ratio library (4-way inverter)
- `chemistry/charles-law.query.adj` — worked examples (V₂=3, T₂=6, V₁=2, T₁=4)
- `formula_charles_law_e2e.rs` — 4 e2e tests through the built CLI vs the shipped stdlib

## Verification
- `cargo test -p adj-lang-cli --test formula_charles_law_e2e` → 4 passed
- Ran the shipped `.query.adj` through the built CLI: V₂=3, T₂=6, V₁=2, T₁=4, each carrying the LibreTexts citation + `authoritative` trust
- Definitional sentence byte-verified against the cited LibreTexts page
- Security review passed (data + test only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)