### PR TITLE
feat(task-app): structured task rows — toggle, name, and meta chips (UI design, step 2)

### DIFF
--- a/code/programs/mosaic/task-app/CHANGELOG.md
+++ b/code/programs/mosaic/task-app/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to the `task-app` web program are documented here.
 
 ## [0.1.0] - Unreleased
 
+### Changed - structured task rows (UI design, step 2)
+
+- **Each task row is now a structured set of styled elements** — a round completion
+  toggle, the task name, and meta chips (due / schedule / overdue) — instead of one
+  baked string in a single button. This is the richer-row step of
+  [`code/specs/task-app-ui-design.md`](../../../specs/task-app-ui-design.md), and it
+  needed **no compiler change**: the `task-rows` slot became `list<list<text>>` (each
+  row a list of cells), and the layout places each cell with a `For` over the rows plus
+  `( row[n] )` cell access. Each chip is wrapped in an `If` on its own cell, so an empty
+  cell (no due date, not overdue) renders nothing at all.
+  - `TaskApp.mil` — `task-rows : list<text>` → `list<list<text>>`; the cell order
+    `[ done-glyph, name, due, schedule, overdue ]` is now the documented contract
+    between the host and the layout's `row[n]` indices.
+  - `TaskApp.mll` — the single row button is replaced by a toggle (whose `number`
+    payload still carries the outer row index `i`), a name, three conditional chips,
+    and Delete.
+  - `TaskApp.light.msl` / `.dark.msl` — new `toggle`, `task-name`, `chip-due`,
+    `chip-sched`, `chip-over` parts (both themes); the old `row-btn` part is gone.
+  - `host/web/src/main.tsx` — `getProps` returns each row as a `string[]` of the
+    engine's already-formatted cells rather than concatenating them into one string.
+    The engine still owns every value (glyph, date formatting, "overdue"); the host
+    just stops flattening them.
+  - Verified without the browser: `cargo test -p task-app` compiles all sources (both
+    themes); regenerating via `mosaic-compile` produces the structured rows with the
+    toggle/Delete dispatching the correct row index and the chips conditionally
+    rendered; and the generated `taskRows: Array<Array<string>>` matches the host's
+    `string[][]`. (Pre-existing, not from this change: the emitter maps mosstyle
+    `align` to an invalid CSS `align` property — already present on other parts.)
+
 ### Changed - warm visual system on the app shell (UI design, step 1)
 
 - **`TaskApp.light.msl` restyled to the "warm & approachable" identity** from

