### PR TITLE
feat(hl03): Browse a syllabary as its consonant × vowel matrix (HL03 syllabary PR5)

### DIFF
--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.21.0 — Browse a syllabary as its consonant × vowel matrix (syllabary, PR 5)
+
+- **The syllabaries now offer a grid view.** A Dravidian abugida isn't a flat
+  list of ~450 signs; it's a table — every consonant marching across the same
+  vowel row (ka kā ki … , kha khā khi … , ga gā gi …). Browse gains a **List /
+  Matrix** toggle (syllabaries only; alphabets stay a plain list): Matrix lays
+  the syllables out as **rows = consonants, columns = vowels**, so the abugida's
+  regularity is the first thing you see. Clicking any cell selects that syllable
+  and opens the existing "break it apart" detail panel. No new data — the same
+  generated syllables, re-arranged.
+- **New pure helper `buildSyllableMatrix(letters)` in `matrix.ts`.** It reuses
+  the grounded consonant boundary from `syllabary.ts` (a new row at each bare
+  consonant) and reads the column vowels off the first consonant's own row (its
+  base syllable's sound minus its inherent vowel gives the consonant prefix;
+  stripping that off each syllable yields the vowel it carries — kā → "ā",
+  kr̥ → "r̥"). Nothing is invented. If the rows don't all span the same vowels it
+  returns **null** rather than risk a syllable sitting under the wrong vowel
+  header. Unit-tested with a **control** that a ragged input yields no matrix,
+  plus a check against the real Telugu data (a full 35 × 13 grid; the vocalic-R
+  column header is ISO-15919 r̥ = r + U+0325, not the IAST dot-below ṛ).
+
 ## 0.20.0 — flag the special consonants: retroflex ḷ, alveolar ṟ / ṉ (syllabary, PR 4)
 
 - **The three Dravidian "special" consonants now carry a contrast hint.** To an

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -166,6 +166,17 @@ retroflex/alveolar distinction, and a tinted tile. The classifier
 script-agnostic ISO-15919 mark — leading ḷ (U+1E37) / ṟ (U+1E5F) / ṉ (U+1E49) —
 which appears only on these consonants, so no data changed to add it.
 
+**Browse them as a matrix.** An abugida is really a table, so for the
+syllabaries Browse offers a **List / Matrix** toggle (alphabets stay a plain
+list). Matrix lays the syllables out as **rows = consonants, columns = vowels**
+— the same ka/kā/ki… pattern repeating down every consonant, made visible at a
+glance — and clicking a cell opens the usual decomposition panel. The layout is
+pure (`buildSyllableMatrix` in `src/matrix.ts`): rows reuse the grounded
+consonant boundary from `syllabary.ts`, the vowel column headers are read off
+the first consonant's own row, and a ragged script yields **no matrix** rather
+than a mislabelled cell (unit-tested with a control). No new data — the same
+generated syllables, re-arranged.
+
 ## Design
 
 - **`src/core.ts`** — the pure, unit-tested heart: `buildScriptView`,

--- a/code/programs/typescript/language-ladder/package.json
+++ b/code/programs/typescript/language-ladder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ladder",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "private": true,
   "description": "The unified curriculum learning app (HL03): walk the language chain concept by concept, seeing the threads back to what you already know, then review it all with a randomised SRS quiz. (Was the HL02 script-writing-visualizer, whose Browse/Practice/Lessons/Concepts modes it now subsumes.)",
   "type": "module",

--- a/code/programs/typescript/language-ladder/src/main.ts
+++ b/code/programs/typescript/language-ladder/src/main.ts
@@ -37,6 +37,8 @@ import {
   unlockedConsonantCount,
   unlockedLetterIndices,
 } from "./syllabary.ts";
+import { buildSyllableMatrix } from "./matrix.ts";
+import type { Letter } from "./types.ts";
 import { loadLessons, indicesByLanguage, nextDue } from "./lessons.ts";
 import {
   planSession,
@@ -205,6 +207,9 @@ function persistLessons(): void {
 }
 let currentScript = 0;
 let currentLetter = 0;
+// Browse layout for the syllabaries: the flat "list" of tiles, or the
+// consonant × vowel "matrix" that makes the abugida's regularity visible.
+let browseLayout: "list" | "matrix" = "list";
 
 // Practice state
 type Scope = "script" | "mixed";
@@ -390,6 +395,86 @@ function renderGrid(views: LetterView[], dir: "ltr" | "rtl"): HTMLElement {
     grid.appendChild(tile);
   });
   return grid;
