### PR TITLE
feat(semantic-ir-to-ruby): classes slice 6 — class variables (@@x) (0.16.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.16.0 — classes slice 6: class variables (@@x)
+
+Accepts `Feature::ClassVars` — `@@` class variables.
+
+- `@@x = v` → `Stmt::Assign { scope: ClassVar }`; `@@x` → `Expr::VarRef { scope:
+  ClassVar }` (the name includes the leading `@@`).
+- A class-BODY initializer `@@x = init` — the FIRST accepted non-empty class body.
+
+**Why not a bare `@@x`.** A method body runs in a hoisted top-level function, not
+a lexical class scope, so a bare `@@x` is a Ruby error ("class variable access
+from toplevel"). Read/write in a method therefore routes through a new runtime
+helper: `sir_cvar_owner(self).class_variable_get/set(:"@@x")`, where
+`sir_cvar_owner(s) = s.is_a?(Module) ? s : s.class` resolves the owning class in
+*both* contexts — an instance method (`self.class`) and a class method (`self`
+*is* the class). So an instance method and a class method share the same `@@x`,
+matching Ruby.
+
+**The class-body initializer** runs where `self` is `main`, not the class, so it
+can't use the `sir_cvar_owner(self)` path; it writes on the class by NAME:
+`<Class>.class_variable_set(:"@@x", init)`. This is why a non-empty class body is
+now legal — but ONLY for `@@x` initializers; any other class-body content stays
+rejected.
+
+**Injection safety.** Every `@@`-name — a `ClassVar` `Assign`/`VarRef` and a
+class-body initializer — is validated as `@@<identifier>` (new
+`is_valid_classvar_name`) in the co-total scan and emitted as a safely-quoted
+symbol, so a crafted name cannot inject. The `emit_var_ref` scope match is now
+exhaustive (every `Scope` handled), so a new variant is a compile error rather
+than reaching a catch-all `unreachable!`.
+
+**Still rejects** modules (`__include__` / `__extend__`) — the last OOP slice.
+
 ## 0.15.0 — classes slice 5: class methods (def self.foo)
 
 Class (singleton) **methods**. No new `Feature` (they lower to builtins).

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/README.md
+++ b/code/packages/rust/semantic-ir-to-ruby/README.md
@@ -93,12 +93,16 @@ still `sir_um_`-prefixed so `instance_method` can only fetch a user method
 &closure)` and `Class.m(…)` → `(Class).public_send(:sir_um_m, …)` — the same
 `sir_um_` prefix (a separate singleton table, no collision), gated by an
 independent class-method allowlist so a built-in class-method call rejects cleanly.
+**Class variables** (slice 6): `@@x` (`Scope::ClassVar`) routes through
+`sir_cvar_owner(self).class_variable_get/set(:"@@x")` (the owner is the class in
+both instance- and class-method contexts, so they share one `@@x`), and a
+class-body `@@x = init` — the first accepted non-empty class body — writes on the
+class by name; each `@@`-name validated (no injection).
 Rejects `TailCalls`, `Intrinsics`, and every not-yet-wired feature (array
 indexing / slicing via `IndexGet` — `NDArrays`; array-pattern destructuring;
-built-in collection methods; and the rest of OOP — class variables (`@@x`,
-with the class-body initializer they need), modules — plus a namespaced
-class/constant definition) until its slice lands — each a clean,
-source-positioned `UnsupportedFeature`.
+built-in collection methods; and the last of OOP — modules — plus a namespaced
+class/constant definition or other class-body content) until its slice lands —
+each a clean, source-positioned `UnsupportedFeature`.
 
 ## Verification
 

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -185,6 +185,9 @@ pub enum ScanHit {
     /// metacharacter would inject source.  Same injection guard as `ConstantName`,
     /// at the instance-variable positions.
     InstanceVarName(String, semantic_ir::Span),
+    /// A `Scope::ClassVar` name (`@@x`) that is not a valid Ruby class-variable
+    /// name (`@@<identifier>`) — injection guard at the class-variable positions.
+    ClassVarName(String, semantic_ir::Span),
 }
 
 /// Scan the module — in a SINGLE traversal shared with the unsupported-builtin
@@ -428,6 +431,15 @@ impl Scan {
                 } else {
                     self.expr(value)
                 }
+            } else if matches!(scope, Scope::ClassVar) {
+                // A `Scope::ClassVar` target (`@@x = …`) emits the name into a
+                // `class_variable_set` symbol, so validate it as `@@<identifier>`
+                // at this position; then scan the value.
+                if !is_valid_classvar_name(name) {
+                    Some(ScanHit::ClassVarName(name.clone(), span.clone()))
+                } else {
+                    self.expr(value)
+                }
             } else {
                 self.expr(value)
             }
@@ -520,13 +532,32 @@ impl Scan {
                     superclass.clone().unwrap_or_default(),
                     span.clone(),
                 ))
-            } else if !body.is_empty() {
-                Some(ScanHit::Unsupported(
-                    "a non-empty class body (class-level code or constants)".to_string(),
-                    span.clone(),
-                ))
             } else {
-                None
+                // OOP slice 6: a class BODY may contain `@@x = <init>` class-
+                // variable initializers — the emitter renders each as
+                // `<Class>.class_variable_set(:"@@x", …)`.  Admit ONLY those (with a
+                // validated `@@`-name and a scanned value); any OTHER body content
+                // (class-level code / constants) stays deferred, rejected cleanly.
+                body.iter().find_map(|st| match st {
+                    Stmt::Assign {
+                        name: cv,
+                        scope: Scope::ClassVar,
+                        value,
+                        span: aspan,
+                    } => {
+                        if !is_valid_classvar_name(cv) {
+                            Some(ScanHit::ClassVarName(cv.clone(), aspan.clone()))
+                        } else {
+                            self.expr(value)
+                        }
+                    }
+                    _ => Some(ScanHit::Unsupported(
+                        "a class body with content other than `@@class` variable \
+                         initializers (class-level code / constants)"
+                            .to_string(),
+                        span.clone(),
+                    )),
+                })
             }
         }
         // A `Stmt::SingletonClassDef` (`class << self`) ALSO observes
@@ -570,6 +601,19 @@ fn is_valid_constant_path(name: &str) -> bool {
 fn is_valid_ivar_name(name: &str) -> bool {
     let mut chars = name.chars();
     chars.next() == Some('@')
+        && matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Whether `name` is a syntactically valid Ruby class-variable name — `@@`
+/// followed by an identifier (`@@count`).  The frontend puts the `@@` in the
+/// node's `name`; the emitter renders it through a quoted symbol in
+/// `class_variable_get/set`, but a `class_variable_*` still requires a
+/// `@@`-prefixed name and this gates any metacharacter (defence in depth).
+fn is_valid_classvar_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars.next() == Some('@')
+        && chars.next() == Some('@')
         && matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '_')
         && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
@@ -766,6 +810,15 @@ impl Scan {
             scope: Scope::Instance,
             span,
         } if !is_valid_ivar_name(name) => Some(ScanHit::InstanceVarName(name.clone(), span.clone())),
+        // A `Scope::ClassVar` reference (`@@x`, `Feature::ClassVars`) emits its name
+        // into a `class_variable_get` symbol, so validate it as `@@<identifier>`.
+        Expr::VarRef {
+            name,
+            scope: Scope::ClassVar,
+            span,
+        } if !is_valid_classvar_name(name) => {
+            Some(ScanHit::ClassVarName(name.clone(), span.clone()))
+        }
         _ => None,
     }
     }
@@ -879,6 +932,18 @@ fn emit_stmt(s: &Stmt) -> String {
                 // Inside a `define_method`-installed method `self` is the receiver,
                 // so this writes the instance's own variable.
                 format!("{} = {}", name, emit_expr(value))
+            } else if matches!(scope, Scope::ClassVar) {
+                // A `Scope::ClassVar` target (`@@x = …`, `Feature::ClassVars`, OOP
+                // slice 6) IN A METHOD BODY: a bare `@@x = …` is a toplevel error in
+                // a hoisted function, so write it via `class_variable_set` on the
+                // owner (`sir_cvar_owner(self)`).  (The class-BODY initializer takes
+                // a different path — see the `ClassDef` emit, where the owner is the
+                // class by name.)  The `@@`-name is a validated, safely-quoted symbol.
+                format!(
+                    "sir_cvar_owner(self).class_variable_set({}, {})",
+                    emit_symbol(name),
+                    emit_expr(value)
+                )
             } else {
                 format!("{} = {}", sanitize_ident(name), emit_expr(value))
             }
@@ -1052,11 +1117,38 @@ fn emit_stmt(s: &Stmt) -> String {
         // scan validated it as a constant path), so the subclass inherits its
         // ancestry natively (`Dog.new.is_a?(Animal)`, and `super` resolves up it).
         Stmt::ClassDef {
-            name, superclass, ..
-        } => match superclass {
-            Some(sup) => format!("Object.const_set(:{name}, Class.new({sup}))"),
-            None => format!("Object.const_set(:{name}, Class.new)"),
-        },
+            name,
+            superclass,
+            body,
+            ..
+        } => {
+            let mut s = match superclass {
+                Some(sup) => format!("Object.const_set(:{name}, Class.new({sup}))"),
+                None => format!("Object.const_set(:{name}, Class.new)"),
+            };
+            // OOP slice 6: a class-BODY `@@x = <init>` (`Scope::ClassVar` Assign,
+            // the ONLY body content the scan admits) initialises a class variable.
+            // It runs where `self` is `main`, NOT the class, so it CANNOT use the
+            // method-body `sir_cvar_owner(self)` path — write it on the class by
+            // NAME instead.  The `@@`-name is a validated, safely-quoted symbol.
+            for st in body {
+                if let Stmt::Assign {
+                    name: cv,
+                    scope: Scope::ClassVar,
+                    value,
+                    ..
+                } = st
+                {
+                    let _ = write!(
+                        s,
+                        "\n{name}.class_variable_set({}, {})",
+                        emit_symbol(cv),
+                        emit_expr(value)
+                    );
+                }
+            }
+            s
+        }
         // Other not-yet-supported statements (e.g. index-set, module/singleton
         // defs) are rejected by the capability check / scan before emit.
         other => unreachable!("Ruby backend reached unsupported statement: {other:?}"),
@@ -1255,9 +1347,21 @@ fn emit_var_ref(name: &str, scope: Scope) -> String {
         // `define_method`-installed method (slice 2) `self` IS the receiver, so
         // `@v` reads the instance's own variable — no runtime plumbing.
         Scope::Instance => name.to_string(),
-        // `Scope::ClassVar` (`@@x`) is a later OOP slice's feature, not yet
-        // accepted → such a module is rejected before emit.
-        other => unreachable!("Ruby backend reached unsupported var scope: {other:?}"),
+        // A `Scope::ClassVar` reference (`@@x`, `Feature::ClassVars`, OOP slice 6).
+        // A method body runs in a hoisted top-level function, where a bare `@@x`
+        // is a Ruby error ("class variable access from toplevel"), so read it via
+        // `class_variable_get` on the owner resolved by `sir_cvar_owner(self)` (the
+        // class in both instance- and class-method contexts).  The name (incl.
+        // `@@`) is validated as `@@<identifier>` and emitted as a safe quoted
+        // symbol (no injection).
+        Scope::ClassVar => {
+            format!(
+                "sir_cvar_owner(self).class_variable_get({})",
+                emit_symbol(name)
+            )
+        }
+        // Every `Scope` is now handled; a new variant is a compile error here
+        // (the totality signal), so no `unreachable!` catch-all is needed.
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
@@ -196,9 +196,23 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // `define_method` (slice 2), which binds `self` to the receiver, so `@v`
     // inside a method reads/writes the instance's own variable — no runtime
     // support.  The `__self__` builtin (a bare `self`) rides in here too,
-    // rendering the native `self`.  `@@class` variables are the separate
-    // `Feature::ClassVars` (a later slice), still rejected.
+    // rendering the native `self`.
     Feature::InstanceVars,
+    // ── OOP classes, slice 6: class variables (`@@x`) ────────────────────
+    // `Feature::ClassVars` is observed by a `Scope::ClassVar` name (`@@x`).
+    //   `@@x = v` → `Stmt::Assign { scope: ClassVar }`
+    //   `@@x`     → `Expr::VarRef  { scope: ClassVar }`
+    // A method body runs in a HOISTED top-level function (not a lexical class
+    // scope), where a bare `@@x` is a Ruby error ("class variable access from
+    // toplevel").  So `@@x` read/write in a method routes through
+    // `sir_cvar_owner(self).class_variable_get/set(:"@@x")` — the owner is the
+    // class in both instance- (`self.class`) and class-method (`self`) contexts,
+    // so both share the same `@@x`.  A class-BODY `@@x = <init>` (the only body
+    // content accepted, making a non-empty class body legal for the first time)
+    // instead writes on the class by NAME (`<Class>.class_variable_set`), since it
+    // runs where `self` is `main`, not the class.  Every `@@`-name is validated as
+    // `@@<identifier>` in the co-total scan (no injection).
+    Feature::ClassVars,
 ];
 
 impl Backend for RubyBackend {
@@ -302,6 +316,17 @@ impl Backend for RubyBackend {
                     message: format!(
                         "the Ruby backend cannot emit the instance variable `{name}` \
                          (not a valid `@identifier`)"
+                    ),
+                    span,
+                });
+            }
+            // A `Scope::ClassVar` name that is not a valid `@@identifier`.
+            Some(emit::ScanHit::ClassVarName(name, span)) => {
+                return Err(BackendError {
+                    kind: BackendErrorKind::UnsupportedFeature,
+                    message: format!(
+                        "the Ruby backend cannot emit the class variable `{name}` \
+                         (not a valid `@@identifier`)"
                     ),
                     span,
                 });

--- a/code/packages/rust/semantic-ir-to-ruby/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/runtime.rs
@@ -56,6 +56,16 @@ def sir_eq(a, b) = a == b
 # Call a closure value (a Ruby lambda) with the given arguments.
 def sir_apply(target, *args) = target.call(*args)
 
+# OOP slice 6 — the class that owns a `@@class variable` in the CURRENT method.
+# A method body runs in a hoisted top-level function (not a lexical class scope),
+# so `@@x` cannot be written directly ("class variable access from toplevel").
+# Instead the emitter routes `@@x` through `.class_variable_get/set` on the owner
+# resolved here: inside an INSTANCE method `self` is the receiver, so the owner is
+# `self.class`; inside a CLASS method `self` IS the class (a `Module`), so it is
+# the owner itself.  This gives ONE class in both contexts, so an instance method
+# and a class method share the same `@@x` (matching Ruby).
+def sir_cvar_owner(s) = s.is_a?(Module) ? s : s.class
+
 # Indexed write `a[i] = v` with the SIR bounds rule.  The reference
 # (`_sir_seq_set`) treats ONLY `0 <= i < length` as valid and RAISES on a
 # negative or out-of-range index — whereas Ruby's native `a[i] = v` would

--- a/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
@@ -2195,3 +2195,137 @@ fn a_malformed_def_class_method_missing_its_closure_is_rejected() {
     let m = method_module(vec![classdef("Foo", None, vec![]), bad]);
     assert!(compile(&m).is_err(), "a malformed __def_class_method__ must be rejected");
 }
+
+// ── OOP classes slice 6 — class variables (@@x) ─────────────────────────────
+//
+// `@@x = v` / `@@x` (`Scope::ClassVar`, name incl. `@@`) can't be a bare `@@x` in
+// the hoisted method function (a Ruby toplevel error). A method-body read/write
+// routes through `sir_cvar_owner(self).class_variable_get/set(:"@@x")` (the owner
+// is the class in both instance- and class-method contexts). A class-BODY
+// initializer `@@x = init` (the only body content admitted) writes on the class
+// by name: `<Class>.class_variable_set(:"@@x", init)`. Each `@@`-name is validated.
+
+fn classvar_module(stmts: Vec<Stmt>) -> Module {
+    Module {
+        name: "cvprog".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::ClassVars,
+            Feature::MutableBindings,
+            Feature::Strings,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s2() }, span: s2() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new().with_source_language("test"),
+            span: s2(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s2(),
+    }
+}
+fn classvar_ref(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::ClassVar, span: s2() }
+}
+fn classvar_assign(name: &str, value: Expr) -> Stmt {
+    Stmt::Assign { name: name.into(), scope: Scope::ClassVar, value, span: s2() }
+}
+
+// ---- positive, through the real frontend + interpreter --------------------
+
+#[test]
+fn e2e_class_variable_init_and_shared_reads() {
+    // `@@count` is initialised in the class body, mutated by a class method, and
+    // read by BOTH a class method and an instance method — all seeing the same
+    // value (2), proving the shared class-variable semantics.
+    let rb = ruby_to_ruby(
+        "class Counter\n  @@count = 0\n  def self.bump\n    @@count = @@count + 1\n  end\n  \
+         def self.total\n    @@count\n  end\n  def peek\n    @@count\n  end\nend\n\
+         Counter.bump\nCounter.bump\nputs Counter.total\nputs Counter.new.peek\n",
+    );
+    assert!(rb.contains("Counter.class_variable_set(:\"@@count\", 0)"), "class-body init:\n{rb}");
+    assert!(rb.contains("sir_cvar_owner(self).class_variable_get(:\"@@count\")"), "method read:\n{rb}");
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "2\n2"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+// ---- hand-built: emit shape + injection -----------------------------------
+
+#[test]
+fn classvar_read_and_write_emit_via_owner_helper() {
+    let m = classvar_module(vec![classvar_assign("@@n", ilit(1)), puts(classvar_ref("@@n"))]);
+    let rb = compile(&m).expect("classvar module compiles").source;
+    assert!(rb.contains("sir_cvar_owner(self).class_variable_set(:\"@@n\", 1)"), "write:\n{rb}");
+    assert!(rb.contains("sir_cvar_owner(self).class_variable_get(:\"@@n\")"), "read:\n{rb}");
+}
+
+#[test]
+fn a_class_body_of_only_classvar_inits_compiles() {
+    // A non-empty class body is now legal WHEN it holds only `@@x` initializers.
+    // (The module declares `Classes` + `ClassVars` — the body assign observes both.)
+    let m = Module {
+        name: "cfgprog".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Classes,
+            Feature::ClassVars,
+            Feature::MutableBindings,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![classdef("Cfg", None, vec![classvar_assign("@@v", ilit(7))])],
+                value: Expr::NilLit { span: s2() },
+                span: s2(),
+            },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new().with_source_language("test"),
+            span: s2(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s2(),
+    };
+    let rb = compile(&m).expect("classvar-init class body compiles").source;
+    assert!(rb.contains("Cfg.class_variable_set(:\"@@v\", 7)"), "by-name init:\n{rb}");
+}
+
+#[test]
+fn a_class_body_with_non_classvar_content_is_rejected() {
+    // Any other class-body content is still deferred.
+    let m = class_module(vec![classdef("Cfg", None, vec![puts(strlit("side effect"))])]);
+    assert!(compile(&m).is_err(), "non-classvar class body must be rejected");
+}
+
+#[test]
+fn an_injectable_classvar_write_name_is_rejected() {
+    let m = classvar_module(vec![classvar_assign("@@n = 1; system('x')", ilit(1))]);
+    let err = compile(&m).expect_err("an injectable classvar write must be rejected");
+    assert_eq!(err.kind, semantic_ir::BackendErrorKind::UnsupportedFeature);
+}
+
+#[test]
+fn an_injectable_classvar_read_name_is_rejected() {
+    let m = classvar_module(vec![puts(classvar_ref("@@n; system('x')"))]);
+    assert!(compile(&m).is_err(), "an injectable classvar read must be rejected");
+}
+
+#[test]
+fn a_non_double_at_classvar_name_is_rejected() {
+    // A `Scope::ClassVar` name must start with `@@` and a valid identifier.
+    assert!(compile(&classvar_module(vec![classvar_assign("@n", ilit(1))])).is_err(), "single @");
+    assert!(compile(&classvar_module(vec![classvar_assign("@@", ilit(1))])).is_err(), "bare @@");
+    assert!(compile(&classvar_module(vec![classvar_assign("@@1x", ilit(1))])).is_err(), "@@ + digit");
+}

--- a/code/specs/SIR25-semantic-ir-to-ruby.md
+++ b/code/specs/SIR25-semantic-ir-to-ruby.md
@@ -138,12 +138,24 @@ instance one, gates `__class_method__`: a dispatch to an unregistered name is a
 built-in class method (the Collections batch), rejected cleanly, and an instance
 registration never authorises a class dispatch of the same name.
 
+The sixth OOP slice (0.16.0) adds `@@` class **variables**. A method-body `@@x`
+read/write (`Scope::ClassVar`) cannot be a bare `@@x` (a Ruby toplevel error in
+the hoisted method function), so it routes through
+`sir_cvar_owner(self).class_variable_get/set(:"@@x")`, where `sir_cvar_owner(s) =
+s.is_a?(Module) ? s : s.class` yields the class in both instance-method
+(`self.class`) and class-method (`self`) contexts — so both share one `@@x`. The
+class-BODY initializer `@@x = init` (the FIRST accepted non-empty class body,
+holding ONLY such initializers) instead writes on the class by name
+(`<Class>.class_variable_set`), since it runs where `self` is `main`. Each
+`@@`-name is validated as `@@<identifier>` and emitted as a quoted symbol (no
+injection); `emit_var_ref` now matches every `Scope` exhaustively.
+
 **Still rejects** `TailCalls`, `Intrinsics`, `NDArrays`, and every not-yet-landed
-feature — including the rest of OOP: class variables (`@@x`, with the class-body
-initializer they need) and modules; plus a malformed `__def_method__` /
-`__def_class_method__`, a
-non-empty class body, a namespaced (`Foo::Bar`) class/constant *definition*
-(`const_set` names one namespace), and a **singleton class** (`class << self` —
+feature — including the last of OOP, modules (`__include__` / `__extend__`); plus
+a malformed `__def_method__` / `__def_class_method__`, a class body with content
+other than `@@x` initializers, a namespaced (`Foo::Bar`) class/constant
+*definition* (`const_set` names one namespace), and a **singleton class**
+(`class << self` —
 `Stmt::SingletonClassDef`, which also observes `Feature::Classes`, so accepting
 `Classes` obligates rejecting it in the scan lest it reach the emitter's
 `unreachable!`). Each rejection is a clean, source-positioned
@@ -191,6 +203,8 @@ or temporaries:
 | `BuiltinCall("__super__", [m, class, args…])` | `(<class>).superclass.instance_method(:sir_um_<m>).bind(self).call(<args>)` — explicit prefixed ancestry walk |
 | `BuiltinCall("__def_class_method__", [class, m, closure])` | `<class>.define_singleton_method(:sir_um_<m>, &closure)` — class (singleton) method |
 | `BuiltinCall("__class_method__", [class, m, args…])` | `(<class>).public_send(:sir_um_<m>, <args>)` — class-name-receiver dispatch (allowlisted, anti-RCE) |
+| `VarRef { ClassVar }` / `Assign { ClassVar }` (method body) | `sir_cvar_owner(self).class_variable_get/set(:"@@x", …)` — owner is the class in both contexts |
+| `Assign { ClassVar }` (class body) | `<Class>.class_variable_set(:"@@x", <init>)` — the only accepted non-empty class-body content |
 | `If` | `(if sir_truthy(<cond>) then <then> else <else> end)` |
 | `LogicalAnd { lhs, rhs }` | `(<lhs> && <rhs>)` — native short-circuit, yields the deciding operand |
 | `LogicalOr { lhs, rhs }` | `(<lhs> \|\| <rhs>)` — native short-circuit, yields the deciding operand |
@@ -293,8 +307,9 @@ growing `ACCEPTED_FEATURES`, the runtime, and the conformance corpus in lockstep
    reserved `sir_um_` prefix, landed 0.12), instance **variables** (`@v`, native,
    landed 0.13), **inheritance** + `super` (`Class.new(Super)` + an explicit
    ancestry walk, landed 0.14), class **methods** (`def self.m`, native
-   `define_singleton_method`, landed 0.15), then **class variables** (`@@x`) and
-   **modules**/mixins.
+   `define_singleton_method`, landed 0.15), class **variables** (`@@x` via
+   `class_variable_get/set`, landed 0.16), then **modules**/mixins (the last
+   slice).
 6. **Collections** — the `__method__` catalog for built-in `String`/`Array`/
    `Hash`/numeric methods (Ruby methods are largely native), sharing the same
    `__method__` dispatch surface as OOP.


### PR DESCRIPTION
## What

The **sixth OOP slice**: `@@` class variables. Bumps `semantic-ir-to-ruby` 0.15.0 → 0.16.0. Accepts `Feature::ClassVars`.

- `@@x = v` / `@@x` in a method body → `sir_cvar_owner(self).class_variable_set/get(:"@@x", …)`.
- `@@x = init` in a class body → `(Class).class_variable_set(:"@@x", init)` — the **first accepted non-empty class body**.

## Why not a bare `@@x`

A method body runs in a hoisted top-level function (slice 2), not a lexical class scope, so a bare `@@x` is a Ruby error ("class variable access from toplevel"). Read/write in a method routes through a new runtime helper: `sir_cvar_owner(s) = s.is_a?(Module) ? s : s.class`, which resolves the owning class in **both** contexts — an instance method (`self.class`) and a class method (`self` *is* the class) — so both share the same `@@x`, matching Ruby. Verified end-to-end: a class-body `@@count = 0`, mutated by a class method, is read as `2` by both a class method and an instance method.

The class-body initializer runs where `self` is `main` (not the class), so it can't use the `sir_cvar_owner(self)` path — it writes on the class by name. That's why a non-empty class body is now legal, but **only** for `@@x` initializers; any other class-body content stays rejected.

## Injection safety & totality

Every `@@`-name (a `ClassVar` `Assign`/`VarRef` and a class-body initializer) is validated as `@@<identifier>` (new `is_valid_classvar_name`) at exactly its emit position in the co-total scan, and emitted as a safely-quoted symbol. `emit_var_ref`'s `Scope` match is now **exhaustive** (all 8 variants handled) — the dead `unreachable!` catch-all was removed, so a future `Scope` variant is a compile error (the totality signal). The ClassDef emit and scan agree on class-body content: the scan rejects any non-`@@x` body stmt, so the emit never renders an unvalidated one.

## Security review

A read-only security sub-agent reviewed the diff with injection + totality as the focus and returned **PASSED — no vulnerabilities**: all three `@@x` emit sites are guarded co-totally, `is_valid_classvar_name` rejects every malformed shape, `emit_symbol`/`quote_ruby_string` are a safe fallback, the class name stays constant-path validated, and the exhaustive `Scope` match has no reachable panic.

## Tests

111 tests pass (new: frontend+interpreter e2e for a class-body-initialized `@@count` shared across a class method and an instance method; hand-built for the owner-helper read/write emit, a class body of only `@@x` inits compiling, a non-`@@x` class body rejecting, two injectable `@@`-names, and non-`@@` / bare-`@@` / `@@digit` rejections). `cargo clippy` clean. CHANGELOG, README, and SIR25 spec (node table + roadmap) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)