### PR TITLE
feat(adj-formula-stdlib): kinematic-viscosity-conversions — NIST SP 811 B.9 stokes/centistokes→m²/s exact factors (RS-5 table)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -631,6 +631,49 @@ fn shipped_dynamic_viscosity_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b13) Shipped table — reference/kinematic-viscosity-conversions.adj resolves via
+//       import (a NEW dimension: kinematic viscosity → square metre per second, the
+//       EXACT SP 811 B.9 boldface CGS factors stokes and centistokes), and a unit
+//       with no row (`square_foot_per_second`) abstains.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_kinematic_viscosity_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_kvisc");
+    let src = stdlib().join("reference/kinematic-viscosity-conversions.adj");
+    std::fs::copy(&src, dir.join("kinematic-viscosity-conversions.adj"))
+        .expect("copy shipped kinematic-viscosity-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"kinematic-viscosity-conversions.adj\"\n\
+         ? kinematic_viscosity_to_square_metres_per_second(stokes, $v)\n\
+         ? kinematic_viscosity_to_square_metres_per_second(centistokes, $v)\n\
+         ? kinematic_viscosity_to_square_metres_per_second(square_foot_per_second, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 "Viscosity, kinematic" exact factors resolve, character-for-
+    // character from the table (boldface = exact; scientific notation to plain decimal).
+    assert!(out.contains("\"v\":\"0.0001\""), "stokes = 0.0001 m²/s: {out}");
+    assert!(
+        out.contains("\"v\":\"0.000001\""),
+        "centistokes = 0.000001 m²/s: {out}"
+    );
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `square_foot_per_second` has no row in this CGS-stokes-family table, so the engine
+    // abstains rather than inventing a factor the table does not carry.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a unit with no row abstains, never a fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/kinematic-viscosity-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/kinematic-viscosity-conversions.adj
@@ -1,0 +1,60 @@
+% ============================================================================
+% kinematic-viscosity-conversions — kinematic-viscosity-unit → square-metre-per-
+% second factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of `dynamic-viscosity-conversions.adj` and `speed-conversions.adj`:
+% a native tabular relation ingested VERBATIM from a published NIST conversion table.
+% Each row states the factor converting one kinematic-viscosity unit to the SI
+% coherent unit of kinematic viscosity, the square metre per second (m²/s):
+%
+%     ? kinematic_viscosity_to_square_metres_per_second(stokes, $v)       % 0.0001
+%     ? kinematic_viscosity_to_square_metres_per_second(centistokes, $v)  % 0.000001
+%
+% This is a NEW dimension alongside the length/mass/area/volume/time/speed/energy/
+% pressure/force/acceleration/dynamic-viscosity tables: where those normalise their
+% own quantity, this one normalises a KINEMATIC VISCOSITY (a dynamic viscosity divided
+% by a mass density — units of area per time). It pairs naturally with the
+% dynamic-viscosity table: a dynamic viscosity in poise over a density gives a
+% kinematic viscosity in stokes, and this table then puts that stokes value into SI
+% (write-once-use-many). Why a `table` and not several hand-written `relate` clauses:
+% this is exactly the shape reference data comes in — a published table, not prose.
+% The citable artifact IS the NIST conversion-factors table at the `locator` below;
+% every factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors
+% for units listed alphabetically"), and the whole table is defended by one provenance
+% envelope rather than repeating `source`/`locator`/`trust` on every row. Each `row`
+% lowers to a ground relation
+% `kinematic_viscosity_to_square_metres_per_second(unit, m2s)`, so the exact lookup
+% above is the ordinary SLD binding query — the engine returns the factor WITH this
+% table's citation as its proof, on the CPU, with zero model calls.
+%
+% HONESTY NOTE: NIST SP 811 B.9 prints these two "Viscosity, kinematic" factors in
+% BOLDFACE, its convention for factors that are EXACT by definition, transcribed here
+% as the plain decimal number of square metres per second each unit names:
+%
+%     stokes (St)        1.0 E-04  →  0.0001
+%     centistokes (cSt)  1.0 E-06  →  0.000001
+%
+% These two are exact because the stokes is a coherent CGS unit — one stokes is one
+% centimetre squared per second, i.e. exactly 10⁻⁴ m²/s — and the centistokes is
+% exactly one hundredth of a stokes, i.e. exactly 10⁻⁶ m²/s. Both terminate; nothing
+% here is a rounded measurement. This table's scope is precisely that CGS stokes
+% family (the two boldface SI-coherent entries NIST lists under "Viscosity,
+% kinematic"); a unit with NO row — e.g. a `square_foot_per_second` — ABSTAINS rather
+% than returning a factor the table does not carry. The only claim this table makes is
+% "these are the exact factors NIST SP 811 B.9 prints", which is exactly what a
+% byte-check against the cited table verifies. `trust authoritative` — a primary,
+% re-fetchable standards reference. (See ADJ-TABLES.md; and
+% feedback_nothing_human_authored — every factor is a verbatim cell of the cited
+% table, nothing asserted from memory.)
+% ============================================================================
+
+table kinematic_viscosity_to_square_metres_per_second {
+    columns unit, m2s
+
+    row (stokes, 0.0001)
+    row (centistokes, 0.000001)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/kinematic-viscosity-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/kinematic-viscosity-conversions.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% kinematic-viscosity-conversions.query.adj — a worked lookup over the kinematic-
+% viscosity table.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a "how many square
+% metres per second is one stokes?" question: it states no conversion fact — it only
+% `import`s the grounded table and asks binding queries. The native adj-lang engine
+% resolves each `?` against the table's rows (lowered to
+% `kinematic_viscosity_to_square_metres_per_second` relations) and returns the binding
+% + the table's source/locator/trust. A unit not in the table abstains honestly — the
+% engine never invents a factor (e.g. a `square_foot_per_second`, which this table
+% does not carry a row for).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli kinematic-viscosity-conversions.query.adj
+% ============================================================================
+
+import "kinematic-viscosity-conversions.adj"
+
+? kinematic_viscosity_to_square_metres_per_second(stokes, $v)                % expect 0.0001
+? kinematic_viscosity_to_square_metres_per_second(centistokes, $v)           % expect 0.000001
+? kinematic_viscosity_to_square_metres_per_second(square_foot_per_second, $v) % expect abstain — no row


### PR DESCRIPTION
## What

Adds `reference/kinematic-viscosity-conversions.adj` — a native RS-5 `table` for a **new dimension**, kinematic viscosity → the SI **square metre per second (m²/s)** — a sibling of the dynamic-viscosity / length / mass / area / volume / time / speed / energy / pressure / force / acceleration conversion tables. Two rows, **both exact** (NIST prints them boldface = exact by definition), transcribed **verbatim** from NIST Special Publication 811, Appendix B.9 ("Factors for units listed alphabetically"):

| unit | NIST B.9 factor | m²/s |
|---|---|---|
| stokes (St) | **1.0 E-04** | 0.0001 |
| centistokes (cSt) | **1.0 E-06** | 0.000001 |

Each `row` lowers to a ground relation `kinematic_viscosity_to_square_metres_per_second(unit, m2s)`, so an exact lookup is the ordinary SLD binding query — the engine returns the factor **with the table's one provenance envelope** (`source`/`locator`/`trust authoritative`), on the CPU, zero model calls.

## Honesty / abstention

This table's scope is the **CGS stokes family** (the two boldface SI-coherent "Viscosity, kinematic" entries NIST lists). A unit with **no row** — e.g. a `square_foot_per_second` — **abstains** rather than returning a factor the table does not carry. The only claim the table makes is "these are the exact factors NIST SP 811 B.9 prints" — which a byte-check against the cited page verifies.

It pairs naturally with the recently-merged dynamic-viscosity table: a dynamic viscosity in poise over a mass density gives a kinematic viscosity in stokes, and this table then puts that stokes value into SI (write-once-use-many).

## Files

- `reference/kinematic-viscosity-conversions.adj` — the grounded RS-5 table
- `reference/kinematic-viscosity-conversions.query.adj` — worked lookups (stokes → 0.0001, centistokes → 0.000001, and an abstaining miss)
- `adj-lang-cli/tests/rs5_table_e2e.rs` — new **(b13)** block on the shared table anchor, driving the built CLI against the shipped table

## Verification

- `cargo test -p adj-lang-cli --test rs5_table_e2e` → **18/18 pass** (new block asserts exact `0.0001` / `0.000001`, the NIST B.9 locator on the answer, and abstention on the no-row unit)
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean
- Shipped query run through the CLI → `0.0001` / `0.000001` exact, `abstained:true` on the no-row unit, NIST B.9 locator carried
- NUL-scan: 0 bytes in all touched files
- Byte-verified verbatim against NIST SP 811 B.9 (stokes `1.0 E-04`, centistokes `1.0 E-06`, both boldface/exact)
- Data + test only — **no version bump**
- `/security-review` → PASSED (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)