### PR TITLE
fix(ci): repair main Python lint and Lua E2E crashes

### DIFF
--- a/code/packages/lua/conduit/CHANGELOG.md
+++ b/code/packages/lua/conduit/CHANGELOG.md
@@ -5,6 +5,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## Unreleased
+
+### Fixed
+
+- Run the real-TCP E2E fixture through foreground `serve()` in a dedicated Lua
+  child process. The previous in-process `serve_background()` fixture allowed
+  Busted and native request threads to access one `lua_State` concurrently,
+  causing intermittent Linux segmentation faults.
+
 ## [1.0.0] — 2026-04-24
 
 ### Added

--- a/code/packages/lua/conduit/README.md
+++ b/code/packages/lua/conduit/README.md
@@ -104,13 +104,17 @@ Or just run the `BUILD` script via the repo build tool.
 - `tests/test_request.lua` — Request accessor methods
 - `tests/test_handler_context.lua` — Response helpers
 - `tests/test_application.lua` — Route registration and settings
-- `tests/test_server.lua` — Full E2E via real TCP (requires luasocket)
+- `tests/test_server.lua` — Full E2E via real TCP, with the foreground server
+  isolated in a child process (requires luasocket)
 
 ## Threading model
 
 Lua 5.4 is single-threaded. `web-core` dispatches requests on background Rust
 I/O threads. Every dispatch closure acquires an `Arc<Mutex<()>>` (the "Lua lock")
-before calling `lua_pcall`, serialising all Lua re-entries to a single OS thread.
+before calling `lua_pcall`, serialising native callbacks with each other. The
+lock does not guard ordinary execution on the Lua process's main thread, so
+tests run the foreground server in a dedicated child process while Busted
+drives it over TCP.
 
 ## Dependencies
 

--- a/code/packages/lua/conduit/tests/server_fixture.lua
+++ b/code/packages/lua/conduit/tests/server_fixture.lua
@@ -1,0 +1,57 @@
+-- Shared application fixture for the Conduit server E2E tests.
+
+local conduit = require("conduit")
+
+local M = {}
+
+function M.build_app()
+    local app = conduit.Application.new()
+    app:set("app_name", "Conduit E2E Test")
+
+    app:before(function(ctx)
+        if ctx:path() == "/down" then
+            conduit.halt(503, "Under maintenance")
+        end
+    end)
+
+    app:get("/", function()
+        return conduit.html("<h1>Hello from Conduit!</h1>")
+    end)
+
+    app:get("/hello/:name", function(ctx)
+        local name = ctx:params()["name"]
+        return conduit.json({ message = "Hello " .. name })
+    end)
+
+    app:post("/echo", function(ctx)
+        return conduit.json(ctx:json_body())
+    end)
+
+    app:get("/redirect", function()
+        return conduit.redirect("/", 301)
+    end)
+
+    app:get("/halt", function()
+        conduit.halt(403, "Forbidden — this route always halts")
+    end)
+
+    app:get("/down", function()
+        return conduit.html("this should never be reached")
+    end)
+
+    app:get("/error", function()
+        error("Intentional error for testing")
+    end)
+
+    app:not_found(function(ctx)
+        return conduit.json({ message = "Not Found", path = ctx:path() }, 404)
+    end)
+
+    app:error_handler(function()
+        return conduit.json({ error = "Internal Server Error" }, 500)
+    end)
+
+    return app
+end
+
+return M

--- a/code/packages/lua/conduit/tests/server_process.lua
+++ b/code/packages/lua/conduit/tests/server_process.lua
@@ -1,0 +1,24 @@
+-- Run the Conduit E2E fixture in a dedicated foreground Lua process.
+
+package.path = "../?.lua;../?/init.lua;" .. package.path
+package.cpath = "../?.so;../?.dll;" .. package.cpath
+
+local conduit = require("conduit")
+local fixture = dofile("server_fixture.lua")
+local app = fixture.build_app()
+local server
+
+app:get("/__test_running", function()
+    return conduit.json({ running = server:running() })
+end)
+
+app:get("/__test_shutdown", function()
+    server:stop()
+    return conduit.json({ status = "stopping" })
+end)
+
+server = conduit.Server.new(app, { host = "127.0.0.1", port = 0 })
+
+io.write("CONDUIT_READY " .. server:local_port() .. "\n")
+io.flush()
+server:serve()

