### PR TITLE
feat(adj-formula-stdlib): cardiac-output — OpenStax A&P CO = HR·SV 3-way inverter (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_cardiac_output_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_cardiac_output_e2e.rs
@@ -1,0 +1,141 @@
+//! End-to-end tests for the `clinical/cardiac-output.adj` library — the definition
+//! of cardiac output (CO = HR·SV) and its two exact rearrangements (HR = CO/SV,
+//! SV = CO/HR) — driven through the built CLI binary against the SHIPPED stdlib.
+//! Each proves the same invariant as the other formula libraries: a consumer states
+//! NO arithmetic; it imports the grounded library, binds the physiological
+//! quantities with `observe`, and the engine applies the cited definition on the
+//! CPU, computing the EXACT value and rendering the definition's citation and trust
+//! tier in the `derived` section (the auditable answer). The three formulas INVERT
+//! around the worked case HR = 75 bpm, SV = 70 mL: 75 * 70 = 5250, and both
+//! 5250 / 70 = 75 and 5250 / 75 = 70 recover the inputs.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped cardiac-output library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_cardiac_output_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/cardiac-output.adj")
+        .canonicalize()
+        .expect("shipped cardiac-output.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_co_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_cardiac_output_lib()).unwrap();
+    std::fs::write(dir.join("cardiac-output.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// cardiac_output — the definition: the heart rate times the stroke volume.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_cardiac_output_library_and_computes_definition_with_citation() {
+    let dir = scratch("def");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"cardiac-output.adj\"\n\
+         observe heart_rate(75)\n\
+         observe stroke_volume(70)\n\
+         ? cardiac_output(heart_rate, stroke_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied definition's result: 75 * 70 = 5250.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"cardiac_output\"") && s.contains("\"value\":5250"),
+        "cardiac_output(75, 70) = 5250: {s}"
+    );
+    // … AND the OpenStax/LibreTexts citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("med.libretexts.org"),
+        "applied definition carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// heart_rate — the same definition solved for HR: the cardiac output divided by the
+// stroke volume, which INVERTS the cardiac output just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_heart_rate_as_cardiac_output_over_stroke_volume_with_citation() {
+    let dir = scratch("hr");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"cardiac-output.adj\"\n\
+         observe cardiac_output(5250)\n\
+         observe stroke_volume(70)\n\
+         ? heart_rate(cardiac_output, stroke_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 5250 / 70 = 75, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"heart_rate\"") && s.contains("\"value\":75"),
+        "heart_rate(5250, 70) = 75: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("med.libretexts.org"),
+        "heart_rate carries its LibreTexts citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// stroke_volume — the same definition solved for SV: the cardiac output divided by
+// the heart rate, the third exact reading of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_stroke_volume_as_cardiac_output_over_heart_rate_with_citation() {
+    let dir = scratch("sv");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"cardiac-output.adj\"\n\
+         observe cardiac_output(5250)\n\
+         observe heart_rate(75)\n\
+         ? stroke_volume(cardiac_output, heart_rate)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 5250 / 75 = 70, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"stroke_volume\"") && s.contains("\"value\":70"),
+        "stroke_volume(5250, 75) = 70: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("med.libretexts.org"),
+        "stroke_volume carries its LibreTexts citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/cardiac-output.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/cardiac-output.adj
@@ -1,0 +1,102 @@
+% ============================================================================
+% cardiac-output.adj — the definition of cardiac output (CO = HR × SV) in the
+% ADJ standard library.
+% ============================================================================
+% The cardiac-output entry of the *clinical* track, a physiology sibling of
+% `bmi.adj` and `cockcroft_gault.adj`: the foundational cardiovascular definition
+% a first course states as CARDIAC OUTPUT IS THE STROKE VOLUME MULTIPLIED BY THE
+% HEART RATE — the amount of blood each ventricle pumps per minute — as an
+% importable, byte-provenanced, PARAMETERIZED `formula`, together with its two exact
+% rearrangements (the heart rate a cardiac output implies for a stroke volume, and
+% the stroke volume it implies for a heart rate). As with every compute library, a
+% consumer states NO arithmetic: it `import`s this file, binds the measured
+% quantities from its own byte-provenance decomposition, and asks the engine to
+% APPLY the cited definition on the CPU. Zero math is performed by the model; the
+% engine computes each value EXACTLY, carrying the definition's citation.
+%
+%     import "cardiac-output.adj"
+%     observe heart_rate(75)            % "…75 bpm…"     (span cited by the model)
+%     observe stroke_volume(70)         % "…70 mL/beat…" (span cited by the model)
+%     ? cardiac_output(heart_rate, stroke_volume)
+%                                          % engine → 5250, carrying CO = HR·SV
+%
+% All three formulas are EXACT over their parameters — one a product, two quotients
+% of measured quantities. There is no *separately grounded* physiological constant
+% here, so every value the engine returns is exact. The three COMPOSE and invert
+% cleanly around the worked case HR = 75 bpm, SV = 70 mL (CO = 75·70 = 5250 mL/min
+% = 5.25 L/min, the average resting value): the `cardiac_output` a consumer computes
+% from a heart rate and stroke volume is exactly the `cardiac_output` the
+% `heart_rate` formula divides by that stroke volume to recover the heart rate, and
+% exactly the `cardiac_output` the `stroke_volume` formula divides by that heart
+% rate to recover the stroke volume.
+%
+%   cardiac_output(heart_rate, stroke_volume)   = heart_rate * stroke_volume     % CO = HR·SV  (definition)
+%   heart_rate(cardiac_output, stroke_volume)   = cardiac_output / stroke_volume  % HR = CO/SV  (same def, solved for HR)
+%   stroke_volume(cardiac_output, heart_rate)   = cardiac_output / heart_rate     % SV = CO/HR  (same def, solved for SV)
+%
+% NOTE: the units must be consistent — a stroke volume in millilitres per beat and a
+% heart rate in beats per minute give a cardiac output in millilitres per minute
+% (divide by 1000 for L/min); this library computes the exact value over whatever
+% consistent units it is given.
+%
+% All three formulas are defended by the SAME definitional sentence — "To calculate
+% this value, multiply stroke volume (SV), the amount of blood pumped by each
+% ventricle, by heart rate (HR), in contractions per minute (or beats per minute,
+% bpm)." — because that one definition (cardiac output IS stroke volume times heart
+% rate) sanctions the relation read every way (CO from HR and SV, HR from CO and SV,
+% or SV from CO and HR). The quote is transcribed verbatim from the OpenStax Anatomy
+% and Physiology 2e "Cardiac Physiology" chapter on Medicine LibreTexts (a
+% university-hosted open physiology text — the same primary reference family the
+% other clinical libraries draw on), so each `formula` carries the provenance
+% envelope every shipped grounded clause carries; the linter rejects an unsourced
+% one. (See feedback_nothing_human_authored — the definitional sentence is a
+% verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable physiological quantity the definition
+% ranges over, and each result is the derived quantity. `cardiac_output`,
+% `heart_rate` and `stroke_volume` each appear BOTH as a derived result and as an
+% input (of the other formulas), so each is a single dictionary term used in both
+% roles. The `surface` lists are the everyday names a decomposer maps onto the
+% canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary cardiac_output_vocab {
+    define heart_rate     : finding  surface "heart rate", "HR"                    % beats per minute (bpm)
+    define stroke_volume  : finding  surface "stroke volume", "SV"                 % millilitres per beat (mL)
+    define cardiac_output : finding  surface "cardiac output", "CO"                % millilitres per minute (mL/min)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable `let` over
+% its formal parameters, bound at apply time, and each carries the definitional
+% quote from OpenStax A&P on LibreTexts (a quote is required on a shipped formula).
+% One is a product and two are quotients, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook cardiac_output_laws {
+    use cardiac_output_vocab
+
+    % Cardiac output — the product of heart rate and stroke volume. OpenStax defines
+    % cardiac output as the stroke volume multiplied by the heart rate, i.e.
+    % CO = HR·SV.
+    formula cardiac_output(heart_rate, stroke_volume) = heart_rate * stroke_volume
+        source "To calculate this value, multiply stroke volume (SV), the amount of blood pumped by each ventricle, by heart rate (HR), in contractions per minute (or beats per minute, bpm)."
+        locator "https://med.libretexts.org/Bookshelves/Anatomy_and_Physiology/Anatomy_and_Physiology_2e_(OpenStax)/04:_Fluids_and_Transport/19:_The_Cardiovascular_System_-_The_Heart/19.05:_Cardiac_Physiology"
+        trust authoritative
+
+    % Heart rate — the same definition solved for the heart rate a cardiac output
+    % implies for a stroke volume (HR = CO/SV). Defended by the SAME definitional
+    % sentence, read the other way.
+    formula heart_rate(cardiac_output, stroke_volume) = cardiac_output / stroke_volume
+        source "To calculate this value, multiply stroke volume (SV), the amount of blood pumped by each ventricle, by heart rate (HR), in contractions per minute (or beats per minute, bpm)."
+        locator "https://med.libretexts.org/Bookshelves/Anatomy_and_Physiology/Anatomy_and_Physiology_2e_(OpenStax)/04:_Fluids_and_Transport/19:_The_Cardiovascular_System_-_The_Heart/19.05:_Cardiac_Physiology"
+        trust authoritative
+
+    % Stroke volume — the same definition solved for the stroke volume a cardiac
+    % output implies for a heart rate (SV = CO/HR). Again the SAME definitional
+    % sentence, read the third way.
+    formula stroke_volume(cardiac_output, heart_rate) = cardiac_output / heart_rate
+        source "To calculate this value, multiply stroke volume (SV), the amount of blood pumped by each ventricle, by heart rate (HR), in contractions per minute (or beats per minute, bpm)."
+        locator "https://med.libretexts.org/Bookshelves/Anatomy_and_Physiology/Anatomy_and_Physiology_2e_(OpenStax)/04:_Fluids_and_Transport/19:_The_Cardiovascular_System_-_The_Heart/19.05:_Cardiac_Physiology"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/cardiac-output.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/cardiac-output.query.adj
@@ -1,0 +1,34 @@
+% ============================================================================
+% cardiac-output.query.adj — worked examples over the clinical cardiac-output library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a cardiac-output
+% question: it states NO arithmetic and NO definition — it only `import`s the
+% grounded library, `observe`s the physiological quantities it decomposed from the
+% prompt (each a byte-provenanced span, elided here), and asks the engine to APPLY
+% the cited definition. The native adj-lang engine binds the parameters, computes
+% each value EXACTLY on the CPU, and returns it with the definition's
+% source/locator/trust.
+%
+% The three questions INVERT: a heart pumping 70 mL per beat at 75 bpm has a cardiac
+% output of 75·70 = 5250 mL/min (5.25 L/min); that 5250 mL/min output at the same
+% 70 mL stroke volume is exactly what the heart-rate formula divides to recover the
+% 75 bpm, and that 5250 mL/min at the same 75 bpm is exactly what the stroke-volume
+% formula divides to recover the 70 mL.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli cardiac-output.query.adj
+% ============================================================================
+
+import "cardiac-output.adj"
+
+% 75 bpm at 70 mL/beat: cardiac output = 75 * 70.
+observe heart_rate(75)
+observe stroke_volume(70)
+? cardiac_output(heart_rate, stroke_volume)   % expect 5250   (definition: CO = HR·SV)
+
+% That 5250 mL/min output for the same 70 mL stroke volume: heart rate = 5250 / 70.
+observe cardiac_output(5250)
+? heart_rate(cardiac_output, stroke_volume)    % expect 75     (same definition, solved for HR = CO/SV)
+
+% That 5250 mL/min output at the same 75 bpm: stroke volume = 5250 / 75.
+? stroke_volume(cardiac_output, heart_rate)    % expect 70     (same definition, solved for SV = CO/HR)


### PR DESCRIPTION
## What

Adds `clinical/cardiac-output.adj` — the definition of **cardiac output** as the product of heart rate and stroke volume (**CO = HR·SV**), with its two exact rearrangements (HR = CO/SV, SV = CO/HR). A parameterized, byte-provenanced `formula`: a consumer states **no arithmetic** — it imports the library, `observe`s the measured quantities, and the engine applies the cited definition on the CPU, computing each value **exactly** (BigRational) and carrying the citation into the auditable `derived` section.

All three formulas are **exact over their parameters** (one product, two quotients), so no separately-grounded constant is needed. They compose and invert cleanly around the worked case **HR = 75 bpm, SV = 70 mL → CO = 5250 mL/min = 5.25 L/min** (the average resting value).

## Grounding

The defining sentence is transcribed **verbatim** from the OpenStax *Anatomy and Physiology 2e* "Cardiac Physiology" chapter on Medicine LibreTexts:

> "To calculate this value, multiply stroke volume (SV), the amount of blood pumped by each ventricle, by heart rate (HR), in contractions per minute (or beats per minute, bpm)."

— the one definition that sanctions the relation read every way. `trust authoritative`. (Per `feedback_nothing_human_authored`: the sentence is a verbatim span of the cited page, not asserted from memory.)

## Files

- `clinical/cardiac-output.adj` — the grounded 3-way library (dictionary + formulabook)
- `clinical/cardiac-output.query.adj` — worked examples over the three inversions
- `adj-lang-cli/tests/formula_cardiac_output_e2e.rs` — dedicated end-to-end test driving the built CLI against the shipped stdlib

## Verification

- `cargo test -p adj-lang-cli --test formula_cardiac_output_e2e` → **3/3 pass** (asserts exact 5250/75/70, `trust authoritative`, and the LibreTexts citation)
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean
- Shipped query run through the CLI → 5250 / 75 / 70, all exact, authoritative, LibreTexts-cited
- NUL-scan: 0 bytes in all three files
- Data + test only — **no version bump**
- `/security-review` → PASSED (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)