### PR TITLE
Add MOS forward depletion coefficient

### DIFF
--- a/code/packages/python/mosfet-models/CHANGELOG.md
+++ b/code/packages/python/mosfet-models/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [0.1.0] — Unreleased
 
 ### Added
+- `Level1Params.FC` adds the continuous Berkeley forward-bias continuation to
+  the existing `PB` / `MJ` bulk-junction depletion-capacitance model.
 - `Level1Params.AF` provides the Level-1 MOS flicker-noise current exponent,
   defaulting to one.
 - `Level1Params.KF` provides the Level-1 MOS flicker-noise coefficient, with a

--- a/code/packages/python/mosfet-models/README.md
+++ b/code/packages/python/mosfet-models/README.md
@@ -22,7 +22,7 @@ print(r.Id, r.gm, r.gds, r.region)
 
 ## v0.1.0 scope
 
-- `Level1Params`: Level-1 DC, capacitance, and noise parameter set with sane defaults for 130 nm-style NMOS, including `PB` / `MJ` bulk-junction depletion shaping for `CBS` / `CBD`, zero-default `KF` flicker noise, and a unit-default `AF` current exponent.
+- `Level1Params`: Level-1 DC, capacitance, and noise parameter set with sane defaults for 130 nm-style NMOS, including `PB` / `MJ` / `FC` bulk-junction depletion shaping for `CBS` / `CBD`, zero-default `KF` flicker noise, and a unit-default `AF` current exponent.
 - `evaluate_level1(params, V_GS, V_DS, V_BS, T)`: returns `MosResult` with Id, gm, gds, gmb, Cgs/Cgd/Cgb/Cbs/Cbd, region.
 - Region detection: cutoff (subthreshold-aware), triode, saturation.
 - Body effect via gamma * (sqrt(PHI-V_BS) - sqrt(PHI)) shift.

--- a/code/packages/python/mosfet-models/src/mosfet_models/level1.py
+++ b/code/packages/python/mosfet-models/src/mosfet_models/level1.py
@@ -8,7 +8,7 @@ analytical Jacobian. Pedagogy-grade — for hand calculations and the canonical
 from __future__ import annotations
 
 from dataclasses import dataclass
-from math import exp, sqrt
+from math import exp, isfinite, sqrt
 
 from device_physics import thermal_voltage
 
@@ -35,6 +35,7 @@ class Level1Params:
     CBD: float = 0.0  # drain-bulk zero-bias junction capacitance (F)
     PB: float = 0.8  # bulk junction potential (V)
     MJ: float = 0.5  # bulk junction grading coefficient
+    FC: float = 0.5  # forward-bias depletion transition coefficient
     KF: float = 0.0  # flicker-noise coefficient
     AF: float = 1.0  # flicker-noise drain-current exponent
     subthreshold_enable: bool = True
@@ -61,6 +62,7 @@ def bulk_junction_capacitance(
     junction_voltage: float,
     junction_potential: float,
     grading_coefficient: float,
+    forward_bias_coefficient: float = 0.5,
 ) -> float:
     """Return the Level-1 bulk-junction depletion capacitance.
 
@@ -70,10 +72,28 @@ def bulk_junction_capacitance(
 
     if zero_bias_capacitance <= 0.0:
         return zero_bias_capacitance
+    if (
+        not isfinite(forward_bias_coefficient)
+        or forward_bias_coefficient < 0.0
+        or forward_bias_coefficient >= 1.0
+    ):
+        raise ValueError("MOSFET FC must be finite and in [0, 1)")
     if junction_potential <= 0.0 or grading_coefficient == 0.0:
         return zero_bias_capacitance
-    reverse_scale = max(0.0, -junction_voltage) / junction_potential
-    return zero_bias_capacitance / ((1.0 + reverse_scale) ** grading_coefficient)
+    normalized_voltage = junction_voltage / junction_potential
+    if normalized_voltage < forward_bias_coefficient:
+        return zero_bias_capacitance / (
+            (1.0 - normalized_voltage) ** grading_coefficient
+        )
+    denominator = (1.0 - forward_bias_coefficient) ** (
+        1.0 + grading_coefficient
+    )
+    continuation = (
+        1.0
+        - forward_bias_coefficient * (1.0 + grading_coefficient)
+        + grading_coefficient * normalized_voltage
+    )
+    return zero_bias_capacitance * continuation / denominator
 
 
 def evaluate_level1(
@@ -89,6 +109,8 @@ def evaluate_level1(
     sign of inputs/outputs externally.
     """
     p = params
+    if not isfinite(p.FC) or p.FC < 0.0 or p.FC >= 1.0:
+        raise ValueError("MOSFET FC must be finite and in [0, 1)")
     beta = p.KP * (p.W / p.L)
 
     # Threshold with body effect. The formula is well-defined whenever
