### PR TITLE
Add MOS lateral diffusion

### DIFF
--- a/code/packages/python/mosfet-models/CHANGELOG.md
+++ b/code/packages/python/mosfet-models/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [0.1.0] — Unreleased
 
 ### Added
+- `Level1Params.LD` applies Berkeley lateral-diffusion geometry through
+  `L_eff = L - 2*LD` to channel current and length-scaled capacitance.
 - `Level1Params.FC` adds the continuous Berkeley forward-bias continuation to
   the existing `PB` / `MJ` bulk-junction depletion-capacitance model.
 - `Level1Params.AF` provides the Level-1 MOS flicker-noise current exponent,

--- a/code/packages/python/mosfet-models/README.md
+++ b/code/packages/python/mosfet-models/README.md
@@ -22,7 +22,10 @@ print(r.Id, r.gm, r.gds, r.region)
 
 ## v0.1.0 scope
 
-- `Level1Params`: Level-1 DC, capacitance, and noise parameter set with sane defaults for 130 nm-style NMOS, including `PB` / `MJ` / `FC` bulk-junction depletion shaping for `CBS` / `CBD`, zero-default `KF` flicker noise, and a unit-default `AF` current exponent.
+- `Level1Params`: Level-1 DC, geometry, capacitance, and noise parameters with
+  sane defaults for 130 nm-style NMOS, including zero-default `LD` lateral
+  diffusion through `L_eff = L - 2*LD`, `PB` / `MJ` / `FC` bulk-junction
+  depletion shaping, and `KF` / `AF` flicker noise.
 - `evaluate_level1(params, V_GS, V_DS, V_BS, T)`: returns `MosResult` with Id, gm, gds, gmb, Cgs/Cgd/Cgb/Cbs/Cbd, region.
 - Region detection: cutoff (subthreshold-aware), triode, saturation.
 - Body effect via gamma * (sqrt(PHI-V_BS) - sqrt(PHI)) shift.

--- a/code/packages/python/mosfet-models/src/mosfet_models/level1.py
+++ b/code/packages/python/mosfet-models/src/mosfet_models/level1.py
@@ -25,6 +25,7 @@ class Level1Params:
     PHI: float = 0.84  # surface potential at threshold, 2*phi_F (V)
     W: float = 1e-6  # channel width (m)
     L: float = 130e-9  # channel length (m)
+    LD: float = 0.0  # source/drain lateral diffusion length (m)
     IS: float = 1e-15  # saturation current (A)
     N_SUB: float = 1.4  # subthreshold slope factor
     T_NOM: float = 300.15  # nominal temperature (K)
