### PR TITLE
Add MOS Level-1 flicker noise coefficient

### DIFF
--- a/code/packages/python/mosfet-models/CHANGELOG.md
+++ b/code/packages/python/mosfet-models/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [0.1.0] — Unreleased
 
 ### Added
+- `Level1Params.KF` provides the Level-1 MOS flicker-noise coefficient, with a
+  noise-disabled default of zero.
 - `Level1Params` now includes MOS Level-1 capacitance footholds (`CGSO`,
   `CGDO`, `CGBO`, `CBS`, `CBD`) and reports them through `MosResult`.
 - `Level1Params.PB` and `Level1Params.MJ` now shape zero-bias bulk-junction

--- a/code/packages/python/mosfet-models/README.md
+++ b/code/packages/python/mosfet-models/README.md
@@ -22,7 +22,7 @@ print(r.Id, r.gm, r.gds, r.region)
 
 ## v0.1.0 scope
 
-- `Level1Params`: Level-1 DC plus capacitance parameter set with sane defaults for 130 nm-style NMOS, including `PB` / `MJ` bulk-junction depletion shaping for `CBS` / `CBD`.
+- `Level1Params`: Level-1 DC, capacitance, and noise parameter set with sane defaults for 130 nm-style NMOS, including `PB` / `MJ` bulk-junction depletion shaping for `CBS` / `CBD` and zero-default `KF` flicker noise.
 - `evaluate_level1(params, V_GS, V_DS, V_BS, T)`: returns `MosResult` with Id, gm, gds, gmb, Cgs/Cgd/Cgb/Cbs/Cbd, region.
 - Region detection: cutoff (subthreshold-aware), triode, saturation.
 - Body effect via gamma * (sqrt(PHI-V_BS) - sqrt(PHI)) shift.

--- a/code/packages/python/mosfet-models/src/mosfet_models/level1.py
+++ b/code/packages/python/mosfet-models/src/mosfet_models/level1.py
@@ -35,6 +35,7 @@ class Level1Params:
     CBD: float = 0.0  # drain-bulk zero-bias junction capacitance (F)
     PB: float = 0.8  # bulk junction potential (V)
     MJ: float = 0.5  # bulk junction grading coefficient
+    KF: float = 0.0  # flicker-noise coefficient
     subthreshold_enable: bool = True
 
 

--- a/code/packages/python/mosfet-models/tests/test_models.py
+++ b/code/packages/python/mosfet-models/tests/test_models.py
@@ -210,3 +210,4 @@ def test_default_params_match_spec():
     assert p.KP == 220e-6
     assert p.W == 1e-6
     assert p.L == 130e-9
+    assert p.KF == 0.0

--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add Level-1 MOS model-card `KF` support and emit drain-current-scaled
+  inverse-frequency flicker noise alongside channel thermal noise.
 - Add JFET model-card `NLEV` and `GDSNOI` support, preserving the legacy
   channel thermal-noise path below level 3 and adding the Berkeley
   linear-region equation at level 3 and above.

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -87,6 +87,8 @@ to `1`, which preserves the Shichman-Hodges equations.
 JFET `NLEV` values below `3` preserve the legacy `2/3 * gm` channel thermal
 noise model. `NLEV >= 3` selects the Berkeley linear-region equation, with
 `GDSNOI` (default `1`) scaling its channel-noise conductance.
+Level-1 MOS model cards accept `KF` (default `0`) and add
+`KF * abs(Id) / frequency` flicker noise alongside channel thermal noise.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.
 `dc_temperature_sweep()` and `dc_temperature_sweep_corners()` run
 `.temp`-style DC operating-point snapshots across explicit analysis

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -15598,18 +15598,37 @@ def _collect_noise_sources(
                 sources.append((el.name, "flicker", n_b, n_e, el.Kf * abs(base_current) ** el.Af, 1.0))
 
         elif isinstance(el, Mosfet):
-            # Long-channel MOSFET channel thermal noise: S_i = 4kTγgm.
+            # Long-channel channel thermal noise plus model-card 1/f noise.
             Vd = 0.0 if _is_ground(el.drain) else dc_x[node_to_idx[el.drain]]
             Vg = 0.0 if _is_ground(el.gate) else dc_x[node_to_idx[el.gate]]
             Vs = 0.0 if _is_ground(el.source) else dc_x[node_to_idx[el.source]]
             Vb = 0.0 if _is_ground(el.body) else dc_x[node_to_idx[el.body]]
             r = el.model.dc(Vg - Vs, Vd - Vs, Vb - Vs)  # type: ignore[attr-defined]
+            flicker_noise_coefficient = el.model.model.params.KF  # type: ignore[attr-defined]
+            if (
+                not math.isfinite(flicker_noise_coefficient)
+                or flicker_noise_coefficient < 0.0
+            ):
+                raise ValueError(
+                    f"{el.name}: MOSFET KF must be finite and non-negative"
+                )
             gm = max(0.0, float(r.gm))
+            n_d = None if _is_ground(el.drain) else node_to_idx[el.drain]
+            n_s = None if _is_ground(el.source) else node_to_idx[el.source]
             if gm > 0.0:
                 psd = kT4 * _MOSFET_CHANNEL_NOISE_GAMMA * gm
-                n_d = None if _is_ground(el.drain) else node_to_idx[el.drain]
-                n_s = None if _is_ground(el.source) else node_to_idx[el.source]
                 sources.append((el.name, "thermal", n_d, n_s, psd, 0.0))
+            if flicker_noise_coefficient > 0.0:
+                sources.append(
+                    (
+                        el.name,
+                        "flicker",
+                        n_d,
+                        n_s,
+                        flicker_noise_coefficient * abs(float(r.Id)),
+                        1.0,
+                    )
+                )
 
         elif isinstance(el, JFET):
             intrinsic_drain = _jfet_intrinsic_drain_node(el)

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -311,8 +311,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "PNP": (41, 58, 13, 4),
     "NJF": (22, 30, 7, 3),
     "PJF": (22, 30, 7, 3),
-    "NMOS": (18, 25, 6, 3),
-    "PMOS": (18, 25, 6, 3),
+    "NMOS": (19, 26, 6, 3),
+    "PMOS": (19, 26, 6, 3),
 }
 
 
