### PR TITLE
feat(semantic-ir-to-ruby): classes slice 5 — class methods (0.15.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.15.0 — classes slice 5: class methods (def self.foo)
+
+Class (singleton) **methods**. No new `Feature` (they lower to builtins).
+
+- `def self.m` → a hoisted top-level function `Class__m_cm` +
+  `__def_class_method__("Class", "m", MakeClosure(fn))` →
+  `Class.define_singleton_method(:sir_um_m, &closure)`.
+- `Class.m(args…)` → `__class_method__("Class", "m", args…)` →
+  `(Class).public_send(:sir_um_m, args…)` — the receiver is the class *name* (a
+  bare constant), not an instance.
+
+Mirrors instance methods (slice 2) but installs on the class's **singleton**
+method table via `define_singleton_method`. The SAME reserved `sir_um_` prefix is
+reused: a class's singleton methods and its instance methods live in separate
+tables, so the shared prefix cannot collide, and class-method dispatch stays
+**closed** (anti-RCE) — `public_send` with a crafted class-method name can only
+reach a `sir_um_*` (user) method, never `Class.instance_eval`/`send`/etc.
+
+**Totality / clean rejection.** A SECOND allowlist (collected from
+`__def_class_method__`, alongside the instance-method allowlist) gates
+`__class_method__`: a dispatch to a name the module never registers as a class
+method is a **built-in class method** (`Foo.name`, …) — the Collections batch —
+rejected cleanly. The two allowlists are independent, so an instance registration
+does not authorise a class dispatch of the same name (and vice-versa). The class
+name in both builtins is emitted verbatim as a bare constant and validated as a
+constant path (co-total injection guard); a malformed `__def_class_method__`
+(missing/non-closure third argument) is rejected.
+
+**Still rejects** class variables (`@@x`, `Feature::ClassVars`) — which also pull
+in a non-empty class body — and modules; each a later slice.
+
 ## 0.14.0 — classes slice 4: inheritance + super
 
 Class **inheritance** and `super`. No new `Feature` (a superclass rides on

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/README.md
+++ b/code/packages/rust/semantic-ir-to-ruby/README.md
@@ -89,10 +89,14 @@ injection). **Inheritance** (slice 4): `class Dog < Animal` →
 ancestry walk (the body is a hoisted function, so native `super` is unavailable),
 still `sir_um_`-prefixed so `instance_method` can only fetch a user method
 (anti-RCE); the superclass and defining-class names are constant-path validated.
+**Class methods** (slice 5): `def self.m` → `Class.define_singleton_method(:sir_um_m,
+&closure)` and `Class.m(…)` → `(Class).public_send(:sir_um_m, …)` — the same
+`sir_um_` prefix (a separate singleton table, no collision), gated by an
+independent class-method allowlist so a built-in class-method call rejects cleanly.
 Rejects `TailCalls`, `Intrinsics`, and every not-yet-wired feature (array
 indexing / slicing via `IndexGet` — `NDArrays`; array-pattern destructuring;
-built-in collection methods; and the rest of OOP — class variables (`@@x`),
-class methods, modules — plus a non-empty class body or a namespaced
+built-in collection methods; and the rest of OOP — class variables (`@@x`,
+with the class-body initializer they need), modules — plus a namespaced
 class/constant definition) until its slice lands — each a clean,
 source-positioned `UnsupportedFeature`.
 

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -98,6 +98,15 @@ const SUPPORTED_BUILTINS: &[&str] = &[
     // `super` call — dispatches the superclass's `sir_um_m` on `self`.  (The
     // subclass relation itself rides on `Stmt::ClassDef { superclass }`.)
     "__super__",
+    // OOP classes slice 5 (class methods): `def self.m` registers via
+    // `__def_class_method__("Class", "m", MakeClosure(fn))` (a singleton method
+    // on the class), and `Class.m(args…)` dispatches via
+    // `__class_method__("Class", "m", args…)`.  Both use the SAME reserved
+    // `sir_um_` prefix as instance methods (a class's singleton method table is
+    // separate from its instance methods, so the shared prefix cannot collide),
+    // keeping dispatch CLOSED (anti-RCE).
+    "__def_class_method__",
+    "__class_method__",
 ];
 
 /// Emit a complete self-contained Ruby source file for `m`.
@@ -189,8 +198,10 @@ pub enum ScanHit {
 /// A first collection pass gathers that set (a dispatch can textually precede
 /// its registration), then the single scan validates against it.
 pub fn first_scan_issue(m: &Module) -> Option<ScanHit> {
+    let registered = collect_registered_methods(m);
     let scan = Scan {
-        registered_methods: collect_registered_methods(m),
+        registered_methods: registered.instance,
+        registered_class_methods: registered.class_methods,
     };
     for f in &m.functions {
         // A SIR19 parameter default is an expression evaluated at call time, so
@@ -218,13 +229,21 @@ pub fn first_scan_issue(m: &Module) -> Option<ScanHit> {
 /// rejected until then.  (The `sir_um_` dispatch prefix is the SECURITY
 /// guarantee against reflection-RCE; this allowlist is for clean COMPILE-TIME
 /// rejection of not-yet-supported built-in dispatch.)
-fn collect_registered_methods(m: &Module) -> HashSet<String> {
-    fn from_expr(e: &Expr, out: &mut HashSet<String>) {
+fn collect_registered_methods(m: &Module) -> Registered {
+    fn from_expr(e: &Expr, out: &mut Registered) {
         match e {
             Expr::BuiltinCall { name, args, .. } => {
+                // A registration's method name is `args[1]`.  Route an instance
+                // method (`__def_method__`) and a class method
+                // (`__def_class_method__`) into their SEPARATE allowlists — an
+                // instance dispatch and a class dispatch are distinct namespaces.
                 if name == "__def_method__" {
                     if let Some(Expr::StrLit { value, .. }) = args.get(1) {
-                        out.insert(value.clone());
+                        out.instance.insert(value.clone());
+                    }
+                } else if name == "__def_class_method__" {
+                    if let Some(Expr::StrLit { value, .. }) = args.get(1) {
+                        out.class_methods.insert(value.clone());
                     }
                 }
                 for a in args {
@@ -273,7 +292,7 @@ fn collect_registered_methods(m: &Module) -> HashSet<String> {
             _ => {}
         }
     }
-    fn from_stmt(s: &Stmt, out: &mut HashSet<String>) {
+    fn from_stmt(s: &Stmt, out: &mut Registered) {
         match s {
             Stmt::LetBinding { value, .. }
             | Stmt::LetStarBinding { value, .. }
@@ -330,11 +349,11 @@ fn collect_registered_methods(m: &Module) -> HashSet<String> {
             _ => {}
         }
     }
-    fn from_block(b: &Block, out: &mut HashSet<String>) {
+    fn from_block(b: &Block, out: &mut Registered) {
         b.stmts.iter().for_each(|s| from_stmt(s, out));
         from_expr(&b.value, out);
     }
-    let mut out = HashSet::new();
+    let mut out = Registered::default();
     for f in &m.functions {
         for p in &f.params {
             if let Some(d) = &p.default {
@@ -346,10 +365,21 @@ fn collect_registered_methods(m: &Module) -> HashSet<String> {
     out
 }
 
-/// The pre-emit scan, carrying the module's registered-method allowlist so the
-/// single co-total traversal can validate `__method__` dispatch.
+/// The module-wide sets of method names registered via `__def_method__` (instance
+/// methods) and `__def_class_method__` (class methods) — the two CLOSED sets that
+/// `__method__` / `__class_method__` dispatch may target.  A dispatch to any other
+/// name is a built-in-method call (the Collections batch), rejected until then.
+#[derive(Default)]
+struct Registered {
+    instance: HashSet<String>,
+    class_methods: HashSet<String>,
+}
+
+/// The pre-emit scan, carrying the module's registered-method allowlists so the
+/// single co-total traversal can validate instance- and class-method dispatch.
 struct Scan {
     registered_methods: HashSet<String>,
+    registered_class_methods: HashSet<String>,
 }
 
 impl Scan {
@@ -630,6 +660,51 @@ impl Scan {
                     (Some(Expr::StrLit { .. }), Some(Expr::StrLit { value, span })) => {
                         if !is_valid_constant_path(value) {
                             return Some(ScanHit::ConstantName(value.clone(), span.clone()));
+                        }
+                    }
+                    _ => return Some(ScanHit::Builtin(name.clone(), span.clone())),
+                }
+            }
+            // `__def_class_method__("Class", "m", closure)` (OOP slice 5) — like
+            // `__def_method__` but the class NAME (args[0], emitted as the
+            // `define_singleton_method` receiver) is a bare constant, so validate
+            // it as a constant path; require args[1] StrLit + args[2] MakeClosure.
+            if name == "__def_class_method__" {
+                match args.first() {
+                    Some(Expr::StrLit { value, span }) if !is_valid_constant_path(value) => {
+                        return Some(ScanHit::ConstantName(value.clone(), span.clone()));
+                    }
+                    Some(Expr::StrLit { .. }) => {}
+                    _ => return Some(ScanHit::Builtin(name.clone(), span.clone())),
+                }
+                if !matches!(args.get(1), Some(Expr::StrLit { .. }))
+                    || !matches!(args.get(2), Some(Expr::MakeClosure { .. }))
+                {
+                    return Some(ScanHit::Builtin(name.clone(), span.clone()));
+                }
+            }
+            // `__class_method__("Class", "m", args…)` (OOP slice 5) dispatches a
+            // class method: `(<Class>).public_send(:sir_um_m, …)`.  The class name
+            // (args[0]) is emitted verbatim as the bare-constant receiver, so
+            // validate it as a constant path; the method name (args[1]) rides the
+            // same `sir_um_` prefix (anti-RCE) but must be a method the module
+            // REGISTERS via `__def_class_method__` — else it is a built-in class
+            // method (`Foo.name`, …), the Collections batch, rejected cleanly.
+            if name == "__class_method__" {
+                match (args.first(), args.get(1)) {
+                    (Some(Expr::StrLit { value: cls, span: cspan }), Some(Expr::StrLit { value: m, span: mspan })) => {
+                        if !is_valid_constant_path(cls) {
+                            return Some(ScanHit::ConstantName(cls.clone(), cspan.clone()));
+                        }
+                        if !self.registered_class_methods.contains(m) {
+                            return Some(ScanHit::Unsupported(
+                                format!(
+                                    "a call to the built-in class method `{m}` (only \
+                                     user-defined class methods dispatch this slice; \
+                                     built-in methods are the Collections batch)"
+                                ),
+                                mspan.clone(),
+                            ));
                         }
                     }
                     _ => return Some(ScanHit::Builtin(name.clone(), span.clone())),
@@ -1314,6 +1389,29 @@ fn emit_builtin(name: &str, args: &[Expr]) -> String {
                 "({class}).superclass.instance_method({sym}).bind(self).call({})",
                 a[2..].join(", ")
             )
+        }
+        // OOP classes slice 5 — register a class (singleton) method.  `args[0]` =
+        // class name (a bare validated constant), `args[1]` = method name,
+        // `args[2]` = the `MakeClosure` (in `a[2]`).  `define_singleton_method`
+        // installs it on the class's singleton, under the SAME reserved `sir_um_`
+        // prefix as instance methods (separate method tables, so no collision) —
+        // keeping class-method dispatch closed (anti-RCE).
+        "__def_class_method__" => {
+            let class = str_arg(args, 0);
+            let sym = emit_symbol(&format!("sir_um_{}", str_arg(args, 1)));
+            format!("{class}.define_singleton_method({sym}, &({}))", a[2])
+        }
+        // Dispatch a class method: `(<Class>).public_send(:sir_um_<m>, args…)`.
+        // The class NAME (`args[0]`) is the bare-constant receiver; the method
+        // name (`args[1]`) is `sir_um_`-prefixed so `public_send` can only reach a
+        // registered class method (anti-RCE).  `args[2..]` (in `a`) are the call
+        // arguments.
+        "__class_method__" => {
+            let class = str_arg(args, 0);
+            let sym = emit_symbol(&format!("sir_um_{}", str_arg(args, 1)));
+            let mut parts = vec![sym];
+            parts.extend_from_slice(&a[2..]);
+            format!("({class}).public_send({})", parts.join(", "))
         }
         // Unreachable: first_scan_issue rejected anything else.
         other => unreachable!("v0 Ruby backend reached unsupported builtin: {other}"),

--- a/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
@@ -1829,23 +1829,6 @@ fn an_injectable_def_method_class_name_is_rejected() {
     assert!(compile(&m).is_err(), "an injectable def_method class name must be rejected");
 }
 
-#[test]
-fn still_rejected_super_self_classmethod_builtins() {
-    // The remaining OOP builtins are later slices — a hand-built module carrying
-    // any is rejected cleanly (never `unreachable!`).  (`__self__` landed in
-    // slice 3 and `__super__` in slice 4, so they are no longer in this list.)
-    for bad in ["__class_method__", "__def_class_method__"] {
-        let call = Expr::BuiltinCall {
-            name: bad.into(),
-            args: vec![strlit("Foo"), strlit("m")],
-            effects: EffectSet::PURE,
-            span: s2(),
-        };
-        let m = method_module(vec![puts(call)]);
-        assert!(compile(&m).is_err(), "`{bad}` must still be rejected");
-    }
-}
-
 // ── OOP classes slice 3 — instance variables (@ivars) + self ────────────────
 //
 // `@v = x` / `@v` lower to a `Scope::Instance` `Assign` / `VarRef` whose `name`
@@ -2083,4 +2066,132 @@ fn a_malformed_super_missing_the_class_is_rejected() {
     };
     let m = method_module(vec![puts(bad)]);
     assert!(compile(&m).is_err(), "a malformed __super__ must be rejected");
+}
+
+// ── OOP classes slice 5 — class methods (def self.foo) ──────────────────────
+//
+// `def self.m` lowers to a hoisted top-level function `Class__m_cm`, a
+// `__def_class_method__("Class", "m", MakeClosure(fn))` registration, and a
+// `Class.m(args…)` dispatch → `__class_method__("Class", "m", args…)`. Rendered
+// as `Class.define_singleton_method(:sir_um_m, &closure)` and
+// `(Class).public_send(:sir_um_m, args…)` — the SAME reserved `sir_um_` prefix
+// (a class's singleton method table is separate from its instances, so no
+// collision), so class-method dispatch is closed (anti-RCE) just like instances.
+// A dispatch to a name the module never registers as a class method is a
+// built-in class method (`Foo.name`, …) — the Collections batch — rejected.
+
+fn def_class_method(class: &str, method: &str, fn_name: &str) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "__def_class_method__".into(),
+            args: vec![strlit(class), strlit(method), make_closure(fn_name)],
+            effects: EffectSet::PURE,
+            span: s2(),
+        },
+        span: s2(),
+    }
+}
+fn class_method_call(class: &str, method: &str, args: Vec<Expr>) -> Expr {
+    let mut a = vec![strlit(class), strlit(method)];
+    a.extend(args);
+    Expr::BuiltinCall { name: "__class_method__".into(), args: a, effects: EffectSet::PURE, span: s2() }
+}
+
+// ---- positive, through the real frontend + interpreter --------------------
+
+#[test]
+fn e2e_class_method_call() {
+    // `class Greeter; def self.hi; puts "class hi"; end; end; Greeter.hi`.
+    let rb = ruby_to_ruby("class Greeter\n  def self.hi\n    puts \"class hi\"\n  end\nend\nGreeter.hi\n");
+    assert!(rb.contains("define_singleton_method(:sir_um_hi"), "singleton registration:\n{rb}");
+    assert!(rb.contains("(Greeter).public_send(:sir_um_hi"), "class-name dispatch:\n{rb}");
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "class hi"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn e2e_class_method_with_args_and_return() {
+    let rb = ruby_to_ruby("class M\n  def self.double(x)\n    x * 2\n  end\nend\nputs M.double(21)\n");
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "42"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+// ---- hand-built: anti-RCE + totality --------------------------------------
+
+#[test]
+fn class_method_dispatch_is_prefixed_so_reflection_is_unreachable() {
+    // A class method named `instance_eval` dispatches as `:sir_um_instance_eval`
+    // on the class — Ruby's real `Class.instance_eval` is unreachable.
+    let m = method_module_fns(
+        vec![
+            classdef("Foo", None, vec![]),
+            def_class_method("Foo", "instance_eval", "Foo__ie_cm"),
+            puts(class_method_call("Foo", "instance_eval", vec![strlit("code")])),
+        ],
+        vec![hoisted("Foo__ie_cm")],
+    );
+    let rb = compile(&m).expect("registered class-method dispatch compiles").source;
+    assert!(rb.contains(":sir_um_instance_eval"), "prefixed:\n{rb}");
+    assert!(!rb.contains(").public_send(:instance_eval"), "no unprefixed reflection dispatch:\n{rb}");
+}
+
+#[test]
+fn a_built_in_class_method_dispatch_is_rejected_cleanly() {
+    // `Foo.name` (no `__def_class_method__` for "name") is a built-in class
+    // method (Collections batch) — rejected, not compiled to a runtime error.
+    let m = method_module(vec![
+        classdef("Foo", None, vec![]),
+        puts(class_method_call("Foo", "name", vec![])),
+    ]);
+    let err = compile(&m).expect_err("a built-in class-method dispatch must be rejected");
+    assert_eq!(err.kind, semantic_ir::BackendErrorKind::UnsupportedFeature);
+}
+
+#[test]
+fn instance_and_class_method_allowlists_are_separate() {
+    // A method registered as an INSTANCE method does not authorise a CLASS-method
+    // dispatch of the same name (distinct namespaces), and vice-versa.
+    let m = method_module_fns(
+        vec![
+            classdef("Foo", None, vec![]),
+            def_method("Foo", "greet", "Foo__greet"), // instance only
+            puts(class_method_call("Foo", "greet", vec![])), // dispatched as a class method
+        ],
+        vec![hoisted("Foo__greet")],
+    );
+    assert!(compile(&m).is_err(), "an instance registration must not authorise a class dispatch");
+}
+
+#[test]
+fn an_injectable_def_class_method_class_name_is_rejected() {
+    let m = method_module_fns(
+        vec![def_class_method("Foo\n  system('x')", "hi", "Foo__hi_cm")],
+        vec![hoisted("Foo__hi_cm")],
+    );
+    assert!(compile(&m).is_err(), "an injectable def_class_method class must be rejected");
+}
+
+#[test]
+fn an_injectable_class_method_receiver_is_rejected() {
+    let m = method_module(vec![puts(class_method_call("Foo\n  system('x')", "hi", vec![]))]);
+    assert!(compile(&m).is_err(), "an injectable __class_method__ receiver must be rejected");
+}
+
+#[test]
+fn a_malformed_def_class_method_missing_its_closure_is_rejected() {
+    let bad = Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "__def_class_method__".into(),
+            args: vec![strlit("Foo"), strlit("hi")], // no closure
+            effects: EffectSet::PURE,
+            span: s2(),
+        },
+        span: s2(),
+    };
+    let m = method_module(vec![classdef("Foo", None, vec![]), bad]);
+    assert!(compile(&m).is_err(), "a malformed __def_class_method__ must be rejected");
 }

--- a/code/specs/SIR25-semantic-ir-to-ruby.md
+++ b/code/specs/SIR25-semantic-ir-to-ruby.md
@@ -127,10 +127,21 @@ in a hoisted top-level function (not a real method context) where native `super`
 is unavailable. It resolves a multi-level chain correctly, and the `sir_um_`
 prefix keeps `instance_method` restricted to user methods (anti-RCE).
 
+The fifth OOP slice (0.15.0) adds class (singleton) **methods**. `def self.m` →
+`__def_class_method__("Class", "m", closure)` → `Class.define_singleton_method(
+:sir_um_m, &closure)`, and `Class.m(args…)` → `__class_method__("Class", "m",
+args…)` → `(Class).public_send(:sir_um_m, args…)` — the receiver is the class
+NAME. It reuses the `sir_um_` prefix (a class's singleton and instance method
+tables are separate, so no collision), so class dispatch is closed (anti-RCE). A
+SECOND allowlist, collected from `__def_class_method__` independently of the
+instance one, gates `__class_method__`: a dispatch to an unregistered name is a
+built-in class method (the Collections batch), rejected cleanly, and an instance
+registration never authorises a class dispatch of the same name.
+
 **Still rejects** `TailCalls`, `Intrinsics`, `NDArrays`, and every not-yet-landed
-feature — including the rest of OOP: class methods (`__class_method__` /
-`__def_class_method__`), class variables (`@@x`), and modules; plus a malformed
-`__def_method__`, a
+feature — including the rest of OOP: class variables (`@@x`, with the class-body
+initializer they need) and modules; plus a malformed `__def_method__` /
+`__def_class_method__`, a
 non-empty class body, a namespaced (`Foo::Bar`) class/constant *definition*
 (`const_set` names one namespace), and a **singleton class** (`class << self` —
 `Stmt::SingletonClassDef`, which also observes `Feature::Classes`, so accepting
@@ -178,6 +189,8 @@ or temporaries:
 | `BuiltinCall("__self__", [])` | `self` — native |
 | `ClassDef { superclass: Some(S) }` | `Object.const_set(:<name>, Class.new(<S>))` — native inheritance (`S` a validated constant ref) |
 | `BuiltinCall("__super__", [m, class, args…])` | `(<class>).superclass.instance_method(:sir_um_<m>).bind(self).call(<args>)` — explicit prefixed ancestry walk |
+| `BuiltinCall("__def_class_method__", [class, m, closure])` | `<class>.define_singleton_method(:sir_um_<m>, &closure)` — class (singleton) method |
+| `BuiltinCall("__class_method__", [class, m, args…])` | `(<class>).public_send(:sir_um_<m>, <args>)` — class-name-receiver dispatch (allowlisted, anti-RCE) |
 | `If` | `(if sir_truthy(<cond>) then <then> else <else> end)` |
 | `LogicalAnd { lhs, rhs }` | `(<lhs> && <rhs>)` — native short-circuit, yields the deciding operand |
 | `LogicalOr { lhs, rhs }` | `(<lhs> \|\| <rhs>)` — native short-circuit, yields the deciding operand |
@@ -279,8 +292,9 @@ growing `ACCEPTED_FEATURES`, the runtime, and the conformance corpus in lockstep
    landed 0.11), instance **methods** (`define_method`/`public_send` under a
    reserved `sir_um_` prefix, landed 0.12), instance **variables** (`@v`, native,
    landed 0.13), **inheritance** + `super` (`Class.new(Super)` + an explicit
-   ancestry walk, landed 0.14), then **class variables** (`@@x`), class methods,
-   and **modules**/mixins.
+   ancestry walk, landed 0.14), class **methods** (`def self.m`, native
+   `define_singleton_method`, landed 0.15), then **class variables** (`@@x`) and
+   **modules**/mixins.
 6. **Collections** — the `__method__` catalog for built-in `String`/`Array`/
    `Hash`/numeric methods (Ruby methods are largely native), sharing the same
    `__method__` dispatch surface as OOP.


### PR DESCRIPTION
## What

The **fifth OOP slice**: class (singleton) methods. Bumps `semantic-ir-to-ruby` 0.14.0 → 0.15.0. No new `Feature` (they lower to builtins).

- `def self.m` → a hoisted `Class__m_cm` function + `__def_class_method__("Class", "m", closure)` → `Class.define_singleton_method(:sir_um_m, &closure)`.
- `Class.m(args…)` → `__class_method__("Class", "m", args…)` → `(Class).public_send(:sir_um_m, args…)` — the receiver is the class *name* (a bare constant), not an instance.

Mirrors instance methods (slice 2) but installs on the class's **singleton** method table. Verified end-to-end: `Class.hi` (no args) and `Class.double(21) → 42`.

## Anti-RCE

Reuses the reserved `sir_um_` prefix — a class's singleton and instance method tables are separate, so the shared prefix can't collide, and class dispatch stays **closed**: `public_send` on the class with a crafted class-method name can only reach a `sir_um_*` user method, never `Class.class_eval` / `Class.instance_eval` / `Class.send` (class-level reflection sinks). The class-name receiver in both builtins is emitted verbatim as a bare constant and validated as a constant path in the co-total scan.

## Totality / clean rejection

A **second allowlist** (`registered_class_methods`, collected from `__def_class_method__` in the same first pass, independent of the instance-method allowlist) gates `__class_method__`: a dispatch to a name the module never registers as a class method is a **built-in class method** (`Foo.name`, …) — the Collections batch — rejected cleanly. The two allowlists are independent, so an instance registration does not authorise a class dispatch of the same name (tested). A malformed `__def_class_method__` (missing/non-closure third arg) is rejected.

## Security review

A read-only security sub-agent reviewed the diff with class-level RCE + injection as the focus and returned **PASSED — no vulnerabilities**: both emit sites hard-prefix `sir_um_` before `emit_symbol` (no unprefixed path, `class_eval`/`instance_eval` unreachable), both class-name receivers are constant-path validated co-totally, the scan guarantees the indexed args, and the two allowlists are not conflated.

## Tests

104 tests pass (new: frontend+interpreter e2e for a no-arg class method and an arg+return one; hand-built for the prefix neutralising a registered `instance_eval` class-method dispatch, a built-in class-method dispatch rejecting, the separate instance/class allowlists, two injectable class names, and a malformed `__def_class_method__`). A superseded still-rejected-builtins test was removed (class-method builtins are now supported). `cargo clippy` clean. CHANGELOG, README, and SIR25 spec (node table + roadmap) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)