### PR TITLE
feat(hl03): the independent (word-initial) vowels (HL03 syllabary PR6)

### DIFF
--- a/code/learning/human-languages/data/scripts/generate_syllabary.py
+++ b/code/learning/human-languages/data/scripts/generate_syllabary.py
@@ -125,6 +125,31 @@ def build_script(script_id: str, name: str, base: int, font: str, signature: str
                 "strokeOrder": [],       # recognition only — ductus is a separate, paused effort
                 "strokeOrderNote": "",
             })
+
+    # The independent (standalone) vowels — the letters a word writes when it
+    # BEGINS with a vowel (అ a, ఆ ā, …), as opposed to the vowel SIGNS above that
+    # ride on a consonant. Same vowels, different glyphs; without them a
+    # vowel-initial word can't be read. Grounded the same way: each is a Unicode
+    # "<SCRIPT> LETTER <V>" (the inherent /a/ is LETTER A), romanized in ISO-15919
+    # from the shared VOWELS table — never guessed. Kept in a SEPARATE list, not
+    # mixed into `letters`, so the consonant syllabary (and everything keyed on it
+    # being all-syllables) is untouched. Recognition only — no ductus.
+    independent = []
+    for vow_tok, vow_rom in VOWELS:
+        letter_tok = "A" if vow_tok == "" else vow_tok
+        cp = codepoint_by_name(f"{up} LETTER {letter_tok}", base)
+        if cp is None:
+            continue  # this script lacks this independent vowel — skip, never invent
+        ch = chr(cp)
+        independent.append({
+            "glyph": ch,
+            "sound": vow_rom,
+            "role": "vowel",
+            "components": [f"{ch}  {vow_rom} — independent vowel (word-initial)"],
+            "strokeOrder": [],
+            "strokeOrderNote": "",
+        })
+
     return {
         "script": script_id,
         "name": name,
@@ -136,9 +161,11 @@ def build_script(script_id: str, name: str, base: int, font: str, signature: str
         "notes": (
             "Syllabary generated from Unicode by generate_syllabary.py: each syllable is a base "
             "consonant (varga order) composed with a core vowel sign. Romanization is ISO-15919. "
+            "The independent (word-initial) vowels are in `independentVowels`. "
             "Recognition only — stroke order is a separate, source-gated effort and is omitted."
         ),
         "letters": letters,
+        "independentVowels": independent,
     }
 
 

--- a/code/learning/human-languages/data/scripts/kannada.json
+++ b/code/learning/human-languages/data/scripts/kannada.json
@@ -6,7 +6,7 @@
   "system": "abugida",
   "signature": "Rounded and looping like Telugu (its sister script), most letters topped by a small curved headstroke; no continuous top line.",
   "complete": false,
-  "notes": "Syllabary generated from Unicode by generate_syllabary.py: each syllable is a base consonant (varga order) composed with a core vowel sign. Romanization is ISO-15919. Recognition only — stroke order is a separate, source-gated effort and is omitted.",
+  "notes": "Syllabary generated from Unicode by generate_syllabary.py: each syllable is a base consonant (varga order) composed with a core vowel sign. Romanization is ISO-15919. The independent (word-initial) vowels are in `independentVowels`. Recognition only — stroke order is a separate, source-gated effort and is omitted.",
   "letters": [
     {
       "glyph": "ಕ",
@@ -5429,6 +5429,138 @@
       "components": [
         "ಱ  ṟa — base consonant",
         "ೃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    }
+  ],
+  "independentVowels": [
+    {
+      "glyph": "ಅ",
+      "sound": "a",
+      "role": "vowel",
+      "components": [
+        "ಅ  a — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಆ",
+      "sound": "ā",
+      "role": "vowel",
+      "components": [
+        "ಆ  ā — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಇ",
+      "sound": "i",
+      "role": "vowel",
+      "components": [
+        "ಇ  i — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಈ",
+      "sound": "ī",
+      "role": "vowel",
+      "components": [
+        "ಈ  ī — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಉ",
+      "sound": "u",
+      "role": "vowel",
+      "components": [
+        "ಉ  u — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಊ",
+      "sound": "ū",
+      "role": "vowel",
+      "components": [
+        "ಊ  ū — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಎ",
+      "sound": "e",
+      "role": "vowel",
+      "components": [
+        "ಎ  e — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಏ",
+      "sound": "ē",
+      "role": "vowel",
+      "components": [
+        "ಏ  ē — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಒ",
+      "sound": "o",
+      "role": "vowel",
+      "components": [
+        "ಒ  o — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಓ",
+      "sound": "ō",
+      "role": "vowel",
+      "components": [
+        "ಓ  ō — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಐ",
+      "sound": "ai",
+      "role": "vowel",
+      "components": [
+        "ಐ  ai — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಔ",
+      "sound": "au",
+      "role": "vowel",
+      "components": [
+        "ಔ  au — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ಋ",
+      "sound": "r̥",
+      "role": "vowel",
+      "components": [
+        "ಋ  r̥ — independent vowel (word-initial)"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""

--- a/code/learning/human-languages/data/scripts/malayalam.json
+++ b/code/learning/human-languages/data/scripts/malayalam.json
@@ -6,7 +6,7 @@
   "system": "abugida",
   "signature": "Highly rounded and loopy — full circles, hooks and curls, with almost no straight lines.",
   "complete": false,
-  "notes": "Syllabary generated from Unicode by generate_syllabary.py: each syllable is a base consonant (varga order) composed with a core vowel sign. Romanization is ISO-15919. Recognition only — stroke order is a separate, source-gated effort and is omitted.",
+  "notes": "Syllabary generated from Unicode by generate_syllabary.py: each syllable is a base consonant (varga order) composed with a core vowel sign. Romanization is ISO-15919. The independent (word-initial) vowels are in `independentVowels`. Recognition only — stroke order is a separate, source-gated effort and is omitted.",
   "letters": [
     {
       "glyph": "ക",
@@ -5584,6 +5584,138 @@
       "components": [
         "ഩ  ṉa — base consonant",
         "ൃ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    }
+  ],
+  "independentVowels": [
+    {
+      "glyph": "അ",
+      "sound": "a",
+      "role": "vowel",
+      "components": [
+        "അ  a — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ആ",
+      "sound": "ā",
+      "role": "vowel",
+      "components": [
+        "ആ  ā — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഇ",
+      "sound": "i",
+      "role": "vowel",
+      "components": [
+        "ഇ  i — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഈ",
+      "sound": "ī",
+      "role": "vowel",
+      "components": [
+        "ഈ  ī — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഉ",
+      "sound": "u",
+      "role": "vowel",
+      "components": [
+        "ഉ  u — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഊ",
+      "sound": "ū",
+      "role": "vowel",
+      "components": [
+        "ഊ  ū — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "എ",
+      "sound": "e",
+      "role": "vowel",
+      "components": [
+        "എ  e — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഏ",
+      "sound": "ē",
+      "role": "vowel",
+      "components": [
+        "ഏ  ē — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഒ",
+      "sound": "o",
+      "role": "vowel",
+      "components": [
+        "ഒ  o — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഓ",
+      "sound": "ō",
+      "role": "vowel",
+      "components": [
+        "ഓ  ō — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഐ",
+      "sound": "ai",
+      "role": "vowel",
+      "components": [
+        "ഐ  ai — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഔ",
+      "sound": "au",
+      "role": "vowel",
+      "components": [
+        "ഔ  au — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ഋ",
+      "sound": "r̥",
+      "role": "vowel",
+      "components": [
+        "ഋ  r̥ — independent vowel (word-initial)"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""

--- a/code/learning/human-languages/data/scripts/telugu.json
+++ b/code/learning/human-languages/data/scripts/telugu.json
@@ -6,7 +6,7 @@
   "system": "abugida",
   "signature": "Rounded, curvy letters, most crowned with a small tick or check-mark headstroke; no continuous top line.",
   "complete": false,
-  "notes": "Syllabary generated from Unicode by generate_syllabary.py: each syllable is a base consonant (varga order) composed with a core vowel sign. Romanization is ISO-15919. Recognition only — stroke order is a separate, source-gated effort and is omitted.",
+  "notes": "Syllabary generated from Unicode by generate_syllabary.py: each syllable is a base consonant (varga order) composed with a core vowel sign. Romanization is ISO-15919. The independent (word-initial) vowels are in `independentVowels`. Recognition only — stroke order is a separate, source-gated effort and is omitted.",
   "letters": [
     {
       "glyph": "క",
@@ -5429,6 +5429,138 @@
       "components": [
         "ఱ  ṟa — base consonant",
         "ృ  “r̥” vowel sign"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    }
+  ],
+  "independentVowels": [
+    {
+      "glyph": "అ",
+      "sound": "a",
+      "role": "vowel",
+      "components": [
+        "అ  a — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఆ",
+      "sound": "ā",
+      "role": "vowel",
+      "components": [
+        "ఆ  ā — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఇ",
+      "sound": "i",
+      "role": "vowel",
+      "components": [
+        "ఇ  i — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఈ",
+      "sound": "ī",
+      "role": "vowel",
+      "components": [
+        "ఈ  ī — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఉ",
+      "sound": "u",
+      "role": "vowel",
+      "components": [
+        "ఉ  u — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఊ",
+      "sound": "ū",
+      "role": "vowel",
+      "components": [
+        "ఊ  ū — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఎ",
+      "sound": "e",
+      "role": "vowel",
+      "components": [
+        "ఎ  e — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఏ",
+      "sound": "ē",
+      "role": "vowel",
+      "components": [
+        "ఏ  ē — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఒ",
+      "sound": "o",
+      "role": "vowel",
+      "components": [
+        "ఒ  o — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఓ",
+      "sound": "ō",
+      "role": "vowel",
+      "components": [
+        "ఓ  ō — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఐ",
+      "sound": "ai",
+      "role": "vowel",
+      "components": [
+        "ఐ  ai — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఔ",
+      "sound": "au",
+      "role": "vowel",
+      "components": [
+        "ఔ  au — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "ఋ",
+      "sound": "r̥",
+      "role": "vowel",
+      "components": [
+        "ఋ  r̥ — independent vowel (word-initial)"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.22.0 — the independent (word-initial) vowels (syllabary, PR 6)
+
+- **The syllabaries now carry their standalone vowels.** Everything so far was
+  consonant syllables (a consonant + a vowel *sign*); but a word that *begins*
+  with a vowel writes a different letter — the **independent vowel** (అ *a*,
+  ఆ *ā*, ఇ *i* … ఔ *au*, ఋ *r̥*). Without them a vowel-initial word can't be read.
+  Browse now shows an **"Independent vowels (word-initial)"** strip above the
+  grid for the three Dravidian scripts.
+- **Still Unicode-grounded, still additive.** The generator composes each from
+  `<SCRIPT> LETTER <V>` (the inherent /a/ is `LETTER A`), romanized in ISO-15919
+  from the same vetted vowel table as the signs — never re-typed, so the vocalic
+  R is r̥ (r + U+0325), not IAST ṛ. They live in a **separate `independentVowels`
+  field**, not mixed into `letters`, so the consonant syllabary — and the
+  slow-unlock gate and the matrix that key on it being all-syllables — is
+  completely untouched (the generated `letters` are byte-for-byte unchanged).
+- **Control test.** Asserts the real Telugu independent vowels are the 13 expected
+  glyphs + ISO-15919 romans (role `vowel`, no fabricated ductus, r̥ = r + U+0325),
+  all three scripts carry them, and — the control — none leak into `letters`, so
+  `isSyllabary` still holds and the matrix still builds its full 35 × 13 grid.
+
 ## 0.21.0 — Browse a syllabary as its consonant × vowel matrix (syllabary, PR 5)
 
 - **The syllabaries now offer a grid view.** A Dravidian abugida isn't a flat

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -177,6 +177,15 @@ the first consonant's own row, and a ragged script yields **no matrix** rather
 than a mislabelled cell (unit-tested with a control). No new data — the same
 generated syllables, re-arranged.
 
+**The independent (word-initial) vowels.** Everything above is consonant + vowel
+*sign*; a word that *begins* with a vowel writes a different letter — the
+independent vowel (అ *a*, ఆ *ā* … ఔ *au*, ఋ *r̥*). Browse shows these as a small
+strip above the grid. They are generated the same way (`<SCRIPT> LETTER <V>`,
+ISO-15919 roman from the shared vowel table) but kept in a **separate
+`independentVowels` field**, not mixed into `letters`, so the syllabary and the
+gate/matrix that key on it being all-syllables are untouched. Control-tested
+(the 13 grounded glyphs; none leak into `letters`, so `isSyllabary` still holds).
+
 ## Design
 
 - **`src/core.ts`** — the pure, unit-tested heart: `buildScriptView`,

--- a/code/programs/typescript/language-ladder/package.json
+++ b/code/programs/typescript/language-ladder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ladder",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "private": true,
   "description": "The unified curriculum learning app (HL03): walk the language chain concept by concept, seeing the threads back to what you already know, then review it all with a randomised SRS quiz. (Was the HL02 script-writing-visualizer, whose Browse/Practice/Lessons/Concepts modes it now subsumes.)",
   "type": "module",

--- a/code/programs/typescript/language-ladder/src/main.ts
+++ b/code/programs/typescript/language-ladder/src/main.ts
@@ -397,6 +397,32 @@ function renderGrid(views: LetterView[], dir: "ltr" | "rtl"): HTMLElement {
   return grid;
 }
 
+/**
+ * The independent (word-initial) vowels as a small read-only strip — the letters
+ * a word writes when it BEGINS with a vowel (అ a, ఆ ā), distinct from the vowel
+ * signs that ride on a consonant in the grid below. Recognition only; each tile
+ * shows the glyph and its ISO-15919 romanization.
+ */
+function renderIndependentVowels(vowels: Letter[]): HTMLElement {
+  const wrap = el("div", "ivowels");
+  const label = el("span", "ivowels__label");
+  label.textContent = "Independent vowels (word-initial):";
+  wrap.appendChild(label);
+  const row = el("div", "ivowels__row");
+  vowels.forEach((v) => {
+    const tile = el("div", "ivowel");
+    const glyph = el("span", "ivowel__glyph");
+    glyph.textContent = v.glyph;
+    const sound = el("span", "ivowel__sound");
+    sound.textContent = v.sound;
+    tile.append(glyph, sound);
+    tile.title = v.sound;
+    row.appendChild(tile);
+  });
+  wrap.appendChild(row);
+  return wrap;
+}
+
 /** For a syllabary, a "List / Matrix" switch — the flat grid, or the table. */
 function renderBrowseLayoutToggle(): HTMLElement {
   const wrap = el("div", "layouts");
@@ -1394,6 +1420,9 @@ function render(): void {
     // The syllabaries also offer a consonant × vowel matrix; alphabets stay a
     // plain list. A ragged syllabary yields no matrix, so we fall back to the grid.
     const syllabary = isSyllabary(data.letters);
+    if (data.independentVowels && data.independentVowels.length > 0) {
+      app!.appendChild(renderIndependentVowels(data.independentVowels));
+    }
     if (syllabary) app!.appendChild(renderBrowseLayoutToggle());
     const matrix = syllabary && browseLayout === "matrix" ? renderMatrix(data.letters) : null;
     const body = el("div", "body");

--- a/code/programs/typescript/language-ladder/src/styles.css
+++ b/code/programs/typescript/language-ladder/src/styles.css
@@ -504,3 +504,15 @@ body {
 .matrix__syllable:hover { background: var(--special-bg); }
 .matrix__glyph { font-size: 1.25rem; line-height: 1.1; }
 .matrix__sound { font-size: 0.62rem; color: var(--muted); }
+
+/* --- independent (word-initial) vowels strip ---------------------------- */
+.ivowels { margin-bottom: 14px; }
+.ivowels__label { display: block; color: var(--muted); font-size: 0.85rem; margin-bottom: 6px; }
+.ivowels__row { display: flex; flex-wrap: wrap; gap: 6px; }
+.ivowel {
+  display: flex; flex-direction: column; align-items: center; gap: 1px;
+  min-width: 44px; padding: 5px 6px;
+  background: var(--card); border: 1px solid var(--line); border-radius: 8px;
+}
+.ivowel__glyph { font-size: 1.35rem; line-height: 1.1; }
+.ivowel__sound { font-size: 0.68rem; color: var(--muted); }

--- a/code/programs/typescript/language-ladder/src/types.ts
+++ b/code/programs/typescript/language-ladder/src/types.ts
@@ -44,6 +44,11 @@ export interface ScriptData {
    *  "spot the script" identification mode. Verified by rendering the font. */
   signature?: string;
   letters: Letter[];
+  /** For an abugida: the independent (word-initial) vowels — the letters a word
+   *  writes when it BEGINS with a vowel (అ a, ఆ ā), as opposed to the vowel signs
+   *  that ride on a consonant. Kept separate from `letters` so the consonant
+   *  syllabary (and anything keyed on it being all-syllables) is untouched. */
+  independentVowels?: Letter[];
   marks?: unknown[];
   combination?: string;
   complete?: boolean;

--- a/code/programs/typescript/language-ladder/tests/independentvowels.test.ts
+++ b/code/programs/typescript/language-ladder/tests/independentvowels.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { SCRIPTS } from "../src/data";
+import { isSyllabary } from "../src/syllabary";
+import { buildSyllableMatrix } from "../src/matrix";
+
+const DRAVIDIAN = ["telugu", "kannada", "malayalam"] as const;
+
+describe("independent (word-initial) vowels", () => {
+  it("Telugu carries the 13 independent vowels, grounded glyph + ISO-15919 roman", () => {
+    const telugu = SCRIPTS.find((s) => s.script === "telugu")!;
+    const iv = telugu.independentVowels!;
+    expect(iv.map((v) => v.glyph)).toEqual(
+      ["అ", "ఆ", "ఇ", "ఈ", "ఉ", "ఊ", "ఎ", "ఏ", "ఒ", "ఓ", "ఐ", "ఔ", "ఋ"],
+    );
+    expect(iv.map((v) => v.sound)).toEqual(
+      ["a", "ā", "i", "ī", "u", "ū", "e", "ē", "o", "ō", "ai", "au", "r̥"],
+    );
+    // Independent vowels are vowels, not syllables, and carry no fabricated ductus.
+    expect(iv.every((v) => v.role === "vowel")).toBe(true);
+    expect(iv.every((v) => v.strokeOrder.length === 0)).toBe(true);
+    // The vocalic-R vowel is ISO-15919 r̥ = r + U+0325 (ring below), not IAST ṛ.
+    expect([...iv[12]!.sound].map((c) => c.codePointAt(0))).toEqual([0x72, 0x325]);
+  });
+
+  it("all three Dravidian scripts carry them", () => {
+    DRAVIDIAN.forEach((id) => {
+      const s = SCRIPTS.find((x) => x.script === id)!;
+      expect(s.independentVowels?.length).toBe(13);
+    });
+  });
+
+  it("CONTROL: they are SEPARATE from the syllabary — letters, isSyllabary and the matrix are untouched", () => {
+    const telugu = SCRIPTS.find((s) => s.script === "telugu")!;
+    // None of the independent-vowel glyphs leak into the consonant syllable list…
+    const syllableGlyphs = new Set(telugu.letters.map((l) => l.glyph));
+    expect(telugu.independentVowels!.some((v) => syllableGlyphs.has(v.glyph))).toBe(false);
+    // …so the script still reads as an all-syllable syllabary, and the matrix
+    // still builds a full 35 × 13 grid (adding the vowels changed neither).
+    expect(isSyllabary(telugu.letters)).toBe(true);
+    const m = buildSyllableMatrix(telugu.letters as never)!;
+    expect(m.rows.length).toBe(35);
+    expect(m.rows.every((r) => r.cells.length === 13)).toBe(true);
+  });
+
+  it("an alphabet (Cyrillic) has no independent-vowel list", () => {
+    const cyr = SCRIPTS.find((s) => s.script === "cyrillic")!;
+    expect(cyr.independentVowels).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What & why

Everything so far was **consonant syllables** (a consonant + a vowel *sign*). But a word that **begins** with a vowel writes a different letter — the **independent vowel** (అ *a*, ఆ *ā* … ఔ *au*, ఋ *r̥*). Without them a vowel-initial word can't be read. This adds them and shows an **"Independent vowels (word-initial)"** strip in Browse above the grid.

## Eyeball sample (native reader, please check)

Straight from the regenerated JSON, all 13 per script:

| script | a | ā | i | ī | u | ū | e | ē | o | ō | ai | au | r̥ |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| Telugu | అ | ఆ | ఇ | ఈ | ఉ | ఊ | ఎ | ఏ | ఒ | ఓ | ఐ | ఔ | ఋ |
| Kannada | ಅ | ಆ | ಇ | ಈ | ಉ | ಊ | ಎ | ಏ | ಒ | ಓ | ಐ | ಔ | ಋ |
| Malayalam | അ | ആ | ഇ | ഈ | ഉ | ഊ | എ | ഏ | ഒ | ഓ | ഐ | ഔ | ഋ |

(Note the short/long pairs: e ఎ / ē ఏ and o ఒ / ō ఓ. The `r̥` roman is ISO-15919 r + U+0325, not IAST ṛ.)

## How

- **generate_syllabary.py** — emit each independent vowel from Unicode by name: `<SCRIPT> LETTER <V>` (the inherent /a/ → `LETTER A`), romanized in ISO-15919 from the **same vetted vowel table as the signs** (never re-typed). Emitted in a **separate `independentVowels` field**, NOT mixed into `letters` — so the consonant syllabary, and the slow-unlock gate + matrix that key on it being all-syllables, are **completely untouched** (regenerated JSON `letters` are byte-for-byte unchanged).
- **types.ts** — `independentVowels?: Letter[]` on ScriptData.
- **main.ts** — the read-only Browse strip (glyph + roman) for scripts that carry them.
- **styles.css** — `.ivowels` strip.
- **tests** — control asserts the 13 expected Telugu glyphs + romans (role `vowel`, r̥ = r + U+0325); all three scripts carry them; and — the control — **none leak into `letters`**, so `isSyllabary` still holds and the matrix still builds its full 35 × 13 grid.

Recognition only — `strokeOrder` stays `[]`, the ductus remains paused.

## Verification

- App suite **253 → 257** pass; human-language-data **38** pass (the new field is additive/optional — forward-compatible); `npm run build` clean.
- Grounding review (native reader can't catch glyph/roman slips): all 13 glyphs correct incl. the short/long e·o traps, inherent-a → LETTER A, vocalic-R = r̥, and the separation is confirmed non-breaking.
- Browser (headless): the Telugu strip renders అ ఆ ఇ ఈ ఉ ఊ ఎ ఏ ఒ ఓ ఐ ఔ ఋ above the grid (real glyphs, no tofu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)