### PR TITLE
Add MOS oxide thickness

### DIFF
--- a/code/packages/python/mosfet-models/CHANGELOG.md
+++ b/code/packages/python/mosfet-models/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [0.1.0] — Unreleased
 
 ### Added
+- `Level1Params.TOX` adds Berkeley-default gate oxide thickness and derives
+  Meyer gate capacitance from `Cox = epsilon_ox / TOX`.
 - `Level1Params.LD` applies Berkeley lateral-diffusion geometry through
   `L_eff = L - 2*LD` to channel current and length-scaled capacitance.
 - `Level1Params.FC` adds the continuous Berkeley forward-bias continuation to

--- a/code/packages/python/mosfet-models/README.md
+++ b/code/packages/python/mosfet-models/README.md
@@ -25,7 +25,9 @@ print(r.Id, r.gm, r.gds, r.region)
 - `Level1Params`: Level-1 DC, geometry, capacitance, and noise parameters with
   sane defaults for 130 nm-style NMOS, including zero-default `LD` lateral
   diffusion through `L_eff = L - 2*LD`, `PB` / `MJ` / `FC` bulk-junction
-  depletion shaping, and `KF` / `AF` flicker noise.
+  depletion shaping, Berkeley-default `TOX` gate oxide thickness for intrinsic
+  Meyer capacitance through `Cox = epsilon_ox / TOX`, and `KF` / `AF` flicker
+  noise.
 - `evaluate_level1(params, V_GS, V_DS, V_BS, T)`: returns `MosResult` with Id, gm, gds, gmb, Cgs/Cgd/Cgb/Cbs/Cbd, region.
 - Region detection: cutoff (subthreshold-aware), triode, saturation.
 - Body effect via gamma * (sqrt(PHI-V_BS) - sqrt(PHI)) shift.

--- a/code/packages/python/mosfet-models/src/mosfet_models/level1.py
+++ b/code/packages/python/mosfet-models/src/mosfet_models/level1.py
@@ -12,6 +12,8 @@ from math import exp, isfinite, sqrt
 
 from device_physics import thermal_voltage
 
+OXIDE_PERMITTIVITY = 3.453133e-11
+
 
 @dataclass(frozen=True, slots=True)
 class Level1Params:
@@ -26,6 +28,7 @@ class Level1Params:
     W: float = 1e-6  # channel width (m)
     L: float = 130e-9  # channel length (m)
     LD: float = 0.0  # source/drain lateral diffusion length (m)
+    TOX: float = 1e-7  # gate oxide thickness (m)
     IS: float = 1e-15  # saturation current (A)
     N_SUB: float = 1.4  # subthreshold slope factor
     T_NOM: float = 300.15  # nominal temperature (K)
