### PR TITLE
feat(hl03): flag the special consonants — retroflex ḷ, alveolar ṟ/ṉ (HL03 syllabary PR4)

### DIFF
--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.20.0 — flag the special consonants: retroflex ḷ, alveolar ṟ / ṉ (syllabary, PR 4)
+
+- **The three Dravidian "special" consonants now carry a contrast hint.** To an
+  outsider ల vs ళ (*la* vs *ḷa*) is the kind of near-miss that stalls reading, so
+  the app now flags the **retroflex ḷ** and the **alveolar ṟ / ṉ** the same way
+  it flags Latin false friends: a **★ special consonant** badge on the Browse
+  detail, a *"Special letter — tell it apart from 'l/r/n'"* section with a
+  grounded note on how it differs, and a tinted grid tile. No new data — these
+  letters were already generated (LLA / RRA / NNNA); this only surfaces them.
+- **New pure helper `specialConsonant(letter)` in `core.ts`** (mirrors
+  `isFalseFriend`): it keys on the syllable's ISO-15919 romanization, which is
+  script-agnostic — the leading code point ḷ (U+1E37, dot below) / ṟ (U+1E5F) /
+  ṉ (U+1E49, line below) is the retroflex/alveolar marker. Those marks appear
+  *only* on these consonants in our data — the vocalic-R vowel uses a different
+  code point (ring-below r̥, U+0325) — so the test is exact, not heuristic.
+  `LetterView` gains a `special` field. Unit-tested with a **control** that keeps
+  the ordinary l / r / n and the vocalic r̥ un-flagged, plus a check that exactly
+  the 26 LLA+RRA rows of the real Telugu data are marked (Telugu has no ṉ).
+
 ## 0.19.0 — the full vowel row: ai, au & vocalic R (syllabary, PR 3)
 
 - **Each consonant now carries three more syllables.** The generator's core

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -157,6 +157,15 @@ read-out is scoped to the open rows, and a cue shows *"Learning consonant N of M
 helper (with a control that keeps the 2nd consonant locked until row 1 is done);
 the alphabets and Mixed mode are unaffected.
 
+**The special consonants are flagged** the way Latin false friends are. The
+retroflex **ḷ** and the alveolar **ṟ / ṉ** are exactly the letters an outsider
+mistakes for the ordinary *l / r / n* (ల vs ళ), so Browse gives them a **★
+special consonant** badge, a *"tell it apart from 'l'"* note grounded in the
+retroflex/alveolar distinction, and a tinted tile. The classifier
+(`specialConsonant` in `core.ts`, unit-tested with a control) keys on the
+script-agnostic ISO-15919 mark — leading ḷ (U+1E37) / ṟ (U+1E5F) / ṉ (U+1E49) —
+which appears only on these consonants, so no data changed to add it.
+
 ## Design
 
 - **`src/core.ts`** — the pure, unit-tested heart: `buildScriptView`,

--- a/code/programs/typescript/language-ladder/package.json
+++ b/code/programs/typescript/language-ladder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ladder",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "private": true,
   "description": "The unified curriculum learning app (HL03): walk the language chain concept by concept, seeing the threads back to what you already know, then review it all with a randomised SRS quiz. (Was the HL02 script-writing-visualizer, whose Browse/Practice/Lessons/Concepts modes it now subsumes.)",
   "type": "module",

--- a/code/programs/typescript/language-ladder/src/core.ts
+++ b/code/programs/typescript/language-ladder/src/core.ts
@@ -25,6 +25,53 @@ export function isFalseFriend(letter: Pick<Letter, "notes">): boolean {
   return /false friend/i.test(letter.notes ?? "");
 }
 