@@ -111,7 +112,12 @@ def evaluate_level1(
     p = params
     if not isfinite(p.FC) or p.FC < 0.0 or p.FC >= 1.0:
         raise ValueError("MOSFET FC must be finite and in [0, 1)")
-    beta = p.KP * (p.W / p.L)
+    effective_length = p.L - 2.0 * p.LD
+    if not isfinite(p.LD) or p.LD < 0.0 or effective_length <= 0.0:
+        raise ValueError(
+            "MOSFET LD must be finite and non-negative with L - 2*LD > 0"
+        )
+    beta = p.KP * (p.W / effective_length)
 
     # Threshold with body effect. The formula is well-defined whenever
     # PHI - V_BS >= 0 (sqrt domain). If V_BS rises above PHI (heavy forward
@@ -126,8 +132,8 @@ def evaluate_level1(
 
     Cgs_overlap = p.CGSO * p.W
     Cgd_overlap = p.CGDO * p.W
-    Cgb_overlap = p.CGBO * p.L
-    Cgs_intrinsic = (2.0 / 3.0) * p.W * p.L * p.KP / 1.0  # placeholder; Meyer model
+    Cgb_overlap = p.CGBO * effective_length
+    Cgs_intrinsic = (2.0 / 3.0) * p.W * effective_length * p.KP / 1.0  # placeholder; Meyer model
     Cgd_intrinsic = 0.0
     Cgb_intrinsic = 0.0
     Cbs_bulk = bulk_junction_capacitance(p.CBS, V_BS, p.PB, p.MJ, p.FC)

--- a/code/packages/python/mosfet-models/tests/test_models.py
+++ b/code/packages/python/mosfet-models/tests/test_models.py
@@ -125,6 +125,31 @@ def test_gds_increases_with_lambda():
     assert r_yes.gds > r_no.gds
 
 
+def test_lateral_diffusion_uses_effective_channel_length():
+    base = Level1Params(
+        L=1e-6, CGBO=2e-6, subthreshold_enable=False
+    )
+    diffused = Level1Params(
+        L=1e-6, LD=0.1e-6, CGBO=2e-6, subthreshold_enable=False
+    )
+
+    nominal = evaluate_level1(base, V_GS=1.8, V_DS=1.8)
+    shortened = evaluate_level1(diffused, V_GS=1.8, V_DS=1.8)
+
+    assert shortened.Id / nominal.Id == pytest.approx(1.25)
+    assert shortened.Cgb / nominal.Cgb == pytest.approx(0.8)
+    assert shortened.Cgs < nominal.Cgs
+
+
+@pytest.mark.parametrize("ld", [-1e-9, float("inf"), 0.5e-6])
+def test_lateral_diffusion_validates_effective_channel_length(ld):
+    with pytest.raises(
+        ValueError,
+        match=r"MOSFET LD must be finite and non-negative with L - 2\*LD > 0",
+    ):
+        evaluate_level1(Level1Params(L=1e-6, LD=ld), V_GS=1.8, V_DS=1.8)
+
+
 def test_overlap_and_bulk_capacitances_are_reported():
     p = Level1Params(
         W=2e-6,

--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add Level-1 MOS model-card `LD` support, using `L - 2*LD` for channel
+  current and length-scaled intrinsic/`CGBO` capacitance.
 - Add Level-1 MOS model-card `FC` support, applying the continuous Berkeley
   forward-bias continuation to `CBS` / `CBD` in AC and transient analysis.
 - Add Level-1 MOS model-card `AF` support and apply the configurable

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -89,6 +89,8 @@ noise model. `NLEV >= 3` selects the Berkeley linear-region equation, with
 `GDSNOI` (default `1`) scaling its channel-noise conductance.
 Level-1 MOS model cards accept `KF` (default `0`) and `AF` (default `1`) and add
 `KF * abs(Id)^AF / frequency` flicker noise alongside channel thermal noise.
+`LD` defaults to zero and applies `L_eff = L - 2*LD` to channel current and
+length-scaled intrinsic/`CGBO` capacitance.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -311,8 +311,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "PNP": (41, 58, 13, 4),
     "NJF": (22, 30, 7, 3),
     "PJF": (22, 30, 7, 3),
-    "NMOS": (21, 28, 6, 3),
-    "PMOS": (21, 28, 6, 3),
+    "NMOS": (22, 29, 6, 3),
+    "PMOS": (22, 29, 6, 3),
 }
 
 
@@ -463,6 +463,7 @@ _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
     "PHI": "PHI",
     "W": "W",
     "L": "L",
+    "LD": "LD",
     "IS": "IS",
     "NSUB": "N_SUB",
     "N_SUB": "N_SUB",
@@ -1067,6 +1068,7 @@ def mosfet_from_model_card(
         PHI=p.get("PHI", defaults.PHI),
         W=p.get("W", defaults.W),
         L=p.get("L", defaults.L),
+        LD=p.get("LD", defaults.LD),
         IS=p.get("IS", defaults.IS),
         N_SUB=p.get("N_SUB", defaults.N_SUB),
         T_NOM=p.get("T_NOM", defaults.T_NOM),

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -408,7 +408,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 183
+    assert len(coverage) == 185
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -423,7 +423,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tAF\tAF\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 183
+    assert len(records) == 185
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -446,8 +446,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert summary[0].max_alias_count == 3
     assert summary[0].aliased_parameters == ("IS", "VT", "CJO", "VJ", "M")
     assert summary[5].kind == "NMOS"
-    assert summary[5].canonical_parameter_count == 21
-    assert summary[5].accepted_name_count == 28
+    assert summary[5].canonical_parameter_count == 22
+    assert summary[5].accepted_name_count == 29
     assert summary[5].aliased_parameter_count == 6
     assert summary[5].max_alias_count == 3
     assert summary[5].aliased_parameters == (
@@ -469,7 +469,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert table.splitlines()[1] == "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M"
     assert (
         table.splitlines()[-1]
-        == "PMOS\t21\t28\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        == "PMOS\t22\t29\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
     )
     records = model_card_supported_parameter_coverage_summary_records()
     assert len(records) == 7
@@ -497,9 +497,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 183
-    assert report.expected_canonical_parameter_count == 183
-    assert report.accepted_name_count == 253
+    assert report.canonical_parameter_count == 185
+    assert report.expected_canonical_parameter_count == 185
+    assert report.accepted_name_count == 255
     assert report.aliased_parameter_count == 57
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -507,7 +507,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t183\t183\t253\t57\t4\t0"
+        "true\t7\t7\t185\t185\t255\t57\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -535,15 +535,15 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 182
-    assert report.accepted_name_count == 250
+    assert report.canonical_parameter_count == 184
+    assert report.accepted_name_count == 252
     assert report.aliased_parameter_count == 56
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
     assert report.issues[0].field == "canonical_parameter_count"
     assert report.issues[0].message == (
-        "expected NMOS to expose 21 canonical supported parameters, found 20"
+        "expected NMOS to expose 22 canonical supported parameters, found 21"
     )
     assert report.issues[-1].field == "max_alias_count"
     assert report.issues[-1].message == "expected NMOS max alias count 3, found 2"
@@ -551,12 +551,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t182\t183\t250\t56\t4\t4\n"
+        "false\t7\t7\t184\t185\t252\t56\t4\t4\n"
         "kind\tfield\tmessage\n"
-        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 21 canonical "
-        "supported parameters, found 20\n"
-        "NMOS\taccepted_name_count\texpected NMOS to expose 28 accepted model-card "
-        "names, found 25\n"
+        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 22 canonical "
+        "supported parameters, found 21\n"
+        "NMOS\taccepted_name_count\texpected NMOS to expose 29 accepted model-card "
+        "names, found 26\n"
         "NMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing "
         "parameters, found 5\n"
         "NMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
@@ -565,12 +565,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
     assert records[0] == {
         "kind": "NMOS",
         "field": "canonical_parameter_count",
-        "message": "expected NMOS to expose 21 canonical supported parameters, found 20",
+        "message": "expected NMOS to expose 22 canonical supported parameters, found 21",
     }
     assert format_model_card_supported_parameter_coverage_gate_issue_csv(report).startswith(
         "kind,field,message\n"
-        'NMOS,canonical_parameter_count,"expected NMOS to expose 21 canonical '
-        'supported parameters, found 20"\n'
+        'NMOS,canonical_parameter_count,"expected NMOS to expose 22 canonical '
+        'supported parameters, found 21"\n'
     )
     assert (
         json.loads(format_model_card_supported_parameter_coverage_gate_issue_json(report))
@@ -747,6 +747,7 @@ def test_model_card_aliases_build_device_instances() -> None:
             "PB": 0.9,
             "MJ": 0.45,
             "FC": 0.4,
+            "LD": 50.0e-9,
             "KF": 2.0e-24,
             "AF": 1.4,
         },
@@ -761,6 +762,7 @@ def test_model_card_aliases_build_device_instances() -> None:
         "PB": 0.9,
         "MJ": 0.45,
         "FC": 0.4,
+        "LD": 50.0e-9,
         "KF": 2.0e-24,
         "AF": 1.4,
     }
@@ -774,6 +776,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(0.9) == mos_model.model.model.params.PB
     assert pytest.approx(0.45) == mos_model.model.model.params.MJ
     assert pytest.approx(0.4) == mos_model.model.model.params.FC
+    assert pytest.approx(50.0e-9) == mos_model.model.model.params.LD
     assert pytest.approx(2.0e-24) == mos_model.model.model.params.KF
     assert pytest.approx(1.4) == mos_model.model.model.params.AF
 
@@ -1842,6 +1845,46 @@ def test_mosfet_rejects_invalid_forward_bias_depletion_coefficient(fc: float) ->
         dc_op(circuit)
 
 
+@pytest.mark.parametrize("ld", [float("nan"), -0.1e-6, 0.5e-6])
+def test_mosfet_rejects_invalid_lateral_diffusion_length(ld: float) -> None:
+    circuit = Circuit()
+    circuit.add(Mosfet(
+        "Mbad",
+        "drain",
+        "gate",
+        "0",
+        "0",
+        MOSFET(MosfetType.NMOS, Level1Model(Level1Params(L=1.0e-6, LD=ld))),
+    ))
+
+    with pytest.raises(
+        ValueError,
+        match=r"MOSFET LD must be finite and non-negative with L - 2\*LD > 0",
+    ):
+        dc_op(circuit)
+
+
+def test_mosfet_lateral_diffusion_uses_effective_channel_length() -> None:
+    def drain_current(ld: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vdrain", "drain", "0", 1.8))
+        circuit.add(VoltageSource("Vgate", "gate", "0", 1.8))
+        circuit.add(Mosfet(
+            "M1",
+            "drain",
+            "gate",
+            "0",
+            "0",
+            MOSFET(
+                MosfetType.NMOS,
+                Level1Model(Level1Params(L=1.0e-6, LD=ld)),
+            ),
+        ))
+        return abs(dc_op(circuit).branch_currents["I(Vdrain)"])
+
+    assert drain_current(0.1e-6) / drain_current(0.0) == pytest.approx(1.25)
+
+
 def test_transient_diode_transit_time_holds_forward_charge_on_turnoff() -> None:
     def run(transit_time: float) -> TransientResult:
         circuit = Circuit()
@@ -2764,6 +2807,35 @@ def test_subcircuit_expansion_preserves_complete_jfet_model():
     assert expanded.Bex == pytest.approx(1.5)
     assert expanded.Betatce == pytest.approx(-0.5)
     assert expanded.Tnom == pytest.approx(323.15)
+
+
+def test_subcircuit_expansion_preserves_mos_lateral_diffusion():
+    cell = SubcircuitDefinition(
+        "mos-cell",
+        ("d", "g", "s", "b"),
+        (
+            Mosfet(
+                "Mcell",
+                "d",
+                "g",
+                "s",
+                "b",
+                MOSFET(
+                    MosfetType.NMOS,
+                    Level1Model(Level1Params(L=1.0e-6, LD=0.1e-6)),
+                ),
+            ),
+        ),
+    )
+    circuit = Circuit()
+    circuit.define_subcircuit(cell)
+    circuit.add(XInstance("X1", ("d1", "g1", "0", "0"), "mos-cell"))
+
+    expanded = next(
+        element for element in circuit.elements if isinstance(element, Mosfet)
+    )
+    assert expanded.model.model.params.L == pytest.approx(1.0e-6)
+    assert expanded.model.model.params.LD == pytest.approx(0.1e-6)
 
 
 def test_subcircuit_expansion_preserves_complete_bjt_model():

--- a/code/packages/rust/mosfet-models/CHANGELOG.md
+++ b/code/packages/rust/mosfet-models/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `Level1Params::ld` applies Berkeley lateral-diffusion geometry through
+  `L_eff = L - 2*LD` to channel current and length-scaled capacitance.
 - `Level1Params::pb`, `Level1Params::mj`, and `Level1Params::fc` provide
   continuous Berkeley bulk-junction depletion-capacitance shaping for `CBS`
   and `CBD`.

--- a/code/packages/rust/mosfet-models/README.md
+++ b/code/packages/rust/mosfet-models/README.md
@@ -6,7 +6,9 @@ SPICE Level-1 (Shockley) MOSFET I-V model with full small-signal parameter extra
 
 This crate implements the classical square-law MOSFET model used in introductory SPICE circuit analysis:
 
-- **`Level1Params`** — 18 parameters (VT0, KP, LAMBDA, GAMMA, PHI, W, L, capacitances, temperature, zero-default KF flicker noise, and unit-default AF exponent) with textbook defaults for a 130 nm NMOS.
+- **`Level1Params`** — Level-1 geometry, DC, capacitance, temperature, and
+  noise parameters, including zero-default `LD` lateral diffusion, `KF`
+  flicker noise, and a unit-default `AF` exponent.
 - **`evaluate_level1`** — core I-V evaluation returning `MosResult` with `Id`, `gm`, `gds`, `gmb`, gate/body capacitances, and the operating `Region`.
 - **`Region`** — `Cutoff`, `Subthreshold`, `Triode`, `Saturation`.
 - **`MosfetType`** — `Nmos` / `Pmos`.
@@ -21,7 +23,8 @@ This crate implements the classical square-law MOSFET model used in introductory
 | Triode      | 0 < V_DS < V_OV   | β(V_OV V_DS − V_DS²/2)(1 + λV_DS)        |
 | Saturation  | V_DS ≥ V_OV      | (β/2) V_OV² (1 + λV_DS)                   |
 
-where β = KP × W/L and V_OV = V_GS − V_t.
+where β = KP × W/(L − 2LD) and V_OV = V_GS − V_t. `LD` defaults to zero
+and must leave a positive effective channel length.
 
 ## Usage
 

--- a/code/packages/rust/mosfet-models/src/lib.rs
+++ b/code/packages/rust/mosfet-models/src/lib.rs
@@ -36,6 +36,7 @@ use device_physics::thermal_voltage;
 /// | PHI       | Surface potential 2φ_F (V)         | 0.84     |
 /// | W         | Channel width (m)                  | 1 µm     |
 /// | L         | Channel length (m)                 | 130 nm   |
+/// | LD        | Lateral diffusion length (m)       | 0        |
 /// | IS        | Drain–body saturation current (A)  | 1 fA     |
 /// | N_SUB     | Subthreshold slope factor          | 1.4      |
 /// | T_NOM     | Nominal temperature (K)            | 300.15   |
@@ -57,6 +58,8 @@ pub struct Level1Params {
     pub w: f64,
     /// Channel length [m].
     pub l: f64,
+    /// Source/drain lateral diffusion length [m].
+    pub ld: f64,
     /// Drain–body saturation current [A] (used for subthreshold floor).
     pub is: f64,
     /// Subthreshold slope factor n.  Subthreshold current ∝ exp(V_OV / (n V_T)).
@@ -97,6 +100,7 @@ impl Default for Level1Params {
             phi: 0.84,
             w: 1e-6,
             l: 130e-9,
+            ld: 0.0,
             is: 1e-15,
             n_sub: 1.4,
             t_nom: 300.15,
@@ -225,7 +229,12 @@ pub fn evaluate_level1(
     t: f64,
 ) -> MosResult {
     let p = params;
-    let beta = p.kp * (p.w / p.l);
+    let effective_length = p.l - 2.0 * p.ld;
+    assert!(
+        p.ld.is_finite() && p.ld >= 0.0 && effective_length > 0.0,
+        "MOSFET LD must be finite and non-negative with L - 2*LD > 0"
+    );
+    let beta = p.kp * (p.w / effective_length);
 
     // Threshold with body effect.
     // The formula √(PHI − V_BS) is valid when PHI ≥ V_BS.
@@ -242,12 +251,12 @@ pub fn evaluate_level1(
     // Overlap capacitances scale with W or L.
     let cgs_overlap = p.cgso * p.w;
     let cgd_overlap = p.cgdo * p.w;
-    let cgb_overlap = p.cgbo * p.l;
+    let cgb_overlap = p.cgbo * effective_length;
 
     // Placeholder intrinsic capacitance (Meyer model, saturation reference).
     // In saturation: C_gs_intrinsic ≈ (2/3) W L C_ox.
     // We approximate C_ox as KP (units collapse to F/m² in the placeholder).
-    let cgs_intrinsic = (2.0 / 3.0) * p.w * p.l * p.kp;
+    let cgs_intrinsic = (2.0 / 3.0) * p.w * effective_length * p.kp;
     let cbs_bulk = bulk_junction_capacitance(p.cbs, v_bs, p.pb, p.mj, p.fc);
     let cbd_bulk = bulk_junction_capacitance(p.cbd, v_bs - v_ds, p.pb, p.mj, p.fc);
 

--- a/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
+++ b/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
@@ -14,6 +14,7 @@ fn test_default_params() {
     assert_eq!(p.phi, 0.84);
     assert_eq!(p.w, 1e-6);
     assert!((p.l - 130e-9).abs() < 1e-15);
+    assert_eq!(p.ld, 0.0);
     assert_eq!(p.kf, 0.0);
     assert_eq!(p.af, 1.0);
     assert!(p.subthreshold_enable);
@@ -94,6 +95,37 @@ fn test_gds_without_clm() {
     };
     let r = evaluate_level1(&p, 1.8, 1.8, 0.0, 300.15);
     assert!(r.gds.abs() < 1e-12, "gds≈0 when lambda=0");
+}
+
+#[test]
+fn test_lateral_diffusion_uses_effective_channel_length() {
+    let base = Level1Params {
+        l: 1.0e-6,
+        cgbo: 2.0e-6,
+        subthreshold_enable: false,
+        ..Level1Params::default()
+    };
+    let diffused = Level1Params {
+        ld: 0.1e-6,
+        ..base.clone()
+    };
+    let nominal = evaluate_level1(&base, 1.8, 1.8, 0.0, 300.15);
+    let shortened = evaluate_level1(&diffused, 1.8, 1.8, 0.0, 300.15);
+
+    assert!((shortened.id / nominal.id - 1.25).abs() < 1.0e-12);
+    assert!((shortened.cgb / nominal.cgb - 0.8).abs() < 1.0e-12);
+    assert!(shortened.cgs < nominal.cgs);
+}
+
+#[test]
+#[should_panic(expected = "MOSFET LD must be finite and non-negative with L - 2*LD > 0")]
+fn test_lateral_diffusion_rejects_nonpositive_effective_length() {
+    let params = Level1Params {
+        l: 1.0e-6,
+        ld: 0.5e-6,
+        ..Level1Params::default()
+    };
+    let _ = evaluate_level1(&params, 1.8, 1.8, 0.0, 300.15);
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add Level-1 MOS model-card `LD` support, using `L - 2*LD` for channel
+  current and length-scaled intrinsic/`CGBO` capacitance.
 - Add Level-1 MOS model-card `FC` support, applying the continuous Berkeley
   forward-bias continuation to `CBS` / `CBD` in AC and transient analysis.
 - Add Level-1 MOS model-card `AF` support and apply the configurable

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -130,6 +130,8 @@ noise model. `NLEV >= 3` selects the Berkeley linear-region equation, with
 `GDSNOI` (default `1`) scaling its channel-noise conductance.
 Level-1 MOS model cards accept `KF` (default `0`) and `AF` (default `1`) and add
 `KF * abs(Id)^AF / frequency` flicker noise alongside channel thermal noise.
+`LD` defaults to zero and applies `L_eff = L - 2*LD` to channel current and
+length-scaled intrinsic/`CGBO` capacitance.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3606,6 +3606,7 @@ pub struct MosfetLevel1Params {
     pub phi: f64,
     pub w: f64,
     pub l: f64,
+    pub lateral_diffusion_length: f64,
     pub saturation_current: f64,
     pub n_sub: f64,
     pub t_nom: f64,
@@ -3631,6 +3632,7 @@ impl Default for MosfetLevel1Params {
             phi: 0.84,
             w: 1.0e-6,
             l: 130.0e-9,
+            lateral_diffusion_length: 0.0,
             saturation_current: 1.0e-15,
             n_sub: 1.4,
             t_nom: 300.15,
@@ -3987,8 +3989,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     (ModelCardKind::Pnp, 41, 58, 13, 4),
     (ModelCardKind::Njf, 22, 30, 7, 3),
     (ModelCardKind::Pjf, 22, 30, 7, 3),
-    (ModelCardKind::Nmos, 21, 28, 6, 3),
-    (ModelCardKind::Pmos, 21, 28, 6, 3),
+    (ModelCardKind::Nmos, 22, 29, 6, 3),
+    (ModelCardKind::Pmos, 22, 29, 6, 3),
 ];
 const DIODE_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IS", "IS"),
@@ -4117,6 +4119,7 @@ const MOS_LEVEL1_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("PHI", "PHI"),
     ("W", "W"),
     ("L", "L"),
+    ("LD", "LD"),
     ("IS", "IS"),
     ("NSUB", "N_SUB"),
     ("N_SUB", "N_SUB"),
@@ -4892,6 +4895,9 @@ pub fn mosfet_from_model_card(
     }
     if let Some(value) = model.parameters.get("L") {
         params.l = *value;
+    }
+    if let Some(value) = model.parameters.get("LD") {
+        params.lateral_diffusion_length = *value;
     }
     if let Some(value) = model.parameters.get("IS") {
         params.saturation_current = *value;
@@ -24206,11 +24212,12 @@ fn evaluate_nmos_level1(
     vds: f64,
     vbs: f64,
 ) -> MosfetDcResult {
-    let beta = params.kp * (params.w / params.l);
+    let effective_length = params.l - 2.0 * params.lateral_diffusion_length;
+    let beta = params.kp * (params.w / effective_length);
     let cgs_overlap = params.gate_source_overlap_capacitance * params.w;
     let cgd_overlap = params.gate_drain_overlap_capacitance * params.w;
-    let cgb_overlap = params.gate_bulk_overlap_capacitance * params.l;
-    let cgs_intrinsic = (2.0 / 3.0) * params.w * params.l * params.kp;
+    let cgb_overlap = params.gate_bulk_overlap_capacitance * effective_length;
+    let cgs_intrinsic = (2.0 / 3.0) * params.w * effective_length * params.kp;
     let cbs_bulk = mosfet_bulk_junction_capacitance(
         params.source_bulk_capacitance,
         vbs,
@@ -25502,6 +25509,7 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         ("PHI", params.phi),
         ("W", params.w),
         ("L", params.l),
+        ("LD", params.lateral_diffusion_length),
         ("IS", params.saturation_current),
         ("N_SUB", params.n_sub),
         ("T_NOM", params.t_nom),
@@ -25533,6 +25541,14 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: mosfet.name.clone(),
             reason: "MOSFET W and L must be positive".to_string(),
+        });
+    }
+    if params.lateral_diffusion_length < 0.0
+        || params.l - 2.0 * params.lateral_diffusion_length <= 0.0
+    {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET LD must be non-negative with L - 2*LD > 0".to_string(),
         });
     }
     if params.phi <= 0.0 {

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -95,7 +95,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 183);
+    assert_eq!(coverage.len(), 185);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -114,7 +114,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tAF\tAF\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 183);
+    assert_eq!(records.len(), 185);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -147,8 +147,8 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         vec!["IS", "VT", "CJO", "VJ", "M"]
     );
     assert_eq!(summary[5].kind, ModelCardKind::Nmos);
-    assert_eq!(summary[5].canonical_parameter_count, 21);
-    assert_eq!(summary[5].accepted_name_count, 28);
+    assert_eq!(summary[5].canonical_parameter_count, 22);
+    assert_eq!(summary[5].accepted_name_count, 29);
     assert_eq!(summary[5].aliased_parameter_count, 6);
     assert_eq!(summary[5].max_alias_count, 3);
     assert_eq!(
@@ -166,7 +166,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     assert_eq!(lines[1], "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\t21\t28\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        &"PMOS\t22\t29\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
     );
     let records = model_card_supported_parameter_coverage_summary_records();
     assert_eq!(records.len(), 7);
@@ -184,7 +184,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         "[{\"kind\":\"D\",\"canonical_parameter_count\":\"15\",\"accepted_name_count\":\"21\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
     ));
     assert!(json.ends_with(
-        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"21\",\"accepted_name_count\":\"28\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
+        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"22\",\"accepted_name_count\":\"29\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
     ));
 }
 
@@ -195,15 +195,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 183);
-    assert_eq!(report.expected_canonical_parameter_count, 183);
-    assert_eq!(report.accepted_name_count, 253);
+    assert_eq!(report.canonical_parameter_count, 185);
+    assert_eq!(report.expected_canonical_parameter_count, 185);
+    assert_eq!(report.accepted_name_count, 255);
     assert_eq!(report.aliased_parameter_count, 57);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t183\t183\t253\t57\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t185\t185\t255\t57\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -230,8 +230,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 182);
-    assert_eq!(report.accepted_name_count, 250);
+    assert_eq!(report.canonical_parameter_count, 184);
+    assert_eq!(report.accepted_name_count, 252);
     assert_eq!(report.aliased_parameter_count, 56);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -239,7 +239,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     assert_eq!(report.issues[0].field, "canonical_parameter_count");
     assert_eq!(
         report.issues[0].message,
-        "expected NMOS to expose 21 canonical supported parameters, found 20"
+        "expected NMOS to expose 22 canonical supported parameters, found 21"
     );
     assert_eq!(report.issues.last().unwrap().field, "max_alias_count");
     assert_eq!(
@@ -248,20 +248,20 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t182\t183\t250\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 21 canonical supported parameters, found 20\nNMOS\taccepted_name_count\texpected NMOS to expose 28 accepted model-card names, found 25\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t184\t185\t252\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 22 canonical supported parameters, found 21\nNMOS\taccepted_name_count\texpected NMOS to expose 29 accepted model-card names, found 26\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
     assert_eq!(records[0]["field"], "canonical_parameter_count");
     assert_eq!(
         records[0]["message"],
-        "expected NMOS to expose 21 canonical supported parameters, found 20"
+        "expected NMOS to expose 22 canonical supported parameters, found 21"
     );
     assert!(format_model_card_supported_parameter_coverage_gate_issue_csv(&report).starts_with(
-        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 21 canonical supported parameters, found 20\"\n"
+        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 22 canonical supported parameters, found 21\"\n"
     ));
     assert!(format_model_card_supported_parameter_coverage_gate_issue_json(&report).starts_with(
-        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 21 canonical supported parameters, found 20\"}"
+        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 22 canonical supported parameters, found 21\"}"
     ));
 }
 
@@ -283,8 +283,8 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(dashboard[0].issue_count, 0);
     assert!(dashboard[0].issue_fields.is_empty());
     assert_eq!(dashboard[5].kind, ModelCardKind::Nmos);
-    assert_eq!(dashboard[5].canonical_parameter_count, 21);
-    assert_eq!(dashboard[5].accepted_name_count, 28);
+    assert_eq!(dashboard[5].canonical_parameter_count, 22);
+    assert_eq!(dashboard[5].accepted_name_count, 29);
     assert_eq!(dashboard[5].issue_count, 0);
 
     let table = format_model_card_supported_parameter_coverage_dashboard_table(&coverage);
@@ -296,7 +296,7 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(lines[1], "D\ttrue\t15\t15\t21\t21\t5\t5\t3\t3\t0\t");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\ttrue\t21\t21\t28\t28\t6\t6\t3\t3\t0\t"
+        &"PMOS\ttrue\t22\t22\t29\t29\t6\t6\t3\t3\t0\t"
     );
     let records = model_card_supported_parameter_coverage_dashboard_records(&coverage);
     assert_eq!(records.len(), 7);
@@ -328,10 +328,10 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         .unwrap();
 
     assert!(!nmos.passed);
-    assert_eq!(nmos.canonical_parameter_count, 20);
-    assert_eq!(nmos.expected_canonical_parameter_count, 21);
-    assert_eq!(nmos.accepted_name_count, 25);
-    assert_eq!(nmos.expected_accepted_name_count, 28);
+    assert_eq!(nmos.canonical_parameter_count, 21);
+    assert_eq!(nmos.expected_canonical_parameter_count, 22);
+    assert_eq!(nmos.accepted_name_count, 26);
+    assert_eq!(nmos.expected_accepted_name_count, 29);
     assert_eq!(nmos.aliased_parameter_count, 5);
     assert_eq!(nmos.expected_aliased_parameter_count, 6);
     assert_eq!(nmos.max_alias_count, 2);
@@ -347,7 +347,7 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         ]
     );
     assert!(format_model_card_supported_parameter_coverage_dashboard_table(&coverage).contains(
-        "NMOS\tfalse\t20\t21\t25\t28\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
+        "NMOS\tfalse\t21\t22\t26\t29\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
     ));
 }
 