@@ -117,6 +120,8 @@ def evaluate_level1(
         raise ValueError(
             "MOSFET LD must be finite and non-negative with L - 2*LD > 0"
         )
+    if not isfinite(p.TOX) or p.TOX <= 0.0:
+        raise ValueError("MOSFET TOX must be finite and positive")
     beta = p.KP * (p.W / effective_length)
 
     # Threshold with body effect. The formula is well-defined whenever
@@ -133,7 +138,9 @@ def evaluate_level1(
     Cgs_overlap = p.CGSO * p.W
     Cgd_overlap = p.CGDO * p.W
     Cgb_overlap = p.CGBO * effective_length
-    Cgs_intrinsic = (2.0 / 3.0) * p.W * effective_length * p.KP / 1.0  # placeholder; Meyer model
+    channel_capacitance = (
+        p.W * effective_length * OXIDE_PERMITTIVITY / p.TOX
+    )
     Cgd_intrinsic = 0.0
     Cgb_intrinsic = 0.0
     Cbs_bulk = bulk_junction_capacitance(p.CBS, V_BS, p.PB, p.MJ, p.FC)
@@ -152,7 +159,7 @@ def evaluate_level1(
             gds_sub = (beta * n * V_T) * exp(V_OV / (n * V_T)) * exp(-V_DS / V_T)
             return MosResult(
                 Id=Id_sub, gm=gm_sub, gds=gds_sub, gmb=0.0,
-                Cgs=Cgs_overlap + Cgs_intrinsic,
+                Cgs=Cgs_overlap + channel_capacitance,
                 Cgd=Cgd_overlap + Cgd_intrinsic,
                 Cgb=Cgb_overlap + Cgb_intrinsic,
                 Cbs=Cbs_bulk,
@@ -161,7 +168,7 @@ def evaluate_level1(
             )
         return MosResult(
             Id=0.0, gm=0.0, gds=0.0, gmb=0.0,
-            Cgs=Cgs_overlap + Cgs_intrinsic,
+            Cgs=Cgs_overlap + channel_capacitance,
             Cgd=Cgd_overlap + Cgd_intrinsic,
             Cgb=Cgb_overlap + Cgb_intrinsic,
             Cbs=Cbs_bulk,
@@ -185,8 +192,8 @@ def evaluate_level1(
             gmb = 0.0
         return MosResult(
             Id=Id, gm=gm, gds=gds, gmb=gmb,
-            Cgs=Cgs_overlap + Cgs_intrinsic / 2.0,
-            Cgd=Cgd_overlap + Cgd_intrinsic / 2.0,
+            Cgs=Cgs_overlap + channel_capacitance / 2.0,
+            Cgd=Cgd_overlap + channel_capacitance / 2.0,
             Cgb=Cgb_overlap + Cgb_intrinsic,
             Cbs=Cbs_bulk,
             Cbd=Cbd_bulk,
@@ -204,7 +211,7 @@ def evaluate_level1(
         gmb = 0.0
     return MosResult(
         Id=Id, gm=gm, gds=gds, gmb=gmb,
-        Cgs=Cgs_overlap + (2.0 / 3.0) * Cgs_intrinsic,
+        Cgs=Cgs_overlap + (2.0 / 3.0) * channel_capacitance,
         Cgd=Cgd_overlap,
         Cgb=Cgb_overlap,
         Cbs=Cbs_bulk,

--- a/code/packages/python/mosfet-models/tests/test_models.py
+++ b/code/packages/python/mosfet-models/tests/test_models.py
@@ -150,6 +150,23 @@ def test_lateral_diffusion_validates_effective_channel_length(ld):
         evaluate_level1(Level1Params(L=1e-6, LD=ld), V_GS=1.8, V_DS=1.8)
 
 
+def test_oxide_thickness_scales_intrinsic_gate_capacitance():
+    def capacitance(tox):
+        return evaluate_level1(
+            Level1Params(W=2e-6, L=1e-6, TOX=tox),
+            V_GS=1.8,
+            V_DS=1.8,
+        ).Cgs
+
+    assert capacitance(50e-9) / capacitance(100e-9) == pytest.approx(2.0)
+
+
+@pytest.mark.parametrize("tox", [float("nan"), 0.0, -1e-9])
+def test_oxide_thickness_validates_positive_finite_value(tox):
+    with pytest.raises(ValueError, match="MOSFET TOX must be finite and positive"):
+        evaluate_level1(Level1Params(TOX=tox), V_GS=1.8, V_DS=1.8)
+
+
 def test_overlap_and_bulk_capacitances_are_reported():
     p = Level1Params(
         W=2e-6,

--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add Level-1 MOS model-card `TOX` support, defaulting to `100 nm` and deriving
+  intrinsic Meyer gate capacitance from silicon-dioxide permittivity and oxide
+  thickness.
 - Add Level-1 MOS model-card `LD` support, using `L - 2*LD` for channel
   current and length-scaled intrinsic/`CGBO` capacitance.
 - Add Level-1 MOS model-card `FC` support, applying the continuous Berkeley

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -91,6 +91,8 @@ Level-1 MOS model cards accept `KF` (default `0`) and `AF` (default `1`) and add
 `KF * abs(Id)^AF / frequency` flicker noise alongside channel thermal noise.
 `LD` defaults to zero and applies `L_eff = L - 2*LD` to channel current and
 length-scaled intrinsic/`CGBO` capacitance.
+`TOX` defaults to `1e-7 m`, must be finite and positive, and derives intrinsic
+Meyer gate capacitance from `Cox = epsilon_ox / TOX`.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -311,8 +311,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "PNP": (41, 58, 13, 4),
     "NJF": (22, 30, 7, 3),
     "PJF": (22, 30, 7, 3),
-    "NMOS": (22, 29, 6, 3),
-    "PMOS": (22, 29, 6, 3),
+    "NMOS": (23, 30, 6, 3),
+    "PMOS": (23, 30, 6, 3),
 }
 
 
@@ -464,6 +464,7 @@ _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
     "W": "W",
     "L": "L",
     "LD": "LD",
+    "TOX": "TOX",
     "IS": "IS",
     "NSUB": "N_SUB",
     "N_SUB": "N_SUB",
@@ -1069,6 +1070,7 @@ def mosfet_from_model_card(
         W=p.get("W", defaults.W),
         L=p.get("L", defaults.L),
         LD=p.get("LD", defaults.LD),
+        TOX=p.get("TOX", defaults.TOX),
         IS=p.get("IS", defaults.IS),
         N_SUB=p.get("N_SUB", defaults.N_SUB),
         T_NOM=p.get("T_NOM", defaults.T_NOM),

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -408,7 +408,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 185
+    assert len(coverage) == 187
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -423,7 +423,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tAF\tAF\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 185
+    assert len(records) == 187
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -446,8 +446,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert summary[0].max_alias_count == 3
     assert summary[0].aliased_parameters == ("IS", "VT", "CJO", "VJ", "M")
     assert summary[5].kind == "NMOS"
-    assert summary[5].canonical_parameter_count == 22
-    assert summary[5].accepted_name_count == 29
+    assert summary[5].canonical_parameter_count == 23
+    assert summary[5].accepted_name_count == 30
     assert summary[5].aliased_parameter_count == 6
     assert summary[5].max_alias_count == 3
     assert summary[5].aliased_parameters == (
@@ -469,7 +469,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert table.splitlines()[1] == "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M"
     assert (
         table.splitlines()[-1]
-        == "PMOS\t22\t29\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        == "PMOS\t23\t30\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
     )
     records = model_card_supported_parameter_coverage_summary_records()
     assert len(records) == 7
@@ -497,9 +497,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 185
-    assert report.expected_canonical_parameter_count == 185
-    assert report.accepted_name_count == 255
+    assert report.canonical_parameter_count == 187
+    assert report.expected_canonical_parameter_count == 187
+    assert report.accepted_name_count == 257
     assert report.aliased_parameter_count == 57
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -507,7 +507,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t185\t185\t255\t57\t4\t0"
+        "true\t7\t7\t187\t187\t257\t57\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -535,15 +535,15 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 184
-    assert report.accepted_name_count == 252
+    assert report.canonical_parameter_count == 186
+    assert report.accepted_name_count == 254
     assert report.aliased_parameter_count == 56
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
     assert report.issues[0].field == "canonical_parameter_count"
     assert report.issues[0].message == (
-        "expected NMOS to expose 22 canonical supported parameters, found 21"
+        "expected NMOS to expose 23 canonical supported parameters, found 22"
     )
     assert report.issues[-1].field == "max_alias_count"
     assert report.issues[-1].message == "expected NMOS max alias count 3, found 2"
@@ -551,12 +551,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t184\t185\t252\t56\t4\t4\n"
+        "false\t7\t7\t186\t187\t254\t56\t4\t4\n"
         "kind\tfield\tmessage\n"
-        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 22 canonical "
-        "supported parameters, found 21\n"
-        "NMOS\taccepted_name_count\texpected NMOS to expose 29 accepted model-card "
-        "names, found 26\n"
+        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 23 canonical "
+        "supported parameters, found 22\n"
+        "NMOS\taccepted_name_count\texpected NMOS to expose 30 accepted model-card "
+        "names, found 27\n"
         "NMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing "
         "parameters, found 5\n"
         "NMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
@@ -565,12 +565,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
     assert records[0] == {
         "kind": "NMOS",
         "field": "canonical_parameter_count",
-        "message": "expected NMOS to expose 22 canonical supported parameters, found 21",
+        "message": "expected NMOS to expose 23 canonical supported parameters, found 22",
     }
     assert format_model_card_supported_parameter_coverage_gate_issue_csv(report).startswith(
         "kind,field,message\n"
-        'NMOS,canonical_parameter_count,"expected NMOS to expose 22 canonical '
-        'supported parameters, found 21"\n'
+        'NMOS,canonical_parameter_count,"expected NMOS to expose 23 canonical '
+        'supported parameters, found 22"\n'
     )
     assert (
         json.loads(format_model_card_supported_parameter_coverage_gate_issue_json(report))
@@ -748,6 +748,7 @@ def test_model_card_aliases_build_device_instances() -> None:
             "MJ": 0.45,
             "FC": 0.4,
             "LD": 50.0e-9,
+            "TOX": 25.0e-9,
             "KF": 2.0e-24,
             "AF": 1.4,
         },
@@ -763,6 +764,7 @@ def test_model_card_aliases_build_device_instances() -> None:
         "MJ": 0.45,
         "FC": 0.4,
         "LD": 50.0e-9,
+        "TOX": 25.0e-9,
         "KF": 2.0e-24,
         "AF": 1.4,
     }
@@ -777,6 +779,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(0.45) == mos_model.model.model.params.MJ
     assert pytest.approx(0.4) == mos_model.model.model.params.FC
     assert pytest.approx(50.0e-9) == mos_model.model.model.params.LD
+    assert pytest.approx(25.0e-9) == mos_model.model.model.params.TOX
     assert pytest.approx(2.0e-24) == mos_model.model.model.params.KF
     assert pytest.approx(1.4) == mos_model.model.model.params.AF
 
@@ -1692,7 +1695,15 @@ def test_transient_mosfet_overlap_capacitance_slows_gate_step() -> None:
             "0",
             MOSFET(
                 MosfetType.NMOS,
-                Level1Model(Level1Params(KP=1.0e-12, W=1.0, L=1.0, CGSO=cgso)),
+                Level1Model(
+                    Level1Params(
+                        KP=1.0e-12,
+                        W=1.0,
+                        L=1.0,
+                        TOX=1.0e9,
+                        CGSO=cgso,
+                    )
+                ),
             ),
         ))
         return transient(circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler")
@@ -1883,6 +1894,25 @@ def test_mosfet_lateral_diffusion_uses_effective_channel_length() -> None:
         return abs(dc_op(circuit).branch_currents["I(Vdrain)"])
 
     assert drain_current(0.1e-6) / drain_current(0.0) == pytest.approx(1.25)
+
+
+@pytest.mark.parametrize("tox", [float("nan"), 0.0, -1.0e-9])
+def test_mosfet_rejects_invalid_oxide_thickness(tox: float) -> None:
+    circuit = Circuit()
+    circuit.add(Mosfet(
+        "Mbad",
+        "drain",
+        "gate",
+        "0",
+        "0",
+        MOSFET(MosfetType.NMOS, Level1Model(Level1Params(TOX=tox))),
+    ))
+
+    with pytest.raises(
+        ValueError,
+        match="MOSFET TOX must be finite and positive",
+    ):
+        dc_op(circuit)
 
 
 def test_transient_diode_transit_time_holds_forward_charge_on_turnoff() -> None:
@@ -2809,7 +2839,7 @@ def test_subcircuit_expansion_preserves_complete_jfet_model():
     assert expanded.Tnom == pytest.approx(323.15)
 
 
-def test_subcircuit_expansion_preserves_mos_lateral_diffusion():
+def test_subcircuit_expansion_preserves_mos_geometry():
     cell = SubcircuitDefinition(
         "mos-cell",
         ("d", "g", "s", "b"),
@@ -2822,7 +2852,9 @@ def test_subcircuit_expansion_preserves_mos_lateral_diffusion():
                 "b",
                 MOSFET(
                     MosfetType.NMOS,
-                    Level1Model(Level1Params(L=1.0e-6, LD=0.1e-6)),
+                    Level1Model(
+                        Level1Params(L=1.0e-6, LD=0.1e-6, TOX=25.0e-9)
+                    ),
                 ),
             ),
         ),
@@ -2836,6 +2868,7 @@ def test_subcircuit_expansion_preserves_mos_lateral_diffusion():
     )
     assert expanded.model.model.params.L == pytest.approx(1.0e-6)
     assert expanded.model.model.params.LD == pytest.approx(0.1e-6)
+    assert expanded.model.model.params.TOX == pytest.approx(25.0e-9)
 
 
 def test_subcircuit_expansion_preserves_complete_bjt_model():
@@ -5488,7 +5521,15 @@ def test_ac_mosfet_overlap_capacitance_shunts_high_frequency_gate_drive():
             "0",
             MOSFET(
                 MosfetType.NMOS,
-                Level1Model(Level1Params(KP=1.0e-12, W=1.0, L=1.0, CGSO=cgso)),
+                Level1Model(
+                    Level1Params(
+                        KP=1.0e-12,
+                        W=1.0,
+                        L=1.0,
+                        TOX=1.0e9,
+                        CGSO=cgso,
+                    )
+                ),
             ),
         ))
         result = ac_sweep(c, f_start=100000.0, f_stop=100000.0, n_points=1)
@@ -5499,6 +5540,28 @@ def test_ac_mosfet_overlap_capacitance_shunts_high_frequency_gate_drive():
 
     assert without_capacitance > 0.9
     assert with_capacitance < without_capacitance / 100.0
+
+
+def test_ac_mosfet_oxide_thickness_scales_intrinsic_gate_capacitance():
+    def gate_amplitude(tox: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vac", "in", "0", 0.0, ac=AcSource(1.0)))
+        circuit.add(Resistor("Rin", "in", "gate", 1.0e6))
+        circuit.add(Mosfet(
+            "M1",
+            "0",
+            "gate",
+            "0",
+            "0",
+            MOSFET(
+                MosfetType.NMOS,
+                Level1Model(Level1Params(W=10.0e-6, L=1.0e-6, TOX=tox)),
+            ),
+        ))
+        result = ac_sweep(circuit, f_start=1.0e9, f_stop=1.0e9, n_points=1)
+        return abs(result.points[0].node_voltages["gate"])
+
+    assert gate_amplitude(50.0e-9) < gate_amplitude(100.0e-9)
 
 
 # ============================================================================

--- a/code/packages/rust/mosfet-models/CHANGELOG.md
+++ b/code/packages/rust/mosfet-models/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `Level1Params::tox` adds Berkeley-default gate oxide thickness and derives
+  Meyer gate capacitance from `Cox = epsilon_ox / TOX`.
 - `Level1Params::ld` applies Berkeley lateral-diffusion geometry through
   `L_eff = L - 2*LD` to channel current and length-scaled capacitance.
 - `Level1Params::pb`, `Level1Params::mj`, and `Level1Params::fc` provide

--- a/code/packages/rust/mosfet-models/README.md
+++ b/code/packages/rust/mosfet-models/README.md
@@ -7,8 +7,9 @@ SPICE Level-1 (Shockley) MOSFET I-V model with full small-signal parameter extra
 This crate implements the classical square-law MOSFET model used in introductory SPICE circuit analysis:
 
 - **`Level1Params`** — Level-1 geometry, DC, capacitance, temperature, and
-  noise parameters, including zero-default `LD` lateral diffusion, `KF`
-  flicker noise, and a unit-default `AF` exponent.
+  noise parameters, including zero-default `LD` lateral diffusion,
+  Berkeley-default `TOX` gate oxide thickness, `KF` flicker noise, and a
+  unit-default `AF` exponent.
 - **`evaluate_level1`** — core I-V evaluation returning `MosResult` with `Id`, `gm`, `gds`, `gmb`, gate/body capacitances, and the operating `Region`.
 - **`Region`** — `Cutoff`, `Subthreshold`, `Triode`, `Saturation`.
 - **`MosfetType`** — `Nmos` / `Pmos`.
@@ -24,7 +25,9 @@ This crate implements the classical square-law MOSFET model used in introductory
 | Saturation  | V_DS ≥ V_OV      | (β/2) V_OV² (1 + λV_DS)                   |
 
 where β = KP × W/(L − 2LD) and V_OV = V_GS − V_t. `LD` defaults to zero
-and must leave a positive effective channel length.
+and must leave a positive effective channel length. `TOX` defaults to
+`100 nm`, must be positive, and derives intrinsic Meyer gate capacitance from
+`Cox = epsilon_ox / TOX`.
 
 ## Usage
 

--- a/code/packages/rust/mosfet-models/src/lib.rs
+++ b/code/packages/rust/mosfet-models/src/lib.rs
@@ -19,6 +19,8 @@
 
 use device_physics::thermal_voltage;
 
+const OXIDE_PERMITTIVITY: f64 = 3.453_133e-11;
+
 // ---------------------------------------------------------------------------
 // Level-1 parameter set
 // ---------------------------------------------------------------------------
@@ -37,6 +39,7 @@ use device_physics::thermal_voltage;
 /// | W         | Channel width (m)                  | 1 µm     |
 /// | L         | Channel length (m)                 | 130 nm   |
 /// | LD        | Lateral diffusion length (m)       | 0        |
+/// | TOX       | Gate oxide thickness (m)           | 100 nm   |
 /// | IS        | Drain–body saturation current (A)  | 1 fA     |
 /// | N_SUB     | Subthreshold slope factor          | 1.4      |
 /// | T_NOM     | Nominal temperature (K)            | 300.15   |
@@ -60,6 +63,8 @@ pub struct Level1Params {
     pub l: f64,
     /// Source/drain lateral diffusion length [m].
     pub ld: f64,
+    /// Gate oxide thickness [m].
+    pub tox: f64,
     /// Drain–body saturation current [A] (used for subthreshold floor).
     pub is: f64,
     /// Subthreshold slope factor n.  Subthreshold current ∝ exp(V_OV / (n V_T)).
@@ -101,6 +106,7 @@ impl Default for Level1Params {
             w: 1e-6,
             l: 130e-9,
             ld: 0.0,
+            tox: 1.0e-7,
             is: 1e-15,
             n_sub: 1.4,
             t_nom: 300.15,
@@ -234,6 +240,10 @@ pub fn evaluate_level1(
         p.ld.is_finite() && p.ld >= 0.0 && effective_length > 0.0,
         "MOSFET LD must be finite and non-negative with L - 2*LD > 0"
     );
+    assert!(
+        p.tox.is_finite() && p.tox > 0.0,
+        "MOSFET TOX must be finite and positive"
+    );
     let beta = p.kp * (p.w / effective_length);
 
     // Threshold with body effect.
@@ -253,10 +263,8 @@ pub fn evaluate_level1(
     let cgd_overlap = p.cgdo * p.w;
     let cgb_overlap = p.cgbo * effective_length;
 
-    // Placeholder intrinsic capacitance (Meyer model, saturation reference).
-    // In saturation: C_gs_intrinsic ≈ (2/3) W L C_ox.
-    // We approximate C_ox as KP (units collapse to F/m² in the placeholder).
-    let cgs_intrinsic = (2.0 / 3.0) * p.w * effective_length * p.kp;
+    // Meyer gate-to-channel capacitance, partitioned by operating region below.
+    let channel_capacitance = p.w * effective_length * (OXIDE_PERMITTIVITY / p.tox);
     let cbs_bulk = bulk_junction_capacitance(p.cbs, v_bs, p.pb, p.mj, p.fc);
     let cbd_bulk = bulk_junction_capacitance(p.cbd, v_bs - v_ds, p.pb, p.mj, p.fc);
 
@@ -277,7 +285,7 @@ pub fn evaluate_level1(
                 gm: gm_sub,
                 gds: gds_sub,
                 gmb: 0.0,
-                cgs: cgs_overlap + cgs_intrinsic,
+                cgs: cgs_overlap + channel_capacitance,
                 cgd: cgd_overlap,
                 cgb: cgb_overlap,
                 cbs: cbs_bulk,
@@ -291,7 +299,7 @@ pub fn evaluate_level1(
             gm: 0.0,
             gds: 0.0,
             gmb: 0.0,
-            cgs: cgs_overlap + cgs_intrinsic,
+            cgs: cgs_overlap + channel_capacitance,
             cgd: cgd_overlap,
             cgb: cgb_overlap,
             cbs: cbs_bulk,
@@ -322,8 +330,8 @@ pub fn evaluate_level1(
             gm,
             gds,
             gmb,
-            cgs: cgs_overlap + cgs_intrinsic / 2.0,
-            cgd: cgd_overlap + cgs_intrinsic / 2.0,
+            cgs: cgs_overlap + channel_capacitance / 2.0,
+            cgd: cgd_overlap + channel_capacitance / 2.0,
             cgb: cgb_overlap,
             cbs: cbs_bulk,
             cbd: cbd_bulk,
@@ -343,7 +351,7 @@ pub fn evaluate_level1(
         gm,
         gds,
         gmb,
-        cgs: cgs_overlap + (2.0 / 3.0) * cgs_intrinsic,
+        cgs: cgs_overlap + (2.0 / 3.0) * channel_capacitance,
         cgd: cgd_overlap,
         cgb: cgb_overlap,
         cbs: cbs_bulk,

--- a/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
+++ b/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
@@ -128,6 +128,42 @@ fn test_lateral_diffusion_rejects_nonpositive_effective_length() {
     let _ = evaluate_level1(&params, 1.8, 1.8, 0.0, 300.15);
 }
 
+#[test]
+fn test_oxide_thickness_scales_intrinsic_gate_capacitance() {
+    let capacitance = |tox| {
+        evaluate_level1(
+            &Level1Params {
+                w: 2.0e-6,
+                l: 1.0e-6,
+                tox,
+                ..Level1Params::default()
+            },
+            1.8,
+            1.8,
+            0.0,
+            300.15,
+        )
+        .cgs
+    };
+
+    assert!((capacitance(50.0e-9) / capacitance(100.0e-9) - 2.0).abs() < 1.0e-12);
+}
+
+#[test]
+#[should_panic(expected = "MOSFET TOX must be finite and positive")]
+fn test_oxide_thickness_rejects_nonpositive_value() {
+    evaluate_level1(
+        &Level1Params {
+            tox: 0.0,
+            ..Level1Params::default()
+        },
+        1.8,
+        1.8,
+        0.0,
+        300.15,
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Body effect
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add Level-1 MOS model-card `TOX` support, defaulting to `100 nm` and deriving
+  intrinsic Meyer gate capacitance from silicon-dioxide permittivity and oxide
+  thickness.
 - Add Level-1 MOS model-card `LD` support, using `L - 2*LD` for channel
   current and length-scaled intrinsic/`CGBO` capacitance.
 - Add Level-1 MOS model-card `FC` support, applying the continuous Berkeley

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -132,6 +132,8 @@ Level-1 MOS model cards accept `KF` (default `0`) and `AF` (default `1`) and add
 `KF * abs(Id)^AF / frequency` flicker noise alongside channel thermal noise.
 `LD` defaults to zero and applies `L_eff = L - 2*LD` to channel current and
 length-scaled intrinsic/`CGBO` capacitance.
+`TOX` defaults to `1e-7 m`, must be finite and positive, and derives intrinsic
+Meyer gate capacitance from `Cox = epsilon_ox / TOX`.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -19,6 +19,7 @@ const BOLTZMANN: f64 = 1.380_649e-23;
 const ELECTRON_CHARGE: f64 = 1.602_176_634e-19;
 const MOSFET_CHANNEL_NOISE_GAMMA: f64 = 2.0 / 3.0;
 const DIGITAL_BRIDGE_TIME_EPSILON: f64 = 1.0e-18;
+const OXIDE_PERMITTIVITY: f64 = 3.453_133e-11;
 
 fn real_solver_kind(matrix_size: usize) -> &'static str {
     if matrix_size == 0 {
@@ -3607,6 +3608,7 @@ pub struct MosfetLevel1Params {
     pub w: f64,
     pub l: f64,
     pub lateral_diffusion_length: f64,
+    pub oxide_thickness: f64,
     pub saturation_current: f64,
     pub n_sub: f64,
     pub t_nom: f64,
@@ -3633,6 +3635,7 @@ impl Default for MosfetLevel1Params {
             w: 1.0e-6,
             l: 130.0e-9,
             lateral_diffusion_length: 0.0,
+            oxide_thickness: 1.0e-7,
             saturation_current: 1.0e-15,
             n_sub: 1.4,
             t_nom: 300.15,
@@ -3989,8 +3992,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     (ModelCardKind::Pnp, 41, 58, 13, 4),
     (ModelCardKind::Njf, 22, 30, 7, 3),
     (ModelCardKind::Pjf, 22, 30, 7, 3),
-    (ModelCardKind::Nmos, 22, 29, 6, 3),
-    (ModelCardKind::Pmos, 22, 29, 6, 3),
+    (ModelCardKind::Nmos, 23, 30, 6, 3),
+    (ModelCardKind::Pmos, 23, 30, 6, 3),
 ];
 const DIODE_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IS", "IS"),
@@ -4120,6 +4123,7 @@ const MOS_LEVEL1_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("W", "W"),
     ("L", "L"),
     ("LD", "LD"),
+    ("TOX", "TOX"),
     ("IS", "IS"),
     ("NSUB", "N_SUB"),
     ("N_SUB", "N_SUB"),
@@ -4898,6 +4902,9 @@ pub fn mosfet_from_model_card(
     }
     if let Some(value) = model.parameters.get("LD") {
         params.lateral_diffusion_length = *value;
+    }
+    if let Some(value) = model.parameters.get("TOX") {
+        params.oxide_thickness = *value;
     }
     if let Some(value) = model.parameters.get("IS") {
         params.saturation_current = *value;
@@ -24217,7 +24224,8 @@ fn evaluate_nmos_level1(
     let cgs_overlap = params.gate_source_overlap_capacitance * params.w;
     let cgd_overlap = params.gate_drain_overlap_capacitance * params.w;
     let cgb_overlap = params.gate_bulk_overlap_capacitance * effective_length;
-    let cgs_intrinsic = (2.0 / 3.0) * params.w * effective_length * params.kp;
+    let channel_capacitance =
+        params.w * effective_length * (OXIDE_PERMITTIVITY / params.oxide_thickness);
     let cbs_bulk = mosfet_bulk_junction_capacitance(
         params.source_bulk_capacitance,
         vbs,
@@ -24244,7 +24252,7 @@ fn evaluate_nmos_level1(
             gm: 0.0,
             gds: 0.0,
             gmb: 0.0,
-            cgs: cgs_overlap + cgs_intrinsic,
+            cgs: cgs_overlap + channel_capacitance,
             cgd: cgd_overlap,
             cgb: cgb_overlap,
             cbs: cbs_bulk,
@@ -24266,7 +24274,7 @@ fn evaluate_nmos_level1(
             gm,
             gds: beta * (overdrive - vds) * modulation + beta * channel * params.lambda,
             gmb: gm * body_factor,
-            cgs: cgs_overlap + cgs_intrinsic / 2.0,
+            cgs: cgs_overlap + channel_capacitance / 2.0,
             cgd: cgd_overlap,
             cgb: cgb_overlap,
             cbs: cbs_bulk,
@@ -24281,7 +24289,7 @@ fn evaluate_nmos_level1(
         gm,
         gds: 0.5 * beta * overdrive * overdrive * params.lambda,
         gmb: gm * body_factor,
-        cgs: cgs_overlap + (2.0 / 3.0) * cgs_intrinsic,
+        cgs: cgs_overlap + (2.0 / 3.0) * channel_capacitance,
         cgd: cgd_overlap,
         cgb: cgb_overlap,
         cbs: cbs_bulk,
@@ -25510,6 +25518,7 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         ("W", params.w),
         ("L", params.l),
         ("LD", params.lateral_diffusion_length),
+        ("TOX", params.oxide_thickness),
         ("IS", params.saturation_current),
         ("N_SUB", params.n_sub),
         ("T_NOM", params.t_nom),
@@ -25549,6 +25558,12 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: mosfet.name.clone(),
             reason: "MOSFET LD must be non-negative with L - 2*LD > 0".to_string(),
+        });
+    }
+    if params.oxide_thickness <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET TOX must be positive".to_string(),
         });
     }
     if params.phi <= 0.0 {

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -1336,6 +1336,7 @@ fn ac_mosfet_overlap_capacitance_shunts_high_frequency_gate_drive() {
                 kp: 1.0e-12,
                 w: 1.0,
                 l: 1.0,
+                oxide_thickness: 1.0e9,
                 gate_source_overlap_capacitance: cgso,
                 ..MosfetLevel1Params::default()
             },
@@ -1352,6 +1353,38 @@ fn ac_mosfet_overlap_capacitance_shunts_high_frequency_gate_drive() {
 
     assert!(without_capacitance > 0.9);
     assert!(with_capacitance < without_capacitance / 100.0);
+}
+
+#[test]
+fn ac_mosfet_oxide_thickness_scales_intrinsic_gate_capacitance() {
+    let gate_amplitude = |oxide_thickness| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "in", "0", 0.0, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new("Rin", "in", "gate", 1.0e6)));
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "M1",
+            "0",
+            "gate",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                w: 10.0e-6,
+                l: 1.0e-6,
+                oxide_thickness,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+
+        ac_sweep(&circuit, 1.0e9, 1.0e9, 1).unwrap()[0]
+            .voltage("gate")
+            .unwrap()
+            .abs()
+    };
+
+    assert!(gate_amplitude(50.0e-9) < gate_amplitude(100.0e-9));
 }
 
 #[test]

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -95,7 +95,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 185);
+    assert_eq!(coverage.len(), 187);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -114,7 +114,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tAF\tAF\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 185);
+    assert_eq!(records.len(), 187);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -147,8 +147,8 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         vec!["IS", "VT", "CJO", "VJ", "M"]
     );
     assert_eq!(summary[5].kind, ModelCardKind::Nmos);
-    assert_eq!(summary[5].canonical_parameter_count, 22);
-    assert_eq!(summary[5].accepted_name_count, 29);
+    assert_eq!(summary[5].canonical_parameter_count, 23);
+    assert_eq!(summary[5].accepted_name_count, 30);
     assert_eq!(summary[5].aliased_parameter_count, 6);
     assert_eq!(summary[5].max_alias_count, 3);
     assert_eq!(
@@ -166,7 +166,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     assert_eq!(lines[1], "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\t22\t29\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        &"PMOS\t23\t30\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
     );
     let records = model_card_supported_parameter_coverage_summary_records();
     assert_eq!(records.len(), 7);
@@ -184,7 +184,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         "[{\"kind\":\"D\",\"canonical_parameter_count\":\"15\",\"accepted_name_count\":\"21\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
     ));
     assert!(json.ends_with(
-        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"22\",\"accepted_name_count\":\"29\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
+        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"23\",\"accepted_name_count\":\"30\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
     ));
 }
 
@@ -195,15 +195,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 185);
-    assert_eq!(report.expected_canonical_parameter_count, 185);
-    assert_eq!(report.accepted_name_count, 255);
+    assert_eq!(report.canonical_parameter_count, 187);
+    assert_eq!(report.expected_canonical_parameter_count, 187);
+    assert_eq!(report.accepted_name_count, 257);
     assert_eq!(report.aliased_parameter_count, 57);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t185\t185\t255\t57\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t187\t187\t257\t57\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -230,8 +230,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 184);
-    assert_eq!(report.accepted_name_count, 252);
+    assert_eq!(report.canonical_parameter_count, 186);
+    assert_eq!(report.accepted_name_count, 254);
     assert_eq!(report.aliased_parameter_count, 56);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -239,7 +239,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     assert_eq!(report.issues[0].field, "canonical_parameter_count");
     assert_eq!(
         report.issues[0].message,
-        "expected NMOS to expose 22 canonical supported parameters, found 21"
+        "expected NMOS to expose 23 canonical supported parameters, found 22"
     );
     assert_eq!(report.issues.last().unwrap().field, "max_alias_count");
     assert_eq!(
@@ -248,20 +248,20 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t184\t185\t252\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 22 canonical supported parameters, found 21\nNMOS\taccepted_name_count\texpected NMOS to expose 29 accepted model-card names, found 26\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t186\t187\t254\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 23 canonical supported parameters, found 22\nNMOS\taccepted_name_count\texpected NMOS to expose 30 accepted model-card names, found 27\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
     assert_eq!(records[0]["field"], "canonical_parameter_count");
     assert_eq!(
         records[0]["message"],
-        "expected NMOS to expose 22 canonical supported parameters, found 21"
+        "expected NMOS to expose 23 canonical supported parameters, found 22"
     );
     assert!(format_model_card_supported_parameter_coverage_gate_issue_csv(&report).starts_with(
-        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 22 canonical supported parameters, found 21\"\n"
+        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 23 canonical supported parameters, found 22\"\n"
     ));
     assert!(format_model_card_supported_parameter_coverage_gate_issue_json(&report).starts_with(
-        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 22 canonical supported parameters, found 21\"}"
+        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 23 canonical supported parameters, found 22\"}"
     ));
 }
 
@@ -283,8 +283,8 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(dashboard[0].issue_count, 0);
     assert!(dashboard[0].issue_fields.is_empty());
     assert_eq!(dashboard[5].kind, ModelCardKind::Nmos);
-    assert_eq!(dashboard[5].canonical_parameter_count, 22);
-    assert_eq!(dashboard[5].accepted_name_count, 29);
+    assert_eq!(dashboard[5].canonical_parameter_count, 23);
+    assert_eq!(dashboard[5].accepted_name_count, 30);
     assert_eq!(dashboard[5].issue_count, 0);
 
     let table = format_model_card_supported_parameter_coverage_dashboard_table(&coverage);
@@ -296,7 +296,7 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(lines[1], "D\ttrue\t15\t15\t21\t21\t5\t5\t3\t3\t0\t");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\ttrue\t22\t22\t29\t29\t6\t6\t3\t3\t0\t"
+        &"PMOS\ttrue\t23\t23\t30\t30\t6\t6\t3\t3\t0\t"
     );
     let records = model_card_supported_parameter_coverage_dashboard_records(&coverage);
     assert_eq!(records.len(), 7);
@@ -328,10 +328,10 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         .unwrap();
 
     assert!(!nmos.passed);
-    assert_eq!(nmos.canonical_parameter_count, 21);
-    assert_eq!(nmos.expected_canonical_parameter_count, 22);
-    assert_eq!(nmos.accepted_name_count, 26);
-    assert_eq!(nmos.expected_accepted_name_count, 29);
+    assert_eq!(nmos.canonical_parameter_count, 22);
+    assert_eq!(nmos.expected_canonical_parameter_count, 23);
+    assert_eq!(nmos.accepted_name_count, 27);
+    assert_eq!(nmos.expected_accepted_name_count, 30);
     assert_eq!(nmos.aliased_parameter_count, 5);
     assert_eq!(nmos.expected_aliased_parameter_count, 6);
     assert_eq!(nmos.max_alias_count, 2);
@@ -347,7 +347,7 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         ]
     );
     assert!(format_model_card_supported_parameter_coverage_dashboard_table(&coverage).contains(
-        "NMOS\tfalse\t21\t22\t26\t29\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
+        "NMOS\tfalse\t22\t23\t27\t30\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
     ));
 }
 
@@ -594,6 +594,7 @@ fn model_card_aliases_build_device_instances() {
             ("MJ", 0.45),
             ("FC", 0.4),
             ("LD", 50.0e-9),
+            ("TOX", 25.0e-9),
             ("KF", 2.0e-24),
             ("AF", 1.4),
         ],
@@ -608,6 +609,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*mos_card.parameters.get("MJ").unwrap(), 0.45);
     assert_close(*mos_card.parameters.get("FC").unwrap(), 0.4);
     assert_close(*mos_card.parameters.get("LD").unwrap(), 50.0e-9);
+    assert_close(*mos_card.parameters.get("TOX").unwrap(), 25.0e-9);
     assert_close(*mos_card.parameters.get("KF").unwrap(), 2.0e-24);
     assert_close(*mos_card.parameters.get("AF").unwrap(), 1.4);
     assert_eq!(mos_model.mosfet_type, MosfetType::Nmos);
@@ -619,6 +621,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(mos_model.params.bulk_junction_grading_coefficient, 0.45);
     assert_close(mos_model.params.forward_bias_depletion_coefficient, 0.4);
     assert_close(mos_model.params.lateral_diffusion_length, 50.0e-9);
+    assert_close(mos_model.params.oxide_thickness, 25.0e-9);
     assert_close(mos_model.params.flicker_noise_coefficient, 2.0e-24);
     assert_close(mos_model.params.flicker_noise_exponent, 1.4);
 }
@@ -1687,7 +1690,7 @@ fn jfet_gate_saturation_current_loads_a_forward_biased_gate() {
 }
 
 #[test]
-fn subcircuit_expansion_preserves_mos_lateral_diffusion() {
+fn subcircuit_expansion_preserves_mos_geometry() {
     let mosfet = Mosfet::with_model(
         "Mcell",
         "d",
@@ -1698,6 +1701,7 @@ fn subcircuit_expansion_preserves_mos_lateral_diffusion() {
         MosfetLevel1Params {
             l: 1.0e-6,
             lateral_diffusion_length: 0.1e-6,
+            oxide_thickness: 25.0e-9,
             ..MosfetLevel1Params::default()
         },
     );
@@ -1737,6 +1741,7 @@ fn subcircuit_expansion_preserves_mos_lateral_diffusion() {
         .unwrap();
     assert_close(expanded.params.l, 1.0e-6);
     assert_close(expanded.params.lateral_diffusion_length, 0.1e-6);
+    assert_close(expanded.params.oxide_thickness, 25.0e-9);
 }
 
 #[test]
@@ -3747,6 +3752,38 @@ fn dc_mosfet_rejects_invalid_lateral_diffusion_length() {
                     "MOSFET LD must be non-negative with L - 2*LD > 0".to_string()
                 } else {
                     "MOSFET LD must be finite".to_string()
+                },
+            }
+        );
+    }
+}
+
+#[test]
+fn dc_mosfet_rejects_invalid_oxide_thickness() {
+    for oxide_thickness in [f64::NAN, 0.0, -1.0e-9] {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "Mbad",
+            "drain",
+            "gate",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                oxide_thickness,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+
+        let err = dc_op(&circuit).unwrap_err();
+        assert_eq!(
+            err,
+            SpiceError::InvalidElement {
+                name: "Mbad".to_string(),
+                reason: if oxide_thickness.is_finite() {
+                    "MOSFET TOX must be positive".to_string()
+                } else {
+                    "MOSFET TOX must be finite".to_string()
                 },
             }
         );

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add Level-1 MOS model-card `TOX` support, defaulting to `100 nm` and deriving
+  intrinsic Meyer gate capacitance from silicon-dioxide permittivity and oxide
+  thickness.
 - Add Level-1 MOS model-card `LD` support, using `L - 2*LD` for channel
   current and length-scaled intrinsic/`CGBO` capacitance.
 - Add Level-1 MOS model-card `FC` support, applying the continuous Berkeley

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -83,6 +83,8 @@ Level-1 MOS model cards accept `KF` (default `0`) and `AF` (default `1`) and add
 `KF * abs(Id)^AF / frequency` flicker noise alongside channel thermal noise.
 `LD` defaults to zero and applies `L_eff = L - 2*LD` to channel current and
 length-scaled intrinsic/`CGBO` capacitance.
+`TOX` defaults to `1e-7 m`, must be finite and positive, and derives intrinsic
+Meyer gate capacitance from `Cox = epsilon_ox / TOX`.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -6,6 +6,7 @@ const BOLTZMANN = 1.380_649e-23;
 const ELECTRON_CHARGE = 1.602_176_634e-19;
 const MOSFET_CHANNEL_NOISE_GAMMA = 2.0 / 3.0;
 const DIGITAL_BRIDGE_TIME_EPSILON = 1.0e-18;
+const OXIDE_PERMITTIVITY = 3.453133e-11;
 const SPICE_SUFFIX_FACTORS: Readonly<Record<string, number>> = Object.freeze({
   t: 1.0e12,
   g: 1.0e9,
@@ -1775,6 +1776,7 @@ export interface MosfetLevel1Params {
   readonly W: number;
   readonly L: number;
   readonly LD: number;
+  readonly TOX: number;
   readonly IS: number;
   readonly N_SUB: number;
   readonly T_NOM: number;
@@ -2047,8 +2049,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   PNP: [41, 58, 13, 4],
   NJF: [22, 30, 7, 3],
   PJF: [22, 30, 7, 3],
-  NMOS: [22, 29, 6, 3],
-  PMOS: [22, 29, 6, 3],
+  NMOS: [23, 30, 6, 3],
+  PMOS: [23, 30, 6, 3],
 };
 
 export interface Vccs {
@@ -8031,6 +8033,7 @@ export function defaultMosfetLevel1Params(): MosfetLevel1Params {
     W: 1.0e-6,
     L: 130.0e-9,
     LD: 0.0,
+    TOX: 1.0e-7,
     IS: 1.0e-15,
     N_SUB: 1.4,
     T_NOM: 300.15,
@@ -8217,6 +8220,7 @@ const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   W: "W",
   L: "L",
   LD: "LD",
+  TOX: "TOX",
   IS: "IS",
   NSUB: "N_SUB",
   N_SUB: "N_SUB",
@@ -8790,6 +8794,7 @@ export function mosfetFromModelCard(
     ...(p.W !== undefined ? { W: p.W } : {}),
     ...(p.L !== undefined ? { L: p.L } : {}),
     ...(p.LD !== undefined ? { LD: p.LD } : {}),
+    ...(p.TOX !== undefined ? { TOX: p.TOX } : {}),
     ...(p.IS !== undefined ? { IS: p.IS } : {}),
     ...(p.N_SUB !== undefined ? { N_SUB: p.N_SUB } : {}),
     ...(p.T_NOM !== undefined ? { T_NOM: p.T_NOM } : {}),
@@ -20256,7 +20261,8 @@ function evaluateNmosLevel1(
   const cgsOverlap = params.CGSO * params.W;
   const cgdOverlap = params.CGDO * params.W;
   const cgbOverlap = params.CGBO * effectiveLength;
-  const cgsIntrinsic = (2.0 / 3.0) * params.W * effectiveLength * params.KP;
+  const channelCapacitance =
+    params.W * effectiveLength * (OXIDE_PERMITTIVITY / params.TOX);
   const cbsBulk = mosfetBulkJunctionCapacitance(
     params.CBS, vbs, params.PB, params.MJ, params.FC,
   );
@@ -20264,7 +20270,7 @@ function evaluateNmosLevel1(
     params.CBD, vbs - vds, params.PB, params.MJ, params.FC,
   );
   const capacitances = {
-    cgs: cgsOverlap + cgsIntrinsic,
+    cgs: cgsOverlap + channelCapacitance,
     cgd: cgdOverlap,
     cgb: cgbOverlap,
     cbs: cbsBulk,
@@ -20291,7 +20297,7 @@ function evaluateNmosLevel1(
       gm,
       gds: beta * (overdrive - vds) * modulation + beta * channel * params.LAMBDA,
       gmb: gm * bodyFactor,
-      cgs: cgsOverlap + cgsIntrinsic / 2.0,
+      cgs: cgsOverlap + channelCapacitance / 2.0,
       cgd: cgdOverlap,
       cgb: cgbOverlap,
       cbs: cbsBulk,
@@ -20305,7 +20311,7 @@ function evaluateNmosLevel1(
     gm,
     gds: 0.5 * beta * overdrive * overdrive * params.LAMBDA,
     gmb: gm * bodyFactor,
-    cgs: cgsOverlap + (2.0 / 3.0) * cgsIntrinsic,
+    cgs: cgsOverlap + (2.0 / 3.0) * channelCapacitance,
     cgd: cgdOverlap,
     cgb: cgbOverlap,
     cbs: cbsBulk,
@@ -21028,6 +21034,9 @@ function validateMosfet(element: Mosfet): void {
   }
   if (params.LD < 0.0 || params.L - 2.0 * params.LD <= 0.0) {
     throw invalidElement(element.name, "MOSFET LD must be non-negative with L - 2*LD > 0");
+  }
+  if (params.TOX <= 0.0) {
+    throw invalidElement(element.name, "MOSFET TOX must be positive");
   }
   if (params.PHI <= 0.0) {
     throw invalidElement(element.name, "MOSFET PHI must be positive");

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -561,6 +561,7 @@ describe("acSweep", () => {
         KP: 1.0e-12,
         W: 1.0,
         L: 1.0,
+        TOX: 1.0e9,
         CGSO,
       }));
       return complexAbs(acSweep(circuit, 100_000.0, 100_000.0, 1)[0].voltage("gate")!);
@@ -571,6 +572,22 @@ describe("acSweep", () => {
 
     expect(withoutCapacitance).toBeGreaterThan(0.9);
     expect(withCapacitance).toBeLessThan(withoutCapacitance / 100.0);
+  });
+
+  it("uses MOSFET oxide thickness to scale intrinsic gate capacitance", () => {
+    function gateAmplitude(TOX: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "in", "0", 0.0, 1.0));
+      circuit.add(resistor("Rin", "in", "gate", 1.0e6));
+      circuit.add(mosfet("M1", "0", "gate", "0", "0", "NMOS", {
+        W: 10.0e-6,
+        L: 1.0e-6,
+        TOX,
+      }));
+      return complexAbs(acSweep(circuit, 1.0e9, 1.0e9, 1)[0].voltage("gate")!);
+    }
+
+    expect(gateAmplitude(50.0e-9)).toBeLessThan(gateAmplitude(100.0e-9));
   });
 
   it("uses BJT base-emitter capacitance in AC analysis", () => {

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -121,7 +121,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(185);
+    expect(coverage).toHaveLength(187);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -141,7 +141,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tAF\tAF\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(185);
+    expect(records).toHaveLength(187);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -167,8 +167,8 @@ describe("dcOp", () => {
     });
     expect(summary[5]).toStrictEqual({
       kind: "NMOS",
-      canonicalParameterCount: 22,
-      acceptedNameCount: 29,
+      canonicalParameterCount: 23,
+      acceptedNameCount: 30,
       aliasedParameterCount: 6,
       maxAliasCount: 3,
       aliasedParameters: ["VT0", "LAMBDA", "N_SUB", "T_NOM", "CBS", "CBD"],
@@ -181,7 +181,7 @@ describe("dcOp", () => {
     );
     expect(table.split("\n")[1]).toBe("D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     expect(table.split("\n").at(-1)).toBe(
-      "PMOS\t22\t29\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
+      "PMOS\t23\t30\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
     );
     const records = modelCardSupportedParameterCoverageSummaryRecords();
     expect(records).toHaveLength(7);
@@ -206,15 +206,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 185,
-      expectedCanonicalParameterCount: 185,
-      acceptedNameCount: 255,
+      canonicalParameterCount: 187,
+      expectedCanonicalParameterCount: 187,
+      acceptedNameCount: 257,
       aliasedParameterCount: 57,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t185\t185\t255\t57\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t187\t187\t257\t57\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -237,15 +237,15 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(184);
-    expect(report.acceptedNameCount).toBe(252);
+    expect(report.canonicalParameterCount).toBe(186);
+    expect(report.acceptedNameCount).toBe(254);
     expect(report.aliasedParameterCount).toBe(56);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 22 canonical supported parameters, found 21",
+      message: "expected NMOS to expose 23 canonical supported parameters, found 22",
     });
     expect(report.issues.at(-1)).toStrictEqual({
       kind: "NMOS",
@@ -253,16 +253,16 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t184\t185\t252\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 22 canonical supported parameters, found 21\nNMOS\taccepted_name_count\texpected NMOS to expose 29 accepted model-card names, found 26\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t186\t187\t254\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 23 canonical supported parameters, found 22\nNMOS\taccepted_name_count\texpected NMOS to expose 30 accepted model-card names, found 27\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 22 canonical supported parameters, found 21",
+      message: "expected NMOS to expose 23 canonical supported parameters, found 22",
     });
     expect(formatModelCardSupportedParameterCoverageGateIssueCsv(report)).toMatch(
-      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 22 canonical supported parameters, found 21"\n/,
+      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 23 canonical supported parameters, found 22"\n/,
     );
     expect(JSON.parse(formatModelCardSupportedParameterCoverageGateIssueJson(report))).toStrictEqual(
       records,
@@ -419,6 +419,7 @@ describe("dcOp", () => {
       MJ: 0.45,
       FC: 0.4,
       LD: 50.0e-9,
+      TOX: 25.0e-9,
       KF: 2.0e-24,
       AF: 1.4,
     });
@@ -433,6 +434,7 @@ describe("dcOp", () => {
       MJ: 0.45,
       FC: 0.4,
       LD: 50.0e-9,
+      TOX: 25.0e-9,
       KF: 2.0e-24,
       AF: 1.4,
     });
@@ -445,6 +447,7 @@ describe("dcOp", () => {
     expectClose(mosModel.params.MJ, 0.45);
     expectClose(mosModel.params.FC, 0.4);
     expectClose(mosModel.params.LD, 50.0e-9);
+    expectClose(mosModel.params.TOX, 25.0e-9);
     expectClose(mosModel.params.KF, 2.0e-24);
     expectClose(mosModel.params.AF, 1.4);
   });
@@ -1195,13 +1198,14 @@ describe("dcOp", () => {
     );
   });
 
-  it("preserves MOS lateral diffusion through subcircuit expansion", () => {
+  it("preserves MOS geometry through subcircuit expansion", () => {
     const circuit = new Circuit();
     circuit.defineSubcircuit(
       subcircuitDefinition("mos-cell", ["d", "g", "s", "b"], [
         mosfet("Mcell", "d", "g", "s", "b", "NMOS", {
           L: 1.0e-6,
           LD: 0.1e-6,
+          TOX: 25.0e-9,
         }),
       ]),
     );
@@ -1213,6 +1217,7 @@ describe("dcOp", () => {
     expect(expanded).toBeDefined();
     expectClose(expanded!.params.L, 1.0e-6);
     expectClose(expanded!.params.LD, 0.1e-6);
+    expectClose(expanded!.params.TOX, 25.0e-9);
   });
 
   it("preserves the complete BJT model through subcircuit expansion", () => {
@@ -2407,6 +2412,20 @@ describe("dcOp", () => {
     };
 
     expect(drainCurrent(0.1e-6) / drainCurrent(0.0)).toBeCloseTo(1.25);
+  });
+
+  it("rejects invalid MOSFET oxide thicknesses", () => {
+    for (const oxideThickness of [Number.NaN, 0.0, -1.0e-9]) {
+      const circuit = new Circuit();
+      circuit.add(mosfet("Mbad", "drain", "gate", "0", "0", "NMOS", {
+        TOX: oxideThickness,
+      }));
+      expect(() => dcOp(circuit)).toThrowError(
+        Number.isFinite(oxideThickness)
+          ? "MOSFET TOX must be positive"
+          : "MOSFET TOX must be finite",
+      );
+    }
   });
 
   it("rejects invalid BJT model parameters", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,16 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS lateral diffusion.
+1. Cross-language Level-1 MOS oxide thickness.
    - Status: current PR completion candidate.
-   - Add Berkeley Level-1 MOS `LD` model-card support in Rust, Python, and
-     TypeScript, defaulting to zero.
-   - Apply `L_eff = L - 2*LD` to channel current and length-scaled intrinsic
-     and `CGBO` capacitance while preserving width-scaled overlap capacitance.
-   - Preserve the geometry through hierarchy and cloning, require finite
-     non-negative `LD` with positive effective length, and extend the
-     supported-parameter coverage gate from 183 to 185 canonical rows.
+   - Add Berkeley Level-1 MOS `TOX` model-card support in Rust, Python, and
+     TypeScript, defaulting to `1e-7 m`.
+   - Derive `Cox = epsilon_ox / TOX` and use
+     `Cox * W * (L - 2*LD)` for region-partitioned intrinsic Meyer gate
+     capacitance while preserving overlap capacitance.
+   - Preserve the oxide thickness through hierarchy and cloning, require
+     finite positive `TOX`, and extend the supported-parameter coverage gate
+     from 185 to 187 canonical rows.
 
 ## Completed Slices
 
@@ -3413,6 +3414,15 @@ the Rust, Python, and TypeScript surfaces together.
    - Hierarchy and cloning preserve the coefficient, shared validation
      enforces its finite `[0, 1)` domain, and the supported-parameter release
      gate now covers 183 canonical rows.
+
+267. Cross-language Level-1 MOS lateral diffusion.
+   - Status: completed in PR 9001.
+   - Rust, Python, and TypeScript Level-1 MOS model cards now accept `LD`,
+     defaulting to zero, and apply `L_eff = L - 2*LD` to channel current and
+     length-scaled intrinsic and `CGBO` capacitance.
+   - Hierarchy and cloning preserve the geometry, shared validation enforces
+     finite non-negative `LD` with positive effective length, and the
+     supported-parameter release gate now covers 185 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- add Berkeley Level-1 MOS `TOX` model-card support in Rust, Python, and TypeScript with the `1e-7 m` default
- derive intrinsic Meyer gate capacitance from silicon-dioxide permittivity and effective channel geometry while preserving overlap capacitance
- validate and preserve oxide thickness through parsing, hierarchy, cloning, coverage exports, documentation, and the SPICE completion plan

## Verification

- `cargo fmt -p mosfet-models -p spice-engine -- --check`
- `cargo test -p mosfet-models -p spice-engine`
- Python mosfet-models: 31 passed, 96.15% coverage
- Python spice-engine: 627 passed, 88.76% coverage
- TypeScript spice-engine: build passed, 377 tests passed
- `git diff --check`