### PR TITLE
Add MOS drain resistance

### DIFF
--- a/code/packages/python/mosfet-models/CHANGELOG.md
+++ b/code/packages/python/mosfet-models/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [0.1.0] — Unreleased
 
 ### Added
+- `Level1Params.RD` adds the zero-default Berkeley external drain resistance
+  parameter with finite, non-negative validation.
 - `Level1Params.TOX` adds Berkeley-default gate oxide thickness and derives
   Meyer gate capacitance from `Cox = epsilon_ox / TOX`.
 - `Level1Params.LD` applies Berkeley lateral-diffusion geometry through

--- a/code/packages/python/mosfet-models/README.md
+++ b/code/packages/python/mosfet-models/README.md
@@ -26,8 +26,8 @@ print(r.Id, r.gm, r.gds, r.region)
   sane defaults for 130 nm-style NMOS, including zero-default `LD` lateral
   diffusion through `L_eff = L - 2*LD`, `PB` / `MJ` / `FC` bulk-junction
   depletion shaping, Berkeley-default `TOX` gate oxide thickness for intrinsic
-  Meyer capacitance through `Cox = epsilon_ox / TOX`, and `KF` / `AF` flicker
-  noise.
+  Meyer capacitance through `Cox = epsilon_ox / TOX`, zero-default `RD`
+  external drain resistance, and `KF` / `AF` flicker noise.
 - `evaluate_level1(params, V_GS, V_DS, V_BS, T)`: returns `MosResult` with Id, gm, gds, gmb, Cgs/Cgd/Cgb/Cbs/Cbd, region.
 - Region detection: cutoff (subthreshold-aware), triode, saturation.
 - Body effect via gamma * (sqrt(PHI-V_BS) - sqrt(PHI)) shift.

--- a/code/packages/python/mosfet-models/src/mosfet_models/level1.py
+++ b/code/packages/python/mosfet-models/src/mosfet_models/level1.py
@@ -29,6 +29,7 @@ class Level1Params:
     L: float = 130e-9  # channel length (m)
     LD: float = 0.0  # source/drain lateral diffusion length (m)
     TOX: float = 1e-7  # gate oxide thickness (m)
+    RD: float = 0.0  # external drain resistance (ohm)
     IS: float = 1e-15  # saturation current (A)
     N_SUB: float = 1.4  # subthreshold slope factor
     T_NOM: float = 300.15  # nominal temperature (K)
@@ -122,6 +123,8 @@ def evaluate_level1(
         )
     if not isfinite(p.TOX) or p.TOX <= 0.0:
         raise ValueError("MOSFET TOX must be finite and positive")
+    if not isfinite(p.RD) or p.RD < 0.0:
+        raise ValueError("MOSFET RD must be finite and non-negative")
     beta = p.KP * (p.W / effective_length)
 
     # Threshold with body effect. The formula is well-defined whenever

--- a/code/packages/python/mosfet-models/tests/test_models.py
+++ b/code/packages/python/mosfet-models/tests/test_models.py
@@ -167,6 +167,14 @@ def test_oxide_thickness_validates_positive_finite_value(tox):
         evaluate_level1(Level1Params(TOX=tox), V_GS=1.8, V_DS=1.8)
 
 
