### PR TITLE
feat(adj-formula-stdlib): combined-gas-law — LibreTexts P₁V₁/T₁ = P₂V₂/T₂ conserved-quantity library (chemistry track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_combined_gas_law_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_combined_gas_law_e2e.rs
@@ -1,0 +1,253 @@
+//! End-to-end tests for the `chemistry/combined-gas-law.adj` library — the combined gas
+//! law (P1V1/T1 = P2V2/T2, the conserved quantity P*V/T for a fixed amount of gas) and
+//! its SIX exact readings (solve for any one of the six state variables from the other
+//! five) — driven through the built CLI binary against the SHIPPED stdlib. Each proves
+//! the same invariant as the other formula libraries: a consumer states NO arithmetic;
+//! it imports the grounded library, binds the measured quantities with `observe`, and the
+//! engine applies the cited relation on the CPU — computing the EXACT value and rendering
+//! the relation's citation and trust tier in the `derived` section (the auditable
+//! answer). The six readings INVERT around the worked case P1 = 2, V1 = 3, T1 = 6,
+//! P2 = 4, V2 = 3, T2 = 12 (P1V1/T1 = 2*3/6 = 1 = 4*3/12 = P2V2/T2).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped combined-gas-law library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_combined_gas_law_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/chemistry/combined-gas-law.adj")
+        .canonicalize()
+        .expect("shipped combined-gas-law.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_combgas_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_combined_gas_law_lib()).unwrap();
+    std::fs::write(dir.join("combined-gas-law.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// final_pressure — the pressure a fixed amount of gas reaches at a new volume and
+// absolute temperature (P2 = P1V1T2 / (T1V2)).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_combined_gas_law_library_and_computes_final_pressure_with_citation() {
+    let dir = scratch("p2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"combined-gas-law.adj\"\n\
+         observe initial_pressure(2)\n\
+         observe initial_volume(3)\n\
+         observe initial_temperature(6)\n\
+         observe final_volume(3)\n\
+         observe final_temperature(12)\n\
+         ? final_pressure(initial_pressure, initial_volume, initial_temperature, final_volume, final_temperature)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 2*3*12/(6*3) = 4.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"final_pressure\"") && s.contains("\"value\":4"),
+        "final_pressure(2,3,6,3,12) = 4: {s}"
+    );
+    // … AND the LibreTexts citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// final_volume — the volume at a new pressure and temperature (V2 = P1V1T2 / (T1P2)).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_final_volume_with_citation() {
+    let dir = scratch("v2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"combined-gas-law.adj\"\n\
+         observe initial_pressure(2)\n\
+         observe initial_volume(3)\n\
+         observe initial_temperature(6)\n\
+         observe final_pressure(4)\n\
+         observe final_temperature(12)\n\
+         ? final_volume(initial_pressure, initial_volume, initial_temperature, final_pressure, final_temperature)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 2*3*12/(6*4) = 3, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"final_volume\"") && s.contains("\"value\":3"),
+        "final_volume(2,3,6,4,12) = 3: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "final_volume carries its LibreTexts citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// final_temperature — the absolute temperature at a new pressure and volume
+// (T2 = P2V2T1 / (P1V1)).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_final_temperature_with_citation() {
+    let dir = scratch("t2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"combined-gas-law.adj\"\n\
+         observe final_pressure(4)\n\
+         observe final_volume(3)\n\
+         observe initial_pressure(2)\n\
+         observe initial_volume(3)\n\
+         observe initial_temperature(6)\n\
+         ? final_temperature(final_pressure, final_volume, initial_pressure, initial_volume, initial_temperature)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 4*3*6/(2*3) = 12, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"final_temperature\"") && s.contains("\"value\":12"),
+        "final_temperature(4,3,2,3,6) = 12: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "final_temperature carries its LibreTexts citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// initial_pressure — the pressure the gas started at (P1 = P2V2T1 / (T2V1)).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_initial_pressure_with_citation() {
+    let dir = scratch("p1");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"combined-gas-law.adj\"\n\
+         observe final_pressure(4)\n\
+         observe final_volume(3)\n\
+         observe initial_temperature(6)\n\
+         observe final_temperature(12)\n\
+         observe initial_volume(3)\n\
+         ? initial_pressure(final_pressure, final_volume, initial_temperature, final_temperature, initial_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 4*3*6/(12*3) = 2, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"initial_pressure\"") && s.contains("\"value\":2"),
+        "initial_pressure(4,3,6,12,3) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "initial_pressure carries its LibreTexts citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// initial_volume — the volume the gas started at (V1 = P2V2T1 / (T2P1)).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_initial_volume_with_citation() {
+    let dir = scratch("v1");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"combined-gas-law.adj\"\n\
+         observe final_pressure(4)\n\
+         observe final_volume(3)\n\
+         observe initial_temperature(6)\n\
+         observe final_temperature(12)\n\
+         observe initial_pressure(2)\n\
+         ? initial_volume(final_pressure, final_volume, initial_temperature, final_temperature, initial_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 4*3*6/(12*2) = 3, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"initial_volume\"") && s.contains("\"value\":3"),
+        "initial_volume(4,3,6,12,2) = 3: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "initial_volume carries its LibreTexts citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// initial_temperature — the absolute temperature the gas started at
+// (T1 = P1V1T2 / (P2V2)), the sixth exact reading of the one conserved quantity.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_initial_temperature_with_citation() {
+    let dir = scratch("t1");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"combined-gas-law.adj\"\n\
+         observe initial_pressure(2)\n\
+         observe initial_volume(3)\n\
+         observe final_pressure(4)\n\
+         observe final_volume(3)\n\
+         observe final_temperature(12)\n\
+         ? initial_temperature(initial_pressure, initial_volume, final_pressure, final_volume, final_temperature)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 2*3*12/(4*3) = 6, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"initial_temperature\"") && s.contains("\"value\":6"),
+        "initial_temperature(2,3,4,3,12) = 6: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("chem.libretexts.org"),
+        "initial_temperature carries its LibreTexts citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/chemistry/combined-gas-law.adj
+++ b/code/specs/data/adj-formula-stdlib/chemistry/combined-gas-law.adj
@@ -1,0 +1,134 @@
+% ============================================================================
+% combined-gas-law.adj — the combined gas law (P₁V₁/T₁ = P₂V₂/T₂) in the ADJ
+% standard library.
+% ============================================================================
+% The capstone of the *chemistry* gas-law track: where `boyles-law.adj` holds
+% temperature fixed (P₁V₁ = P₂V₂), `charles-law.adj` holds pressure fixed
+% (V₁/T₁ = V₂/T₂) and `gay-lussac-law.adj` holds volume fixed (P₁/T₁ = P₂/T₂), the
+% COMBINED gas law lets ALL THREE of pressure, volume and absolute temperature change
+% for a fixed amount of gas and conserves the single quantity P·V/T — i.e. the relation
+% P₁V₁/T₁ = P₂V₂/T₂. It is an importable, byte-provenanced, PARAMETERIZED `formula`,
+% together with the SIX exact readings that one conserved quantity sanctions (solve for
+% any one of the six state variables from the other five). As with every compute
+% library, a consumer states NO arithmetic: it `import`s this file, binds the measured
+% quantities from its own byte-provenance decomposition, and asks the engine to APPLY
+% the cited relation on the CPU. Zero math is performed by the model; the engine computes
+% each value EXACTLY, carrying the relation's citation.
+%
+%     import "combined-gas-law.adj"
+%     observe initial_pressure(2)       % "…2 atm…"      (span cited by the model)
+%     observe initial_volume(3)         % "…3 L…"
+%     observe initial_temperature(6)    % "…at 6 K…"
+%     observe final_volume(3)           % "…compressed/held at 3 L…"
+%     observe final_temperature(12)     % "…heated to 12 K…"
+%     ? final_pressure(initial_pressure, initial_volume, initial_temperature, final_volume, final_temperature)
+%                                          % engine → 4, carrying P₁V₁/T₁ = P₂V₂/T₂
+%
+% The combined gas law GENERALISES the three simple gas laws and is itself the
+% amount-fixed special case of `ideal-gas-law.adj` (PV = nRT): holding n constant makes
+% PV/T = nR constant, so P₁V₁/T₁ = P₂V₂/T₂. Fix any one variable and it degenerates to a
+% sibling — fix T and it is Boyle's, fix P and it is Charles's, fix V and it is
+% Gay-Lussac's — so all four libraries compose (write-once-use-many).
+%
+% NOTE: the temperature here MUST be the ABSOLUTE (kelvin) temperature — the relation
+% holds only on the kelvin scale. A decomposer that reads a Celsius temperature from a
+% prompt must convert to kelvin BEFORE binding it; this library computes the exact value
+% over whatever absolute temperatures it is given.
+%
+% All six formulas are EXACT over their parameters — each is a product of three measured
+% quantities divided by a product of two — so every value the engine returns is exact;
+% there is no *separately grounded* constant here (the nR that would appear in the ideal
+% gas law cancels between the two states). The six COMPOSE and invert cleanly around the
+% worked case P₁ = 2, V₁ = 3, T₁ = 6, P₂ = 4, V₂ = 3, T₂ = 12 (note P₁V₁/T₁ = 2·3/6 = 1
+% = 4·3/12 = P₂V₂/T₂, i.e. the cross-product P₁V₁T₂ = 2·3·12 = 72 = 4·3·6 = P₂V₂T₁):
+%
+%   final_pressure(P₁, V₁, T₁, V₂, T₂)      = P₁·V₁·T₂ / (T₁·V₂)   % P₂ = 2·3·12/(6·3) = 4
+%   final_volume(P₁, V₁, T₁, P₂, T₂)        = P₁·V₁·T₂ / (T₁·P₂)   % V₂ = 2·3·12/(6·4) = 3
+%   final_temperature(P₂, V₂, P₁, V₁, T₁)   = P₂·V₂·T₁ / (P₁·V₁)   % T₂ = 4·3·6/(2·3) = 12
+%   initial_pressure(P₂, V₂, T₁, T₂, V₁)    = P₂·V₂·T₁ / (T₂·V₁)   % P₁ = 4·3·6/(12·3) = 2
+%   initial_volume(P₂, V₂, T₁, T₂, P₁)      = P₂·V₂·T₁ / (T₂·P₁)   % V₁ = 4·3·6/(12·2) = 3
+%   initial_temperature(P₁, V₁, P₂, V₂, T₂) = P₁·V₁·T₂ / (P₂·V₂)   % T₁ = 2·3·12/(4·3) = 6
+%
+% All six formulas are defended by the SAME sentence — "The combined gas law expresses
+% the relationship between the pressure, volume, and absolute temperature of a fixed
+% amount of gas." — because that relationship IS the conserved quantity P·V/T (equal
+% between the two states, P₁V₁/T₁ = P₂V₂/T₂), which sanctions the relation solved for any
+% single variable. The quote is transcribed verbatim from Chemistry LibreTexts (the CK-12
+% Introductory Chemistry text — the same primary reference family `boyles-law.adj`,
+% `charles-law.adj`, `gay-lussac-law.adj`, `molarity.adj`, `dilution.adj` and
+% `ideal-gas-law.adj` cite), so each `formula` carries the provenance envelope every
+% shipped grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the sentence is a verbatim span of the cited page,
+% not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. The combined gas law ranges over six observable quantities: the pressure,
+% volume and absolute temperature of the gas BEFORE the change and the pressure, volume
+% and absolute temperature AFTER (amount held constant). Each appears BOTH as a derived
+% result (of one formula) and as an input (of the others), so each is a single dictionary
+% term used in both roles. The `surface` lists are the everyday names a decomposer maps
+% onto the canonical term; the trailing comment records the intended unit (a pressure e.g.
+% in atm, a volume in L and a temperature in K — the temperature MUST be absolute/kelvin).
+% ----------------------------------------------------------------------------
+dictionary combined_gas_law_vocab {
+    define initial_pressure    : finding  surface "initial pressure", "P1"      % before, e.g. atm
+    define initial_volume      : finding  surface "initial volume", "V1"        % before, e.g. L
+    define initial_temperature : finding  surface "initial temperature", "T1"   % before, e.g. K (kelvin)
+    define final_pressure      : finding  surface "final pressure", "P2"        % after, e.g. atm
+    define final_volume        : finding  surface "final volume", "V2"          % after, e.g. L
+    define final_temperature   : finding  surface "final temperature", "T2"     % after, e.g. K (kelvin)
+}
+
+% ----------------------------------------------------------------------------
+% The combined gas law, all six ways. Each is a named, importable, reusable `let` over
+% its formal parameters, bound at apply time, and each carries the definitional sentence
+% from LibreTexts (a quote is required on a shipped formula). Each body is a product of
+% three measured quantities divided by a product of two, so the engine returns each value
+% EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook combined_gas_law_laws {
+    use combined_gas_law_vocab
+
+    % Final pressure — the pressure a fixed amount of gas reaches at a new volume and
+    % absolute temperature (P₂ = P₁V₁T₂ / (T₁V₂)).
+    formula final_pressure(initial_pressure, initial_volume, initial_temperature, final_volume, final_temperature) = initial_pressure * initial_volume * final_temperature / (initial_temperature * final_volume)
+        source "The combined gas law expresses the relationship between the pressure, volume, and absolute temperature of a fixed amount of gas."
+        locator "https://chem.libretexts.org/Bookshelves/Introductory_Chemistry/Introductory_Chemistry_(CK-12)/14:_The_Behavior_of_Gases/14.06:_Combined_Gas_Law"
+        trust authoritative
+
+    % Final volume — the volume a fixed amount of gas reaches at a new pressure and
+    % absolute temperature (V₂ = P₁V₁T₂ / (T₁P₂)). Same relation, read another way.
+    formula final_volume(initial_pressure, initial_volume, initial_temperature, final_pressure, final_temperature) = initial_pressure * initial_volume * final_temperature / (initial_temperature * final_pressure)
+        source "The combined gas law expresses the relationship between the pressure, volume, and absolute temperature of a fixed amount of gas."
+        locator "https://chem.libretexts.org/Bookshelves/Introductory_Chemistry/Introductory_Chemistry_(CK-12)/14:_The_Behavior_of_Gases/14.06:_Combined_Gas_Law"
+        trust authoritative
+
+    % Final temperature — the absolute temperature a fixed amount of gas reaches at a new
+    % pressure and volume (T₂ = P₂V₂T₁ / (P₁V₁)). Same relation, solved for T₂.
+    formula final_temperature(final_pressure, final_volume, initial_pressure, initial_volume, initial_temperature) = final_pressure * final_volume * initial_temperature / (initial_pressure * initial_volume)
+        source "The combined gas law expresses the relationship between the pressure, volume, and absolute temperature of a fixed amount of gas."
+        locator "https://chem.libretexts.org/Bookshelves/Introductory_Chemistry/Introductory_Chemistry_(CK-12)/14:_The_Behavior_of_Gases/14.06:_Combined_Gas_Law"
+        trust authoritative
+
+    % Initial pressure — the pressure a fixed amount of gas started at
+    % (P₁ = P₂V₂T₁ / (T₂V₁)). Same relation, solved for P₁.
+    formula initial_pressure(final_pressure, final_volume, initial_temperature, final_temperature, initial_volume) = final_pressure * final_volume * initial_temperature / (final_temperature * initial_volume)
+        source "The combined gas law expresses the relationship between the pressure, volume, and absolute temperature of a fixed amount of gas."
+        locator "https://chem.libretexts.org/Bookshelves/Introductory_Chemistry/Introductory_Chemistry_(CK-12)/14:_The_Behavior_of_Gases/14.06:_Combined_Gas_Law"
+        trust authoritative
+
+    % Initial volume — the volume a fixed amount of gas started at
+    % (V₁ = P₂V₂T₁ / (T₂P₁)). Same relation, solved for V₁.
+    formula initial_volume(final_pressure, final_volume, initial_temperature, final_temperature, initial_pressure) = final_pressure * final_volume * initial_temperature / (final_temperature * initial_pressure)
+        source "The combined gas law expresses the relationship between the pressure, volume, and absolute temperature of a fixed amount of gas."
+        locator "https://chem.libretexts.org/Bookshelves/Introductory_Chemistry/Introductory_Chemistry_(CK-12)/14:_The_Behavior_of_Gases/14.06:_Combined_Gas_Law"
+        trust authoritative
+
+    % Initial temperature — the absolute temperature a fixed amount of gas started at
+    % (T₁ = P₁V₁T₂ / (P₂V₂)). The sixth exact reading of the one conserved quantity.
+    formula initial_temperature(initial_pressure, initial_volume, final_pressure, final_volume, final_temperature) = initial_pressure * initial_volume * final_temperature / (final_pressure * final_volume)
+        source "The combined gas law expresses the relationship between the pressure, volume, and absolute temperature of a fixed amount of gas."
+        locator "https://chem.libretexts.org/Bookshelves/Introductory_Chemistry/Introductory_Chemistry_(CK-12)/14:_The_Behavior_of_Gases/14.06:_Combined_Gas_Law"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/chemistry/combined-gas-law.query.adj
+++ b/code/specs/data/adj-formula-stdlib/chemistry/combined-gas-law.query.adj
@@ -1,0 +1,45 @@
+% ============================================================================
+% combined-gas-law.query.adj — worked examples over the chemistry combined-gas-law library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a combined-gas-law
+% question: it states NO arithmetic and NO relation — it only `import`s the grounded
+% library, `observe`s the measured quantities it decomposed from the prompt (each a
+% byte-provenanced span, elided here), and asks the engine to APPLY the cited relation.
+% The native adj-lang engine binds the parameters, computes each value EXACTLY on the
+% CPU, and returns it with the relation's source/locator/trust.
+%
+% The six questions INVERT around the conserved quantity P₁V₁/T₁ = P₂V₂/T₂ (worked case
+% P₁ = 2, V₁ = 3, T₁ = 6, P₂ = 4, V₂ = 3, T₂ = 12; note 2·3/6 = 1 = 4·3/12, i.e. the
+% cross-product P₁V₁T₂ = 2·3·12 = 72 = 4·3·6 = P₂V₂T₁): a gas at 2 atm, 3 L, 6 K taken to
+% 3 L and 12 K reaches 4 atm; and each other reading recovers one state variable from the
+% remaining five.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli combined-gas-law.query.adj
+% ============================================================================
+
+import "combined-gas-law.adj"
+
+% 2 atm, 3 L, 6 K → 3 L, 12 K: final pressure = 2*3*12 / (6*3).
+observe initial_pressure(2)
+observe initial_volume(3)
+observe initial_temperature(6)
+observe final_volume(3)
+observe final_temperature(12)
+? final_pressure(initial_pressure, initial_volume, initial_temperature, final_volume, final_temperature)   % expect 4   (P₂ = P₁V₁T₂/(T₁V₂))
+
+% Same state, solve for the final volume instead: final volume = 2*3*12 / (6*4).
+observe final_pressure(4)
+? final_volume(initial_pressure, initial_volume, initial_temperature, final_pressure, final_temperature)    % expect 3   (V₂ = P₁V₁T₂/(T₁P₂))
+
+% Final temperature from the two states' P and V: final temperature = 4*3*6 / (2*3).
+? final_temperature(final_pressure, final_volume, initial_pressure, initial_volume, initial_temperature)    % expect 12  (T₂ = P₂V₂T₁/(P₁V₁))
+
+% Recover the initial pressure: initial pressure = 4*3*6 / (12*3).
+? initial_pressure(final_pressure, final_volume, initial_temperature, final_temperature, initial_volume)    % expect 2   (P₁ = P₂V₂T₁/(T₂V₁))
+
+% Recover the initial volume: initial volume = 4*3*6 / (12*2).
+? initial_volume(final_pressure, final_volume, initial_temperature, final_temperature, initial_pressure)    % expect 3   (V₁ = P₂V₂T₁/(T₂P₁))
+
+% Recover the initial temperature: initial temperature = 2*3*12 / (4*3).
+? initial_temperature(initial_pressure, initial_volume, final_pressure, final_volume, final_temperature)    % expect 6   (T₁ = P₁V₁T₂/(P₂V₂))


### PR DESCRIPTION
Capstone of the chemistry **gas-law track**: where **Boyle's** (#8980) holds T fixed, **Charles's** (#8982) holds P fixed, and **Gay-Lussac's** (#8989) holds V fixed, the **combined gas law** lets all three of pressure, volume and absolute temperature change for a fixed amount of gas and conserves **P·V/T** — i.e. **P₁V₁/T₁ = P₂V₂/T₂**.

## What's here (data + one test only — no engine change, no version bump)
- `chemistry/combined-gas-law.adj` — a `formulabook` with the **six exact readings** of the one conserved quantity (solve for any of the six state variables). Each `formula` carries the **verbatim CK-12 Chemistry LibreTexts** definition sentence + locator + `trust authoritative`; constant-free (the `nR` of the ideal gas law cancels between the two states), so every value is exact.
- `chemistry/combined-gas-law.query.adj` — worked examples inverting around P₁=2, V₁=3, T₁=6, P₂=4, V₂=3, T₂=12 (2·3/6 = 1 = 4·3/12).
- `adj-lang-cli/tests/formula_combined_gas_law_e2e.rs` — its **own dedicated** e2e test file (6 tests), so no shared-anchor conflict.

It generalizes the three simple gas laws (fix any one variable → a sibling law) and is the amount-fixed special case of `ideal-gas-law.adj` (PV = nRT), so the libraries compose (write-once-use-many).

## Provenance
Source sentence transcribed verbatim (byte-verified against the page): *"The combined gas law expresses the relationship between the pressure, volume, and absolute temperature of a fixed amount of gas."*

## Verification
- `cargo test -p adj-lang-cli --test formula_combined_gas_law_e2e` → 6 passed.
- `cargo clippy -p adj-lang-cli --test formula_combined_gas_law_e2e -- -D warnings` → clean.
- Shipped query through the CLI returns final_pressure=4, final_volume=3, final_temperature=12, initial_pressure=2, initial_volume=3, initial_temperature=6, each carrying the chem.libretexts.org citation.
- NUL-scanned clean; `/security-review` passed (no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)