### PR TITLE
feat(c-to-semantic-ir): division & modulo / % (SIR27 milestone 6)

### DIFF
--- a/code/packages/rust/c-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/c-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+### Milestone 6 — division & modulo (`/ %`, truncating)
+
+- C `/` **truncates toward zero** and `%` takes the dividend's sign (`-7/2 = -3`,
+  `-7%2 = -1`), unlike SIR/Ruby `/`/`%` and the C backend's `_sir_ifloordiv`,
+  which floor.  So they lower to dedicated `tdiv`/`tmod` builtins, never the
+  flooring ones.
+- **C backend** — `_sir_itdiv`/`_sir_itmod`: C's native `int64_t /`/`%` already
+  truncate, so these are thin wrappers, guarded against division by zero and
+  `INT64_MIN / -1` (returns the two's-complement wrap, which the width `Convert`
+  narrows — x86 hardware traps on it otherwise).  As with `>>`, an unsigned
+  common type routes to `utdiv`/`utmod` (`_sir_utdiv`/`_sir_utmod`, done over
+  `uint64_t`), because a `uint64_t` ≥ 2^63 is a negative int64 on which a signed
+  division would be wrong.
+- **Ruby backend** — `sir_tdiv`/`sir_tmod`: `Integer#remainder` is already C's
+  `%`, and `(a - a.remainder(b)) / b` recovers the truncated quotient exactly.
+- Both backends' builtin allowlists (`SUPPORTED_BUILTINS` / `fixed_helper` +
+  dispatch) extended with `tdiv`/`tmod`.
+- Corpus grows with all four sign combinations, an unsigned division, and a real
+  Euclid `gcd` (`%` in a loop) — byte-identical across reference `clang -fwrapv`,
+  emitted Ruby, and emitted C (and clang+gcc+MSVC).  `INT_MIN / -1` is UB (the
+  reference traps) so it is not a conformance case, but a unit test confirms the
+  emitted C is guarded and does not crash.
+- With this, **every C integer operator is implemented** — arithmetic, bitwise,
+  shifts, comparisons, logical, and now division/modulo.
+
 ### Milestone 5 — bitwise `& | ^ ~` and shifts `<< >>`
 
 - `& | ^` and unary `~` take the usual arithmetic conversions and wrap the

--- a/code/packages/rust/c-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/c-to-semantic-ir/src/lib.rs
@@ -20,6 +20,8 @@
 //!   reusing the truthiness bridge (`and`/`or`/`not` builtins).
 //! - **Milestone 5** — bitwise `& | ^ ~` and shifts `<< >>` (shifts take the
 //!   promoted left operand's type, not the usual common type).
+//! - **Milestone 6** — division/modulo `/ %`, which *truncate toward zero* in C
+//!   (unlike SIR/Ruby floor), via dedicated `tdiv`/`tmod` builtins.
 
 mod lower;
 
@@ -232,19 +234,26 @@ mod tests {
     }
 
     #[test]
