### PR TITLE
Add MOS source resistance

### DIFF
--- a/code/packages/python/mosfet-models/CHANGELOG.md
+++ b/code/packages/python/mosfet-models/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [0.1.0] — Unreleased
 
 ### Added
+- `Level1Params.RS` adds the zero-default Berkeley external source resistance
+  parameter with finite, non-negative validation.
 - `Level1Params.RD` adds the zero-default Berkeley external drain resistance
   parameter with finite, non-negative validation.
 - `Level1Params.TOX` adds Berkeley-default gate oxide thickness and derives

--- a/code/packages/python/mosfet-models/README.md
+++ b/code/packages/python/mosfet-models/README.md
@@ -26,8 +26,8 @@ print(r.Id, r.gm, r.gds, r.region)
   sane defaults for 130 nm-style NMOS, including zero-default `LD` lateral
   diffusion through `L_eff = L - 2*LD`, `PB` / `MJ` / `FC` bulk-junction
   depletion shaping, Berkeley-default `TOX` gate oxide thickness for intrinsic
-  Meyer capacitance through `Cox = epsilon_ox / TOX`, zero-default `RD`
-  external drain resistance, and `KF` / `AF` flicker noise.
+  Meyer capacitance through `Cox = epsilon_ox / TOX`, zero-default `RD` / `RS`
+  external drain/source resistance, and `KF` / `AF` flicker noise.
 - `evaluate_level1(params, V_GS, V_DS, V_BS, T)`: returns `MosResult` with Id, gm, gds, gmb, Cgs/Cgd/Cgb/Cbs/Cbd, region.
 - Region detection: cutoff (subthreshold-aware), triode, saturation.
 - Body effect via gamma * (sqrt(PHI-V_BS) - sqrt(PHI)) shift.

--- a/code/packages/python/mosfet-models/src/mosfet_models/level1.py
+++ b/code/packages/python/mosfet-models/src/mosfet_models/level1.py
@@ -30,6 +30,7 @@ class Level1Params:
     LD: float = 0.0  # source/drain lateral diffusion length (m)
     TOX: float = 1e-7  # gate oxide thickness (m)
     RD: float = 0.0  # external drain resistance (ohm)
+    RS: float = 0.0  # external source resistance (ohm)
     IS: float = 1e-15  # saturation current (A)
     N_SUB: float = 1.4  # subthreshold slope factor
     T_NOM: float = 300.15  # nominal temperature (K)