--- a/code/programs/mosaic/task-app/host/web/src/main.tsx
+++ b/code/programs/mosaic/task-app/host/web/src/main.tsx
@@ -95,15 +95,18 @@ function makeController(engine: any, init: ControllerInit = {}) {
     getProps() {
       // Ask the ENGINE for render-ready cells. The host no longer formats dates,
       // picks the ✓/○ glyph, or decides what "overdue" means — those all come back
-      // already resolved and formatted, identically for every future host. All this
-      // code does is lay the cells out as a text row (presentation, not logic).
+      // already resolved and formatted, identically for every future host. Each row
+      // is handed to the layout as a *list of cells* in the order the interface
+      // documents — [ done-glyph, name, due, schedule, overdue ] — and the Mosaic
+      // layout places each cell in its own styled element (toggle, name, chips).
+      // Empty cells become empty strings, which the layout hides.
       const { byTask, ids } = rows();
-      const taskRows = ids.map((id) => {
+      const taskRows: string[][] = ids.map((id) => {
         const c = byTask.get(id)!;
-        const due = c.display[DEADLINE] ? ` · due ${c.display[DEADLINE]}` : "";
-        const sched = c.display[START] ? ` · ${c.display[START]} → ${c.display[FINISH]}` : "";
-        const late = c.value[OVERDUE]?.value === true ? " · ⚠ overdue" : "";
-        return `${c.display[DONE]} ${c.display[NAME]}${due}${sched}${late}`;
+        const due = c.display[DEADLINE] ? `due ${c.display[DEADLINE]}` : "";
+        const sched = c.display[START] ? `${c.display[START]} → ${c.display[FINISH]}` : "";
+        const late = c.value[OVERDUE]?.value === true ? "⚠ overdue" : "";
+        return [c.display[DONE], c.display[NAME], due, sched, late];
       });
       const doneCount = ids.filter((id) => byTask.get(id)!.value[DONE]?.value === true).length;
       const finish = engine.gantt(today).data.projectFinish;

--- a/code/programs/mosaic/task-app/src/TaskApp.dark.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.dark.msl
@@ -65,21 +65,49 @@ style TaskApp {
     gap : 8 ;
   }
   part task-row {
-    gap : 8 ;
+    gap : 10 ;
     align : center-vertical ;
   }
-  part row-btn {
+  // The completion toggle — a round button whose label is the engine's done glyph.
+  part toggle {
     background : "#252019" ;
-    color : "#f1ebe1" ;
-    font-size : 14 ;
-    padding : 12 ;
-    border-width : 1 ;
-    border-color : "#352e25" ;
-    border-radius : 11 ;
+    color : "#6fb489" ;
+    font-size : 15 ;
+    padding : 6 ;
+    border-width : 2 ;
+    border-color : "#4a4136" ;
+    border-radius : 20 ;
     state hover {
       border-color : "#eaa63f" ;
-      background : "#3a2c17" ;
     }
+  }
+  part task-name {
+    color : "#f1ebe1" ;
+    font-size : 14 ;
+  }
+  // Meta chips. Due is honey (time), schedule is a quiet surface, overdue is the
+  // one place semantic red appears in a row.
+  part chip-due {
+    background : "#3a2c17" ;
+    color : "#eaa63f" ;
+    font-size : 12 ;
+    padding : 5 ;
+    border-radius : 20 ;
+  }
+  part chip-sched {
+    background : "#2d271f" ;
+    color : "#b3a99c" ;
+    font-size : 12 ;
+    padding : 5 ;
+    border-radius : 20 ;
+  }
+  part chip-over {
+    background : "#3a221c" ;
+    color : "#e26a52" ;
+    font-size : 12 ;
+    font-weight : bold ;
+    padding : 5 ;
+    border-radius : 20 ;
   }
   part del-btn {
     background : "#3a221c" ;

--- a/code/programs/mosaic/task-app/src/TaskApp.light.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.light.msl
@@ -65,21 +65,49 @@ style TaskApp {
     gap : 8 ;
   }
   part task-row {
-    gap : 8 ;
+    gap : 10 ;
     align : center-vertical ;
   }
-  part row-btn {
+  // The completion toggle — a round button whose label is the engine's done glyph.
+  part toggle {
     background : "#fffdfa" ;
-    color : "#2b2723" ;
-    font-size : 14 ;
-    padding : 12 ;
-    border-width : 1 ;
-    border-color : "#e6ded3" ;
-    border-radius : 11 ;
+    color : "#4f8e6a" ;
+    font-size : 15 ;
+    padding : 6 ;
+    border-width : 2 ;
+    border-color : "#c7bfb4" ;
+    border-radius : 20 ;
     state hover {
       border-color : "#e0942a" ;
-      background : "#faedd6" ;
     }
+  }
+  part task-name {
+    color : "#2b2723" ;
+    font-size : 14 ;
+  }
+  // Meta chips. Due is honey (time), schedule is a quiet surface, overdue is the
+  // one place semantic red appears in a row.
+  part chip-due {
+    background : "#faedd6" ;
+    color : "#b6741a" ;
+    font-size : 12 ;
+    padding : 5 ;
+    border-radius : 20 ;
+  }
+  part chip-sched {
+    background : "#f7f2ea" ;
+    color : "#6a625a" ;
+    font-size : 12 ;
+    padding : 5 ;
+    border-radius : 20 ;
+  }
+  part chip-over {
+    background : "#f8e4df" ;
+    color : "#cf4b34" ;
+    font-size : 12 ;
+    font-weight : bold ;
+    padding : 5 ;
+    border-radius : 20 ;
   }
   part del-btn {
     background : "#f8e4df" ;

--- a/code/programs/mosaic/task-app/src/TaskApp.mil
+++ b/code/programs/mosaic/task-app/src/TaskApp.mil
@@ -2,9 +2,11 @@
 //
 // A to-do app that *auto-schedules*. The host fills these slots from the pure
 // task-core engine (via task-wasm) and turns the emitted events back into engine
-// operations. Rows are pre-formatted strings (name · due · computed schedule) because
-// moslayout iterates a single `list<text>` and cannot bind parallel per-row arrays —
-// so the host bakes each row's display into one string.
+// operations. Each row is a *list of cells* — [done-glyph, name, due, schedule,
+// overdue] — pre-formatted by the engine's `table` projection, so the layout can
+// place each cell in its own styled element (a real toggle, the name, meta chips)
+// via a `For` over `list<list<text>>` with `( row[n] )` cell access. The cell order
+// here is the contract between the host (main.tsx) and the layout's `row[n]` indices.
 
 component TaskApp {
   // Header + add-row inputs.
@@ -15,8 +17,10 @@ component TaskApp {
   // A one-line summary (counts, project finish).
   slot summary : text ;
 
-  // One pre-formatted line per task, in schedule order.
-  slot task-rows : list<text> ;
+  // One row per task, in schedule order; each row is a list of pre-formatted cells
+  // in the order [ done-glyph, name, due, schedule, overdue ]. Empty cells (e.g. no
+  // due date) are the empty string, and the layout hides those chips.
+  slot task-rows : list<list<text>> ;
 
   // Typing in the two inputs.
   emit onNewTaskNameChange ( value : text ) ;

--- a/code/programs/mosaic/task-app/src/TaskApp.mll
+++ b/code/programs/mosaic/task-app/src/TaskApp.mll
@@ -24,9 +24,23 @@ layout TaskApp {
     Text [ summary ] ( content : slot: summary )
 
     Column [ task-list ] {
+      // Each row is a list of cells. The toggle and Delete buttons sit directly in
+      // the For body so their `number` payload carries the outer row index `i`; the
+      // name and the meta chips read individual cells by `( row[n] )`. Each chip is
+      // wrapped in an `If` on its own cell so an empty cell renders nothing at all.
       For ( each: slot: task-rows , as: row , index: i ) {
         Row [ task-row ] {
-          HostButton [ row-btn ] ( label : row , onClick : emit: onToggleTask )
+          HostButton [ toggle ] ( label : ( row[0] ) , onClick : emit: onToggleTask )
+          Text [ task-name ] ( content : ( row[1] ) )
+          If ( when: ( row[2] ) ) {
+            Text [ chip-due ] ( content : ( row[2] ) )
+          }
+          If ( when: ( row[3] ) ) {
+            Text [ chip-sched ] ( content : ( row[3] ) )
+          }
+          If ( when: ( row[4] ) ) {
+            Text [ chip-over ] ( content : ( row[4] ) )
+          }
           HostButton [ del-btn ] ( label : "Delete" , onClick : emit: onDeleteTask )
         }
       }


### PR DESCRIPTION
Step 2 of the task-app UI design landing in the real app: each task row is now a set of separately-styled elements — a round **completion toggle**, the **task name**, and conditional **meta chips** (due / schedule / overdue) — instead of one baked string in a single button.

## The key finding: no compiler change needed

The interface used to say moslayout "cannot bind parallel per-row arrays." That's outdated — **mosmodel already supports `list<list<text>>` and moslayout already supports `For`-over-rows with `( row[n] )` cell access** (there are passing tests for nested For and indexed Expr access). So this is entirely a `.mil` / `.mll` / `.msl` / host rewrite, no changes to the Mosaic compilers.

## What changed

- **`TaskApp.mil`** — `task-rows : list<text>` → `list<list<text>>`. The cell order `[ done-glyph, name, due, schedule, overdue ]` is now the documented contract between the host and the layout's `row[n]` indices.
- **`TaskApp.mll`** — the single row button becomes a toggle (whose `number` payload still carries the **outer** row index `i`, because it sits directly in the `For` body), a name, three chips each wrapped in `If ( when: (row[n]) )` so empty cells render nothing, and Delete.
- **`TaskApp.light.msl` / `.dark.msl`** — new `toggle` / `task-name` / `chip-due` / `chip-sched` / `chip-over` parts in **both themes**; the old `row-btn` part is gone.
- **`host/web/src/main.tsx`** — `getProps` returns each row as a `string[]` of the engine's already-formatted cells instead of concatenating them. The engine still owns every value (glyph, dates, "overdue"); the host just stops flattening them.

## Verified without the browser (the in-app pane has been unresponsive this session)

- `cargo test -p task-app` compiles all sources, both themes.
- Regenerated via `mosaic-compile`: rows lower to the structured shape, the toggle/Delete dispatch the correct row index `i`, chips render conditionally, and generated `taskRows: Array<Array<string>>` matches the host's `string[][]`.
- **Security review (subagent): clean** — user task names render only as auto-escaped JSX text (no `innerHTML` / `dangerouslySetInnerHTML`), row-index dispatch stays synchronized with the rendered `ids`, and the due-date input is regex-validated before reaching the engine.

## Noted, not fixed here

The emitter maps mosstyle `align` to an invalid CSS `align` property — **pre-existing** (already on other parts before this change), worth a separate fix.

## Next

Progressive-disclosure detail on row click, and the timeline/board/calendar views. The prototype at `design/ui-prototype.html` remains the target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)