--- a/code/packages/lua/conduit/tests/test_server.lua
+++ b/code/packages/lua/conduit/tests/test_server.lua
@@ -3,8 +3,8 @@
 -- Starts a real TCP server on an ephemeral port, makes HTTP requests via
 -- luasocket, and asserts on status codes, headers, and response bodies.
 --
--- All tests share a single server instance (started in before_all / lazy
--- startup) to keep test run time short.
+-- All tests share a foreground server in a dedicated child process. This keeps
+-- Busted and native request threads from concurrently accessing one lua_State.
 --
 -- If luasocket is not installed, the E2E tests are pending (skipped).
 
@@ -21,7 +21,9 @@ if not (socket_http_ok and ltn12_ok and socket_ok) then
     return
 end
 
-local conduit = require("conduit")
+socket_http.TIMEOUT = 5
+
+local fixture = dofile("server_fixture.lua")
 
 -- ---------------------------------------------------------------------------
 -- Helpers
@@ -78,79 +80,24 @@ end
 local server_instance
 local server_port
 
-local function build_app()
-    local app = conduit.Application.new()
-    app:set("app_name", "Conduit E2E Test")
-
-    -- Before filter: block /down
-    app:before(function(ctx)
-        if ctx:path() == "/down" then
-            conduit.halt(503, "Under maintenance")
-        end
-    end)
-
-    -- GET /
-    app:get("/", function(ctx)
-        return conduit.html("<h1>Hello from Conduit!</h1>")
-    end)
-
-    -- GET /hello/:name
-    app:get("/hello/:name", function(ctx)
-        local name = ctx:params()["name"]
-        return conduit.json({ message = "Hello " .. name })
-    end)
-
-    -- POST /echo  — echoes the JSON body
-    app:post("/echo", function(ctx)
-        local data = ctx:json_body()
-        return conduit.json(data)
-    end)
-
-    -- GET /redirect → 301 to /
-    app:get("/redirect", function(ctx)
-        return conduit.redirect("/", 301)
-    end)
-
-    -- GET /halt → 403 Forbidden via halt()
-    app:get("/halt", function(ctx)
-        conduit.halt(403, "Forbidden — this route always halts")
-    end)
-
-    -- GET /down → unreachable (before filter intercepts)
-    app:get("/down", function(ctx)
-        return conduit.html("this should never be reached")
-    end)
-
-    -- GET /error → triggers error handler
-    app:get("/error", function(ctx)
-        error("Intentional error for testing")
-    end)
-
-    -- Custom not-found handler (JSON to avoid XSS from raw path interpolation)
-    app:not_found(function(ctx)
-        return conduit.json({ message = "Not Found", path = ctx:path() }, 404)
-    end)
-
-    -- Custom error handler
-    app:error_handler(function(ctx, err)
-        return conduit.json({ error = "Internal Server Error" }, 500)
-    end)
-
-    return app
-end
-
 setup(function()
-    local app = build_app()
-    server_instance = conduit.Server.new(app, { host = "127.0.0.1", port = 0 })
-    server_instance:serve_background()
-    server_port = server_instance:local_port()
+    server_instance = assert(io.popen("lua server_process.lua 2>&1", "r"))
+    local ready_line = server_instance:read("*l")
+    assert.is_truthy(ready_line, "Conduit server process exited before startup")
+    server_port = tonumber(ready_line:match("^CONDUIT_READY (%d+)$"))
+    assert.is_truthy(
+        server_port,
+        "unexpected Conduit server startup output: " .. ready_line
+    )
     assert.is_true(wait_for_server(server_port, 5), "Server did not start in time")
 end)
 
 teardown(function()
+    if server_instance and server_port then
+        pcall(get, server_port, "/__test_shutdown")
+    end
     if server_instance then
-        server_instance:stop()
-        socket.sleep(0.1)
+        server_instance:close()
     end
 end)
 
@@ -240,13 +187,13 @@ describe("conduit.Server (E2E)", function()
     end)
 
     it("server:running() returns true while serving", function()
-        assert.is_true(server_instance:running())
+        local r = get(server_port, "/__test_running")
+        assert.equal(200, r.status)
+        assert.truthy(r.body:find('"running":true', 1, true))
     end)
 
     it("app:get(key) returns the configured setting", function()
-        -- Verify settings survive from Application creation to request time.
-        -- We test this by checking the app object directly (not via HTTP).
-        local app = build_app()
+        local app = fixture.build_app()
         assert.equal("Conduit E2E Test", app:get("app_name"))
     end)
 

