### PR TITLE
feat(hl03): the same syllable in its sister scripts (HL03 syllabary PR9)

### DIFF
--- a/code/programs/typescript/language-ladder/CHANGELOG.md
+++ b/code/programs/typescript/language-ladder/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.25.0 — the same syllable in its sister scripts (syllabary, PR 9)
+
+- **Telugu కి, Kannada ಕಿ, Malayalam കി — side by side.** The three Dravidian
+  cousins write one sound three ways, and once you can read one the others are a
+  short hop. The Browse detail panel now shows, under **"Same sound, sister
+  scripts,"** the selected syllable as the *other* syllabaries write it — turning
+  "learn Telugu" into "learn the family" by making the connection visible (the
+  spiral model's whole premise: the links between languages are the memory hooks).
+- **Grounded, nothing invented.** A new pure `crossScriptSiblings` matches the
+  syllable's romanization *exactly* across scripts. That is safe because Telugu /
+  Kannada / Malayalam are all emitted by the one generator from the same
+  ISO-15919 scheme, so "ki" is byte-identical everywhere; every sibling glyph is
+  a real letter already in another script's data, pulled out by that match.
+- **Restricted to the fully-syllabic trio.** Only scripts where every letter is a
+  `syllable` (the `isSyllabary` predicate) contribute siblings, so Tamil /
+  Devanagari / Gujarati — abugidas that model a consonant and a vowel-sign
+  separately — are never mis-matched, and alphabets get no sibling row at all. A
+  Malayalam-only row (the alveolar **ṉa**) correctly shows no siblings.
+- **Control test.** Telugu "ki" resolves to the real Kannada ಕಿ + Malayalam കി
+  (and never Telugu itself); an alphabet and the Malayalam-only ṉa row yield
+  none; and — the control — the helper is read-only: `letters`, `isSyllabary` and
+  the matrix are untouched.
+
 ## 0.24.0 — the script's numerals (syllabary, PR 8)
 
 - **The syllabaries now carry their own digits.** Reading a language means

--- a/code/programs/typescript/language-ladder/README.md
+++ b/code/programs/typescript/language-ladder/README.md
@@ -194,6 +194,19 @@ these scripts write them with distinct glyphs (Telugu ౦౧౨…). Browse show
 romanized as its value, kept in a **separate `digits` field** (same non-breaking
 pattern as the vowels). Control-tested (the 10 grounded glyphs → 0–9).
 
+**The same syllable in its sister scripts.** The three cousins write one sound
+three ways — కి / ಕಿ / കി are all *ki* — and once you can read one, the others
+are a short hop. When you select a syllable in Browse, the detail panel shows it
+as the *other* syllabaries write it, under **"Same sound, sister scripts"**, so
+the family connection (the spiral model's core memory hook) is visible on the
+page. The pure `crossScriptSiblings` (`src/siblings.ts`) matches by the shared
+ISO-15919 romanization — safe because the trio come from one generator, so "ki"
+is byte-identical everywhere — and is **restricted to fully-syllabic scripts**
+(`isSyllabary`), so Tamil / Devanagari / Gujarati and the alphabets are never
+mis-matched, and a Malayalam-only row (alveolar *ṉa*) correctly shows none.
+Control-tested (Telugu *ki* → the real Kannada + Malayalam glyphs, never itself;
+read-only — `letters` / `isSyllabary` / the matrix untouched).
+
 ## Design
 
 - **`src/core.ts`** — the pure, unit-tested heart: `buildScriptView`,

--- a/code/programs/typescript/language-ladder/package.json
+++ b/code/programs/typescript/language-ladder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ladder",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "private": true,
   "description": "The unified curriculum learning app (HL03): walk the language chain concept by concept, seeing the threads back to what you already know, then review it all with a randomised SRS quiz. (Was the HL02 script-writing-visualizer, whose Browse/Practice/Lessons/Concepts modes it now subsumes.)",
   "type": "module",

--- a/code/programs/typescript/language-ladder/src/main.ts
+++ b/code/programs/typescript/language-ladder/src/main.ts
@@ -38,6 +38,7 @@ import {
   unlockedLetterIndices,
 } from "./syllabary.ts";
 import { buildSyllableMatrix } from "./matrix.ts";
+import { crossScriptSiblings, type Sibling } from "./siblings.ts";
 import type { Letter } from "./types.ts";
 import { loadLessons, indicesByLanguage, nextDue } from "./lessons.ts";
 import {
@@ -531,7 +532,7 @@ function renderMatrix(letters: Letter[]): HTMLElement | null {
   return scroll;
 }
 
-function renderDetail(v: LetterView): HTMLElement {
+function renderDetail(v: LetterView, siblings: Sibling[] = []): HTMLElement {
   const d = el("div", "detail");
   const head = el("div", "detail__head");
   const big = el("div", "detail__glyph");
@@ -563,6 +564,23 @@ function renderDetail(v: LetterView): HTMLElement {
     const p = el("p", "detail__special");
     p.textContent = v.special.hint;
     d.appendChild(section(`Special letter — tell it apart from “${v.special.plain}”`, p));
+  }
+  // The same syllable in the sibling Dravidian scripts — Telugu కి next to
+  // Kannada ಕಿ next to Malayalam കി. Seeing the three shapes for one sound is
+  // how the cousins bootstrap each other (see siblings.ts). Only appears when
+  // there is at least one sibling, i.e. only for the syllabary trio.
+  if (siblings.length > 0) {
+    const strip = el("div", "siblings");
+    for (const s of siblings) {
+      const item = el("div", "sibling");
+      const g = el("div", "sibling__glyph");
+      g.textContent = s.glyph;
+      const label = el("div", "sibling__label");
+      label.textContent = s.name;
+      item.append(g, label);
+      strip.appendChild(item);
+    }
+    d.appendChild(section(`Same sound, sister scripts — “${v.sound}” elsewhere`, strip));
   }
   // Only offer stroke order when we actually have it. The Dravidian syllabaries
   // are recognition-only (their ductus is a separate, paused effort), so showing
@@ -1456,8 +1474,11 @@ function render(): void {
     }
     if (syllabary) app!.appendChild(renderBrowseLayoutToggle());
     const matrix = syllabary && browseLayout === "matrix" ? renderMatrix(data.letters) : null;
+    // For a syllabary, offer the same syllable in its sister scripts; alphabets
+    // (where the match would be meaningless) get none.
+    const siblings = syllabary ? crossScriptSiblings(active.sound, data.script, SCRIPTS) : [];
     const body = el("div", "body");
-    body.append(matrix ?? renderGrid(views, data.direction), renderDetail(active));
+    body.append(matrix ?? renderGrid(views, data.direction), renderDetail(active, siblings));
     app!.appendChild(body);
   } else {
     if (!question) startPractice();

--- a/code/programs/typescript/language-ladder/src/siblings.ts
+++ b/code/programs/typescript/language-ladder/src/siblings.ts
@@ -1,0 +1,80 @@
+// siblings.ts — the SAME syllable, as written in the other Dravidian scripts.
+//
+// The learner's chain ends with four Dravidian cousins — Tamil → Kannada →
+// Telugu → Malayalam — and the whole point of learning them together (the
+// spiral model) is that the *connections* become the memory hooks. Telugu,
+// Kannada and Malayalam are especially close: the syllable ki is written కి
+// (Telugu), ಕಿ (Kannada), കി (Malayalam) — three different shapes for one and
+// the same sound. Once you can read one, the other two are a short hop, and the
+// fastest way to feel that is to see the three side by side.
+//
+// So when you're looking at a syllable in Browse, this helper finds that same
+// syllable — matched by its romanization — in the sibling syllabaries, and the
+// detail panel shows the sibling glyphs next to it. Nothing here is invented:
+// every sibling glyph is a real letter already present in another script's
+// generated data, pulled out by an exact `sound` match.
+//
+// Why the match is safe. Telugu, Kannada and Malayalam are all produced by the
+// one generator (generate_syllabary.py) from the same ISO-15919 scheme, so a
+// given syllable carries a byte-identical `sound` across the three ("ki" is
+// "ki" everywhere). We therefore compare sounds by exact string equality — no
+// fuzzy matching, no transliteration guesswork.
+//
+// Why we restrict to syllabaries. Only the generated Dravidian trio has every
+// letter tagged role "syllable" (see `isSyllabary`). Tamil, Devanagari and
+// Gujarati are also abugidas, but their data models a *consonant* and a
+// *vowel-sign* separately (roles "consonant" / "independent-vowel"), never a
+// pre-composed ka/ki/ku — so their "ka" is a different pedagogical unit, and
+// cross-matching it would be misleading. Restricting the sibling search to
+// scripts that are wholly syllabic keeps the comparison honest and apples-to-
+// apples. (Tamil is thus deliberately absent here; its precomposed-syllable
+// view would need its own, separate slice.)
+
+import type { ScriptData } from "./types.ts";
+import { isSyllabary } from "./syllabary.ts";
+
+/** One sibling rendering of a syllable: the same sound, a different script. */
+export interface Sibling {
+  /** The sibling script's id, e.g. "kannada". */
+  script: string;
+  /** Its human name, e.g. "Kannada" — what the panel labels the glyph with. */
+  name: string;
+  /** The syllable as that script writes it, e.g. "ಕಿ". */
+  glyph: string;
+  /** The shared romanization (identical to the source syllable's), e.g. "ki". */
+  sound: string;
+}
+
+/**
+ * The same syllable, as written in the OTHER Dravidian syllabaries.
+ *
+ * Given a syllable's romanization and the id of the script you're currently
+ * reading, scan every *other* script and, for each one that is wholly syllabic,
+ * return the glyph whose `sound` matches exactly. Scripts with no match — e.g.
+ * Malayalam's alveolar-n row (ṉa, ṉi, …), which simply has no Telugu/Kannada
+ * counterpart — contribute nothing, which is correct.
+ *
+ * Pure: it reads its arguments and allocates a fresh array; it touches no
+ * module state, mutates nothing, and never looks at the current script's own
+ * letters.
+ *
+ *   crossScriptSiblings("ki", "telugu", SCRIPTS)
+ *     → [ {script:"kannada", name:"Kannada", glyph:"ಕಿ", sound:"ki"},
+ *         {script:"malayalam", name:"Malayalam", glyph:"കി", sound:"ki"} ]
+ */
+export function crossScriptSiblings(
+  sound: string,
+  currentScript: string,
+  allScripts: ScriptData[],
+): Sibling[] {
+  const out: Sibling[] = [];
+  for (const data of allScripts) {
+    if (data.script === currentScript) continue; // never echo the source script
+    if (!isSyllabary(data.letters)) continue; // only the fully-syllabic cousins
+    const match = data.letters.find((l) => l.sound === sound);
+    if (match) {
+      out.push({ script: data.script, name: data.name, glyph: match.glyph, sound });
+    }
+  }
+  return out;
+}

--- a/code/programs/typescript/language-ladder/src/styles.css
+++ b/code/programs/typescript/language-ladder/src/styles.css
@@ -517,3 +517,13 @@ body {
 }
 .ivowel__glyph { font-size: 1.35rem; line-height: 1.1; }
 .ivowel__sound { font-size: 0.68rem; color: var(--muted); }
+
+/* The same syllable in the sister Dravidian scripts, shown in the detail panel. */
+.siblings { display: flex; flex-wrap: wrap; gap: 8px; }
+.sibling {
+  display: flex; flex-direction: column; align-items: center; gap: 2px;
+  min-width: 56px; padding: 8px 10px;
+  background: var(--card); border: 1px solid var(--line); border-radius: 8px;
+}
+.sibling__glyph { font-size: 2rem; line-height: 1.1; }
+.sibling__label { font-size: 0.7rem; color: var(--muted); }

--- a/code/programs/typescript/language-ladder/tests/siblings.test.ts
+++ b/code/programs/typescript/language-ladder/tests/siblings.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { SCRIPTS } from "../src/data";
+import { crossScriptSiblings } from "../src/siblings";
+import { isSyllabary } from "../src/syllabary";
+import { buildSyllableMatrix } from "../src/matrix";
+
+describe("cross-script siblings (the same syllable in the sister scripts)", () => {
+  it("Telugu “ki” → the real Kannada and Malayalam glyphs, matched by sound", () => {
+    const sibs = crossScriptSiblings("ki", "telugu", SCRIPTS);
+    // Two siblings, in SCRIPTS order (kannada before malayalam), never Telugu itself.
+    expect(sibs.map((s) => s.script)).toEqual(["kannada", "malayalam"]);
+    const by = Object.fromEntries(sibs.map((s) => [s.script, s]));
+    expect(by.kannada.glyph).toBe("ಕಿ");
+    expect(by.kannada.name).toBe("Kannada");
+    expect(by.malayalam.glyph).toBe("കി");
+    // The shared romanization rides along unchanged.
+    expect(sibs.every((s) => s.sound === "ki")).toBe(true);
+  });
+
+  it("works symmetrically from any of the trio (Malayalam “kha” → Telugu + Kannada)", () => {
+    const sibs = crossScriptSiblings("kha", "malayalam", SCRIPTS);
+    expect(sibs.map((s) => s.script)).toEqual(["kannada", "telugu"]);
+    expect(sibs.find((s) => s.script === "telugu")!.glyph).toBe("ఖ");
+  });
+
+  it("a syllable with no counterpart yields no siblings (Malayalam-only ṉa row)", () => {
+    // The alveolar-n row (ṉa, ṉi, …) exists only in Malayalam — Telugu/Kannada
+    // have no such consonant, so there is nothing to show, correctly.
+    expect(crossScriptSiblings("ṉa", "malayalam", SCRIPTS)).toEqual([]);
+  });
+
+  it("CONTROL: only the syllabary trio are siblings — an alphabet is never matched", () => {
+    // Cyrillic “a” must not pull in any Dravidian syllable, nor vice versa.
+    expect(crossScriptSiblings("a", "cyrillic", SCRIPTS)).toEqual([]);
+    // And the source script never appears in its own sibling list.
+    const sibs = crossScriptSiblings("ka", "kannada", SCRIPTS);
+    expect(sibs.some((s) => s.script === "kannada")).toBe(false);
+    expect(sibs.map((s) => s.script)).toEqual(["telugu", "malayalam"]);
+  });
+
+  it("CONTROL: siblings are read-only — letters, isSyllabary and the matrix are untouched", () => {
+    const telugu = SCRIPTS.find((s) => s.script === "telugu")!;
+    const before = telugu.letters.length;
+    crossScriptSiblings("ki", "telugu", SCRIPTS);
+    expect(telugu.letters.length).toBe(before);
+    expect(isSyllabary(telugu.letters)).toBe(true);
+    expect(buildSyllableMatrix(telugu.letters as never)!.rows.length).toBe(35);
+  });
+});


### PR DESCRIPTION
## What & why

The learner's chain ends in four Dravidian cousins, and the whole reason to learn them together (the spiral model) is that the **connections become the memory hooks**. Telugu, Kannada and Malayalam are especially close — one sound, three shapes — so once you can read one, the other two are a short hop.

This PR makes that visible: in **Browse**, selecting a Dravidian syllable now shows it as the *other* syllabaries write it, in the detail panel under **"Same sound, sister scripts"**.

### Native-reader eyeball — the same sound across the trio

| sound | Telugu | Kannada | Malayalam |
|-------|--------|---------|-----------|
| ka | క | ಕ | ക |
| ki | కి | ಕಿ | കി |
| ku | కు | ಕು | കു |
| kha | ఖ | ಖ | ഖ |
| ṭa | ట | ಟ | ട |
| ḷa | ళ | ಳ | ള |

(All pulled straight from the existing generated JSON — please confirm the glyphs read correctly.)

## Grounding (non-negotiable)

- New pure `crossScriptSiblings` (`src/siblings.ts`) matches the syllable's **romanization exactly** across scripts. Safe because Telugu/Kannada/Malayalam are all emitted by the one generator from the same ISO-15919 scheme, so `"ki"` is byte-identical everywhere.
- Every sibling glyph is a **real letter already in another script's data**, pulled out by that match — **no glyph or romanization is hand-typed into source**.
- **Restricted to the fully-syllabic trio** via the existing `isSyllabary` predicate, so Tamil / Devanagari / Gujarati (abugidas that model a consonant + vowel-sign separately) and the alphabets are never mis-matched. A Malayalam-only row (alveolar **ṉa**) correctly shows no siblings.
- Read-only: `letters`, `isSyllabary` and the matrix are untouched.

## Tests & verification

- **Control test** (`tests/siblings.test.ts`): Telugu `"ki"` → the real Kannada ಕಿ + Malayalam കി (never itself); an alphabet and the ṉa row yield none; helper is read-only.
- App suite **263 → 268**, human-language-data **38**, build clean.
- **Browser-verified** (headless Chrome): Telugu కి selected → the sister-scripts strip renders Kannada ಕಿ + Malayalam కി.
- Grounding-reviewed by a subagent (a mislabeled Malayalam glyph in the CHANGELOG prose was caught and fixed before commit).

## Scope

One bounded slice. Tamil is deliberately excluded — its precomposed-syllable view would need its own separate slice (different data model). No fabricated conjuncts or archaic vocalics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)