@@ -477,6 +477,7 @@ _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
     "CJD": "CBD",
     "PB": "PB",
     "MJ": "MJ",
+    "KF": "KF",
 }
 
 
@@ -1074,6 +1075,7 @@ def mosfet_from_model_card(
         CBD=p.get("CBD", defaults.CBD),
         PB=p.get("PB", defaults.PB),
         MJ=p.get("MJ", defaults.MJ),
+        KF=p.get("KF", defaults.KF),
     )
     mos_type = MosfetType.NMOS if model.kind == "NMOS" else MosfetType.PMOS
     return Mosfet(name, drain, gate, source, body, MOSFET(mos_type, Level1Model(params)))

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -408,22 +408,22 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 177
+    assert len(coverage) == 179
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
     assert coverage[0].alias_count == 2
     assert coverage[-1].kind == "PMOS"
-    assert coverage[-1].canonical_parameter == "MJ"
-    assert coverage[-1].accepted_names == ("MJ",)
+    assert coverage[-1].canonical_parameter == "KF"
+    assert coverage[-1].accepted_names == ("KF",)
 
     table = format_model_card_supported_parameter_coverage_table()
     assert table.splitlines()[0] == "kind\tcanonical_parameter\taccepted_names\talias_count"
     assert table.splitlines()[1] == "D\tIS\tIS|JS\t2"
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
-    assert table.splitlines()[-1] == "PMOS\tMJ\tMJ\t1"
+    assert table.splitlines()[-1] == "PMOS\tKF\tKF\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 177
+    assert len(records) == 179
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -446,8 +446,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert summary[0].max_alias_count == 3
     assert summary[0].aliased_parameters == ("IS", "VT", "CJO", "VJ", "M")
     assert summary[5].kind == "NMOS"
-    assert summary[5].canonical_parameter_count == 18
-    assert summary[5].accepted_name_count == 25
+    assert summary[5].canonical_parameter_count == 19
+    assert summary[5].accepted_name_count == 26
     assert summary[5].aliased_parameter_count == 6
     assert summary[5].max_alias_count == 3
     assert summary[5].aliased_parameters == (
@@ -469,7 +469,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert table.splitlines()[1] == "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M"
     assert (
         table.splitlines()[-1]
-        == "PMOS\t18\t25\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        == "PMOS\t19\t26\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
     )
     records = model_card_supported_parameter_coverage_summary_records()
     assert len(records) == 7
@@ -497,9 +497,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 177
-    assert report.expected_canonical_parameter_count == 177
-    assert report.accepted_name_count == 247
+    assert report.canonical_parameter_count == 179
+    assert report.expected_canonical_parameter_count == 179
+    assert report.accepted_name_count == 249
     assert report.aliased_parameter_count == 57
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -507,7 +507,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t177\t177\t247\t57\t4\t0"
+        "true\t7\t7\t179\t179\t249\t57\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -535,15 +535,15 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 176
-    assert report.accepted_name_count == 244
+    assert report.canonical_parameter_count == 178
+    assert report.accepted_name_count == 246
     assert report.aliased_parameter_count == 56
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
     assert report.issues[0].field == "canonical_parameter_count"
     assert report.issues[0].message == (
-        "expected NMOS to expose 18 canonical supported parameters, found 17"
+        "expected NMOS to expose 19 canonical supported parameters, found 18"
     )
     assert report.issues[-1].field == "max_alias_count"
     assert report.issues[-1].message == "expected NMOS max alias count 3, found 2"
@@ -551,12 +551,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t176\t177\t244\t56\t4\t4\n"
+        "false\t7\t7\t178\t179\t246\t56\t4\t4\n"
         "kind\tfield\tmessage\n"
-        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical "
-        "supported parameters, found 17\n"
-        "NMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card "
-        "names, found 22\n"
+        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 19 canonical "
+        "supported parameters, found 18\n"
+        "NMOS\taccepted_name_count\texpected NMOS to expose 26 accepted model-card "
+        "names, found 23\n"
         "NMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing "
         "parameters, found 5\n"
         "NMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
@@ -565,12 +565,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
     assert records[0] == {
         "kind": "NMOS",
         "field": "canonical_parameter_count",
-        "message": "expected NMOS to expose 18 canonical supported parameters, found 17",
+        "message": "expected NMOS to expose 19 canonical supported parameters, found 18",
     }
     assert format_model_card_supported_parameter_coverage_gate_issue_csv(report).startswith(
         "kind,field,message\n"
-        'NMOS,canonical_parameter_count,"expected NMOS to expose 18 canonical '
-        'supported parameters, found 17"\n'
+        'NMOS,canonical_parameter_count,"expected NMOS to expose 19 canonical '
+        'supported parameters, found 18"\n'
     )
     assert (
         json.loads(format_model_card_supported_parameter_coverage_gate_issue_json(report))
@@ -746,6 +746,7 @@ def test_model_card_aliases_build_device_instances() -> None:
             "CJD": 3.0e-13,
             "PB": 0.9,
             "MJ": 0.45,
+            "KF": 2.0e-24,
         },
     )
     mos_model = mosfet_from_model_card("M1", "d", "g", "s", "b", mos_card)