--- a/code/packages/python/audio-device-sink/src/audio_device_sink/__init__.py
+++ b/code/packages/python/audio-device-sink/src/audio_device_sink/__init__.py
@@ -45,7 +45,7 @@ def _integer_sample_rate(value: Any) -> int:
         converted = float(value)
         if not isfinite(converted) or converted != round(converted):
             raise ValueError("sample_rate_hz must be an integer-valued rate")
-        rate = int(round(converted))
+        rate = round(converted)
     else:
         raise TypeError("sample_rate_hz must be an integer")
 
@@ -127,7 +127,7 @@ def play_pcm_buffer(buffer: Any) -> PlaybackReport:
 
 __version__ = "0.1.0"
 
-__all__ = [
+__all__ = [  # noqa: RUF022 - preserve the package's stable export order
     "AudioDeviceError",
     "MAX_BLOCKING_DURATION_SECONDS",
     "MAX_SAMPLE_RATE_HZ",

--- a/code/packages/python/audio-device-sink/tests/test_audio_device_sink.py
+++ b/code/packages/python/audio-device-sink/tests/test_audio_device_sink.py
@@ -2,16 +2,15 @@ from __future__ import annotations
 
 import sys
 
-import pytest
-from pcm_audio import PCMBuffer, PCMFormat
-
 import audio_device_sink as audio_device_sink_module
+import pytest
 from audio_device_sink import (
     AudioDeviceError,
     PlaybackReport,
     play_pcm_buffer,
     play_samples,
 )
+from pcm_audio import PCMBuffer, PCMFormat
 
 
 def test_play_samples_normalizes_and_delegates_to_native_boundary(

--- a/code/packages/python/audio-device-sink/tests/test_audio_device_sink.py
+++ b/code/packages/python/audio-device-sink/tests/test_audio_device_sink.py
@@ -2,15 +2,16 @@ from __future__ import annotations
 
 import sys
 
-import audio_device_sink as audio_device_sink_module
 import pytest
+from pcm_audio import PCMBuffer, PCMFormat
+
+import audio_device_sink as audio_device_sink_module
 from audio_device_sink import (
     AudioDeviceError,
     PlaybackReport,
     play_pcm_buffer,
     play_samples,
 )
-from pcm_audio import PCMBuffer, PCMFormat
 
 
 def test_play_samples_normalizes_and_delegates_to_native_boundary(

--- a/code/packages/python/note-frequency/src/note_frequency/__init__.py
+++ b/code/packages/python/note-frequency/src/note_frequency/__init__.py
@@ -1,4 +1,3 @@
 from .note import Note, note_to_frequency, parse_note
 
-__all__ = ["Note", "parse_note", "note_to_frequency"]
-
+__all__ = ["Note", "note_to_frequency", "parse_note"]

--- a/code/packages/python/note-frequency/src/note_frequency/note.py
+++ b/code/packages/python/note-frequency/src/note_frequency/note.py
@@ -13,8 +13,8 @@ From there, each semitone step changes frequency by a factor of ``2 ** (1/12)``.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import re
+from dataclasses import dataclass
 
 NOTE_PATTERN = re.compile(r"^([A-Ga-g])([#b]?)(-?\d+)$")
 
@@ -122,4 +122,3 @@ def note_to_frequency(text: str) -> float:
     """Parse a note label and return its equal-tempered frequency in Hertz."""
 
     return parse_note(text).frequency()
-

--- a/code/packages/python/note-frequency/tests/test_note_frequency.py
+++ b/code/packages/python/note-frequency/tests/test_note_frequency.py
@@ -1,4 +1,5 @@
 import pytest
+
 from note_frequency import Note, note_to_frequency, parse_note
 
 

--- a/code/packages/python/note-frequency/tests/test_note_frequency.py
+++ b/code/packages/python/note-frequency/tests/test_note_frequency.py
@@ -1,5 +1,4 @@
 import pytest
-
 from note_frequency import Note, note_to_frequency, parse_note
 
 
@@ -69,4 +68,3 @@ class TestFrequencyMapping:
 
     def test_note_to_frequency_wrapper(self) -> None:
         assert note_to_frequency("Bb3") == pytest.approx(parse_note("Bb3").frequency(), rel=1e-12)
-

--- a/code/programs/lua/conduit-hello/CHANGELOG.md
+++ b/code/programs/lua/conduit-hello/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — conduit-hello (Lua)
 
+## Unreleased
+
+### Fixed
+- Run the E2E server in a dedicated Lua child process using the production
+  foreground `serve()` path. The previous in-process `serve_background()` test
+  allowed the Busted runner and native request threads to access one
+  `lua_State` concurrently, causing a segmentation fault on Linux CI.
+
 ## 1.0.0 — 2026-06-15
 
 Standardise the Lua demo to match every other Conduit `conduit-hello` program

--- a/code/programs/lua/conduit-hello/README.md
+++ b/code/programs/lua/conduit-hello/README.md
@@ -43,16 +43,17 @@ curl http://127.0.0.1:3000/missing
 `hello.lua` exposes a `build_app()` factory that returns a configured
 `conduit.Application` without starting a server, plus a `serve()` helper. When
 run directly (`lua hello.lua`) it serves in the foreground on port 3000; when
-loaded as a module (by the tests) it only returns the factory. This is what lets
-the test suite construct the same app and drive it over a background server.
+loaded as a module it only returns the factory. The test helper loads that
+factory in a dedicated child process and runs the same foreground server mode.
 
 ## Tests
 
 `tests/test_hello.lua` is an end-to-end suite (busted): it loads `build_app()`,
-serves it on an ephemeral port in the background, and hits every route over real
-HTTP via `luasocket`, asserting status codes and bodies. If `luasocket` is not
-installed the E2E tests are skipped (pending), mirroring the conduit library's
-own server tests.
+starts the foreground server on an ephemeral port in a dedicated Lua child
+process, and hits every route over real HTTP via `luasocket`, asserting status
+codes and bodies. Isolating the server also prevents the test runner and native
+request threads from concurrently accessing one Lua state. If `luasocket` is
+not installed the E2E tests are skipped (pending).
 
 ```sh
 cd tests && busted . --pattern=test_

--- a/code/programs/lua/conduit-hello/tests/server_process.lua
+++ b/code/programs/lua/conduit-hello/tests/server_process.lua
@@ -1,0 +1,29 @@
+-- Run the conduit-hello demo in a dedicated Lua process for the E2E suite.
+--
+-- A Lua state cannot be driven by the test runner while native worker threads
+-- invoke callbacks on that same state. Keeping the foreground server in this
+-- child process leaves its main Lua thread blocked in Server:serve(), which is
+-- the production execution model, while the parent process drives HTTP.
+
+package.path = "../../../../packages/lua/conduit/?.lua;"
+    .. "../../../../packages/lua/conduit/?/init.lua;"
+    .. package.path
+package.cpath = "../../../../packages/lua/conduit/?.so;"
+    .. "../../../../packages/lua/conduit/?.dll;"
+    .. package.cpath
+
+local conduit = require("conduit")
+local demo = dofile("../hello.lua")
+local app = demo.build_app()
+local server
+
+app:get("/__test_shutdown", function()
+    server:stop()
+    return conduit.json({ status = "stopping" })
+end)
+
+server = conduit.Server.new(app, { host = "127.0.0.1", port = 0 })
+
+io.write("CONDUIT_READY " .. server:local_port() .. "\n")
+io.flush()
+server:serve()

--- a/code/programs/lua/conduit-hello/tests/test_hello.lua
+++ b/code/programs/lua/conduit-hello/tests/test_hello.lua
@@ -1,8 +1,8 @@
 -- test_hello.lua — End-to-end tests for the conduit-hello Lua demo.
 --
--- Loads the demo's `build_app()` (without starting its foreground server),
--- serves it on an ephemeral port in the background, and drives every route over
--- real HTTP via luasocket — mirroring the conduit library's own `test_server`.
+-- Starts the demo's production foreground server in a dedicated child process,
+-- then drives every route over real HTTP via luasocket — mirroring the conduit
+-- library's own `test_server`.
 --
 -- If luasocket is not installed the E2E tests are pending (skipped), exactly
 -- like the library suite, so the demo still builds where the optional socket
@@ -30,7 +30,7 @@ if not (socket_http_ok and ltn12_ok and socket_ok) then
     return
 end
 
-local conduit = require("conduit")
+socket_http.TIMEOUT = 5
 
 -- ---------------------------------------------------------------------------
 -- HTTP helpers (same shape as the library's test_server.lua)
@@ -86,21 +86,23 @@ local server_port
 
 describe("conduit-hello demo (Lua)", function()
     setup(function()
-        -- `dofile` the demo: its bottom-of-file guard only serves when invoked
-        -- as `lua hello.lua` (arg[0] ends in hello.lua), so under busted it just
-        -- returns the module table without starting a foreground server.
-        local demo = dofile("../hello.lua")
-        local app = demo.build_app()
-        server_instance = conduit.Server.new(app, { host = "127.0.0.1", port = 0 })
-        server_instance:serve_background()
-        server_port = server_instance:local_port()
+        server_instance = assert(io.popen("lua server_process.lua 2>&1", "r"))
+        local ready_line = server_instance:read("*l")
+        assert.is_truthy(ready_line, "demo server process exited before startup")
+        server_port = tonumber(ready_line:match("^CONDUIT_READY (%d+)$"))
+        assert.is_truthy(
+            server_port,
+            "unexpected demo server startup output: " .. ready_line
+        )
         assert.is_true(wait_for_server(server_port, 5), "demo server did not start in time")
     end)
 
     teardown(function()
+        if server_instance and server_port then
+            pcall(get, server_port, "/__test_shutdown")
+        end
         if server_instance then
-            server_instance:stop()
-            socket.sleep(0.1)
+            server_instance:close()
         end
     end)
 

--- a/lessons.md
+++ b/lessons.md
@@ -162,6 +162,13 @@ A condensed quick-reference of mistakes made during development, grouped by cate
 
 ## Native extensions & FFI
 
+- **Do not drive a Lua state from the test runner while native worker threads
+  invoke callbacks on that same state.** A Rust mutex can serialize the worker
+  callbacks with each other, but it cannot guard ordinary Lua execution in the
+  parent test thread. The result is nondeterministic stack corruption and
+  SIGSEGVs. Exercise a foreground native server in a dedicated Lua child process
+  and drive it over TCP from the parent.
+
 - **Ruby `QNIL = 0x04` on 64-bit Ruby (USE_FLONUM), not `0x08`.** The pre-FLONUM `0x08` causes Ruby to dereference it as an object pointer (klass at `+8` → SIGSEGV at `0x10`). Constants: `QFALSE=0x00, QNIL=0x04, QTRUE=0x14, QUNDEF=0x24`. Confirm against `ruby/internal/special_consts.h`. When a Ruby native ext SIGSEGVs at low addresses like `0x10`, suspect a special-constant bit-pattern bug.
 - **Lua 5.4 `LUA_REGISTRYINDEX = -1_001_000`** (derived from `-LUAI_MAXSTACK - 1000`), NOT the Lua 5.1 value `-10000`. Using `-10000` in `luaL_ref` treats it as a regular negative stack index, landing 10000 slots below the frame and causing SIGBUS/SIGSEGV.
 - **Lua userdata GC + raw `luaL_ref` integers**: integer slots aren't tracked by the GC. If Rust holds `i32` registry refs derived from a userdata's state, pin the userdata itself in the registry (extra `lua_pushvalue` + `luaL_ref`) and unref it only after all integer refs retire — otherwise Linux's aggressive incremental GC collects the parent and your slots become nil mid-flight.


### PR DESCRIPTION
## What changed

- fix the `note-frequency` and `audio-device-sink` Ruff failures reported by the full main build
- preserve `audio-device-sink`'s stable public export order while documenting the targeted Ruff exception
- run both Lua Conduit real-TCP E2E suites in dedicated child processes through the production foreground `serve()` path
- share the package E2E application fixture between its parent assertions and child server
- document the corrected Lua threading model in the package/demo docs, changelogs, and repository lessons

## Root cause

The Python failures were deterministic import/export ordering and redundant conversion violations.

Both Lua suites used `serve_background()` inside their Busted processes. That allowed the Busted main thread and native request threads to touch the same non-thread-safe `lua_State`; the Rust mutex only serialized native callbacks with each other, so Linux CI could corrupt the Lua stack and segfault nondeterministically. The linked run happened to crash in the demo, while the PR matrix exposed the same latent race in the prerequisite package suite.

The child processes keep each foreground server's Lua main thread blocked in its normal production execution path while Busted drives real HTTP from the parent.

Fixes the package failures in https://github.com/adhithyan15/coding-adventures/actions/runs/30179498588/

## Validation

- CI-matched Ruff classification across both changed Python packages
- `note-frequency`: 22 tests passed
- `audio-device-sink`: 18 wrapper tests passed against a controlled native boundary
- Lua native extension: `cargo build --release`
- all changed Lua test files: `luac -p`
- both foreground child servers: real HTTP route sweeps and clean shutdown
- `git diff --check`
- repository build tool compiled and detected the affected dependency plan

The full local Windows build-tool validation remains blocked by unrelated existing `BUILD_windows` metadata errors; the PR's Linux/macOS/Windows matrix is the end-to-end gate.