### PR TITLE
feat(hl03): flag the special-consonant rows in the matrix (HL03 syllabary PR7)

### DIFF
--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.23.0 — flag the special-consonant rows in the matrix (syllabary, PR 7)
+
+- **The matrix now marks its tricky rows.** In the consonant × vowel grid the
+  retroflex **ḷa** and alveolar **ṟa / ṉa** rows — the ones a reader confuses
+  with the ordinary *la / ra / na* — now carry a **★** and the same teal tint the
+  Browse tiles give them, so in the full grid the confusable rows stand out at a
+  glance. Connects the special-consonant flag (PR 4) to the matrix (PR 5).
+- **No new judgement.** `buildSyllableMatrix` gains a `special` flag per row,
+  computed by reusing the already-tested `specialConsonant` classifier on the
+  row's base syllable — so the matrix flags exactly the same rows the tiles do
+  (Telugu ḷa / ṟa; Malayalam also ṉa; Telugu has no ṉa). Control-tested: a "ḷa"
+  row is flagged, "ka"/"la"/"ra" are not, and the real Telugu grid flags exactly
+  the ḷa / ṟa rows. Zero new data.
+
 ## 0.22.0 — the independent (word-initial) vowels (syllabary, PR 6)
 
 - **The syllabaries now carry their standalone vowels.** Everything so far was

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -175,7 +175,9 @@ pure (`buildSyllableMatrix` in `src/matrix.ts`): rows reuse the grounded
 consonant boundary from `syllabary.ts`, the vowel column headers are read off
 the first consonant's own row, and a ragged script yields **no matrix** rather
 than a mislabelled cell (unit-tested with a control). No new data — the same
-generated syllables, re-arranged.
+generated syllables, re-arranged. The **special-consonant rows** (retroflex ḷa,
+alveolar ṟa / ṉa) are marked with a ★ in the grid, reusing the same
+`specialConsonant` classifier the tiles use so the confusable rows stand out.
 
 **The independent (word-initial) vowels.** Everything above is consonant + vowel
 *sign*; a word that *begins* with a vowel writes a different letter — the

--- a/code/programs/typescript/language-ladder/package.json
+++ b/code/programs/typescript/language-ladder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ladder",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "private": true,
   "description": "The unified curriculum learning app (HL03): walk the language chain concept by concept, seeing the threads back to what you already know, then review it all with a randomised SRS quiz. (Was the HL02 script-writing-visualizer, whose Browse/Practice/Lessons/Concepts modes it now subsumes.)",
   "type": "module",