@@ -125,6 +126,8 @@ def evaluate_level1(
         raise ValueError("MOSFET TOX must be finite and positive")
     if not isfinite(p.RD) or p.RD < 0.0:
         raise ValueError("MOSFET RD must be finite and non-negative")
+    if not isfinite(p.RS) or p.RS < 0.0:
+        raise ValueError("MOSFET RS must be finite and non-negative")
     beta = p.KP * (p.W / effective_length)
 
     # Threshold with body effect. The formula is well-defined whenever

--- a/code/packages/python/mosfet-models/tests/test_models.py
+++ b/code/packages/python/mosfet-models/tests/test_models.py
@@ -175,6 +175,14 @@ def test_drain_resistance_rejects_negative_value():
         evaluate_level1(Level1Params(RD=-1.0), V_GS=1.8, V_DS=1.8)
 
 
+def test_source_resistance_rejects_negative_value():
+    with pytest.raises(
+        ValueError,
+        match="MOSFET RS must be finite and non-negative",
+    ):
+        evaluate_level1(Level1Params(RS=-1.0), V_GS=1.8, V_DS=1.8)
+
+
 def test_overlap_and_bulk_capacitances_are_reported():
     p = Level1Params(
         W=2e-6,

--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- Add Level-1 MOS model-card `RS` support. Nonzero values create an intrinsic
+  source node, stamp the external resistor in DC, TF, AC, and transient
+  analyses, route source-side capacitances through it, and emit `:RS` Johnson
+  noise.
 - Add Level-1 MOS model-card `RD` support. Nonzero values create an intrinsic
   drain node, stamp the external resistor in DC, TF, AC, and transient
   analyses, route drain-side capacitances through it, and emit `:RD` Johnson

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -96,6 +96,9 @@ Meyer gate capacitance from `Cox = epsilon_ox / TOX`.
 `RD` defaults to zero ohms. A finite positive value inserts an intrinsic drain
 node, routes the channel and drain-side capacitances through it, and contributes
 `4kT/RD` thermal noise.
+`RS` defaults to zero ohms. A finite positive value inserts an intrinsic source
+node, routes the channel and source-side capacitances through it, and contributes
+`4kT/RS` thermal noise.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -7336,6 +7336,8 @@ def _element_nodes(el: Element) -> list[str]:
         nodes = [el.drain, el.gate, el.source, el.body]
         if _mosfet_drain_resistance(el) > 0.0:
             nodes.append(_mosfet_intrinsic_drain_node(el))
+        if _mosfet_source_resistance(el) > 0.0:
+            nodes.append(_mosfet_intrinsic_source_node(el))
         return nodes
     if isinstance(el, BJT):
         nodes = [el.collector, el.base, el.emitter]
@@ -9074,6 +9076,20 @@ def _mosfet_intrinsic_drain_node(el: Mosfet) -> str:
     )
 
 
+def _mosfet_source_resistance(el: Mosfet) -> float:
+    params = getattr(getattr(el.model, "model", None), "params", None)
+    return float(getattr(params, "RS", 0.0))
+
+
+def _mosfet_intrinsic_source_node(el: Mosfet) -> str:
+    source_resistance = _mosfet_source_resistance(el)
+    return (
+        el.source
+        if not math.isfinite(source_resistance) or source_resistance <= 0.0
+        else f"__spice_{el.name}_source"
+    )
+
+
 def _mosfet_charge_state_specs(el: Mosfet) -> list[tuple[str, str, str, float]]:
     params = getattr(getattr(el.model, "model", None), "params", None)
     if params is None:
@@ -9087,7 +9103,14 @@ def _mosfet_charge_state_specs(el: Mosfet) -> list[tuple[str, str, str, float]]:
     cbs = getattr(params, "CBS", 0.0)
     cbd = getattr(params, "CBD", 0.0)
     if cgs > 0.0:
-        specs.append((_mosfet_gate_source_charge_state_name(el), el.gate, el.source, cgs))
+        specs.append(
+            (
+                _mosfet_gate_source_charge_state_name(el),
+                el.gate,
+                _mosfet_intrinsic_source_node(el),
+                cgs,
+            )
+        )
     if cgd > 0.0:
         specs.append(
             (
@@ -9100,7 +9123,14 @@ def _mosfet_charge_state_specs(el: Mosfet) -> list[tuple[str, str, str, float]]:
     if cgb > 0.0:
         specs.append((_mosfet_gate_body_charge_state_name(el), el.gate, el.body, cgb))
     if cbs > 0.0:
-        specs.append((_mosfet_source_body_charge_state_name(el), el.source, el.body, cbs))
+        specs.append(
+            (
+                _mosfet_source_body_charge_state_name(el),
+                _mosfet_intrinsic_source_node(el),
+                el.body,
+                cbs,
+            )
+        )
     if cbd > 0.0:
         specs.append(
             (
@@ -9164,9 +9194,10 @@ def _stamp_mosfet(
 ) -> None:
     """Linearized MOSFET via mosfet_models.MOSFET.dc()."""
     intrinsic_drain = _mosfet_intrinsic_drain_node(el)
+    intrinsic_source = _mosfet_intrinsic_source_node(el)
     Vd = 0.0 if _is_ground(intrinsic_drain) else x[node_to_idx[intrinsic_drain]]
     Vg = 0.0 if _is_ground(el.gate) else x[node_to_idx[el.gate]]
-    Vs = 0.0 if _is_ground(el.source) else x[node_to_idx[el.source]]
+    Vs = 0.0 if _is_ground(intrinsic_source) else x[node_to_idx[intrinsic_source]]
     Vb = 0.0 if _is_ground(el.body) else x[node_to_idx[el.body]]
 
     V_GS = Vg - Vs
@@ -9180,26 +9211,26 @@ def _stamp_mosfet(
     gds = r.gds
 
     # Stamp gds (drain-source conductance) + Id companion source.
-    _stamp_g(G, node_to_idx, intrinsic_drain, el.source, gds)
+    _stamp_g(G, node_to_idx, intrinsic_drain, intrinsic_source, gds)
     # Stamp gm (transconductance: drain-current per V_GS).
     if not _is_ground(intrinsic_drain):
         d = node_to_idx[intrinsic_drain]
         if not _is_ground(el.gate):
             G[d][node_to_idx[el.gate]] += gm
-        if not _is_ground(el.source):
-            G[d][node_to_idx[el.source]] -= gm
-    if not _is_ground(el.source):
-        s = node_to_idx[el.source]
+        if not _is_ground(intrinsic_source):
+            G[d][node_to_idx[intrinsic_source]] -= gm
+    if not _is_ground(intrinsic_source):
+        s = node_to_idx[intrinsic_source]
         if not _is_ground(el.gate):
             G[s][node_to_idx[el.gate]] -= gm
-        if not _is_ground(el.source):
-            G[s][node_to_idx[el.source]] += gm
+        if not _is_ground(intrinsic_source):
+            G[s][node_to_idx[intrinsic_source]] += gm
     # Companion current source for Id at this operating point
     Ieq = Id - gm * V_GS - gds * V_DS
     if not _is_ground(intrinsic_drain):
         b[node_to_idx[intrinsic_drain]] -= Ieq
-    if not _is_ground(el.source):
-        b[node_to_idx[el.source]] += Ieq
+    if not _is_ground(intrinsic_source):
+        b[node_to_idx[intrinsic_source]] += Ieq
     drain_resistance = _mosfet_drain_resistance(el)
     if drain_resistance > 0.0:
         _stamp_g(
@@ -9208,6 +9239,15 @@ def _stamp_mosfet(
             el.drain,
             intrinsic_drain,
             1.0 / drain_resistance,
+        )
+    source_resistance = _mosfet_source_resistance(el)
+    if source_resistance > 0.0:
+        _stamp_g(
+            G,
+            node_to_idx,
+            el.source,
+            intrinsic_source,
+            1.0 / source_resistance,
         )
 
 
@@ -13078,35 +13118,40 @@ def _stamp_ac(
         # Small-signal model: gds (output conductance) + gm (transconductance).
         # The gm VCCS is stamped as off-diagonal conductance entries.
         intrinsic_drain = _mosfet_intrinsic_drain_node(el)
+        intrinsic_source = _mosfet_intrinsic_source_node(el)
         Vd = (
             0.0
             if _is_ground(intrinsic_drain)
             else dc_x[node_to_idx[intrinsic_drain]]
         )
         Vg = 0.0 if _is_ground(el.gate) else dc_x[node_to_idx[el.gate]]
-        Vs = 0.0 if _is_ground(el.source) else dc_x[node_to_idx[el.source]]
+        Vs = (
+            0.0
+            if _is_ground(intrinsic_source)
+            else dc_x[node_to_idx[intrinsic_source]]
+        )
         Vb = 0.0 if _is_ground(el.body) else dc_x[node_to_idx[el.body]]
         r = el.model.dc(Vg - Vs, Vd - Vs, Vb - Vs)  # type: ignore[attr-defined]
         gm_m: float = r.gm
         gds_m: float = r.gds
-        _stamp_g_c(G, node_to_idx, intrinsic_drain, el.source, gds_m + 0j)
-        _stamp_g_c(G, node_to_idx, el.gate, el.source, 1j * omega * r.Cgs)
+        _stamp_g_c(G, node_to_idx, intrinsic_drain, intrinsic_source, gds_m + 0j)
+        _stamp_g_c(G, node_to_idx, el.gate, intrinsic_source, 1j * omega * r.Cgs)
         _stamp_g_c(G, node_to_idx, el.gate, intrinsic_drain, 1j * omega * r.Cgd)
         _stamp_g_c(G, node_to_idx, el.gate, el.body, 1j * omega * r.Cgb)
-        _stamp_g_c(G, node_to_idx, el.body, el.source, 1j * omega * r.Cbs)
+        _stamp_g_c(G, node_to_idx, el.body, intrinsic_source, 1j * omega * r.Cbs)
         _stamp_g_c(G, node_to_idx, el.body, intrinsic_drain, 1j * omega * r.Cbd)
         if not _is_ground(intrinsic_drain):
             d = node_to_idx[intrinsic_drain]
             if not _is_ground(el.gate):
                 G[d][node_to_idx[el.gate]] += gm_m + 0j
-            if not _is_ground(el.source):
-                G[d][node_to_idx[el.source]] -= gm_m + 0j
-        if not _is_ground(el.source):
-            s = node_to_idx[el.source]
+            if not _is_ground(intrinsic_source):
+                G[d][node_to_idx[intrinsic_source]] -= gm_m + 0j
+        if not _is_ground(intrinsic_source):
+            s = node_to_idx[intrinsic_source]
             if not _is_ground(el.gate):
                 G[s][node_to_idx[el.gate]] -= gm_m + 0j
-            if not _is_ground(el.source):
-                G[s][node_to_idx[el.source]] += gm_m + 0j
+            if not _is_ground(intrinsic_source):
+                G[s][node_to_idx[intrinsic_source]] += gm_m + 0j
         drain_resistance = _mosfet_drain_resistance(el)
         if drain_resistance > 0.0:
             _stamp_g_c(
@@ -13115,6 +13160,15 @@ def _stamp_ac(
                 el.drain,
                 intrinsic_drain,
                 1.0 / drain_resistance,
+            )
+        source_resistance = _mosfet_source_resistance(el)
+        if source_resistance > 0.0:
+            _stamp_g_c(
+                G,
+                node_to_idx,
+                el.source,
+                intrinsic_source,
+                1.0 / source_resistance,
             )
 
     elif isinstance(el, BJT):
@@ -13819,30 +13873,35 @@ def _build_ss_matrix(
             # Small-signal model: gds (drain–source) + gm VCCS (gate–source
             # controls drain current).  Mirrors the AC _stamp_ac Mosfet block.
             intrinsic_drain = _mosfet_intrinsic_drain_node(el)
+            intrinsic_source = _mosfet_intrinsic_source_node(el)
             Vd = (
                 0.0
                 if _is_ground(intrinsic_drain)
                 else dc_x[node_to_idx[intrinsic_drain]]
             )
             Vg = 0.0 if _is_ground(el.gate) else dc_x[node_to_idx[el.gate]]
-            Vs = 0.0 if _is_ground(el.source) else dc_x[node_to_idx[el.source]]
+            Vs = (
+                0.0
+                if _is_ground(intrinsic_source)
+                else dc_x[node_to_idx[intrinsic_source]]
+            )
             Vb = 0.0 if _is_ground(el.body) else dc_x[node_to_idx[el.body]]
             r = el.model.dc(Vg - Vs, Vd - Vs, Vb - Vs)  # type: ignore[attr-defined]
             gm_m: float = r.gm
             gds_m: float = r.gds
-            _stamp_g(G, node_to_idx, intrinsic_drain, el.source, gds_m)
+            _stamp_g(G, node_to_idx, intrinsic_drain, intrinsic_source, gds_m)
             if not _is_ground(intrinsic_drain):
                 d = node_to_idx[intrinsic_drain]
                 if not _is_ground(el.gate):
                     G[d][node_to_idx[el.gate]] += gm_m
-                if not _is_ground(el.source):
-                    G[d][node_to_idx[el.source]] -= gm_m
-            if not _is_ground(el.source):
-                s = node_to_idx[el.source]
+                if not _is_ground(intrinsic_source):
+                    G[d][node_to_idx[intrinsic_source]] -= gm_m
+            if not _is_ground(intrinsic_source):
+                s = node_to_idx[intrinsic_source]
                 if not _is_ground(el.gate):
                     G[s][node_to_idx[el.gate]] -= gm_m
-                if not _is_ground(el.source):
-                    G[s][node_to_idx[el.source]] += gm_m
+                if not _is_ground(intrinsic_source):
+                    G[s][node_to_idx[intrinsic_source]] += gm_m
             drain_resistance = _mosfet_drain_resistance(el)
             if drain_resistance > 0.0:
                 _stamp_g(
@@ -13851,6 +13910,15 @@ def _build_ss_matrix(
                     el.drain,
                     intrinsic_drain,
                     1.0 / drain_resistance,
+                )
+            source_resistance = _mosfet_source_resistance(el)
+            if source_resistance > 0.0:
+                _stamp_g(
+                    G,
+                    node_to_idx,
+                    el.source,
+                    intrinsic_source,
+                    1.0 / source_resistance,
                 )
 
         elif isinstance(el, BJT):
@@ -15677,13 +15745,18 @@ def _collect_noise_sources(
         elif isinstance(el, Mosfet):
             # Long-channel channel thermal noise plus model-card 1/f noise.
             intrinsic_drain = _mosfet_intrinsic_drain_node(el)
+            intrinsic_source = _mosfet_intrinsic_source_node(el)
             Vd = (
                 0.0
                 if _is_ground(intrinsic_drain)
                 else dc_x[node_to_idx[intrinsic_drain]]
             )
             Vg = 0.0 if _is_ground(el.gate) else dc_x[node_to_idx[el.gate]]
-            Vs = 0.0 if _is_ground(el.source) else dc_x[node_to_idx[el.source]]
+            Vs = (
+                0.0
+                if _is_ground(intrinsic_source)
+                else dc_x[node_to_idx[intrinsic_source]]
+            )
             Vb = 0.0 if _is_ground(el.body) else dc_x[node_to_idx[el.body]]
             r = el.model.dc(Vg - Vs, Vd - Vs, Vb - Vs)  # type: ignore[attr-defined]
             flicker_noise_coefficient = el.model.model.params.KF  # type: ignore[attr-defined]
@@ -15705,7 +15778,11 @@ def _collect_noise_sources(
                 if _is_ground(intrinsic_drain)
                 else node_to_idx[intrinsic_drain]
             )
-            n_s = None if _is_ground(el.source) else node_to_idx[el.source]
+            n_s = (
+                None
+                if _is_ground(intrinsic_source)
+                else node_to_idx[intrinsic_source]
+            )
             if gm > 0.0:
                 psd = kT4 * _MOSFET_CHANNEL_NOISE_GAMMA * gm
                 sources.append((el.name, "thermal", n_d, n_s, psd, 0.0))
@@ -15730,6 +15807,18 @@ def _collect_noise_sources(
                         None if _is_ground(el.drain) else node_to_idx[el.drain],
                         n_d,
                         kT4 / drain_resistance,
+                        0.0,
+                    )
+                )
+            source_resistance = _mosfet_source_resistance(el)
+            if source_resistance > 0.0:
+                sources.append(
+                    (
+                        f"{el.name}:RS",
+                        "thermal",
+                        None if _is_ground(el.source) else node_to_idx[el.source],
+                        n_s,
+                        kT4 / source_resistance,
                         0.0,
                     )
                 )

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -311,8 +311,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "PNP": (41, 58, 13, 4),
     "NJF": (22, 30, 7, 3),
     "PJF": (22, 30, 7, 3),
-    "NMOS": (24, 31, 6, 3),
-    "PMOS": (24, 31, 6, 3),
+    "NMOS": (25, 32, 6, 3),
+    "PMOS": (25, 32, 6, 3),
 }
 
 
@@ -466,6 +466,7 @@ _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
     "LD": "LD",
     "TOX": "TOX",
     "RD": "RD",
+    "RS": "RS",
     "IS": "IS",
     "NSUB": "N_SUB",
     "N_SUB": "N_SUB",
@@ -1073,6 +1074,7 @@ def mosfet_from_model_card(
         LD=p.get("LD", defaults.LD),
         TOX=p.get("TOX", defaults.TOX),
         RD=p.get("RD", defaults.RD),
+        RS=p.get("RS", defaults.RS),
         IS=p.get("IS", defaults.IS),
         N_SUB=p.get("N_SUB", defaults.N_SUB),
         T_NOM=p.get("T_NOM", defaults.T_NOM),

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -408,7 +408,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 189
+    assert len(coverage) == 191
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -423,7 +423,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tAF\tAF\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 189
+    assert len(records) == 191
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -446,8 +446,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert summary[0].max_alias_count == 3
     assert summary[0].aliased_parameters == ("IS", "VT", "CJO", "VJ", "M")
     assert summary[5].kind == "NMOS"
-    assert summary[5].canonical_parameter_count == 24
-    assert summary[5].accepted_name_count == 31
+    assert summary[5].canonical_parameter_count == 25
+    assert summary[5].accepted_name_count == 32
     assert summary[5].aliased_parameter_count == 6
     assert summary[5].max_alias_count == 3
     assert summary[5].aliased_parameters == (
@@ -469,7 +469,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert table.splitlines()[1] == "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M"
     assert (
         table.splitlines()[-1]
-        == "PMOS\t24\t31\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        == "PMOS\t25\t32\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
     )
     records = model_card_supported_parameter_coverage_summary_records()
     assert len(records) == 7
@@ -497,9 +497,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 189
-    assert report.expected_canonical_parameter_count == 189
-    assert report.accepted_name_count == 259
+    assert report.canonical_parameter_count == 191
+    assert report.expected_canonical_parameter_count == 191
+    assert report.accepted_name_count == 261
     assert report.aliased_parameter_count == 57
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -507,7 +507,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t189\t189\t259\t57\t4\t0"
+        "true\t7\t7\t191\t191\t261\t57\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -535,15 +535,15 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 188
-    assert report.accepted_name_count == 256
+    assert report.canonical_parameter_count == 190
+    assert report.accepted_name_count == 258
     assert report.aliased_parameter_count == 56
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
     assert report.issues[0].field == "canonical_parameter_count"
     assert report.issues[0].message == (
-        "expected NMOS to expose 24 canonical supported parameters, found 23"
+        "expected NMOS to expose 25 canonical supported parameters, found 24"
     )
     assert report.issues[-1].field == "max_alias_count"
     assert report.issues[-1].message == "expected NMOS max alias count 3, found 2"
@@ -551,12 +551,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t188\t189\t256\t56\t4\t4\n"
+        "false\t7\t7\t190\t191\t258\t56\t4\t4\n"
         "kind\tfield\tmessage\n"
-        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 24 canonical "
-        "supported parameters, found 23\n"
-        "NMOS\taccepted_name_count\texpected NMOS to expose 31 accepted model-card "
-        "names, found 28\n"
+        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 25 canonical "
+        "supported parameters, found 24\n"
+        "NMOS\taccepted_name_count\texpected NMOS to expose 32 accepted model-card "
+        "names, found 29\n"
         "NMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing "
         "parameters, found 5\n"
         "NMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
@@ -565,12 +565,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
     assert records[0] == {
         "kind": "NMOS",
         "field": "canonical_parameter_count",
-        "message": "expected NMOS to expose 24 canonical supported parameters, found 23",
+        "message": "expected NMOS to expose 25 canonical supported parameters, found 24",
     }
     assert format_model_card_supported_parameter_coverage_gate_issue_csv(report).startswith(
         "kind,field,message\n"
-        'NMOS,canonical_parameter_count,"expected NMOS to expose 24 canonical '
-        'supported parameters, found 23"\n'
+        'NMOS,canonical_parameter_count,"expected NMOS to expose 25 canonical '
+        'supported parameters, found 24"\n'
     )
     assert (
         json.loads(format_model_card_supported_parameter_coverage_gate_issue_json(report))
@@ -749,6 +749,7 @@ def test_model_card_aliases_build_device_instances() -> None:
             "FC": 0.4,
             "LD": 50.0e-9,
             "RD": 125.0,
+            "RS": 75.0,
             "TOX": 25.0e-9,
             "KF": 2.0e-24,
             "AF": 1.4,
@@ -766,6 +767,7 @@ def test_model_card_aliases_build_device_instances() -> None:
         "FC": 0.4,
         "LD": 50.0e-9,
         "RD": 125.0,
+        "RS": 75.0,
         "TOX": 25.0e-9,
         "KF": 2.0e-24,
         "AF": 1.4,
@@ -782,6 +784,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(0.4) == mos_model.model.model.params.FC
     assert pytest.approx(50.0e-9) == mos_model.model.model.params.LD
     assert pytest.approx(125.0) == mos_model.model.model.params.RD
+    assert pytest.approx(75.0) == mos_model.model.model.params.RS
     assert pytest.approx(25.0e-9) == mos_model.model.model.params.TOX
     assert pytest.approx(2.0e-24) == mos_model.model.model.params.KF
     assert pytest.approx(1.4) == mos_model.model.model.params.AF
@@ -919,6 +922,26 @@ def test_dc_mosfet_drain_resistance_drops_intrinsic_drain_voltage() -> None:
     result = dc_op(circuit)
     assert result.node_voltages["drain"] == pytest.approx(5.0)
     assert result.node_voltages["__spice_M1_drain"] < 5.0
+
+
+def test_dc_mosfet_source_resistance_raises_intrinsic_source_voltage() -> None:
+    circuit = Circuit()
+    circuit.add(VoltageSource("Vdrain", "drain", "0", 5.0))
+    circuit.add(VoltageSource("Vgate", "gate", "0", 3.0))
+    circuit.add(Mosfet(
+        "M1",
+        "drain",
+        "gate",
+        "0",
+        "0",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(Level1Params(RS=1_000.0)),
+        ),
+    ))
+
+    result = dc_op(circuit)
+    assert result.node_voltages["__spice_M1_source"] > 0.0
 
 
 def test_dc_jfet_source_resistance_raises_intrinsic_source_voltage() -> None:
@@ -1963,6 +1986,30 @@ def test_mosfet_rejects_invalid_drain_resistance(
         dc_op(circuit)
 
 
+@pytest.mark.parametrize("source_resistance", [float("nan"), -1.0])
+def test_mosfet_rejects_invalid_source_resistance(
+    source_resistance: float,
+) -> None:
+    circuit = Circuit()
+    circuit.add(Mosfet(
+        "Mbad",
+        "drain",
+        "gate",
+        "0",
+        "0",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(Level1Params(RS=source_resistance)),
+        ),
+    ))
+
+    with pytest.raises(
+        ValueError,
+        match="MOSFET RS must be finite and non-negative",
+    ):
+        dc_op(circuit)
+
+
 def test_transient_diode_transit_time_holds_forward_charge_on_turnoff() -> None:
     def run(transit_time: float) -> TransientResult:
         circuit = Circuit()
@@ -2905,6 +2952,7 @@ def test_subcircuit_expansion_preserves_mos_geometry():
                             L=1.0e-6,
                             LD=0.1e-6,
                             RD=125.0,
+                            RS=75.0,
                             TOX=25.0e-9,
                         )
                     ),
@@ -2922,6 +2970,7 @@ def test_subcircuit_expansion_preserves_mos_geometry():
     assert pytest.approx(1.0e-6) == expanded.model.model.params.L
     assert pytest.approx(0.1e-6) == expanded.model.model.params.LD
     assert pytest.approx(125.0) == expanded.model.model.params.RD
+    assert pytest.approx(75.0) == expanded.model.model.params.RS
     assert pytest.approx(25.0e-9) == expanded.model.model.params.TOX
 
 
@@ -8146,6 +8195,32 @@ def test_noise_mosfet_rd_adds_thermal_noise() -> None:
         if entry.element_name == "M1:RD" and entry.noise_type == "thermal"
     )
     assert rd.source_psd == pytest.approx(4.0 * 1.380_649e-23 * 300.0 / 250.0)
+
+
+def test_noise_mosfet_rs_adds_thermal_noise() -> None:
+    circuit = Circuit()
+    circuit.add(VoltageSource("Vdd", "vdd", "0", 5.0))
+    circuit.add(VoltageSource("Vgate", "gate", "0", 3.0))
+    circuit.add(Resistor("Rload", "vdd", "out", 1_000.0))
+    circuit.add(Mosfet(
+        "M1",
+        "out",
+        "gate",
+        "0",
+        "0",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(Level1Params(RS=250.0)),
+        ),
+    ))
+
+    entries = noise_ac(circuit, "out", "Vgate", freqs=[1_000.0]).points[0].entries
+    rs = next(
+        entry
+        for entry in entries
+        if entry.element_name == "M1:RS" and entry.noise_type == "thermal"
+    )
+    assert rs.source_psd == pytest.approx(4.0 * 1.380_649e-23 * 300.0 / 250.0)
 
 
 def test_noise_jfet_rs_adds_thermal_noise() -> None:

--- a/code/packages/rust/mosfet-models/CHANGELOG.md
+++ b/code/packages/rust/mosfet-models/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `Level1Params::rs` adds the zero-default Berkeley external source resistance
+  parameter with finite, non-negative validation.
 - `Level1Params::rd` adds the zero-default Berkeley external drain resistance
   parameter with finite, non-negative validation.
 - `Level1Params::tox` adds Berkeley-default gate oxide thickness and derives

--- a/code/packages/rust/mosfet-models/README.md
+++ b/code/packages/rust/mosfet-models/README.md
@@ -27,8 +27,8 @@ This crate implements the classical square-law MOSFET model used in introductory
 where β = KP × W/(L − 2LD) and V_OV = V_GS − V_t. `LD` defaults to zero
 and must leave a positive effective channel length. `TOX` defaults to
 `100 nm`, must be positive, and derives intrinsic Meyer gate capacitance from
-`Cox = epsilon_ox / TOX`. `RD` is a finite, non-negative external drain
-resistance parameter for engine topology and defaults to zero ohms.
+`Cox = epsilon_ox / TOX`. `RD` and `RS` are finite, non-negative external drain
+and source resistance parameters for engine topology and default to zero ohms.
 
 ## Usage
 

--- a/code/packages/rust/mosfet-models/src/lib.rs
+++ b/code/packages/rust/mosfet-models/src/lib.rs
@@ -41,6 +41,7 @@ const OXIDE_PERMITTIVITY: f64 = 3.453_133e-11;
 /// | LD        | Lateral diffusion length (m)       | 0        |
 /// | TOX       | Gate oxide thickness (m)           | 100 nm   |
 /// | RD        | Drain resistance (ohm)              | 0        |
+/// | RS        | Source resistance (ohm)             | 0        |
 /// | IS        | Drain–body saturation current (A)  | 1 fA     |
 /// | N_SUB     | Subthreshold slope factor          | 1.4      |
 /// | T_NOM     | Nominal temperature (K)            | 300.15   |
@@ -68,6 +69,8 @@ pub struct Level1Params {
     pub tox: f64,
     /// External drain resistance [ohm].
     pub rd: f64,
+    /// External source resistance [ohm].
+    pub rs: f64,
     /// Drain–body saturation current [A] (used for subthreshold floor).
     pub is: f64,
     /// Subthreshold slope factor n.  Subthreshold current ∝ exp(V_OV / (n V_T)).
@@ -111,6 +114,7 @@ impl Default for Level1Params {
             ld: 0.0,
             tox: 1.0e-7,
             rd: 0.0,
+            rs: 0.0,
             is: 1e-15,
             n_sub: 1.4,
             t_nom: 300.15,
@@ -251,6 +255,10 @@ pub fn evaluate_level1(
     assert!(
         p.rd.is_finite() && p.rd >= 0.0,
         "MOSFET RD must be finite and non-negative"
+    );
+    assert!(
+        p.rs.is_finite() && p.rs >= 0.0,
+        "MOSFET RS must be finite and non-negative"
     );
     let beta = p.kp * (p.w / effective_length);
 

--- a/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
+++ b/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
@@ -179,6 +179,21 @@ fn test_drain_resistance_rejects_negative_value() {
     );
 }
 
+#[test]
+#[should_panic(expected = "MOSFET RS must be finite and non-negative")]
+fn test_source_resistance_rejects_negative_value() {
+    evaluate_level1(
+        &Level1Params {
+            rs: -1.0,
+            ..Level1Params::default()
+        },
+        1.8,
+        1.8,
+        0.0,
+        300.15,
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Body effect
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- Add Level-1 MOS model-card `RS` support. Nonzero values create an intrinsic
+  source node, stamp the external resistor in DC, TF, AC, and transient
+  analyses, route source-side capacitances through it, and emit `:RS` Johnson
+  noise.
 - Add Level-1 MOS model-card `RD` support. Nonzero values create an intrinsic
   drain node, stamp the external resistor in DC, TF, AC, and transient
   analyses, route drain-side capacitances through it, and emit `:RD` Johnson

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -137,6 +137,9 @@ Meyer gate capacitance from `Cox = epsilon_ox / TOX`.
 `RD` defaults to zero ohms. A finite positive value inserts an intrinsic drain
 node, routes the channel and drain-side capacitances through it, and contributes
 `4kT/RD` thermal noise.
+`RS` defaults to zero ohms. A finite positive value inserts an intrinsic source
+node, routes the channel and source-side capacitances through it, and contributes
+`4kT/RS` thermal noise.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3610,6 +3610,7 @@ pub struct MosfetLevel1Params {
     pub lateral_diffusion_length: f64,
     pub oxide_thickness: f64,
     pub drain_resistance: f64,
+    pub source_resistance: f64,
     pub saturation_current: f64,
     pub n_sub: f64,
     pub t_nom: f64,
@@ -3638,6 +3639,7 @@ impl Default for MosfetLevel1Params {
             lateral_diffusion_length: 0.0,
             oxide_thickness: 1.0e-7,
             drain_resistance: 0.0,
+            source_resistance: 0.0,
             saturation_current: 1.0e-15,
             n_sub: 1.4,
             t_nom: 300.15,
@@ -3994,8 +3996,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     (ModelCardKind::Pnp, 41, 58, 13, 4),
     (ModelCardKind::Njf, 22, 30, 7, 3),
     (ModelCardKind::Pjf, 22, 30, 7, 3),
-    (ModelCardKind::Nmos, 24, 31, 6, 3),
-    (ModelCardKind::Pmos, 24, 31, 6, 3),
+    (ModelCardKind::Nmos, 25, 32, 6, 3),
+    (ModelCardKind::Pmos, 25, 32, 6, 3),
 ];
 const DIODE_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IS", "IS"),
@@ -4127,6 +4129,7 @@ const MOS_LEVEL1_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("LD", "LD"),
     ("TOX", "TOX"),
     ("RD", "RD"),
+    ("RS", "RS"),
     ("IS", "IS"),
     ("NSUB", "N_SUB"),
     ("N_SUB", "N_SUB"),
@@ -4911,6 +4914,9 @@ pub fn mosfet_from_model_card(
     }
     if let Some(value) = model.parameters.get("RD") {
         params.drain_resistance = *value;
+    }
+    if let Some(value) = model.parameters.get("RS") {
+        params.source_resistance = *value;
     }
     if let Some(value) = model.parameters.get("IS") {
         params.saturation_current = *value;
@@ -22329,6 +22335,9 @@ fn collect_node_indices(circuit: &Circuit) -> HashMap<String, usize> {
                 if mosfet.params.drain_resistance > 0.0 {
                     insert_node(&mut names, &mosfet_intrinsic_drain_node(mosfet));
                 }
+                if mosfet.params.source_resistance > 0.0 {
+                    insert_node(&mut names, &mosfet_intrinsic_source_node(mosfet));
+                }
             }
             Element::Vccs(source) => {
                 insert_node(&mut names, &source.positive);
@@ -22792,9 +22801,10 @@ fn collect_noise_sources(
             Element::Mosfet(mosfet) => {
                 validate_mosfet(mosfet)?;
                 let intrinsic_drain = mosfet_intrinsic_drain_node(mosfet);
+                let intrinsic_source = mosfet_intrinsic_source_node(mosfet);
                 let drain = node_index(node_indices, &intrinsic_drain);
                 let gate = node_index(node_indices, &mosfet.gate);
-                let source = node_index(node_indices, &mosfet.source);
+                let source = node_index(node_indices, &intrinsic_source);
                 let body = node_index(node_indices, &mosfet.body);
                 let drain_voltage = vector_voltage(operating_point, drain);
                 let gate_voltage = vector_voltage(operating_point, gate);
@@ -22843,6 +22853,17 @@ fn collect_noise_sources(
                         negative: drain,
                         source_psd: 4.0 * BOLTZMANN * temperature_kelvin
                             / mosfet.params.drain_resistance,
+                        frequency_exponent: 0.0,
+                    });
+                }
+                if mosfet.params.source_resistance > 0.0 {
+                    sources.push(NoiseSource {
+                        element_name: format!("{}:RS", mosfet.name),
+                        noise_type: NoiseType::Thermal,
+                        positive: node_index(node_indices, &mosfet.source),
+                        negative: source,
+                        source_psd: 4.0 * BOLTZMANN * temperature_kelvin
+                            / mosfet.params.source_resistance,
                         frequency_exponent: 0.0,
                     });
                 }
@@ -24148,9 +24169,10 @@ fn stamp_mosfet(
 ) -> Result<(), SpiceError> {
     validate_mosfet(mosfet)?;
     let intrinsic_drain = mosfet_intrinsic_drain_node(mosfet);
+    let intrinsic_source = mosfet_intrinsic_source_node(mosfet);
     let drain = node_index(node_indices, &intrinsic_drain);
     let gate = node_index(node_indices, &mosfet.gate);
-    let source = node_index(node_indices, &mosfet.source);
+    let source = node_index(node_indices, &intrinsic_source);
     let body = node_index(node_indices, &mosfet.body);
     let drain_voltage = vector_voltage(operating_point, drain);
     let gate_voltage = vector_voltage(operating_point, gate);
@@ -24174,6 +24196,14 @@ fn stamp_mosfet(
             node_index(node_indices, &mosfet.drain),
             drain,
             1.0 / mosfet.params.drain_resistance,
+        );
+    }
+    if mosfet.params.source_resistance > 0.0 {
+        stamp_conductance(
+            matrix,
+            node_index(node_indices, &mosfet.source),
+            source,
+            1.0 / mosfet.params.source_resistance,
         );
     }
     Ok(())
@@ -24339,9 +24369,10 @@ fn stamp_mosfet_small_signal(
 ) -> Result<(), SpiceError> {
     validate_mosfet(mosfet)?;
     let intrinsic_drain = mosfet_intrinsic_drain_node(mosfet);
+    let intrinsic_source = mosfet_intrinsic_source_node(mosfet);
     let drain = node_index(node_indices, &intrinsic_drain);
     let gate = node_index(node_indices, &mosfet.gate);
-    let source = node_index(node_indices, &mosfet.source);
+    let source = node_index(node_indices, &intrinsic_source);
     let body = node_index(node_indices, &mosfet.body);
     let drain_voltage = vector_voltage(operating_point, drain);
     let gate_voltage = vector_voltage(operating_point, gate);
@@ -24360,6 +24391,14 @@ fn stamp_mosfet_small_signal(
             node_index(node_indices, &mosfet.drain),
             drain,
             1.0 / mosfet.params.drain_resistance,
+        );
+    }
+    if mosfet.params.source_resistance > 0.0 {
+        stamp_conductance(
+            matrix,
+            node_index(node_indices, &mosfet.source),
+            source,
+            1.0 / mosfet.params.source_resistance,
         );
     }
     Ok(())
@@ -24421,9 +24460,10 @@ fn stamp_ac_mosfet_small_signal(
 ) -> Result<(), SpiceError> {
     validate_mosfet(mosfet)?;
     let intrinsic_drain = mosfet_intrinsic_drain_node(mosfet);
+    let intrinsic_source = mosfet_intrinsic_source_node(mosfet);
     let drain = node_index(node_indices, &intrinsic_drain);
     let gate = node_index(node_indices, &mosfet.gate);
-    let source = node_index(node_indices, &mosfet.source);
+    let source = node_index(node_indices, &intrinsic_source);
     let body = node_index(node_indices, &mosfet.body);
     let drain_voltage = vector_voltage(operating_point, drain);
     let gate_voltage = vector_voltage(operating_point, gate);
@@ -24461,6 +24501,14 @@ fn stamp_ac_mosfet_small_signal(
             node_index(node_indices, &mosfet.drain),
             drain,
             Complex::new(1.0 / mosfet.params.drain_resistance, 0.0),
+        );
+    }
+    if mosfet.params.source_resistance > 0.0 {
+        stamp_complex_conductance(
+            matrix,
+            node_index(node_indices, &mosfet.source),
+            source,
+            Complex::new(1.0 / mosfet.params.source_resistance, 0.0),
         );
     }
     Ok(())
@@ -24885,6 +24933,14 @@ fn mosfet_intrinsic_drain_node(mosfet: &Mosfet) -> String {
     }
 }
 
+fn mosfet_intrinsic_source_node(mosfet: &Mosfet) -> String {
+    if !mosfet.params.source_resistance.is_finite() || mosfet.params.source_resistance <= 0.0 {
+        mosfet.source.clone()
+    } else {
+        format!("__spice_{}_source", mosfet.name)
+    }
+}
+
 fn jfet_charge_dynamic_capacitance(
     jfet: &Jfet,
     zero_bias_capacitance: f64,
@@ -24953,7 +25009,7 @@ fn mosfet_charge_state_specs(mosfet: &Mosfet) -> Vec<MosfetChargeStateSpec> {
         specs.push(MosfetChargeStateSpec {
             name: mosfet_gate_source_charge_state_name(mosfet),
             positive: mosfet.gate.clone(),
-            negative: mosfet.source.clone(),
+            negative: mosfet_intrinsic_source_node(mosfet),
             capacitance: gate_source_capacitance,
             kind: MosfetChargeStateKind::GateOverlap,
         });
@@ -24979,7 +25035,7 @@ fn mosfet_charge_state_specs(mosfet: &Mosfet) -> Vec<MosfetChargeStateSpec> {
     if source_body_capacitance > 0.0 {
         specs.push(MosfetChargeStateSpec {
             name: mosfet_source_body_charge_state_name(mosfet),
-            positive: mosfet.source.clone(),
+            positive: mosfet_intrinsic_source_node(mosfet),
             negative: mosfet.body.clone(),
             capacitance: source_body_capacitance,
             kind: MosfetChargeStateKind::SourceBody,
@@ -25575,6 +25631,7 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         ("L", params.l),
         ("LD", params.lateral_diffusion_length),
         ("RD", params.drain_resistance),
+        ("RS", params.source_resistance),
         ("TOX", params.oxide_thickness),
         ("IS", params.saturation_current),
         ("N_SUB", params.n_sub),
@@ -25621,6 +25678,12 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: mosfet.name.clone(),
             reason: "MOSFET RD must be non-negative".to_string(),
+        });
+    }
+    if params.source_resistance < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET RS must be non-negative".to_string(),
         });
     }
     if params.oxide_thickness <= 0.0 {

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -95,7 +95,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 189);
+    assert_eq!(coverage.len(), 191);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -114,7 +114,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tAF\tAF\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 189);
+    assert_eq!(records.len(), 191);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -147,8 +147,8 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         vec!["IS", "VT", "CJO", "VJ", "M"]
     );
     assert_eq!(summary[5].kind, ModelCardKind::Nmos);
-    assert_eq!(summary[5].canonical_parameter_count, 24);
-    assert_eq!(summary[5].accepted_name_count, 31);
+    assert_eq!(summary[5].canonical_parameter_count, 25);
+    assert_eq!(summary[5].accepted_name_count, 32);
     assert_eq!(summary[5].aliased_parameter_count, 6);
     assert_eq!(summary[5].max_alias_count, 3);
     assert_eq!(
@@ -166,7 +166,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     assert_eq!(lines[1], "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\t24\t31\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        &"PMOS\t25\t32\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
     );
     let records = model_card_supported_parameter_coverage_summary_records();
     assert_eq!(records.len(), 7);
@@ -184,7 +184,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         "[{\"kind\":\"D\",\"canonical_parameter_count\":\"15\",\"accepted_name_count\":\"21\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
     ));
     assert!(json.ends_with(
-        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"24\",\"accepted_name_count\":\"31\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
+        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"25\",\"accepted_name_count\":\"32\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
     ));
 }
 
@@ -195,15 +195,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 189);
-    assert_eq!(report.expected_canonical_parameter_count, 189);
-    assert_eq!(report.accepted_name_count, 259);
+    assert_eq!(report.canonical_parameter_count, 191);
+    assert_eq!(report.expected_canonical_parameter_count, 191);
+    assert_eq!(report.accepted_name_count, 261);
     assert_eq!(report.aliased_parameter_count, 57);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t189\t189\t259\t57\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t191\t191\t261\t57\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -230,8 +230,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 188);
-    assert_eq!(report.accepted_name_count, 256);
+    assert_eq!(report.canonical_parameter_count, 190);
+    assert_eq!(report.accepted_name_count, 258);
     assert_eq!(report.aliased_parameter_count, 56);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -239,7 +239,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     assert_eq!(report.issues[0].field, "canonical_parameter_count");
     assert_eq!(
         report.issues[0].message,
-        "expected NMOS to expose 24 canonical supported parameters, found 23"
+        "expected NMOS to expose 25 canonical supported parameters, found 24"
     );
     assert_eq!(report.issues.last().unwrap().field, "max_alias_count");
     assert_eq!(
@@ -248,20 +248,20 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t188\t189\t256\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 24 canonical supported parameters, found 23\nNMOS\taccepted_name_count\texpected NMOS to expose 31 accepted model-card names, found 28\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t190\t191\t258\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 25 canonical supported parameters, found 24\nNMOS\taccepted_name_count\texpected NMOS to expose 32 accepted model-card names, found 29\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
     assert_eq!(records[0]["field"], "canonical_parameter_count");
     assert_eq!(
         records[0]["message"],
-        "expected NMOS to expose 24 canonical supported parameters, found 23"
+        "expected NMOS to expose 25 canonical supported parameters, found 24"
     );
     assert!(format_model_card_supported_parameter_coverage_gate_issue_csv(&report).starts_with(
-        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 24 canonical supported parameters, found 23\"\n"
+        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 25 canonical supported parameters, found 24\"\n"
     ));
     assert!(format_model_card_supported_parameter_coverage_gate_issue_json(&report).starts_with(
-        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 24 canonical supported parameters, found 23\"}"
+        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 25 canonical supported parameters, found 24\"}"
     ));
 }
 
@@ -283,8 +283,8 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(dashboard[0].issue_count, 0);
     assert!(dashboard[0].issue_fields.is_empty());
     assert_eq!(dashboard[5].kind, ModelCardKind::Nmos);
-    assert_eq!(dashboard[5].canonical_parameter_count, 24);
-    assert_eq!(dashboard[5].accepted_name_count, 31);
+    assert_eq!(dashboard[5].canonical_parameter_count, 25);
+    assert_eq!(dashboard[5].accepted_name_count, 32);
     assert_eq!(dashboard[5].issue_count, 0);
 
     let table = format_model_card_supported_parameter_coverage_dashboard_table(&coverage);
@@ -296,7 +296,7 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(lines[1], "D\ttrue\t15\t15\t21\t21\t5\t5\t3\t3\t0\t");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\ttrue\t24\t24\t31\t31\t6\t6\t3\t3\t0\t"
+        &"PMOS\ttrue\t25\t25\t32\t32\t6\t6\t3\t3\t0\t"
     );
     let records = model_card_supported_parameter_coverage_dashboard_records(&coverage);
     assert_eq!(records.len(), 7);
@@ -328,10 +328,10 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         .unwrap();
 
     assert!(!nmos.passed);
-    assert_eq!(nmos.canonical_parameter_count, 23);
-    assert_eq!(nmos.expected_canonical_parameter_count, 24);
-    assert_eq!(nmos.accepted_name_count, 28);
-    assert_eq!(nmos.expected_accepted_name_count, 31);
+    assert_eq!(nmos.canonical_parameter_count, 24);
+    assert_eq!(nmos.expected_canonical_parameter_count, 25);
+    assert_eq!(nmos.accepted_name_count, 29);
+    assert_eq!(nmos.expected_accepted_name_count, 32);
     assert_eq!(nmos.aliased_parameter_count, 5);
     assert_eq!(nmos.expected_aliased_parameter_count, 6);
     assert_eq!(nmos.max_alias_count, 2);
@@ -347,7 +347,7 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         ]
     );
     assert!(format_model_card_supported_parameter_coverage_dashboard_table(&coverage).contains(
-        "NMOS\tfalse\t23\t24\t28\t31\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
+        "NMOS\tfalse\t24\t25\t29\t32\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
     ));
 }
 
@@ -595,6 +595,7 @@ fn model_card_aliases_build_device_instances() {
             ("FC", 0.4),
             ("LD", 50.0e-9),
             ("RD", 125.0),
+            ("RS", 75.0),
             ("TOX", 25.0e-9),
             ("KF", 2.0e-24),
             ("AF", 1.4),
@@ -611,6 +612,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*mos_card.parameters.get("FC").unwrap(), 0.4);
     assert_close(*mos_card.parameters.get("LD").unwrap(), 50.0e-9);
     assert_close(*mos_card.parameters.get("RD").unwrap(), 125.0);
+    assert_close(*mos_card.parameters.get("RS").unwrap(), 75.0);
     assert_close(*mos_card.parameters.get("TOX").unwrap(), 25.0e-9);
     assert_close(*mos_card.parameters.get("KF").unwrap(), 2.0e-24);
     assert_close(*mos_card.parameters.get("AF").unwrap(), 1.4);
@@ -624,6 +626,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(mos_model.params.forward_bias_depletion_coefficient, 0.4);
     assert_close(mos_model.params.lateral_diffusion_length, 50.0e-9);
     assert_close(mos_model.params.drain_resistance, 125.0);
+    assert_close(mos_model.params.source_resistance, 75.0);
     assert_close(mos_model.params.oxide_thickness, 25.0e-9);
     assert_close(mos_model.params.flicker_noise_coefficient, 2.0e-24);
     assert_close(mos_model.params.flicker_noise_exponent, 1.4);
@@ -1630,6 +1633,32 @@ fn dc_mosfet_drain_resistance_drops_intrinsic_drain_voltage() {
 }
 
 #[test]
+fn dc_mosfet_source_resistance_raises_intrinsic_source_voltage() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vdrain", "drain", "0", 5.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 3.0,
+    )));
+    circuit.add(Element::Mosfet(Mosfet::with_model(
+        "M1",
+        "drain",
+        "gate",
+        "0",
+        "0",
+        MosfetType::Nmos,
+        MosfetLevel1Params {
+            source_resistance: 1_000.0,
+            ..MosfetLevel1Params::default()
+        },
+    )));
+
+    let result = dc_op(&circuit).unwrap();
+    assert!(result.node_voltages["__spice_M1_source"] > 0.0);
+}
+
+#[test]
 fn dc_jfet_source_resistance_raises_intrinsic_source_voltage() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(
@@ -1732,6 +1761,7 @@ fn subcircuit_expansion_preserves_mos_geometry() {
             l: 1.0e-6,
             lateral_diffusion_length: 0.1e-6,
             drain_resistance: 125.0,
+            source_resistance: 75.0,
             oxide_thickness: 25.0e-9,
             ..MosfetLevel1Params::default()
         },
@@ -1773,6 +1803,7 @@ fn subcircuit_expansion_preserves_mos_geometry() {
     assert_close(expanded.params.l, 1.0e-6);
     assert_close(expanded.params.lateral_diffusion_length, 0.1e-6);
     assert_close(expanded.params.drain_resistance, 125.0);
+    assert_close(expanded.params.source_resistance, 75.0);
     assert_close(expanded.params.oxide_thickness, 25.0e-9);
 }
 
@@ -3848,6 +3879,38 @@ fn dc_mosfet_rejects_invalid_drain_resistance() {
                     "MOSFET RD must be non-negative".to_string()
                 } else {
                     "MOSFET RD must be finite".to_string()
+                },
+            }
+        );
+    }
+}
+
+#[test]
+fn dc_mosfet_rejects_invalid_source_resistance() {
+    for source_resistance in [f64::NAN, -1.0] {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "Mbad",
+            "drain",
+            "gate",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                source_resistance,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+
+        let err = dc_op(&circuit).unwrap_err();
+        assert_eq!(
+            err,
+            SpiceError::InvalidElement {
+                name: "Mbad".to_string(),
+                reason: if source_resistance.is_finite() {
+                    "MOSFET RS must be non-negative".to_string()
+                } else {
+                    "MOSFET RS must be finite".to_string()
                 },
             }
         );

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -571,6 +571,44 @@ fn mosfet_drain_resistance_emits_thermal_noise() {
 }
 
 #[test]
+fn mosfet_source_resistance_emits_thermal_noise() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vdd", "vdd", "0", 5.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 3.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "vdd", "out", 1_000.0,
+    )));
+    circuit.add(Element::Mosfet(Mosfet::with_model(
+        "M1",
+        "out",
+        "gate",
+        "0",
+        "0",
+        MosfetType::Nmos,
+        MosfetLevel1Params {
+            source_resistance: 250.0,
+            ..MosfetLevel1Params::default()
+        },
+    )));
+
+    let result = noise_ac(&circuit, "out", "Vgate", &[1_000.0], 300.0).unwrap();
+    let entry = result.points[0]
+        .entries
+        .iter()
+        .find(|entry| entry.element_name == "M1:RS" && entry.noise_type == NoiseType::Thermal)
+        .unwrap();
+    assert_close(
+        entry.source_psd,
+        4.0 * 1.380_649e-23 * 300.0 / 250.0,
+        1.0e-30,
+    );
+}
+
+#[test]
 fn jfet_source_resistance_emits_thermal_noise() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- Add Level-1 MOS model-card `RS` support. Nonzero values create an intrinsic