@@ -593,6 +593,7 @@ fn model_card_aliases_build_device_instances() {
             ("PB", 0.9),
             ("MJ", 0.45),
             ("FC", 0.4),
+            ("LD", 50.0e-9),
             ("KF", 2.0e-24),
             ("AF", 1.4),
         ],
@@ -606,6 +607,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*mos_card.parameters.get("PB").unwrap(), 0.9);
     assert_close(*mos_card.parameters.get("MJ").unwrap(), 0.45);
     assert_close(*mos_card.parameters.get("FC").unwrap(), 0.4);
+    assert_close(*mos_card.parameters.get("LD").unwrap(), 50.0e-9);
     assert_close(*mos_card.parameters.get("KF").unwrap(), 2.0e-24);
     assert_close(*mos_card.parameters.get("AF").unwrap(), 1.4);
     assert_eq!(mos_model.mosfet_type, MosfetType::Nmos);
@@ -616,6 +618,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(mos_model.params.bulk_junction_potential, 0.9);
     assert_close(mos_model.params.bulk_junction_grading_coefficient, 0.45);
     assert_close(mos_model.params.forward_bias_depletion_coefficient, 0.4);
+    assert_close(mos_model.params.lateral_diffusion_length, 50.0e-9);
     assert_close(mos_model.params.flicker_noise_coefficient, 2.0e-24);
     assert_close(mos_model.params.flicker_noise_exponent, 1.4);
 }