@@ -108,8 +130,8 @@ def evaluate_level1(
     Cgs_intrinsic = (2.0 / 3.0) * p.W * p.L * p.KP / 1.0  # placeholder; Meyer model
     Cgd_intrinsic = 0.0
     Cgb_intrinsic = 0.0
-    Cbs_bulk = bulk_junction_capacitance(p.CBS, V_BS, p.PB, p.MJ)
-    Cbd_bulk = bulk_junction_capacitance(p.CBD, V_BS - V_DS, p.PB, p.MJ)
+    Cbs_bulk = bulk_junction_capacitance(p.CBS, V_BS, p.PB, p.MJ, p.FC)
+    Cbd_bulk = bulk_junction_capacitance(p.CBD, V_BS - V_DS, p.PB, p.MJ, p.FC)
 
     if V_OV <= 0:
         # Cutoff — optionally subthreshold.

--- a/code/packages/python/mosfet-models/tests/test_models.py
+++ b/code/packages/python/mosfet-models/tests/test_models.py
@@ -158,6 +158,38 @@ def test_bulk_junction_capacitance_uses_pb_mj_for_reverse_bias():
     assert r.Cbs == pytest.approx(4e-12 / (2.0 ** 0.5))
     assert r.Cbd == pytest.approx(8e-12 / (4.0 ** 0.5))
 
+def test_bulk_junction_capacitance_uses_continuous_forward_bias_transition():
+    early = Level1Params(
+        CBS=4e-12, PB=1.0, MJ=0.5, FC=0.4, subthreshold_enable=False
+    )
+    below = evaluate_level1(early, V_GS=0.0, V_DS=0.0, V_BS=0.4 - 1e-9)
+    above = evaluate_level1(early, V_GS=0.0, V_DS=0.0, V_BS=0.4 + 1e-9)
+    later = evaluate_level1(
+        Level1Params(
+            CBS=4e-12, PB=1.0, MJ=0.5, FC=0.8, subthreshold_enable=False
+        ),
+        V_GS=0.0,
+        V_DS=0.0,
+        V_BS=0.7,
+    )
+    transitioned = evaluate_level1(
+        early, V_GS=0.0, V_DS=0.0, V_BS=0.7
+    )
+
+    assert below.Cbs == pytest.approx(above.Cbs, rel=1e-8)
+    assert later.Cbs > transitioned.Cbs
+
+
+@pytest.mark.parametrize("fc", [float("nan"), -0.1, 1.0])
+def test_bulk_junction_capacitance_rejects_invalid_forward_bias_coefficient(fc):
+    with pytest.raises(ValueError, match=r"MOSFET FC must be finite and in \[0, 1\)"):
+        evaluate_level1(
+            Level1Params(CBS=1e-12, FC=fc),
+            V_GS=0.0,
+            V_DS=0.0,
+            V_BS=0.0,
+        )
+
 
 # ---- MOSFET wrapper ----
 

--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add Level-1 MOS model-card `FC` support, applying the continuous Berkeley
+  forward-bias continuation to `CBS` / `CBD` in AC and transient analysis.
 - Add Level-1 MOS model-card `AF` support and apply the configurable
   drain-current exponent to MOS flicker-noise power spectral density.
 - Add Level-1 MOS model-card `KF` support and emit drain-current-scaled

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -89,6 +89,8 @@ noise model. `NLEV >= 3` selects the Berkeley linear-region equation, with
 `GDSNOI` (default `1`) scaling its channel-noise conductance.
 Level-1 MOS model cards accept `KF` (default `0`) and `AF` (default `1`) and add
 `KF * abs(Id)^AF / frequency` flicker noise alongside channel thermal noise.
+`FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
+for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.
 `dc_temperature_sweep()` and `dc_temperature_sweep_corners()` run
 `.temp`-style DC operating-point snapshots across explicit analysis
@@ -318,8 +320,9 @@ probe-voltage windows, and charge-behavior notes for diode, BJT, JFET, and
 Level-1 MOS charge audits. Diode `Cjo` / `Tt`, BJT `Cje` / `Cjc` / `Tf` /
 `Tr`, JFET `Cgs` / `Cgd`, and Level-1 MOS `CGSO` / `CGDO` / `CGBO` plus
 bulk-junction `CBS` / `CBD` model-card parameters also stamp transient
-storage, with MOS `PB` / `MJ` shaping reverse-biased source-body and
-drain-body capacitance to match their small-signal AC semantics.
+storage, with MOS `PB` / `MJ` / `FC` shaping source-body and drain-body
+capacitance continuously across reverse and forward bias to match their
+small-signal AC semantics.
 `device_model_reference_deck_audit_fixtures()` flattens those DC,
 temperature, AC, noise, and transient fixture families into a stable
 reference-deck coverage matrix for each supported diode, BJT, JFET, and

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -9102,10 +9102,17 @@ def _mosfet_charge_dynamic_capacitance(
         return zero_bias_capacitance
     junction_potential = getattr(params, "PB", 0.8)
     grading_coefficient = getattr(params, "MJ", 0.5)
+    forward_bias_coefficient = getattr(params, "FC", 0.5)
     if not math.isfinite(junction_potential) or junction_potential <= 0.0:
         raise ValueError(f"{el.name}: MOSFET PB must be finite and positive")
     if not math.isfinite(grading_coefficient) or grading_coefficient < 0.0:
         raise ValueError(f"{el.name}: MOSFET MJ must be finite and non-negative")
+    if (
+        not math.isfinite(forward_bias_coefficient)
+        or forward_bias_coefficient < 0.0
+        or forward_bias_coefficient >= 1.0
+    ):
+        raise ValueError(f"{el.name}: MOSFET FC must be finite and in [0, 1)")
     mosfet_type = getattr(el.model, "type", None)
     junction_voltage = state_voltage if mosfet_type == MosfetType.PMOS else -state_voltage
     return bulk_junction_capacitance(
@@ -9113,6 +9120,7 @@ def _mosfet_charge_dynamic_capacitance(
         junction_voltage,
         junction_potential,
         grading_coefficient,
+        forward_bias_coefficient,
     )
 
 

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -311,8 +311,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "PNP": (41, 58, 13, 4),
     "NJF": (22, 30, 7, 3),
     "PJF": (22, 30, 7, 3),
-    "NMOS": (20, 27, 6, 3),
-    "PMOS": (20, 27, 6, 3),
+    "NMOS": (21, 28, 6, 3),
+    "PMOS": (21, 28, 6, 3),
 }
 
 
@@ -477,6 +477,7 @@ _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
     "CJD": "CBD",
     "PB": "PB",
     "MJ": "MJ",
+    "FC": "FC",
     "KF": "KF",
     "AF": "AF",
 }
@@ -1076,6 +1077,7 @@ def mosfet_from_model_card(
         CBD=p.get("CBD", defaults.CBD),
         PB=p.get("PB", defaults.PB),
         MJ=p.get("MJ", defaults.MJ),
+        FC=p.get("FC", defaults.FC),
         KF=p.get("KF", defaults.KF),
         AF=p.get("AF", defaults.AF),
     )

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -408,7 +408,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 181
+    assert len(coverage) == 183
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -423,7 +423,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tAF\tAF\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 181
+    assert len(records) == 183
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -446,8 +446,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert summary[0].max_alias_count == 3
     assert summary[0].aliased_parameters == ("IS", "VT", "CJO", "VJ", "M")
     assert summary[5].kind == "NMOS"
-    assert summary[5].canonical_parameter_count == 20
-    assert summary[5].accepted_name_count == 27
+    assert summary[5].canonical_parameter_count == 21
+    assert summary[5].accepted_name_count == 28
     assert summary[5].aliased_parameter_count == 6
     assert summary[5].max_alias_count == 3
     assert summary[5].aliased_parameters == (
@@ -469,7 +469,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert table.splitlines()[1] == "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M"
     assert (
         table.splitlines()[-1]
-        == "PMOS\t20\t27\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        == "PMOS\t21\t28\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
     )
     records = model_card_supported_parameter_coverage_summary_records()
     assert len(records) == 7
@@ -497,9 +497,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 181
-    assert report.expected_canonical_parameter_count == 181
-    assert report.accepted_name_count == 251
+    assert report.canonical_parameter_count == 183
+    assert report.expected_canonical_parameter_count == 183
+    assert report.accepted_name_count == 253
     assert report.aliased_parameter_count == 57
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -507,7 +507,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t181\t181\t251\t57\t4\t0"
+        "true\t7\t7\t183\t183\t253\t57\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -535,15 +535,15 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 180
-    assert report.accepted_name_count == 248
+    assert report.canonical_parameter_count == 182
+    assert report.accepted_name_count == 250
     assert report.aliased_parameter_count == 56
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
     assert report.issues[0].field == "canonical_parameter_count"
     assert report.issues[0].message == (
-        "expected NMOS to expose 20 canonical supported parameters, found 19"
+        "expected NMOS to expose 21 canonical supported parameters, found 20"
     )
     assert report.issues[-1].field == "max_alias_count"
     assert report.issues[-1].message == "expected NMOS max alias count 3, found 2"
@@ -551,12 +551,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t180\t181\t248\t56\t4\t4\n"
+        "false\t7\t7\t182\t183\t250\t56\t4\t4\n"
         "kind\tfield\tmessage\n"
-        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 20 canonical "
-        "supported parameters, found 19\n"
-        "NMOS\taccepted_name_count\texpected NMOS to expose 27 accepted model-card "
-        "names, found 24\n"
+        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 21 canonical "
+        "supported parameters, found 20\n"
+        "NMOS\taccepted_name_count\texpected NMOS to expose 28 accepted model-card "
+        "names, found 25\n"
         "NMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing "
         "parameters, found 5\n"
         "NMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
@@ -565,12 +565,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
     assert records[0] == {
         "kind": "NMOS",
         "field": "canonical_parameter_count",
-        "message": "expected NMOS to expose 20 canonical supported parameters, found 19",
+        "message": "expected NMOS to expose 21 canonical supported parameters, found 20",
     }
     assert format_model_card_supported_parameter_coverage_gate_issue_csv(report).startswith(
         "kind,field,message\n"
-        'NMOS,canonical_parameter_count,"expected NMOS to expose 20 canonical '
-        'supported parameters, found 19"\n'
+        'NMOS,canonical_parameter_count,"expected NMOS to expose 21 canonical '
+        'supported parameters, found 20"\n'
     )
     assert (
         json.loads(format_model_card_supported_parameter_coverage_gate_issue_json(report))
@@ -746,6 +746,7 @@ def test_model_card_aliases_build_device_instances() -> None:
             "CJD": 3.0e-13,
             "PB": 0.9,
             "MJ": 0.45,
+            "FC": 0.4,
             "KF": 2.0e-24,
             "AF": 1.4,
         },
@@ -759,6 +760,7 @@ def test_model_card_aliases_build_device_instances() -> None:
         "CBD": 3.0e-13,
         "PB": 0.9,
         "MJ": 0.45,
+        "FC": 0.4,
         "KF": 2.0e-24,
         "AF": 1.4,
     }
@@ -771,6 +773,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(3.0e-13) == mos_model.model.model.params.CBD
     assert pytest.approx(0.9) == mos_model.model.model.params.PB
     assert pytest.approx(0.45) == mos_model.model.model.params.MJ
+    assert pytest.approx(0.4) == mos_model.model.model.params.FC
     assert pytest.approx(2.0e-24) == mos_model.model.model.params.KF
     assert pytest.approx(1.4) == mos_model.model.model.params.AF
 
@@ -1780,6 +1783,63 @@ def test_transient_mosfet_bulk_junction_depletion_shaping_reduces_reverse_bias_c
     assert fixed_first == pytest.approx(1.5, rel=0.05)
     assert shaped_first > fixed_first + 0.04
     assert shaped_first < 1.7
+
+
+def test_transient_mosfet_forward_bias_depletion_coefficient_shapes_bulk_charge() -> None:
+    def first_drain_voltage(fc: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource(
+            "Vstep",
+            "in",
+            "0",
+            -0.6,
+            waveform=PwlWaveform(((0.0, -0.6), (1.0e-9, -0.8), (5.0e-9, -0.8))),
+        ))
+        circuit.add(Resistor("Rin", "in", "drain", 1_000.0))
+        circuit.add(Mosfet(
+            "M1",
+            "drain",
+            "0",
+            "0",
+            "0",
+            MOSFET(
+                MosfetType.NMOS,
+                Level1Model(Level1Params(
+                    KP=1.0e-12,
+                    W=1.0,
+                    L=1.0,
+                    CBD=1.0e-12,
+                    PB=1.0,
+                    MJ=0.5,
+                    FC=fc,
+                )),
+            ),
+        ))
+        result = transient(
+            circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler"
+        )
+        assert result.converged
+        return result.points[1].node_voltages["drain"]
+
+    assert first_drain_voltage(0.2) < first_drain_voltage(0.8)
+
+
+@pytest.mark.parametrize("fc", [float("nan"), -0.1, 1.0])
+def test_mosfet_rejects_invalid_forward_bias_depletion_coefficient(fc: float) -> None:
+    circuit = Circuit()
+    circuit.add(VoltageSource("Vin", "in", "0", 0.0))
+    circuit.add(Resistor("Rin", "in", "drain", 1_000.0))
+    circuit.add(Mosfet(
+        "Mbad",
+        "drain",
+        "gate",
+        "0",
+        "0",
+        MOSFET(MosfetType.NMOS, Level1Model(Level1Params(FC=fc))),
+    ))
+
+    with pytest.raises(ValueError, match=r"MOSFET FC must be finite and in \[0, 1\)"):
+        dc_op(circuit)
 
 
 def test_transient_diode_transit_time_holds_forward_charge_on_turnoff() -> None:

--- a/code/packages/rust/mosfet-models/CHANGELOG.md
+++ b/code/packages/rust/mosfet-models/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- `Level1Params::pb`, `Level1Params::mj`, and `Level1Params::fc` provide
+  continuous Berkeley bulk-junction depletion-capacitance shaping for `CBS`
+  and `CBD`.
 - `Level1Params::af` provides the Level-1 MOS flicker-noise current exponent,
   defaulting to one.
 

--- a/code/packages/rust/mosfet-models/README.md
+++ b/code/packages/rust/mosfet-models/README.md
@@ -1,6 +1,6 @@
 # mosfet-models
 
-SPICE Level-1 (Shockley) MOSFET I-V model with full small-signal parameter extraction, body effect, subthreshold conduction, and PMOS sign conventions.
+SPICE Level-1 (Shockley) MOSFET I-V model with full small-signal parameter extraction, body effect, subthreshold conduction, and PMOS sign conventions. Bulk-junction capacitance supports Berkeley `PB`, `MJ`, and `FC` depletion shaping.
 
 ## What it does
 

--- a/code/packages/rust/mosfet-models/src/lib.rs
+++ b/code/packages/rust/mosfet-models/src/lib.rs
@@ -73,6 +73,12 @@ pub struct Level1Params {
     pub cbs: f64,
     /// Drain–bulk zero-bias junction capacitance [F].
     pub cbd: f64,
+    /// Bulk-junction potential [V].
+    pub pb: f64,
+    /// Bulk-junction grading coefficient.
+    pub mj: f64,
+    /// Forward-bias depletion-capacitance transition coefficient.
+    pub fc: f64,
     /// Flicker-noise coefficient.
     pub kf: f64,
     /// Flicker-noise drain-current exponent.
@@ -99,11 +105,38 @@ impl Default for Level1Params {
             cgbo: 0.0,
             cbs: 0.0,
             cbd: 0.0,
+            pb: 0.8,
+            mj: 0.5,
+            fc: 0.5,
             kf: 0.0,
             af: 1.0,
             subthreshold_enable: true,
         }
     }
+}
+
+/// Return the Level-1 bulk-junction depletion capacitance.
+pub fn bulk_junction_capacitance(
+    zero_bias_capacitance: f64,
+    junction_voltage: f64,
+    junction_potential: f64,
+    grading_coefficient: f64,
+    forward_bias_coefficient: f64,
+) -> f64 {
+    if zero_bias_capacitance <= 0.0 {
+        return zero_bias_capacitance;
+    }
+    if junction_potential <= 0.0 || grading_coefficient == 0.0 {
+        return zero_bias_capacitance;
+    }
+    let normalized_voltage = junction_voltage / junction_potential;
+    if normalized_voltage < forward_bias_coefficient {
+        return zero_bias_capacitance / (1.0 - normalized_voltage).powf(grading_coefficient);
+    }
+    let denominator = (1.0 - forward_bias_coefficient).powf(1.0 + grading_coefficient);
+    let continuation = 1.0 - forward_bias_coefficient * (1.0 + grading_coefficient)
+        + grading_coefficient * normalized_voltage;
+    zero_bias_capacitance * continuation / denominator
 }
 
 // ---------------------------------------------------------------------------
@@ -215,6 +248,8 @@ pub fn evaluate_level1(
     // In saturation: C_gs_intrinsic ≈ (2/3) W L C_ox.
     // We approximate C_ox as KP (units collapse to F/m² in the placeholder).
     let cgs_intrinsic = (2.0 / 3.0) * p.w * p.l * p.kp;
+    let cbs_bulk = bulk_junction_capacitance(p.cbs, v_bs, p.pb, p.mj, p.fc);
+    let cbd_bulk = bulk_junction_capacitance(p.cbd, v_bs - v_ds, p.pb, p.mj, p.fc);
 
     // -----------------------------------------------------------------------
     // Cutoff / subthreshold
@@ -224,15 +259,10 @@ pub fn evaluate_level1(
             // Subthreshold: Id = β n V_T² exp(V_OV/(n V_T)) (1 − exp(−V_DS/V_T))
             // This smoothly matches the strong-inversion model at V_OV ≈ 0.
             let n = p.n_sub;
-            let id_sub = beta
-                * n
-                * vth
-                * vth
-                * (v_ov / (n * vth)).exp()
-                * (1.0 - (-v_ds / vth).exp());
+            let id_sub =
+                beta * n * vth * vth * (v_ov / (n * vth)).exp() * (1.0 - (-v_ds / vth).exp());
             let gm_sub = id_sub / (n * vth);
-            let gds_sub =
-                (beta * n * vth) * (v_ov / (n * vth)).exp() * (-v_ds / vth).exp();
+            let gds_sub = (beta * n * vth) * (v_ov / (n * vth)).exp() * (-v_ds / vth).exp();
             return MosResult {
                 id: id_sub,
                 gm: gm_sub,
@@ -241,8 +271,8 @@ pub fn evaluate_level1(
                 cgs: cgs_overlap + cgs_intrinsic,
                 cgd: cgd_overlap,
                 cgb: cgb_overlap,
-                cbs: p.cbs,
-                cbd: p.cbd,
+                cbs: cbs_bulk,
+                cbd: cbd_bulk,
                 region: Region::Subthreshold,
             };
         }
@@ -255,8 +285,8 @@ pub fn evaluate_level1(
             cgs: cgs_overlap + cgs_intrinsic,
             cgd: cgd_overlap,
             cgb: cgb_overlap,
-            cbs: p.cbs,
-            cbd: p.cbd,
+            cbs: cbs_bulk,
+            cbd: cbd_bulk,
             region: Region::Cutoff,
         };
     }
@@ -273,9 +303,7 @@ pub fn evaluate_level1(
     // Triode (linear) region: 0 < V_DS < V_OV
     // -----------------------------------------------------------------------
     if v_ds < v_ov {
-        let id = beta
-            * (v_ov * v_ds - v_ds * v_ds / 2.0)
-            * (1.0 + p.lambda * v_ds);
+        let id = beta * (v_ov * v_ds - v_ds * v_ds / 2.0) * (1.0 + p.lambda * v_ds);
         let gm = beta * v_ds * (1.0 + p.lambda * v_ds);
         let gds = beta * (v_ov - v_ds) * (1.0 + p.lambda * v_ds)
             + beta * (v_ov * v_ds - v_ds * v_ds / 2.0) * p.lambda;
@@ -288,8 +316,8 @@ pub fn evaluate_level1(
             cgs: cgs_overlap + cgs_intrinsic / 2.0,
             cgd: cgd_overlap + cgs_intrinsic / 2.0,
             cgb: cgb_overlap,
-            cbs: p.cbs,
-            cbd: p.cbd,
+            cbs: cbs_bulk,
+            cbd: cbd_bulk,
             region: Region::Triode,
         };
     }
@@ -309,8 +337,8 @@ pub fn evaluate_level1(
         cgs: cgs_overlap + (2.0 / 3.0) * cgs_intrinsic,
         cgd: cgd_overlap,
         cgb: cgb_overlap,
-        cbs: p.cbs,
-        cbd: p.cbd,
+        cbs: cbs_bulk,
+        cbd: cbd_bulk,
         region: Region::Saturation,
     }
 }

--- a/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
+++ b/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
@@ -1,6 +1,4 @@
-use mosfet_models::{
-    evaluate_level1, Level1Model, Level1Params, MosfetType, Mosfet, Region,
-};
+use mosfet_models::{evaluate_level1, Level1Model, Level1Params, Mosfet, MosfetType, Region};
 
 // ---------------------------------------------------------------------------
 // Level1Params defaults
@@ -81,7 +79,10 @@ fn test_gm_positive_in_saturation() {
 fn test_gds_positive_in_saturation() {
     let p = Level1Params::default();
     let r = evaluate_level1(&p, 1.8, 1.8, 0.0, 300.15);
-    assert!(r.gds > 0.0, "gds must be positive (channel-length modulation)");
+    assert!(
+        r.gds > 0.0,
+        "gds must be positive (channel-length modulation)"
+    );
 }
 
 #[test]
@@ -113,6 +114,35 @@ fn test_gmb_nonzero_with_body_bias() {
     let p = Level1Params::default();
     let r = evaluate_level1(&p, 1.8, 1.8, -0.5, 300.15);
     assert!(r.gmb > 0.0, "gmb must be positive with reverse body bias");
+}
+
+#[test]
+fn test_bulk_junction_capacitance_uses_continuous_forward_bias_transition() {
+    let params = Level1Params {
+        cbs: 4.0e-12,
+        pb: 1.0,
+        mj: 0.5,
+        fc: 0.4,
+        subthreshold_enable: false,
+        ..Level1Params::default()
+    };
+    let below = evaluate_level1(&params, 0.0, 0.0, 0.4 - 1.0e-9, 300.15).cbs;
+    let above = evaluate_level1(&params, 0.0, 0.0, 0.4 + 1.0e-9, 300.15).cbs;
+    let later_transition = evaluate_level1(
+        &Level1Params {
+            fc: 0.8,
+            ..params.clone()
+        },
+        0.0,
+        0.0,
+        0.7,
+        300.15,
+    )
+    .cbs;
+    let early_transition = evaluate_level1(&params, 0.0, 0.0, 0.7, 300.15).cbs;
+
+    assert!((below - above).abs() < 1.0e-19);
+    assert!(later_transition > early_transition);
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add Level-1 MOS model-card `FC` support, applying the continuous Berkeley
+  forward-bias continuation to `CBS` / `CBD` in AC and transient analysis.
 - Add Level-1 MOS model-card `AF` support and apply the configurable
   drain-current exponent to MOS flicker-noise power spectral density.
 - Add Level-1 MOS model-card `KF` support and emit drain-current-scaled

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -130,6 +130,8 @@ noise model. `NLEV >= 3` selects the Berkeley linear-region equation, with
 `GDSNOI` (default `1`) scaling its channel-noise conductance.
 Level-1 MOS model cards accept `KF` (default `0`) and `AF` (default `1`) and add
 `KF * abs(Id)^AF / frequency` flicker noise alongside channel thermal noise.
+`FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
+for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.
 
 `normalize_model_card`, `diode_from_model_card`, `bjt_from_model_card`,
@@ -239,8 +241,10 @@ BJT `base_emitter_capacitance` / `base_collector_capacitance` /
 `gate_bulk_overlap_capacitance`, and bulk-junction
 `source_bulk_capacitance` / `drain_bulk_capacitance` model-card parameters
 also stamp transient storage, with MOS `bulk_junction_potential` /
-`bulk_junction_grading_coefficient` shaping reverse-biased source-body and
-drain-body capacitance to match their small-signal AC semantics.
+`bulk_junction_grading_coefficient` /
+`forward_bias_depletion_coefficient` shaping source-body and drain-body
+capacitance continuously across reverse and forward bias to match their
+small-signal AC semantics.
 `device_model_reference_deck_audit_fixtures` flattens those DC, temperature,
 AC, noise, and transient fixture families into a stable reference-deck
 coverage matrix for each supported diode, BJT, JFET, and Level-1 MOS model

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3616,6 +3616,7 @@ pub struct MosfetLevel1Params {
     pub drain_bulk_capacitance: f64,
     pub bulk_junction_potential: f64,
     pub bulk_junction_grading_coefficient: f64,
+    pub forward_bias_depletion_coefficient: f64,
     pub flicker_noise_coefficient: f64,
     pub flicker_noise_exponent: f64,
 }
@@ -3640,6 +3641,7 @@ impl Default for MosfetLevel1Params {
             drain_bulk_capacitance: 0.0,
             bulk_junction_potential: 0.8,
             bulk_junction_grading_coefficient: 0.5,
+            forward_bias_depletion_coefficient: 0.5,
             flicker_noise_coefficient: 0.0,
             flicker_noise_exponent: 1.0,
         }
@@ -3985,8 +3987,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     (ModelCardKind::Pnp, 41, 58, 13, 4),
     (ModelCardKind::Njf, 22, 30, 7, 3),
     (ModelCardKind::Pjf, 22, 30, 7, 3),
-    (ModelCardKind::Nmos, 20, 27, 6, 3),
-    (ModelCardKind::Pmos, 20, 27, 6, 3),
+    (ModelCardKind::Nmos, 21, 28, 6, 3),
+    (ModelCardKind::Pmos, 21, 28, 6, 3),
 ];
 const DIODE_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IS", "IS"),