+/**
+ * The three Dravidian "special" consonants a learner must tell apart from their
+ * plain look-/sound-alikes: the RETROFLEX ḷ and the ALVEOLAR ṟ / ṉ, set against
+ * the ordinary l / r / n. Telugu, Kannada, and Malayalam all carry them, and to
+ * an outsider ల vs ళ (la vs ḷa) is exactly the kind of near-miss that stalls
+ * reading — so the app flags them the way it flags Latin false friends.
+ *
+ * We key on the syllable's ISO-15919 romanization, which is script-agnostic (ḷ
+ * looks different in each script but romanizes the same): the LEADING code point
+ * of the sound is the retroflex/alveolar marker —
+ *   ḷ = U+1E37 (LATIN SMALL LETTER L WITH DOT BELOW),
+ *   ṟ = U+1E5F (… R WITH LINE BELOW),
+ *   ṉ = U+1E49 (… N WITH LINE BELOW).
+ * These markers appear ONLY on these consonants in our data (the vocalic-R vowel
+ * uses a ring-below r̥, U+0325 — a different code point — so there is no clash),
+ * so testing the first character is exact, not heuristic. Returns the contrast
+ * hint for a special consonant, or null for an ordinary letter.
+ *
+ *   specialConsonant({ sound: "ḷa" }).plain === "l"
+ *   specialConsonant({ sound: "la" })       === null
+ */
+export interface SpecialConsonant {
+  /** The ordinary letter it is most confused with. */
+  plain: string;
+  /** A grounded, cross-Dravidian-safe note on how it differs. */
+  hint: string;
+}
+const SPECIAL_CONSONANTS: Record<string, SpecialConsonant> = {
+  "ḷ": {
+    plain: "l",
+    hint: "Retroflex ḷ — the tongue tip curls back to the roof of the mouth. Set apart from the ordinary l (ల-type).",
+  },
+  "ṟ": {
+    plain: "r",
+    hint: "Alveolar ṟ — a distinct, harder r made at the ridge behind the teeth. Set apart from the ordinary tapped r.",
+  },
+  "ṉ": {
+    plain: "n",
+    hint: "Alveolar ṉ — an n made at that same ridge, further back than the ordinary (dental) n it contrasts with.",
+  },
+};
+
+export function specialConsonant(letter: Pick<Letter, "sound">): SpecialConsonant | null {
+  const first = [...(letter.sound ?? "")][0];
+  return (first !== undefined && SPECIAL_CONSONANTS[first]) || null;
+}
+
 /** The view-model for a single letter card + its "how to write it" detail. */
 export interface LetterView {
   glyph: string;
@@ -38,6 +85,8 @@ export interface LetterView {
   strokeOrderNote: string;
   notes: string;
   falseFriend: boolean;
+  /** Set when this is a retroflex/alveolar special consonant (ḷ/ṟ/ṉ). */
+  special: SpecialConsonant | null;
   /** How many distinct strokes/pieces — a rough "how hard to draw" signal. */
   strokeCount: number;
 }
@@ -55,6 +104,7 @@ export function toLetterView(letter: Letter): LetterView {
     strokeOrderNote: letter.strokeOrderNote ?? "",
     notes: letter.notes ?? "",
     falseFriend: isFalseFriend(letter),
+    special: specialConsonant(letter),
     strokeCount: (letter.strokeOrder ?? []).length,
   };
 }

--- a/code/programs/typescript/language-ladder/src/main.ts
+++ b/code/programs/typescript/language-ladder/src/main.ts
@@ -370,7 +370,13 @@ function renderGrid(views: LetterView[], dir: "ltr" | "rtl"): HTMLElement {
   const grid = el("div", "grid");
   grid.dir = dir;
   views.forEach((v, i) => {
-    const tile = el("button", "tile" + (i === currentLetter ? " tile--active" : "") + (v.falseFriend ? " tile--ff" : ""));
+    const tile = el(
+      "button",
+      "tile" +
+        (i === currentLetter ? " tile--active" : "") +
+        (v.falseFriend ? " tile--ff" : "") +
+        (v.special ? " tile--special" : ""),
+    );
     const glyph = el("span", "tile__glyph");
     glyph.textContent = v.glyph;
     const sound = el("span", "tile__sound");
@@ -404,9 +410,21 @@ function renderDetail(v: LetterView): HTMLElement {
     badge.textContent = "⚠ false friend";
     meta.appendChild(badge);
   }
+  if (v.special) {
+    const badge = el("span", "badge badge--special");
+    badge.textContent = `★ special consonant`;
+    meta.appendChild(badge);
+  }
   head.append(big, meta);
   d.appendChild(head);
   d.appendChild(section("Break it apart — the pieces", listOf(v.components, "pieces")));
+  // The retroflex/alveolar special consonants (ḷ/ṟ/ṉ) — flag how they differ
+  // from the plain letter they're most confused with, the way false friends are.
+  if (v.special) {
+    const p = el("p", "detail__special");
+    p.textContent = v.special.hint;
+    d.appendChild(section(`Special letter — tell it apart from “${v.special.plain}”`, p));
+  }
   // Only offer stroke order when we actually have it. The Dravidian syllabaries
   // are recognition-only (their ductus is a separate, paused effort), so showing
   // an empty "Write it" section would imply data we don't have.

--- a/code/programs/typescript/language-ladder/src/styles.css
+++ b/code/programs/typescript/language-ladder/src/styles.css
@@ -7,6 +7,8 @@
   --accent: #3b5bdb;
   --ff: #b4531a;
   --ff-bg: #fff4ec;
+  --special: #0f766e;
+  --special-bg: #ecfdf7;
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
 }
 
@@ -93,6 +95,19 @@ body {
   border: 1px solid #f0d7c4;
   border-radius: 6px;
   padding: 2px 8px;
+}
+
+.badge--special {
+  color: var(--special);
+  background: var(--special-bg);
+  border-color: #b8e6da;
+}
+.tile--special { background: var(--special-bg); }
+.tile--special.tile--ff { background: var(--ff-bg); } /* a false friend wins the tint; both can't apply */
+.detail__special {
+  margin: 0;
+  color: var(--special);
+  font-weight: 500;
 }
 
 .sec { margin-top: 14px; }

--- a/code/programs/typescript/language-ladder/tests/core.test.ts
+++ b/code/programs/typescript/language-ladder/tests/core.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   isFalseFriend,
+  specialConsonant,
   toLetterView,
   buildScriptView,
   scriptSummary,
@@ -42,6 +43,31 @@ describe("isFalseFriend", () => {
     expect(isFalseFriend({ notes: "From Greek delta." })).toBe(false);
     expect(isFalseFriend({ notes: "" })).toBe(false);
     expect(isFalseFriend({})).toBe(false);
+  });
+});
+
+describe("specialConsonant", () => {
+  it("flags the retroflex/alveolar special consonants by their ISO-15919 mark", () => {
+    expect(specialConsonant({ sound: "ḷa" })?.plain).toBe("l"); // U+1E37 dot below
+    expect(specialConsonant({ sound: "ḷī" })?.plain).toBe("l"); // signed form too
+    expect(specialConsonant({ sound: "ṟa" })?.plain).toBe("r"); // U+1E5F line below
+    expect(specialConsonant({ sound: "ṉa" })?.plain).toBe("n"); // U+1E49 line below
+    expect(specialConsonant({ sound: "ḷa" })?.hint).toMatch(/retroflex/i);
+  });
+  it("CONTROL: the ordinary l / r / n and the ring-below vocalic r̥ are NOT special", () => {
+    expect(specialConsonant({ sound: "la" })).toBeNull();
+    expect(specialConsonant({ sound: "ra" })).toBeNull();
+    expect(specialConsonant({ sound: "na" })).toBeNull();
+    expect(specialConsonant({ sound: "kr̥" })).toBeNull(); // r + U+0325 ring, a vowel — not ṟ
+    expect(specialConsonant({ sound: "" })).toBeNull();
+  });
+  it("marks exactly the LLA/RRA/NNNA rows in the real generated data", () => {
+    // Telugu has ḷa and ṟa (no ṉa); every one of their 13 syllables is flagged,
+    // and nothing else in the 455-syllable inventory is.
+    const telugu = SCRIPTS.find((s) => s.script === "telugu")!;
+    const flagged = telugu.letters.filter((l) => specialConsonant(l) !== null);
+    expect(flagged.length).toBe(26); // 2 special consonants × 13 vowels
+    expect(new Set(flagged.map((l) => specialConsonant(l)!.plain))).toEqual(new Set(["l", "r"]));
   });
 });
 

