### PR TITLE
feat(gc): incremental collector C ABI + Incremental marked available — PR-3 (AOT00-T4)

### DIFF
--- a/code/packages/rust/gc-core-capi/CHANGELOG.md
+++ b/code/packages/rust/gc-core-capi/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this crate are documented here.
 
+## 0.17.0 - 2026-07-25 — incremental collector C ABI `__gc_collect_incremental_{start,step,finish}` (AOT00-T4 §6)
+
+- **Three new exports in `stack_scan.rs`** — the bounded-pause incremental collection cycle,
+  driven as `start(); while (!step(BUDGET)) { …mutator… } finish();`:
+  - `__gc_collect_incremental_start()` captures the precise roots **once** via the *same*
+    frame-pointer walk as `__gc_collect_precise` (precise slots + conservative regions + the
+    spilled callee-saved registers) and shades them grey. Reference stores the mutator makes
+    *between* steps are caught by `__gc_write_barrier`'s incremental shading (the Dijkstra
+    insertion barrier landed in gc-core 0.19.0) — no capi change needed there, it already
+    forwards to `FlatHeap::write_barrier`.
+  - `__gc_collect_incremental_step(budget) -> i64` advances marking by up to `budget` objects,
+    returning `1` when complete / `0` otherwise (negative budget → 0).
+  - `__gc_collect_incremental_finish() -> i64` sweeps the unreachable objects and returns the
+    count reclaimed.
+  - **Untrustworthy stack ⇒ safe no-op cycle:** if `start` can't trust the stack it enters no
+    phase; `step` then returns `1` immediately and `finish` returns `0` (guarded by
+    `FlatHeap::incremental_in_progress()`), so nothing is swept — the same bias-to-leak as
+    `__gc_collect_precise`. Declared in `include/gc_core.h`.
+- **Tests (+2):** an end-to-end smoke test drives the real start→step(budget 1)→finish protocol
+  on this thread's stack (a live local is kept, a dead object reclaimed, several slices) + a
+  no-phase-safety test (step/finish without a start free nothing). Real-stack asm path isn't
+  Miri-able (same limitation as the `__gc_collect_precise` tests); the underlying gc-core
+  `incremental_*` logic is Miri-clean.
+
 ## 0.16.0 - 2026-07-24 — twig-compat alias `__twig_gc_collect_compacting` (frontend GC.compact)
 
 - **`__twig_gc_collect_compacting()`** (new `twig_compat` alias → [`__gc_collect_compacting`]) —

--- a/code/packages/rust/gc-core-capi/Cargo.toml
+++ b/code/packages/rust/gc-core-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core-capi"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "C ABI for gc-core's flat-native heap — the gc_runtime_<target> archive linked into native-AOT output (LANG16 / AOT00 T1)."
 license = "MIT"

--- a/code/packages/rust/gc-core-capi/include/gc_core.h
+++ b/code/packages/rust/gc-core-capi/include/gc_core.h
@@ -165,6 +165,28 @@ int64_t __gc_collect_precise(void);
  * must be built with frame pointers. Same threading contract as __gc_collect_precise. */
 int64_t __gc_collect_compacting(void);
 
