### PR TITLE
feat(adj-formula-stdlib): minute-ventilation — minute volume MV = TV × Rf 3-way inverter (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_minute_ventilation_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_minute_ventilation_e2e.rs
@@ -1,0 +1,142 @@
+//! End-to-end tests for the `clinical/minute-ventilation.adj` library — the definition
+//! of minute ventilation (minute volume MV = tidal volume TV × respiratory frequency
+//! Rf) and its two exact rearrangements (TV = MV/Rf, Rf = MV/TV) — driven through the
+//! built CLI binary against the SHIPPED stdlib.
+//! Each proves the same invariant as the other formula libraries: a consumer states
+//! NO arithmetic; it imports the grounded library, binds the respiratory quantities
+//! with `observe`, and the engine applies the cited definition on the CPU, computing
+//! the EXACT value and rendering the definition's citation and trust tier in the
+//! `derived` section (the auditable answer). The three formulas INVERT around the
+//! worked case TV = 500 mL, Rf = 12 breaths/min: 500 * 12 = 6000, and both
+//! 6000 / 12 = 500 and 6000 / 500 = 12 recover the inputs.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped minute-ventilation library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_minute_ventilation_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/minute-ventilation.adj")
+        .canonicalize()
+        .expect("shipped minute-ventilation.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_mv_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_minute_ventilation_lib()).unwrap();
+    std::fs::write(dir.join("minute-ventilation.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// minute_volume — the definition: the tidal volume times the respiratory frequency.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_minute_ventilation_library_and_computes_definition_with_citation() {
+    let dir = scratch("def");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"minute-ventilation.adj\"\n\
+         observe tidal_volume(500)\n\
+         observe respiratory_frequency(12)\n\
+         ? minute_volume(tidal_volume, respiratory_frequency)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied definition's result: 500 * 12 = 6000.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"minute_volume\"") && s.contains("\"value\":6000"),
+        "minute_volume(500, 12) = 6000: {s}"
+    );
+    // … AND the LibreTexts citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("med.libretexts.org"),
+        "applied definition carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// tidal_volume — the same definition solved for TV: the minute volume divided by the
+// respiratory frequency, which INVERTS the minute volume just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_tidal_volume_as_minute_volume_over_frequency_with_citation() {
+    let dir = scratch("tv");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"minute-ventilation.adj\"\n\
+         observe minute_volume(6000)\n\
+         observe respiratory_frequency(12)\n\
+         ? tidal_volume(minute_volume, respiratory_frequency)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 6000 / 12 = 500, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"tidal_volume\"") && s.contains("\"value\":500"),
+        "tidal_volume(6000, 12) = 500: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("med.libretexts.org"),
+        "tidal_volume carries its LibreTexts citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// respiratory_frequency — the same definition solved for Rf: the minute volume divided
+// by the tidal volume, the third exact reading of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_frequency_as_minute_volume_over_tidal_volume_with_citation() {
+    let dir = scratch("rf");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"minute-ventilation.adj\"\n\
+         observe minute_volume(6000)\n\
+         observe tidal_volume(500)\n\
+         ? respiratory_frequency(minute_volume, tidal_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 6000 / 500 = 12, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"respiratory_frequency\"") && s.contains("\"value\":12"),
+        "respiratory_frequency(6000, 500) = 12: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("med.libretexts.org"),
+        "respiratory_frequency carries its LibreTexts citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/minute-ventilation.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/minute-ventilation.adj
@@ -1,0 +1,103 @@
+% ============================================================================
+% minute-ventilation.adj — the definition of minute ventilation
+% (minute volume MV = tidal volume × respiratory frequency) in the ADJ standard
+% library.
+% ============================================================================
+% The minute-ventilation entry of the *clinical* track, a respiratory-physiology
+% sibling of `cardiac-output.adj` and `mean-arterial-pressure.adj`: the foundational
+% pulmonary definition a first course states as THE MINUTE VOLUME IS THE TIDAL VOLUME
+% MULTIPLIED BY THE RESPIRATORY FREQUENCY — the total volume of air moved in and out of
+% the lungs per minute — as an importable, byte-provenanced, PARAMETERIZED `formula`,
+% together with its two exact rearrangements (the tidal volume a minute volume implies
+% for a respiratory frequency, and the respiratory frequency it implies for a tidal
+% volume). As with every compute library, a consumer states NO arithmetic: it
+% `import`s this file, binds the measured quantities from its own byte-provenance
+% decomposition, and asks the engine to APPLY the cited definition on the CPU. Zero
+% math is performed by the model; the engine computes each value EXACTLY, carrying the
+% definition's citation.
+%
+%     import "minute-ventilation.adj"
+%     observe tidal_volume(500)             % "…500 mL per breath…"  (span cited by the model)
+%     observe respiratory_frequency(12)     % "…12 breaths/min…"     (span cited by the model)
+%     ? minute_volume(tidal_volume, respiratory_frequency)
+%                                          % engine → 6000, carrying MV = TV·Rf
+%
+% All three formulas are EXACT over their parameters — one a product, two quotients of
+% measured quantities. There is no *separately grounded* physiological constant here,
+% so every value the engine returns is exact. The three COMPOSE and invert cleanly
+% around the worked case TV = 500 mL, Rf = 12 breaths/min (MV = 500·12 = 6000 mL/min
+% = 6 L/min, the average resting value): the `minute_volume` a consumer computes from a
+% tidal volume and respiratory frequency is exactly the `minute_volume` the
+% `tidal_volume` formula divides by that respiratory frequency to recover the tidal
+% volume, and exactly the `minute_volume` the `respiratory_frequency` formula divides by
+% that tidal volume to recover the respiratory frequency.
+%
+%   minute_volume(tidal_volume, respiratory_frequency)         = tidal_volume * respiratory_frequency  % MV = TV·Rf  (definition)
+%   tidal_volume(minute_volume, respiratory_frequency)         = minute_volume / respiratory_frequency  % TV = MV/Rf  (same def, solved for TV)
+%   respiratory_frequency(minute_volume, tidal_volume)         = minute_volume / tidal_volume           % Rf = MV/TV  (same def, solved for Rf)
+%
+% NOTE: the units must be consistent — a tidal volume in millilitres per breath and a
+% respiratory frequency in breaths per minute give a minute volume in millilitres per
+% minute (divide by 1000 for L/min); this library computes the exact value over
+% whatever consistent units it is given.
+%
+% All three formulas are defended by the SAME definitional sentence — "To calculate the
+% minute volume: MV=TV*Rf, or, the minute volume is equal to tidal volume multiplied by
+% the respiratory frequency (number of breaths per minute)." — because that one
+% definition (minute volume IS tidal volume times respiratory frequency) sanctions the
+% relation read every way (MV from TV and Rf, TV from MV and Rf, or Rf from MV and TV).
+% The quote is transcribed verbatim from a university-hosted open human-physiology lab
+% text on Medicine LibreTexts (the same primary reference family the other clinical
+% libraries draw on), so each `formula` carries the provenance envelope every shipped
+% grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the definitional sentence is a verbatim span of the
+% cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable respiratory quantity the definition
+% ranges over, and each result is the derived quantity. `tidal_volume`,
+% `respiratory_frequency` and `minute_volume` each appear BOTH as a derived result and
+% as an input (of the other formulas), so each is a single dictionary term used in both
+% roles. The `surface` lists are the everyday names a decomposer maps onto the
+% canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary minute_ventilation_vocab {
+    define tidal_volume          : finding  surface "tidal volume", "TV"                                 % millilitres per breath (mL)
+    define respiratory_frequency : finding  surface "respiratory frequency", "respiratory rate", "Rf", "RR"  % breaths per minute
+    define minute_volume         : finding  surface "minute volume", "minute ventilation", "MV"          % millilitres per minute (mL/min)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable `let` over its
+% formal parameters, bound at apply time, and each carries the definitional quote from
+% the LibreTexts human-physiology text (a quote is required on a shipped formula). One
+% is a product and two are quotients, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook minute_ventilation_laws {
+    use minute_ventilation_vocab
+
+    % Minute volume — the product of tidal volume and respiratory frequency. The text
+    % defines the minute volume as the tidal volume multiplied by the respiratory
+    % frequency, i.e. MV = TV·Rf.
+    formula minute_volume(tidal_volume, respiratory_frequency) = tidal_volume * respiratory_frequency
+        source "To calculate the minute volume: MV=TV*Rf, or, the minute volume is equal to tidal volume multiplied by the respiratory frequency (number of breaths per minute)."
+        locator "https://med.libretexts.org/Bookshelves/Anatomy_and_Physiology/A_Mixed_Course_Based_Research_Approach_to_Human_Physiology_(Whitmer)/02:_Labs/2.12:_Assessment_of_Pulmonary_Function"
+        trust authoritative
+
+    % Tidal volume — the same definition solved for the tidal volume a minute volume
+    % implies for a respiratory frequency (TV = MV/Rf). Defended by the SAME definitional
+    % sentence, read the other way.
+    formula tidal_volume(minute_volume, respiratory_frequency) = minute_volume / respiratory_frequency
+        source "To calculate the minute volume: MV=TV*Rf, or, the minute volume is equal to tidal volume multiplied by the respiratory frequency (number of breaths per minute)."
+        locator "https://med.libretexts.org/Bookshelves/Anatomy_and_Physiology/A_Mixed_Course_Based_Research_Approach_to_Human_Physiology_(Whitmer)/02:_Labs/2.12:_Assessment_of_Pulmonary_Function"
+        trust authoritative
+
+    % Respiratory frequency — the same definition solved for the respiratory frequency a
+    % minute volume implies for a tidal volume (Rf = MV/TV). Again the SAME definitional
+    % sentence, read the third way.
+    formula respiratory_frequency(minute_volume, tidal_volume) = minute_volume / tidal_volume
+        source "To calculate the minute volume: MV=TV*Rf, or, the minute volume is equal to tidal volume multiplied by the respiratory frequency (number of breaths per minute)."
+        locator "https://med.libretexts.org/Bookshelves/Anatomy_and_Physiology/A_Mixed_Course_Based_Research_Approach_to_Human_Physiology_(Whitmer)/02:_Labs/2.12:_Assessment_of_Pulmonary_Function"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/minute-ventilation.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/minute-ventilation.query.adj
@@ -1,0 +1,34 @@
+% ============================================================================
+% minute-ventilation.query.adj — worked examples over the clinical minute-ventilation
+% library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a minute-ventilation
+% question: it states NO arithmetic and NO definition — it only `import`s the grounded
+% library, `observe`s the respiratory quantities it decomposed from the prompt (each a
+% byte-provenanced span, elided here), and asks the engine to APPLY the cited
+% definition. The native adj-lang engine binds the parameters, computes each value
+% EXACTLY on the CPU, and returns it with the definition's source/locator/trust.
+%
+% The three questions INVERT: breathing 500 mL per breath at 12 breaths/min gives a
+% minute volume of 500·12 = 6000 mL/min (6 L/min); that 6000 mL/min at the same 12
+% breaths/min is exactly what the tidal-volume formula divides to recover the 500 mL,
+% and that 6000 mL/min at the same 500 mL tidal volume is exactly what the
+% respiratory-frequency formula divides to recover the 12 breaths/min.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli minute-ventilation.query.adj
+% ============================================================================
+
+import "minute-ventilation.adj"
+
+% 500 mL/breath at 12 breaths/min: minute volume = 500 * 12.
+observe tidal_volume(500)
+observe respiratory_frequency(12)
+? minute_volume(tidal_volume, respiratory_frequency)   % expect 6000  (definition: MV = TV·Rf)
+
+% That 6000 mL/min for the same 12 breaths/min: tidal volume = 6000 / 12.
+observe minute_volume(6000)
+? tidal_volume(minute_volume, respiratory_frequency)    % expect 500   (same definition, solved for TV = MV/Rf)
+
+% That 6000 mL/min at the same 500 mL tidal volume: respiratory frequency = 6000 / 500.
+? respiratory_frequency(minute_volume, tidal_volume)    % expect 12    (same definition, solved for Rf = MV/TV)


### PR DESCRIPTION
## What

Adds the clinical **minute-ventilation** library — a respiratory-physiology sibling of `cardiac-output.adj` and `mean-arterial-pressure.adj`. Minute volume is the tidal volume times the respiratory frequency, shipped as a byte-provenanced, parameterized `formula` together with its two exact rearrangements:

| formula | body | reading |
|---|---|---|
| `minute_volume(tidal_volume, respiratory_frequency)` | `tidal_volume * respiratory_frequency` | MV = TV·Rf  (definition) |
| `tidal_volume(minute_volume, respiratory_frequency)` | `minute_volume / respiratory_frequency` | TV = MV/Rf |
| `respiratory_frequency(minute_volume, tidal_volume)` | `minute_volume / tidal_volume` | Rf = MV/TV |

A consumer states **no arithmetic** — it imports the grounded library, `observe`s the measured respiratory quantities from its own byte-provenance decomposition, and the engine applies the cited definition on the CPU, **exact**, carrying the definition's `source`/`locator`/`trust`.

## Grounding

There is no separately grounded physiological constant here, so every value is exact. All three formulas carry the **verbatim** definitional sentence — "To calculate the minute volume: MV=TV\*Rf, or, the minute volume is equal to tidal volume multiplied by the respiratory frequency (number of breaths per minute)." — from a university-hosted open human-physiology lab text on Medicine LibreTexts (the same primary-reference family the other clinical libraries draw on). `trust authoritative`; byte-verified against the cited page.

The three **INVERT** around the worked case TV=500 mL, Rf=12 breaths/min → MV=6000 mL/min (6 L/min) → recovers TV=500 and Rf=12.

## Files

- `clinical/minute-ventilation.adj` — the grounded 3-way formula library
- `clinical/minute-ventilation.query.adj` — worked inverting lookups (6000 / 500 / 12)
- `adj-lang-cli/tests/formula_minute_ventilation_e2e.rs` — 3 dedicated e2e tests driving the built CLI against the shipped library

## Verification

- `cargo test -p adj-lang-cli --test formula_minute_ventilation_e2e` → **3/3 pass** (assert exact 6000/500/12 + `trust authoritative` + `med.libretexts.org` on each answer)
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean
- Shipped query run through the CLI → `6000` / `500` / `12` exact, each carrying `trust authoritative` and the LibreTexts locator
- NUL-scan: 0 bytes in all three files
- Data + test only — **no version bump**
- `/security-review` → PASSED (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)