@@ -1681,6 +1684,59 @@ fn jfet_gate_saturation_current_loads_a_forward_biased_gate() {
         gate_voltage(JfetPolarity::Pjf, -0.3, 1.0e-9)
             > gate_voltage(JfetPolarity::Pjf, -0.3, 1.0e-14)
     );
+}
+
+#[test]
+fn subcircuit_expansion_preserves_mos_lateral_diffusion() {
+    let mosfet = Mosfet::with_model(
+        "Mcell",
+        "d",
+        "g",
+        "s",
+        "b",
+        MosfetType::Nmos,
+        MosfetLevel1Params {
+            l: 1.0e-6,
+            lateral_diffusion_length: 0.1e-6,
+            ..MosfetLevel1Params::default()
+        },
+    );
+    let mut circuit = Circuit::new();
+    circuit
+        .define_subcircuit(SubcircuitDefinition::new(
+            "mos-cell",
+            vec![
+                "d".to_string(),
+                "g".to_string(),
+                "s".to_string(),
+                "b".to_string(),
+            ],
+            vec![SubcircuitElement::from(Element::Mosfet(mosfet))],
+        ))
+        .unwrap();
+    circuit
+        .instantiate(XInstance::new(
+            "X1",
+            vec![
+                "d1".to_string(),
+                "g1".to_string(),
+                "0".to_string(),
+                "0".to_string(),
+            ],
+            "mos-cell",
+        ))
+        .unwrap();
+
+    let expanded = circuit
+        .elements()
+        .iter()
+        .find_map(|element| match element {
+            Element::Mosfet(mosfet) => Some(mosfet),
+            _ => None,
+        })
+        .unwrap();
+    assert_close(expanded.params.l, 1.0e-6);
+    assert_close(expanded.params.lateral_diffusion_length, 0.1e-6);
 }
 
 #[test]