+  source node, stamp the external resistor in DC, TF, AC, and transient
+  analyses, route source-side capacitances through it, and emit `:RS` Johnson
+  noise.
 - Add Level-1 MOS model-card `RD` support. Nonzero values create an intrinsic
   drain node, stamp the external resistor in DC, TF, AC, and transient
   analyses, route drain-side capacitances through it, and emit `:RD` Johnson

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -88,6 +88,9 @@ Meyer gate capacitance from `Cox = epsilon_ox / TOX`.
 `RD` defaults to zero ohms. A finite positive value inserts an intrinsic drain
 node, routes the channel and drain-side capacitances through it, and contributes
 `4kT/RD` thermal noise.
+`RS` defaults to zero ohms. A finite positive value inserts an intrinsic source
+node, routes the channel and source-side capacitances through it, and contributes
+`4kT/RS` thermal noise.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1778,6 +1778,7 @@ export interface MosfetLevel1Params {
   readonly LD: number;
   readonly TOX: number;
   readonly RD: number;
+  readonly RS: number;
   readonly IS: number;
   readonly N_SUB: number;
   readonly T_NOM: number;
@@ -2050,8 +2051,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   PNP: [41, 58, 13, 4],
   NJF: [22, 30, 7, 3],
   PJF: [22, 30, 7, 3],
-  NMOS: [24, 31, 6, 3],
-  PMOS: [24, 31, 6, 3],
+  NMOS: [25, 32, 6, 3],
+  PMOS: [25, 32, 6, 3],
 };
 
 export interface Vccs {
@@ -8036,6 +8037,7 @@ export function defaultMosfetLevel1Params(): MosfetLevel1Params {
     LD: 0.0,
     TOX: 1.0e-7,
     RD: 0.0,
+    RS: 0.0,
     IS: 1.0e-15,
     N_SUB: 1.4,
     T_NOM: 300.15,
@@ -8224,6 +8226,7 @@ const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   LD: "LD",
   TOX: "TOX",
   RD: "RD",
+  RS: "RS",
   IS: "IS",
   NSUB: "N_SUB",
   N_SUB: "N_SUB",
@@ -8799,6 +8802,7 @@ export function mosfetFromModelCard(
     ...(p.LD !== undefined ? { LD: p.LD } : {}),
     ...(p.TOX !== undefined ? { TOX: p.TOX } : {}),
     ...(p.RD !== undefined ? { RD: p.RD } : {}),
+    ...(p.RS !== undefined ? { RS: p.RS } : {}),
     ...(p.IS !== undefined ? { IS: p.IS } : {}),
     ...(p.N_SUB !== undefined ? { N_SUB: p.N_SUB } : {}),
     ...(p.T_NOM !== undefined ? { T_NOM: p.T_NOM } : {}),
@@ -18571,6 +18575,9 @@ function collectNodeIndices(circuit: Circuit): Map<string, number> {
         if (element.params.RD > 0.0) {
           insertNode(names, mosfetIntrinsicDrainNode(element));
         }
+        if (element.params.RS > 0.0) {
+          insertNode(names, mosfetIntrinsicSourceNode(element));
+        }
         break;
       case "vccs":
         insertNode(names, element.positive);
@@ -18966,7 +18973,7 @@ function collectNoiseSources(
       validateMosfet(element);
       const drain = nodeIndex(nodeIndices, mosfetIntrinsicDrainNode(element));
       const gate = nodeIndex(nodeIndices, element.gate);
-      const source = nodeIndex(nodeIndices, element.source);
+      const source = nodeIndex(nodeIndices, mosfetIntrinsicSourceNode(element));
       const body = nodeIndex(nodeIndices, element.body);
       const drainVoltage = vectorVoltage(operatingPoint, drain);
       const gateVoltage = vectorVoltage(operatingPoint, gate);
@@ -19008,6 +19015,16 @@ function collectNoiseSources(
           positive: nodeIndex(nodeIndices, element.drain),
           negative: drain,
           sourcePsd: 4.0 * BOLTZMANN * temperatureKelvin / element.params.RD,
+          frequencyExponent: 0.0,
+        });
+      }
+      if (element.params.RS > 0.0) {
+        sources.push({
+          elementName: `${element.name}:RS`,
+          noiseType: "thermal",
+          positive: nodeIndex(nodeIndices, element.source),
+          negative: source,
+          sourcePsd: 4.0 * BOLTZMANN * temperatureKelvin / element.params.RS,
           frequencyExponent: 0.0,
         });
       }
@@ -20182,7 +20199,7 @@ function stampMosfet(
   validateMosfet(element);
   const drain = nodeIndex(nodeIndices, mosfetIntrinsicDrainNode(element));
   const gate = nodeIndex(nodeIndices, element.gate);
-  const source = nodeIndex(nodeIndices, element.source);
+  const source = nodeIndex(nodeIndices, mosfetIntrinsicSourceNode(element));
   const body = nodeIndex(nodeIndices, element.body);
   const drainVoltage = vectorVoltage(operatingPoint, drain);
   const gateVoltage = vectorVoltage(operatingPoint, gate);
@@ -20206,6 +20223,14 @@ function stampMosfet(
       nodeIndex(nodeIndices, element.drain),
       drain,
       1.0 / element.params.RD,
+    );
+  }
+  if (element.params.RS > 0.0) {
+    stampConductance(
+      matrix,
+      nodeIndex(nodeIndices, element.source),
+      source,
+      1.0 / element.params.RS,
     );
   }
 }
@@ -20769,6 +20794,12 @@ function mosfetIntrinsicDrainNode(element: Mosfet): string {
     : `__spice_${element.name}_drain`;
 }
 
+function mosfetIntrinsicSourceNode(element: Mosfet): string {
+  return !Number.isFinite(element.params.RS) || element.params.RS <= 0.0
+    ? element.source
+    : `__spice_${element.name}_source`;
+}
+
 function jfetChargeStateVoltage(
   spec: JfetChargeStateSpec,
   nodeVoltages: ReadonlyMap<string, number>,
@@ -20835,7 +20866,7 @@ function mosfetChargeStateSpecs(element: Mosfet): MosfetChargeStateSpec[] {
     specs.push({
       name: mosfetGateSourceChargeStateName(element),
       positive: element.gate,
-      negative: element.source,
+      negative: mosfetIntrinsicSourceNode(element),
       capacitance: gateSourceCapacitance,
       kind: "gate-overlap",
     });
@@ -20861,7 +20892,7 @@ function mosfetChargeStateSpecs(element: Mosfet): MosfetChargeStateSpec[] {
   if (sourceBodyCapacitance > 0.0) {
     specs.push({
       name: mosfetSourceBodyChargeStateName(element),
-      positive: element.source,
+      positive: mosfetIntrinsicSourceNode(element),
       negative: element.body,
       capacitance: sourceBodyCapacitance,
       kind: "source-body",
@@ -21068,6 +21099,9 @@ function validateMosfet(element: Mosfet): void {
   }
   if (params.RD < 0.0) {
     throw invalidElement(element.name, "MOSFET RD must be non-negative");
+  }
+  if (params.RS < 0.0) {
+    throw invalidElement(element.name, "MOSFET RS must be non-negative");
   }
   if (params.TOX <= 0.0) {
     throw invalidElement(element.name, "MOSFET TOX must be positive");
@@ -22488,7 +22522,7 @@ function stampMosfetSmallSignal(
   validateMosfet(element);
   const drain = nodeIndex(nodeIndices, mosfetIntrinsicDrainNode(element));
   const gate = nodeIndex(nodeIndices, element.gate);
-  const source = nodeIndex(nodeIndices, element.source);
+  const source = nodeIndex(nodeIndices, mosfetIntrinsicSourceNode(element));
   const body = nodeIndex(nodeIndices, element.body);
   const drainVoltage = vectorVoltage(operatingPoint, drain);
   const gateVoltage = vectorVoltage(operatingPoint, gate);
@@ -22509,6 +22543,14 @@ function stampMosfetSmallSignal(
       nodeIndex(nodeIndices, element.drain),
       drain,
       1.0 / element.params.RD,
+    );
+  }
+  if (element.params.RS > 0.0) {
+    stampConductance(
+      matrix,
+      nodeIndex(nodeIndices, element.source),
+      source,
+      1.0 / element.params.RS,
     );
   }
 }
@@ -23236,7 +23278,7 @@ function stampAcMosfetSmallSignal(
   validateMosfet(element);
   const drain = nodeIndex(nodeIndices, mosfetIntrinsicDrainNode(element));
   const gate = nodeIndex(nodeIndices, element.gate);
-  const source = nodeIndex(nodeIndices, element.source);
+  const source = nodeIndex(nodeIndices, mosfetIntrinsicSourceNode(element));
   const body = nodeIndex(nodeIndices, element.body);
   const drainVoltage = vectorVoltage(operatingPoint, drain);
   const gateVoltage = vectorVoltage(operatingPoint, gate);
@@ -23276,6 +23318,14 @@ function stampAcMosfetSmallSignal(
       nodeIndex(nodeIndices, element.drain),
       drain,
       complex(1.0 / element.params.RD, 0.0),
+    );
+  }
+  if (element.params.RS > 0.0) {
+    stampComplexConductance(
+      matrix,
+      nodeIndex(nodeIndices, element.source),
+      source,
+      complex(1.0 / element.params.RS, 0.0),
     );
   }
 }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -121,7 +121,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(189);
+    expect(coverage).toHaveLength(191);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -141,7 +141,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tAF\tAF\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(189);
+    expect(records).toHaveLength(191);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -167,8 +167,8 @@ describe("dcOp", () => {
     });
     expect(summary[5]).toStrictEqual({
       kind: "NMOS",
-      canonicalParameterCount: 24,
-      acceptedNameCount: 31,
+      canonicalParameterCount: 25,
+      acceptedNameCount: 32,
       aliasedParameterCount: 6,
       maxAliasCount: 3,
       aliasedParameters: ["VT0", "LAMBDA", "N_SUB", "T_NOM", "CBS", "CBD"],
@@ -181,7 +181,7 @@ describe("dcOp", () => {
     );
     expect(table.split("\n")[1]).toBe("D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     expect(table.split("\n").at(-1)).toBe(
-      "PMOS\t24\t31\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
+      "PMOS\t25\t32\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
     );
     const records = modelCardSupportedParameterCoverageSummaryRecords();
     expect(records).toHaveLength(7);
@@ -206,15 +206,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 189,
-      expectedCanonicalParameterCount: 189,
-      acceptedNameCount: 259,
+      canonicalParameterCount: 191,
+      expectedCanonicalParameterCount: 191,
+      acceptedNameCount: 261,
       aliasedParameterCount: 57,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t189\t189\t259\t57\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t191\t191\t261\t57\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -237,15 +237,15 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(188);
-    expect(report.acceptedNameCount).toBe(256);
+    expect(report.canonicalParameterCount).toBe(190);
+    expect(report.acceptedNameCount).toBe(258);
     expect(report.aliasedParameterCount).toBe(56);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 24 canonical supported parameters, found 23",
+      message: "expected NMOS to expose 25 canonical supported parameters, found 24",
     });
     expect(report.issues.at(-1)).toStrictEqual({
       kind: "NMOS",
@@ -253,16 +253,16 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t188\t189\t256\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 24 canonical supported parameters, found 23\nNMOS\taccepted_name_count\texpected NMOS to expose 31 accepted model-card names, found 28\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t190\t191\t258\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 25 canonical supported parameters, found 24\nNMOS\taccepted_name_count\texpected NMOS to expose 32 accepted model-card names, found 29\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 24 canonical supported parameters, found 23",
+      message: "expected NMOS to expose 25 canonical supported parameters, found 24",
     });
     expect(formatModelCardSupportedParameterCoverageGateIssueCsv(report)).toMatch(
-      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 24 canonical supported parameters, found 23"\n/,
+      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 25 canonical supported parameters, found 24"\n/,
     );
     expect(JSON.parse(formatModelCardSupportedParameterCoverageGateIssueJson(report))).toStrictEqual(
       records,
@@ -420,6 +420,7 @@ describe("dcOp", () => {
       FC: 0.4,
       LD: 50.0e-9,
       RD: 125.0,
+      RS: 75.0,
       TOX: 25.0e-9,
       KF: 2.0e-24,
       AF: 1.4,
@@ -436,6 +437,7 @@ describe("dcOp", () => {
       FC: 0.4,
       LD: 50.0e-9,
       RD: 125.0,
+      RS: 75.0,
       TOX: 25.0e-9,
       KF: 2.0e-24,
       AF: 1.4,
@@ -450,6 +452,7 @@ describe("dcOp", () => {
     expectClose(mosModel.params.FC, 0.4);
     expectClose(mosModel.params.LD, 50.0e-9);
     expectClose(mosModel.params.RD, 125.0);
+    expectClose(mosModel.params.RS, 75.0);
     expectClose(mosModel.params.TOX, 25.0e-9);
     expectClose(mosModel.params.KF, 2.0e-24);
     expectClose(mosModel.params.AF, 1.4);
@@ -1157,6 +1160,18 @@ describe("dcOp", () => {
     expect(result.nodeVoltages.get("__spice_M1_drain")!).toBeLessThan(5.0);
   });
 
+  it("raises the intrinsic MOSFET source voltage across RS", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vdrain", "drain", "0", 5.0));
+    circuit.add(voltageSource("Vgate", "gate", "0", 3.0));
+    circuit.add(mosfet("M1", "drain", "gate", "0", "0", "NMOS", {
+      RS: 1_000.0,
+    }));
+
+    const result = dcOp(circuit);
+    expect(result.nodeVoltages.get("__spice_M1_source")!).toBeGreaterThan(0.0);
+  });
+
   it("raises the intrinsic JFET source voltage across RS", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vdrain", "drain", "0", 5.0));
@@ -1222,6 +1237,7 @@ describe("dcOp", () => {
           L: 1.0e-6,
           LD: 0.1e-6,
           RD: 125.0,
+          RS: 75.0,
           TOX: 25.0e-9,
         }),
       ]),
@@ -1235,6 +1251,7 @@ describe("dcOp", () => {
     expectClose(expanded!.params.L, 1.0e-6);
     expectClose(expanded!.params.LD, 0.1e-6);
     expectClose(expanded!.params.RD, 125.0);
+    expectClose(expanded!.params.RS, 75.0);
     expectClose(expanded!.params.TOX, 25.0e-9);
   });
 
@@ -2456,6 +2473,20 @@ describe("dcOp", () => {
         Number.isFinite(drainResistance)
           ? "MOSFET RD must be non-negative"
           : "MOSFET RD must be finite",
+      );
+    }
+  });
+
+  it("rejects invalid MOSFET source resistances", () => {
+    for (const sourceResistance of [Number.NaN, -1.0]) {
+      const circuit = new Circuit();
+      circuit.add(mosfet("Mbad", "drain", "gate", "0", "0", "NMOS", {
+        RS: sourceResistance,
+      }));
+      expect(() => dcOp(circuit)).toThrowError(
+        Number.isFinite(sourceResistance)
+          ? "MOSFET RS must be non-negative"
+          : "MOSFET RS must be finite",
       );
     }
   });

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -186,6 +186,23 @@ describe("noiseAc", () => {
     );
   });
 
+  it("emits MOSFET source-resistance thermal noise", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vdd", "vdd", "0", 5.0));
+    circuit.add(voltageSource("Vgate", "gate", "0", 3.0));
+    circuit.add(resistor("Rload", "vdd", "out", 1_000.0));
+    circuit.add(mosfet("M1", "out", "gate", "0", "0", "NMOS", { RS: 250.0 }));
+
+    const entry = noiseAc(circuit, "out", "Vgate", [1_000.0], 300.0).points[0]!.entries
+      .find((candidate) =>
+        candidate.elementName === "M1:RS" && candidate.noiseType === "thermal"
+      );
+    expect(entry?.sourcePsd).toBeCloseTo(
+      4.0 * 1.380_649e-23 * 300.0 / 250.0,
+      30,
+    );
+  });
+
   it("emits JFET source-resistance thermal noise", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vdd", "vdd", "0", 5.0));

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,16 +33,16 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS drain resistance.
+1. Cross-language Level-1 MOS source resistance.
    - Status: current PR completion candidate.
-   - Add Berkeley Level-1 MOS `RD` model-card support in Rust, Python, and
+   - Add Berkeley Level-1 MOS `RS` model-card support in Rust, Python, and
      TypeScript, defaulting to zero ohms.
-   - For positive values, create an intrinsic drain node, stamp the external
+   - For positive values, create an intrinsic source node, stamp the external
      resistor in DC, TF, AC, and transient analyses, and route the channel plus
-     drain-side capacitances through the intrinsic node.
-   - Preserve `RD` through hierarchy and cloning, require a finite non-negative
-     value, emit the resistor's `4kT/RD` Johnson noise as `<name>:RD`, and
-     extend the supported-parameter coverage gate from 187 to 189 canonical
+     source-side capacitances through the intrinsic node.
+   - Preserve `RS` through hierarchy and cloning, require a finite non-negative
+     value, emit the resistor's `4kT/RS` Johnson noise as `<name>:RS`, and
+     extend the supported-parameter coverage gate from 189 to 191 canonical
      rows.
 
 ## Completed Slices
@@ -3431,8 +3431,18 @@ the Rust, Python, and TypeScript surfaces together.
      defaulting to `1e-7 m`, and derive intrinsic Meyer gate capacitance from
      `Cox = epsilon_ox / TOX`.
    - Hierarchy and cloning preserve the oxide thickness, shared validation
-     enforces finite positive `TOX`, and the supported-parameter release gate
-     now covers 187 canonical rows.
+   enforces finite positive `TOX`, and the supported-parameter release gate
+   now covers 187 canonical rows.
+
+269. Cross-language Level-1 MOS drain resistance.
+   - Status: completed in PR 9011.
+   - Rust, Python, and TypeScript Level-1 MOS model cards now accept `RD`,
+     defaulting to zero, and create an intrinsic drain node for positive values
+     across DC, transient, AC, transfer-function, and noise analyses.
+   - Hierarchy and cloning preserve `RD`, finite non-negative validation is
+     shared across analyses, drain-side capacitances terminate at the intrinsic
+     node, and the supported-parameter release gate now covers 189 canonical
+     rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley Level-1 MOS `RS` model-card support across Rust, Python, and TypeScript
- route the channel and source-side capacitances through an intrinsic source node in DC, transient, AC, TF, and noise analyses
- preserve RS through hierarchy, validate it, emit `<name>:RS` Johnson noise, and advance the coverage gate to 191 canonical parameters
- reconcile the SPICE implementation plan after merged drain-resistance work

## Verification
- `cargo fmt -p mosfet-models -p spice-engine -- --check`
- `cargo test -p mosfet-models -p spice-engine`
- `python -m pytest code/packages/python/mosfet-models code/packages/python/spice-engine` (668 passed)
- `python -m ruff check --ignore SIM108,F841 code/packages/python/mosfet-models code/packages/python/spice-engine`
- `npm run build && npm test` in TypeScript spice-engine (383 passed)
- `git diff --check`