### PR TITLE
feat(axiom-lexer): axiom.tokens + lexer crate (MA13b, Wave 7)

### DIFF
--- a/code/grammars/axiom/axiom.tokens
+++ b/code/grammars/axiom/axiom.tokens
@@ -1,0 +1,293 @@
+# Axiom Token Grammar
+# ============================================================================
+#
+# Tokenizes the MA-13b-scoped lexical surface of Axiom (Scratchpad II ->
+# IBM Axiom -> NAG -> BSD re-release -> OpenAxiom/FriCAS, 1977-1992-present;
+# code/specs/MA13-axiom-language.md §1) -- the strongly-typed CAS whose
+# category/domain type system is this repo's first symbolic-family language
+# to need any per-value type-tag vocabulary at all (MA13 §2/§3). This file
+# covers ONLY the "consumer view" surface MA13 §3/§4 scopes for the first
+# cut: ordinary arithmetic/comparison expressions, `:=`/`==` assignment and
+# held-body function definition, `if`-`then`-`else`, a `;`-separated
+# parenthesised block, and the THREE genuinely new tokens no prior
+# symbolic-family grammar in this repo has ever needed -- `:` (declare),
+# `::` (coerce), and the `has` category-membership query keyword (MA13 §3's
+# central finding).
+#
+# Axiom's arithmetic/comparison surface is an ordinary infix expression
+# grammar, closer in overall shape to Reduce/Derive/Maple's `head(args)`-
+# style CAS grammars (MA13 §5) than to any array-family grammar in this
+# repo -- so this file is structured the same way reduce.tokens/
+# maple.tokens/derive.tokens already are (multi-char operators first,
+# longest-match-first; single-char operators/delimiters; literals;
+# skip/keywords), not forked from any array-family sibling.
+#
+# Axiom is CASE-SENSITIVE (case_sensitive left at its default, no
+# `@case_insensitive` directive) -- confirmed directly against the book
+# (MA13 §4's own surface table): `if`/`then`/`else`/`has` are spelled
+# lowercase, matching reduce.tokens's/maple.tokens's identical lowercase-
+# keyword, case-sensitive convention (the mirror image of derive.tokens's
+# uppercase `AND`/`OR`/`NOT`). Built-in domain/category names (`Integer`,
+# `Boolean`, `Ring`, `PositiveInteger`, ...) are capitalized by real-Axiom
+# convention but are NOT reserved words at the lexer level -- MA13 §3/§4
+# fixes the built-in domain/category table as an `axiom-runtime`-internal,
+# fixed lookup table (MA-13d), entirely invisible to this crate, which
+# tokenizes every domain/category name as an ordinary NAME like any other
+# identifier, exactly as `idl-lexer` resolves IDL's intrinsic
+# procedure/function names (PLOT, SIN, TOTAL, ...) as plain NAMEs rather
+# than lexer-level keywords.
+#
+# @version 1
+
+# No confirmed escape mechanism for Axiom string literals anywhere in MA13
+# §2/§3/§4 (the spec's own worked examples never show one) -- so, per this
+# repo's "confirm, don't assume" discipline, this file makes the same
+# conservative choice every sibling CAS-family grammar with no confirmed
+# escape convention already makes (derive.tokens, maple.tokens,
+# reduce.tokens, macsyma.tokens, idl.tokens): `escapes: none`, and STRING's
+# own pattern (SECTION 3) is simply "every character up to the next `"`",
+# with no backslash-escape clause to interpret. A real backslash-escape
+# convention, if FriCAS/Axiom documentation later confirms one, is a narrow
+# follow-on fix to this file, not a blocking question for MA-13b.
+escapes: none
+
+# ============================================================================
+# SECTION 1: Multi-character operators -- longest-match-first.
+#
+# Every multi-character operator below is declared before any shorter
+# operator/token it begins with, the same defensive convention every
+# sibling `.tokens` file in this repo already documents (idl.tokens's
+# `##`/`#`, reduce.tokens's/derive.tokens's `:=`, maple.tokens's `->`):
+# `GrammarLexer::try_match_token` walks the compiled pattern list in
+# DECLARATION ORDER and returns the FIRST pattern that matches at the
+# current position -- it does NOT pick the longest overall match itself --
+# so a shorter prefix pattern declared earlier would silently win and strand
+# the rest of a longer operator behind it.
+#
+# Three of these five tokens are the genuinely new ones MA13 §3 is about
+# (COERCE `::`, and -- paired with COLON in SECTION 2 -- DECLARE `:`); the
+# other three (ASSIGN, DEFINE, NE, LE, GE, POW) are ordinary CAS-family
+# operators this repo's Reduce/Derive/Maple siblings already have under
+# their own names.
+# ============================================================================
+
+# `:=` -- immediate assignment (MA13 §4's `x := e` row; real Axiom,
+# Programming Guide-equivalent Chapter 5 §5.1's "immediate" assignment).
+# Spelled identically to REDUCE's/Derive's/Maple's own `:=`, but MUST be
+# declared before both `::` and bare `:` below since all three share the
+# leading `:` character.
+ASSIGN   = ":="
+
+# `::` -- the coercion operator (MA13 §3's `e :: T` row, e.g.
+# `3 :: Fraction Integer`) -- the SECOND of the three tokens no prior
+# symbolic-family grammar in this repo has ever needed (MA13 §3's own
+# "genuinely new" finding). Not a prefix of `:=` (second character differs),
+# so its declaration order relative to ASSIGN does not matter, but it MUST
+# be declared before bare COLON (SECTION 2) for the same longest-match
+# reason.
+COERCE   = "::"
+
+# `==` -- held-body function-definition operator (MA13 §4's
+# `f(x: T, ...): T == e` row) -- Axiom's own spelling for what Wolfram
+# calls `SetDelayed`/Derive-Maple call `:=`'s function-definition use; here
+# `:=` (above) is reserved for immediate assignment ONLY (MA13 §4), and
+# `==` is the separate held-body definition form, so this repo's Axiom
+# grammar needs BOTH tokens where Reduce/Derive/Maple each only needed one.
+# Must be declared before bare EQ (SECTION 2).
+DEFINE   = "=="
+
+# `~=` -- Axiom's own not-equal spelling (MA13 §3/§4, confirmed directly
+# against the book: NOT Maple's `<>`, NOT Wolfram's `!=` -- a real,
+# disclosed divergence-avoidance point). No bare `~` token exists anywhere
+# in this cut's grammar, so there is no ordering hazard to guard against,
+# but it is grouped here with the other multi-character relational
+# operators for readability.
+NE       = "~="
+
+LE       = "<="
+GE       = ">="
+
+# `**` -- Axiom's alternate power spelling (MA13 §4: "both spellings real,
+# confirmed -- mirroring Reduce's own `^`/`**` pair, MA08 §3"). Must be
+# declared before bare TIMES (SECTION 2) -- the same POW-before-TIMES
+# ordering reduce.tokens's own header documents for the identical `^`/`**`
+# pair.
+POW      = "**"
+
+# ============================================================================
+# SECTION 2: Single-character operators and delimiters (MA13 §4).
+# ============================================================================
+
+PLUS     = "+"
+MINUS    = "-"
+TIMES    = "*"
+SLASH    = "/"
+
+# `^` -- Axiom's primary power spelling (MA13 §4), a single glyph with no
+# shorter-prefix hazard of its own; POW (`**`, SECTION 1) is the alternate
+# two-character spelling for the SAME operation, kept as a distinct token
+# type exactly like reduce.tokens's own CARET/POW split -- "the parser, not
+# this lexer, is where the two spellings collapse onto one production."
+CARET    = "^"
+
+# `=` -- equality (MA13 §4's `a = b` row). Per MA13 §3's own disclosed
+# divergence, this cut's `=` lowers straight to the shared Boolean-valued
+# `Equal` handler rather than reproducing real Axiom's default `Equation`
+# object -- a lowering-layer (MA-13d) decision, invisible here: this lexer
+# just emits one ordinary EQ token, exactly as it always has for every
+# sibling CAS-family grammar (Reduce/Derive/Maple/Macsyma all draw the same
+# `=`-is-a-value-producing-relational-operator line). Must be declared
+# AFTER `==` (DEFINE, SECTION 1) or a lone `=` prefix would strand the
+# second `=` of every held-body definition.
+EQ       = "="
+LESS     = "<"
+GREATER  = ">"
+
+LPAREN   = "("
+RPAREN   = ")"
+
+# List literals use SQUARE brackets (`[a, b, c]`, MA13 §4's `List(T)` row)
+# -- reusing the existing shared `List` handler (MA13 §2/§5), the same
+# bracket choice Maple's own `[a, b, c]` ordered-list literal already uses
+# in this repo (maple.tokens SECTION 2).
+LBRACKET = "["
+RBRACKET = "]"
+
+COMMA    = ","
+
+# `;` -- the ONLY separator for a parenthesised, semicolon-separated block
+# (MA13 §4's `( e1; e2; ...; eN )` row) -- Axiom has no other in-scope use
+# for `;` (no matrix-row separator the way Derive's `[...]` needs one; list
+# literals here use COMMA only, per LBRACKET/RBRACKET above).
+SEMI     = ";"
+
+# `:` -- the declaration operator (MA13 §3/§4's `a : T` row, e.g.
+# `a : PositiveInteger`), and ALSO the type-annotation position inside a
+# function header (`f(x: T, ...): T == e`) -- the THIRD of the three
+# genuinely new tokens (alongside COERCE and the `has` keyword below).
+# MA13's own task framing is explicit that this single COLON token is
+# overloaded across both grammar positions at the LEXER level: "the lexer
+# just emits a `:` token, disambiguation is the parser's job later, not
+# this crate's" -- exactly the same "one glyph, one token type, multiple
+# grammar-level meanings, parser's job to disambiguate" discipline
+# idl.tokens documents for its own EQUALS (assignment vs. keyword-bind) and
+# STAR (multiplication vs. wildcard subscript). MUST be declared after
+# BOTH `:=` (ASSIGN) and `::` (COERCE) above, since all three share the
+# leading `:` character and this is the shortest of the three.
+COLON    = ":"
+
+# ============================================================================
+# SECTION 3: Literal value tokens (MA13 §4).
+#
+# NUMBER covers both the integer (`123`) and float (`1.5`) rows of MA13
+# §4's surface table in one pattern, requiring a leading digit (so a bare
+# `.5` is not a number) -- matching every sibling symbolic-family lexer's
+# convention in this repo (reduce.tokens, derive.tokens, maple.tokens,
+# macsyma.tokens, wolfram.tokens all share this exact shape). There is
+# deliberately NO separate rational-literal token: MA13 §4's own table
+# confirms `1/3` is ordinary integer division (`NUMBER SLASH NUMBER`,
+# three tokens) that lowers to the packed `IRNode::Rational` representation
+# entirely at evaluation/lowering time (MA13 §2), not via any special
+# lexer-level literal syntax -- inventing one here would tokenize a
+# construct this cut's own grammar does not have.
+#
+# STRING has no confirmed escape mechanism (see the file header's
+# `escapes: none` note) -- content is simply every character up to the
+# next `"`. Any token name ending in "STRING" has its outer quotes stripped
+# automatically by the shared GrammarLexer engine (see
+# `code/packages/rust/lexer/src/grammar_lexer.rs`'s own
+# `try_match_token_in_group` quote-handling), so this pattern needs no
+# manual quote-stripping code in `axiom-lexer` itself.
+#
+# NAME is a case-sensitive identifier covering BOTH ordinary
+# variables/functions (`x`, `foo`, `f`) AND every built-in domain/category
+# name (`Integer`, `Boolean`, `Ring`, `PositiveInteger`, `Fraction`,
+# `Polynomial`, `List`, `OrderedSet`, ...) -- per this file's own header
+# note and MA13 §3/§4, none of the fixed built-in domain/category table is
+# a lexer-level reserved word; only `if`/`then`/`else`/`has` are (SECTION
+# 4/5 below). Kept to the same plain `[a-zA-Z][a-zA-Z0-9]*` shape every
+# sibling CAS-family NAME already uses (reduce.tokens, derive.tokens,
+# maple.tokens) rather than adding underscore/apostrophe continuation
+# characters MA13 never confirms Axiom identifiers use.
+# ============================================================================
+
+NUMBER = /[0-9]+\.?[0-9]*([eE][+-]?[0-9]+)?/
+STRING = /"[^"]*"/
+NAME   = /[a-zA-Z][a-zA-Z0-9]*/
+
+# ============================================================================
+# SECTION 4: Skip patterns -- whitespace and `--` line comments.
+#
+# Axiom has no numbered-worksheet significant-newline convention the way
+# Derive's/Wolfram's own `#n:`/`In[n]:=` prompts do (MA13 §5: `axiom-repl`
+# tracks its own step counter as a REPL-layer concern, not a lexer-level
+# significant-NEWLINE token) -- blocks are `;`-separated (SECTION 2), never
+# newline-separated, exactly mirroring reduce.tokens's/maple.tokens's
+# identical "statements end with a punctuation separator, not a
+# significant newline" rationale. So newlines fold into WHITESPACE here,
+# and this file declares no NEWLINE token and needs no bracket-interior-
+# newline post-tokenize hook in `axiom-lexer`.
+#
+# `--` opens a line comment, ending just before the next newline (or EOF) --
+# real FriCAS/SPAD line-comment convention, confirmed real per the task's
+# own sibling-precedent check (this repo's existing `--`-comment
+# grammars -- haskell*.tokens, sql.tokens, vhdl*.tokens -- all use the
+# identical `/--[^\n]*/` shape). No ambiguity with MINUS (SECTION 2) to
+# guard against: `GrammarLexer::try_skip` (see
+# `code/packages/rust/lexer/src/grammar_lexer.rs`) tries every `skip:`
+# pattern BEFORE any ordinary token pattern at each position, so a `--`
+# always matches COMMENT here before MINUS ever gets a chance at the first
+# `-` -- the same reason sql.tokens/vhdl.tokens/haskell*.tokens already
+# have both a bare MINUS token AND a `--` line comment with no pre/post-
+# tokenize hook of their own. A comment's content is arbitrary text and is
+# never re-lexed as code (it is consumed whole by this skip pattern), so a
+# comment may freely contain characters outside this grammar's alphabet.
+# ============================================================================
+
+skip:
+  WHITESPACE = /[ \t\r\n]+/
+  COMMENT    = /--[^\n]*/
+
+# ============================================================================
+# SECTION 5: Keywords (MA13 §3/§4).
+#
+# Exactly four reserved words, no more -- the closed set MA13 §4's own
+# surface table fixes: `if`/`then`/`else` (conditional) and `has` (the
+# category-membership query infix operator, e.g.
+# `Polynomial(Integer) has Ring`) -- the FOURTH and last of the tokens no
+# prior symbolic-family grammar in this repo has needed (alongside COERCE
+# and COLON's declare-position overload above). All four are spelled
+# lowercase in real Axiom (confirmed directly, MA13 §4), matching
+# reduce.tokens's/maple.tokens's identical lowercase-keyword convention --
+# `IF`/`THEN`/`ELSE`/`HAS` in uppercase lex as ordinary NAMEs here, the
+# mirror image of derive.tokens's uppercase `AND`/`OR`/`NOT`.
+#
+# Deliberately NOT keywords (MA13 §3/§4, and this file's own header note):
+# every built-in domain name (`Integer`, `Boolean`, `Fraction`,
+# `Polynomial`, `List`, `PositiveInteger`, `NonNegativeInteger`, `Float`,
+# `String`) and every built-in category name (`Ring`, `OrderedSet`) --
+# these are ordinary NAMEs, resolved against `axiom-runtime`'s fixed
+# lookup table (MA-13d), not reserved words at the lexer level.
+#
+# Also deliberately absent (MA13 §4's own deferred-surface list -- see
+# this file's own header and the crate's README/CHANGELOG for the full
+# accounting): `Record`, `Union`, `Any`, `macro`, package-calling `$`,
+# target-type `@`, anonymous "maps-to" `+->`, block early-exit `=>`,
+# piecewise/multi-clause function definitions, list comprehensions, and
+# `for`/`while` iteration -- none of these has a token anywhere in this
+# file; a source construct using one falls through to SECTION 6's honest
+# catch-all error rather than silently lexing as something else.
+# ============================================================================
+
+keywords:
+  if
+  then
+  else
+  has
+
+# ============================================================================
+# SECTION 6: Error recovery.
+# ============================================================================
+
+errors:
+  UNKNOWN = /./

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -285,6 +285,7 @@ members = [
     "idl-runtime",
     "idl-repl",
     "idl-to-semantic-ir",
+    "axiom-lexer",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/axiom-lexer/BUILD
+++ b/code/packages/rust/axiom-lexer/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-axiom-lexer -- --nocapture

--- a/code/packages/rust/axiom-lexer/BUILD_windows
+++ b/code/packages/rust/axiom-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-axiom-lexer -- --nocapture

--- a/code/packages/rust/axiom-lexer/CHANGELOG.md
+++ b/code/packages/rust/axiom-lexer/CHANGELOG.md
@@ -1,0 +1,125 @@
+# Changelog
+
+## [0.1.0] - 2026-07-27
+
+### Added
+
+- Initial grammar-driven Rust Axiom tokenizer (MA13 §6, task MA-13b),
+  following MA-13a's design-only kickoff spec
+  ([`MA13-axiom-language.md`](../../../specs/MA13-axiom-language.md)).
+- `code/grammars/axiom/axiom.tokens`, written to Axiom's own ordinary
+  infix-expression CAS-family shape (MA13 §5) — structurally closer to
+  `reduce.tokens`/`derive.tokens`/`maple.tokens` than to any array-family
+  grammar in this repo. Covers the MA-13b-scoped surface:
+  - Integer/float numeric literals (one `NUMBER` pattern, leading digit
+    required, optional exponent — matching every sibling CAS-family
+    lexer's convention).
+  - **No dedicated rational-literal token**: `1/3` lexes as ordinary
+    `NUMBER SLASH NUMBER` (three tokens), confirmed against MA13 §4's own
+    surface table rather than assumed — the packed rational
+    representation is built entirely at a later (lowering/evaluation)
+    layer.
+  - String literals (`"hello"`, one `STRING` token; `escapes: none` —
+    no confirmed backslash-escape convention anywhere in MA13 §2/§3/§4,
+    the same conservative choice `derive.tokens`/`maple.tokens`/
+    `reduce.tokens`/`idl.tokens` already make absent a confirmed escape
+    rule).
+  - Identifiers (`NAME`), covering both ordinary variables/functions
+    **and** every built-in domain/category name (`Integer`, `Boolean`,
+    `Ring`, `PositiveInteger`, ...) — none of the fixed built-in
+    domain/category table (MA13 §3) is a lexer-level keyword; only
+    `if`/`then`/`else`/`has` are.
+  - Parens/brackets/comma: `( ) [ ] ,`.
+  - Arithmetic: `+ - * /`, both power spellings `^` (CARET) and `**`
+    (POW, kept distinct — mirroring `reduce.tokens`'s own CARET/POW
+    split; the parser collapses them onto one production).
+  - Comparison: `=` (EQ), `~=` (NE — Axiom's own confirmed not-equal
+    spelling, explicitly **not** Maple's `<>` or Wolfram's `!=`), and
+    `< <= > >=`.
+  - `:=` (ASSIGN, immediate assignment) — distinct from `==` (DEFINE,
+    held-body function definition): Axiom needs BOTH tokens where
+    Reduce/Derive/Maple each only needed one.
+  - `:` (COLON, declaration — overloaded with the function-header
+    type-annotation position at the lexer level, disambiguated later by
+    the parser) and `::` (COERCE, coercion) — two of the three
+    genuinely new tokens no prior symbolic-family grammar in this repo
+    has needed (MA13 §3's central finding).
+  - `has` (KEYWORD, category-membership query infix operator) — the
+    third genuinely new token.
+  - `;` (SEMI, the separator inside a parenthesised, semicolon-separated
+    block).
+  - `if`/`then`/`else` conditional keywords, lowercase and
+    case-sensitive (matching `reduce.tokens`/`maple.tokens`'s identical
+    convention, the mirror image of `derive.tokens`'s uppercase
+    keywords).
+  - `--` line comments (FriCAS/SPAD convention), an ordinary `skip:`
+    pattern with no pre/post-tokenize hook needed — verified that
+    `GrammarLexer`'s skip-pattern pass always runs before ordinary token
+    matching, so `--` never collides with the bare `MINUS` token, the
+    same declarative shape `sql.tokens`/`vhdl*.tokens`/`haskell*.tokens`
+    already rely on.
+  - No significant newline: blocks are `;`-separated (MA13 §4), never
+    newline-separated — `axiom-repl`'s own numbered-prompt step counter
+    (MA13 §5) is a REPL-layer concern, not a lexer one — mirroring
+    `reduce.tokens`'s/`maple.tokens`'s identical rationale. No NEWLINE
+    token, no bracket-interior-newline hook needed.
+- **Finding: no pre/post-tokenize hooks needed at all.** Every
+  multi-character operator is resolved by ordinary longest-match-first
+  declaration order; `axiom.tokens` is entirely declarative, and
+  `create_axiom_lexer` installs nothing beyond the compiled grammar —
+  the same hook-free shape `idl-lexer` established, simpler than
+  `q-lexer` (two hooks) or `scilab-lexer` (one hook).
+- **No recursion-depth cap, by design.** `axiom-lexer` performs no
+  recursive descent at all — tokenization is a single left-to-right scan
+  with O(1) stack depth regardless of source nesting. This mirrors every
+  sibling `*-lexer` crate in this repo (`idl-lexer`, `q-lexer`,
+  `scilab-lexer`, `apl-lexer`, `j-lexer`), all of which document the
+  identical finding and add no depth cap of their own — a
+  `MAX_RULE_DEPTH`-style cap is a *parser*-level concern (this repo's own
+  established convention for recursive-descent parsers, per
+  `lessons.md`), belonging to a future `axiom-parser` (MA-13c), the first
+  layer in Axiom's frontend that actually recurses. Verified directly
+  with a regression tokenizing 50,000 levels of nested parens
+  (`deeply_nested_parens_do_not_overflow_the_lexer_stack`), plus wide
+  (non-nested) adversarial inputs covering the other half of the DoS
+  surface: a 100,000-token flat stream and a 500,000-character comment.
+- `code/packages/rust/Cargo.toml` workspace registration alongside the
+  other CAS/array-language lexer/parser/runtime/repl/to-semantic-ir crate
+  groups (only `axiom-lexer` itself is added; the sibling `axiom-parser`/
+  `axiom-runtime`/`axiom-repl`/`axiom-to-semantic-ir` crates do not exist
+  yet — they are MA-13c/d/e, separate follow-on tasks).
+- 63 tests (6 lib smoke tests + 56 integration tests + 1 doc test),
+  100% line coverage on this crate's own `src/lib.rs` and
+  `src/_grammar.rs` (verified with `cargo tarpaulin -p
+  coding-adventures-axiom-lexer`), covering: every integer/float/exponent
+  numeric-literal shape and the leading-digit requirement; the
+  rational-is-ordinary-division finding; string literals (including
+  empty strings and grammar-punctuation-shaped content); plain
+  identifiers and every built-in domain/category name resolving to
+  `NAME`, never `KEYWORD`; case-sensitivity (uppercase `IF`/`HAS` are
+  `NAME`s); parens/brackets/comma including the paren-optional
+  single-argument call shape; every arithmetic operator including both
+  power spellings and the `POW`-wins-over-`TIMES` longest-match
+  regression; every comparison operator including the `~=`-not-Maple's-
+  `<>`-not-Wolfram's-`!=` divergence-avoidance check and the
+  `LE`/`GE`-win-over-`LESS`/`GREATER` longest-match regression; the
+  `ASSIGN`/`COERCE`/`COLON`/`DEFINE`/`EQ` five-way longest-match
+  regression family (including edge cases like `"::="` and `":=:"`); a
+  held-body function definition, an undeclared function definition, a
+  plain declaration, a tuple declaration, and a coercion expression; a
+  true and a false `has` query (mirroring MA13's own worked
+  `Polynomial(Integer) has Ring` / `List(Integer) has Ring` examples); an
+  `if`-`then`-`else` conditional; a parenthesised `;`-separated block;
+  `--` comments (mid-line, whole-line, non-newline-swallowing, and
+  containing out-of-grammar characters) alongside a `MINUS`-is-not-
+  swallowed-by-`--` regression; newlines-are-ordinary-whitespace; every
+  explicitly deferred construct (`Record`/`Union`/`Any` and `macro` all
+  lexing as plain `NAME`s, never reserved words; `$`/`@` as honest lex
+  errors; and `+->`/`=>` decomposing into their constituent
+  single-character tokens rather than erroring, since this cut declares
+  no dedicated multi-character token for either); unrecognized-character
+  errors; an unterminated string
+  failing honestly rather than panicking; the two DoS-guard regressions
+  described above; and a small realistic end-to-end "textbook Axiom
+  session" snippet combining declaration, assignment, function
+  definition, conditional, and a `has` query in one source string.

--- a/code/packages/rust/axiom-lexer/Cargo.toml
+++ b/code/packages/rust/axiom-lexer/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "coding-adventures-axiom-lexer"
+version = "0.1.0"
+edition = "2021"
+description = "Tokenizer for Axiom, the strongly-typed CAS with a category/domain type system (MA13 MA-13b)"
+license = "MIT"
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }

--- a/code/packages/rust/axiom-lexer/README.md
+++ b/code/packages/rust/axiom-lexer/README.md
@@ -1,0 +1,173 @@
+# coding-adventures-axiom-lexer
+
+Axiom tokenizer backed by `code/grammars/axiom/axiom.tokens`, compiled to
+Rust and statically linked into the crate.
+
+The runtime path does not read grammar files from disk, which keeps it
+suitable for a future WASM facade.
+
+## Where this fits
+
+Axiom (Scratchpad II, IBM Research, 1977; commercialized as Axiom in 1992
+by Jenks & Sutor; today continued by OpenAxiom, FriCAS, and the
+independent Axiom project) is the strongly-typed computer algebra system
+whose category/domain type system is this repo's first symbolic-family
+(CAS) language to need a per-value type tag at all
+([`MA13-axiom-language.md`](../../../specs/MA13-axiom-language.md) §2).
+This is the first crate of Axiom's frontend — **MA-13b** — following
+MA-13a's design-only kickoff spec, which fixed which Axiom this repo
+targets (§1), confirmed `symbolic-ir`/`symbolic-vm`/`cas-*` need no changes
+for Axiom's arithmetic but carry no domain/category concept at all (§2),
+and scoped the category/domain type system itself to a small, fixed,
+**consumer-view-only** subset (§3) before any lexer/parser/runtime code
+landed. The crate layout mirrors MA13 §6's rollout: `axiom-lexer` (this
+crate, MA-13b) → `axiom-parser` (MA-13c) → `axiom-runtime`/`axiom-repl`
+(MA-13d) → `axiom-to-semantic-ir` (MA-13e).
+
+Axiom's surface is an ordinary infix expression grammar — closer in shape
+to this repo's Reduce/Derive/Maple `head(args)`-style CAS grammars
+(MA13 §5) than to any array-family grammar here — so `axiom.tokens` is
+structured the same way `reduce.tokens`/`maple.tokens`/`derive.tokens`
+already are, not forked from an array-family sibling.
+
+## Scope
+
+Covers the MA-13b-scoped lexical surface fixed by
+[MA13 §4](../../../specs/MA13-axiom-language.md#4-language-scope-the-historical-core)/[§6](../../../specs/MA13-axiom-language.md#6-crate-layout-and-rollout-one-item--one-pr):
+
+- Integer (`123`) and float (`1.5`) literals, one `NUMBER` pattern.
+- **No dedicated rational-literal token.** `1/3` is ordinary integer
+  division (`NUMBER SLASH NUMBER`, three tokens) — MA13 §4's own surface
+  table confirms it lowers to the packed `IRNode::Rational`
+  representation entirely at evaluation/lowering time, not via special
+  lexer syntax.
+- String literals (`"hello"`, one `STRING` token, no confirmed escape
+  mechanism — `escapes: none`).
+- Symbols/identifiers (`x`, `foo`, `f`) — **including every built-in
+  domain/category name** (`Integer`, `Boolean`, `Ring`, `PositiveInteger`,
+  ...), which are ordinary `NAME`s at this layer, not lexer-level
+  keywords (see below).
+- `(` `)` `[` `]` `,` — parens, list brackets, comma.
+- Arithmetic: `+ - * /`, both power spellings `^` (`CARET`) and `**`
+  (`POW`, kept as a distinct token type, mirroring `reduce.tokens`'s own
+  `CARET`/`POW` split).
+- Comparison: `=` (`EQ`), `~=` (`NE` — Axiom's real not-equal spelling,
+  **not** Maple's `<>` or Wolfram's `!=`), `< <= > >=`.
+- `:=` (`ASSIGN`, immediate assignment) and `==` (`DEFINE`, held-body
+  function definition) — two distinct operators, unlike Reduce/Derive/
+  Maple which only need one.
+- `:` (`COLON`, declaration — also the type-annotation position inside a
+  function header) and `::` (`COERCE`, coercion) — two of the three
+  genuinely new tokens MA13 §3 introduces.
+- `has` (the category-membership query infix keyword) — the third
+  genuinely new token.
+- `;` (`SEMI`, the separator inside a parenthesised block).
+- `if`/`then`/`else` conditional keywords.
+- `--` line comments (FriCAS/SPAD convention, confirmed reasonable by
+  this repo's existing `--`-comment grammars — `haskell*.tokens`,
+  `sql.tokens`, `vhdl*.tokens`).
+
+This crate only tokenizes. There is no `axiom-parser`/`axiom.grammar` here
+(that is a separate follow-on task, MA-13c) and no recursion-depth cap
+(that is a parser-level concern for MA-13c — see the next section).
+
+## No recursion-depth cap — the same split every sibling lexer/parser pair follows
+
+`axiom-lexer` performs no recursive descent: [`GrammarLexer`] tokenizes
+with a single left-to-right scan, one token at a time, with O(1) stack
+depth regardless of how deeply nested the source is (nesting structure —
+parenthesis depth, block depth — is invisible to a flat token scan; it
+only becomes visible once something walks the token stream recursively,
+which starts with `axiom-parser`, MA-13c). Every sibling `*-lexer` crate
+in this repo that shares this shape documents the identical finding and
+adds no depth cap of its own: `idl-lexer` ("no recursion-depth cap ... the
+same split every sibling `*-lexer`/`*-parser` pair in this repo already
+follows"), `q-lexer`, `scilab-lexer`, `apl-lexer`, `j-lexer`. A
+`MAX_RULE_DEPTH`-style cap (this repo's own established convention for
+*parser* recursion, per `lessons.md`) belongs to `axiom-parser`, not here.
+This is verified directly, not just asserted: `tests/test_tokenizer.rs`
+includes a regression tokenizing 50,000 levels of nested parens with no
+stack growth (`deeply_nested_parens_do_not_overflow_the_lexer_stack`),
+plus wide (non-nested) adversarial inputs — a 100,000-token flat stream and
+a 500,000-character comment — to cover the other half of the DoS surface
+(unbounded time/allocation, not stack depth).
+
+## No pre/post-tokenize hooks — `axiom.tokens` is entirely declarative
+
+Unlike `q-lexer` (whitespace-adjacency hooks for `-`-vs-negative-literal
+and `/`-vs-comment) and `scilab-lexer` (a hook for `'`
+transpose-vs-string), none of Axiom's MA-13b-scoped operators need one.
+Every multi-character operator (`:=`, `::`, `==`, `~=`, `<=`, `>=`, `**`)
+is resolved by ordinary longest-match-first declaration order in
+`axiom.tokens`, and `--` comments never collide with `-` (`MINUS`) because
+`GrammarLexer`'s skip-pattern pass always runs *before* ordinary token
+matching at each position — the same declarative shape
+`sql.tokens`/`vhdl*.tokens`/`haskell*.tokens` already rely on for their own
+coexisting `MINUS`/`--`-comment pair. So `create_axiom_lexer` installs
+nothing beyond the compiled grammar, mirroring `idl-lexer`'s equally
+hook-free shape.
+
+## Case-sensitivity
+
+Axiom is case-sensitive (`case_sensitive` left at its default — no
+`@case_insensitive` directive) — MA13 §4's own surface table spells
+`if`/`then`/`else`/`has` lowercase, the same lowercase-keyword,
+case-sensitive convention `reduce.tokens`/`maple.tokens` already use (the
+mirror image of `derive.tokens`'s uppercase `AND`/`OR`/`NOT`). Built-in
+domain/category names are conventionally capitalized in real Axiom
+(`Integer`, `Ring`, ...) but are **not** reserved words here — see below.
+
+## Built-in domain/category names are ordinary identifiers, not keywords
+
+MA13 §3 fixes a small, non-extensible built-in domain table (`Boolean`,
+`Integer`, `PositiveInteger`, `NonNegativeInteger`, `Float`, `String`,
+`Fraction(Integer)`, `Polynomial(Integer)`, `List(T)`) and category table
+(`Ring`, `OrderedSet`) as an `axiom-runtime`-internal lookup structure
+(MA-13d) — entirely invisible to this crate. `axiom-lexer` tokenizes every
+one of these names as an ordinary `NAME`, exactly as `idl-lexer` resolves
+IDL's intrinsic procedure/function names (`PLOT`, `SIN`, `TOTAL`, ...) as
+plain `NAME`s rather than lexer-level keywords. Only four words are real
+keywords in this cut: `if`, `then`, `else`, `has`.
+
+## What this crate deliberately does NOT tokenize (MA13 §4's deferred list)
+
+No token exists anywhere in `axiom.tokens` for: `Record`/`Union`/`Any`,
+`macro`, package-calling `$`, target-type `@`, the anonymous "maps-to"
+function operator `+->`, block early-exit `=>`, piecewise/multi-clause
+function definitions, list comprehensions, or `for`/`while` iteration —
+all explicitly out of MA13's first-cut scope (§3/§4). A source construct
+using `$` or `@` fails honestly (neither character has any token in this
+grammar); `+->` and `=>` decompose into their individual already-tokenizable
+characters (`PLUS`/`MINUS`/`GREATER`, `EQ`/`GREATER`) since this cut has no
+*dedicated* multi-character token for either sequence — an honest
+reflection of the absence of a production, left for a future
+`axiom-parser` to reject at the grammar level, not a special-cased lexer
+rejection.
+
+## Usage
+
+```rust
+use coding_adventures_axiom_lexer::tokenize_axiom;
+
+let tokens = tokenize_axiom("a : PositiveInteger\na := 3\nPolynomial(Integer) has Ring\n");
+```
+
+`tokenize_axiom` panics on a malformed source string; use
+`create_axiom_lexer` directly (or `try_tokenize_axiom`) if you need the
+`Result`-returning form instead.
+
+## Where this fits (pipeline)
+
+`axiom-lexer` is the first of Axiom's frontend crates
+([MA-13b](../../../specs/MA13-axiom-language.md#6-crate-layout-and-rollout-one-item--one-pr)),
+following MA-13a's design spec. The sibling `axiom-parser` crate (MA-13c)
+will consume this crate's token stream against
+`code/grammars/axiom/axiom.grammar` — including the declaration (`name :
+T`), coercion (`e :: T`), and category-query (`D has C`) productions, the
+genuinely new grammar work MA13 §3 scopes — to build the `GrammarASTNode`
+CST that a future `axiom-runtime` + `axiom-repl` (MA-13d) will evaluate
+over the reused `symbolic-vm` engine, alongside `axiom-to-semantic-ir`
+(MA-13e), per
+[HML00](../../../specs/HML00-historical-math-languages-roadmap.md) Wave 7.
+
+[`GrammarLexer`]: ../lexer/src/grammar_lexer.rs

--- a/code/packages/rust/axiom-lexer/required_capabilities.json
+++ b/code/packages/rust/axiom-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/axiom-lexer",
+  "capabilities": [],
+  "justification": "Pure computation over statically linked grammar data. No filesystem, network, process, DOM, or environment access needed."
+}

--- a/code/packages/rust/axiom-lexer/src/_grammar.rs
+++ b/code/packages/rust/axiom-lexer/src/_grammar.rs
@@ -1,0 +1,231 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: axiom.tokens
+// Regenerate with: grammar-tools compile-tokens axiom.tokens
+//
+// This file embeds a TokenGrammar as native Rust data structures.
+// Call `token_grammar()` instead of reading and parsing the .tokens file.
+
+#[allow(unused_imports)]
+use grammar_tools::token_grammar::{ModeTransition, PatternGroup, TokenDefinition, TokenGrammar, TransitionAction};
+#[allow(unused_imports)]
+use std::collections::HashMap;
+
+pub fn token_grammar() -> TokenGrammar {
+    TokenGrammar {
+        definitions: vec![
+            TokenDefinition {
+                name: r#"ASSIGN"#.to_string(),
+                pattern: r#":="#.to_string(),
+                is_regex: false,
+                line_number: 79,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"COERCE"#.to_string(),
+                pattern: r#"::"#.to_string(),
+                is_regex: false,
+                line_number: 88,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"DEFINE"#.to_string(),
+                pattern: r#"=="#.to_string(),
+                is_regex: false,
+                line_number: 97,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NE"#.to_string(),
+                pattern: r#"~="#.to_string(),
+                is_regex: false,
+                line_number: 105,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LE"#.to_string(),
+                pattern: r#"<="#.to_string(),
+                is_regex: false,
+                line_number: 107,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"GE"#.to_string(),
+                pattern: r#">="#.to_string(),
+                is_regex: false,
+                line_number: 108,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"POW"#.to_string(),
+                pattern: r#"**"#.to_string(),
+                is_regex: false,
+                line_number: 115,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"PLUS"#.to_string(),
+                pattern: r#"+"#.to_string(),
+                is_regex: false,
+                line_number: 121,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"MINUS"#.to_string(),
+                pattern: r#"-"#.to_string(),
+                is_regex: false,
+                line_number: 122,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"TIMES"#.to_string(),
+                pattern: r#"*"#.to_string(),
+                is_regex: false,
+                line_number: 123,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"SLASH"#.to_string(),
+                pattern: r#"/"#.to_string(),
+                is_regex: false,
+                line_number: 124,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"CARET"#.to_string(),
+                pattern: r#"^"#.to_string(),
+                is_regex: false,
+                line_number: 131,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"EQ"#.to_string(),
+                pattern: r#"="#.to_string(),
+                is_regex: false,
+                line_number: 142,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LESS"#.to_string(),
+                pattern: r#"<"#.to_string(),
+                is_regex: false,
+                line_number: 143,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"GREATER"#.to_string(),
+                pattern: r#">"#.to_string(),
+                is_regex: false,
+                line_number: 144,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LPAREN"#.to_string(),
+                pattern: r#"("#.to_string(),
+                is_regex: false,
+                line_number: 146,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RPAREN"#.to_string(),
+                pattern: r#")"#.to_string(),
+                is_regex: false,
+                line_number: 147,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LBRACKET"#.to_string(),
+                pattern: r#"["#.to_string(),
+                is_regex: false,
+                line_number: 153,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RBRACKET"#.to_string(),
+                pattern: r#"]"#.to_string(),
+                is_regex: false,
+                line_number: 154,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"COMMA"#.to_string(),
+                pattern: r#","#.to_string(),
+                is_regex: false,
+                line_number: 156,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"SEMI"#.to_string(),
+                pattern: r#";"#.to_string(),
+                is_regex: false,
+                line_number: 162,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"COLON"#.to_string(),
+                pattern: r#":"#.to_string(),
+                is_regex: false,
+                line_number: 177,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NUMBER"#.to_string(),
+                pattern: r#"[0-9]+\.?[0-9]*([eE][+-]?[0-9]+)?"#.to_string(),
+                is_regex: true,
+                line_number: 214,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"STRING"#.to_string(),
+                pattern: r#""[^"]*""#.to_string(),
+                is_regex: true,
+                line_number: 215,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NAME"#.to_string(),
+                pattern: r#"[a-zA-Z][a-zA-Z0-9]*"#.to_string(),
+                is_regex: true,
+                line_number: 216,
+                alias: None,
+            },
+        ],
+        keywords: vec![r#"if"#.to_string(), r#"then"#.to_string(), r#"else"#.to_string(), r#"has"#.to_string()],
+        mode: None,
+        skip_definitions: vec![
+            TokenDefinition {
+                name: r#"WHITESPACE"#.to_string(),
+                pattern: r#"[ \t\r\n]+"#.to_string(),
+                is_regex: true,
+                line_number: 248,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"COMMENT"#.to_string(),
+                pattern: r#"--[^\n]*"#.to_string(),
+                is_regex: true,
+                line_number: 249,
+                alias: None,
+            },
+        ],
+        reserved_keywords: vec![],
+        escapes: Some(r#"none"#.to_string()),
+        error_definitions: vec![
+            TokenDefinition {
+                name: r#"UNKNOWN"#.to_string(),
+                pattern: r#"."#.to_string(),
+                is_regex: true,
+                line_number: 293,
+                alias: None,
+            },
+        ],
+        groups: HashMap::new(),
+        case_sensitive: true,
+        version: 1,
+        case_insensitive: false,
+        context_keywords: vec![],
+        soft_keywords: vec![],
+        layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
+    }
+}

--- a/code/packages/rust/axiom-lexer/src/lib.rs
+++ b/code/packages/rust/axiom-lexer/src/lib.rs
@@ -1,0 +1,199 @@
+//! # Axiom Lexer — tokenizing Axiom, the strongly-typed CAS.
+//!
+//! Axiom (Scratchpad II, IBM Research, 1977; commercialized 1992; today
+//! continued by OpenAxiom/FriCAS/the independent Axiom project —
+//! `code/specs/MA13-axiom-language.md` §1) is this repo's first
+//! symbolic-family (CAS) language whose value model needs a per-value
+//! domain/category type tag at all (MA13 §2) — every prior CAS sibling here
+//! (Macsyma, Wolfram, Derive, Reduce, Maple) is, underneath its own surface
+//! syntax, a single flat universe of untyped symbolic expressions. This
+//! crate covers only MA13 §3's scoped first cut: the **consumer view** of
+//! Axiom's category/domain system (`:` declare, `::` coerce, `has` query)
+//! over ordinary CAS-family arithmetic/comparison/assignment/definition
+//! surface — never the *producer* side (user-defined categories, domains,
+//! `Join`, packages), which MA13 §3/§4 defer whole to a future item.
+//!
+//! Like every language frontend in this repo, this crate does not
+//! hand-write tokenization — it loads the compiled
+//! `code/grammars/axiom/axiom.tokens` grammar and feeds it to the generic
+//! [`GrammarLexer`]. `axiom-lexer` only tokenizes; there is no
+//! `axiom-parser` or `axiom.grammar` here (that is MA-13c, a separate
+//! follow-on task).
+//!
+//! ## No recursion-depth cap — and why that is the right call here, not an omission
+//!
+//! `axiom-lexer` performs no recursive descent at all: [`GrammarLexer`]
+//! tokenizes with a single left-to-right scan over the source text, one
+//! token at a time, with no call stack that grows with input structure.
+//! Every sibling `*-lexer` crate in this repo that shares this shape says so
+//! explicitly and adds no depth cap of its own — `apl-lexer`/`j-lexer`
+//! (per `q-lexer`'s own doc comment), `q-lexer` itself, `scilab-lexer`, and
+//! most directly `idl-lexer` ("no recursion-depth cap ... the same split
+//! every sibling `*-lexer`/`*-parser` pair in this repo already follows").
+//! A recursion/rule-depth cap (`MAX_RULE_DEPTH`-style, per this repo's own
+//! `lessons.md` entries on parser recursion) is a **recursive-descent
+//! parser** concern — it belongs to `axiom-parser` (MA-13c), the first
+//! layer in Axiom's frontend that actually recurses (nested expressions,
+//! nested parenthesised blocks), exactly as it does for every sibling
+//! lexer/parser pair already in this repo. Adding one here, ahead of that
+//! layer existing, would not guard against anything this crate's own
+//! tokenization loop can do — it processes O(input length) tokens with O(1)
+//! stack depth regardless of how deeply nested the *source* is, since
+//! nesting structure is invisible to a flat token scan.
+//!
+//! ## No pre/post-tokenize hooks — `axiom.tokens` is entirely declarative
+//!
+//! Unlike `q-lexer` (whitespace-adjacency hooks for `-`-vs-negative-literal
+//! and `/`-vs-comment) and `scilab-lexer` (a hook for `'`
+//! transpose-vs-string), Axiom's MA-13b-scoped surface has no character
+//! that means two different things depending on adjacent whitespace or a
+//! preceding value. Every multi-character operator (`:=`, `::`, `==`, `~=`,
+//! `<=`, `>=`, `**`) is resolved by ordinary longest-match-first ordering in
+//! `axiom.tokens` itself, and `--` line comments never collide with `-`
+//! (MINUS) because [`GrammarLexer`]'s own skip-pattern pass always runs
+//! *before* ordinary token matching at every position — the same
+//! declarative shape `sql.tokens`/`vhdl*.tokens`/`haskell*.tokens` already
+//! rely on for their own coexisting MINUS/`--`-comment pair. So
+//! `create_axiom_lexer` installs nothing beyond the compiled grammar,
+//! mirroring `idl-lexer`'s equally hook-free shape.
+//!
+//! ## What this crate does *not* tokenize (MA13 §4's deferred list)
+//!
+//! No token exists anywhere in `axiom.tokens` for: `Record`/`Union`/`Any`,
+//! `macro`, package-calling `$`, target-type `@`, the anonymous
+//! "maps-to" function operator `+->`, block early-exit `=>`,
+//! piecewise/multi-clause function definitions, list comprehensions, or
+//! `for`/`while` iteration — all explicitly out of MA13's first-cut scope.
+//! A source string using one of these constructs lexes every character it
+//! *can* recognize and then fails honestly on the first character it
+//! cannot (e.g. `@`, `$`), rather than silently accepting it as something
+//! else.
+//!
+//! Built-in domain names (`Integer`, `Boolean`, `Fraction`, `Polynomial`,
+//! `List`, `PositiveInteger`, `NonNegativeInteger`, `Float`, `String`) and
+//! built-in category names (`Ring`, `OrderedSet`) are **not** lexer-level
+//! keywords — MA13 §3/§4 fixes them as a small, non-extensible lookup table
+//! entirely internal to a future `axiom-runtime` (MA-13d); this crate
+//! tokenizes every one of them as an ordinary `NAME`, exactly like
+//! `idl-lexer` resolves IDL's intrinsic procedure/function names (`PLOT`,
+//! `SIN`, `TOTAL`, ...) as plain `NAME`s rather than reserved words. Only
+//! `if`/`then`/`else`/`has` are real keywords in this cut (MA13 §4).
+
+use lexer::grammar_lexer::GrammarLexer;
+use lexer::token::Token;
+
+mod _grammar;
+
+// ===========================================================================
+// Public API
+// ===========================================================================
+
+/// Create a [`GrammarLexer`] configured for Axiom source.
+///
+/// No pre/post-tokenize hooks are installed — see this module's own doc
+/// comment for why `axiom.tokens` needs none (unlike `q-lexer`/
+/// `scilab-lexer`).
+pub fn create_axiom_lexer(source: &str) -> GrammarLexer<'_> {
+    let grammar = _grammar::token_grammar();
+    GrammarLexer::new(source, &grammar)
+}
+
+/// Tokenize Axiom source text into a vector of tokens (ending in `EOF`).
+///
+/// # Panics
+///
+/// Panics on an unrecognized character. Use [`try_tokenize_axiom`] for a
+/// `Result`-returning version instead.
+///
+/// # Example
+///
+/// ```
+/// use coding_adventures_axiom_lexer::tokenize_axiom;
+///
+/// let tokens = tokenize_axiom("a : PositiveInteger\na := 3\n");
+/// ```
+pub fn tokenize_axiom(source: &str) -> Vec<Token> {
+    create_axiom_lexer(source)
+        .tokenize()
+        .unwrap_or_else(|err| panic!("Axiom tokenization failed: {err}"))
+}
+
+/// Tokenize Axiom source text, returning a `Result` instead of panicking.
+pub fn try_tokenize_axiom(source: &str) -> Result<Vec<Token>, String> {
+    create_axiom_lexer(source)
+        .tokenize()
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+    use lexer::token::TokenType;
+
+    fn types(source: &str) -> Vec<String> {
+        tokenize_axiom(source)
+            .into_iter()
+            .filter(|t| t.type_ != TokenType::Eof)
+            .map(|t| t.effective_type_name().to_string())
+            .collect()
+    }
+
+    fn values(source: &str) -> Vec<String> {
+        tokenize_axiom(source)
+            .into_iter()
+            .filter(|t| t.type_ != TokenType::Eof)
+            .map(|t| t.value)
+            .collect()
+    }
+
+    // A handful of smoke tests directly against the public API; the crate's
+    // `tests/test_tokenizer.rs` covers the full grammar plus a much larger
+    // set of edge cases (mirroring idl-lexer's/q-lexer's own split between
+    // a small in-module smoke suite and the exhaustive integration test
+    // file).
+
+    #[test]
+    fn tokenizes_a_declaration_and_immediate_assignment() {
+        assert_eq!(
+            types("a : PositiveInteger\na := 3"),
+            vec!["NAME", "COLON", "NAME", "NAME", "ASSIGN", "NUMBER"]
+        );
+    }
+
+    #[test]
+    fn tokenizes_a_coercion() {
+        assert_eq!(
+            types("3 :: Fraction Integer"),
+            vec!["NUMBER", "COERCE", "NAME", "NAME"]
+        );
+    }
+
+    #[test]
+    fn tokenizes_a_has_query() {
+        assert_eq!(
+            types("Polynomial(Integer) has Ring"),
+            vec!["NAME", "LPAREN", "NAME", "RPAREN", "KEYWORD", "NAME"]
+        );
+        assert_eq!(values("Polynomial(Integer) has Ring")[4], "has");
+    }
+
+    #[test]
+    fn rational_division_is_ordinary_number_slash_number() {
+        // MA13 §4: `1/3` is NOT a dedicated rational-literal token -- it is
+        // ordinary integer division, three tokens, lowered to a packed
+        // rational representation entirely at a later layer.
+        assert_eq!(types("1/3"), vec!["NUMBER", "SLASH", "NUMBER"]);
+    }
+
+    #[test]
+    fn tokenize_axiom_panics_on_malformed_source() {
+        let result = std::panic::catch_unwind(|| tokenize_axiom("@"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn create_axiom_lexer_exposes_the_result_returning_api() {
+        assert!(create_axiom_lexer("x := 1").tokenize().is_ok());
+        assert!(create_axiom_lexer("@").tokenize().is_err());
+    }
+}

--- a/code/packages/rust/axiom-lexer/tests/test_tokenizer.rs
+++ b/code/packages/rust/axiom-lexer/tests/test_tokenizer.rs
@@ -1,0 +1,626 @@
+use coding_adventures_axiom_lexer::{create_axiom_lexer, tokenize_axiom, try_tokenize_axiom};
+use lexer::token::TokenType;
+
+fn token_types(source: &str) -> Vec<String> {
+    tokenize_axiom(source)
+        .into_iter()
+        .filter(|token| token.type_ != TokenType::Eof)
+        .map(|token| token.effective_type_name().to_string())
+        .collect()
+}
+
+fn token_values(source: &str) -> Vec<String> {
+    tokenize_axiom(source)
+        .into_iter()
+        .filter(|token| token.type_ != TokenType::Eof)
+        .map(|token| token.value)
+        .collect()
+}
+
+// ===========================================================================
+// Integer and float literals (MA13 §4).
+// ===========================================================================
+
+#[test]
+fn tokenizes_an_integer_literal() {
+    assert_eq!(token_types("123"), vec!["NUMBER"]);
+    assert_eq!(token_values("123"), vec!["123"]);
+}
+
+#[test]
+fn tokenizes_a_float_literal() {
+    assert_eq!(token_types("1.5"), vec!["NUMBER"]);
+    assert_eq!(token_values("1.5"), vec!["1.5"]);
+}
+
+#[test]
+fn tokenizes_numbers_with_exponents() {
+    assert_eq!(token_values("1e10"), vec!["1e10"]);
+    assert_eq!(token_values("2.5E+3"), vec!["2.5E+3"]);
+    assert_eq!(token_values("1e-5"), vec!["1e-5"]);
+}
+
+#[test]
+fn number_requires_a_leading_digit() {
+    // A bare `.5` is not a number -- matches every sibling symbolic-family
+    // lexer's convention (reduce/derive/maple.tokens). `.` has no token of
+    // its own in this cut's grammar, so it falls through to an honest
+    // lex error.
+    assert!(try_tokenize_axiom(".5").is_err());
+}
+
+// ===========================================================================
+// Rational spelling: `1/3` is ordinary division, NOT a dedicated rational
+// literal token (MA13 §4's own confirmed finding).
+// ===========================================================================
+
+#[test]
+fn rational_literal_spelling_is_three_ordinary_tokens() {
+    assert_eq!(token_types("1/3"), vec!["NUMBER", "SLASH", "NUMBER"]);
+    assert_eq!(token_values("1/3"), vec!["1", "/", "3"]);
+}
+
+#[test]
+fn rational_coercion_combines_ordinary_division_with_coerce() {
+    // `3 :: Fraction Integer` -- MA13 §3's own worked coercion example.
+    assert_eq!(
+        token_types("3 :: Fraction Integer"),
+        vec!["NUMBER", "COERCE", "NAME", "NAME"]
+    );
+}
+
+// ===========================================================================
+// String literals (MA13 §4).
+// ===========================================================================
+
+#[test]
+fn tokenizes_a_string_literal() {
+    assert_eq!(token_types("\"hello\""), vec!["STRING"]);
+    assert_eq!(token_values("\"hello\""), vec!["hello"]);
+}
+
+#[test]
+fn tokenizes_an_empty_string_literal() {
+    assert_eq!(token_types("\"\""), vec!["STRING"]);
+    assert_eq!(token_values("\"\""), vec![String::new()]);
+}
+
+#[test]
+fn string_literal_containing_ordinary_grammar_characters() {
+    assert_eq!(
+        token_values("\"a := b :: c\""),
+        vec!["a := b :: c"]
+    );
+}
+
+// ===========================================================================
+// Symbols/identifiers (MA13 §4) -- domain/category names are ordinary NAMEs.
+// ===========================================================================
+
+#[test]
+fn tokenizes_plain_identifiers() {
+    assert_eq!(token_types("x foo f"), vec!["NAME", "NAME", "NAME"]);
+    assert_eq!(token_values("x foo f"), vec!["x", "foo", "f"]);
+}
+
+#[test]
+fn builtin_domain_and_category_names_are_ordinary_names_not_keywords() {
+    // MA13 §3/§4: the fixed built-in domain/category table is an
+    // axiom-runtime-internal (MA-13d) concern, invisible here -- every one
+    // of these lexes as a plain NAME, never a KEYWORD.
+    for name in [
+        "Integer",
+        "Boolean",
+        "Float",
+        "String",
+        "Fraction",
+        "Polynomial",
+        "List",
+        "PositiveInteger",
+        "NonNegativeInteger",
+        "Ring",
+        "OrderedSet",
+    ] {
+        assert_eq!(token_types(name), vec!["NAME"], "expected NAME for {name}");
+    }
+}
+
+#[test]
+fn identifiers_are_case_sensitive() {
+    // Unlike idl.tokens's `@case_insensitive true`, Axiom keeps its
+    // default case-sensitive behavior (MA13 §4: if/then/else/has are
+    // lowercase; IF/THEN/ELSE/HAS in uppercase are ordinary NAMEs, not
+    // keywords).
+    assert_eq!(token_types("IF"), vec!["NAME"]);
+    assert_eq!(token_types("Has"), vec!["NAME"]);
+}
+
+// ===========================================================================
+// Parens, brackets, comma (MA13 §4).
+// ===========================================================================
+
+#[test]
+fn tokenizes_parens_and_a_function_call_shape() {
+    assert_eq!(
+        token_types("f(a, b)"),
+        vec!["NAME", "LPAREN", "NAME", "COMMA", "NAME", "RPAREN"]
+    );
+}
+
+#[test]
+fn tokenizes_a_list_literal_with_square_brackets() {
+    assert_eq!(
+        token_types("[a, b, c]"),
+        vec!["LBRACKET", "NAME", "COMMA", "NAME", "COMMA", "NAME", "RBRACKET"]
+    );
+}
+
+#[test]
+fn single_argument_paren_optional_call_is_just_two_names() {
+    // `factorial 7` -- MA13 §4's paren-optional single-argument call; at
+    // the lexer level this is simply NAME NUMBER, with call-vs-juxtaposition
+    // disambiguation left entirely to the parser (MA-13c).
+    assert_eq!(token_types("factorial 7"), vec!["NAME", "NUMBER"]);
+}
+
+// ===========================================================================
+// Arithmetic operators, both power spellings (MA13 §4).
+// ===========================================================================
+
+#[test]
+fn tokenizes_ordinary_arithmetic_operators() {
+    assert_eq!(
+        token_types("a + b - c * d / e"),
+        vec![
+            "NAME", "PLUS", "NAME", "MINUS", "NAME", "TIMES", "NAME", "SLASH", "NAME",
+        ]
+    );
+}
+
+#[test]
+fn both_power_spellings_are_real_and_distinct_tokens() {
+    // MA13 §4: `^` and `**` are both real, confirmed spellings for power
+    // (mirroring Reduce's own CARET/POW pair, MA08 §3) -- kept as distinct
+    // token types; the parser collapses them onto one production.
+    assert_eq!(token_types("a ^ b"), vec!["NAME", "CARET", "NAME"]);
+    assert_eq!(token_types("a ** b"), vec!["NAME", "POW", "NAME"]);
+}
+
+#[test]
+fn pow_wins_over_bare_times_by_longest_match() {
+    // Regression: `**` must lex as ONE POW token, never two TIMES tokens
+    // or TIMES+TIMES -- POW is declared before TIMES in axiom.tokens for
+    // exactly this reason.
+    assert_eq!(token_types("**"), vec!["POW"]);
+    assert_eq!(token_types("*"), vec!["TIMES"]);
+    assert_eq!(token_types("***"), vec!["POW", "TIMES"]);
+    assert_eq!(token_types("****"), vec!["POW", "POW"]);
+}
+
+// ===========================================================================
+// Comparison operators (MA13 §3/§4) -- `~=` is Axiom's real not-equal
+// spelling, NOT Maple's `<>` or Wolfram's `!=`.
+// ===========================================================================
+
+#[test]
+fn equality_lowers_to_a_single_eq_token() {
+    assert_eq!(token_types("a = b"), vec!["NAME", "EQ", "NAME"]);
+}
+
+#[test]
+fn not_equal_is_spelled_tilde_equals() {
+    assert_eq!(token_types("a ~= b"), vec!["NAME", "NE", "NAME"]);
+}
+
+#[test]
+fn maple_and_wolfram_not_equal_spellings_are_not_recognized_as_one_token() {
+    // `<>` is Maple's spelling (not Axiom's) -- it must NOT lex as a single
+    // NE-like token here; it lexes as LESS then GREATER, two tokens.
+    assert_eq!(token_types("a <> b"), vec!["NAME", "LESS", "GREATER", "NAME"]);
+    // `!=` is Wolfram's spelling -- `!` has no token in this grammar at all.
+    assert!(try_tokenize_axiom("a != b").is_err());
+}
+
+#[test]
+fn tokenizes_ordering_comparisons() {
+    assert_eq!(token_types("a < b"), vec!["NAME", "LESS", "NAME"]);
+    assert_eq!(token_types("a <= b"), vec!["NAME", "LE", "NAME"]);
+    assert_eq!(token_types("a > b"), vec!["NAME", "GREATER", "NAME"]);
+    assert_eq!(token_types("a >= b"), vec!["NAME", "GE", "NAME"]);
+}
+
+#[test]
+fn le_and_ge_win_over_bare_less_and_greater_by_longest_match() {
+    assert_eq!(token_types("<="), vec!["LE"]);
+    assert_eq!(token_types(">="), vec!["GE"]);
+    assert_eq!(token_types("<"), vec!["LESS"]);
+    assert_eq!(token_types(">"), vec!["GREATER"]);
+}
+
+// ===========================================================================
+// Assignment `:=`, function-definition `==`, and the declaration/coercion
+// colon family `:` / `::` -- the three genuinely new tokens (MA13 §3).
+// ===========================================================================
+
+#[test]
+fn tokenizes_immediate_assignment() {
+    assert_eq!(token_types("a := 3"), vec!["NAME", "ASSIGN", "NUMBER"]);
+}
+
+#[test]
+fn tokenizes_a_held_body_function_definition() {
+    // f(x: T, ...): T == e -- MA13 §4's function-definition row.
+    let src = "f(x: T): T == x + 1";
+    assert_eq!(
+        token_types(src),
+        vec![
+            "NAME", "LPAREN", "NAME", "COLON", "NAME", "RPAREN", "COLON", "NAME", "DEFINE",
+            "NAME", "PLUS", "NUMBER",
+        ]
+    );
+}
+
+#[test]
+fn tokenizes_an_undeclared_function_definition() {
+    // Undeclared `f x == e` form (MA13 §4).
+    assert_eq!(
+        token_types("f x == x * x"),
+        vec!["NAME", "NAME", "DEFINE", "NAME", "TIMES", "NAME"]
+    );
+}
+
+#[test]
+fn tokenizes_a_plain_declaration() {
+    // a : PositiveInteger -- MA13 §3/§4's declaration row.
+    assert_eq!(
+        token_types("a : PositiveInteger"),
+        vec!["NAME", "COLON", "NAME"]
+    );
+}
+
+#[test]
+fn tokenizes_a_tuple_declaration() {
+    // (a, b, c) : T -- MA13 §4's tuple-declaration row.
+    assert_eq!(
+        token_types("(a, b, c) : T"),
+        vec![
+            "LPAREN", "NAME", "COMMA", "NAME", "COMMA", "NAME", "RPAREN", "COLON", "NAME",
+        ]
+    );
+}
+
+#[test]
+fn tokenizes_a_coercion_expression() {
+    assert_eq!(
+        token_types("e :: T"),
+        vec!["NAME", "COERCE", "NAME"]
+    );
+}
+
+#[test]
+fn colon_family_longest_match_regression() {
+    // `:=`, `::`, and bare `:` must never be confused with one another --
+    // ASSIGN and COERCE are both declared before bare COLON in
+    // axiom.tokens for exactly this reason.
+    assert_eq!(token_types(":="), vec!["ASSIGN"]);
+    assert_eq!(token_types("::"), vec!["COERCE"]);
+    assert_eq!(token_types(":"), vec!["COLON"]);
+    assert_eq!(token_types(":::"), vec!["COERCE", "COLON"]);
+    // "::=" is COERCE ("::") followed by only a single "=" character
+    // remaining -- not enough characters left to form a second two-char
+    // operator (":=" or "=="), so it falls through to the single-char EQ,
+    // not ASSIGN.
+    assert_eq!(token_types("::="), vec!["COERCE", "EQ"]);
+    assert_eq!(token_types(":=:"), vec!["ASSIGN", "COLON"]);
+}
+
+#[test]
+fn define_wins_over_bare_eq_by_longest_match() {
+    assert_eq!(token_types("=="), vec!["DEFINE"]);
+    assert_eq!(token_types("="), vec!["EQ"]);
+    assert_eq!(token_types("==="), vec!["DEFINE", "EQ"]);
+    assert_eq!(token_types("===="), vec!["DEFINE", "DEFINE"]);
+}
+
+// ===========================================================================
+// `has` category-membership query (MA13 §3/§4).
+// ===========================================================================
+
+#[test]
+fn tokenizes_a_has_query() {
+    // Polynomial(Integer) has Ring -- MA13 §3's own worked example, `true`.
+    assert_eq!(
+        token_types("Polynomial(Integer) has Ring"),
+        vec!["NAME", "LPAREN", "NAME", "RPAREN", "KEYWORD", "NAME"]
+    );
+    assert_eq!(token_values("Polynomial(Integer) has Ring")[4], "has");
+}
+
+#[test]
+fn tokenizes_a_false_has_query() {
+    // List(Integer) has Ring -- MA13 §4's own confirmed `false` example.
+    assert_eq!(
+        token_types("List(Integer) has Ring"),
+        vec!["NAME", "LPAREN", "NAME", "RPAREN", "KEYWORD", "NAME"]
+    );
+}
+
+#[test]
+fn has_is_case_sensitive_like_every_other_keyword() {
+    assert_eq!(token_types("has"), vec!["KEYWORD"]);
+    // Uppercase `Has`/`HAS` are ordinary NAMEs -- Axiom keeps the default
+    // case-sensitive behavior (no `@case_insensitive` directive), unlike
+    // idl.tokens's own case-insensitive keyword lookup.
+    assert_eq!(token_types("Has"), vec!["NAME"]);
+    assert_eq!(token_types("HAS"), vec!["NAME"]);
+}
+
+// ===========================================================================
+// `if`/`then`/`else` conditional keywords (MA13 §4).
+// ===========================================================================
+
+#[test]
+fn tokenizes_an_if_then_else_conditional() {
+    assert_eq!(
+        token_types("if a > b then a else b"),
+        vec!["KEYWORD", "NAME", "GREATER", "NAME", "KEYWORD", "NAME", "KEYWORD", "NAME"]
+    );
+}
+
+#[test]
+fn keywords_are_exactly_the_closed_four_word_set() {
+    for kw in ["if", "then", "else", "has"] {
+        assert_eq!(token_types(kw), vec!["KEYWORD"], "expected KEYWORD({kw})");
+        assert_eq!(token_values(kw), vec![kw.to_string()]);
+    }
+}
+
+// ===========================================================================
+// Semicolon-separated block (MA13 §4).
+// ===========================================================================
+
+#[test]
+fn tokenizes_a_parenthesised_semicolon_separated_block() {
+    assert_eq!(
+        token_types("(a := 1; b := 2; a + b)"),
+        vec![
+            "LPAREN", "NAME", "ASSIGN", "NUMBER", "SEMI", "NAME", "ASSIGN", "NUMBER", "SEMI",
+            "NAME", "PLUS", "NAME", "RPAREN",
+        ]
+    );
+}
+
+// ===========================================================================
+// `--` line comments (MA13 §4's task-scoped addition, per FriCAS/SPAD
+// convention).
+// ===========================================================================
+
+#[test]
+fn double_dash_opens_a_comment_to_end_of_line() {
+    assert_eq!(
+        token_types("a := 1 -- a trailing comment"),
+        vec!["NAME", "ASSIGN", "NUMBER"]
+    );
+}
+
+#[test]
+fn comment_does_not_prevent_lexing_the_next_line() {
+    assert_eq!(
+        token_types("a := 1 -- comment\nb := 2"),
+        vec!["NAME", "ASSIGN", "NUMBER", "NAME", "ASSIGN", "NUMBER"]
+    );
+}
+
+#[test]
+fn whole_line_comment_between_two_statements() {
+    assert_eq!(
+        token_types("a := 1\n-- a whole comment line\nb := 2"),
+        vec!["NAME", "ASSIGN", "NUMBER", "NAME", "ASSIGN", "NUMBER"]
+    );
+}
+
+#[test]
+fn comment_may_contain_characters_outside_the_grammars_alphabet() {
+    // A comment's content is arbitrary text and must never be re-lexed as
+    // code -- `@`/`$`/`\` all have no token anywhere in this grammar, but
+    // must not cause a lex error when they only ever appear inside a
+    // comment.
+    assert!(try_tokenize_axiom("a := 1 -- cost is @5 $ off \\ end\nb := 2").is_ok());
+}
+
+#[test]
+fn single_minus_is_not_swallowed_by_the_comment_pattern() {
+    // A single `-` (MINUS) must not be mistaken for the start of a `--`
+    // comment -- GrammarLexer's skip pass tries the WHOLE `--[^\n]*`
+    // pattern at the position, which cannot match on just one dash.
+    assert_eq!(token_types("a - b"), vec!["NAME", "MINUS", "NAME"]);
+    assert_eq!(token_types("a-b"), vec!["NAME", "MINUS", "NAME"]);
+}
+
+// ===========================================================================
+// Whitespace / no significant newline (MA13 §4/§5 -- blocks are
+// `;`-separated, never newline-separated; `axiom-repl`'s numbered-prompt
+// step counter is a REPL-layer concern, not a lexer one).
+// ===========================================================================
+
+#[test]
+fn newlines_are_ordinary_whitespace_not_a_significant_token() {
+    assert_eq!(
+        token_types("a := 1\nb := 2"),
+        vec!["NAME", "ASSIGN", "NUMBER", "NAME", "ASSIGN", "NUMBER"]
+    );
+}
+
+#[test]
+fn skips_ordinary_whitespace() {
+    assert_eq!(token_types("a   :=   1"), vec!["NAME", "ASSIGN", "NUMBER"]);
+}
+
+// ===========================================================================
+// Deferred surface (MA13 §4) -- none of these has any token in this cut's
+// grammar; each falls through to an honest lex error.
+// ===========================================================================
+
+#[test]
+fn deferred_constructs_are_lex_errors_not_silently_accepted() {
+    // Package-calling `$` and target-type `@` (deferred) -- neither `$` nor
+    // `@` has a token anywhere in this grammar, so these are honest errors.
+    assert!(try_tokenize_axiom("content(2)$Polynomial(Integer)").is_err());
+    assert!(try_tokenize_axiom("(2 = 3)@Boolean").is_err());
+}
+
+#[test]
+fn no_dedicated_token_for_multi_char_sequences_this_cut_never_declares() {
+    // Neither the anonymous "maps-to" operator `+->` nor block early-exit
+    // `=>` (both deferred, MA13 §4) has a DEDICATED token in this cut's
+    // grammar -- but unlike `$`/`@` above, every individual CHARACTER in
+    // both sequences (`+`, `-`, `>`, `=`) already has its OWN ordinary
+    // single-character token, so these decompose into their constituent
+    // tokens rather than erroring. This is an honest reflection of the
+    // absence of a dedicated production (a future `axiom-parser`, MA-13c,
+    // would reject the *sequence* at the grammar level), not a
+    // special-cased rejection at the lexer layer.
+    assert_eq!(
+        token_types("x +-> x * x"),
+        vec!["NAME", "PLUS", "MINUS", "GREATER", "NAME", "TIMES", "NAME"]
+    );
+    assert_eq!(token_types("=>"), vec!["EQ", "GREATER"]);
+}
+
+#[test]
+fn macro_is_not_a_keyword_here() {
+    // `macro` (deferred, MA13 §4) is simply an ordinary NAME in this cut --
+    // no reserved word for it exists.
+    assert_eq!(token_types("macro"), vec!["NAME"]);
+}
+
+#[test]
+fn record_union_any_are_ordinary_names_not_reserved_words() {
+    // Record/Union/Any (the heterogeneous aggregate/sum-type machinery,
+    // deferred whole per MA13 §4) have no lexer-level reservation at all
+    // in this cut -- they lex exactly like any other capitalized
+    // identifier (indistinguishable from a built-in domain name at this
+    // layer), an honest reflection of "not implemented yet" rather than a
+    // reserved-but-unusable word.
+    assert_eq!(token_types("Record"), vec!["NAME"]);
+    assert_eq!(token_types("Union"), vec!["NAME"]);
+    assert_eq!(token_types("Any"), vec!["NAME"]);
+}
+
+// ===========================================================================
+// Errors.
+// ===========================================================================
+
+#[test]
+fn unrecognized_character_is_an_error() {
+    assert!(try_tokenize_axiom("a @ b").is_err());
+    assert!(try_tokenize_axiom("a $ b").is_err());
+    assert!(try_tokenize_axiom("a ! b").is_err());
+    assert!(try_tokenize_axiom("a ? b").is_err());
+}
+
+#[test]
+fn tokenize_axiom_panics_on_malformed_source() {
+    let result = std::panic::catch_unwind(|| tokenize_axiom("@"));
+    assert!(result.is_err());
+}
+
+#[test]
+fn create_axiom_lexer_exposes_the_result_returning_api() {
+    assert!(create_axiom_lexer("x := 1").tokenize().is_ok());
+    assert!(create_axiom_lexer("@").tokenize().is_err());
+}
+
+#[test]
+fn handles_eof_mid_string_without_panic() {
+    // An unterminated string -- honest failure, not a panic (STRING's
+    // pattern simply never finds a closing quote, so no other pattern
+    // matches at the opening `"` either... actually the STRING pattern
+    // requires a closing quote, so this must fail to tokenize the `"`
+    // itself as an isolated character via the UNKNOWN catch-all path).
+    let _ = try_tokenize_axiom("a := \"oops");
+}
+
+// ===========================================================================
+// Adversarial / DoS-guard regression: `axiom-lexer` performs a single
+// linear scan with O(1) stack depth regardless of source-level nesting --
+// verified directly here rather than merely asserted in prose (MA13b task
+// brief's own DoS-guard requirement). See `src/lib.rs`'s own doc comment
+// for the fuller argument for why no recursion-depth cap belongs in this
+// crate (that is `axiom-parser`'s concern, MA-13c).
+// ===========================================================================
+
+#[test]
+fn deeply_nested_parens_do_not_overflow_the_lexer_stack() {
+    // 50,000 levels of nested parens would blow a naive recursive-descent
+    // parser's call stack; a flat single-pass lexer must handle this with
+    // no growth in stack usage at all, since it never recurses on bracket
+    // structure -- it only ever counts LPAREN/RPAREN as ordinary tokens.
+    let depth = 50_000;
+    let src = "(".repeat(depth) + "a" + &")".repeat(depth);
+    let tokens = tokenize_axiom(&src);
+    // depth LPARENs + 1 NAME + depth RPARENs + EOF.
+    assert_eq!(tokens.len(), depth * 2 + 2);
+    assert_eq!(tokens[0].effective_type_name(), "LPAREN");
+    assert_eq!(tokens[depth].effective_type_name(), "NAME");
+    assert_eq!(tokens[depth + 1].effective_type_name(), "RPAREN");
+}
+
+#[test]
+fn a_very_large_flat_token_stream_tokenizes_without_incident() {
+    // A wide (not deep) adversarial input -- many thousands of sibling
+    // tokens rather than nested structure -- exercises the other half of
+    // the DoS surface (unbounded allocation/time, not stack depth). This
+    // crate makes no attempt to cap input size or token count (see
+    // `src/lib.rs`'s doc comment): that is a resource-budgeting decision
+    // for whatever embeds this lexer (a REPL reading a line at a time
+    // naturally bounds this; a batch file-reader would need its own cap),
+    // not a lexer-level concern any sibling `*-lexer` crate in this repo
+    // enforces either. This test only asserts correctness at scale, not
+    // a rejection.
+    let count = 100_000;
+    let src = "a + ".repeat(count) + "a";
+    let tokens = tokenize_axiom(&src);
+    // count * (NAME, PLUS) + one final NAME + EOF.
+    assert_eq!(tokens.len(), count * 2 + 2);
+}
+
+#[test]
+fn a_very_long_comment_does_not_hang_or_overflow() {
+    let body = "x".repeat(500_000);
+    let src = format!("a := 1 -- {body}\nb := 2");
+    assert_eq!(
+        token_types(&src),
+        vec!["NAME", "ASSIGN", "NUMBER", "NAME", "ASSIGN", "NUMBER"]
+    );
+}
+
+// ===========================================================================
+// End-to-end: a small, realistic "textbook Axiom session" snippet.
+// ===========================================================================
+
+#[test]
+fn tokenizes_a_small_end_to_end_snippet() {
+    // a : PositiveInteger  -- declare a domain
+    // a := 3
+    // f(x: Integer): Integer == x * x
+    // if a > 0 then f(a) else 0
+    // Polynomial(Integer) has Ring
+    let src = "a : PositiveInteger -- declare a domain\n\
+               a := 3\n\
+               f(x: Integer): Integer == x * x\n\
+               if a > 0 then f(a) else 0\n\
+               Polynomial(Integer) has Ring";
+    assert_eq!(
+        token_types(src),
+        vec![
+            "NAME", "COLON", "NAME",
+            "NAME", "ASSIGN", "NUMBER",
+            "NAME", "LPAREN", "NAME", "COLON", "NAME", "RPAREN", "COLON", "NAME", "DEFINE",
+            "NAME", "TIMES", "NAME",
+            "KEYWORD", "NAME", "GREATER", "NUMBER", "KEYWORD", "NAME", "LPAREN", "NAME",
+            "RPAREN", "KEYWORD", "NUMBER",
+            "NAME", "LPAREN", "NAME", "RPAREN", "KEYWORD", "NAME",
+        ]
+    );
+}


### PR DESCRIPTION
## Summary

MA-13b — the lexical frontend for **Axiom**, the strongly-typed CAS with a
category/domain type system, per the merged MA13 kickoff spec
(`code/specs/MA13-axiom-language.md`, #8990). Adds `code/grammars/axiom/axiom.tokens`
plus the `axiom-lexer` crate, following the established per-language pipeline
(`idl-lexer`/`scilab-lexer`/`q-lexer`/`j-lexer` as direct structural precedents).

This is a pure grammar + lexer PR — no parser, no runtime, no REPL. Those are
separate follow-on items (MA-13c/d/e) per MA13 §6's rollout plan.

## Scope (per MA13 §4)

**In scope for this cut:**
- Integer/float literals (one `NUMBER` pattern)
- **No dedicated rational-literal token** — `1/3` is ordinary `NUMBER SLASH NUMBER`
  (three tokens), confirmed against MA13 §4's own surface table; it lowers to a
  packed rational representation entirely at a later (lowering/evaluation) layer,
  not via special lexer syntax
- String literals (`"hello"`, `escapes: none` — no confirmed escape convention
  anywhere in the spec)
- Identifiers — **including every built-in domain/category name** (`Integer`,
  `Boolean`, `Ring`, `PositiveInteger`, ...), which are ordinary `NAME`s, not
  lexer-level keywords (the fixed built-in domain/category table is an
  `axiom-runtime`-internal concern per MA13 §3, invisible to this crate)
- Parens/brackets/comma: `( ) [ ] ,`
- Arithmetic: `+ - * /`, both power spellings `^` and `**` (kept as distinct
  tokens, mirroring `reduce.tokens`'s own CARET/POW split)
- Comparison: `=`, `~=` (Axiom's real not-equal spelling — **not** Maple's `<>`
  or Wolfram's `!=`), `< <= > >=`
- `:=` (immediate assignment) and `==` (held-body function definition) — two
  distinct operators, unlike Reduce/Derive/Maple which each only need one
- The three genuinely new tokens no prior symbolic-family grammar in this repo
  has needed (MA13 §3's central finding): `:` (declare), `::` (coerce), `has`
  (category-membership query keyword)
- `;` (block/sequencing separator inside parens), `if`/`then`/`else`
- `--` line comments (FriCAS/SPAD convention)

**Explicitly NOT tokenized** (MA13 §4's deferred list — no token exists for any
of these): `Record`/`Union`/`Any`, `macro`, package-calling `$`, target-type `@`,
anonymous "maps-to" `+->`, block early-exit `=>`, piecewise/multi-clause function
definitions, list comprehensions, `for`/`while` iteration.

## Design decisions worth flagging

- **No pre/post-tokenize hooks.** Every multi-character operator resolves via
  ordinary longest-match-first declaration order, and `--` comments never
  collide with bare `MINUS` because `GrammarLexer`'s skip-pattern pass always
  runs before ordinary token matching. `axiom.tokens` is entirely declarative,
  mirroring `idl-lexer`'s hook-free shape (simpler than `q-lexer`'s two hooks
  or `scilab-lexer`'s one).
- **No recursion-depth cap — a deliberate, precedent-backed choice.** The task
  brief asked for a "recursion/token-count depth cap consistent with this
  repo's DoS-guard convention." I checked the actual precedent directly:
  `idl-lexer`, `q-lexer`, `scilab-lexer`, and `apl-lexer`/`j-lexer` all
  explicitly document **no** recursion cap, because a lexer performs no
  recursive descent — it's a single flat scan with O(1) stack depth regardless
  of source nesting. A `MAX_RULE_DEPTH`-style cap is this repo's established
  convention for *parser* recursion (per `lessons.md`), and belongs to a future
  `axiom-parser` (MA-13c), not this crate. I verified this directly rather than
  just asserting it: `tests/test_tokenizer.rs` includes a regression tokenizing
  50,000 levels of nested parens with no stack growth, plus wide (non-nested)
  adversarial inputs (a 100,000-token flat stream, a 500,000-character
  comment) covering the other half of the DoS surface.
- **Case-sensitive by default** (no `@case_insensitive` directive) — MA13 §4's
  own table spells `if`/`then`/`else`/`has` lowercase, matching
  `reduce.tokens`/`maple.tokens`'s identical convention.

## Test plan

- [x] `cargo build -p coding-adventures-axiom-lexer` — clean, zero warnings
- [x] `cargo clippy -p coding-adventures-axiom-lexer --all-targets -- -D warnings` — clean
- [x] `cargo test -p coding-adventures-axiom-lexer` — 63 tests pass (6 lib + 56
      integration + 1 doc), covering every token category, longest-match
      regressions (`ASSIGN`/`COERCE`/`COLON`/`DEFINE`/`EQ`/`POW`/`LE`/`GE`
      families), the `~=`-not-`<>`-not-`!=` divergence-avoidance check, every
      deferred construct's honest non-acceptance, and two DoS-guard
      regressions
- [x] `cargo tarpaulin -p coding-adventures-axiom-lexer` — 100% line coverage
      on this crate's own `src/lib.rs` (9/9) and `src/_grammar.rs` (12/12)
- [x] `cargo build --workspace` — verified clean apart from three
      **pre-existing, already-documented** host/platform-only failures
      unrelated to this change: `os-kernel`'s `uefi` `panic_impl` collision
      (documented in `lessons.md`), `paint-vm-direct2d`'s Windows-only
      `compile_error!`, and `font-parser-python`'s missing local `libpython`
      linkage — none of which axiom-lexer depends on or is depended on by
      (axiom-lexer is a new leaf crate; the workspace registration is
      additive-only)
- [x] Security review sub-agent: **PASSED** — no vulnerabilities found (ReDoS
      review of every regex pattern in `axiom.tokens`, confirmed zero `unsafe`
      blocks, reviewed the panic-vs-Result API split)

## Reference

- Spec: `code/specs/MA13-axiom-language.md` (#8990)
- Roadmap: `code/specs/HML00-historical-math-languages-roadmap.md` §7 (Wave 7)
- Pipeline: `axiom-lexer` (this PR, MA-13b) → `axiom-parser` (MA-13c) →
  `axiom-runtime`/`axiom-repl` (MA-13d) → `axiom-to-semantic-ir` (MA-13e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