@@ -757,6 +758,7 @@ def test_model_card_aliases_build_device_instances() -> None:
         "CBD": 3.0e-13,
         "PB": 0.9,
         "MJ": 0.45,
+        "KF": 2.0e-24,
     }
     assert isinstance(mos_model.model, MOSFET)
     assert mos_model.model.type == MosfetType.NMOS
@@ -767,6 +769,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(3.0e-13) == mos_model.model.model.params.CBD
     assert pytest.approx(0.9) == mos_model.model.model.params.PB
     assert pytest.approx(0.45) == mos_model.model.model.params.MJ
+    assert pytest.approx(2.0e-24) == mos_model.model.model.params.KF
 
 
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
@@ -8122,6 +8125,63 @@ def test_noise_mosfet_channel_thermal_noise() -> None:
         expected_source_psd * 1000.0 ** 2,
         rel_tol=1e-6,
     )
+
+
+def test_noise_mosfet_flicker_noise_scales_inversely_with_frequency() -> None:
+    """KF adds drain-current-scaled inverse-frequency MOSFET noise."""
+    c = Circuit()
+    c.add(VoltageSource("Vdd", "vdd", "0", 5.0))
+    c.add(VoltageSource("Vgate", "gate", "0", 3.0))
+    c.add(Resistor("Rload", "vdd", "out", 1000.0))
+    c.add(Mosfet(
+        "M1",
+        "out",
+        "gate",
+        "0",
+        "0",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(Level1Params(VT0=1.0, KP=1.0e-3, KF=2.0e-18)),
+        ),
+    ))
+
+    result = noise_ac(c, "out", "Vgate", freqs=[100.0, 1000.0])
+    flicker_psds = [
+        next(
+            entry.source_psd
+            for entry in point.entries
+            if entry.element_name == "M1" and entry.noise_type == "flicker"
+        )
+        for point in result.points
+    ]
+
+    assert flicker_psds[0] > 0.0
+    assert isclose(flicker_psds[0], 10.0 * flicker_psds[1], rel_tol=1e-12)
+    assert any(
+        entry.element_name == "M1" and entry.noise_type == "thermal"
+        for entry in result.points[0].entries
+    )
+
+
+def test_noise_rejects_invalid_mosfet_flicker_noise_coefficient() -> None:
+    """MOSFET KF must remain finite and non-negative."""
+    c = Circuit()
+    c.add(VoltageSource("Vgate", "gate", "0", 3.0))
+    c.add(Resistor("Rload", "out", "0", 1000.0))
+    c.add(Mosfet(
+        "M1",
+        "out",
+        "gate",
+        "0",
+        "0",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(Level1Params(KF=-1.0)),
+        ),
+    ))
+
+    with pytest.raises(ValueError, match="KF must be finite and non-negative"):
+        noise_ac(c, "out", "Vgate", freqs=[1000.0])
 
 
 # ---------------------------------------------------------------------------

--- a/code/packages/rust/mosfet-models/CHANGELOG.md
+++ b/code/packages/rust/mosfet-models/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `Level1Params` — 16-parameter SPICE Level-1 MOSFET parameter set with 130 nm NMOS defaults.
+- `Level1Params` — 17-parameter SPICE Level-1 MOSFET parameter set with 130 nm NMOS defaults, including the zero-default `KF` flicker-noise coefficient.
 - `Region` enum — `Cutoff`, `Subthreshold`, `Triode`, `Saturation` with `as_str()`.
 - `MosResult` — complete small-signal result: `Id`, `gm`, `gds`, `gmb`, 5 capacitances, `region`.
 - `evaluate_level1(params, V_GS, V_DS, V_BS, T)` — core Level-1 model:

--- a/code/packages/rust/mosfet-models/README.md
+++ b/code/packages/rust/mosfet-models/README.md
@@ -6,7 +6,7 @@ SPICE Level-1 (Shockley) MOSFET I-V model with full small-signal parameter extra
 
 This crate implements the classical square-law MOSFET model used in introductory SPICE circuit analysis:
 
-- **`Level1Params`** — 16 parameters (VT0, KP, LAMBDA, GAMMA, PHI, W, L, capacitances, temperature) with textbook defaults for a 130 nm NMOS.
+- **`Level1Params`** — 17 parameters (VT0, KP, LAMBDA, GAMMA, PHI, W, L, capacitances, temperature, and zero-default KF flicker noise) with textbook defaults for a 130 nm NMOS.
 - **`evaluate_level1`** — core I-V evaluation returning `MosResult` with `Id`, `gm`, `gds`, `gmb`, gate/body capacitances, and the operating `Region`.
 - **`Region`** — `Cutoff`, `Subthreshold`, `Triode`, `Saturation`.
 - **`MosfetType`** — `Nmos` / `Pmos`.

--- a/code/packages/rust/mosfet-models/src/lib.rs
+++ b/code/packages/rust/mosfet-models/src/lib.rs
@@ -39,6 +39,7 @@ use device_physics::thermal_voltage;
 /// | IS        | Drain–body saturation current (A)  | 1 fA     |
 /// | N_SUB     | Subthreshold slope factor          | 1.4      |
 /// | T_NOM     | Nominal temperature (K)            | 300.15   |
+/// | KF        | Flicker-noise coefficient           | 0        |
 #[derive(Debug, Clone, PartialEq)]
 pub struct Level1Params {
     /// Threshold voltage at zero source-body bias [V].
@@ -71,6 +72,8 @@ pub struct Level1Params {
     pub cbs: f64,
     /// Drain–bulk zero-bias junction capacitance [F].
     pub cbd: f64,
+    /// Flicker-noise coefficient.
+    pub kf: f64,
     /// Enable subthreshold current below V_t.
     pub subthreshold_enable: bool,
 }
@@ -93,6 +96,7 @@ impl Default for Level1Params {
             cgbo: 0.0,
             cbs: 0.0,
             cbd: 0.0,
+            kf: 0.0,
             subthreshold_enable: true,
         }
     }