--- a/code/programs/typescript/language-ladder/src/main.ts
+++ b/code/programs/typescript/language-ladder/src/main.ts
@@ -476,8 +476,11 @@ function renderMatrix(letters: Letter[]): HTMLElement | null {
   const tbody = el("tbody", "");
   m.rows.forEach((row) => {
     const tr = el("tr", "");
-    const rh = el("th", "matrix__consonant");
-    rh.textContent = row.label;
+    const rh = el("th", "matrix__consonant" + (row.special ? " matrix__consonant--special" : ""));
+    // Mark the retroflex/alveolar rows (ḷ/ṟ/ṉ) so the confusable ones stand out
+    // in the full grid, the same rows the tiles flag as special consonants.
+    rh.textContent = row.special ? `★ ${row.label}` : row.label;
+    if (row.special) rh.title = "Special consonant — tell it apart from the ordinary letter";
     tr.appendChild(rh);
     row.cells.forEach((cell) => {
       const td = el("td", "matrix__cell" + (cell.index === currentLetter ? " matrix__cell--active" : ""));

--- a/code/programs/typescript/language-ladder/src/matrix.ts
+++ b/code/programs/typescript/language-ladder/src/matrix.ts
@@ -20,6 +20,7 @@
 // ---------------------------------------------------------------------------
 
 import { consonantGroups } from "./syllabary.ts";
+import { specialConsonant } from "./core.ts";
 
 /** The minimal syllable shape the matrix needs. */
 interface MatrixLetter {
@@ -43,8 +44,10 @@ export interface SyllableMatrix {
   /** ISO-15919 vowel per column (a, ā, i, …, ai, au, r̥) — read off the data. */
   vowels: string[];
   /** Rows in consonant-major order; `label` is the consonant's inherent-"a"
-   *  form (ka, kha, ḷa), `cells` its syllables across the vowel columns. */
-  rows: { label: string; cells: MatrixCell[] }[];
+   *  form (ka, kha, ḷa), `cells` its syllables across the vowel columns, and
+   *  `special` marks the retroflex/alveolar consonants (ḷ/ṟ/ṉ) — the rows a
+   *  reader confuses with the ordinary la/ra/na. */
+  rows: { label: string; cells: MatrixCell[]; special: boolean }[];
 }
 
 /**
@@ -76,10 +79,16 @@ export function buildSyllableMatrix(letters: MatrixLetter[]): SyllableMatrix | n
     return s.startsWith(prefix) ? s.slice(prefix.length) : s;
   });
 
-  const rows = groups.map((g) => ({
-    label: letters[g[0]!]!.sound,
-    cells: g.map((i) => ({ index: i, glyph: letters[i]!.glyph, sound: letters[i]!.sound })),
-  }));
+  const rows = groups.map((g) => {
+    const label = letters[g[0]!]!.sound;
+    return {
+      label,
+      // Reuse the tested false-friend classifier so the matrix flags the same
+      // retroflex/alveolar rows the Browse tiles do — no separate judgement here.
+      special: specialConsonant({ sound: label }) !== null,
+      cells: g.map((i) => ({ index: i, glyph: letters[i]!.glyph, sound: letters[i]!.sound })),
+    };
+  });
 
   return { vowels, rows };
 }

--- a/code/programs/typescript/language-ladder/src/styles.css
+++ b/code/programs/typescript/language-ladder/src/styles.css
@@ -493,6 +493,7 @@ body {
   background: var(--bg); color: var(--muted);
   font-size: 0.75rem; padding: 4px 8px; white-space: nowrap;
 }
+.matrix__consonant--special { background: var(--special-bg); color: var(--special); font-weight: 600; }
 .matrix__corner { position: sticky; left: 0; top: 0; z-index: 2; background: var(--bg); }
 .matrix__cell { padding: 0; }
 .matrix__cell--active { box-shadow: inset 0 0 0 2px var(--accent); }

--- a/code/programs/typescript/language-ladder/tests/matrix.test.ts
+++ b/code/programs/typescript/language-ladder/tests/matrix.test.ts
@@ -41,6 +41,27 @@ describe("buildSyllableMatrix", () => {
   });
 });
 
+describe("special-consonant rows", () => {
+  it("flags the retroflex/alveolar rows and leaves the ordinary ones alone", () => {
+    // Two consonant rows: ordinary "la" and retroflex "ḷa" (LLA).
+    const letters = [
+      base("la"), signed("li"), signed("lu"),
+      base("ḷa"), signed("ḷi"), signed("ḷu"),
+    ];
+    const m = buildSyllableMatrix(letters)!;
+    expect(m.rows.map((r) => r.label)).toEqual(["la", "ḷa"]);
+    // CONTROL: only the special consonant's row is flagged.
+    expect(m.rows.map((r) => r.special)).toEqual([false, true]);
+  });
+
+  it("flags exactly the ḷa / ṟa rows of the real Telugu grid (Telugu has no ṉa)", () => {
+    const telugu = SCRIPTS.find((s) => s.script === "telugu")!;
+    const m = buildSyllableMatrix(telugu.letters as never)!;
+    const flagged = m.rows.filter((r) => r.special).map((r) => r.label);
+    expect(flagged).toEqual(["ḷa", "ṟa"]);
+  });
+});
+
 describe("against the real generated Telugu syllabary", () => {
   const telugu = SCRIPTS.find((s) => s.script === "telugu")!;
 


### PR DESCRIPTION
## What & why

Finishing polish connecting the special-consonant flag (PR #8988) to the matrix (PR #8993). In the consonant × vowel grid, the retroflex **ḷa** and alveolar **ṟa / ṉa** rows — the ones a reader confuses with the ordinary *la / ra / na* — now carry a **★** and the same teal tint the Browse tiles give them, so the confusable rows stand out at a glance in the full grid.

## Eyeball (native reader)

In the Telugu matrix, the last two rows are marked: **★ ḷa (ళ)** and **★ ṟa (ఱ)** — teal-tinted, ★-prefixed — while the ordinary **la (ల)**, **ra (ర)**, **ha (హ)** rows are unmarked. (Malayalam additionally marks **★ ṉa (ഩ)**; Telugu has no ṉa.)

## How

- **matrix.ts** — `buildSyllableMatrix` rows gain a `special` flag, computed by **reusing the already-tested `specialConsonant` classifier** on the row's base syllable. No new judgement — the matrix flags exactly the rows the tiles do. (No circular import: `matrix.ts → core.ts`, `core.ts → types.ts` only.)
- **main.ts** — renderMatrix prefixes `★ ` and a class on special row headers.
- **styles.css** — `.matrix__consonant--special` reuses the `--special` tokens.
- **tests** — CONTROL: a "ḷa" row is flagged, "ka"/"la"/"ra" are not; the real Telugu grid flags **exactly** the ḷa / ṟa rows.

Zero new data.

## Verification

- App suite **257 → 259** pass; human-language-data **38** pass; `npm run build` clean.
- Grounding review: Telugu flags exactly [ḷa, ṟa], Malayalam [ḷa, ṟa, ṉa]; no false positives (the retroflex nasal ṇa, dot-below, is correctly **not** flagged — different code point from the alveolar ṉ); no cell-alignment impact (only the row `<th>` changes).
- Browser (headless): confirmed the ★-marked ళ / ఱ rows at the bottom of the Telugu matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)