@@ -4129,6 +4131,7 @@ const MOS_LEVEL1_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("CJD", "CBD"),
     ("PB", "PB"),
     ("MJ", "MJ"),
+    ("FC", "FC"),
     ("KF", "KF"),
     ("AF", "AF"),
 ];
@@ -4919,6 +4922,9 @@ pub fn mosfet_from_model_card(
     }
     if let Some(value) = model.parameters.get("MJ") {
         params.bulk_junction_grading_coefficient = *value;
+    }
+    if let Some(value) = model.parameters.get("FC") {
+        params.forward_bias_depletion_coefficient = *value;
     }
     if let Some(value) = model.parameters.get("KF") {
         params.flicker_noise_coefficient = *value;
@@ -23859,6 +23865,7 @@ fn mosfet_bulk_junction_capacitance(
     junction_voltage: f64,
     junction_potential: f64,
     grading_coefficient: f64,
+    forward_bias_coefficient: f64,
 ) -> f64 {
     if zero_bias_capacitance <= 0.0 {
         return zero_bias_capacitance;
@@ -23866,8 +23873,14 @@ fn mosfet_bulk_junction_capacitance(
     if junction_potential <= 0.0 || grading_coefficient == 0.0 {
         return zero_bias_capacitance;
     }
-    let reverse_scale = (-junction_voltage).max(0.0) / junction_potential;
-    zero_bias_capacitance / (1.0 + reverse_scale).powf(grading_coefficient)
+    let normalized_voltage = junction_voltage / junction_potential;
+    if normalized_voltage < forward_bias_coefficient {
+        return zero_bias_capacitance / (1.0 - normalized_voltage).powf(grading_coefficient);
+    }
+    let denominator = (1.0 - forward_bias_coefficient).powf(1.0 + grading_coefficient);
+    let continuation = 1.0 - forward_bias_coefficient * (1.0 + grading_coefficient)
+        + grading_coefficient * normalized_voltage;
+    zero_bias_capacitance * continuation / denominator
 }
 
 struct JfetDcResult {
@@ -24203,12 +24216,14 @@ fn evaluate_nmos_level1(
         vbs,
         params.bulk_junction_potential,
         params.bulk_junction_grading_coefficient,
+        params.forward_bias_depletion_coefficient,
     );
     let cbd_bulk = mosfet_bulk_junction_capacitance(
         params.drain_bulk_capacitance,
         vbs - vds,
         params.bulk_junction_potential,
         params.bulk_junction_grading_coefficient,
+        params.forward_bias_depletion_coefficient,
     );
     let threshold = if params.phi - vbs >= 0.0 {
         params.vt0 + params.gamma * ((params.phi - vbs).sqrt() - params.phi.sqrt())
@@ -24938,6 +24953,7 @@ fn mosfet_charge_dynamic_capacitance(
         junction_voltage,
         mosfet.params.bulk_junction_potential,
         mosfet.params.bulk_junction_grading_coefficient,
+        mosfet.params.forward_bias_depletion_coefficient,
     )
 }
 
@@ -25496,6 +25512,7 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         ("CBD", params.drain_bulk_capacitance),
         ("PB", params.bulk_junction_potential),
         ("MJ", params.bulk_junction_grading_coefficient),
+        ("FC", params.forward_bias_depletion_coefficient),
         ("KF", params.flicker_noise_coefficient),
         ("AF", params.flicker_noise_exponent),
     ] {
@@ -25534,6 +25551,12 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: mosfet.name.clone(),
             reason: "MOSFET PB must be positive and MJ must be non-negative".to_string(),
+        });
+    }
+    if !(0.0..1.0).contains(&params.forward_bias_depletion_coefficient) {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET FC must be in [0, 1)".to_string(),
         });
     }
     if params.flicker_noise_coefficient < 0.0 {

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -95,7 +95,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 181);
+    assert_eq!(coverage.len(), 183);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -114,7 +114,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tAF\tAF\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 181);
+    assert_eq!(records.len(), 183);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -147,8 +147,8 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         vec!["IS", "VT", "CJO", "VJ", "M"]
     );
     assert_eq!(summary[5].kind, ModelCardKind::Nmos);