+def test_drain_resistance_rejects_negative_value():
+    with pytest.raises(
+        ValueError,
+        match="MOSFET RD must be finite and non-negative",
+    ):
+        evaluate_level1(Level1Params(RD=-1.0), V_GS=1.8, V_DS=1.8)
+
+
 def test_overlap_and_bulk_capacitances_are_reported():
     p = Level1Params(
         W=2e-6,

--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- Add Level-1 MOS model-card `RD` support. Nonzero values create an intrinsic
+  drain node, stamp the external resistor in DC, TF, AC, and transient
+  analyses, route drain-side capacitances through it, and emit `:RD` Johnson
+  noise.
 - Add Level-1 MOS model-card `TOX` support, defaulting to `100 nm` and deriving
   intrinsic Meyer gate capacitance from silicon-dioxide permittivity and oxide
   thickness.

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -93,6 +93,9 @@ Level-1 MOS model cards accept `KF` (default `0`) and `AF` (default `1`) and add
 length-scaled intrinsic/`CGBO` capacitance.
 `TOX` defaults to `1e-7 m`, must be finite and positive, and derives intrinsic
 Meyer gate capacitance from `Cox = epsilon_ox / TOX`.
+`RD` defaults to zero ohms. A finite positive value inserts an intrinsic drain
+node, routes the channel and drain-side capacitances through it, and contributes
+`4kT/RD` thermal noise.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -7333,7 +7333,10 @@ def _element_nodes(el: Element) -> list[str]:
             nodes.append(_jfet_intrinsic_source_node(el))
         return nodes
     if isinstance(el, Mosfet):
-        return [el.drain, el.gate, el.source, el.body]
+        nodes = [el.drain, el.gate, el.source, el.body]
+        if _mosfet_drain_resistance(el) > 0.0:
+            nodes.append(_mosfet_intrinsic_drain_node(el))
+        return nodes
     if isinstance(el, BJT):
         nodes = [el.collector, el.base, el.emitter]
         if el.Re > 0.0:
@@ -9057,6 +9060,20 @@ def _mosfet_drain_body_charge_state_name(el: Mosfet) -> str:
     return f"_M_{el.name}_db_charge"
 
 
+def _mosfet_drain_resistance(el: Mosfet) -> float:
+    params = getattr(getattr(el.model, "model", None), "params", None)
+    return float(getattr(params, "RD", 0.0))
+
+
+def _mosfet_intrinsic_drain_node(el: Mosfet) -> str:
+    drain_resistance = _mosfet_drain_resistance(el)
+    return (
+        el.drain
+        if not math.isfinite(drain_resistance) or drain_resistance <= 0.0
+        else f"__spice_{el.name}_drain"
+    )
+
+
 def _mosfet_charge_state_specs(el: Mosfet) -> list[tuple[str, str, str, float]]:
     params = getattr(getattr(el.model, "model", None), "params", None)
     if params is None:
@@ -9072,13 +9089,27 @@ def _mosfet_charge_state_specs(el: Mosfet) -> list[tuple[str, str, str, float]]:
     if cgs > 0.0:
         specs.append((_mosfet_gate_source_charge_state_name(el), el.gate, el.source, cgs))
     if cgd > 0.0:
-        specs.append((_mosfet_gate_drain_charge_state_name(el), el.gate, el.drain, cgd))
+        specs.append(
+            (
+                _mosfet_gate_drain_charge_state_name(el),
+                el.gate,
+                _mosfet_intrinsic_drain_node(el),
+                cgd,
+            )
+        )
     if cgb > 0.0:
         specs.append((_mosfet_gate_body_charge_state_name(el), el.gate, el.body, cgb))
     if cbs > 0.0:
         specs.append((_mosfet_source_body_charge_state_name(el), el.source, el.body, cbs))
     if cbd > 0.0:
-        specs.append((_mosfet_drain_body_charge_state_name(el), el.drain, el.body, cbd))
+        specs.append(
+            (
+                _mosfet_drain_body_charge_state_name(el),
+                _mosfet_intrinsic_drain_node(el),
+                el.body,
+                cbd,
+            )
+        )
     return specs
 
 
@@ -9132,7 +9163,8 @@ def _stamp_mosfet(
     el: Mosfet,
 ) -> None:
     """Linearized MOSFET via mosfet_models.MOSFET.dc()."""
-    Vd = 0.0 if _is_ground(el.drain) else x[node_to_idx[el.drain]]
+    intrinsic_drain = _mosfet_intrinsic_drain_node(el)
+    Vd = 0.0 if _is_ground(intrinsic_drain) else x[node_to_idx[intrinsic_drain]]
     Vg = 0.0 if _is_ground(el.gate) else x[node_to_idx[el.gate]]
     Vs = 0.0 if _is_ground(el.source) else x[node_to_idx[el.source]]
     Vb = 0.0 if _is_ground(el.body) else x[node_to_idx[el.body]]
@@ -9148,10 +9180,10 @@ def _stamp_mosfet(
     gds = r.gds
 
     # Stamp gds (drain-source conductance) + Id companion source.
-    _stamp_g(G, node_to_idx, el.drain, el.source, gds)
+    _stamp_g(G, node_to_idx, intrinsic_drain, el.source, gds)
     # Stamp gm (transconductance: drain-current per V_GS).
-    if not _is_ground(el.drain):
-        d = node_to_idx[el.drain]
+    if not _is_ground(intrinsic_drain):
+        d = node_to_idx[intrinsic_drain]
         if not _is_ground(el.gate):
             G[d][node_to_idx[el.gate]] += gm
         if not _is_ground(el.source):
@@ -9164,10 +9196,19 @@ def _stamp_mosfet(
             G[s][node_to_idx[el.source]] += gm
     # Companion current source for Id at this operating point
     Ieq = Id - gm * V_GS - gds * V_DS
-    if not _is_ground(el.drain):
-        b[node_to_idx[el.drain]] -= Ieq
+    if not _is_ground(intrinsic_drain):
+        b[node_to_idx[intrinsic_drain]] -= Ieq
     if not _is_ground(el.source):
         b[node_to_idx[el.source]] += Ieq
+    drain_resistance = _mosfet_drain_resistance(el)
+    if drain_resistance > 0.0:
+        _stamp_g(
+            G,
+            node_to_idx,
+            el.drain,
+            intrinsic_drain,
+            1.0 / drain_resistance,
+        )
 
 
 def _eval_jfet(el: JFET, vgs: float, vds: float) -> tuple[float, float, float]:
@@ -13036,21 +13077,26 @@ def _stamp_ac(
     elif isinstance(el, Mosfet):
         # Small-signal model: gds (output conductance) + gm (transconductance).
         # The gm VCCS is stamped as off-diagonal conductance entries.
-        Vd = 0.0 if _is_ground(el.drain) else dc_x[node_to_idx[el.drain]]
+        intrinsic_drain = _mosfet_intrinsic_drain_node(el)
+        Vd = (
+            0.0
+            if _is_ground(intrinsic_drain)
+            else dc_x[node_to_idx[intrinsic_drain]]
+        )
         Vg = 0.0 if _is_ground(el.gate) else dc_x[node_to_idx[el.gate]]
         Vs = 0.0 if _is_ground(el.source) else dc_x[node_to_idx[el.source]]
         Vb = 0.0 if _is_ground(el.body) else dc_x[node_to_idx[el.body]]
         r = el.model.dc(Vg - Vs, Vd - Vs, Vb - Vs)  # type: ignore[attr-defined]
         gm_m: float = r.gm
         gds_m: float = r.gds
-        _stamp_g_c(G, node_to_idx, el.drain, el.source, gds_m + 0j)
+        _stamp_g_c(G, node_to_idx, intrinsic_drain, el.source, gds_m + 0j)
         _stamp_g_c(G, node_to_idx, el.gate, el.source, 1j * omega * r.Cgs)
-        _stamp_g_c(G, node_to_idx, el.gate, el.drain, 1j * omega * r.Cgd)
+        _stamp_g_c(G, node_to_idx, el.gate, intrinsic_drain, 1j * omega * r.Cgd)
         _stamp_g_c(G, node_to_idx, el.gate, el.body, 1j * omega * r.Cgb)
         _stamp_g_c(G, node_to_idx, el.body, el.source, 1j * omega * r.Cbs)
-        _stamp_g_c(G, node_to_idx, el.body, el.drain, 1j * omega * r.Cbd)
-        if not _is_ground(el.drain):
-            d = node_to_idx[el.drain]
+        _stamp_g_c(G, node_to_idx, el.body, intrinsic_drain, 1j * omega * r.Cbd)
+        if not _is_ground(intrinsic_drain):
+            d = node_to_idx[intrinsic_drain]
             if not _is_ground(el.gate):
                 G[d][node_to_idx[el.gate]] += gm_m + 0j
             if not _is_ground(el.source):
@@ -13061,6 +13107,15 @@ def _stamp_ac(
                 G[s][node_to_idx[el.gate]] -= gm_m + 0j
             if not _is_ground(el.source):
                 G[s][node_to_idx[el.source]] += gm_m + 0j
+        drain_resistance = _mosfet_drain_resistance(el)
+        if drain_resistance > 0.0:
+            _stamp_g_c(
+                G,
+                node_to_idx,
+                el.drain,
+                intrinsic_drain,
+                1.0 / drain_resistance,
+            )
 
     elif isinstance(el, BJT):
         # Small-signal model: g_π (junction conductance) + gm (transconductance
@@ -13763,16 +13818,21 @@ def _build_ss_matrix(
         elif isinstance(el, Mosfet):
             # Small-signal model: gds (drain–source) + gm VCCS (gate–source
             # controls drain current).  Mirrors the AC _stamp_ac Mosfet block.
-            Vd = 0.0 if _is_ground(el.drain) else dc_x[node_to_idx[el.drain]]
+            intrinsic_drain = _mosfet_intrinsic_drain_node(el)
+            Vd = (
+                0.0
+                if _is_ground(intrinsic_drain)
+                else dc_x[node_to_idx[intrinsic_drain]]
+            )
             Vg = 0.0 if _is_ground(el.gate) else dc_x[node_to_idx[el.gate]]
             Vs = 0.0 if _is_ground(el.source) else dc_x[node_to_idx[el.source]]
             Vb = 0.0 if _is_ground(el.body) else dc_x[node_to_idx[el.body]]
             r = el.model.dc(Vg - Vs, Vd - Vs, Vb - Vs)  # type: ignore[attr-defined]
             gm_m: float = r.gm
             gds_m: float = r.gds
-            _stamp_g(G, node_to_idx, el.drain, el.source, gds_m)
-            if not _is_ground(el.drain):
-                d = node_to_idx[el.drain]
+            _stamp_g(G, node_to_idx, intrinsic_drain, el.source, gds_m)
+            if not _is_ground(intrinsic_drain):
+                d = node_to_idx[intrinsic_drain]
                 if not _is_ground(el.gate):
                     G[d][node_to_idx[el.gate]] += gm_m
                 if not _is_ground(el.source):
@@ -13783,6 +13843,15 @@ def _build_ss_matrix(
                     G[s][node_to_idx[el.gate]] -= gm_m
                 if not _is_ground(el.source):
                     G[s][node_to_idx[el.source]] += gm_m
+            drain_resistance = _mosfet_drain_resistance(el)
+            if drain_resistance > 0.0:
+                _stamp_g(
+                    G,
+                    node_to_idx,
+                    el.drain,
+                    intrinsic_drain,
+                    1.0 / drain_resistance,
+                )
 
         elif isinstance(el, BJT):
             # Small-signal model: g_π (junction conductance) + gm VCCS.
@@ -15607,7 +15676,12 @@ def _collect_noise_sources(
 
         elif isinstance(el, Mosfet):
             # Long-channel channel thermal noise plus model-card 1/f noise.
-            Vd = 0.0 if _is_ground(el.drain) else dc_x[node_to_idx[el.drain]]
+            intrinsic_drain = _mosfet_intrinsic_drain_node(el)
+            Vd = (
+                0.0
+                if _is_ground(intrinsic_drain)
+                else dc_x[node_to_idx[intrinsic_drain]]
+            )
             Vg = 0.0 if _is_ground(el.gate) else dc_x[node_to_idx[el.gate]]
             Vs = 0.0 if _is_ground(el.source) else dc_x[node_to_idx[el.source]]
             Vb = 0.0 if _is_ground(el.body) else dc_x[node_to_idx[el.body]]
@@ -15626,7 +15700,11 @@ def _collect_noise_sources(
                     f"{el.name}: MOSFET AF must be finite and non-negative"
                 )
             gm = max(0.0, float(r.gm))
-            n_d = None if _is_ground(el.drain) else node_to_idx[el.drain]
+            n_d = (
+                None
+                if _is_ground(intrinsic_drain)
+                else node_to_idx[intrinsic_drain]
+            )
             n_s = None if _is_ground(el.source) else node_to_idx[el.source]
             if gm > 0.0:
                 psd = kT4 * _MOSFET_CHANNEL_NOISE_GAMMA * gm
@@ -15641,6 +15719,18 @@ def _collect_noise_sources(
                         flicker_noise_coefficient
                         * abs(float(r.Id)) ** flicker_noise_exponent,
                         1.0,
+                    )
+                )
+            drain_resistance = _mosfet_drain_resistance(el)
+            if drain_resistance > 0.0:
+                sources.append(
+                    (
+                        f"{el.name}:RD",
+                        "thermal",
+                        None if _is_ground(el.drain) else node_to_idx[el.drain],
+                        n_d,
+                        kT4 / drain_resistance,
+                        0.0,
                     )
                 )
 

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -311,8 +311,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "PNP": (41, 58, 13, 4),
     "NJF": (22, 30, 7, 3),
     "PJF": (22, 30, 7, 3),
-    "NMOS": (23, 30, 6, 3),
-    "PMOS": (23, 30, 6, 3),
+    "NMOS": (24, 31, 6, 3),
+    "PMOS": (24, 31, 6, 3),
 }
 
 
@@ -465,6 +465,7 @@ _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
     "L": "L",
     "LD": "LD",
     "TOX": "TOX",
+    "RD": "RD",
     "IS": "IS",
     "NSUB": "N_SUB",
     "N_SUB": "N_SUB",
@@ -1071,6 +1072,7 @@ def mosfet_from_model_card(
         L=p.get("L", defaults.L),
         LD=p.get("LD", defaults.LD),
         TOX=p.get("TOX", defaults.TOX),
+        RD=p.get("RD", defaults.RD),
         IS=p.get("IS", defaults.IS),
         N_SUB=p.get("N_SUB", defaults.N_SUB),
         T_NOM=p.get("T_NOM", defaults.T_NOM),

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -408,7 +408,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 187
+    assert len(coverage) == 189
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -423,7 +423,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tAF\tAF\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 187
+    assert len(records) == 189
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -446,8 +446,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert summary[0].max_alias_count == 3
     assert summary[0].aliased_parameters == ("IS", "VT", "CJO", "VJ", "M")
     assert summary[5].kind == "NMOS"
-    assert summary[5].canonical_parameter_count == 23
-    assert summary[5].accepted_name_count == 30
+    assert summary[5].canonical_parameter_count == 24
+    assert summary[5].accepted_name_count == 31
     assert summary[5].aliased_parameter_count == 6
     assert summary[5].max_alias_count == 3
     assert summary[5].aliased_parameters == (
@@ -469,7 +469,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert table.splitlines()[1] == "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M"
     assert (
         table.splitlines()[-1]
-        == "PMOS\t23\t30\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        == "PMOS\t24\t31\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
     )
     records = model_card_supported_parameter_coverage_summary_records()
     assert len(records) == 7
@@ -497,9 +497,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 187
-    assert report.expected_canonical_parameter_count == 187
-    assert report.accepted_name_count == 257
+    assert report.canonical_parameter_count == 189
+    assert report.expected_canonical_parameter_count == 189
+    assert report.accepted_name_count == 259
     assert report.aliased_parameter_count == 57
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -507,7 +507,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t187\t187\t257\t57\t4\t0"
+        "true\t7\t7\t189\t189\t259\t57\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -535,15 +535,15 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 186
-    assert report.accepted_name_count == 254
+    assert report.canonical_parameter_count == 188
+    assert report.accepted_name_count == 256
     assert report.aliased_parameter_count == 56
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
     assert report.issues[0].field == "canonical_parameter_count"
     assert report.issues[0].message == (
-        "expected NMOS to expose 23 canonical supported parameters, found 22"
+        "expected NMOS to expose 24 canonical supported parameters, found 23"
     )
     assert report.issues[-1].field == "max_alias_count"
     assert report.issues[-1].message == "expected NMOS max alias count 3, found 2"
@@ -551,12 +551,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t186\t187\t254\t56\t4\t4\n"
+        "false\t7\t7\t188\t189\t256\t56\t4\t4\n"
         "kind\tfield\tmessage\n"
-        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 23 canonical "
-        "supported parameters, found 22\n"
-        "NMOS\taccepted_name_count\texpected NMOS to expose 30 accepted model-card "
-        "names, found 27\n"
+        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 24 canonical "
+        "supported parameters, found 23\n"
+        "NMOS\taccepted_name_count\texpected NMOS to expose 31 accepted model-card "
+        "names, found 28\n"
         "NMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing "
         "parameters, found 5\n"
         "NMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
@@ -565,12 +565,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
     assert records[0] == {
         "kind": "NMOS",
         "field": "canonical_parameter_count",
-        "message": "expected NMOS to expose 23 canonical supported parameters, found 22",
+        "message": "expected NMOS to expose 24 canonical supported parameters, found 23",
     }
     assert format_model_card_supported_parameter_coverage_gate_issue_csv(report).startswith(
         "kind,field,message\n"
-        'NMOS,canonical_parameter_count,"expected NMOS to expose 23 canonical '
-        'supported parameters, found 22"\n'
+        'NMOS,canonical_parameter_count,"expected NMOS to expose 24 canonical '
+        'supported parameters, found 23"\n'
     )
     assert (
         json.loads(format_model_card_supported_parameter_coverage_gate_issue_json(report))
@@ -748,6 +748,7 @@ def test_model_card_aliases_build_device_instances() -> None:
             "MJ": 0.45,
             "FC": 0.4,
             "LD": 50.0e-9,
+            "RD": 125.0,
             "TOX": 25.0e-9,
             "KF": 2.0e-24,
             "AF": 1.4,
@@ -764,6 +765,7 @@ def test_model_card_aliases_build_device_instances() -> None:
         "MJ": 0.45,
         "FC": 0.4,
         "LD": 50.0e-9,
+        "RD": 125.0,
         "TOX": 25.0e-9,
         "KF": 2.0e-24,
         "AF": 1.4,
@@ -779,6 +781,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(0.45) == mos_model.model.model.params.MJ
     assert pytest.approx(0.4) == mos_model.model.model.params.FC
     assert pytest.approx(50.0e-9) == mos_model.model.model.params.LD
+    assert pytest.approx(125.0) == mos_model.model.model.params.RD
     assert pytest.approx(25.0e-9) == mos_model.model.model.params.TOX
     assert pytest.approx(2.0e-24) == mos_model.model.model.params.KF
     assert pytest.approx(1.4) == mos_model.model.model.params.AF
@@ -895,6 +898,27 @@ def test_dc_jfet_drain_resistance_drops_intrinsic_drain_voltage() -> None:
     result = dc_op(circuit)
     assert result.node_voltages["drain"] == pytest.approx(5.0)
     assert result.node_voltages["__spice_J1_drain"] < 5.0
+
+
+def test_dc_mosfet_drain_resistance_drops_intrinsic_drain_voltage() -> None:
+    circuit = Circuit()
+    circuit.add(VoltageSource("Vdrain", "drain", "0", 5.0))
+    circuit.add(VoltageSource("Vgate", "gate", "0", 3.0))
+    circuit.add(Mosfet(
+        "M1",
+        "drain",
+        "gate",
+        "0",
+        "0",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(Level1Params(RD=1_000.0)),
+        ),
+    ))
+
+    result = dc_op(circuit)
+    assert result.node_voltages["drain"] == pytest.approx(5.0)
+    assert result.node_voltages["__spice_M1_drain"] < 5.0
 
 
 def test_dc_jfet_source_resistance_raises_intrinsic_source_voltage() -> None:
@@ -1915,6 +1939,30 @@ def test_mosfet_rejects_invalid_oxide_thickness(tox: float) -> None:
         dc_op(circuit)
 
 
+@pytest.mark.parametrize("drain_resistance", [float("nan"), -1.0])
+def test_mosfet_rejects_invalid_drain_resistance(
+    drain_resistance: float,
+) -> None:
+    circuit = Circuit()
+    circuit.add(Mosfet(
+        "Mbad",
+        "drain",
+        "gate",
+        "0",
+        "0",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(Level1Params(RD=drain_resistance)),
+        ),
+    ))
+
+    with pytest.raises(
+        ValueError,
+        match="MOSFET RD must be finite and non-negative",
+    ):
+        dc_op(circuit)
+
+
 def test_transient_diode_transit_time_holds_forward_charge_on_turnoff() -> None:
     def run(transit_time: float) -> TransientResult:
         circuit = Circuit()
@@ -2853,7 +2901,12 @@ def test_subcircuit_expansion_preserves_mos_geometry():
                 MOSFET(
                     MosfetType.NMOS,
                     Level1Model(
-                        Level1Params(L=1.0e-6, LD=0.1e-6, TOX=25.0e-9)
+                        Level1Params(
+                            L=1.0e-6,
+                            LD=0.1e-6,
+                            RD=125.0,
+                            TOX=25.0e-9,
+                        )
                     ),
                 ),
             ),
@@ -2866,9 +2919,10 @@ def test_subcircuit_expansion_preserves_mos_geometry():
     expanded = next(
         element for element in circuit.elements if isinstance(element, Mosfet)
     )
-    assert expanded.model.model.params.L == pytest.approx(1.0e-6)
-    assert expanded.model.model.params.LD == pytest.approx(0.1e-6)
-    assert expanded.model.model.params.TOX == pytest.approx(25.0e-9)
+    assert pytest.approx(1.0e-6) == expanded.model.model.params.L
+    assert pytest.approx(0.1e-6) == expanded.model.model.params.LD
+    assert pytest.approx(125.0) == expanded.model.model.params.RD
+    assert pytest.approx(25.0e-9) == expanded.model.model.params.TOX
 
 
 def test_subcircuit_expansion_preserves_complete_bjt_model():
@@ -8064,6 +8118,32 @@ def test_noise_jfet_rd_adds_thermal_noise() -> None:
         entry
         for entry in entries
         if entry.element_name == "J1:RD" and entry.noise_type == "thermal"
+    )
+    assert rd.source_psd == pytest.approx(4.0 * 1.380_649e-23 * 300.0 / 250.0)
+
+
+def test_noise_mosfet_rd_adds_thermal_noise() -> None:
+    circuit = Circuit()
+    circuit.add(VoltageSource("Vdd", "vdd", "0", 5.0))
+    circuit.add(VoltageSource("Vgate", "gate", "0", 3.0))
+    circuit.add(Resistor("Rload", "vdd", "out", 1_000.0))
+    circuit.add(Mosfet(
+        "M1",
+        "out",
+        "gate",
+        "0",
+        "0",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(Level1Params(RD=250.0)),
+        ),
+    ))
+
+    entries = noise_ac(circuit, "out", "Vgate", freqs=[1_000.0]).points[0].entries
+    rd = next(
+        entry
+        for entry in entries
+        if entry.element_name == "M1:RD" and entry.noise_type == "thermal"
     )
     assert rd.source_psd == pytest.approx(4.0 * 1.380_649e-23 * 300.0 / 250.0)
 

--- a/code/packages/rust/mosfet-models/CHANGELOG.md
+++ b/code/packages/rust/mosfet-models/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `Level1Params::rd` adds the zero-default Berkeley external drain resistance
+  parameter with finite, non-negative validation.
 - `Level1Params::tox` adds Berkeley-default gate oxide thickness and derives
   Meyer gate capacitance from `Cox = epsilon_ox / TOX`.
 - `Level1Params::ld` applies Berkeley lateral-diffusion geometry through

--- a/code/packages/rust/mosfet-models/README.md
+++ b/code/packages/rust/mosfet-models/README.md
@@ -27,7 +27,8 @@ This crate implements the classical square-law MOSFET model used in introductory
 where β = KP × W/(L − 2LD) and V_OV = V_GS − V_t. `LD` defaults to zero
 and must leave a positive effective channel length. `TOX` defaults to
 `100 nm`, must be positive, and derives intrinsic Meyer gate capacitance from
-`Cox = epsilon_ox / TOX`.
+`Cox = epsilon_ox / TOX`. `RD` is a finite, non-negative external drain
+resistance parameter for engine topology and defaults to zero ohms.
 
 ## Usage
 

--- a/code/packages/rust/mosfet-models/src/lib.rs
+++ b/code/packages/rust/mosfet-models/src/lib.rs
@@ -40,6 +40,7 @@ const OXIDE_PERMITTIVITY: f64 = 3.453_133e-11;
 /// | L         | Channel length (m)                 | 130 nm   |
 /// | LD        | Lateral diffusion length (m)       | 0        |
 /// | TOX       | Gate oxide thickness (m)           | 100 nm   |
+/// | RD        | Drain resistance (ohm)              | 0        |
 /// | IS        | Drain–body saturation current (A)  | 1 fA     |
 /// | N_SUB     | Subthreshold slope factor          | 1.4      |
 /// | T_NOM     | Nominal temperature (K)            | 300.15   |
@@ -65,6 +66,8 @@ pub struct Level1Params {
     pub ld: f64,
     /// Gate oxide thickness [m].
     pub tox: f64,
+    /// External drain resistance [ohm].
+    pub rd: f64,
     /// Drain–body saturation current [A] (used for subthreshold floor).
     pub is: f64,
     /// Subthreshold slope factor n.  Subthreshold current ∝ exp(V_OV / (n V_T)).
@@ -107,6 +110,7 @@ impl Default for Level1Params {
             l: 130e-9,
             ld: 0.0,
             tox: 1.0e-7,
+            rd: 0.0,
             is: 1e-15,
             n_sub: 1.4,
             t_nom: 300.15,
@@ -243,6 +247,10 @@ pub fn evaluate_level1(
     assert!(
         p.tox.is_finite() && p.tox > 0.0,
         "MOSFET TOX must be finite and positive"
+    );
+    assert!(
+        p.rd.is_finite() && p.rd >= 0.0,
+        "MOSFET RD must be finite and non-negative"
     );
     let beta = p.kp * (p.w / effective_length);
 

--- a/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
+++ b/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
@@ -164,6 +164,21 @@ fn test_oxide_thickness_rejects_nonpositive_value() {
     );
 }
 
+#[test]
+#[should_panic(expected = "MOSFET RD must be finite and non-negative")]
+fn test_drain_resistance_rejects_negative_value() {
+    evaluate_level1(
+        &Level1Params {
+            rd: -1.0,
+            ..Level1Params::default()
+        },
+        1.8,
+        1.8,
+        0.0,
+        300.15,
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Body effect
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- Add Level-1 MOS model-card `RD` support. Nonzero values create an intrinsic
+  drain node, stamp the external resistor in DC, TF, AC, and transient
+  analyses, route drain-side capacitances through it, and emit `:RD` Johnson
+  noise.
 - Add Level-1 MOS model-card `TOX` support, defaulting to `100 nm` and deriving
   intrinsic Meyer gate capacitance from silicon-dioxide permittivity and oxide
   thickness.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -134,6 +134,9 @@ Level-1 MOS model cards accept `KF` (default `0`) and `AF` (default `1`) and add
 length-scaled intrinsic/`CGBO` capacitance.
 `TOX` defaults to `1e-7 m`, must be finite and positive, and derives intrinsic
 Meyer gate capacitance from `Cox = epsilon_ox / TOX`.
+`RD` defaults to zero ohms. A finite positive value inserts an intrinsic drain
+node, routes the channel and drain-side capacitances through it, and contributes
+`4kT/RD` thermal noise.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3609,6 +3609,7 @@ pub struct MosfetLevel1Params {
     pub l: f64,
     pub lateral_diffusion_length: f64,
     pub oxide_thickness: f64,
+    pub drain_resistance: f64,
     pub saturation_current: f64,
     pub n_sub: f64,
     pub t_nom: f64,
@@ -3636,6 +3637,7 @@ impl Default for MosfetLevel1Params {
             l: 130.0e-9,
             lateral_diffusion_length: 0.0,
             oxide_thickness: 1.0e-7,
+            drain_resistance: 0.0,
             saturation_current: 1.0e-15,
             n_sub: 1.4,
             t_nom: 300.15,
@@ -3992,8 +3994,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     (ModelCardKind::Pnp, 41, 58, 13, 4),
     (ModelCardKind::Njf, 22, 30, 7, 3),
     (ModelCardKind::Pjf, 22, 30, 7, 3),
-    (ModelCardKind::Nmos, 23, 30, 6, 3),
-    (ModelCardKind::Pmos, 23, 30, 6, 3),
+    (ModelCardKind::Nmos, 24, 31, 6, 3),
+    (ModelCardKind::Pmos, 24, 31, 6, 3),
 ];
 const DIODE_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IS", "IS"),
@@ -4124,6 +4126,7 @@ const MOS_LEVEL1_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("L", "L"),
     ("LD", "LD"),
     ("TOX", "TOX"),
+    ("RD", "RD"),
     ("IS", "IS"),
     ("NSUB", "N_SUB"),
     ("N_SUB", "N_SUB"),
@@ -4905,6 +4908,9 @@ pub fn mosfet_from_model_card(
     }
     if let Some(value) = model.parameters.get("TOX") {
         params.oxide_thickness = *value;
+    }
+    if let Some(value) = model.parameters.get("RD") {
+        params.drain_resistance = *value;
     }
     if let Some(value) = model.parameters.get("IS") {
         params.saturation_current = *value;
@@ -22320,6 +22326,9 @@ fn collect_node_indices(circuit: &Circuit) -> HashMap<String, usize> {
                 insert_node(&mut names, &mosfet.gate);
                 insert_node(&mut names, &mosfet.source);
                 insert_node(&mut names, &mosfet.body);
+                if mosfet.params.drain_resistance > 0.0 {
+                    insert_node(&mut names, &mosfet_intrinsic_drain_node(mosfet));
+                }
             }
             Element::Vccs(source) => {
                 insert_node(&mut names, &source.positive);
@@ -22782,7 +22791,8 @@ fn collect_noise_sources(
             }
             Element::Mosfet(mosfet) => {
                 validate_mosfet(mosfet)?;
-                let drain = node_index(node_indices, &mosfet.drain);
+                let intrinsic_drain = mosfet_intrinsic_drain_node(mosfet);
+                let drain = node_index(node_indices, &intrinsic_drain);
                 let gate = node_index(node_indices, &mosfet.gate);
                 let source = node_index(node_indices, &mosfet.source);
                 let body = node_index(node_indices, &mosfet.body);
@@ -22823,6 +22833,17 @@ fn collect_noise_sources(
                                 .abs()
                                 .powf(mosfet.params.flicker_noise_exponent),
                         frequency_exponent: 1.0,
+                    });
+                }
+                if mosfet.params.drain_resistance > 0.0 {
+                    sources.push(NoiseSource {
+                        element_name: format!("{}:RD", mosfet.name),
+                        noise_type: NoiseType::Thermal,
+                        positive: node_index(node_indices, &mosfet.drain),
+                        negative: drain,
+                        source_psd: 4.0 * BOLTZMANN * temperature_kelvin
+                            / mosfet.params.drain_resistance,
+                        frequency_exponent: 0.0,
                     });
                 }
             }
@@ -24126,7 +24147,8 @@ fn stamp_mosfet(
     operating_point: &[f64],
 ) -> Result<(), SpiceError> {
     validate_mosfet(mosfet)?;
-    let drain = node_index(node_indices, &mosfet.drain);
+    let intrinsic_drain = mosfet_intrinsic_drain_node(mosfet);
+    let drain = node_index(node_indices, &intrinsic_drain);
     let gate = node_index(node_indices, &mosfet.gate);
     let source = node_index(node_indices, &mosfet.source);
     let body = node_index(node_indices, &mosfet.body);
@@ -24146,6 +24168,14 @@ fn stamp_mosfet(
     stamp_transconductance(matrix, drain, source, body, source, result.gmb);
     stamp_equivalent_current_source(rhs, drain, source, equivalent_current);
     stamp_mosfet_charge(mosfet, capacitor_states, node_indices, matrix, rhs)?;
+    if mosfet.params.drain_resistance > 0.0 {
+        stamp_conductance(
+            matrix,
+            node_index(node_indices, &mosfet.drain),
+            drain,
+            1.0 / mosfet.params.drain_resistance,
+        );
+    }
     Ok(())
 }
 
@@ -24180,8 +24210,8 @@ fn stamp_mosfet_charge(
             }
             TransientMethod::Euler => conductance * state.previous_voltage,
         };
-        let positive = node_index(node_indices, spec.positive);
-        let negative = node_index(node_indices, spec.negative);
+        let positive = node_index(node_indices, &spec.positive);
+        let negative = node_index(node_indices, &spec.negative);
         stamp_conductance(matrix, positive, negative, conductance);
         if let Some(index) = positive {
             rhs[index] += history_current;
@@ -24308,7 +24338,8 @@ fn stamp_mosfet_small_signal(
     operating_point: &[f64],
 ) -> Result<(), SpiceError> {
     validate_mosfet(mosfet)?;
-    let drain = node_index(node_indices, &mosfet.drain);
+    let intrinsic_drain = mosfet_intrinsic_drain_node(mosfet);
+    let drain = node_index(node_indices, &intrinsic_drain);
     let gate = node_index(node_indices, &mosfet.gate);
     let source = node_index(node_indices, &mosfet.source);
     let body = node_index(node_indices, &mosfet.body);
@@ -24323,6 +24354,14 @@ fn stamp_mosfet_small_signal(
     stamp_conductance(matrix, drain, source, result.gds);
     stamp_transconductance(matrix, drain, source, gate, source, result.gm);
     stamp_transconductance(matrix, drain, source, body, source, result.gmb);
+    if mosfet.params.drain_resistance > 0.0 {
+        stamp_conductance(
+            matrix,
+            node_index(node_indices, &mosfet.drain),
+            drain,
+            1.0 / mosfet.params.drain_resistance,
+        );
+    }
     Ok(())
 }
 
@@ -24381,7 +24420,8 @@ fn stamp_ac_mosfet_small_signal(
     omega: f64,
 ) -> Result<(), SpiceError> {
     validate_mosfet(mosfet)?;
-    let drain = node_index(node_indices, &mosfet.drain);
+    let intrinsic_drain = mosfet_intrinsic_drain_node(mosfet);
+    let drain = node_index(node_indices, &intrinsic_drain);
     let gate = node_index(node_indices, &mosfet.gate);
     let source = node_index(node_indices, &mosfet.source);
     let body = node_index(node_indices, &mosfet.body);
@@ -24415,6 +24455,14 @@ fn stamp_ac_mosfet_small_signal(
         source,
         Complex::new(result.gmb, 0.0),
     );
+    if mosfet.params.drain_resistance > 0.0 {
+        stamp_complex_conductance(
+            matrix,
+            node_index(node_indices, &mosfet.drain),
+            drain,
+            Complex::new(1.0 / mosfet.params.drain_resistance, 0.0),
+        );
+    }
     Ok(())
 }
 
@@ -24829,6 +24877,14 @@ fn jfet_intrinsic_source_node(jfet: &Jfet) -> String {
     }
 }
 
+fn mosfet_intrinsic_drain_node(mosfet: &Mosfet) -> String {
+    if !mosfet.params.drain_resistance.is_finite() || mosfet.params.drain_resistance <= 0.0 {
+        mosfet.drain.clone()
+    } else {
+        format!("__spice_{}_drain", mosfet.name)
+    }
+}
+
 fn jfet_charge_dynamic_capacitance(
     jfet: &Jfet,
     zero_bias_capacitance: f64,
@@ -24857,10 +24913,10 @@ enum MosfetChargeStateKind {
     DrainBody,
 }
 
-struct MosfetChargeStateSpec<'a> {
+struct MosfetChargeStateSpec {
     name: String,
-    positive: &'a str,
-    negative: &'a str,
+    positive: String,
+    negative: String,
     capacitance: f64,
     kind: MosfetChargeStateKind,
 }
@@ -24885,7 +24941,7 @@ fn mosfet_drain_body_charge_state_name(mosfet: &Mosfet) -> String {
     format!("_M_{}_db_charge", mosfet.name)
 }
 
-fn mosfet_charge_state_specs(mosfet: &Mosfet) -> Vec<MosfetChargeStateSpec<'_>> {
+fn mosfet_charge_state_specs(mosfet: &Mosfet) -> Vec<MosfetChargeStateSpec> {
     let mut specs = Vec::new();
     let params = mosfet.params;
     let gate_source_capacitance = params.gate_source_overlap_capacitance * params.w;
@@ -24896,8 +24952,8 @@ fn mosfet_charge_state_specs(mosfet: &Mosfet) -> Vec<MosfetChargeStateSpec<'_>> 
     if gate_source_capacitance > 0.0 {
         specs.push(MosfetChargeStateSpec {
             name: mosfet_gate_source_charge_state_name(mosfet),
-            positive: mosfet.gate.as_str(),
-            negative: mosfet.source.as_str(),
+            positive: mosfet.gate.clone(),
+            negative: mosfet.source.clone(),
             capacitance: gate_source_capacitance,
             kind: MosfetChargeStateKind::GateOverlap,
         });
@@ -24905,8 +24961,8 @@ fn mosfet_charge_state_specs(mosfet: &Mosfet) -> Vec<MosfetChargeStateSpec<'_>> 
     if gate_drain_capacitance > 0.0 {
         specs.push(MosfetChargeStateSpec {
             name: mosfet_gate_drain_charge_state_name(mosfet),
-            positive: mosfet.gate.as_str(),
-            negative: mosfet.drain.as_str(),
+            positive: mosfet.gate.clone(),
+            negative: mosfet_intrinsic_drain_node(mosfet),
             capacitance: gate_drain_capacitance,
             kind: MosfetChargeStateKind::GateOverlap,
         });
@@ -24914,8 +24970,8 @@ fn mosfet_charge_state_specs(mosfet: &Mosfet) -> Vec<MosfetChargeStateSpec<'_>> 
     if gate_body_capacitance > 0.0 {
         specs.push(MosfetChargeStateSpec {
             name: mosfet_gate_body_charge_state_name(mosfet),
-            positive: mosfet.gate.as_str(),
-            negative: mosfet.body.as_str(),
+            positive: mosfet.gate.clone(),
+            negative: mosfet.body.clone(),
             capacitance: gate_body_capacitance,
             kind: MosfetChargeStateKind::GateOverlap,
         });
@@ -24923,8 +24979,8 @@ fn mosfet_charge_state_specs(mosfet: &Mosfet) -> Vec<MosfetChargeStateSpec<'_>> 
     if source_body_capacitance > 0.0 {
         specs.push(MosfetChargeStateSpec {
             name: mosfet_source_body_charge_state_name(mosfet),
-            positive: mosfet.source.as_str(),
-            negative: mosfet.body.as_str(),
+            positive: mosfet.source.clone(),
+            negative: mosfet.body.clone(),
             capacitance: source_body_capacitance,
             kind: MosfetChargeStateKind::SourceBody,
         });
@@ -24932,8 +24988,8 @@ fn mosfet_charge_state_specs(mosfet: &Mosfet) -> Vec<MosfetChargeStateSpec<'_>> 
     if drain_body_capacitance > 0.0 {
         specs.push(MosfetChargeStateSpec {
             name: mosfet_drain_body_charge_state_name(mosfet),
-            positive: mosfet.drain.as_str(),
-            negative: mosfet.body.as_str(),
+            positive: mosfet_intrinsic_drain_node(mosfet),
+            negative: mosfet.body.clone(),
             capacitance: drain_body_capacitance,
             kind: MosfetChargeStateKind::DrainBody,
         });
@@ -24942,15 +24998,15 @@ fn mosfet_charge_state_specs(mosfet: &Mosfet) -> Vec<MosfetChargeStateSpec<'_>> 
 }
 
 fn mosfet_charge_state_voltage(
-    spec: &MosfetChargeStateSpec<'_>,
+    spec: &MosfetChargeStateSpec,
     node_voltages: &BTreeMap<String, f64>,
 ) -> f64 {
-    voltage_at(node_voltages, spec.positive) - voltage_at(node_voltages, spec.negative)
+    voltage_at(node_voltages, &spec.positive) - voltage_at(node_voltages, &spec.negative)
 }
 
 fn mosfet_charge_dynamic_capacitance(
     mosfet: &Mosfet,
-    spec: &MosfetChargeStateSpec<'_>,
+    spec: &MosfetChargeStateSpec,
     state_voltage: f64,
 ) -> f64 {
     if !matches!(
@@ -25518,6 +25574,7 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         ("W", params.w),
         ("L", params.l),
         ("LD", params.lateral_diffusion_length),
+        ("RD", params.drain_resistance),
         ("TOX", params.oxide_thickness),
         ("IS", params.saturation_current),
         ("N_SUB", params.n_sub),
@@ -25558,6 +25615,12 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: mosfet.name.clone(),
             reason: "MOSFET LD must be non-negative with L - 2*LD > 0".to_string(),
+        });
+    }
+    if params.drain_resistance < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET RD must be non-negative".to_string(),
         });
     }
     if params.oxide_thickness <= 0.0 {

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -95,7 +95,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 187);
+    assert_eq!(coverage.len(), 189);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -114,7 +114,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tAF\tAF\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 187);
+    assert_eq!(records.len(), 189);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -147,8 +147,8 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         vec!["IS", "VT", "CJO", "VJ", "M"]
     );
     assert_eq!(summary[5].kind, ModelCardKind::Nmos);
-    assert_eq!(summary[5].canonical_parameter_count, 23);
-    assert_eq!(summary[5].accepted_name_count, 30);
+    assert_eq!(summary[5].canonical_parameter_count, 24);
+    assert_eq!(summary[5].accepted_name_count, 31);
     assert_eq!(summary[5].aliased_parameter_count, 6);
     assert_eq!(summary[5].max_alias_count, 3);
     assert_eq!(
@@ -166,7 +166,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     assert_eq!(lines[1], "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\t23\t30\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        &"PMOS\t24\t31\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
     );
     let records = model_card_supported_parameter_coverage_summary_records();
     assert_eq!(records.len(), 7);
@@ -184,7 +184,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         "[{\"kind\":\"D\",\"canonical_parameter_count\":\"15\",\"accepted_name_count\":\"21\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
     ));
     assert!(json.ends_with(
-        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"23\",\"accepted_name_count\":\"30\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
+        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"24\",\"accepted_name_count\":\"31\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
     ));
 }
 
@@ -195,15 +195,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 187);
-    assert_eq!(report.expected_canonical_parameter_count, 187);
-    assert_eq!(report.accepted_name_count, 257);
+    assert_eq!(report.canonical_parameter_count, 189);
+    assert_eq!(report.expected_canonical_parameter_count, 189);
+    assert_eq!(report.accepted_name_count, 259);
     assert_eq!(report.aliased_parameter_count, 57);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t187\t187\t257\t57\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t189\t189\t259\t57\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -230,8 +230,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 186);
-    assert_eq!(report.accepted_name_count, 254);
+    assert_eq!(report.canonical_parameter_count, 188);
+    assert_eq!(report.accepted_name_count, 256);
     assert_eq!(report.aliased_parameter_count, 56);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -239,7 +239,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     assert_eq!(report.issues[0].field, "canonical_parameter_count");
     assert_eq!(
         report.issues[0].message,
-        "expected NMOS to expose 23 canonical supported parameters, found 22"
+        "expected NMOS to expose 24 canonical supported parameters, found 23"
     );
     assert_eq!(report.issues.last().unwrap().field, "max_alias_count");
     assert_eq!(
@@ -248,20 +248,20 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t186\t187\t254\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 23 canonical supported parameters, found 22\nNMOS\taccepted_name_count\texpected NMOS to expose 30 accepted model-card names, found 27\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t188\t189\t256\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 24 canonical supported parameters, found 23\nNMOS\taccepted_name_count\texpected NMOS to expose 31 accepted model-card names, found 28\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
     assert_eq!(records[0]["field"], "canonical_parameter_count");
     assert_eq!(
         records[0]["message"],
-        "expected NMOS to expose 23 canonical supported parameters, found 22"
+        "expected NMOS to expose 24 canonical supported parameters, found 23"
     );
     assert!(format_model_card_supported_parameter_coverage_gate_issue_csv(&report).starts_with(
-        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 23 canonical supported parameters, found 22\"\n"
+        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 24 canonical supported parameters, found 23\"\n"
     ));
     assert!(format_model_card_supported_parameter_coverage_gate_issue_json(&report).starts_with(
-        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 23 canonical supported parameters, found 22\"}"
+        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 24 canonical supported parameters, found 23\"}"
     ));
 }
 
@@ -283,8 +283,8 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(dashboard[0].issue_count, 0);
     assert!(dashboard[0].issue_fields.is_empty());
     assert_eq!(dashboard[5].kind, ModelCardKind::Nmos);
-    assert_eq!(dashboard[5].canonical_parameter_count, 23);
-    assert_eq!(dashboard[5].accepted_name_count, 30);
+    assert_eq!(dashboard[5].canonical_parameter_count, 24);
+    assert_eq!(dashboard[5].accepted_name_count, 31);
     assert_eq!(dashboard[5].issue_count, 0);
 
     let table = format_model_card_supported_parameter_coverage_dashboard_table(&coverage);
@@ -296,7 +296,7 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(lines[1], "D\ttrue\t15\t15\t21\t21\t5\t5\t3\t3\t0\t");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\ttrue\t23\t23\t30\t30\t6\t6\t3\t3\t0\t"
+        &"PMOS\ttrue\t24\t24\t31\t31\t6\t6\t3\t3\t0\t"
     );
     let records = model_card_supported_parameter_coverage_dashboard_records(&coverage);
     assert_eq!(records.len(), 7);
@@ -328,10 +328,10 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         .unwrap();
 
     assert!(!nmos.passed);
-    assert_eq!(nmos.canonical_parameter_count, 22);
-    assert_eq!(nmos.expected_canonical_parameter_count, 23);
-    assert_eq!(nmos.accepted_name_count, 27);
-    assert_eq!(nmos.expected_accepted_name_count, 30);
+    assert_eq!(nmos.canonical_parameter_count, 23);
+    assert_eq!(nmos.expected_canonical_parameter_count, 24);
+    assert_eq!(nmos.accepted_name_count, 28);
+    assert_eq!(nmos.expected_accepted_name_count, 31);
     assert_eq!(nmos.aliased_parameter_count, 5);
     assert_eq!(nmos.expected_aliased_parameter_count, 6);
     assert_eq!(nmos.max_alias_count, 2);
@@ -347,7 +347,7 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         ]
     );
     assert!(format_model_card_supported_parameter_coverage_dashboard_table(&coverage).contains(
-        "NMOS\tfalse\t22\t23\t27\t30\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
+        "NMOS\tfalse\t23\t24\t28\t31\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
     ));
 }
 
@@ -594,6 +594,7 @@ fn model_card_aliases_build_device_instances() {
             ("MJ", 0.45),
             ("FC", 0.4),
             ("LD", 50.0e-9),
+            ("RD", 125.0),
             ("TOX", 25.0e-9),
             ("KF", 2.0e-24),
             ("AF", 1.4),
@@ -609,6 +610,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*mos_card.parameters.get("MJ").unwrap(), 0.45);
     assert_close(*mos_card.parameters.get("FC").unwrap(), 0.4);
     assert_close(*mos_card.parameters.get("LD").unwrap(), 50.0e-9);
+    assert_close(*mos_card.parameters.get("RD").unwrap(), 125.0);
     assert_close(*mos_card.parameters.get("TOX").unwrap(), 25.0e-9);
     assert_close(*mos_card.parameters.get("KF").unwrap(), 2.0e-24);
     assert_close(*mos_card.parameters.get("AF").unwrap(), 1.4);
@@ -621,6 +623,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(mos_model.params.bulk_junction_grading_coefficient, 0.45);
     assert_close(mos_model.params.forward_bias_depletion_coefficient, 0.4);
     assert_close(mos_model.params.lateral_diffusion_length, 50.0e-9);
+    assert_close(mos_model.params.drain_resistance, 125.0);
     assert_close(mos_model.params.oxide_thickness, 25.0e-9);
     assert_close(mos_model.params.flicker_noise_coefficient, 2.0e-24);
     assert_close(mos_model.params.flicker_noise_exponent, 1.4);
@@ -1600,6 +1603,33 @@ fn dc_jfet_drain_resistance_drops_intrinsic_drain_voltage() {
 }
 
 #[test]
+fn dc_mosfet_drain_resistance_drops_intrinsic_drain_voltage() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vdrain", "drain", "0", 5.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 3.0,
+    )));
+    circuit.add(Element::Mosfet(Mosfet::with_model(
+        "M1",
+        "drain",
+        "gate",
+        "0",
+        "0",
+        MosfetType::Nmos,
+        MosfetLevel1Params {
+            drain_resistance: 1_000.0,
+            ..MosfetLevel1Params::default()
+        },
+    )));
+
+    let result = dc_op(&circuit).unwrap();
+    assert_close(result.node_voltages["drain"], 5.0);
+    assert!(result.node_voltages["__spice_M1_drain"] < 5.0);
+}
+
+#[test]
 fn dc_jfet_source_resistance_raises_intrinsic_source_voltage() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(
@@ -1701,6 +1731,7 @@ fn subcircuit_expansion_preserves_mos_geometry() {
         MosfetLevel1Params {
             l: 1.0e-6,
             lateral_diffusion_length: 0.1e-6,
+            drain_resistance: 125.0,
             oxide_thickness: 25.0e-9,
             ..MosfetLevel1Params::default()
         },
@@ -1741,6 +1772,7 @@ fn subcircuit_expansion_preserves_mos_geometry() {
         .unwrap();
     assert_close(expanded.params.l, 1.0e-6);
     assert_close(expanded.params.lateral_diffusion_length, 0.1e-6);
+    assert_close(expanded.params.drain_resistance, 125.0);
     assert_close(expanded.params.oxide_thickness, 25.0e-9);
 }
 
@@ -3784,6 +3816,38 @@ fn dc_mosfet_rejects_invalid_oxide_thickness() {
                     "MOSFET TOX must be positive".to_string()
                 } else {
                     "MOSFET TOX must be finite".to_string()
+                },
+            }
+        );
+    }
+}
+
+#[test]
+fn dc_mosfet_rejects_invalid_drain_resistance() {
+    for drain_resistance in [f64::NAN, -1.0] {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "Mbad",
+            "drain",
+            "gate",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                drain_resistance,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+
+        let err = dc_op(&circuit).unwrap_err();
+        assert_eq!(
+            err,
+            SpiceError::InvalidElement {
+                name: "Mbad".to_string(),
+                reason: if drain_resistance.is_finite() {
+                    "MOSFET RD must be non-negative".to_string()
+                } else {
+                    "MOSFET RD must be finite".to_string()
                 },
             }
         );

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -533,6 +533,44 @@ fn jfet_drain_resistance_emits_thermal_noise() {
 }
 
 #[test]
+fn mosfet_drain_resistance_emits_thermal_noise() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vdd", "vdd", "0", 5.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 3.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "vdd", "out", 1_000.0,
+    )));
+    circuit.add(Element::Mosfet(Mosfet::with_model(
+        "M1",
+        "out",
+        "gate",
+        "0",
+        "0",
+        MosfetType::Nmos,
+        MosfetLevel1Params {
+            drain_resistance: 250.0,
+            ..MosfetLevel1Params::default()
+        },
+    )));
+
+    let result = noise_ac(&circuit, "out", "Vgate", &[1_000.0], 300.0).unwrap();
+    let entry = result.points[0]
+        .entries
+        .iter()
+        .find(|entry| entry.element_name == "M1:RD" && entry.noise_type == NoiseType::Thermal)
+        .unwrap();
+    assert_close(
+        entry.source_psd,
+        4.0 * 1.380_649e-23 * 300.0 / 250.0,
+        1.0e-30,
+    );
+}
+
+#[test]
 fn jfet_source_resistance_emits_thermal_noise() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- Add Level-1 MOS model-card `RD` support. Nonzero values create an intrinsic