+/* ── Incremental (bounded-pause) collection ─────────────────────────────────
+ * A three-call cooperative cycle (spec AOT00-T4-incremental-collector.md §6) that
+ * decomposes a full mark into bounded slices so the mutator sees short pauses instead of one
+ * long one. Drive it as:
+ *
+ *     __gc_collect_incremental_start();
+ *     while (!__gc_collect_incremental_step(BUDGET)) { ... mutator runs a slice ... }
+ *     freed = __gc_collect_incremental_finish();
+ *
+ * `start` captures the precise roots ONCE (the same frame-pointer walk as
+ * __gc_collect_precise) and shades them grey. Reference stores the mutator makes BETWEEN steps
+ * must go through __gc_write_barrier, whose incremental half shades the stored child grey
+ * (the Dijkstra insertion barrier) so a live object is never stranded. `step` advances marking
+ * by up to `budget` objects and returns 1 when marking is complete, 0 otherwise (a negative
+ * budget is treated as 0). `finish` sweeps the unreachable objects and returns the count
+ * reclaimed. If `start` could not trust the stack it enters no phase: `step` then returns 1
+ * immediately and `finish` returns 0, so nothing is freed (bias-to-leak, as __gc_collect_precise).
+ * Single-threaded; no other collection may run between start and finish. */
+void    __gc_collect_incremental_start(void);
+int64_t __gc_collect_incremental_step(int64_t budget);
+int64_t __gc_collect_incremental_finish(void);
+
 /* One compiled function's stack-map descriptor in a module table (see
  * __gc_register_stackmap_module). Mirrors the __gc_register_stackmap arguments;
  * frame_sizes / callee_masks may be NULL. Emitted into the image's read-only data,

--- a/code/packages/rust/gc-core-capi/src/stack_scan.rs
+++ b/code/packages/rust/gc-core-capi/src/stack_scan.rs
@@ -467,6 +467,104 @@ pub unsafe extern "C" fn __gc_collect_precise() -> i64 {
     freed
 }
 
+/// **Begin** an incremental (bounded-pause) collection rooted precisely at this thread's
+/// stack — the first of the three-call cooperative cycle (spec
+/// `AOT00-T4-incremental-collector.md` §6). Captures the precise roots **once**, via the
+/// *same* frame-pointer walk as [`__gc_collect_precise`] (precise slots for stack-mapped
+/// frames, conservative regions for the rest, plus the spilled callee-saved registers), and
+/// shades them grey. The mutator then runs *between* [`__gc_collect_incremental_step`] calls;
+/// its reference stores are caught by [`__gc_write_barrier`]'s incremental shading (the
+/// Dijkstra insertion barrier). With no stack maps registered the walk tiles the stack
+/// conservatively, exactly as `__gc_collect_precise` degrades.
+///
+/// **Root-snapshot contract (spec §6).** Roots are captured here; a reference that becomes
+/// reachable only *after* this call is retained iff it passed through a barriered store or is
+/// still reachable from this snapshot. The driver must not pop a frame holding the sole
+/// reference to a white object without that reference having been stored. The gc-core mark
+/// re-reads neither the snapshotted slots nor regions (it drains only the grey worklist), so
+/// the fact that they point into *this* frame is safe.
+///
+/// **Untrustworthy stack ⇒ no-op cycle.** If the stack range can't be trusted (base
+/// undetectable, or an absurd span), no phase is entered — [`__gc_collect_incremental_step`]
+/// then reports "done" immediately and [`__gc_collect_incremental_finish`] reclaims nothing,
+/// so no live object is ever freed (the same bias-to-leak as `__gc_collect_precise`).
+///
+/// # Safety
+/// Same contract as [`__gc_collect_precise`]: the calling thread owns its stack; single
+/// mutator; **no other collection runs between `start` and `finish`** (enforced by gc-core's
+/// mixing guard). The driver loops `step` to "done" before calling `finish`.
+#[no_mangle]
+#[inline(never)]
+pub unsafe extern "C" fn __gc_collect_incremental_start() {
+    // Spill callee-saved registers into a stack buffer (in this frame), then SP.
+    let mut regs = [0usize; SPILL_SLOTS];
+    let sp = spill_and_sp(regs.as_mut_ptr());
+    let fp = current_fp();
+    let base = stack_base();
+
+    if base != 0 && sp < base && base - sp <= MAX_STACK_SCAN {
+        let mut slots: Vec<usize> = Vec::new();
+        let mut regions: Vec<(*const u8, usize)> = Vec::new();
+        // Walk the frame-pointer chain into precise slots + conservative regions.
+        crate::precise_walk::build_precise_roots(fp, sp, base, &mut slots, &mut regions);
+        // Always scan the spilled callee-saved registers (a ref live only in one is named by
+        // no stack map). Valid here because `incremental_start` greys these roots NOW, while
+        // `regs` and the walked frames are still live.
+        regions.push((
+            regs.as_ptr() as *const u8,
+            SPILL_SLOTS * core::mem::size_of::<usize>(),
+        ));
+        with_heap(|h| h.incremental_start(&slots, &regions));
+    }
+    // else: untrustworthy stack → don't enter a phase (see the bias-to-leak note above).
+
+    core::hint::black_box(&regs);
+}
+
+/// **Advance** an in-progress incremental mark by up to `budget` objects — the bounded-pause
+/// primitive (spec §6). Returns `1` when marking is complete (the caller should then call
+/// [`__gc_collect_incremental_finish`]), `0` if more steps remain. A negative `budget` is
+/// treated as `0`. If no incremental phase is in progress (e.g. an untrustworthy-stack
+/// `start`, or a spurious call), returns `1` ("done") without touching the heap — so the
+/// driver's `step`-to-done loop terminates and a no-op cycle stays safe.
+///
+/// # Safety
+/// Single-threaded; no other collection runs mid-cycle. Called only after
+/// [`__gc_collect_incremental_start`].
+#[no_mangle]
+#[inline(never)]
+pub unsafe extern "C" fn __gc_collect_incremental_step(budget: i64) -> i64 {
+    let budget = if budget < 0 { 0 } else { budget as usize };
+    with_heap(|h| {
+        if !h.incremental_in_progress() {
+            return 1; // no phase → nothing to mark → "done"
+        }
+        if h.incremental_step(budget) {
+            1
+        } else {
+            0
+        }
+    })
+}
+
+/// **Finish** an in-progress incremental cycle: sweep the unreachable (white) objects and end
+/// the phase (spec §6). Returns the number of objects reclaimed. Marking must be complete
+/// (drive [`__gc_collect_incremental_step`] to `1` first). If no phase is in progress, returns
+/// `0` without sweeping — so an untrustworthy-stack cycle reclaims nothing.
+///
+/// # Safety
+/// Single-threaded; no other collection mid-cycle; called only after marking is complete.
+#[no_mangle]
+#[inline(never)]
+pub unsafe extern "C" fn __gc_collect_incremental_finish() -> i64 {
+    with_heap(|h| {
+        if !h.incremental_in_progress() {
+            return 0; // no phase → nothing collected (no sweep)
+        }
+        h.incremental_finish().freed as i64
+    })
+}
+
 /// A full **moving/compacting** collection rooted precisely at this thread's stack —
 /// the argument-less entry that turns the precise-root machinery into a *relocating*
 /// GC (spec `AOT00-T3-moving-collector.md` §5). It is to
@@ -706,6 +804,67 @@ mod tests {
         assert!(__gc_live_bytes() >= 16);
         assert_eq!(__gc_collection_count(), 1);
         core::hint::black_box(kept);
+    }
+
+    /// End-to-end smoke test for the **incremental** C-ABI cycle
+    /// `__gc_collect_incremental_{start,step,finish}`: an object held in a live stack local
+    /// survives the interruptible collection; a dead one is reclaimed. Drives the real
+    /// three-call protocol (start → step-to-done → finish) on this thread's stack, with a
+    /// deliberately small budget so the mark takes several steps. With no stack maps
+    /// registered every frame is conservative, so the live local is pinned (kept) and the
+    /// unreferenced object is swept — exactly matching a stop-the-world collect, just in
+    /// bounded slices.
+    #[test]
+    fn incremental_collect_keeps_live_local_frees_dead() {
+        let _guard = crate::TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        __gc_reset();
+        run_incremental_collect_case();
+        __gc_reset();
+    }
+
+    #[inline(never)]
+    fn run_incremental_collect_case() {
+        let kept = __gc_alloc(16);
+        assert!(kept != 0);
+        let _ = __gc_alloc(16); // dead: no stack slot retains it
+        assert_eq!(__gc_live_bytes(), 32);
+        unsafe { *(kept as *mut i64) = 0x1ce5 };
+
+        // start → step (budget 1, so several slices) to done → finish.
+        unsafe { __gc_collect_incremental_start() };
+        let mut steps = 0;
+        while unsafe { __gc_collect_incremental_step(1) } == 0 {
+            steps += 1;
+            assert!(steps < 100_000, "incremental mark must converge");
+        }
+        let freed = unsafe { __gc_collect_incremental_finish() };
+
+        assert!(freed >= 1, "the unreferenced object must be reclaimed");
+        assert_eq!(
+            unsafe { *(kept as *const i64) },
+            0x1ce5,
+            "the conservatively-pinned live local survives the incremental collect intact"
+        );
+        assert!(__gc_live_bytes() >= 16);
+        assert_eq!(__gc_collection_count(), 1);
+        core::hint::black_box(kept);
+    }
+
+    /// The incremental C-ABI protocol is safe even if no phase is in progress: `step` reports
+    /// "done" and `finish` reclaims nothing (the no-op cycle an untrustworthy-stack `start`
+    /// produces). Nothing is swept, so no live object could be lost.
+    #[test]
+    fn incremental_step_finish_are_safe_with_no_phase() {
+        let _guard = crate::TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        __gc_reset();
+        let kept = __gc_alloc(16);
+        assert!(kept != 0);
+        // No `start` was called → no phase in progress.
+        assert_eq!(unsafe { __gc_collect_incremental_step(64) }, 1, "no phase ⇒ done");
+        assert_eq!(unsafe { __gc_collect_incremental_finish() }, 0, "no phase ⇒ nothing freed");
+        assert!(__gc_live_bytes() >= 16, "the object was NOT swept without a real cycle");
+        core::hint::black_box(kept);
+        __gc_reset();
     }
 
     /// `spill_and_sp` returns a plausible stack pointer (non-zero, and below the

--- a/code/packages/rust/gc-core/CHANGELOG.md
+++ b/code/packages/rust/gc-core/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — gc-core
 
+## 0.20.0 — 2026-07-25 — `Incremental` algorithm marked available — PR-3 (AOT00-T4)
+
+- **`GcAlgorithm::Incremental::is_available()` now returns `true`** — the incremental
+  collector (`FlatHeap::incremental_start`/`incremental_step`/`incremental_finish` + the
+  Dijkstra insertion write barrier, shipped in 0.18–0.19) is implemented, so the adaptive
+  policy's existing high-pause `SuggestSwitch(Incremental)` recommendation becomes actionable
+  rather than advisory. **All four `GcAlgorithm` variants are now available** — the precision
+  ladder is complete: mark-and-sweep → interior-precise → generational → precise-roots →
+  compacting → **incremental**. Tests updated (`gc_algorithm_incremental_is_available`,
+  `every_gc_algorithm_is_now_available`).
+
 ## 0.19.0 — 2026-07-25 — incremental Dijkstra insertion write barrier — PR-2 (AOT00-T4)
 
 Closes the incremental collector's soundness surface: the mutator may now safely store

--- a/code/packages/rust/gc-core/Cargo.toml
+++ b/code/packages/rust/gc-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "LANG16 — adaptive GC adapter layer wiring garbage-collector into the LANG VM pipeline."
 license = "MIT"

--- a/code/packages/rust/gc-core/src/policy.rs
+++ b/code/packages/rust/gc-core/src/policy.rs
@@ -106,14 +106,20 @@ impl GcAlgorithm {
 
     /// `true` if this algorithm is available in the current gc-core build.
     ///
-    /// `MarkAndSweep` (the conservative/precise full collector), `Generational`
-    /// (`FlatHeap::collect_minor` + the remembered-set write barrier), and
-    /// `Compacting` (`FlatHeap::collect_compacting` — the moving/evacuating
-    /// collector) are implemented; `Incremental` is still planned.
+    /// **All four are now implemented:** `MarkAndSweep` (the conservative/precise full
+    /// collector), `Generational` (`FlatHeap::collect_minor` + the remembered-set write
+    /// barrier), `Compacting` (`FlatHeap::collect_compacting` — the moving/evacuating
+    /// collector), and `Incremental` (`FlatHeap::incremental_start`/`incremental_step`/
+    /// `incremental_finish` — bounded-pause tri-colour marking with the Dijkstra insertion
+    /// write barrier). So this is unconditionally `true` — kept as a method for the policy's
+    /// enact/advise decision and forward compatibility with future algorithms.
     pub fn is_available(self) -> bool {
         matches!(
             self,
-            GcAlgorithm::MarkAndSweep | GcAlgorithm::Generational | GcAlgorithm::Compacting
+            GcAlgorithm::MarkAndSweep
+                | GcAlgorithm::Generational
+                | GcAlgorithm::Compacting
+                | GcAlgorithm::Incremental
         )
     }
 }

--- a/code/packages/rust/gc-core/tests/test_gc_core.rs
+++ b/code/packages/rust/gc-core/tests/test_gc_core.rs
@@ -504,9 +504,23 @@ fn gc_algorithm_compacting_is_available() {
 }
 
 #[test]
-fn gc_algorithm_incremental_not_yet_available() {
-    // Still a planned rung of the precision ladder.
-    assert!(!GcAlgorithm::Incremental.is_available());
+fn gc_algorithm_incremental_is_available() {
+    // Incremental became available with FlatHeap::incremental_start/step/finish + the
+    // Dijkstra insertion write barrier (the last rung of the precision ladder).
+    assert!(GcAlgorithm::Incremental.is_available());
+}
+
+#[test]
+fn every_gc_algorithm_is_now_available() {
+    // The whole ladder is implemented: mark-and-sweep, generational, compacting, incremental.
+    for algo in [
+        GcAlgorithm::MarkAndSweep,
+        GcAlgorithm::Generational,
+        GcAlgorithm::Compacting,
+        GcAlgorithm::Incremental,
+    ] {
+        assert!(algo.is_available(), "{} must be available", algo.name());
+    }
 }
 
 #[test]


### PR DESCRIPTION
## AOT00-T4 incremental collector — PR-3: the C ABI (+ the last algorithm goes available)

Exposes the bounded-pause incremental collector through the C ABI and flips the **last** `GcAlgorithm` to available — **the precision ladder is now complete**.

### `__gc_collect_incremental_{start,step,finish}` (gc-core-capi 0.17.0)
The three-call cooperative cycle (spec §6), driven as `start(); while (!step(BUDGET)) { …mutator… } finish();`:
- **`start()`** captures the precise roots **once**, via the *same* frame-pointer walk as `__gc_collect_precise` (spill registers + `build_precise_roots` + the spilled-regs conservative region), and shades them grey.
- **`step(budget) -> i64`** advances marking by up to `budget` objects (`1` done / `0` more; negative → 0).
- **`finish() -> i64`** sweeps the unreachable objects and returns the count reclaimed.
- Reference stores the mutator makes *between* steps are caught by `__gc_write_barrier`'s incremental shading (the Dijkstra barrier from gc-core 0.19.0) — **no capi change needed**, it already forwards to `FlatHeap::write_barrier`.
- **Untrustworthy stack ⇒ safe no-op cycle:** if `start` can't trust the stack it enters no phase; `step` returns `1` and `finish` returns `0` (guarded by `incremental_in_progress()`), so nothing is swept — the same bias-to-leak as `__gc_collect_precise`. Declared in `gc_core.h`.

### `Incremental::is_available()` → true (gc-core 0.20.0)
**All four `GcAlgorithm` variants are now available** — mark-and-sweep, generational, compacting, incremental. The adaptive policy's high-pause `SuggestSwitch(Incremental)` recommendation becomes actionable. Tests updated (`gc_algorithm_incremental_is_available`, `every_gc_algorithm_is_now_available`).

### Verification
- **Tests (+2 capi):** an end-to-end smoke test drives the real `start → step(budget 1) → finish` protocol on this thread's stack (a live local is kept, a dead object reclaimed, over several slices) + a no-phase-safety test (step/finish without a start free nothing).
- **90 gc-core + 33 gc-core-capi tests** pass; clippy clean; capi staticlib builds. The gc-core `incremental_*` logic is Miri-clean (PR-1/2); the capi asm stack-walk path isn't Miri-able (same limitation as `__gc_collect_precise`).
- **Adversarial `/security-review`: SAFE TO PUSH** — the root snapshot (which points into `start`'s frame) is **dead storage**: `step`/`finish` drain only the grey worklist and never re-read it, and `Vec::clear` frees without dereferencing, so there's no dangling deref; the no-phase guards make `step`/`finish` safe after an untrustworthy `start`; the gate + `build_precise_roots` capture exactly `precise`'s root set; worklist pointers stay valid across the C boundary (nothing frees until `finish`'s done-gated sweep); the `is_available` flip is advisory-only (the enact path is a no-op); the budget cast is truncation-free on 64-bit. `finish`-before-done is the same documented unsafe contract as the Rust API.

**Precision ladder COMPLETE: mark-and-sweep → interior-precise → generational → precise-roots → compacting → incremental (core + barrier + C ABI).** PR-4 = native `gc_collect_incremental_*` builtin trio + end-to-end differential.

gc-core 0.19.0 → 0.20.0, gc-core-capi 0.16.0 → 0.17.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)