-    assert_eq!(summary[5].canonical_parameter_count, 20);
-    assert_eq!(summary[5].accepted_name_count, 27);
+    assert_eq!(summary[5].canonical_parameter_count, 21);
+    assert_eq!(summary[5].accepted_name_count, 28);
     assert_eq!(summary[5].aliased_parameter_count, 6);
     assert_eq!(summary[5].max_alias_count, 3);
     assert_eq!(
@@ -166,7 +166,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     assert_eq!(lines[1], "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\t20\t27\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        &"PMOS\t21\t28\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
     );
     let records = model_card_supported_parameter_coverage_summary_records();
     assert_eq!(records.len(), 7);
@@ -184,7 +184,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         "[{\"kind\":\"D\",\"canonical_parameter_count\":\"15\",\"accepted_name_count\":\"21\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
     ));
     assert!(json.ends_with(
-        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"20\",\"accepted_name_count\":\"27\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
+        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"21\",\"accepted_name_count\":\"28\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
     ));
 }
 
@@ -195,15 +195,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 181);
-    assert_eq!(report.expected_canonical_parameter_count, 181);
-    assert_eq!(report.accepted_name_count, 251);
+    assert_eq!(report.canonical_parameter_count, 183);
+    assert_eq!(report.expected_canonical_parameter_count, 183);
+    assert_eq!(report.accepted_name_count, 253);
     assert_eq!(report.aliased_parameter_count, 57);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t181\t181\t251\t57\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t183\t183\t253\t57\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -230,8 +230,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 180);