--- a/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
+++ b/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
@@ -16,6 +16,7 @@ fn test_default_params() {
     assert_eq!(p.phi, 0.84);
     assert_eq!(p.w, 1e-6);
     assert!((p.l - 130e-9).abs() < 1e-15);
+    assert_eq!(p.kf, 0.0);
     assert!(p.subthreshold_enable);
 }
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add Level-1 MOS model-card `KF` support and emit drain-current-scaled
+  inverse-frequency flicker noise alongside channel thermal noise.
 - Add JFET model-card `NLEV` and `GDSNOI` support, preserving the legacy
   channel thermal-noise path below level 3 and adding the Berkeley
   linear-region equation at level 3 and above.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -128,6 +128,8 @@ to `1`, which preserves the Shichman-Hodges equations.
 JFET `NLEV` values below `3` preserve the legacy `2/3 * gm` channel thermal
 noise model. `NLEV >= 3` selects the Berkeley linear-region equation, with
 `GDSNOI` (default `1`) scaling its channel-noise conductance.
+Level-1 MOS model cards accept `KF` (default `0`) and add
+`KF * abs(Id) / frequency` flicker noise alongside channel thermal noise.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.
 
 `normalize_model_card`, `diode_from_model_card`, `bjt_from_model_card`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3616,6 +3616,7 @@ pub struct MosfetLevel1Params {
     pub drain_bulk_capacitance: f64,
     pub bulk_junction_potential: f64,
     pub bulk_junction_grading_coefficient: f64,
+    pub flicker_noise_coefficient: f64,
 }
 
 impl Default for MosfetLevel1Params {
@@ -3638,6 +3639,7 @@ impl Default for MosfetLevel1Params {
             drain_bulk_capacitance: 0.0,
             bulk_junction_potential: 0.8,
             bulk_junction_grading_coefficient: 0.5,
+            flicker_noise_coefficient: 0.0,
         }
     }
 }
@@ -3981,8 +3983,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     (ModelCardKind::Pnp, 41, 58, 13, 4),
     (ModelCardKind::Njf, 22, 30, 7, 3),
     (ModelCardKind::Pjf, 22, 30, 7, 3),
-    (ModelCardKind::Nmos, 18, 25, 6, 3),
-    (ModelCardKind::Pmos, 18, 25, 6, 3),
+    (ModelCardKind::Nmos, 19, 26, 6, 3),
+    (ModelCardKind::Pmos, 19, 26, 6, 3),
 ];
 const DIODE_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IS", "IS"),
@@ -4125,6 +4127,7 @@ const MOS_LEVEL1_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("CJD", "CBD"),
     ("PB", "PB"),
     ("MJ", "MJ"),
+    ("KF", "KF"),
 ];
 
 fn model_type_key(text: &str) -> String {
@@ -4913,6 +4916,9 @@ pub fn mosfet_from_model_card(
     }
     if let Some(value) = model.parameters.get("MJ") {
         params.bulk_junction_grading_coefficient = *value;
+    }
+    if let Some(value) = model.parameters.get("KF") {
+        params.flicker_noise_coefficient = *value;
     }
     Ok(Mosfet::with_model(
         name,
@@ -22780,6 +22786,17 @@ fn collect_noise_sources(
                         frequency_exponent: 0.0,
                     });
                 }
+                if mosfet.params.flicker_noise_coefficient > 0.0 {
+                    sources.push(NoiseSource {
+                        element_name: mosfet.name.clone(),
+                        noise_type: NoiseType::Flicker,
+                        positive: drain,
+                        negative: source,
+                        source_psd: mosfet.params.flicker_noise_coefficient
+                            * result.drain_current.abs(),
+                        frequency_exponent: 1.0,
+                    });
+                }
             }
             _ => {}
         }
@@ -25470,6 +25487,7 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         ("CBD", params.drain_bulk_capacitance),
         ("PB", params.bulk_junction_potential),
         ("MJ", params.bulk_junction_grading_coefficient),
+        ("KF", params.flicker_noise_coefficient),
     ] {
         if !value.is_finite() {
             return Err(SpiceError::InvalidElement {
@@ -25506,6 +25524,12 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: mosfet.name.clone(),
             reason: "MOSFET PB must be positive and MJ must be non-negative".to_string(),
+        });
+    }
+    if params.flicker_noise_coefficient < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET KF must be non-negative".to_string(),
         });
     }
     if params.gate_source_overlap_capacitance < 0.0

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -95,14 +95,14 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 177);
+    assert_eq!(coverage.len(), 179);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
     assert_eq!(coverage[0].alias_count, 2);
     assert_eq!(coverage.last().unwrap().kind, ModelCardKind::Pmos);
-    assert_eq!(coverage.last().unwrap().canonical_parameter, "MJ");
-    assert_eq!(coverage.last().unwrap().accepted_names, vec!["MJ"]);
+    assert_eq!(coverage.last().unwrap().canonical_parameter, "KF");
+    assert_eq!(coverage.last().unwrap().accepted_names, vec!["KF"]);
 
     let table = format_model_card_supported_parameter_coverage_table();
     let lines = table.lines().collect::<Vec<_>>();