--- a/code/programs/typescript/language-ladder/tests/drill.test.ts
+++ b/code/programs/typescript/language-ladder/tests/drill.test.ts
@@ -22,6 +22,7 @@ function lv(glyph: string, over: Partial<LetterView> = {}): LetterView {
     strokeOrderNote: "",
     notes: "",
     falseFriend: false,
+    special: null,
     strokeCount: 0,
     ...over,
   };


### PR DESCRIPTION
## What & why

The Dravidian syllabaries carry three consonants a beginner keeps confusing with the ordinary **la / ra / na**: **ḷa** (LLA, retroflex l), **ṟa** (RRA, alveolar/trilled r), and **ṉa** (NNNA, alveolar n). They were already in the generated data (last three consonant groups); this PR **surfaces** them so the distinction is legible — a pedagogical slice, not a data change.

## Eyeball sample (native reader, please check)

The glyphs are pulled straight from the generated JSON, so this is exactly what the app shows:

| plain | special | contrast |
|---|---|---|
| **la** ల | **ḷa** ళ | retroflex — tongue tip curls back (Telugu) |
| **ra** ర | **ṟa** ఱ | alveolar/trilled, harder r (Telugu) |
| **na** ന | **ṉa** ഩ | alveolar — further back than the dental n (Malayalam) |

(Telugu has LLA + RRA but not NNNA; NNNA shown from Malayalam.)

## How

- **core.ts** — `SPECIAL_CONSONANTS` keyed by the ISO-15919 marker code point (ḷ = U+1E37, ṟ = U+1E5F, ṉ = U+1E49) + a pure `specialConsonant(letter)` classifier keying on the **first code point** of `letter.sound`. Those markers appear only on these three consonants — the vocalic-R vowel uses a ring-below **r̥** (U+0325, a different code point), so there is no clash — making the test exact, not heuristic. Each carries a grounded, cross-Dravidian-safe hint. `LetterView` gains `special: SpecialConsonant | null`.
- **main.ts** — a "★ special consonant" badge + a "Special letter — tell it apart from …" section in the detail panel; the grid tile is marked.
- **styles.css** — `--special` tokens + `.badge--special` / `.tile--special` / `.detail__special`.
- **tests** — `specialConsonant` flags ḷa/ḷī/ṟa/ṉa and (CONTROL) leaves la/ra/na/"kr̥"/"" null; asserts the real Telugu data flags exactly the LLA/RRA rows.

Recognition only — `strokeOrder` stays `[]`, the ductus remains paused.

## Verification

- App suite **249** pass; human-language-data **38** pass; `npm run build` clean.
- Grounding review (native reader can't catch phonetic/glyph slips): the three hints + plain mappings + first-code-point classifier all confirmed sound.
- Browser: Telugu ళ (ḷa) detail shows the badge + hint; 26 special tiles marked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)