-    assert_eq!(report.accepted_name_count, 248);
+    assert_eq!(report.canonical_parameter_count, 182);
+    assert_eq!(report.accepted_name_count, 250);
     assert_eq!(report.aliased_parameter_count, 56);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -239,7 +239,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     assert_eq!(report.issues[0].field, "canonical_parameter_count");
     assert_eq!(
         report.issues[0].message,
-        "expected NMOS to expose 20 canonical supported parameters, found 19"
+        "expected NMOS to expose 21 canonical supported parameters, found 20"
     );
     assert_eq!(report.issues.last().unwrap().field, "max_alias_count");
     assert_eq!(
@@ -248,20 +248,20 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t180\t181\t248\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 20 canonical supported parameters, found 19\nNMOS\taccepted_name_count\texpected NMOS to expose 27 accepted model-card names, found 24\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t182\t183\t250\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 21 canonical supported parameters, found 20\nNMOS\taccepted_name_count\texpected NMOS to expose 28 accepted model-card names, found 25\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
     assert_eq!(records[0]["field"], "canonical_parameter_count");
     assert_eq!(
         records[0]["message"],
-        "expected NMOS to expose 20 canonical supported parameters, found 19"
+        "expected NMOS to expose 21 canonical supported parameters, found 20"
     );
     assert!(format_model_card_supported_parameter_coverage_gate_issue_csv(&report).starts_with(
-        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 20 canonical supported parameters, found 19\"\n"
+        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 21 canonical supported parameters, found 20\"\n"
     ));
     assert!(format_model_card_supported_parameter_coverage_gate_issue_json(&report).starts_with(
-        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 20 canonical supported parameters, found 19\"}"
+        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 21 canonical supported parameters, found 20\"}"
     ));
 }
 
