### PR TITLE
feat(adj-formula-stdlib): dynamic-viscosity-conversions — NIST SP 811 B.9 poise/centipoise→pascal-second exact factors (RS-5 table)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -589,6 +589,48 @@ fn shipped_acceleration_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b12) Shipped table — reference/dynamic-viscosity-conversions.adj resolves via
+//       import (a NEW dimension: dynamic viscosity → pascal second, the EXACT SP 811
+//       B.9 boldface CGS factors poise and centipoise), and a non-exact customary
+//       unit (`pound_force_second_per_square_foot`) — a rounded factor with no row —
+//       abstains.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_dynamic_viscosity_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_visc");
+    let src = stdlib().join("reference/dynamic-viscosity-conversions.adj");
+    std::fs::copy(&src, dir.join("dynamic-viscosity-conversions.adj"))
+        .expect("copy shipped dynamic-viscosity-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"dynamic-viscosity-conversions.adj\"\n\
+         ? dynamic_viscosity_to_pascal_seconds(poise, $v)\n\
+         ? dynamic_viscosity_to_pascal_seconds(centipoise, $v)\n\
+         ? dynamic_viscosity_to_pascal_seconds(pound_force_second_per_square_foot, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 "Viscosity, dynamic" exact factors resolve, character-for-
+    // character from the table (boldface = exact; scientific notation to plain decimal).
+    assert!(out.contains("\"v\":\"0.1\""), "poise = 0.1 Pa·s: {out}");
+    assert!(out.contains("\"v\":\"0.001\""), "centipoise = 0.001 Pa·s: {out}");
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `pound_force_second_per_square_foot` is a NIST customary row printed as a ROUNDED
+    // (non-boldface) factor — not an exact row here, so the engine abstains rather than
+    // committing to a rounded value.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a non-exact unit abstains, never a fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/dynamic-viscosity-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/dynamic-viscosity-conversions.adj
@@ -1,0 +1,61 @@
+% ============================================================================
+% dynamic-viscosity-conversions — dynamic-viscosity-unit → pascal-second factors
+% (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of `pressure-conversions.adj` / `force-conversions.adj`: a
+% native tabular relation ingested VERBATIM from a published NIST conversion table.
+% Each row states the factor converting one dynamic-viscosity unit to the SI
+% coherent unit of dynamic viscosity, the pascal second (Pa·s):
+%
+%     ? dynamic_viscosity_to_pascal_seconds(poise, $v)         % 0.1
+%     ? dynamic_viscosity_to_pascal_seconds(centipoise, $v)    % 0.001
+%
+% This is a NEW dimension alongside the length/mass/area/volume/time/speed/energy/
+% pressure/force/acceleration tables: where those normalise their own quantity, this
+% one normalises a DYNAMIC VISCOSITY. It pairs naturally with the pressure table (a
+% pascal second is a pascal times a second) and with any fluid-mechanics reasoning —
+% put a viscosity given in the CGS poise into SI first, then reason (write-once-
+% use-many). Why a `table` and not several hand-written `relate` clauses: this is
+% exactly the shape reference data comes in — a published table, not prose. The
+% citable artifact IS the NIST conversion-factors table at the `locator` below; every
+% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors for
+% units listed alphabetically"), and the whole table is defended by one provenance
+% envelope rather than repeating `source`/`locator`/`trust` on every row. Each `row`
+% lowers to a ground relation `dynamic_viscosity_to_pascal_seconds(unit, pas)`, so the
+% exact lookup above is the ordinary SLD binding query — the engine returns the factor
+% WITH this table's citation as its proof, on the CPU, with zero model calls.
+%
+% HONESTY NOTE (like force-conversions, only the EXACT defined factors get a row, not
+% the rounded ones): NIST SP 811 B.9 prints these two "Viscosity, dynamic" factors in
+% BOLDFACE, its convention for factors that are EXACT by definition, transcribed here
+% as the plain decimal number of pascal seconds each unit names:
+%
+%     poise (P)        1.0 E-01  →  0.1
+%     centipoise (cP)  1.0 E-03  →  0.001
+%
+% These two are exact because the poise is a coherent CGS unit — one poise is one gram
+% per centimetre second, i.e. exactly 0.1 pascal second (10⁻¹ Pa·s) — and the
+% centipoise is exactly one hundredth of a poise, i.e. exactly 10⁻³ Pa·s. Both
+% terminate; nothing here is a rounded measurement. NIST's other dynamic-viscosity
+% rows are customary units whose factors NIST prints in plain (non-boldface) type as
+% ROUNDED values — e.g. "pound-force second per square foot" at 4.788 026 E+01 Pa·s
+% and "poundal second per square foot" at 1.488 164 E+00 Pa·s — so they are NOT given
+% rows here; a `? dynamic_viscosity_to_pascal_seconds(pound_force_second_per_square_foot,
+% $v)` ABSTAINS rather than committing to a rounded factor. The only claim this table
+% makes is "these are the exact factors NIST SP 811 B.9 prints" — which is exactly what
+% a byte-check against the cited table verifies. `trust authoritative` — a primary,
+% re-fetchable standards reference. (See ADJ-TABLES.md; and
+% feedback_nothing_human_authored — every factor is a verbatim cell of the cited
+% table, nothing asserted from memory.)
+% ============================================================================
+
+table dynamic_viscosity_to_pascal_seconds {
+    columns unit, pas
+
+    row (poise, 0.1)
+    row (centipoise, 0.001)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/dynamic-viscosity-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/dynamic-viscosity-conversions.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% dynamic-viscosity-conversions.query.adj — a worked lookup over the viscosity table.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a "how many pascal
+% seconds is one poise?" question: it states no conversion fact — it only `import`s
+% the grounded table and asks binding queries. The native adj-lang engine resolves
+% each `?` against the table's rows (lowered to
+% `dynamic_viscosity_to_pascal_seconds` relations) and returns the binding + the
+% table's source/locator/trust. A unit not in the table abstains honestly — the
+% engine never invents a factor (notably NIST's non-exact customary rows, e.g. the
+% pound-force second per square foot, which are rounded and therefore get no row).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli dynamic-viscosity-conversions.query.adj
+% ============================================================================
+
+import "dynamic-viscosity-conversions.adj"
+
+? dynamic_viscosity_to_pascal_seconds(poise, $v)                              % expect 0.1
+? dynamic_viscosity_to_pascal_seconds(centipoise, $v)                         % expect 0.001
+? dynamic_viscosity_to_pascal_seconds(pound_force_second_per_square_foot, $v) % expect abstain — non-exact, no row


### PR DESCRIPTION
## What

Adds `reference/dynamic-viscosity-conversions.adj` — a native RS-5 `table` for a **new dimension**, dynamic viscosity → the SI **pascal second (Pa·s)** — a sibling of the length/mass/area/volume/time/speed/energy/pressure/force/acceleration conversion tables. Two rows, **both exact** (NIST prints them boldface = exact by definition), transcribed **verbatim** from NIST Special Publication 811, Appendix B.9 ("Factors for units listed alphabetically"):

| unit | NIST B.9 factor | Pa·s |
|---|---|---|
| poise (P) | **1.0 E-01** | 0.1 |
| centipoise (cP) | **1.0 E-03** | 0.001 |

Each `row` lowers to a ground relation `dynamic_viscosity_to_pascal_seconds(unit, pas)`, so an exact lookup is the ordinary SLD binding query — the engine returns the factor **with the table's one provenance envelope** (`source`/`locator`/`trust authoritative`), on the CPU, zero model calls.

## Honesty / abstention

A unit NIST prints as a **rounded** (non-boldface) customary factor — e.g. the pound-force second per square foot at `4.788026 E+01` Pa·s — is deliberately given **no row**, so a lookup of it **abstains** rather than committing to a rounded value. The only claim the table makes is "these are the exact factors NIST SP 811 B.9 prints" — which a byte-check against the cited page verifies.

## Files

- `reference/dynamic-viscosity-conversions.adj` — the grounded RS-5 table
- `reference/dynamic-viscosity-conversions.query.adj` — worked lookups (poise → 0.1, centipoise → 0.001, and an abstaining miss)
- `adj-lang-cli/tests/rs5_table_e2e.rs` — new **(b12)** block on the shared table anchor, driving the built CLI against the shipped table

## Verification

- `cargo test -p adj-lang-cli --test rs5_table_e2e` → **17/17 pass** (new block asserts exact `0.1` / `0.001`, the NIST B.9 locator on the answer, and abstention on the non-exact unit)
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean
- Shipped query run through the CLI → `0.1` / `0.001` exact, `abstained:true` on the non-exact unit, NIST B.9 locator carried
- NUL-scan: 0 bytes in all touched files
- Byte-verified verbatim against NIST SP 811 B.9 (poise `1.0 E-01`, centipoise `1.0 E-03`, both boldface/exact)
- Data + test only — **no version bump**
- `/security-review` → PASSED (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)