@@ -112,9 +112,9 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     );
     assert_eq!(lines[1], "D\tIS\tIS|JS\t2");
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
-    assert_eq!(lines.last().unwrap(), &"PMOS\tMJ\tMJ\t1");
+    assert_eq!(lines.last().unwrap(), &"PMOS\tKF\tKF\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 177);
+    assert_eq!(records.len(), 179);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -129,7 +129,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
         "{\"kind\":\"NMOS\",\"canonical_parameter\":\"VT0\",\"accepted_names\":\"VT0|VTO|VTH\",\"alias_count\":\"3\"}"
     ));
     assert!(json.ends_with(
-        "{\"kind\":\"PMOS\",\"canonical_parameter\":\"MJ\",\"accepted_names\":\"MJ\",\"alias_count\":\"1\"}]\n"
+        "{\"kind\":\"PMOS\",\"canonical_parameter\":\"KF\",\"accepted_names\":\"KF\",\"alias_count\":\"1\"}]\n"
     ));
 }
 
@@ -147,8 +147,8 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         vec!["IS", "VT", "CJO", "VJ", "M"]
     );
     assert_eq!(summary[5].kind, ModelCardKind::Nmos);
-    assert_eq!(summary[5].canonical_parameter_count, 18);
-    assert_eq!(summary[5].accepted_name_count, 25);
+    assert_eq!(summary[5].canonical_parameter_count, 19);
+    assert_eq!(summary[5].accepted_name_count, 26);
     assert_eq!(summary[5].aliased_parameter_count, 6);
     assert_eq!(summary[5].max_alias_count, 3);
     assert_eq!(
@@ -166,7 +166,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     assert_eq!(lines[1], "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\t18\t25\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        &"PMOS\t19\t26\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
     );
     let records = model_card_supported_parameter_coverage_summary_records();
     assert_eq!(records.len(), 7);
@@ -184,7 +184,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         "[{\"kind\":\"D\",\"canonical_parameter_count\":\"15\",\"accepted_name_count\":\"21\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
     ));
     assert!(json.ends_with(
-        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"18\",\"accepted_name_count\":\"25\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
+        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"19\",\"accepted_name_count\":\"26\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
     ));
 }
 
@@ -195,15 +195,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 177);
-    assert_eq!(report.expected_canonical_parameter_count, 177);
-    assert_eq!(report.accepted_name_count, 247);
+    assert_eq!(report.canonical_parameter_count, 179);
+    assert_eq!(report.expected_canonical_parameter_count, 179);
+    assert_eq!(report.accepted_name_count, 249);
     assert_eq!(report.aliased_parameter_count, 57);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t177\t177\t247\t57\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t179\t179\t249\t57\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -230,8 +230,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 176);
-    assert_eq!(report.accepted_name_count, 244);
+    assert_eq!(report.canonical_parameter_count, 178);
+    assert_eq!(report.accepted_name_count, 246);
     assert_eq!(report.aliased_parameter_count, 56);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -239,7 +239,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     assert_eq!(report.issues[0].field, "canonical_parameter_count");
     assert_eq!(
         report.issues[0].message,
-        "expected NMOS to expose 18 canonical supported parameters, found 17"
+        "expected NMOS to expose 19 canonical supported parameters, found 18"
     );
     assert_eq!(report.issues.last().unwrap().field, "max_alias_count");
     assert_eq!(
@@ -248,20 +248,20 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t176\t177\t244\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t178\t179\t246\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 19 canonical supported parameters, found 18\nNMOS\taccepted_name_count\texpected NMOS to expose 26 accepted model-card names, found 23\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
     assert_eq!(records[0]["field"], "canonical_parameter_count");
     assert_eq!(
         records[0]["message"],
-        "expected NMOS to expose 18 canonical supported parameters, found 17"
+        "expected NMOS to expose 19 canonical supported parameters, found 18"
     );
     assert!(format_model_card_supported_parameter_coverage_gate_issue_csv(&report).starts_with(
-        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 18 canonical supported parameters, found 17\"\n"
+        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 19 canonical supported parameters, found 18\"\n"
     ));
     assert!(format_model_card_supported_parameter_coverage_gate_issue_json(&report).starts_with(
-        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 18 canonical supported parameters, found 17\"}"
+        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 19 canonical supported parameters, found 18\"}"
     ));
 }
 
@@ -283,8 +283,8 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(dashboard[0].issue_count, 0);
     assert!(dashboard[0].issue_fields.is_empty());
     assert_eq!(dashboard[5].kind, ModelCardKind::Nmos);
-    assert_eq!(dashboard[5].canonical_parameter_count, 18);
-    assert_eq!(dashboard[5].accepted_name_count, 25);
+    assert_eq!(dashboard[5].canonical_parameter_count, 19);
+    assert_eq!(dashboard[5].accepted_name_count, 26);
     assert_eq!(dashboard[5].issue_count, 0);
 
     let table = format_model_card_supported_parameter_coverage_dashboard_table(&coverage);
@@ -296,7 +296,7 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(lines[1], "D\ttrue\t15\t15\t21\t21\t5\t5\t3\t3\t0\t");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\ttrue\t18\t18\t25\t25\t6\t6\t3\t3\t0\t"
+        &"PMOS\ttrue\t19\t19\t26\t26\t6\t6\t3\t3\t0\t"
     );
     let records = model_card_supported_parameter_coverage_dashboard_records(&coverage);
     assert_eq!(records.len(), 7);
@@ -328,10 +328,10 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         .unwrap();
 
     assert!(!nmos.passed);