@@ -283,8 +283,8 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(dashboard[0].issue_count, 0);
     assert!(dashboard[0].issue_fields.is_empty());
     assert_eq!(dashboard[5].kind, ModelCardKind::Nmos);
-    assert_eq!(dashboard[5].canonical_parameter_count, 20);
-    assert_eq!(dashboard[5].accepted_name_count, 27);
+    assert_eq!(dashboard[5].canonical_parameter_count, 21);
+    assert_eq!(dashboard[5].accepted_name_count, 28);
     assert_eq!(dashboard[5].issue_count, 0);
 
     let table = format_model_card_supported_parameter_coverage_dashboard_table(&coverage);
@@ -296,7 +296,7 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(lines[1], "D\ttrue\t15\t15\t21\t21\t5\t5\t3\t3\t0\t");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\ttrue\t20\t20\t27\t27\t6\t6\t3\t3\t0\t"
+        &"PMOS\ttrue\t21\t21\t28\t28\t6\t6\t3\t3\t0\t"
     );
     let records = model_card_supported_parameter_coverage_dashboard_records(&coverage);
     assert_eq!(records.len(), 7);
@@ -328,10 +328,10 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         .unwrap();
 
     assert!(!nmos.passed);
-    assert_eq!(nmos.canonical_parameter_count, 19);
-    assert_eq!(nmos.expected_canonical_parameter_count, 20);
-    assert_eq!(nmos.accepted_name_count, 24);
-    assert_eq!(nmos.expected_accepted_name_count, 27);
+    assert_eq!(nmos.canonical_parameter_count, 20);
+    assert_eq!(nmos.expected_canonical_parameter_count, 21);
+    assert_eq!(nmos.accepted_name_count, 25);
+    assert_eq!(nmos.expected_accepted_name_count, 28);
     assert_eq!(nmos.aliased_parameter_count, 5);
     assert_eq!(nmos.expected_aliased_parameter_count, 6);
     assert_eq!(nmos.max_alias_count, 2);
@@ -347,7 +347,7 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         ]
     );
     assert!(format_model_card_supported_parameter_coverage_dashboard_table(&coverage).contains(
-        "NMOS\tfalse\t19\t20\t24\t27\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
+        "NMOS\tfalse\t20\t21\t25\t28\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
     ));
 }
 
@@ -592,6 +592,7 @@ fn model_card_aliases_build_device_instances() {
             ("CJD", 3.0e-13),
             ("PB", 0.9),
             ("MJ", 0.45),
+            ("FC", 0.4),
             ("KF", 2.0e-24),
             ("AF", 1.4),
         ],
@@ -604,6 +605,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*mos_card.parameters.get("CBD").unwrap(), 3.0e-13);
     assert_close(*mos_card.parameters.get("PB").unwrap(), 0.9);
     assert_close(*mos_card.parameters.get("MJ").unwrap(), 0.45);
+    assert_close(*mos_card.parameters.get("FC").unwrap(), 0.4);
     assert_close(*mos_card.parameters.get("KF").unwrap(), 2.0e-24);
     assert_close(*mos_card.parameters.get("AF").unwrap(), 1.4);
     assert_eq!(mos_model.mosfet_type, MosfetType::Nmos);
@@ -613,6 +615,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(mos_model.params.drain_bulk_capacitance, 3.0e-13);
     assert_close(mos_model.params.bulk_junction_potential, 0.9);
     assert_close(mos_model.params.bulk_junction_grading_coefficient, 0.45);
+    assert_close(mos_model.params.forward_bias_depletion_coefficient, 0.4);
     assert_close(mos_model.params.flicker_noise_coefficient, 2.0e-24);
     assert_close(mos_model.params.flicker_noise_exponent, 1.4);
 }
@@ -3594,6 +3597,38 @@ fn dc_mosfet_rejects_invalid_level1_params() {
             reason: "MOSFET KP must be positive".to_string(),
         }
     );
+}
+
+#[test]
+fn dc_mosfet_rejects_invalid_forward_bias_depletion_coefficient() {
+    for coefficient in [f64::NAN, -0.1, 1.0] {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "Mbad",
+            "drain",
+            "gate",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                forward_bias_depletion_coefficient: coefficient,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+
+        let err = dc_op(&circuit).unwrap_err();
+        assert_eq!(
+            err,
+            SpiceError::InvalidElement {
+                name: "Mbad".to_string(),
+                reason: if coefficient.is_finite() {
+                    "MOSFET FC must be in [0, 1)".to_string()
+                } else {
+                    "MOSFET FC must be finite".to_string()
+                },
+            }
+        );
+    }
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -518,6 +518,55 @@ fn transient_mosfet_bulk_junction_depletion_shaping_reduces_reverse_bias_capacit
 }
 
 #[test]