-    fn division_and_modulo_remain_deferred() {
-        // `/` and `%` need the truncate-vs-floor split (a later milestone), so
-        // they must still be a clean error, not a silently-wrong floor.
-        for src in [
-            "int f(int a, int b) { return a / b; }",
-            "int f(int a, int b) { return a % b; }",
-        ] {
-            let err = compile_source(src, "t").unwrap_err();
-            assert!(
-                err.message.contains("not yet supported"),
-                "wrong error for {src}: {}",
-                err.message
-            );
+    fn division_and_modulo_lower_to_truncating_builtins() {
+        // C `/` truncates toward zero (unlike SIR/Ruby floor), so it must lower
+        // to the dedicated `tdiv`/`tmod` builtins, not the flooring `/`/`%`.
+        let m = lower("int f(int a, int b) { return a / b; }");
+        assert!(semantic_ir::print_module(&m).contains("(builtin-call tdiv"));
+        let m = lower("int f(int a, int b) { return a % b; }");
+        assert!(semantic_ir::print_module(&m).contains("(builtin-call tmod"));
+    }
+
+    #[test]
+    fn int_min_div_is_guarded() {
+        // INT_MIN / -1 is signed-overflow UB (and traps on x86).  Our emitted C
+        // must *not* trap — the `_sir_itdiv` INT64_MIN/-1 guard returns the
+        // two's-complement wrap.  Compile+run the emitted C and confirm it exits
+        // cleanly with the wrapped value rather than a SIGFPE.
+        if let Some(out) = run_c(&lower(
+            "int main(void) { int32_t a = -2147483647 - 1; int32_t b = -1; \
+             printf(\"%d\\n\", a / b); return 0; }",
+        )) {
+            assert_eq!(out, "-2147483648", "guarded INT_MIN/-1");
         }
     }
 

--- a/code/packages/rust/c-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/c-to-semantic-ir/src/lower.rs
@@ -1342,10 +1342,33 @@ impl Lowerer {
         let re = convert_to(re, rp, c);
         // `+ - *` and the bitwise operators `& | ^` all take the usual
         // arithmetic conversions and are performed at the common type.  Division
-        // and remainder (`/ %`) still need the truncate-vs-floor split (C
-        // truncates toward zero; SIR/Ruby floor), so they stay deferred.
+        // and remainder use the *truncating* builtins (see below).
         let sir_op = match op {
             "+" | "-" | "*" | "&" | "|" | "^" => op,
+            // C division/remainder **truncate toward zero** (`-7 / 2 == -3`,
+            // `-7 % 2 == -1`), whereas SIR/Ruby `/`/`%` and the C backend's
+            // `_sir_ifloordiv` **floor** (`-7 / 2 == -4`).  So they lower to
+            // dedicated truncating builtins, distinct from the floor ones.
+            //
+            // Signedness matters for the same reason it does for `>>`: the
+            // backends store values in a signed int64, so an unsigned operand
+            // ≥ 2^63 is a negative int64 and a signed division would be wrong.
+            // Unsigned `/`/`%` therefore route to `utdiv`/`utmod` (which the C
+            // backend does over uint64).
+            "/" => {
+                if c.signed {
+                    "tdiv"
+                } else {
+                    "utdiv"
+                }
+            }
+            "%" => {
+                if c.signed {
+                    "tmod"
+                } else {
+                    "utmod"
+                }
+            }
             other => {
                 return Err(CLowerError {
                     message: format!("binary operator `{other}` not yet supported"),

--- a/code/packages/rust/c-to-semantic-ir/tests/three_way_conformance.rs
+++ b/code/packages/rust/c-to-semantic-ir/tests/three_way_conformance.rs
@@ -472,6 +472,78 @@ fn corpus() -> Vec<Case> {
                    int main(void) { uint64_t x = 1; uint64_t y = x << 63; \
                    printf(\"%llu\\n\", (unsigned long long)(y >> 32)); return 0; }",
         },
+        // ── milestone 6: division & modulo (truncate toward zero) ────────────
+        // All four sign combinations — the whole point is that `/` truncates
+        // (not floors) and `%` takes the sign of the dividend.
+        Case {
+            label: "div/mod + + : 7/2 → 3",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int d(int a, int b) { return a / b; }\n\
+                   int main(void) { printf(\"%d\\n\", d(7, 2)); return 0; }",
+        },
+        Case {
+            label: "div - + truncates toward zero: -7/2 → -3 (not -4)",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int d(int a, int b) { return a / b; }\n\
+                   int main(void) { printf(\"%d\\n\", d(-7, 2)); return 0; }",
+        },
+        Case {
+            label: "div + - : 7/-2 → -3",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int d(int a, int b) { return a / b; }\n\
+                   int main(void) { printf(\"%d\\n\", d(7, -2)); return 0; }",
+        },
+        Case {
+            label: "div - - : -7/-2 → 3",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int d(int a, int b) { return a / b; }\n\
+                   int main(void) { printf(\"%d\\n\", d(-7, -2)); return 0; }",
+        },
+        Case {
+            label: "mod takes the dividend's sign: -7%2 → -1 (not 1)",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int m(int a, int b) { return a % b; }\n\
+                   int main(void) { printf(\"%d\\n\", m(-7, 2)); return 0; }",
+        },
+        Case {
+            label: "mod + - : 7%-2 → 1",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int m(int a, int b) { return a % b; }\n\
+                   int main(void) { printf(\"%d\\n\", m(7, -2)); return 0; }",
+        },
+        // (`INT_MIN / -1` is deliberately NOT a conformance case: it is signed-
+        // overflow UB, and real x86 hardware *traps* (SIGFPE) on it even under
+        // `-fwrapv`, so the reference program crashes rather than producing a
+        // value.  The backends still guard it — see the emitted-C `_sir_itdiv`
+        // INT64_MIN/-1 guard and the `int_min_div_is_guarded` unit test — so our
+        // own output is defined, we just don't claim to match a trapping oracle.)
+        Case {
+            label: "unsigned division 100u / 7u → 14",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int main(void) { uint32_t a = 100; uint32_t b = 7; \
+                   printf(\"%u\\n\", a / b); return 0; }",
+        },
+        Case {
+            // A uint64 with bit 63 set is a negative int64 in the backends'
+            // storage, so a *signed* division would be wrong — unsigned `/` must
+            // route to the uint64 path.
+            label: "uint64 division of a high-bit value (2^63)/2 → 4611686018427387904",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int main(void) { uint64_t x = 1; uint64_t hi = x << 63; \
+                   printf(\"%llu\\n\", (unsigned long long)(hi / 2)); return 0; }",
+        },
+        Case {
+            label: "uint64 modulo of a high-bit value (2^63 + 5) % 2 → 1",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int main(void) { uint64_t x = 1; uint64_t hi = (x << 63) + 5; \
+                   printf(\"%llu\\n\", (unsigned long long)(hi % 2)); return 0; }",
+        },
+        Case {
+            label: "gcd via a % b (Euclid) gcd(48,36) → 12",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int gcd(int a, int b) { while (b != 0) { int t = a % b; a = b; b = t; } return a; }\n\
+                   int main(void) { printf(\"%d\\n\", gcd(48, 36)); return 0; }",
+        },
     ]
 }
 

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -1538,6 +1538,11 @@ fn fixed_helper(name: &str) -> Option<(&'static str, usize)> {
         "<<" => ("_sir_shl", 2),
         ">>" => ("_sir_shr", 2),
         "u>>" => ("_sir_lshr", 2),
+        // Milestone 6 truncating division / remainder (signed + unsigned).
+        "tdiv" => ("_sir_itdiv", 2),
+        "tmod" => ("_sir_itmod", 2),
+        "utdiv" => ("_sir_utdiv", 2),
+        "utmod" => ("_sir_utmod", 2),
         "cons" => ("_sir_cons", 2),
         "car" => ("_sir_car", 1),
         "cdr" => ("_sir_cdr", 1),

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -306,6 +306,34 @@ int64_t _sir_ifloordiv(int64_t a, int64_t b) {
     return q;
 }
 
+/* C truncating division / remainder (the SIR27 `tdiv`/`tmod` builtins).  C's
+ * native int64 `/` and `%` already truncate toward zero and give a remainder
+ * with the sign of the dividend, so these are thin wrappers.  Two guards keep
+ * them UB-free: division by zero (UB in C — fail loudly) and INT64_MIN / -1
+ * (signed-overflow UB — return the two's-complement wrap that `-fwrapv` gives,
+ * so it agrees with the reference and the width `Convert` then narrows it). */
+SirValue _sir_itdiv(SirValue a, SirValue b) {
+    if (b.as.i == 0) { fprintf(stderr, "sir: divided by 0\n"); exit(1); }
+    if (a.as.i == INT64_MIN && b.as.i == -1) return _sir_int(INT64_MIN);
+    return _sir_int(a.as.i / b.as.i);
+}
+SirValue _sir_itmod(SirValue a, SirValue b) {
+    if (b.as.i == 0) { fprintf(stderr, "sir: divided by 0\n"); exit(1); }
+    if (a.as.i == INT64_MIN && b.as.i == -1) return _sir_int(0);
+    return _sir_int(a.as.i % b.as.i);
+}
+/* Unsigned truncating division / remainder.  A uint64_t whose top bit is set is
+ * a negative int64, so signed division would be wrong — do it over uint64.  No
+ * INT64_MIN/-1 guard is needed: unsigned division never overflows or traps. */
+SirValue _sir_utdiv(SirValue a, SirValue b) {
+    if (b.as.i == 0) { fprintf(stderr, "sir: divided by 0\n"); exit(1); }
+    return _sir_int((int64_t)((uint64_t)a.as.i / (uint64_t)b.as.i));
+}
+SirValue _sir_utmod(SirValue a, SirValue b) {
+    if (b.as.i == 0) { fprintf(stderr, "sir: divided by 0\n"); exit(1); }
+    return _sir_int((int64_t)((uint64_t)a.as.i % (uint64_t)b.as.i));
+}
+
 SirValue _sir_divide_v(SirValue *xs, int n) {
     int i;
     if (n <= 0) return _sir_int(1);
@@ -966,6 +994,10 @@ SirValue _sir_builtin_dispatch(SirValue *caps, SirValue *args, int argc) {
     if (strcmp(name, "<<") == 0)       return _sir_shl(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
     if (strcmp(name, ">>") == 0)       return _sir_shr(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
     if (strcmp(name, "u>>") == 0)      return _sir_lshr(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
+    if (strcmp(name, "tdiv") == 0)     return _sir_itdiv(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
+    if (strcmp(name, "tmod") == 0)     return _sir_itmod(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
+    if (strcmp(name, "utdiv") == 0)    return _sir_utdiv(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
+    if (strcmp(name, "utmod") == 0)    return _sir_utmod(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
     if (strcmp(name, "cons") == 0)     return _sir_cons(_sir_arg(args, argc, 0), _sir_arg(args, argc, 1));
     if (strcmp(name, "car") == 0)      return _sir_car(_sir_arg(args, argc, 0));
     if (strcmp(name, "cdr") == 0)      return _sir_cdr(_sir_arg(args, argc, 0));

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -41,6 +41,13 @@ const SUPPORTED_BUILTINS: &[&str] = &[
     "<<",
     ">>",
     "u>>",
+    // Truncating division / remainder (SIR27 milestone 6) — distinct from the
+    // flooring `/`/`%` because C truncates toward zero; `u`-variants for the
+    // unsigned common type.
+    "tdiv",
+    "tmod",
+    "utdiv",
+    "utmod",
     "=",
     "==",
     "!=",
@@ -1209,6 +1216,11 @@ fn emit_builtin(name: &str, args: &[Expr]) -> String {
         // value is a masked non-negative Integer, so `>>` is already logical
         // there (the distinction only matters for the C backend's signed int64).
         ">>" | "u>>" => format!("({} >> {})", arg(&a, 0), arg(&a, 1)),
+        // Truncating (C-style) division / remainder via the runtime helpers.
+        // The unsigned variants reuse them: a Ruby unsigned value is a
+        // non-negative Integer, for which truncation and flooring coincide.
+        "tdiv" | "utdiv" => format!("sir_tdiv({}, {})", arg(&a, 0), arg(&a, 1)),
+        "tmod" | "utmod" => format!("sir_tmod({}, {})", arg(&a, 0), arg(&a, 1)),
         "not" => format!("(!sir_truthy({}))", arg(&a, 0)),
         "<" => format!("({} < {})", arg(&a, 0), arg(&a, 1)),
         ">" => format!("({} > {})", arg(&a, 0), arg(&a, 1)),

--- a/code/packages/rust/semantic-ir-to-ruby/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/runtime.rs
@@ -101,6 +101,14 @@ def sir_i128(v)
   m >= (1 << 127) ? m - (1 << 128) : m
 end
 
+# C truncating division / remainder (SIR27 `tdiv`/`tmod`).  Ruby's Integer#/ and
+# #% FLOOR (toward -inf), but C TRUNCATES toward zero, so `-7 / 2` must be -3 not
+# -4.  Integer#remainder already gives C's remainder (sign of the dividend), and
+# `(a - a.remainder(b))` is an exact multiple of b, so flooring it recovers the
+# truncated quotient.  Division by zero raises (as in C it is undefined).
+def sir_tdiv(a, b) = (a - a.remainder(b)) / b
+def sir_tmod(a, b) = a.remainder(b)
+
 # The key is normalised with to_s so a name that arrives as a Symbol (how the
 # _init function's global_set passes it) and the same name as a String (how a
 # VarRef Global reads it) hit the same entry.

--- a/code/specs/SIR27-c-to-semantic-ir.md
+++ b/code/specs/SIR27-c-to-semantic-ir.md
@@ -326,10 +326,29 @@ helpers over `int64_t` (`<<` through `uint64_t` so a shift into the sign bit is
 not UB; both mask the count `& 63` defensively — a count ≥ width is UB in C
 anyway).
 
-Division/modulo (`/ %`) remain deferred: they need the truncate-vs-floor split
-(C truncates toward zero; SIR/Ruby and the existing `_sir_ifloordiv` floor), so
-they are their own slice — a bare `/` or `%` is a clean positioned error, never a
-silently-wrong floor.
+Division/modulo (`/ %`) are handled in milestone 6 (below).
+
+## Division & modulo (milestone 6)
+
+`/` and `%` are the one place C and SIR **disagree on rounding**: C division
+*truncates toward zero* and `%` takes the sign of the dividend (`-7 / 2 == -3`,
+`-7 % 2 == -1`), whereas SIR/Ruby `/`/`%` and the C backend's existing
+`_sir_ifloordiv` *floor* toward −∞ (`-7 / 2 == -4`, `-7 % 2 == 1`).  So they
+lower to **dedicated `tdiv`/`tmod` builtins**, never the flooring `/`/`%`.
+
+- **C backend** — C's native `int64_t /` and `%` already truncate, so
+  `_sir_itdiv`/`_sir_itmod` are thin wrappers with two guards: division by zero
+  (UB in C; fail loudly) and `INT64_MIN / -1` (signed-overflow UB, and x86
+  hardware traps on it — return the two's-complement wrap `-fwrapv` would give,
+  which the width `Convert` then narrows).
+- **Ruby backend** — `Integer#/` floors, so `sir_tdiv`/`sir_tmod` recover
+  truncation exactly: `Integer#remainder` is already C's `%` (dividend sign), and
+  `(a - a.remainder(b)) / b` is an exact multiple of `b`, so flooring it yields
+  the truncated quotient.
+
+Both agree with `clang -fwrapv` across all four sign combinations.  `INT_MIN /
+-1` is deliberately *not* a conformance case — it is UB and the reference program
+traps — but the backends stay defined so they never crash on it.
 
 ## Pipeline
 


### PR DESCRIPTION
## Milestone 6 of the C → SIR → Ruby initiative — division & modulo

`/` and `%` are the one place C and SIR **disagree on rounding**: C division *truncates toward zero* and `%` takes the dividend's sign (`-7/2 = -3`, `-7%2 = -1`), whereas SIR/Ruby `/`/`%` and the C backend's `_sir_ifloordiv` *floor* (`-7/2 = -4`). So they lower to dedicated **`tdiv`/`tmod`** builtins, never the flooring ones.

**Signedness** matters as it does for `>>`: the backends store values in a signed `int64`, so an unsigned operand ≥ 2^63 is a *negative* int64 on which a signed division is wrong. An unsigned common type routes to **`utdiv`/`utmod`** (C does these over `uint64`). *This fixed a real miscompile caught in review — uint64 `/`/`%` of a high-bit value.*

### Backends
- **C:** `_sir_itdiv`/`_sir_itmod` wrap C's native truncating `int64 /`,`%`, guarded against divide-by-zero and `INT64_MIN/-1` (x86 traps on it); `_sir_utdiv`/`_sir_utmod` do it over `uint64`.
- **Ruby:** `sir_tdiv(a,b) = (a - a.remainder(b)) / b`, `sir_tmod = a.remainder(b)` recover truncation from Ruby's flooring `/`.
- Allowlists extended with `tdiv/tmod/utdiv/utmod`.

### Verified locally
- **38-program three-way conformance corpus** byte-identical across reference `clang -fwrapv`, emitted Ruby (`ruby` 3.4), and emitted C — all four sign combinations, unsigned division, uint64 high-bit `/`,`%`, and a real Euclid `gcd` (`%` in a loop).
- Emitted C also compiles+runs identically on **clang + gcc + MSVC**.
- **Security review (two rounds):** round 1 caught the uint64 signed-division miscompile; round 2 passed after the `utdiv`/`utmod` fix — 27 differential cases incl. mixed signed/unsigned matching C's usual-arithmetic-conversions; helpers UB-free and warning-clean under `-Wall -Wextra -Wconversion`; anti-RCE static switch.
- `INT_MIN / -1` is UB (the reference traps), so it's not a conformance case, but a unit test confirms the emitted C is guarded and doesn't crash.

**With this, every C integer operator is implemented** — arithmetic, bitwise, shifts, comparisons, logical, and division/modulo. Remaining queue: per-block scoping (lifts the shadowing / double-`for` restrictions) and a c-parser depth guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)