-    assert_eq!(nmos.canonical_parameter_count, 17);
-    assert_eq!(nmos.expected_canonical_parameter_count, 18);
-    assert_eq!(nmos.accepted_name_count, 22);
-    assert_eq!(nmos.expected_accepted_name_count, 25);
+    assert_eq!(nmos.canonical_parameter_count, 18);
+    assert_eq!(nmos.expected_canonical_parameter_count, 19);
+    assert_eq!(nmos.accepted_name_count, 23);
+    assert_eq!(nmos.expected_accepted_name_count, 26);
     assert_eq!(nmos.aliased_parameter_count, 5);
     assert_eq!(nmos.expected_aliased_parameter_count, 6);
     assert_eq!(nmos.max_alias_count, 2);
@@ -347,7 +347,7 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         ]
     );
     assert!(format_model_card_supported_parameter_coverage_dashboard_table(&coverage).contains(
-        "NMOS\tfalse\t17\t18\t22\t25\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
+        "NMOS\tfalse\t18\t19\t23\t26\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
     ));
 }
 
@@ -592,6 +592,7 @@ fn model_card_aliases_build_device_instances() {
             ("CJD", 3.0e-13),
             ("PB", 0.9),
             ("MJ", 0.45),
+            ("KF", 2.0e-24),
         ],
     )
     .unwrap();
@@ -602,6 +603,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*mos_card.parameters.get("CBD").unwrap(), 3.0e-13);
     assert_close(*mos_card.parameters.get("PB").unwrap(), 0.9);
     assert_close(*mos_card.parameters.get("MJ").unwrap(), 0.45);
+    assert_close(*mos_card.parameters.get("KF").unwrap(), 2.0e-24);
     assert_eq!(mos_model.mosfet_type, MosfetType::Nmos);
     assert_close(mos_model.params.vt0, 0.55);
     assert_close(mos_model.params.lambda, 0.04);
@@ -609,6 +611,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(mos_model.params.drain_bulk_capacitance, 3.0e-13);
     assert_close(mos_model.params.bulk_junction_potential, 0.9);
     assert_close(mos_model.params.bulk_junction_grading_coefficient, 0.45);
+    assert_close(mos_model.params.flicker_noise_coefficient, 2.0e-24);
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -1062,6 +1062,78 @@ fn noise_ac_includes_mosfet_channel_thermal_noise() {
 }
 
 #[test]
+fn noise_ac_adds_inverse_frequency_mosfet_flicker_noise() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vdd", "vdd", "0", 5.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 3.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "vdd", "out", 1_000.0,
+    )));
+    circuit.add(Element::Mosfet(Mosfet::with_model(
+        "M1",
+        "out",
+        "gate",
+        "0",
+        "0",
+        MosfetType::Nmos,
+        MosfetLevel1Params {
+            vt0: 1.0,
+            kp: 1.0e-3,
+            flicker_noise_coefficient: 2.0e-18,
+            ..MosfetLevel1Params::default()
+        },
+    )));
+
+    let result = noise_ac(&circuit, "out", "Vgate", &[100.0, 1_000.0], 300.0).unwrap();
+    let flicker_psds = result
+        .points
+        .iter()
+        .map(|point| {
+            point
+                .entries
+                .iter()
+                .find(|entry| entry.element_name == "M1" && entry.noise_type == NoiseType::Flicker)
+                .expect("missing MOSFET flicker-noise entry")
+                .source_psd
+        })
+        .collect::<Vec<_>>();
+
+    assert!(flicker_psds[0] > 0.0);
+    assert_close(flicker_psds[0], 10.0 * flicker_psds[1], 1.0e-30);
+    assert!(result.points[0]
+        .entries
+        .iter()
+        .any(|entry| { entry.element_name == "M1" && entry.noise_type == NoiseType::Thermal }));
+}
+
+#[test]
+fn noise_ac_rejects_invalid_mosfet_flicker_noise_coefficient() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 3.0,
+    )));
+    circuit.add(Element::Mosfet(Mosfet::with_model(
+        "M1",
+        "0",
+        "gate",
+        "0",
+        "0",
+        MosfetType::Nmos,
+        MosfetLevel1Params {
+            flicker_noise_coefficient: -1.0,
+            ..MosfetLevel1Params::default()
+        },
+    )));
+
+    let error = noise_ac(&circuit, "0", "Vgate", &[1_000.0], 300.0).unwrap_err();
+    assert!(error.to_string().contains("MOSFET KF must be non-negative"));
+}
+
+#[test]
 fn device_model_noise_audit_fixtures_run_reference_noise_points() {
     let fixtures = device_model_noise_audit_fixtures().unwrap();
     assert_eq!(

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add Level-1 MOS model-card `KF` support and emit drain-current-scaled
+  inverse-frequency flicker noise alongside channel thermal noise.
 - Add JFET model-card `NLEV` and `GDSNOI` support, preserving the legacy
   channel thermal-noise path below level 3 and adding the Berkeley
   linear-region equation at level 3 and above.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -79,6 +79,8 @@ to `1`, which preserves the Shichman-Hodges equations.
 JFET `NLEV` values below `3` preserve the legacy `2/3 * gm` channel thermal
 noise model. `NLEV >= 3` selects the Berkeley linear-region equation, with
 `GDSNOI` (default `1`) scaling its channel-noise conductance.
+Level-1 MOS model cards accept `KF` (default `0`) and add
+`KF * abs(Id) / frequency` flicker noise alongside channel thermal noise.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.
 `dcTemperatureSweep` and `dcTemperatureSweepCorners` run `.temp`-style DC
 operating-point snapshots across explicit analysis temperatures, with stable

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1784,6 +1784,7 @@ export interface MosfetLevel1Params {
   readonly CBD: number;
   readonly PB: number;
   readonly MJ: number;
+  readonly KF: number;
 }
 
 export interface Mosfet {
@@ -2043,8 +2044,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   PNP: [41, 58, 13, 4],
   NJF: [22, 30, 7, 3],
   PJF: [22, 30, 7, 3],
-  NMOS: [18, 25, 6, 3],
-  PMOS: [18, 25, 6, 3],
+  NMOS: [19, 26, 6, 3],
+  PMOS: [19, 26, 6, 3],
 };
 
 export interface Vccs {
@@ -8036,6 +8037,7 @@ export function defaultMosfetLevel1Params(): MosfetLevel1Params {
     CBD: 0.0,
     PB: 0.8,
     MJ: 0.5,
+    KF: 0.0,
   };
 }
 
@@ -8222,6 +8224,7 @@ const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   CJD: "CBD",
   PB: "PB",
   MJ: "MJ",
+  KF: "KF",
 };
 
 function modelTypeKey(text: string): string {
@@ -8787,6 +8790,7 @@ export function mosfetFromModelCard(
     ...(p.CBD !== undefined ? { CBD: p.CBD } : {}),
     ...(p.PB !== undefined ? { PB: p.PB } : {}),
     ...(p.MJ !== undefined ? { MJ: p.MJ } : {}),
+    ...(p.KF !== undefined ? { KF: p.KF } : {}),
   };
   return mosfet(name, drain, gate, source, body, model.kind, params);
 }
@@ -18961,6 +18965,16 @@ function collectNoiseSources(
           frequencyExponent: 0.0,
         });
       }