+}
+
+/** For a syllabary, a "List / Matrix" switch — the flat grid, or the table. */
+function renderBrowseLayoutToggle(): HTMLElement {
+  const wrap = el("div", "layouts");
+  const label = el("span", "layouts__label");
+  label.textContent = "Layout:";
+  wrap.appendChild(label);
+  (
+    [
+      ["list", "List"],
+      ["matrix", "Matrix"],
+    ] as ["list" | "matrix", string][]
+  ).forEach(([l, text]) => {
+    const b = el("button", "layout" + (l === browseLayout ? " layout--active" : ""));
+    b.textContent = text;
+    b.setAttribute("aria-pressed", String(l === browseLayout));
+    b.onclick = () => {
+      if (browseLayout === l) return;
+      browseLayout = l;
+      render();
+    };
+    wrap.appendChild(b);
+  });
+  return wrap;
+}
+
+/**
+ * The consonant × vowel table for a syllabary. Rows are consonants, columns are
+ * the shared vowels; each cell is the syllable glyph + its romanization, and
+ * clicking it selects that syllable so the existing detail panel breaks it apart.
+ * The layout comes from the pure `buildSyllableMatrix`, so nothing here invents
+ * an alignment — a ragged script simply has no matrix to show.
+ */
+function renderMatrix(letters: Letter[]): HTMLElement | null {
+  const m = buildSyllableMatrix(letters);
+  if (!m) return null;
+
+  const scroll = el("div", "matrix-scroll");
+  const table = el("table", "matrix") as HTMLTableElement;
+
+  const thead = el("thead", "");
+  const hrow = el("tr", "");
+  hrow.appendChild(el("th", "matrix__corner")); // top-left, above the row labels
+  m.vowels.forEach((v) => {
+    const th = el("th", "matrix__vowel");
+    th.textContent = v;
+    hrow.appendChild(th);
+  });
+  thead.appendChild(hrow);
+  table.appendChild(thead);
+
+  const tbody = el("tbody", "");
+  m.rows.forEach((row) => {
+    const tr = el("tr", "");
+    const rh = el("th", "matrix__consonant");
+    rh.textContent = row.label;
+    tr.appendChild(rh);
+    row.cells.forEach((cell) => {
+      const td = el("td", "matrix__cell" + (cell.index === currentLetter ? " matrix__cell--active" : ""));
+      const btn = el("button", "matrix__syllable");
+      const glyph = el("span", "matrix__glyph");
+      glyph.textContent = cell.glyph;
+      const sound = el("span", "matrix__sound");
+      sound.textContent = bareSound(cell.sound);
+      btn.append(glyph, sound);
+      btn.title = cell.sound;
+      btn.onclick = () => {
+        currentLetter = cell.index;
+        render();
+      };
+      td.appendChild(btn);
+      tr.appendChild(td);
+    });
+    tbody.appendChild(tr);
+  });
+  table.appendChild(tbody);
+
+  scroll.appendChild(table);
+  return scroll;
 }
 
 function renderDetail(v: LetterView): HTMLElement {
@@ -1306,8 +1391,13 @@ function render(): void {
     const views = buildScriptView(data);
     const active = views[currentLetter] ?? views[0]!;
     app!.appendChild(renderSummary(scriptSummary(data)));
+    // The syllabaries also offer a consonant × vowel matrix; alphabets stay a
+    // plain list. A ragged syllabary yields no matrix, so we fall back to the grid.
+    const syllabary = isSyllabary(data.letters);
+    if (syllabary) app!.appendChild(renderBrowseLayoutToggle());
+    const matrix = syllabary && browseLayout === "matrix" ? renderMatrix(data.letters) : null;
     const body = el("div", "body");
-    body.append(renderGrid(views, data.direction), renderDetail(active));
+    body.append(matrix ?? renderGrid(views, data.direction), renderDetail(active));
     app!.appendChild(body);
   } else {
     if (!question) startPractice();

--- a/code/programs/typescript/language-ladder/src/matrix.ts
+++ b/code/programs/typescript/language-ladder/src/matrix.ts
@@ -1,0 +1,85 @@
+// ---------------------------------------------------------------------------
+// matrix.ts — an abugida's syllables as the consonant × vowel TABLE they are.
+//
+// A Dravidian syllabary isn't a flat list of ~450 signs; it's a grid. Every
+// consonant marches across the SAME vowel row — ka kā ki kī … , kha khā khi … ,
+// ga gā gi … — so once you see one row, the next is the same shape with a new
+// starting consonant. The flat Browse list hides that regularity; laid out as a
+// grid (rows = consonants, columns = vowels) the pattern is the first thing you
+// see, which is the whole point of "build pattern recognition slowly".
+//
+// This module is the pure layout. It knows nothing about the DOM — it turns the
+// generated, consonant-major syllable list into rows and vowel columns, reusing
+// the grounded consonant boundary from syllabary.ts. Nothing here is invented:
+// the glyphs are the generated syllables, the column vowels are read off the
+// first consonant's own row (its sound minus its consonant), and if the rows
+// don't all span the same vowels it refuses to build a grid at all — a
+// misaligned cell would sit a syllable under the wrong vowel header, exactly the
+// silent mislabel a native reader would trust. Unit-tested, with a control that
+// a ragged input yields no matrix.
+// ---------------------------------------------------------------------------
+
+import { consonantGroups } from "./syllabary.ts";
+
+/** The minimal syllable shape the matrix needs. */
+interface MatrixLetter {
+  sound: string;
+  glyph: string;
+  role: string;
+  components: string[];
+  inherentVowel?: string;
+}
+
+/** One cell: the syllable glyph, its romanization, and its index in the flat
+ *  letter list (so the UI can select it and open the existing detail panel). */
+export interface MatrixCell {
+  index: number;
+  glyph: string;
+  sound: string;
+}
+
+/** The whole table: the shared vowel column headers, and one row per consonant. */
+export interface SyllableMatrix {
+  /** ISO-15919 vowel per column (a, ā, i, …, ai, au, r̥) — read off the data. */
+  vowels: string[];
+  /** Rows in consonant-major order; `label` is the consonant's inherent-"a"
+   *  form (ka, kha, ḷa), `cells` its syllables across the vowel columns. */
+  rows: { label: string; cells: MatrixCell[] }[];
+}
+
+/**
+ * Lay the generated syllabary out as a consonant × vowel grid, or null if it
+ * isn't a clean rectangle.
+ *
+ * The consonant boundary is the grounded one from `consonantGroups` (a new row
+ * starts at each bare consonant). The column vowels are taken from the first
+ * consonant's own row — its base syllable's sound minus its inherent vowel gives
+ * the consonant prefix (ka → "k"), and stripping that prefix off each syllable
+ * in the row yields the vowel it carries (kā → "ā", ki → "i", kr̥ → "r̥"). Every
+ * consonant is generated across the same vowels, so column j is the same vowel
+ * in every row; if that invariant is broken (a ragged row), we return null
+ * rather than risk mislabelling a cell.
+ */
+export function buildSyllableMatrix(letters: MatrixLetter[]): SyllableMatrix | null {
+  const groups = consonantGroups(letters);
+  if (groups.length === 0) return null;
+
+  const width = groups[0]!.length;
+  if (!groups.every((g) => g.length === width)) return null; // ragged → no grid
+
+  const base = letters[groups[0]![0]!]!;
+  const iv = base.inherentVowel ?? "a";
+  const prefix = base.sound.slice(0, Math.max(0, base.sound.length - iv.length));
+
+  const vowels = groups[0]!.map((i) => {
+    const s = letters[i]!.sound;
+    return s.startsWith(prefix) ? s.slice(prefix.length) : s;
+  });
+
+  const rows = groups.map((g) => ({
+    label: letters[g[0]!]!.sound,
+    cells: g.map((i) => ({ index: i, glyph: letters[i]!.glyph, sound: letters[i]!.sound })),
+  }));
+
+  return { vowels, rows };
+}

--- a/code/programs/typescript/language-ladder/src/styles.css
+++ b/code/programs/typescript/language-ladder/src/styles.css
@@ -464,3 +464,43 @@ body {
   font-size: 0.82rem;
   cursor: pointer;
 }
+
+/* --- browse layout toggle (list / matrix, syllabaries only) ------------- */
+.layouts { display: flex; align-items: center; gap: 6px; margin-bottom: 14px; }
+.layouts__label { color: var(--muted); font-size: 0.85rem; margin-right: 2px; }
+.layout {
+  border: 1px solid var(--line);
+  background: var(--card);
+  color: var(--ink);
+  padding: 4px 12px;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+.layout--active { background: var(--accent); color: #fff; border-color: var(--accent); }
+
+/* --- syllabary matrix (consonant rows × vowel columns) ------------------ */
+.matrix-scroll { overflow-x: auto; border: 1px solid var(--line); border-radius: 10px; }
+.matrix { border-collapse: collapse; font-variant-numeric: tabular-nums; }
+.matrix th, .matrix td { border: 1px solid var(--line); text-align: center; }
+.matrix__vowel {
+  position: sticky; top: 0; z-index: 1;
+  background: var(--bg); color: var(--muted);
+  font-size: 0.8rem; font-weight: 600; padding: 4px 6px;
+}
+.matrix__consonant {
+  position: sticky; left: 0;
+  background: var(--bg); color: var(--muted);
+  font-size: 0.75rem; padding: 4px 8px; white-space: nowrap;
+}
+.matrix__corner { position: sticky; left: 0; top: 0; z-index: 2; background: var(--bg); }
+.matrix__cell { padding: 0; }
+.matrix__cell--active { box-shadow: inset 0 0 0 2px var(--accent); }
+.matrix__syllable {
+  display: flex; flex-direction: column; align-items: center; gap: 1px;
+  width: 100%; min-width: 46px; padding: 5px 4px;
+  background: var(--card); border: 0; cursor: pointer; color: inherit;
+}
+.matrix__syllable:hover { background: var(--special-bg); }
+.matrix__glyph { font-size: 1.25rem; line-height: 1.1; }
+.matrix__sound { font-size: 0.62rem; color: var(--muted); }

--- a/code/programs/typescript/language-ladder/tests/matrix.test.ts
+++ b/code/programs/typescript/language-ladder/tests/matrix.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { buildSyllableMatrix } from "../src/matrix";
+import { SCRIPTS } from "../src/data";
+
+// A tiny rectangular fixture: 2 consonants × 3 vowels. A base syllable has ONE
+// component (the bare consonant, inherent "a"); a signed one has two.
+function base(sound: string) {
+  return { sound, glyph: sound, role: "syllable", inherentVowel: "a", components: ["c"] };
+}
+function signed(sound: string) {
+  return { sound, glyph: sound, role: "syllable", inherentVowel: "a", components: ["c", "v"] };
+}
+const RECT = [
+  base("ka"), signed("ki"), signed("ku"), // consonant 1
+  base("ga"), signed("gi"), signed("gu"), // consonant 2
+];
+
+describe("buildSyllableMatrix", () => {
+  it("lays a rectangular syllabary out as consonant rows × vowel columns", () => {
+    const m = buildSyllableMatrix(RECT)!;
+    expect(m).not.toBeNull();
+    // Columns read the vowels off the first consonant's row: ka→a, ki→i, ku→u.
+    expect(m.vowels).toEqual(["a", "i", "u"]);
+    // Rows are labelled by the consonant's inherent-"a" form, cells carry the
+    // flat-list index so the UI can select the syllable.
+    expect(m.rows.map((r) => r.label)).toEqual(["ka", "ga"]);
+    expect(m.rows[0]!.cells.map((c) => c.sound)).toEqual(["ka", "ki", "ku"]);
+    expect(m.rows[0]!.cells.map((c) => c.index)).toEqual([0, 1, 2]);
+    expect(m.rows[1]!.cells.map((c) => c.index)).toEqual([3, 4, 5]);
+  });
+
+  it("CONTROL: a ragged syllabary (a consonant missing a vowel) yields NO matrix", () => {
+    // Consonant 2 has only 2 syllables where consonant 1 has 3 — misaligned, so
+    // a cell could sit under the wrong vowel header. Refuse to build the grid.
+    const ragged = [base("ka"), signed("ki"), signed("ku"), base("ga"), signed("gi")];
+    expect(buildSyllableMatrix(ragged)).toBeNull();
+  });
+
+  it("returns null on an empty list", () => {
+    expect(buildSyllableMatrix([])).toBeNull();
+  });
+});
+
+describe("against the real generated Telugu syllabary", () => {
+  const telugu = SCRIPTS.find((s) => s.script === "telugu")!;
+
+  it("is a full 35-consonant × 13-vowel grid with grounded vowel headers", () => {
+    const m = buildSyllableMatrix(telugu.letters as never)!;
+    expect(m).not.toBeNull();
+    expect(m.rows.length).toBe(35);
+    expect(m.vowels).toEqual(["a", "ā", "i", "ī", "u", "ū", "e", "ē", "o", "ō", "ai", "au", "r̥"]);
+    // First row is the ka-series; every row spans all 13 vowels.
+    expect(m.rows[0]!.label).toBe("ka");
+    expect(m.rows.every((r) => r.cells.length === 13)).toBe(true);
+    // The vocalic-R column header is ISO-15919 r̥ = r + U+0325 (ring below),
+    // NOT the IAST dot-below ṛ (U+1E5B).
+    expect([...m.vowels[12]!].map((c) => c.codePointAt(0))).toEqual([0x72, 0x325]);
+  });
+});


### PR DESCRIPTION
## What & why

A Dravidian abugida isn't a flat list of ~450 signs — it's a **table**: every consonant marches across the same vowel row. The flat Browse list hides that regularity; this adds a **List / Matrix** toggle (syllabaries only; alphabets stay a plain list) that lays the syllables out as **rows = consonants, columns = vowels**, so the ka/kā/ki… pattern repeating down every consonant is the first thing you see. Clicking a cell opens the existing "break it apart" panel. **No new data** — the same generated syllables, re-arranged.

## Eyeball sample (native reader, please check)

First four consonant rows of the real Telugu grid, straight from the generated JSON (all 13 vowel columns):

| C | a | ā | i | ī | u | ū | e | ē | o | ō | ai | au | r̥ |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| ka | క | కా | కి | కీ | కు | కూ | కె | కే | కొ | కో | కై | కౌ | కృ |
| kha | ఖ | ఖా | ఖి | ఖీ | ఖు | ఖూ | ఖె | ఖే | ఖొ | ఖో | ఖై | ఖౌ | ఖృ |
| ga | గ | గా | గి | గీ | గు | గూ | గె | గే | గొ | గో | గై | గౌ | గృ |
| gha | ఘ | ఘా | ఘి | ఘీ | ఘు | ఘూ | ఘె | ఘే | ఘొ | ఘో | ఘై | ఘౌ | ఘృ |

(Full grid is 35 consonants × 13 vowels. The `r̥` column header is ISO-15919 r̥ = r + U+0325, not IAST ṛ.)

## How

- **matrix.ts** — new pure `buildSyllableMatrix(letters)`. Rows reuse the grounded consonant boundary from `syllabary.ts` (a new row at each bare consonant); the vowel column headers are read off the **first consonant's own row** — its base syllable's sound minus its inherent vowel gives the consonant prefix (`ka` − `a` = `k`), and stripping that off each syllable yields the vowel it carries (`kā` → ā, `kr̥` → r̥). Nothing invented. If the rows don't all span the same vowels it returns **null** rather than risk a syllable under the wrong vowel header.
- **main.ts** — the Browse List/Matrix toggle + the table (vowel headers, consonant row labels, clickable cells → existing detail panel). A ragged script falls back to the grid.
- **styles.css** — `.layouts` toggle + `.matrix` table (sticky vowel header + consonant column, horizontal scroll for the wide grid).
- **tests** — lays a rectangular fixture out correctly; **CONTROL** — a ragged input (a consonant missing a vowel) yields **no matrix**; plus a real-Telugu check (35 × 13; r̥ = r + U+0325).

Recognition only — `strokeOrder` stays `[]`, the ductus remains paused.

## Verification

- App suite **249 → 253** pass; human-language-data **38** pass; `npm run build` clean.
- Grounding review (native reader can't catch glyph/vowel slips): the prefix-strip vowel derivation, the rectangular/ragged guard, column-header alignment, r̥ codepoints, and cell index→glyph pairing all confirmed **sound** — no cell can sit under the wrong vowel.
- Browser (headless): Telugu Matrix renders the full varga grid with real glyphs (no tofu), correct syllable under each vowel column; clicking ka opens its decomposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)