### PR TITLE
feat(hl03): the script's numerals (HL03 syllabary PR8)

### DIFF
--- a/code/learning/human-languages/data/scripts/generate_syllabary.py
+++ b/code/learning/human-languages/data/scripts/generate_syllabary.py
@@ -150,6 +150,29 @@ def build_script(script_id: str, name: str, base: int, font: str, signature: str
             "strokeOrderNote": "",
         })
 
+    # The script's own digits (౦౧౨…). Reading a language means reading its
+    # numbers too, and these are written with distinct glyphs, not Western 0-9.
+    # Grounded like everything else: each is a Unicode "<SCRIPT> DIGIT <N>", and
+    # the romanization is simply the digit's value (0-9) — the Unicode name (ZERO,
+    # ONE, …) fixes it unambiguously, nothing guessed. Kept in a SEPARATE list, not
+    # mixed into `letters`. Recognition only — no ductus.
+    DIGIT_NAMES = ["ZERO", "ONE", "TWO", "THREE", "FOUR",
+                   "FIVE", "SIX", "SEVEN", "EIGHT", "NINE"]
+    digits = []
+    for value, dname in enumerate(DIGIT_NAMES):
+        cp = codepoint_by_name(f"{up} DIGIT {dname}", base)
+        if cp is None:
+            continue  # this script lacks its own digit — skip, never invent
+        ch = chr(cp)
+        digits.append({
+            "glyph": ch,
+            "sound": str(value),
+            "role": "digit",
+            "components": [f"{ch}  {value} — {name} digit"],
+            "strokeOrder": [],
+            "strokeOrderNote": "",
+        })
+
     return {
         "script": script_id,
         "name": name,
@@ -161,11 +184,13 @@ def build_script(script_id: str, name: str, base: int, font: str, signature: str
         "notes": (
             "Syllabary generated from Unicode by generate_syllabary.py: each syllable is a base "
             "consonant (varga order) composed with a core vowel sign. Romanization is ISO-15919. "
-            "The independent (word-initial) vowels are in `independentVowels`. "
+            "The independent (word-initial) vowels are in `independentVowels`; the "
+            "script's own digits are in `digits`. "
             "Recognition only — stroke order is a separate, source-gated effort and is omitted."
         ),
         "letters": letters,
         "independentVowels": independent,
+        "digits": digits,
     }
 
 

--- a/code/learning/human-languages/data/scripts/kannada.json
+++ b/code/learning/human-languages/data/scripts/kannada.json
@@ -6,7 +6,7 @@
   "system": "abugida",
   "signature": "Rounded and looping like Telugu (its sister script), most letters topped by a small curved headstroke; no continuous top line.",
   "complete": false,
-  "notes": "Syllabary generated from Unicode by generate_syllabary.py: each syllable is a base consonant (varga order) composed with a core vowel sign. Romanization is ISO-15919. The independent (word-initial) vowels are in `independentVowels`. Recognition only — stroke order is a separate, source-gated effort and is omitted.",
+  "notes": "Syllabary generated from Unicode by generate_syllabary.py: each syllable is a base consonant (varga order) composed with a core vowel sign. Romanization is ISO-15919. The independent (word-initial) vowels are in `independentVowels`; the script's own digits are in `digits`. Recognition only — stroke order is a separate, source-gated effort and is omitted.",
   "letters": [
     {
       "glyph": "ಕ",
@@ -5561,6 +5561,108 @@
       "role": "vowel",
       "components": [
         "ಋ  r̥ — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    }
+  ],
+  "digits": [
+    {
+      "glyph": "೦",
+      "sound": "0",
+      "role": "digit",
+      "components": [
+        "೦  0 — Kannada digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "೧",
+      "sound": "1",
+      "role": "digit",
+      "components": [
+        "೧  1 — Kannada digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "೨",
+      "sound": "2",
+      "role": "digit",
+      "components": [
+        "೨  2 — Kannada digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "೩",
+      "sound": "3",
+      "role": "digit",
+      "components": [
+        "೩  3 — Kannada digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "೪",
+      "sound": "4",
+      "role": "digit",
+      "components": [
+        "೪  4 — Kannada digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "೫",
+      "sound": "5",
+      "role": "digit",
+      "components": [
+        "೫  5 — Kannada digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "೬",
+      "sound": "6",
+      "role": "digit",
+      "components": [
+        "೬  6 — Kannada digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "೭",
+      "sound": "7",
+      "role": "digit",
+      "components": [
+        "೭  7 — Kannada digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "೮",
+      "sound": "8",
+      "role": "digit",
+      "components": [
+        "೮  8 — Kannada digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "೯",
+      "sound": "9",
+      "role": "digit",
+      "components": [
+        "೯  9 — Kannada digit"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""

--- a/code/learning/human-languages/data/scripts/malayalam.json
+++ b/code/learning/human-languages/data/scripts/malayalam.json
@@ -6,7 +6,7 @@
   "system": "abugida",
   "signature": "Highly rounded and loopy — full circles, hooks and curls, with almost no straight lines.",
   "complete": false,
-  "notes": "Syllabary generated from Unicode by generate_syllabary.py: each syllable is a base consonant (varga order) composed with a core vowel sign. Romanization is ISO-15919. The independent (word-initial) vowels are in `independentVowels`. Recognition only — stroke order is a separate, source-gated effort and is omitted.",
+  "notes": "Syllabary generated from Unicode by generate_syllabary.py: each syllable is a base consonant (varga order) composed with a core vowel sign. Romanization is ISO-15919. The independent (word-initial) vowels are in `independentVowels`; the script's own digits are in `digits`. Recognition only — stroke order is a separate, source-gated effort and is omitted.",
   "letters": [
     {
       "glyph": "ക",
@@ -5716,6 +5716,108 @@
       "role": "vowel",
       "components": [
         "ഋ  r̥ — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    }
+  ],
+  "digits": [
+    {
+      "glyph": "൦",
+      "sound": "0",
+      "role": "digit",
+      "components": [
+        "൦  0 — Malayalam digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "൧",
+      "sound": "1",
+      "role": "digit",
+      "components": [
+        "൧  1 — Malayalam digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "൨",
+      "sound": "2",
+      "role": "digit",
+      "components": [
+        "൨  2 — Malayalam digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "൩",
+      "sound": "3",
+      "role": "digit",
+      "components": [
+        "൩  3 — Malayalam digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "൪",
+      "sound": "4",
+      "role": "digit",
+      "components": [
+        "൪  4 — Malayalam digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "൫",
+      "sound": "5",
+      "role": "digit",
+      "components": [
+        "൫  5 — Malayalam digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "൬",
+      "sound": "6",
+      "role": "digit",
+      "components": [
+        "൬  6 — Malayalam digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "൭",
+      "sound": "7",
+      "role": "digit",
+      "components": [
+        "൭  7 — Malayalam digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "൮",
+      "sound": "8",
+      "role": "digit",
+      "components": [
+        "൮  8 — Malayalam digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "൯",
+      "sound": "9",
+      "role": "digit",
+      "components": [
+        "൯  9 — Malayalam digit"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""

--- a/code/learning/human-languages/data/scripts/telugu.json
+++ b/code/learning/human-languages/data/scripts/telugu.json
@@ -6,7 +6,7 @@
   "system": "abugida",
   "signature": "Rounded, curvy letters, most crowned with a small tick or check-mark headstroke; no continuous top line.",
   "complete": false,
-  "notes": "Syllabary generated from Unicode by generate_syllabary.py: each syllable is a base consonant (varga order) composed with a core vowel sign. Romanization is ISO-15919. The independent (word-initial) vowels are in `independentVowels`. Recognition only — stroke order is a separate, source-gated effort and is omitted.",
+  "notes": "Syllabary generated from Unicode by generate_syllabary.py: each syllable is a base consonant (varga order) composed with a core vowel sign. Romanization is ISO-15919. The independent (word-initial) vowels are in `independentVowels`; the script's own digits are in `digits`. Recognition only — stroke order is a separate, source-gated effort and is omitted.",
   "letters": [
     {
       "glyph": "క",
@@ -5561,6 +5561,108 @@
       "role": "vowel",
       "components": [
         "ఋ  r̥ — independent vowel (word-initial)"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    }
+  ],
+  "digits": [
+    {
+      "glyph": "౦",
+      "sound": "0",
+      "role": "digit",
+      "components": [
+        "౦  0 — Telugu digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "౧",
+      "sound": "1",
+      "role": "digit",
+      "components": [
+        "౧  1 — Telugu digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "౨",
+      "sound": "2",
+      "role": "digit",
+      "components": [
+        "౨  2 — Telugu digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "౩",
+      "sound": "3",
+      "role": "digit",
+      "components": [
+        "౩  3 — Telugu digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "౪",
+      "sound": "4",
+      "role": "digit",
+      "components": [
+        "౪  4 — Telugu digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "౫",
+      "sound": "5",
+      "role": "digit",
+      "components": [
+        "౫  5 — Telugu digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "౬",
+      "sound": "6",
+      "role": "digit",
+      "components": [
+        "౬  6 — Telugu digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "౭",
+      "sound": "7",
+      "role": "digit",
+      "components": [
+        "౭  7 — Telugu digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "౮",
+      "sound": "8",
+      "role": "digit",
+      "components": [
+        "౮  8 — Telugu digit"
+      ],
+      "strokeOrder": [],
+      "strokeOrderNote": ""
+    },
+    {
+      "glyph": "౯",
+      "sound": "9",
+      "role": "digit",
+      "components": [
+        "౯  9 — Telugu digit"
       ],
       "strokeOrder": [],
       "strokeOrderNote": ""

--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.24.0 — the script's numerals (syllabary, PR 8)
+
+- **The syllabaries now carry their own digits.** Reading a language means
+  reading its numbers, and Telugu / Kannada / Malayalam write them with distinct
+  glyphs, not Western 0-9 (Telugu ౦౧౨౩౪౫౬౭౮౯). Browse now shows a **"Numerals
+  (0–9)"** strip for the three Dravidian scripts, each digit tile the glyph over
+  its value.
+- **Grounded, additive, same pattern as the independent vowels.** The generator
+  composes each from `<SCRIPT> DIGIT <ZERO..NINE>` and romanizes it as the digit
+  value (the Unicode name fixes it unambiguously — these are decimal digits, no
+  guessing). They live in a **separate `digits` field**, not mixed into `letters`,
+  so the consonant syllabary and the gate/matrix that key on it being
+  all-syllables stay untouched (the generated `letters` and `independentVowels`
+  are byte-for-byte unchanged).
+- **Control test.** The real Telugu digits are the 10 expected glyphs mapped to
+  "0"…"9" (role `digit`, no fabricated ductus), all three scripts carry them, and
+  — the control — none leak into `letters`, so `isSyllabary` still holds and the
+  matrix is unaffected.
+
 ## 0.23.0 — flag the special-consonant rows in the matrix (syllabary, PR 7)
 
 - **The matrix now marks its tricky rows.** In the consonant × vowel grid the

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -188,6 +188,12 @@ ISO-15919 roman from the shared vowel table) but kept in a **separate
 gate/matrix that key on it being all-syllables are untouched. Control-tested
 (the 13 grounded glyphs; none leak into `letters`, so `isSyllabary` still holds).
 
+**The script's numerals.** Reading a language means reading its numbers too, and
+these scripts write them with distinct glyphs (Telugu ౦౧౨…). Browse shows a
+**"Numerals (0–9)"** strip; each digit is generated from `<SCRIPT> DIGIT <N>` and
+romanized as its value, kept in a **separate `digits` field** (same non-breaking
+pattern as the vowels). Control-tested (the 10 grounded glyphs → 0–9).
+
 ## Design
 
 - **`src/core.ts`** — the pure, unit-tested heart: `buildScriptView`,

--- a/code/programs/typescript/language-ladder/package.json
+++ b/code/programs/typescript/language-ladder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ladder",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "private": true,
   "description": "The unified curriculum learning app (HL03): walk the language chain concept by concept, seeing the threads back to what you already know, then review it all with a randomised SRS quiz. (Was the HL02 script-writing-visualizer, whose Browse/Practice/Lessons/Concepts modes it now subsumes.)",
   "type": "module",

--- a/code/programs/typescript/language-ladder/src/main.ts
+++ b/code/programs/typescript/language-ladder/src/main.ts
@@ -423,6 +423,31 @@ function renderIndependentVowels(vowels: Letter[]): HTMLElement {
   return wrap;
 }
 
+/**
+ * The script's own numerals as a small read-only strip (౦౧౨… = 0–9). Reading a
+ * language means reading its numbers, and these are distinct glyphs, not Western
+ * 0-9. Recognition only; each tile shows the glyph and its value.
+ */
+function renderNumerals(digits: Letter[]): HTMLElement {
+  const wrap = el("div", "ivowels");
+  const label = el("span", "ivowels__label");
+  label.textContent = "Numerals (0–9):";
+  wrap.appendChild(label);
+  const row = el("div", "ivowels__row");
+  digits.forEach((d) => {
+    const tile = el("div", "ivowel");
+    const glyph = el("span", "ivowel__glyph");
+    glyph.textContent = d.glyph;
+    const value = el("span", "ivowel__sound");
+    value.textContent = d.sound;
+    tile.append(glyph, value);
+    tile.title = d.sound;
+    row.appendChild(tile);
+  });
+  wrap.appendChild(row);
+  return wrap;
+}
+
 /** For a syllabary, a "List / Matrix" switch — the flat grid, or the table. */
 function renderBrowseLayoutToggle(): HTMLElement {
   const wrap = el("div", "layouts");
@@ -1425,6 +1450,9 @@ function render(): void {
     const syllabary = isSyllabary(data.letters);
     if (data.independentVowels && data.independentVowels.length > 0) {
       app!.appendChild(renderIndependentVowels(data.independentVowels));
+    }
+    if (data.digits && data.digits.length > 0) {
+      app!.appendChild(renderNumerals(data.digits));
     }
     if (syllabary) app!.appendChild(renderBrowseLayoutToggle());
     const matrix = syllabary && browseLayout === "matrix" ? renderMatrix(data.letters) : null;

--- a/code/programs/typescript/language-ladder/src/types.ts
+++ b/code/programs/typescript/language-ladder/src/types.ts
@@ -49,6 +49,9 @@ export interface ScriptData {
    *  that ride on a consonant. Kept separate from `letters` so the consonant
    *  syllabary (and anything keyed on it being all-syllables) is untouched. */
   independentVowels?: Letter[];
+  /** For a script with its own numerals: the digits 0–9 in the script's glyphs
+   *  (౦౧౨…). Kept separate from `letters`, like `independentVowels`. */
+  digits?: Letter[];
   marks?: unknown[];
   combination?: string;
   complete?: boolean;

--- a/code/programs/typescript/language-ladder/tests/numerals.test.ts
+++ b/code/programs/typescript/language-ladder/tests/numerals.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { SCRIPTS } from "../src/data";
+import { isSyllabary } from "../src/syllabary";
+import { buildSyllableMatrix } from "../src/matrix";
+
+const DRAVIDIAN = ["telugu", "kannada", "malayalam"] as const;
+
+describe("script numerals (digits)", () => {
+  it("Telugu carries its 10 digits, grounded glyph → value 0–9", () => {
+    const telugu = SCRIPTS.find((s) => s.script === "telugu")!;
+    const d = telugu.digits!;
+    expect(d.map((x) => x.glyph)).toEqual(
+      ["౦", "౧", "౨", "౩", "౪", "౫", "౬", "౭", "౮", "౯"],
+    );
+    // Romanization is simply the digit's value, in order 0..9.
+    expect(d.map((x) => x.sound)).toEqual(
+      ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
+    );
+    expect(d.every((x) => x.role === "digit")).toBe(true);
+    expect(d.every((x) => x.strokeOrder.length === 0)).toBe(true);
+  });
+
+  it("all three Dravidian scripts carry their digits", () => {
+    DRAVIDIAN.forEach((id) => {
+      const s = SCRIPTS.find((x) => x.script === id)!;
+      expect(s.digits?.length).toBe(10);
+      expect(s.digits!.map((x) => x.sound)).toEqual(
+        ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
+      );
+    });
+  });
+
+  it("CONTROL: digits are SEPARATE from the syllabary — letters, isSyllabary and the matrix are untouched", () => {
+    const telugu = SCRIPTS.find((s) => s.script === "telugu")!;
+    const syllableGlyphs = new Set(telugu.letters.map((l) => l.glyph));
+    // No digit glyph leaks into the consonant syllable list…
+    expect(telugu.digits!.some((x) => syllableGlyphs.has(x.glyph))).toBe(false);
+    // …so the script still reads as an all-syllable syllabary, matrix intact.
+    expect(isSyllabary(telugu.letters)).toBe(true);
+    const m = buildSyllableMatrix(telugu.letters as never)!;
+    expect(m.rows.length).toBe(35);
+  });
+
+  it("an alphabet (Cyrillic) has no digits list", () => {
+    const cyr = SCRIPTS.find((s) => s.script === "cyrillic")!;
+    expect(cyr.digits).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What & why

Reading a language means reading its numbers too — and Telugu / Kannada / Malayalam write them with **distinct glyphs**, not Western 0-9. They were absent, so a learner couldn't read the script's own numerals. This adds them and shows a **"Numerals (0–9)"** strip in Browse.

## Eyeball sample (native reader, please check)

Straight from the regenerated JSON, all 10 per script:

| script | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 |
|---|---|---|---|---|---|---|---|---|---|---|
| Telugu | ౦ | ౧ | ౨ | ౩ | ౪ | ౫ | ౬ | ౭ | ౮ | ౯ |
| Kannada | ೦ | ೧ | ೨ | ೩ | ೪ | ೫ | ೬ | ೭ | ೮ | ೯ |
| Malayalam | ൦ | ൧ | ൨ | ൩ | ൪ | ൫ | ൬ | ൭ | ൮ | ൯ |

## How

- **generate_syllabary.py** — emit each digit from Unicode by name: `<SCRIPT> DIGIT <ZERO..NINE>`, romanized as the digit value (the Unicode name fixes it unambiguously — decimal digits, nothing guessed). Emitted in a **separate `digits` field**, NOT mixed into `letters` — same non-breaking pattern as the independent vowels, so the syllabary + gate + matrix are untouched (regenerated JSON `letters` and `independentVowels` are byte-for-byte unchanged).
- **types.ts** — `digits?: Letter[]` on ScriptData.
- **main.ts** — the read-only "Numerals (0–9)" Browse strip (glyph + value), mirroring the independent-vowels strip (reuses its styles — no CSS change).
- **tests** — control asserts the real Telugu digits are the 10 expected glyphs → 0–9 (role `digit`); all three scripts carry them; and — the control — **none leak into `letters`**, so `isSyllabary` still holds and the matrix is unaffected.

Recognition only — `strokeOrder` stays `[]`, the ductus remains paused.

## Verification

- App suite **259 → 263** pass; human-language-data **38** pass; `npm run build` clean.
- Grounding review: decoded all 30 codepoints — every glyph maps to the right value (Telugu U+0C66–6F, Kannada U+0CE6–EF, Malayalam U+0D66–6F = DIGIT ZERO..NINE), no off-by-one, no cross-script contamination, no fractions; separation confirmed non-breaking.
- Browser (headless): the Telugu strip renders ౦ ౧ ౨ ౩ ౪ ౫ ౬ ౭ ౮ ౯ over 0–9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)