### PR TITLE
feat(adj-formula-stdlib): gay-lussac-law — LibreTexts P₁/T₁ = P₂/T₂ conserved-ratio library (chemistry track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_gay_lussac_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_gay_lussac_e2e.rs
@@ -6,7 +6,7 @@
 //! formula libraries: a consumer states NO arithmetic; it imports the grounded library,
 //! binds the measured quantities with `observe`, and the engine applies the cited
 //! relation on the CPU — computing the EXACT value and rendering the relation's citation
-//! + trust tier in the `derived` section (the auditable answer). The four readings
+//! and trust tier in the `derived` section (the auditable answer). The four readings
 //! INVERT around the worked case P₁ = 2, T₁ = 4, P₂ = 3, T₂ = 6 (P₁/T₁ = 2/4 = 3/6 =
 //! P₂/T₂): 2*6/4 = 3, 3*4/2 = 6, 3*4/6 = 2, 2*6/3 = 4.
 

--- a/code/packages/rust/adj-lang-cli/tests/formula_gay_lussac_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_gay_lussac_e2e.rs
@@ -1,0 +1,179 @@
+//! End-to-end tests for the `chemistry/gay-lussac-law.adj` library — Gay-Lussac's law
+//! (P₁/T₁ = P₂/T₂, pressure directly proportional to absolute temperature at constant
+//! volume) and its FOUR exact readings (solve for any one of the initial pressure,
+//! initial temperature, final pressure or final temperature) — driven through the built
+//! CLI binary against the SHIPPED stdlib. Each proves the same invariant as the other
+//! formula libraries: a consumer states NO arithmetic; it imports the grounded library,
+//! binds the measured quantities with `observe`, and the engine applies the cited
+//! relation on the CPU — computing the EXACT value and rendering the relation's citation
+//! + trust tier in the `derived` section (the auditable answer). The four readings
+//! INVERT around the worked case P₁ = 2, T₁ = 4, P₂ = 3, T₂ = 6 (P₁/T₁ = 2/4 = 3/6 =
+//! P₂/T₂): 2*6/4 = 3, 3*4/2 = 6, 3*4/6 = 2, 2*6/3 = 4.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped gay-lussac-law library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_gay_lussac_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/chemistry/gay-lussac-law.adj")
+        .canonicalize()
+        .expect("shipped gay-lussac-law.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_gaylussac_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_gay_lussac_lib()).unwrap();
+    std::fs::write(dir.join("gay-lussac-law.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// final_pressure — the pressure a fixed amount of gas reaches at a new absolute
+// temperature in a rigid vessel (P₂ = P₁T₂/T₁).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_gay_lussac_library_and_computes_final_pressure_with_citation() {
+    let dir = scratch("p2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"gay-lussac-law.adj\"\n\
+         observe initial_pressure(2)\n\
+         observe initial_temperature(4)\n\
+         observe final_temperature(6)\n\
+         ? final_pressure(initial_pressure, initial_temperature, final_temperature)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 2 * 6 / 4 = 3.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"final_pressure\"") && s.contains("\"value\":3"),
+        "final_pressure(2, 4, 6) = 3: {s}"
+    );
+    // … AND the LibreTexts citation + trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// final_temperature — the absolute temperature a fixed amount of gas reaches at a new
+// pressure (T₂ = P₂T₁/P₁), which INVERTS the final pressure just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_final_temperature_with_citation() {
+    let dir = scratch("t2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"gay-lussac-law.adj\"\n\
+         observe final_pressure(3)\n\
+         observe initial_pressure(2)\n\
+         observe initial_temperature(4)\n\
+         ? final_temperature(final_pressure, initial_pressure, initial_temperature)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 3 * 4 / 2 = 6, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"final_temperature\"") && s.contains("\"value\":6"),
+        "final_temperature(3, 2, 4) = 6: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "final_temperature carries its LibreTexts citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// initial_pressure — the pressure a fixed amount of gas started at (P₁ = P₂T₁/T₂), the
+// third exact reading of the one proportionality law.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_initial_pressure_with_citation() {
+    let dir = scratch("p1");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"gay-lussac-law.adj\"\n\
+         observe final_pressure(3)\n\
+         observe final_temperature(6)\n\
+         observe initial_temperature(4)\n\
+         ? initial_pressure(final_pressure, final_temperature, initial_temperature)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 3 * 4 / 6 = 2, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"initial_pressure\"") && s.contains("\"value\":2"),
+        "initial_pressure(3, 6, 4) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "initial_pressure carries its LibreTexts citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// initial_temperature — the absolute temperature a fixed amount of gas started at
+// (T₁ = P₁T₂/P₂), the fourth exact reading of the one proportionality law.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_initial_temperature_with_citation() {
+    let dir = scratch("t1");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"gay-lussac-law.adj\"\n\
+         observe initial_pressure(2)\n\
+         observe final_temperature(6)\n\
+         observe final_pressure(3)\n\
+         ? initial_temperature(initial_pressure, final_temperature, final_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 2 * 6 / 3 = 4, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"initial_temperature\"") && s.contains("\"value\":4"),
+        "initial_temperature(2, 6, 3) = 4: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "initial_temperature carries its LibreTexts citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/chemistry/gay-lussac-law.adj
+++ b/code/specs/data/adj-formula-stdlib/chemistry/gay-lussac-law.adj
@@ -1,0 +1,119 @@
+% ============================================================================
+% gay-lussac-law.adj — Gay-Lussac's law (P₁/T₁ = P₂/T₂) in the ADJ standard library.
+% ============================================================================
+% The Gay-Lussac's-law entry of the *chemistry* track, a sibling of `boyles-law.adj`,
+% `charles-law.adj`, `ideal-gas-law.adj` and `dilution.adj`: the foundational gas
+% relation a first course states as THE PRESSURE OF A GAS AT CONSTANT VOLUME IS DIRECTLY
+% PROPORTIONAL TO ITS ABSOLUTE (KELVIN) TEMPERATURE, as an importable, byte-provenanced,
+% PARAMETERIZED `formula` — together with the FOUR exact readings that one
+% proportionality sanctions (solve for any one of the initial pressure, initial
+% temperature, final pressure or final temperature from the other three). As with every
+% compute library, a consumer states NO arithmetic: it `import`s this file, binds the
+% measured quantities from its own byte-provenance decomposition, and asks the engine to
+% APPLY the cited relation on the CPU. Zero math is performed by the model; the engine
+% computes each value EXACTLY, carrying the relation's citation.
+%
+%     import "gay-lussac-law.adj"
+%     observe initial_pressure(2)       % "…2 atm…"      (span cited by the model)
+%     observe initial_temperature(4)    % "…at 4 K…"     (span cited by the model)
+%     observe final_temperature(6)      % "…heated to 6 K…"
+%     ? final_pressure(initial_pressure, initial_temperature, final_temperature)
+%                                          % engine → 3, carrying P₁/T₁ = P₂/T₂
+%
+% Gay-Lussac's law is the constant-VOLUME member of the three simple gas laws, completing
+% the trio with its two merged siblings: `boyles-law.adj` holds TEMPERATURE fixed and
+% conserves the P·V product; `charles-law.adj` holds PRESSURE fixed and conserves the V/T
+% ratio; Gay-Lussac's holds VOLUME fixed and conserves the P/T ratio. All three are
+% special cases of `ideal-gas-law.adj` (PV = nRT): the ideal gas law DEFINES the full
+% state, and Gay-Lussac's law says that for a fixed amount of gas in a rigid (fixed-
+% volume) container the pressure-to-temperature RATIO is constant, so the libraries
+% compose (an ideal-gas state feeds a Gay-Lussac heating in a sealed rigid vessel). One
+% grounded artifact building on another (write-once-use-many).
+%
+% NOTE: the temperature here MUST be the ABSOLUTE (kelvin) temperature — the direct
+% proportionality holds only on the kelvin scale, since P → 0 as T → 0 K. A decomposer
+% that reads a Celsius temperature from a prompt must convert to kelvin BEFORE binding it;
+% this library computes the exact ratio over whatever absolute temperatures it is given.
+%
+% All four formulas are EXACT over their parameters — each is a product divided by a
+% measured quantity — so every value the engine returns is exact; there is no
+% *separately grounded* constant here. The four COMPOSE and invert cleanly around the
+% worked case P₁ = 2, T₁ = 4, P₂ = 3, T₂ = 6 (note P₁/T₁ = 2/4 = 3/6 = P₂/T₂, i.e. the
+% cross-product P₁T₂ = 2·6 = 12 = 3·4 = P₂T₁):
+%
+%   final_pressure(initial_pressure, initial_temperature, final_temperature)
+%       = initial_pressure * final_temperature / initial_temperature     % P₂ = P₁T₂/T₁ = 2·6/4 = 3
+%   final_temperature(final_pressure, initial_pressure, initial_temperature)
+%       = final_pressure * initial_temperature / initial_pressure        % T₂ = P₂T₁/P₁ = 3·4/2 = 6
+%   initial_pressure(final_pressure, final_temperature, initial_temperature)
+%       = final_pressure * initial_temperature / final_temperature       % P₁ = P₂T₁/T₂ = 3·4/6 = 2
+%   initial_temperature(initial_pressure, final_temperature, final_pressure)
+%       = initial_pressure * final_temperature / final_pressure          % T₁ = P₁T₂/P₂ = 2·6/3 = 4
+%
+% All four formulas are defended by the SAME sentence — "Gay-Lussac's Law states that the
+% pressure of a given mass of gas varies directly with the absolute temperature of the
+% gas, when the volume is kept constant." — because direct proportionality of pressure to
+% temperature at constant volume is exactly P/T = constant, i.e. P₁/T₁ = P₂/T₂, and so
+% sanctions the relation solved for any single variable. The quote is transcribed
+% verbatim from Chemistry LibreTexts (the CK-12 Introductory Chemistry text — the same
+% primary reference family `boyles-law.adj`, `charles-law.adj`, `molarity.adj`,
+% `dilution.adj` and `ideal-gas-law.adj` cite), so each `formula` carries the provenance
+% envelope every shipped grounded clause carries; the linter rejects an unsourced one.
+% (See feedback_nothing_human_authored — the sentence is a verbatim span of the cited
+% page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Gay-Lussac's law ranges over four observable quantities: the pressure and
+% absolute temperature of the gas BEFORE the change and the pressure and absolute
+% temperature AFTER (volume and amount held constant). Each appears BOTH as a derived
+% result (of one formula) and as an input (of the others), so each is a single dictionary
+% term used in both roles. The `surface` lists are the everyday names a decomposer maps
+% onto the canonical term; the trailing comment records the intended unit (a pressure e.g.
+% in atm and a temperature in K — the temperature MUST be absolute/kelvin).
+% ----------------------------------------------------------------------------
+dictionary gay_lussac_law_vocab {
+    define initial_pressure    : finding  surface "initial pressure", "P1"      % before, e.g. atm
+    define initial_temperature : finding  surface "initial temperature", "T1"   % before, e.g. K (kelvin)
+    define final_pressure      : finding  surface "final pressure", "P2"        % after, e.g. atm
+    define final_temperature   : finding  surface "final temperature", "T2"     % after, e.g. K (kelvin)
+}
+
+% ----------------------------------------------------------------------------
+% Gay-Lussac's law, all four ways. Each is a named, importable, reusable `let` over its
+% formal parameters, bound at apply time, and each carries the proportionality sentence
+% from LibreTexts (a quote is required on a shipped formula). Each body is a product
+% divided by a measured quantity, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook gay_lussac_law_laws {
+    use gay_lussac_law_vocab
+
+    % Final pressure — the pressure a fixed amount of gas reaches at a new absolute
+    % temperature in a rigid vessel (P₂ = P₁T₂/T₁). The conserved ratio P₁/T₁ scaled up
+    % to the new T.
+    formula final_pressure(initial_pressure, initial_temperature, final_temperature) = initial_pressure * final_temperature / initial_temperature
+        source "Gay-Lussac's Law states that the pressure of a given mass of gas varies directly with the absolute temperature of the gas, when the volume is kept constant."
+        locator "https://chem.libretexts.org/Bookshelves/Introductory_Chemistry/Introductory_Chemistry_(CK-12)/14:_The_Behavior_of_Gases/14.05:_Gay-Lussac's_Law"
+        trust authoritative
+
+    % Final temperature — the absolute temperature a fixed amount of gas reaches at a new
+    % pressure (T₂ = P₂T₁/P₁). Defended by the SAME proportionality sentence, read another way.
+    formula final_temperature(final_pressure, initial_pressure, initial_temperature) = final_pressure * initial_temperature / initial_pressure
+        source "Gay-Lussac's Law states that the pressure of a given mass of gas varies directly with the absolute temperature of the gas, when the volume is kept constant."
+        locator "https://chem.libretexts.org/Bookshelves/Introductory_Chemistry/Introductory_Chemistry_(CK-12)/14:_The_Behavior_of_Gases/14.05:_Gay-Lussac's_Law"
+        trust authoritative
+
+    % Initial pressure — the pressure a fixed amount of gas started at
+    % (P₁ = P₂T₁/T₂). Again the SAME proportionality sentence, solved for P₁.
+    formula initial_pressure(final_pressure, final_temperature, initial_temperature) = final_pressure * initial_temperature / final_temperature
+        source "Gay-Lussac's Law states that the pressure of a given mass of gas varies directly with the absolute temperature of the gas, when the volume is kept constant."
+        locator "https://chem.libretexts.org/Bookshelves/Introductory_Chemistry/Introductory_Chemistry_(CK-12)/14:_The_Behavior_of_Gases/14.05:_Gay-Lussac's_Law"
+        trust authoritative
+
+    % Initial temperature — the absolute temperature a fixed amount of gas started at
+    % (T₁ = P₁T₂/P₂). The fourth exact reading of the one proportionality law.
+    formula initial_temperature(initial_pressure, final_temperature, final_pressure) = initial_pressure * final_temperature / final_pressure
+        source "Gay-Lussac's Law states that the pressure of a given mass of gas varies directly with the absolute temperature of the gas, when the volume is kept constant."
+        locator "https://chem.libretexts.org/Bookshelves/Introductory_Chemistry/Introductory_Chemistry_(CK-12)/14:_The_Behavior_of_Gases/14.05:_Gay-Lussac's_Law"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/chemistry/gay-lussac-law.query.adj
+++ b/code/specs/data/adj-formula-stdlib/chemistry/gay-lussac-law.query.adj
@@ -1,0 +1,37 @@
+% ============================================================================
+% gay-lussac-law.query.adj — worked examples over the chemistry gay-lussac-law library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a Gay-Lussac's-law
+% question: it states NO arithmetic and NO relation — it only `import`s the grounded
+% library, `observe`s the measured quantities it decomposed from the prompt (each a
+% byte-provenanced span, elided here), and asks the engine to APPLY the cited relation.
+% The native adj-lang engine binds the parameters, computes each value EXACTLY on the
+% CPU, and returns it with the relation's source/locator/trust.
+%
+% The four questions INVERT around the conserved ratio P₁/T₁ = P₂/T₂ (worked case
+% P₁ = 2, T₁ = 4, P₂ = 3, T₂ = 6; note 2/4 = 3/6, i.e. P₁T₂ = 2·6 = 12 = 3·4 = P₂T₁):
+% a gas at 2 atm and 4 K heated to 6 K (constant volume) reaches 3 atm; that 3 atm at
+% 4 K starting temperature is what the final-temperature reading recovers as 6 K; and the
+% initial pressure / initial temperature readings recover 2 atm and 4 K from the rest.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli gay-lussac-law.query.adj
+% ============================================================================
+
+import "gay-lussac-law.adj"
+
+% 2 atm at 4 K, heated at constant volume to 6 K: final pressure = 2 * 6 / 4.
+observe initial_pressure(2)
+observe initial_temperature(4)
+observe final_temperature(6)
+? final_pressure(initial_pressure, initial_temperature, final_temperature)   % expect 3   (P₂ = P₁T₂/T₁)
+
+% That 3 atm final pressure, from 2 atm at 4 K: final temperature = 3 * 4 / 2.
+observe final_pressure(3)
+? final_temperature(final_pressure, initial_pressure, initial_temperature)    % expect 6   (T₂ = P₂T₁/P₁)
+
+% Recover the initial pressure from the final state: initial pressure = 3 * 4 / 6.
+? initial_pressure(final_pressure, final_temperature, initial_temperature)    % expect 2   (P₁ = P₂T₁/T₂)
+
+% Recover the initial temperature from the rest: initial temperature = 2 * 6 / 3.
+? initial_temperature(initial_pressure, final_temperature, final_pressure)    % expect 4   (T₁ = P₁T₂/P₂)


### PR DESCRIPTION
Completes the trio of **simple gas laws** in the chemistry track alongside the just-merged **boyles-law** (P₁V₁=P₂V₂, constant T, #8980) and **charles-law** (V₁/T₁=V₂/T₂, constant P, #8982): **Gay-Lussac's law** holds VOLUME constant and conserves the pressure/temperature ratio **P₁/T₁ = P₂/T₂**.

## What's here (data + one test only — no engine change, no version bump)
- `chemistry/gay-lussac-law.adj` — a `formulabook` with the **four exact readings** of the one proportionality (solve for initial/final pressure or temperature). Each `formula` carries the **verbatim CK-12 Chemistry LibreTexts** definition sentence + locator + `trust authoritative`; the consumer states no arithmetic and the engine computes each value exactly on the CPU.
- `chemistry/gay-lussac-law.query.adj` — worked examples inverting around P₁=2, T₁=4, P₂=3, T₂=6 (2/4 = 3/6).
- `adj-lang-cli/tests/formula_gay_lussac_e2e.rs` — its **own dedicated** e2e test file (4 tests), so no shared-anchor conflict with sibling libraries.

## Provenance
Source sentence transcribed verbatim (byte-verified against the page): *"Gay-Lussac's Law states that the pressure of a given mass of gas varies directly with the absolute temperature of the gas, when the volume is kept constant."* — same LibreTexts reference family the boyles/charles/molarity/dilution/ideal-gas libraries cite.

## Verification
- `cargo test -p adj-lang-cli --test formula_gay_lussac_e2e` → 4 passed.
- Shipped query through the CLI returns final_pressure=3, final_temperature=6, initial_pressure=2, initial_temperature=4, each carrying the chem.libretexts.org citation.
- NUL-scanned clean; `/security-review` passed (no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)