@@ -3431,6 +3487,39 @@ fn dc_mosfet_solves_nmos_source_follower_operating_point() {
 }
 
 #[test]
+fn dc_mosfet_lateral_diffusion_uses_effective_channel_length() {
+    let drain_current = |lateral_diffusion_length| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vdrain", "drain", "0", 1.8,
+        )));
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vgate", "gate", "0", 1.8,
+        )));
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "M1",
+            "drain",
+            "gate",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                l: 1.0e-6,
+                lateral_diffusion_length,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+        dc_op(&circuit)
+            .unwrap()
+            .branch_current("Vdrain")
+            .unwrap()
+            .abs()
+    };
+
+    assert_close(drain_current(0.1e-6) / drain_current(0.0), 1.25);
+}
+
+#[test]
 fn dc_jfet_solves_n_channel_source_resistor_bias() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(
@@ -3625,6 +3714,39 @@ fn dc_mosfet_rejects_invalid_forward_bias_depletion_coefficient() {
                     "MOSFET FC must be in [0, 1)".to_string()
                 } else {
                     "MOSFET FC must be finite".to_string()
+                },
+            }
+        );
+    }
+}
+
+#[test]
+fn dc_mosfet_rejects_invalid_lateral_diffusion_length() {
+    for lateral_diffusion_length in [f64::NAN, -0.1e-6, 0.5e-6] {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "Mbad",
+            "drain",
+            "gate",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                l: 1.0e-6,
+                lateral_diffusion_length,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+
+        let err = dc_op(&circuit).unwrap_err();
+        assert_eq!(
+            err,
+            SpiceError::InvalidElement {
+                name: "Mbad".to_string(),
+                reason: if lateral_diffusion_length.is_finite() {
+                    "MOSFET LD must be non-negative with L - 2*LD > 0".to_string()
+                } else {
+                    "MOSFET LD must be finite".to_string()
                 },
             }
         );

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add Level-1 MOS model-card `LD` support, using `L - 2*LD` for channel
+  current and length-scaled intrinsic/`CGBO` capacitance.
 - Add Level-1 MOS model-card `FC` support, applying the continuous Berkeley
   forward-bias continuation to `CBS` / `CBD` in AC and transient analysis.
 - Add Level-1 MOS model-card `AF` support and apply the configurable

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -81,6 +81,8 @@ noise model. `NLEV >= 3` selects the Berkeley linear-region equation, with
 `GDSNOI` (default `1`) scaling its channel-noise conductance.
 Level-1 MOS model cards accept `KF` (default `0`) and `AF` (default `1`) and add
 `KF * abs(Id)^AF / frequency` flicker noise alongside channel thermal noise.
+`LD` defaults to zero and applies `L_eff = L - 2*LD` to channel current and
+length-scaled intrinsic/`CGBO` capacitance.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1774,6 +1774,7 @@ export interface MosfetLevel1Params {
   readonly PHI: number;
   readonly W: number;
   readonly L: number;
+  readonly LD: number;
   readonly IS: number;
   readonly N_SUB: number;
   readonly T_NOM: number;
@@ -2046,8 +2047,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   PNP: [41, 58, 13, 4],
   NJF: [22, 30, 7, 3],
   PJF: [22, 30, 7, 3],
-  NMOS: [21, 28, 6, 3],
-  PMOS: [21, 28, 6, 3],
+  NMOS: [22, 29, 6, 3],
+  PMOS: [22, 29, 6, 3],
 };
 
 export interface Vccs {
@@ -8029,6 +8030,7 @@ export function defaultMosfetLevel1Params(): MosfetLevel1Params {
     PHI: 0.84,
     W: 1.0e-6,
     L: 130.0e-9,
+    LD: 0.0,
     IS: 1.0e-15,
     N_SUB: 1.4,
     T_NOM: 300.15,
@@ -8214,6 +8216,7 @@ const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   PHI: "PHI",
   W: "W",
   L: "L",
+  LD: "LD",
   IS: "IS",
   NSUB: "N_SUB",
   N_SUB: "N_SUB",
@@ -8786,6 +8789,7 @@ export function mosfetFromModelCard(
     ...(p.PHI !== undefined ? { PHI: p.PHI } : {}),
     ...(p.W !== undefined ? { W: p.W } : {}),
     ...(p.L !== undefined ? { L: p.L } : {}),
+    ...(p.LD !== undefined ? { LD: p.LD } : {}),
     ...(p.IS !== undefined ? { IS: p.IS } : {}),
     ...(p.N_SUB !== undefined ? { N_SUB: p.N_SUB } : {}),
     ...(p.T_NOM !== undefined ? { T_NOM: p.T_NOM } : {}),
@@ -20247,11 +20251,12 @@ function evaluateNmosLevel1(
   vds: number,
   vbs: number,
 ): MosfetDcResult {
-  const beta = params.KP * (params.W / params.L);
+  const effectiveLength = params.L - 2.0 * params.LD;
+  const beta = params.KP * (params.W / effectiveLength);
   const cgsOverlap = params.CGSO * params.W;
   const cgdOverlap = params.CGDO * params.W;
-  const cgbOverlap = params.CGBO * params.L;
-  const cgsIntrinsic = (2.0 / 3.0) * params.W * params.L * params.KP;
+  const cgbOverlap = params.CGBO * effectiveLength;
+  const cgsIntrinsic = (2.0 / 3.0) * params.W * effectiveLength * params.KP;
   const cbsBulk = mosfetBulkJunctionCapacitance(
     params.CBS, vbs, params.PB, params.MJ, params.FC,
   );
@@ -21020,6 +21025,9 @@ function validateMosfet(element: Mosfet): void {
   }
   if (params.W <= 0.0 || params.L <= 0.0) {
     throw invalidElement(element.name, "MOSFET W and L must be positive");
+  }
+  if (params.LD < 0.0 || params.L - 2.0 * params.LD <= 0.0) {
+    throw invalidElement(element.name, "MOSFET LD must be non-negative with L - 2*LD > 0");
   }
   if (params.PHI <= 0.0) {
     throw invalidElement(element.name, "MOSFET PHI must be positive");

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -121,7 +121,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(183);
+    expect(coverage).toHaveLength(185);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -141,7 +141,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tAF\tAF\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(183);
+    expect(records).toHaveLength(185);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -167,8 +167,8 @@ describe("dcOp", () => {
     });
     expect(summary[5]).toStrictEqual({
       kind: "NMOS",
-      canonicalParameterCount: 21,
-      acceptedNameCount: 28,
+      canonicalParameterCount: 22,
+      acceptedNameCount: 29,
       aliasedParameterCount: 6,
       maxAliasCount: 3,
       aliasedParameters: ["VT0", "LAMBDA", "N_SUB", "T_NOM", "CBS", "CBD"],
@@ -181,7 +181,7 @@ describe("dcOp", () => {
     );
     expect(table.split("\n")[1]).toBe("D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     expect(table.split("\n").at(-1)).toBe(
-      "PMOS\t21\t28\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
+      "PMOS\t22\t29\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
     );
     const records = modelCardSupportedParameterCoverageSummaryRecords();
     expect(records).toHaveLength(7);
@@ -206,15 +206,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 183,
-      expectedCanonicalParameterCount: 183,
-      acceptedNameCount: 253,
+      canonicalParameterCount: 185,
+      expectedCanonicalParameterCount: 185,
+      acceptedNameCount: 255,
       aliasedParameterCount: 57,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t183\t183\t253\t57\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t185\t185\t255\t57\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -237,15 +237,15 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(182);
-    expect(report.acceptedNameCount).toBe(250);
+    expect(report.canonicalParameterCount).toBe(184);
+    expect(report.acceptedNameCount).toBe(252);
     expect(report.aliasedParameterCount).toBe(56);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 21 canonical supported parameters, found 20",
+      message: "expected NMOS to expose 22 canonical supported parameters, found 21",
     });
     expect(report.issues.at(-1)).toStrictEqual({
       kind: "NMOS",
@@ -253,16 +253,16 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t182\t183\t250\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 21 canonical supported parameters, found 20\nNMOS\taccepted_name_count\texpected NMOS to expose 28 accepted model-card names, found 25\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t184\t185\t252\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 22 canonical supported parameters, found 21\nNMOS\taccepted_name_count\texpected NMOS to expose 29 accepted model-card names, found 26\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 21 canonical supported parameters, found 20",
+      message: "expected NMOS to expose 22 canonical supported parameters, found 21",
     });
     expect(formatModelCardSupportedParameterCoverageGateIssueCsv(report)).toMatch(
-      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 21 canonical supported parameters, found 20"\n/,
+      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 22 canonical supported parameters, found 21"\n/,
     );
     expect(JSON.parse(formatModelCardSupportedParameterCoverageGateIssueJson(report))).toStrictEqual(
       records,
@@ -418,6 +418,7 @@ describe("dcOp", () => {
       PB: 0.9,
       MJ: 0.45,
       FC: 0.4,
+      LD: 50.0e-9,
       KF: 2.0e-24,
       AF: 1.4,
     });
@@ -431,6 +432,7 @@ describe("dcOp", () => {
       PB: 0.9,
       MJ: 0.45,
       FC: 0.4,
+      LD: 50.0e-9,
       KF: 2.0e-24,
       AF: 1.4,
     });
@@ -442,6 +444,7 @@ describe("dcOp", () => {
     expectClose(mosModel.params.PB, 0.9);
     expectClose(mosModel.params.MJ, 0.45);
     expectClose(mosModel.params.FC, 0.4);
+    expectClose(mosModel.params.LD, 50.0e-9);
     expectClose(mosModel.params.KF, 2.0e-24);
     expectClose(mosModel.params.AF, 1.4);
   });
@@ -1190,6 +1193,26 @@ describe("dcOp", () => {
     expect(gateVoltage("PJF", -0.3, 1.0e-9)).toBeGreaterThan(
       gateVoltage("PJF", -0.3, 1.0e-14),
     );
+  });
+
+  it("preserves MOS lateral diffusion through subcircuit expansion", () => {
+    const circuit = new Circuit();
+    circuit.defineSubcircuit(
+      subcircuitDefinition("mos-cell", ["d", "g", "s", "b"], [
+        mosfet("Mcell", "d", "g", "s", "b", "NMOS", {
+          L: 1.0e-6,
+          LD: 0.1e-6,
+        }),
+      ]),
+    );
+    circuit.instantiate(xInstance("X1", ["d1", "g1", "0", "0"], "mos-cell"));
+
+    const expanded = circuit.elements().find(
+      (element): element is Mosfet => element.kind === "mosfet",
+    );
+    expect(expanded).toBeDefined();
+    expectClose(expanded!.params.L, 1.0e-6);
+    expectClose(expanded!.params.LD, 0.1e-6);
   });
 
   it("preserves the complete BJT model through subcircuit expansion", () => {
@@ -2354,6 +2377,36 @@ describe("dcOp", () => {
           : "MOSFET FC must be finite",
       );
     }
+  });
+
+  it("rejects invalid MOSFET lateral diffusion lengths", () => {
+    for (const lateralDiffusionLength of [Number.NaN, -0.1e-6, 0.5e-6]) {
+      const circuit = new Circuit();
+      circuit.add(mosfet("Mbad", "drain", "gate", "0", "0", "NMOS", {
+        L: 1.0e-6,
+        LD: lateralDiffusionLength,
+      }));
+      expect(() => dcOp(circuit)).toThrowError(
+        Number.isFinite(lateralDiffusionLength)
+          ? "MOSFET LD must be non-negative with L - 2*LD > 0"
+          : "MOSFET LD must be finite",
+      );
+    }
+  });
+
+  it("uses MOSFET lateral diffusion to shorten effective channel length", () => {
+    const drainCurrent = (lateralDiffusionLength: number): number => {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vdrain", "drain", "0", 1.8));
+      circuit.add(voltageSource("Vgate", "gate", "0", 1.8));
+      circuit.add(mosfet("M1", "drain", "gate", "0", "0", "NMOS", {
+        L: 1.0e-6,
+        LD: lateralDiffusionLength,
+      }));
+      return Math.abs(dcOp(circuit).branchCurrent("Vdrain")!);
+    };
+
+    expect(drainCurrent(0.1e-6) / drainCurrent(0.0)).toBeCloseTo(1.25);
   });
 
   it("rejects invalid BJT model parameters", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS forward-bias depletion coefficient.
+1. Cross-language Level-1 MOS lateral diffusion.
    - Status: current PR completion candidate.
-   - Add Berkeley Level-1 MOS `FC` model-card support in Rust, Python, and
-     TypeScript, defaulting to `0.5`.
-   - Apply the continuous piecewise forward-bias continuation to `CBS` and
-     `CBD` depletion capacitance shaped by `PB` and `MJ`.
-   - Preserve the coefficient through hierarchy and cloning, validate its
-     finite `[0, 1)` domain, and extend the supported-parameter coverage gate
-     from 181 to 183 canonical rows.
+   - Add Berkeley Level-1 MOS `LD` model-card support in Rust, Python, and
+     TypeScript, defaulting to zero.
+   - Apply `L_eff = L - 2*LD` to channel current and length-scaled intrinsic
+     and `CGBO` capacitance while preserving width-scaled overlap capacitance.
+   - Preserve the geometry through hierarchy and cloning, require finite
+     non-negative `LD` with positive effective length, and extend the
+     supported-parameter coverage gate from 183 to 185 canonical rows.
 
 ## Completed Slices
 
@@ -3403,6 +3403,16 @@ the Rust, Python, and TypeScript surfaces together.
    - Hierarchy and cloning preserve the exponent, shared validation enforces
      its finite non-negative domain, and the supported-parameter release gate
      now covers 181 canonical rows.
+
+266. Cross-language Level-1 MOS forward-bias depletion coefficient.
+   - Status: completed in PR 8995.
+   - Rust, Python, and TypeScript Level-1 MOS model cards now accept `FC`,
+     defaulting to `0.5`, and apply the continuous piecewise forward-bias
+     continuation to `CBS` and `CBD` depletion capacitance shaped by `PB` and
+     `MJ`.
+   - Hierarchy and cloning preserve the coefficient, shared validation
+     enforces its finite `[0, 1)` domain, and the supported-parameter release
+     gate now covers 183 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley Level-1 MOS `LD` model-card support across Rust, Python, and TypeScript
- apply `L_eff = L - 2*LD` to channel current and length-scaled intrinsic/`CGBO` capacitance
- preserve `LD` through subcircuit expansion, validate effective geometry, and advance the coverage gate from 183 to 185 canonical rows

## Verification
- `cargo fmt -p mosfet-models -p spice-engine -- --check`
- `cargo test -p mosfet-models -p spice-engine`
- Python `mosfet-models`: 27 passed
- Python `spice-engine`: 623 passed, 88.76% coverage
- TypeScript `spice-engine`: build passed, 375 tests passed
- `git diff --check`