+      if (element.params.KF > 0.0) {
+        sources.push({
+          elementName: element.name,
+          noiseType: "flicker",
+          positive: drain,
+          negative: source,
+          sourcePsd: element.params.KF * Math.abs(result.drainCurrent),
+          frequencyExponent: 1.0,
+        });
+      }
     }
   }
   return sources;
@@ -20991,6 +21005,9 @@ function validateMosfet(element: Mosfet): void {
   }
   if (params.PB <= 0.0 || params.MJ < 0.0) {
     throw invalidElement(element.name, "MOSFET PB must be positive and MJ must be non-negative");
+  }
+  if (params.KF < 0.0) {
+    throw invalidElement(element.name, "MOSFET KF must be non-negative");
   }
   if (
     params.CGSO < 0.0 ||

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -121,7 +121,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(177);
+    expect(coverage).toHaveLength(179);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -130,8 +130,8 @@ describe("dcOp", () => {
     });
     expect(coverage.at(-1)).toStrictEqual({
       kind: "PMOS",
-      canonicalParameter: "MJ",
-      acceptedNames: ["MJ"],
+      canonicalParameter: "KF",
+      acceptedNames: ["KF"],
       aliasCount: 1,
     });
 
@@ -139,9 +139,9 @@ describe("dcOp", () => {
     expect(table.split("\n")[0]).toBe("kind\tcanonical_parameter\taccepted_names\talias_count");
     expect(table.split("\n")[1]).toBe("D\tIS\tIS|JS\t2");
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
-    expect(table.split("\n").at(-1)).toBe("PMOS\tMJ\tMJ\t1");
+    expect(table.split("\n").at(-1)).toBe("PMOS\tKF\tKF\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(177);
+    expect(records).toHaveLength(179);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -167,8 +167,8 @@ describe("dcOp", () => {
     });
     expect(summary[5]).toStrictEqual({
       kind: "NMOS",
-      canonicalParameterCount: 18,
-      acceptedNameCount: 25,
+      canonicalParameterCount: 19,
+      acceptedNameCount: 26,
       aliasedParameterCount: 6,
       maxAliasCount: 3,
       aliasedParameters: ["VT0", "LAMBDA", "N_SUB", "T_NOM", "CBS", "CBD"],
@@ -181,7 +181,7 @@ describe("dcOp", () => {
     );
     expect(table.split("\n")[1]).toBe("D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     expect(table.split("\n").at(-1)).toBe(
-      "PMOS\t18\t25\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
+      "PMOS\t19\t26\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
     );
     const records = modelCardSupportedParameterCoverageSummaryRecords();
     expect(records).toHaveLength(7);
@@ -206,15 +206,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 177,
-      expectedCanonicalParameterCount: 177,
-      acceptedNameCount: 247,
+      canonicalParameterCount: 179,
+      expectedCanonicalParameterCount: 179,
+      acceptedNameCount: 249,
       aliasedParameterCount: 57,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t177\t177\t247\t57\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t179\t179\t249\t57\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -237,15 +237,15 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(176);
-    expect(report.acceptedNameCount).toBe(244);
+    expect(report.canonicalParameterCount).toBe(178);
+    expect(report.acceptedNameCount).toBe(246);
     expect(report.aliasedParameterCount).toBe(56);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 18 canonical supported parameters, found 17",
+      message: "expected NMOS to expose 19 canonical supported parameters, found 18",
     });
     expect(report.issues.at(-1)).toStrictEqual({
       kind: "NMOS",
@@ -253,16 +253,16 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t176\t177\t244\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 18 canonical supported parameters, found 17\nNMOS\taccepted_name_count\texpected NMOS to expose 25 accepted model-card names, found 22\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t178\t179\t246\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 19 canonical supported parameters, found 18\nNMOS\taccepted_name_count\texpected NMOS to expose 26 accepted model-card names, found 23\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 18 canonical supported parameters, found 17",
+      message: "expected NMOS to expose 19 canonical supported parameters, found 18",
     });
     expect(formatModelCardSupportedParameterCoverageGateIssueCsv(report)).toMatch(
-      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 18 canonical supported parameters, found 17"\n/,
+      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 19 canonical supported parameters, found 18"\n/,
     );
     expect(JSON.parse(formatModelCardSupportedParameterCoverageGateIssueJson(report))).toStrictEqual(
       records,
@@ -417,6 +417,7 @@ describe("dcOp", () => {
       CJD: 3.0e-13,
       PB: 0.9,
       MJ: 0.45,
+      KF: 2.0e-24,
     });
     const mosModel = mosfetFromModelCard("M1", "d", "g", "s", "b", mosCard);
     expect(mosCard.parameters).toStrictEqual({
@@ -427,6 +428,7 @@ describe("dcOp", () => {
       CBD: 3.0e-13,
       PB: 0.9,
       MJ: 0.45,
+      KF: 2.0e-24,
     });
     expect(mosModel.type).toBe("NMOS");
     expectClose(mosModel.params.VT0, 0.55);
@@ -435,6 +437,7 @@ describe("dcOp", () => {
     expectClose(mosModel.params.CBD, 3.0e-13);
     expectClose(mosModel.params.PB, 0.9);
     expectClose(mosModel.params.MJ, 0.45);
+    expectClose(mosModel.params.KF, 2.0e-24);
   });
 
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -517,6 +517,41 @@ describe("noiseAc", () => {
     expect(entry?.outputPsd).toBeCloseTo(expectedSourcePsd * 1_000.0 ** 2, 30);
   });
 
+  it("adds inverse-frequency MOSFET flicker noise from KF", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vdd", "vdd", "0", 5.0));
+    circuit.add(voltageSource("Vgate", "gate", "0", 3.0));
+    circuit.add(resistor("Rload", "vdd", "out", 1_000.0));
+    circuit.add(mosfet("M1", "out", "gate", "0", "0", "NMOS", {
+      VT0: 1.0,
+      KP: 1.0e-3,
+      KF: 2.0e-18,
+    }));
+
+    const result = noiseAc(circuit, "out", "Vgate", [100.0, 1_000.0], 300.0);
+    const flickerPsds = result.points.map((point) =>
+      point.entries.find(
+        (entry) => entry.elementName === "M1" && entry.noiseType === "flicker",
+      )!.sourcePsd
+    );
+
+    expect(flickerPsds[0]).toBeGreaterThan(0.0);
+    expect(flickerPsds[0]! / flickerPsds[1]!).toBeCloseTo(10.0, 12);
+    expect(result.points[0]!.entries).toContainEqual(
+      expect.objectContaining({ elementName: "M1", noiseType: "thermal" }),
+    );
+  });
+
+  it("rejects an invalid MOSFET flicker-noise coefficient", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vgate", "gate", "0", 3.0));
+    circuit.add(mosfet("M1", "0", "gate", "0", "0", "NMOS", { KF: -1.0 }));
+
+    expect(() => noiseAc(circuit, "0", "Vgate", [1_000.0])).toThrow(
+      /MOSFET KF must be non-negative/,
+    );
+  });
+
   it("runs device model noise audit fixtures as reference noise points", () => {
     const fixtures = deviceModelNoiseAuditFixtures();
     expect(fixtures.map((fixture) => fixture.name)).toStrictEqual([

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,16 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language JFET channel-noise equation selection.
+1. Cross-language Level-1 MOS flicker-noise coefficient.
    - Status: current PR completion candidate.
-   - Add Berkeley JFET `NLEV` and `GDSNOI` model-card support in Rust, Python,
-     and TypeScript.
-   - Preserve the legacy `2/3 * gm` channel thermal-noise path for `NLEV < 3`
-     while implementing the Berkeley linear-region equation for `NLEV >= 3`,
-     scaled by `GDSNOI`.
-   - Preserve both parameters through hierarchy and cloning, validate their
-     domains, and extend the supported-parameter coverage gate from 173 to 177
-     canonical rows.
+   - Add Berkeley Level-1 MOS `KF` model-card support in Rust, Python, and
+     TypeScript, defaulting to zero.
+   - Add `KF * abs(Id) / frequency` flicker noise alongside the existing
+     channel thermal-noise source.
+   - Preserve the coefficient through hierarchy and cloning, validate its
+     finite non-negative domain, and extend the supported-parameter coverage
+     gate from 177 to 179 canonical rows.
 
 ## Completed Slices
 
@@ -3374,8 +3373,18 @@ the Rust, Python, and TypeScript surfaces together.
      Parker-Skellern doping-tail shaping to linear and saturation channel
      current while preserving Shichman-Hodges behavior at the default of 1.
    - Hierarchy and cloning preserve the parameter, finite and denominator
-     validation is shared across analyses, and the supported-parameter release
-     gate now covers 173 canonical rows.
+   validation is shared across analyses, and the supported-parameter release
+   gate now covers 173 canonical rows.
+
+263. Cross-language JFET channel-noise equation selection.
+   - Status: completed in PR 8984.
+   - Rust, Python, and TypeScript JFET model cards now accept `NLEV` and
+     `GDSNOI`, preserving the legacy `2/3 * gm` channel thermal-noise path
+     below level 3 and selecting the Berkeley linear-region equation at level
+     3 and above.
+   - Hierarchy and cloning preserve both parameters, shared validation enforces
+     their domains, and the supported-parameter release gate now covers 177
+     canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add zero-default Level-1 MOS `KF` model-card support across Rust, Python, and TypeScript
- emit `KF * abs(Id) / frequency` flicker noise alongside channel thermal noise and validate the coefficient
- extend the model-card coverage gate to 179 canonical parameters and reconcile the SPICE implementation plan

## Verification
- `cargo test -p mosfet-models`
- `cargo test -p spice-engine`
- Python mosfet-models: 19 passed
- Python spice-engine: 613 passed
- TypeScript spice-engine: 369 passed
- `npm run build`
- Ruff on touched Python SPICE engine files
- `git diff --check`