+fn transient_mosfet_forward_bias_depletion_coefficient_shapes_bulk_charge() {
+    fn first_drain_voltage(coefficient: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
+            "Vstep",
+            "in",
+            "0",
+            -0.6,
+            Waveform::Pwl(PwlWaveform::new(vec![
+                (0.0, -0.6),
+                (1.0e-9, -0.8),
+                (5.0e-9, -0.8),
+            ])),
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "drain", 1_000.0,
+        )));
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "M1",
+            "drain",
+            "0",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                kp: 1.0e-12,
+                w: 1.0,
+                l: 1.0,
+                drain_bulk_capacitance: 1.0e-12,
+                bulk_junction_potential: 1.0,
+                bulk_junction_grading_coefficient: 0.5,
+                forward_bias_depletion_coefficient: coefficient,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+        transient_with_method(&circuit, 1.0e-9, 5.0e-9, TransientMethod::Euler).unwrap()[0]
+            .voltage("drain")
+            .unwrap()
+    }
+
+    let early_transition = first_drain_voltage(0.2);
+    let late_transition = first_drain_voltage(0.8);
+    assert!(
+        early_transition < late_transition,
+        "expected early FC transition to reduce forward capacitance, got early={early_transition} late={late_transition}"
+    );
+}
+
+#[test]
 fn transient_diode_transit_time_holds_forward_charge_on_turnoff() {
     fn run(transit_time: f64) -> Vec<TransientPoint> {
         let mut circuit = Circuit::new();

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add Level-1 MOS model-card `FC` support, applying the continuous Berkeley
+  forward-bias continuation to `CBS` / `CBD` in AC and transient analysis.
 - Add Level-1 MOS model-card `AF` support and apply the configurable
   drain-current exponent to MOS flicker-noise power spectral density.
 - Add Level-1 MOS model-card `KF` support and emit drain-current-scaled

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -81,6 +81,8 @@ noise model. `NLEV >= 3` selects the Berkeley linear-region equation, with
 `GDSNOI` (default `1`) scaling its channel-noise conductance.
 Level-1 MOS model cards accept `KF` (default `0`) and `AF` (default `1`) and add
 `KF * abs(Id)^AF / frequency` flicker noise alongside channel thermal noise.
+`FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
+for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.
 `dcTemperatureSweep` and `dcTemperatureSweepCorners` run `.temp`-style DC
 operating-point snapshots across explicit analysis temperatures, with stable
@@ -306,8 +308,9 @@ Level-1 MOS charge audits. Diode `junctionCapacitance` / `transitTime`, BJT
 `reverseTransitTime`, and JFET `gateSourceCapacitance` /
 `gateDrainCapacitance` plus Level-1 MOS `CGSO` / `CGDO` / `CGBO` model-card
 parameters plus bulk-junction `CBS` / `CBD` model-card parameters also stamp
-transient storage, with MOS `PB` / `MJ` shaping reverse-biased source-body and
-drain-body capacitance to match their small-signal AC semantics.
+transient storage, with MOS `PB` / `MJ` / `FC` shaping source-body and
+drain-body capacitance continuously across reverse and forward bias to match
+their small-signal AC semantics.
 `deviceModelReferenceDeckAuditFixtures` flattens those DC, temperature, AC,
 noise, and transient fixture families into a stable reference-deck coverage
 matrix for each supported diode, BJT, JFET, and Level-1 MOS model family.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1784,6 +1784,7 @@ export interface MosfetLevel1Params {
   readonly CBD: number;
   readonly PB: number;
   readonly MJ: number;
+  readonly FC: number;
   readonly KF: number;
   readonly AF: number;
 }
@@ -2045,8 +2046,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   PNP: [41, 58, 13, 4],
   NJF: [22, 30, 7, 3],
   PJF: [22, 30, 7, 3],
-  NMOS: [20, 27, 6, 3],
-  PMOS: [20, 27, 6, 3],
+  NMOS: [21, 28, 6, 3],
+  PMOS: [21, 28, 6, 3],
 };
 
 export interface Vccs {
@@ -8038,6 +8039,7 @@ export function defaultMosfetLevel1Params(): MosfetLevel1Params {
     CBD: 0.0,
     PB: 0.8,
     MJ: 0.5,
+    FC: 0.5,
     KF: 0.0,
     AF: 1.0,
   };
@@ -8226,6 +8228,7 @@ const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   CJD: "CBD",
   PB: "PB",
   MJ: "MJ",
+  FC: "FC",
   KF: "KF",
   AF: "AF",
 };
@@ -8793,6 +8796,7 @@ export function mosfetFromModelCard(
     ...(p.CBD !== undefined ? { CBD: p.CBD } : {}),
     ...(p.PB !== undefined ? { PB: p.PB } : {}),
     ...(p.MJ !== undefined ? { MJ: p.MJ } : {}),
+    ...(p.FC !== undefined ? { FC: p.FC } : {}),
     ...(p.KF !== undefined ? { KF: p.KF } : {}),
     ...(p.AF !== undefined ? { AF: p.AF } : {}),
   };
@@ -19768,6 +19772,7 @@ function mosfetBulkJunctionCapacitance(
   junctionVoltage: number,
   junctionPotential: number,
   gradingCoefficient: number,
+  forwardBiasCoefficient: number,
 ): number {
   if (zeroBiasCapacitance <= 0.0) {
     return zeroBiasCapacitance;
@@ -19775,8 +19780,16 @@ function mosfetBulkJunctionCapacitance(
   if (junctionPotential <= 0.0 || gradingCoefficient === 0.0) {
     return zeroBiasCapacitance;
   }
-  const reverseScale = Math.max(0.0, -junctionVoltage) / junctionPotential;
-  return zeroBiasCapacitance / ((1.0 + reverseScale) ** gradingCoefficient);
+  const normalizedVoltage = junctionVoltage / junctionPotential;
+  if (normalizedVoltage < forwardBiasCoefficient) {
+    return zeroBiasCapacitance / ((1.0 - normalizedVoltage) ** gradingCoefficient);
+  }
+  const denominator = (1.0 - forwardBiasCoefficient) ** (1.0 + gradingCoefficient);
+  const continuation =
+    1.0 -
+    forwardBiasCoefficient * (1.0 + gradingCoefficient) +
+    gradingCoefficient * normalizedVoltage;
+  return zeroBiasCapacitance * continuation / denominator;
 }
 
 interface JfetDcResult {
@@ -20239,8 +20252,12 @@ function evaluateNmosLevel1(
   const cgdOverlap = params.CGDO * params.W;
   const cgbOverlap = params.CGBO * params.L;
   const cgsIntrinsic = (2.0 / 3.0) * params.W * params.L * params.KP;
-  const cbsBulk = mosfetBulkJunctionCapacitance(params.CBS, vbs, params.PB, params.MJ);
-  const cbdBulk = mosfetBulkJunctionCapacitance(params.CBD, vbs - vds, params.PB, params.MJ);
+  const cbsBulk = mosfetBulkJunctionCapacitance(
+    params.CBS, vbs, params.PB, params.MJ, params.FC,
+  );
+  const cbdBulk = mosfetBulkJunctionCapacitance(
+    params.CBD, vbs - vds, params.PB, params.MJ, params.FC,
+  );
   const capacitances = {
     cgs: cgsOverlap + cgsIntrinsic,
     cgd: cgdOverlap,
@@ -20841,6 +20858,7 @@ function mosfetChargeDynamicCapacitance(
     junctionVoltage,
     element.params.PB,
     element.params.MJ,
+    element.params.FC,
   );
 }
 
@@ -21011,6 +21029,9 @@ function validateMosfet(element: Mosfet): void {
   }
   if (params.PB <= 0.0 || params.MJ < 0.0) {
     throw invalidElement(element.name, "MOSFET PB must be positive and MJ must be non-negative");
+  }
+  if (params.FC < 0.0 || params.FC >= 1.0) {
+    throw invalidElement(element.name, "MOSFET FC must be in [0, 1)");
   }
   if (params.KF < 0.0) {
     throw invalidElement(element.name, "MOSFET KF must be non-negative");

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -121,7 +121,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(181);
+    expect(coverage).toHaveLength(183);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -141,7 +141,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tAF\tAF\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(181);
+    expect(records).toHaveLength(183);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -167,8 +167,8 @@ describe("dcOp", () => {
     });
     expect(summary[5]).toStrictEqual({
       kind: "NMOS",
-      canonicalParameterCount: 20,
-      acceptedNameCount: 27,
+      canonicalParameterCount: 21,
+      acceptedNameCount: 28,
       aliasedParameterCount: 6,
       maxAliasCount: 3,
       aliasedParameters: ["VT0", "LAMBDA", "N_SUB", "T_NOM", "CBS", "CBD"],
@@ -181,7 +181,7 @@ describe("dcOp", () => {
     );
     expect(table.split("\n")[1]).toBe("D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     expect(table.split("\n").at(-1)).toBe(
-      "PMOS\t20\t27\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
+      "PMOS\t21\t28\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
     );
     const records = modelCardSupportedParameterCoverageSummaryRecords();
     expect(records).toHaveLength(7);
@@ -206,15 +206,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 181,
-      expectedCanonicalParameterCount: 181,
-      acceptedNameCount: 251,
+      canonicalParameterCount: 183,
+      expectedCanonicalParameterCount: 183,
+      acceptedNameCount: 253,
       aliasedParameterCount: 57,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t181\t181\t251\t57\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t183\t183\t253\t57\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -237,15 +237,15 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(180);
-    expect(report.acceptedNameCount).toBe(248);
+    expect(report.canonicalParameterCount).toBe(182);
+    expect(report.acceptedNameCount).toBe(250);
     expect(report.aliasedParameterCount).toBe(56);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 20 canonical supported parameters, found 19",
+      message: "expected NMOS to expose 21 canonical supported parameters, found 20",
     });
     expect(report.issues.at(-1)).toStrictEqual({
       kind: "NMOS",
@@ -253,16 +253,16 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t180\t181\t248\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 20 canonical supported parameters, found 19\nNMOS\taccepted_name_count\texpected NMOS to expose 27 accepted model-card names, found 24\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t182\t183\t250\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 21 canonical supported parameters, found 20\nNMOS\taccepted_name_count\texpected NMOS to expose 28 accepted model-card names, found 25\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 20 canonical supported parameters, found 19",
+      message: "expected NMOS to expose 21 canonical supported parameters, found 20",
     });
     expect(formatModelCardSupportedParameterCoverageGateIssueCsv(report)).toMatch(
-      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 20 canonical supported parameters, found 19"\n/,
+      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 21 canonical supported parameters, found 20"\n/,
     );
     expect(JSON.parse(formatModelCardSupportedParameterCoverageGateIssueJson(report))).toStrictEqual(
       records,
@@ -417,6 +417,7 @@ describe("dcOp", () => {
       CJD: 3.0e-13,
       PB: 0.9,
       MJ: 0.45,
+      FC: 0.4,
       KF: 2.0e-24,
       AF: 1.4,
     });
@@ -429,6 +430,7 @@ describe("dcOp", () => {
       CBD: 3.0e-13,
       PB: 0.9,
       MJ: 0.45,
+      FC: 0.4,
       KF: 2.0e-24,
       AF: 1.4,
     });
@@ -439,6 +441,7 @@ describe("dcOp", () => {
     expectClose(mosModel.params.CBD, 3.0e-13);
     expectClose(mosModel.params.PB, 0.9);
     expectClose(mosModel.params.MJ, 0.45);
+    expectClose(mosModel.params.FC, 0.4);
     expectClose(mosModel.params.KF, 2.0e-24);
     expectClose(mosModel.params.AF, 1.4);
   });
@@ -2337,6 +2340,20 @@ describe("dcOp", () => {
     circuit.add(mosfet("Mbad", "out", "gate", "0", "0", "NMOS", { KP: 0.0 }));
 
     expect(() => dcOp(circuit)).toThrowError("MOSFET KP must be positive");
+  });
+
+  it("rejects invalid MOSFET forward-bias depletion coefficients", () => {
+    for (const coefficient of [Number.NaN, -0.1, 1.0]) {
+      const circuit = new Circuit();
+      circuit.add(mosfet("Mbad", "drain", "gate", "0", "0", "NMOS", {
+        FC: coefficient,
+      }));
+      expect(() => dcOp(circuit)).toThrowError(
+        Number.isFinite(coefficient)
+          ? "MOSFET FC must be in [0, 1)"
+          : "MOSFET FC must be finite",
+      );
+    }
   });
 
   it("rejects invalid BJT model parameters", () => {

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -441,6 +441,36 @@ describe("transient", () => {
     expect(shapedFirst!).toBeLessThan(1.4);
   });
 
+  it("uses MOSFET FC to shape forward-biased bulk junction charge", () => {
+    function firstDrainVoltage(coefficient: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithWaveform(
+        "Vstep",
+        "in",
+        "0",
+        -0.6,
+        new PwlWaveform([
+          [0.0, -0.6],
+          [1.0e-9, -0.8],
+          [5.0e-9, -0.8],
+        ]),
+      ));
+      circuit.add(resistor("Rin", "in", "drain", 1_000.0));
+      circuit.add(mosfet("M1", "drain", "0", "0", "0", "NMOS", {
+        KP: 1.0e-12,
+        W: 1.0,
+        L: 1.0,
+        CBD: 1.0e-12,
+        PB: 1.0,
+        MJ: 0.5,
+        FC: coefficient,
+      }));
+      return transient(circuit, 1.0e-9, 5.0e-9, "euler")[0].voltage("drain")!;
+    }
+
+    expect(firstDrainVoltage(0.2)).toBeLessThan(firstDrainVoltage(0.8));
+  });
+
   it("uses diode transit time to hold forward charge on turnoff", () => {
     function run(transitTime: number): TransientPoint[] {
       const circuit = new Circuit();

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS flicker-noise exponent.
+1. Cross-language Level-1 MOS forward-bias depletion coefficient.
    - Status: current PR completion candidate.
-   - Add Berkeley Level-1 MOS `AF` model-card support in Rust, Python, and
-     TypeScript, defaulting to one.
-   - Apply `KF * abs(Id)^AF / frequency` to the existing MOS flicker-noise
-     source.
-   - Preserve the exponent through hierarchy and cloning, validate its finite
-     non-negative domain, and extend the supported-parameter coverage gate from
-     179 to 181 canonical rows.
+   - Add Berkeley Level-1 MOS `FC` model-card support in Rust, Python, and
+     TypeScript, defaulting to `0.5`.
+   - Apply the continuous piecewise forward-bias continuation to `CBS` and
+     `CBD` depletion capacitance shaped by `PB` and `MJ`.
+   - Preserve the coefficient through hierarchy and cloning, validate its
+     finite `[0, 1)` domain, and extend the supported-parameter coverage gate
+     from 181 to 183 canonical rows.
 
 ## Completed Slices
 
@@ -3394,6 +3394,15 @@ the Rust, Python, and TypeScript surfaces together.
    - Hierarchy and cloning preserve the coefficient, shared validation enforces
      its finite non-negative domain, and the supported-parameter release gate
      now covers 179 canonical rows.
+
+265. Cross-language Level-1 MOS flicker-noise current exponent.
+   - Status: completed in PR 8986.
+   - Rust, Python, and TypeScript Level-1 MOS model cards now accept `AF`,
+     defaulting to one, and apply `KF * abs(Id)^AF / frequency` to the MOS
+     flicker-noise source.
+   - Hierarchy and cloning preserve the exponent, shared validation enforces
+     its finite non-negative domain, and the supported-parameter release gate
+     now covers 181 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley Level-1 MOS `FC` model-card support across Rust, Python, and TypeScript
- apply the continuous piecewise forward-bias depletion law to `CBS` and `CBD`, including standalone MOSFET model parity
- validate the finite `[0, 1)` domain, update coverage gates from 181 to 183 rows, and reconcile the SPICE completion plan after PR #8986

## Verification
- `cargo test -p mosfet-models -p spice-engine`
- Python `mosfet-models`: `23 passed`
- Python `spice-engine`: `618 passed`
- TypeScript `spice-engine`: `npm run build` and `372 passed`
- `cargo fmt -p mosfet-models -p spice-engine -- --check`
- `git diff --check`