### PR TITLE
feat(adj-formula-stdlib): mean-arterial-pressure — MAP = DBP + (SBP−DBP)/3 3-way inverter (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_mean_arterial_pressure_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_mean_arterial_pressure_e2e.rs
@@ -1,0 +1,143 @@
+//! End-to-end tests for the `clinical/mean-arterial-pressure.adj` library — the
+//! definition of mean arterial pressure (MAP = diastolic + (systolic − diastolic)/3)
+//! and its two exact rearrangements (SBP = 3·MAP − 2·DBP, DBP = (3·MAP − SBP)/2) —
+//! driven through the built CLI binary against the SHIPPED stdlib.
+//! Each proves the same invariant as the other formula libraries: a consumer states
+//! NO arithmetic; it imports the grounded library, binds the pressures with
+//! `observe`, and the engine applies the cited definition on the CPU, computing the
+//! EXACT value and rendering the definition's citation and trust tier in the
+//! `derived` section (the auditable answer). The three formulas INVERT around the
+//! worked case SBP = 110 mmHg, DBP = 80 mmHg: 80 + (110 − 80)/3 = 90, and both
+//! 3·90 − 2·80 = 110 and (3·90 − 110)/2 = 80 recover the inputs.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped mean-arterial-pressure library, resolved from this
+/// crate's manifest dir so the test is location-independent.
+fn shipped_map_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/mean-arterial-pressure.adj")
+        .canonicalize()
+        .expect("shipped mean-arterial-pressure.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_map_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_map_lib()).unwrap();
+    std::fs::write(dir.join("mean-arterial-pressure.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// mean_arterial_pressure — the definition: diastolic plus one-third of the pulse
+// pressure (systolic minus diastolic).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_map_library_and_computes_definition_with_citation() {
+    let dir = scratch("def");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"mean-arterial-pressure.adj\"\n\
+         observe systolic_pressure(110)\n\
+         observe diastolic_pressure(80)\n\
+         ? mean_arterial_pressure(systolic_pressure, diastolic_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied definition's result: 80 + (110 − 80)/3 = 90.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"mean_arterial_pressure\"") && s.contains("\"value\":90"),
+        "mean_arterial_pressure(110, 80) = 90: {s}"
+    );
+    // … AND the OpenStax/LibreTexts citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("med.libretexts.org"),
+        "applied definition carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// systolic_pressure — the same definition solved for SBP: 3·MAP − 2·DBP, which
+// INVERTS the mean arterial pressure just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_systolic_from_map_and_diastolic_with_citation() {
+    let dir = scratch("sbp");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"mean-arterial-pressure.adj\"\n\
+         observe mean_arterial_pressure(90)\n\
+         observe diastolic_pressure(80)\n\
+         ? systolic_pressure(mean_arterial_pressure, diastolic_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 3·90 − 2·80 = 110, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"systolic_pressure\"") && s.contains("\"value\":110"),
+        "systolic_pressure(90, 80) = 110: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("med.libretexts.org"),
+        "systolic_pressure carries its LibreTexts citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// diastolic_pressure — the same definition solved for DBP: (3·MAP − SBP)/2, the
+// third exact reading of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_diastolic_from_map_and_systolic_with_citation() {
+    let dir = scratch("dbp");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"mean-arterial-pressure.adj\"\n\
+         observe mean_arterial_pressure(90)\n\
+         observe systolic_pressure(110)\n\
+         ? diastolic_pressure(mean_arterial_pressure, systolic_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (3·90 − 110)/2 = 80, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"diastolic_pressure\"") && s.contains("\"value\":80"),
+        "diastolic_pressure(90, 110) = 80: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("med.libretexts.org"),
+        "diastolic_pressure carries its LibreTexts citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/mean-arterial-pressure.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/mean-arterial-pressure.adj
@@ -1,0 +1,110 @@
+% ============================================================================
+% mean-arterial-pressure.adj — the definition of mean arterial pressure
+% (MAP = diastolic + (systolic − diastolic)/3) in the ADJ standard library.
+% ============================================================================
+% The mean-arterial-pressure entry of the *clinical* track, a hemodynamics
+% sibling of `cardiac-output.adj` and `bmi.adj`: the foundational blood-pressure
+% definition a first course states as MEAN ARTERIAL PRESSURE IS THE DIASTOLIC
+% PRESSURE PLUS ONE-THIRD OF THE PULSE PRESSURE (the pulse pressure being the
+% systolic minus the diastolic) — the average driving pressure of blood into the
+% tissues over a cardiac cycle — as an importable, byte-provenanced, PARAMETERIZED
+% `formula`, together with its two exact rearrangements (the systolic a MAP implies
+% for a diastolic, and the diastolic a MAP implies for a systolic). As with every
+% compute library, a consumer states NO arithmetic: it `import`s this file, binds
+% the measured pressures from its own byte-provenance decomposition, and asks the
+% engine to APPLY the cited definition on the CPU. Zero math is performed by the
+% model; the engine computes each value EXACTLY, carrying the definition's citation.
+%
+%     import "mean-arterial-pressure.adj"
+%     observe systolic_pressure(110)    % "…110 mmHg systolic…"  (span cited by the model)
+%     observe diastolic_pressure(80)    % "…80 mmHg diastolic…"  (span cited by the model)
+%     ? mean_arterial_pressure(systolic_pressure, diastolic_pressure)
+%                                          % engine → 90, carrying MAP = DBP + (SBP−DBP)/3
+%
+% The one-third weighting is NOT a separately grounded physiological constant — it
+% is part of the definition itself ("adding the diastolic pressure to one-third of
+% the pulse pressure"), so the sole citation below defends it along with the
+% relation. All three formulas are EXACT over their parameters (the engine works in
+% exact rationals), and the three COMPOSE and invert cleanly around the worked case
+% SBP = 110 mmHg, DBP = 80 mmHg (pulse pressure 30 mmHg, MAP = 80 + 30/3 = 90 mmHg):
+% the `mean_arterial_pressure` a consumer computes from a systolic and diastolic is
+% exactly the MAP the `systolic_pressure` formula uses to recover that systolic, and
+% exactly the MAP the `diastolic_pressure` formula uses to recover that diastolic.
+%
+%   mean_arterial_pressure(systolic, diastolic) = diastolic + (systolic − diastolic)/3   % MAP = DBP + (SBP−DBP)/3  (definition)
+%   systolic_pressure(map, diastolic)           = 3*map − 2*diastolic                     % solve MAP = (SBP + 2·DBP)/3 for SBP
+%   diastolic_pressure(map, systolic)           = (3*map − systolic)/2                    % solve MAP = (SBP + 2·DBP)/3 for DBP
+%
+% The two inversions are algebra on the SAME definition: writing MAP = DBP + (SBP−DBP)/3
+% over a common denominator gives MAP = (SBP + 2·DBP)/3, i.e. 3·MAP = SBP + 2·DBP;
+% solving that for SBP gives SBP = 3·MAP − 2·DBP, and solving it for DBP gives
+% DBP = (3·MAP − SBP)/2. Around the worked case: 3·90 − 2·80 = 270 − 160 = 110 recovers
+% the systolic, and (3·90 − 110)/2 = 160/2 = 80 recovers the diastolic.
+%
+% NOTE: all three pressures must be in the same unit (millimetres of mercury, mmHg,
+% by clinical convention); the MAP then comes out in that same unit. This library
+% computes the exact value over whatever consistent unit it is given.
+%
+% All three formulas are defended by the SAME definitional sentence — "Although
+% complicated to measure directly and complicated to calculate, MAP can be
+% approximated by adding the diastolic pressure to one-third of the pulse pressure
+% or systolic pressure minus the diastolic pressure:" — because that one definition
+% (MAP is the diastolic plus one-third of the systolic-minus-diastolic pulse
+% pressure) sanctions the relation read every way (MAP from SBP and DBP, SBP from
+% MAP and DBP, or DBP from MAP and SBP). The quote is transcribed verbatim from the
+% OpenStax Anatomy and Physiology 2e "Blood Flow, Blood Pressure, and Resistance"
+% chapter on Medicine LibreTexts (a university-hosted open physiology text — the
+% same primary reference family the other clinical libraries draw on), so each
+% `formula` carries the provenance envelope every shipped grounded clause carries;
+% the linter rejects an unsourced one. (See feedback_nothing_human_authored — the
+% definitional sentence is a verbatim span of the cited page, not asserted from
+% memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable hemodynamic quantity the definition
+% ranges over, and each result is the derived quantity. `systolic_pressure`,
+% `diastolic_pressure` and `mean_arterial_pressure` each appear BOTH as a derived
+% result and as an input (of the other formulas), so each is a single dictionary
+% term used in both roles. The `surface` lists are the everyday names a decomposer
+% maps onto the canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary mean_arterial_pressure_vocab {
+    define systolic_pressure       : finding  surface "systolic pressure", "systolic BP", "SBP"   % millimetres of mercury (mmHg)
+    define diastolic_pressure      : finding  surface "diastolic pressure", "diastolic BP", "DBP"  % millimetres of mercury (mmHg)
+    define mean_arterial_pressure  : finding  surface "mean arterial pressure", "MAP"              % millimetres of mercury (mmHg)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable `let` over
+% its formal parameters, bound at apply time, and each carries the definitional
+% quote from OpenStax A&P on LibreTexts (a quote is required on a shipped formula).
+% The engine works in exact rationals, so each value is returned EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook mean_arterial_pressure_laws {
+    use mean_arterial_pressure_vocab
+
+    % Mean arterial pressure — the diastolic pressure plus one-third of the pulse
+    % pressure (systolic minus diastolic). OpenStax defines MAP as the diastolic
+    % plus one-third of the systolic-minus-diastolic pulse pressure.
+    formula mean_arterial_pressure(systolic_pressure, diastolic_pressure) = diastolic_pressure + (systolic_pressure - diastolic_pressure) / 3
+        source "Although complicated to measure directly and complicated to calculate, MAP can be approximated by adding the diastolic pressure to one-third of the pulse pressure or systolic pressure minus the diastolic pressure:"
+        locator "https://med.libretexts.org/Bookshelves/Anatomy_and_Physiology/Anatomy_and_Physiology_2e_(OpenStax)/04:_Fluids_and_Transport/20:_The_Cardiovascular_System_-_Blood_Vessels_and_Circulation/20.03:_Blood_Flow_Blood_Pressure_and_Resistance"
+        trust authoritative
+
+    % Systolic pressure — the same definition solved for the systolic a MAP implies
+    % for a diastolic (SBP = 3·MAP − 2·DBP). Defended by the SAME definitional
+    % sentence, read the other way.
+    formula systolic_pressure(mean_arterial_pressure, diastolic_pressure) = 3 * mean_arterial_pressure - 2 * diastolic_pressure
+        source "Although complicated to measure directly and complicated to calculate, MAP can be approximated by adding the diastolic pressure to one-third of the pulse pressure or systolic pressure minus the diastolic pressure:"
+        locator "https://med.libretexts.org/Bookshelves/Anatomy_and_Physiology/Anatomy_and_Physiology_2e_(OpenStax)/04:_Fluids_and_Transport/20:_The_Cardiovascular_System_-_Blood_Vessels_and_Circulation/20.03:_Blood_Flow_Blood_Pressure_and_Resistance"
+        trust authoritative
+
+    % Diastolic pressure — the same definition solved for the diastolic a MAP
+    % implies for a systolic (DBP = (3·MAP − SBP)/2). Again the SAME definitional
+    % sentence, read the third way.
+    formula diastolic_pressure(mean_arterial_pressure, systolic_pressure) = (3 * mean_arterial_pressure - systolic_pressure) / 2
+        source "Although complicated to measure directly and complicated to calculate, MAP can be approximated by adding the diastolic pressure to one-third of the pulse pressure or systolic pressure minus the diastolic pressure:"
+        locator "https://med.libretexts.org/Bookshelves/Anatomy_and_Physiology/Anatomy_and_Physiology_2e_(OpenStax)/04:_Fluids_and_Transport/20:_The_Cardiovascular_System_-_Blood_Vessels_and_Circulation/20.03:_Blood_Flow_Blood_Pressure_and_Resistance"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/mean-arterial-pressure.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/mean-arterial-pressure.query.adj
@@ -1,0 +1,35 @@
+% ============================================================================
+% mean-arterial-pressure.query.adj — worked examples over the clinical
+% mean-arterial-pressure library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a MAP question: it
+% states NO arithmetic and NO definition — it only `import`s the grounded library,
+% `observe`s the pressures it decomposed from the prompt (each a byte-provenanced
+% span, elided here), and asks the engine to APPLY the cited definition. The native
+% adj-lang engine binds the parameters, computes each value EXACTLY on the CPU, and
+% returns it with the definition's source/locator/trust.
+%
+% The three questions INVERT: a blood pressure of 110/80 mmHg has a pulse pressure of
+% 30 mmHg and a mean arterial pressure of 80 + 30/3 = 90 mmHg; that 90 mmHg MAP at the
+% same 80 mmHg diastolic is exactly what the systolic formula uses to recover the
+% 110 mmHg systolic (3·90 − 2·80 = 110), and that 90 mmHg MAP at the same 110 mmHg
+% systolic is exactly what the diastolic formula uses to recover the 80 mmHg diastolic
+% ((3·90 − 110)/2 = 80).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli mean-arterial-pressure.query.adj
+% ============================================================================
+
+import "mean-arterial-pressure.adj"
+
+% 110/80 mmHg: mean arterial pressure = 80 + (110 − 80)/3.
+observe systolic_pressure(110)
+observe diastolic_pressure(80)
+? mean_arterial_pressure(systolic_pressure, diastolic_pressure)   % expect 90   (definition: MAP = DBP + (SBP−DBP)/3)
+
+% That 90 mmHg MAP for the same 80 mmHg diastolic: systolic = 3·90 − 2·80.
+observe mean_arterial_pressure(90)
+? systolic_pressure(mean_arterial_pressure, diastolic_pressure)    % expect 110  (same definition, solved for SBP = 3·MAP − 2·DBP)
+
+% That 90 mmHg MAP at the same 110 mmHg systolic: diastolic = (3·90 − 110)/2.
+? diastolic_pressure(mean_arterial_pressure, systolic_pressure)    % expect 80   (same definition, solved for DBP = (3·MAP − SBP)/2)


### PR DESCRIPTION
## What

Adds the clinical **mean-arterial-pressure** library — a hemodynamics sibling of `cardiac-output.adj` and `bmi.adj`. MAP is the diastolic pressure plus one-third of the pulse pressure (systolic − diastolic), shipped as a byte-provenanced, parameterized `formula` together with its two exact rearrangements:

| formula | body | reading |
|---|---|---|
| `mean_arterial_pressure(systolic, diastolic)` | `diastolic + (systolic − diastolic)/3` | MAP = DBP + (SBP−DBP)/3  (definition) |
| `systolic_pressure(map, diastolic)` | `3·map − 2·diastolic` | solve MAP = (SBP + 2·DBP)/3 for SBP |
| `diastolic_pressure(map, systolic)` | `(3·map − systolic)/2` | solve MAP = (SBP + 2·DBP)/3 for DBP |

A consumer states **no arithmetic** — it imports the grounded library, `observe`s the measured pressures from its own byte-provenance decomposition, and the engine applies the cited definition on the CPU, **exact** (rationals), carrying the definition's `source`/`locator`/`trust`.

## Grounding / honesty

The one-third weighting is **part of the definition**, not a separately grounded constant, so the single citation defends the relation read every way. All three formulas carry the **verbatim** OpenStax Anatomy & Physiology 2e definitional sentence — "Although complicated to measure directly and complicated to calculate, MAP can be approximated by adding the diastolic pressure to one-third of the pulse pressure or systolic pressure minus the diastolic pressure:" — from the "Blood Flow, Blood Pressure, and Resistance" chapter on Medicine LibreTexts (the same primary-reference family the other clinical libraries draw on). `trust authoritative`; byte-verified against the cited page.

The three **INVERT** around the worked case SBP=110, DBP=80 → MAP=90 → recovers SBP=110 (3·90 − 2·80) and DBP=80 ((3·90 − 110)/2).

## Files

- `clinical/mean-arterial-pressure.adj` — the grounded 3-way formula library
- `clinical/mean-arterial-pressure.query.adj` — worked inverting lookups (90 / 110 / 80)
- `adj-lang-cli/tests/formula_mean_arterial_pressure_e2e.rs` — 3 dedicated e2e tests driving the built CLI against the shipped library

## Verification

- `cargo test -p adj-lang-cli --test formula_mean_arterial_pressure_e2e` → **3/3 pass** (assert exact 90/110/80 + `trust authoritative` + `med.libretexts.org` on each answer)
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean
- Shipped query run through the CLI → `90` / `110` / `80` exact, each carrying `trust authoritative` and the LibreTexts locator
- NUL-scan: 0 bytes in all three files
- Data + test only — **no version bump**
- `/security-review` → PASSED (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)