+  drain node, stamp the external resistor in DC, TF, AC, and transient
+  analyses, route drain-side capacitances through it, and emit `:RD` Johnson
+  noise.
 - Add Level-1 MOS model-card `TOX` support, defaulting to `100 nm` and deriving
   intrinsic Meyer gate capacitance from silicon-dioxide permittivity and oxide
   thickness.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -85,6 +85,9 @@ Level-1 MOS model cards accept `KF` (default `0`) and `AF` (default `1`) and add
 length-scaled intrinsic/`CGBO` capacitance.
 `TOX` defaults to `1e-7 m`, must be finite and positive, and derives intrinsic
 Meyer gate capacitance from `Cox = epsilon_ox / TOX`.
+`RD` defaults to zero ohms. A finite positive value inserts an intrinsic drain
+node, routes the channel and drain-side capacitances through it, and contributes
+`4kT/RD` thermal noise.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1777,6 +1777,7 @@ export interface MosfetLevel1Params {
   readonly L: number;
   readonly LD: number;
   readonly TOX: number;
+  readonly RD: number;
   readonly IS: number;
   readonly N_SUB: number;
   readonly T_NOM: number;
@@ -2049,8 +2050,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   PNP: [41, 58, 13, 4],
   NJF: [22, 30, 7, 3],
   PJF: [22, 30, 7, 3],
-  NMOS: [23, 30, 6, 3],
-  PMOS: [23, 30, 6, 3],
+  NMOS: [24, 31, 6, 3],
+  PMOS: [24, 31, 6, 3],
 };
 
 export interface Vccs {
@@ -8034,6 +8035,7 @@ export function defaultMosfetLevel1Params(): MosfetLevel1Params {
     L: 130.0e-9,
     LD: 0.0,
     TOX: 1.0e-7,
+    RD: 0.0,
     IS: 1.0e-15,
     N_SUB: 1.4,
     T_NOM: 300.15,
@@ -8221,6 +8223,7 @@ const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   L: "L",
   LD: "LD",
   TOX: "TOX",
+  RD: "RD",
   IS: "IS",
   NSUB: "N_SUB",
   N_SUB: "N_SUB",
@@ -8795,6 +8798,7 @@ export function mosfetFromModelCard(
     ...(p.L !== undefined ? { L: p.L } : {}),
     ...(p.LD !== undefined ? { LD: p.LD } : {}),
     ...(p.TOX !== undefined ? { TOX: p.TOX } : {}),
+    ...(p.RD !== undefined ? { RD: p.RD } : {}),
     ...(p.IS !== undefined ? { IS: p.IS } : {}),
     ...(p.N_SUB !== undefined ? { N_SUB: p.N_SUB } : {}),
     ...(p.T_NOM !== undefined ? { T_NOM: p.T_NOM } : {}),
@@ -18564,6 +18568,9 @@ function collectNodeIndices(circuit: Circuit): Map<string, number> {
         insertNode(names, element.gate);
         insertNode(names, element.source);
         insertNode(names, element.body);
+        if (element.params.RD > 0.0) {
+          insertNode(names, mosfetIntrinsicDrainNode(element));
+        }
         break;
       case "vccs":
         insertNode(names, element.positive);
@@ -18957,7 +18964,7 @@ function collectNoiseSources(
       }
     } else if (element.kind === "mosfet") {
       validateMosfet(element);
-      const drain = nodeIndex(nodeIndices, element.drain);
+      const drain = nodeIndex(nodeIndices, mosfetIntrinsicDrainNode(element));
       const gate = nodeIndex(nodeIndices, element.gate);
       const source = nodeIndex(nodeIndices, element.source);
       const body = nodeIndex(nodeIndices, element.body);
@@ -18992,6 +18999,16 @@ function collectNoiseSources(
             element.params.KF *
             Math.abs(result.drainCurrent) ** element.params.AF,
           frequencyExponent: 1.0,
+        });
+      }
+      if (element.params.RD > 0.0) {
+        sources.push({
+          elementName: `${element.name}:RD`,
+          noiseType: "thermal",
+          positive: nodeIndex(nodeIndices, element.drain),
+          negative: drain,
+          sourcePsd: 4.0 * BOLTZMANN * temperatureKelvin / element.params.RD,
+          frequencyExponent: 0.0,
         });
       }
     }
@@ -20163,7 +20180,7 @@ function stampMosfet(
   operatingPoint: readonly number[],
 ): void {
   validateMosfet(element);
-  const drain = nodeIndex(nodeIndices, element.drain);
+  const drain = nodeIndex(nodeIndices, mosfetIntrinsicDrainNode(element));
   const gate = nodeIndex(nodeIndices, element.gate);
   const source = nodeIndex(nodeIndices, element.source);
   const body = nodeIndex(nodeIndices, element.body);
@@ -20183,6 +20200,14 @@ function stampMosfet(
   stampTransconductance(matrix, drain, source, body, source, result.gmb);
   stampCurrentSourceEquivalent(rhs, drain, source, equivalentCurrent);
   stampMosfetCharge(element, capacitorStates, nodeIndices, matrix, rhs);
+  if (element.params.RD > 0.0) {
+    stampConductance(
+      matrix,
+      nodeIndex(nodeIndices, element.drain),
+      drain,
+      1.0 / element.params.RD,
+    );
+  }
 }
 
 function stampMosfetCharge(
@@ -20738,6 +20763,12 @@ function jfetIntrinsicSourceNode(element: Jfet): string {
     : `__spice_${element.name}_source`;
 }
 
+function mosfetIntrinsicDrainNode(element: Mosfet): string {
+  return !Number.isFinite(element.params.RD) || element.params.RD <= 0.0
+    ? element.drain
+    : `__spice_${element.name}_drain`;
+}
+
 function jfetChargeStateVoltage(
   spec: JfetChargeStateSpec,
   nodeVoltages: ReadonlyMap<string, number>,
@@ -20813,7 +20844,7 @@ function mosfetChargeStateSpecs(element: Mosfet): MosfetChargeStateSpec[] {
     specs.push({
       name: mosfetGateDrainChargeStateName(element),
       positive: element.gate,
-      negative: element.drain,
+      negative: mosfetIntrinsicDrainNode(element),
       capacitance: gateDrainCapacitance,
       kind: "gate-overlap",
     });
@@ -20839,7 +20870,7 @@ function mosfetChargeStateSpecs(element: Mosfet): MosfetChargeStateSpec[] {
   if (drainBodyCapacitance > 0.0) {
     specs.push({
       name: mosfetDrainBodyChargeStateName(element),
-      positive: element.drain,
+      positive: mosfetIntrinsicDrainNode(element),
       negative: element.body,
       capacitance: drainBodyCapacitance,
       kind: "drain-body",
@@ -21034,6 +21065,9 @@ function validateMosfet(element: Mosfet): void {
   }
   if (params.LD < 0.0 || params.L - 2.0 * params.LD <= 0.0) {
     throw invalidElement(element.name, "MOSFET LD must be non-negative with L - 2*LD > 0");
+  }
+  if (params.RD < 0.0) {
+    throw invalidElement(element.name, "MOSFET RD must be non-negative");
   }
   if (params.TOX <= 0.0) {
     throw invalidElement(element.name, "MOSFET TOX must be positive");
@@ -22452,7 +22486,7 @@ function stampMosfetSmallSignal(
   operatingPoint: readonly number[],
 ): void {
   validateMosfet(element);
-  const drain = nodeIndex(nodeIndices, element.drain);
+  const drain = nodeIndex(nodeIndices, mosfetIntrinsicDrainNode(element));
   const gate = nodeIndex(nodeIndices, element.gate);
   const source = nodeIndex(nodeIndices, element.source);
   const body = nodeIndex(nodeIndices, element.body);
@@ -22469,6 +22503,14 @@ function stampMosfetSmallSignal(
   stampConductance(matrix, drain, source, result.gds);
   stampTransconductance(matrix, drain, source, gate, source, result.gm);
   stampTransconductance(matrix, drain, source, body, source, result.gmb);
+  if (element.params.RD > 0.0) {
+    stampConductance(
+      matrix,
+      nodeIndex(nodeIndices, element.drain),
+      drain,
+      1.0 / element.params.RD,
+    );
+  }
 }
 
 function stampJfetSmallSignal(
@@ -23192,7 +23234,7 @@ function stampAcMosfetSmallSignal(
   omega: number,
 ): void {
   validateMosfet(element);
-  const drain = nodeIndex(nodeIndices, element.drain);
+  const drain = nodeIndex(nodeIndices, mosfetIntrinsicDrainNode(element));
   const gate = nodeIndex(nodeIndices, element.gate);
   const source = nodeIndex(nodeIndices, element.source);
   const body = nodeIndex(nodeIndices, element.body);
@@ -23228,6 +23270,14 @@ function stampAcMosfetSmallSignal(
     source,
     complex(result.gmb, 0.0),
   );
+  if (element.params.RD > 0.0) {
+    stampComplexConductance(
+      matrix,
+      nodeIndex(nodeIndices, element.drain),
+      drain,
+      complex(1.0 / element.params.RD, 0.0),
+    );
+  }
 }
 
 function stampAcJfetSmallSignal(

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -121,7 +121,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(187);
+    expect(coverage).toHaveLength(189);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -141,7 +141,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tAF\tAF\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(187);
+    expect(records).toHaveLength(189);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -167,8 +167,8 @@ describe("dcOp", () => {
     });
     expect(summary[5]).toStrictEqual({
       kind: "NMOS",
-      canonicalParameterCount: 23,
-      acceptedNameCount: 30,
+      canonicalParameterCount: 24,
+      acceptedNameCount: 31,
       aliasedParameterCount: 6,
       maxAliasCount: 3,
       aliasedParameters: ["VT0", "LAMBDA", "N_SUB", "T_NOM", "CBS", "CBD"],
@@ -181,7 +181,7 @@ describe("dcOp", () => {
     );
     expect(table.split("\n")[1]).toBe("D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     expect(table.split("\n").at(-1)).toBe(
-      "PMOS\t23\t30\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
+      "PMOS\t24\t31\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
     );
     const records = modelCardSupportedParameterCoverageSummaryRecords();
     expect(records).toHaveLength(7);
@@ -206,15 +206,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 187,
-      expectedCanonicalParameterCount: 187,
-      acceptedNameCount: 257,
+      canonicalParameterCount: 189,
+      expectedCanonicalParameterCount: 189,
+      acceptedNameCount: 259,
       aliasedParameterCount: 57,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t187\t187\t257\t57\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t189\t189\t259\t57\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -237,15 +237,15 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(186);
-    expect(report.acceptedNameCount).toBe(254);
+    expect(report.canonicalParameterCount).toBe(188);
+    expect(report.acceptedNameCount).toBe(256);
     expect(report.aliasedParameterCount).toBe(56);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 23 canonical supported parameters, found 22",
+      message: "expected NMOS to expose 24 canonical supported parameters, found 23",
     });
     expect(report.issues.at(-1)).toStrictEqual({
       kind: "NMOS",
@@ -253,16 +253,16 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t186\t187\t254\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 23 canonical supported parameters, found 22\nNMOS\taccepted_name_count\texpected NMOS to expose 30 accepted model-card names, found 27\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t188\t189\t256\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 24 canonical supported parameters, found 23\nNMOS\taccepted_name_count\texpected NMOS to expose 31 accepted model-card names, found 28\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 23 canonical supported parameters, found 22",
+      message: "expected NMOS to expose 24 canonical supported parameters, found 23",
     });
     expect(formatModelCardSupportedParameterCoverageGateIssueCsv(report)).toMatch(
-      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 23 canonical supported parameters, found 22"\n/,
+      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 24 canonical supported parameters, found 23"\n/,
     );
     expect(JSON.parse(formatModelCardSupportedParameterCoverageGateIssueJson(report))).toStrictEqual(
       records,
@@ -419,6 +419,7 @@ describe("dcOp", () => {
       MJ: 0.45,
       FC: 0.4,
       LD: 50.0e-9,
+      RD: 125.0,
       TOX: 25.0e-9,
       KF: 2.0e-24,
       AF: 1.4,
@@ -434,6 +435,7 @@ describe("dcOp", () => {
       MJ: 0.45,
       FC: 0.4,
       LD: 50.0e-9,
+      RD: 125.0,
       TOX: 25.0e-9,
       KF: 2.0e-24,
       AF: 1.4,
@@ -447,6 +449,7 @@ describe("dcOp", () => {
     expectClose(mosModel.params.MJ, 0.45);
     expectClose(mosModel.params.FC, 0.4);
     expectClose(mosModel.params.LD, 50.0e-9);
+    expectClose(mosModel.params.RD, 125.0);
     expectClose(mosModel.params.TOX, 25.0e-9);
     expectClose(mosModel.params.KF, 2.0e-24);
     expectClose(mosModel.params.AF, 1.4);
@@ -1141,6 +1144,19 @@ describe("dcOp", () => {
     expect(result.nodeVoltages.get("__spice_J1_drain")!).toBeLessThan(5.0);
   });
 
+  it("drops the intrinsic MOSFET drain voltage across RD", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vdrain", "drain", "0", 5.0));
+    circuit.add(voltageSource("Vgate", "gate", "0", 3.0));
+    circuit.add(mosfet("M1", "drain", "gate", "0", "0", "NMOS", {
+      RD: 1_000.0,
+    }));
+
+    const result = dcOp(circuit);
+    expectClose(result.nodeVoltages.get("drain")!, 5.0);
+    expect(result.nodeVoltages.get("__spice_M1_drain")!).toBeLessThan(5.0);
+  });
+
   it("raises the intrinsic JFET source voltage across RS", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vdrain", "drain", "0", 5.0));
@@ -1205,6 +1221,7 @@ describe("dcOp", () => {
         mosfet("Mcell", "d", "g", "s", "b", "NMOS", {
           L: 1.0e-6,
           LD: 0.1e-6,
+          RD: 125.0,
           TOX: 25.0e-9,
         }),
       ]),
@@ -1217,6 +1234,7 @@ describe("dcOp", () => {
     expect(expanded).toBeDefined();
     expectClose(expanded!.params.L, 1.0e-6);
     expectClose(expanded!.params.LD, 0.1e-6);
+    expectClose(expanded!.params.RD, 125.0);
     expectClose(expanded!.params.TOX, 25.0e-9);
   });
 
@@ -2424,6 +2442,20 @@ describe("dcOp", () => {
         Number.isFinite(oxideThickness)
           ? "MOSFET TOX must be positive"
           : "MOSFET TOX must be finite",
+      );
+    }
+  });
+
+  it("rejects invalid MOSFET drain resistances", () => {
+    for (const drainResistance of [Number.NaN, -1.0]) {
+      const circuit = new Circuit();
+      circuit.add(mosfet("Mbad", "drain", "gate", "0", "0", "NMOS", {
+        RD: drainResistance,
+      }));
+      expect(() => dcOp(circuit)).toThrowError(
+        Number.isFinite(drainResistance)
+          ? "MOSFET RD must be non-negative"
+          : "MOSFET RD must be finite",
       );
     }
   });

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -169,6 +169,23 @@ describe("noiseAc", () => {
     );
   });
 
+  it("emits MOSFET drain-resistance thermal noise", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vdd", "vdd", "0", 5.0));
+    circuit.add(voltageSource("Vgate", "gate", "0", 3.0));
+    circuit.add(resistor("Rload", "vdd", "out", 1_000.0));
+    circuit.add(mosfet("M1", "out", "gate", "0", "0", "NMOS", { RD: 250.0 }));
+
+    const entry = noiseAc(circuit, "out", "Vgate", [1_000.0], 300.0).points[0]!.entries
+      .find((candidate) =>
+        candidate.elementName === "M1:RD" && candidate.noiseType === "thermal"
+      );
+    expect(entry?.sourcePsd).toBeCloseTo(
+      4.0 * 1.380_649e-23 * 300.0 / 250.0,
+      30,
+    );
+  });
+
   it("emits JFET source-resistance thermal noise", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vdd", "vdd", "0", 5.0));

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,16 +33,17 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS oxide thickness.
+1. Cross-language Level-1 MOS drain resistance.
    - Status: current PR completion candidate.
-   - Add Berkeley Level-1 MOS `TOX` model-card support in Rust, Python, and
-     TypeScript, defaulting to `1e-7 m`.
-   - Derive `Cox = epsilon_ox / TOX` and use
-     `Cox * W * (L - 2*LD)` for region-partitioned intrinsic Meyer gate
-     capacitance while preserving overlap capacitance.
-   - Preserve the oxide thickness through hierarchy and cloning, require
-     finite positive `TOX`, and extend the supported-parameter coverage gate
-     from 185 to 187 canonical rows.
+   - Add Berkeley Level-1 MOS `RD` model-card support in Rust, Python, and
+     TypeScript, defaulting to zero ohms.
+   - For positive values, create an intrinsic drain node, stamp the external
+     resistor in DC, TF, AC, and transient analyses, and route the channel plus
+     drain-side capacitances through the intrinsic node.
+   - Preserve `RD` through hierarchy and cloning, require a finite non-negative
+     value, emit the resistor's `4kT/RD` Johnson noise as `<name>:RD`, and
+     extend the supported-parameter coverage gate from 187 to 189 canonical
+     rows.
 
 ## Completed Slices
 
@@ -3423,6 +3424,15 @@ the Rust, Python, and TypeScript surfaces together.
    - Hierarchy and cloning preserve the geometry, shared validation enforces
      finite non-negative `LD` with positive effective length, and the
      supported-parameter release gate now covers 185 canonical rows.
+
+268. Cross-language Level-1 MOS oxide thickness.
+   - Status: completed in PR 9007.
+   - Rust, Python, and TypeScript Level-1 MOS model cards now accept `TOX`,
+     defaulting to `1e-7 m`, and derive intrinsic Meyer gate capacitance from
+     `Cox = epsilon_ox / TOX`.
+   - Hierarchy and cloning preserve the oxide thickness, shared validation
+     enforces finite positive `TOX`, and the supported-parameter release gate
+     now covers 187 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- add Berkeley Level-1 MOS `RD` parsing, validation, defaults, and hierarchy preservation across Rust, Python, and TypeScript
- create an intrinsic drain for positive `RD`, stamp the resistor in DC, TF, AC, and transient paths, route drain-side capacitances through it, and emit distinct `:RD` Johnson noise
- advance the supported-parameter coverage gate from 187 to 189 canonical rows and reconcile the SPICE completion plan

## Verification

- `cargo fmt -p mosfet-models -p spice-engine -- --check`
- `cargo test -p mosfet-models -p spice-engine`
- `python -m pytest code/packages/python/mosfet-models code/packages/python/spice-engine` (663 passed)
- `npm run build && npm test` in `code/packages/typescript/spice-engine` (380 passed)
- `python -m ruff check --ignore SIM108,F841 code/packages/python/mosfet-models code/packages/python/spice-engine`
- `git diff --check`