### PR TITLE
feat(axiom-parser): axiom.grammar + parser crate (MA13c, Wave 7)

### DIFF
--- a/code/grammars/axiom/axiom.grammar
+++ b/code/grammars/axiom/axiom.grammar
@@ -1,0 +1,421 @@
+# @version 1
+
+# =============================================================================
+# axiom.grammar — Parser grammar for Axiom (the MA13-scoped consumer-view
+# subset)
+# =============================================================================
+#
+# Drives the generic grammar-driven parser engine (parser::GrammarParser) over
+# the token stream from axiom-lexer (MA-13b, code/grammars/axiom/axiom.tokens,
+# already merged). Axiom's arithmetic/comparison surface is an ordinary infix
+# expression grammar, closer in overall shape to Reduce/Derive/Maple's
+# `head(args)`-style CAS grammars than to any array-family grammar in this
+# repo (MA13 §5) — this file is structured accordingly, using reduce.grammar/
+# derive.grammar as its direct structural precedent, NOT forked from any
+# array-family sibling. The genuinely new productions here — declaration
+# (`:`), coercion (`::`), and category-query (`has`) — are the ones MA13 §3
+# says no prior symbolic-family grammar in this repo has ever needed; every
+# other production mirrors an already-established sibling shape.
+#
+# A future `axiom-runtime` (MA-13d) lowers this CST into `symbolic_ir::IRNode`
+# (arithmetic/comparison/assignment/definition/if/list — reused unchanged from
+# the shared `symbolic-vm`, per MA13 §2/§5) plus its own new `AxiomValue`/
+# `AxiomDomain` layer for the declaration/coercion/has-query nodes this file
+# introduces (MA13 §2's own "no domain/category concept anywhere in
+# symbolic-ir" finding).
+#
+# Token names (UPPERCASE) come from the Axiom lexer
+# (code/grammars/axiom/axiom.tokens):
+#   NUMBER STRING NAME          literals and symbols (NAME also covers every
+#                                  built-in domain/category name — see
+#                                  axiom.tokens's own header — this grammar
+#                                  does not distinguish them from ordinary
+#                                  identifiers; that is axiom-runtime's job)
+#   ASSIGN (:=)                  immediate assignment ONLY (never function
+#                                  definition — contrast Derive/Reduce, which
+#                                  share ONE operator for both roles, MA13 §4)
+#   DEFINE (==)                  held-body function definition ONLY (never
+#                                  plain-variable delayed assignment — MA13
+#                                  §4's own "bare-variable delayed `==` is
+#                                  deferred" scope note)
+#   EQ (=)  NE (~=)  LESS (<)  LE (<=)  GREATER (>)  GE (>=)   comparison —
+#                                  `=` lowers straight to Equal/Boolean in
+#                                  this cut (MA13 §3's own disclosed
+#                                  divergence from real Axiom's default
+#                                  `Equation`); `~=` is Axiom's real
+#                                  not-equal spelling, NOT Maple's `<>` or
+#                                  Wolfram's `!=`
+#   PLUS MINUS TIMES SLASH CARET POW (`^`/`**`, same operator)   arithmetic
+#   LPAREN RPAREN                grouping, parenthesised `;`-block, function
+#                                  application `f(...)`, and the declared
+#                                  function-header's typed parameter list
+#   LBRACKET RBRACKET            list literal `[a, b, c]`
+#   COMMA                        argument/list/parameter separator
+#   SEMI                         the ONLY separator inside a parenthesised
+#                                  block (`( e1; e2; ...; eN )`) — no other
+#                                  use anywhere in this grammar (axiom.tokens'
+#                                  own header)
+#   COLON                        declaration (`a : T`) AND the function-
+#                                  header type-annotation position AND the
+#                                  declared-function's return-type position —
+#                                  ONE lexer token, THREE grammar positions,
+#                                  disambiguated here (never by the lexer,
+#                                  per axiom.tokens' own documented
+#                                  "one glyph, one token type, multiple
+#                                  grammar-level meanings" discipline)
+#   COERCE (::)                  coercion (`e :: T`)
+#   "if" "then" "else"           conditional keywords (KEYWORD token type,
+#                                  matched here by literal spelling — same
+#                                  convention reduce.grammar's own
+#                                  "and"/"or"/"not"/"neq" word-operators use)
+#   "has"                        category-membership query infix keyword
+#
+# =============================================================================
+# WHY `program` IS A SINGLE EXPRESSION, NOT A REPEATED `{ statement_line }`
+# -----------------------------------------------------------------------------
+# Every sibling CAS-family grammar in this repo (`derive.grammar`,
+# `reduce.grammar`, `maple.grammar`) parses a whole worksheet FILE in one
+# call — `program = { statement_line }` — because each of those languages'
+# own `.tokens` file gives top-level statements a real separator: Derive's
+# significant NEWLINE, Reduce's/Maple's `;`/`$`. `axiom.tokens` deliberately
+# has NEITHER: newlines fold into ordinary WHITESPACE (axiom.tokens SECTION
+# 4's own comment — "axiom-repl tracks its own step counter as a REPL-layer
+# concern, not a lexer-level significant-NEWLINE token"), and `;` is reserved
+# EXCLUSIVELY for the parenthesised block (axiom.tokens SECTION 2's own
+# comment — "Axiom has no other in-scope use for `;`"). Inventing an
+# unconfirmed top-level separator here (there is no textual evidence in MA13
+# §3/§4 for one) would be exactly the kind of un-narrowed guess this repo's
+# own "confirm, don't assume" discipline warns against.
+#
+# This is not an oversight but a direct consequence of MA13's own framing of
+# Axiom as a **numbered, per-line interactive session** (§5: `axiom-repl`
+# mirrors real Axiom's own `(1) ->` prompt, incrementing per computation
+# step) rather than a batch worksheet file: a future `axiom-repl` (MA-13d)
+# reads one line, hands that ONE line's tokens to this parser, evaluates it,
+# prints `(n)`'s result, and repeats — exactly mirroring how `derive-repl`'s
+# OWN numbered-prompt convention (which this spec explicitly says
+# `axiom-repl` should mirror, MA13 §5) still calls `derive-parser` fresh
+# per submitted chunk, even though `derive.grammar` itself is capable of
+# parsing a whole multi-statement file at once. `program = expr` is
+# therefore this grammar's own deliberate, disclosed, conservative choice:
+# it parses exactly what one interactive input is ever confirmed to be — a
+# single expression, assignment, definition, declaration, coercion, has-query,
+# or conditional — and leaves "how does a REPL decide where one input ends
+# and the next begins" as the REPL-layer concern MA13 §5 already assigns it,
+# not a question this grammar answers by inventing syntax MA13 never shows.
+# =============================================================================
+
+program = expr ;
+
+# =============================================================================
+# `expr` — the top-level ordered choice (PEG). Every one of MA13 §4's
+# in-scope forms is treated as uniformly `expr`-shaped and mutually nestable
+# (an `if`-branch, an assignment's right-hand side, a function body, and a
+# list element are all just `expr`) — mirroring reduce.grammar's own
+# "`if`/`<<...>>` are usable as an expression" design, rather than inventing
+# a separate statement/expression bifurcation MA13 never asks for. Each
+# alternative commits on a unique leading shape (a keyword, or a specific
+# token found a fixed number of tokens after a leading NAME/LPAREN), so
+# ordinary PEG ordered choice with packrat backtracking resolves everything
+# below with NO lookahead predicate of any kind — precisely the same
+# "know which alternative you are inside, backtrack cleanly on failure"
+# discipline idl.grammar's own header comment documents at length.
+# =============================================================================
+
+expr = if_expr
+     | define
+     | assignment
+     | declaration
+     | has_query
+     | comparison ;
+
+# `if p then e1 else e2` (MA13 §4). Unlike reduce.grammar's/idl.grammar's own
+# OPTIONAL else, MA13 §4 explicitly says "missing else -- deferred" for this
+# cut, so `else` is MANDATORY here — a real, confirmed narrowing, not this
+# grammar's own choice. Both branches are `expr` (fully general), matching
+# every sibling's "usable as an expression" convention, so a definition,
+# assignment, or nested `if` can appear as either branch.
+if_expr = "if" expr "then" expr "else" expr ;
+
+# =============================================================================
+# Function definition — `==`, held-body (MA13 §4). This is a GENUINELY
+# different design from Derive's/Reduce's own `:=`, which shares ONE
+# production between plain variable assignment and function definition (the
+# D-4/R-4 runtime disambiguates by inspecting the parsed left-hand side's
+# shape post-hoc). That trick does not transfer here, for a concrete,
+# structural reason: Axiom's DECLARED function-definition form
+# (`f(x: T, ...): T == e`) needs a parameter list of TYPED declarations
+# (`x: T`), which is not a shape any ordinary call's `arglist` (a plain
+# comma-list of `expr`) can express — an ordinary `postfix` call production
+# has no way to parse `x: T` as one of its arguments (`declaration`, MA13's
+# own `:` production, is a full top-level `expr` alternative in its own
+# right, not an argument-list element). So, unlike Derive/Reduce, this
+# grammar cannot simply reuse "whatever the general call/assignment-target
+# production already parses" for `==`'s left-hand side — it needs its OWN,
+# narrower, dedicated shape.
+#
+# Two dedicated forms, matching MA13 §4's own two confirmed rows exactly (a
+# deliberately CONSERVATIVE choice: this grammar does not invent any
+# combination MA13 does not show, e.g. it does NOT accept a parenthesised
+# but UNTYPED parameter list `f(x) == e`, and does NOT make the declared
+# form's return-type annotation optional — both would be permissive
+# extensions beyond what MA13 §4's table literally states, and are left
+# unsupported rather than guessed):
+#
+#   1. declared_define   -- f(x: T, ...): T == e   (every parameter AND the
+#      return type carry an explicit `: T` annotation)
+#   2. undeclared_define  -- f x == e               (the paren-optional
+#      single-argument shape, duck-typed — "evaluated rather than
+#      'recompiled' since this is an interpreter, not Axiom's own compiler",
+#      MA13 §4)
+#
+# Ordering is not load-bearing for correctness (packrat backtracking makes
+# either order safe), but `declared_define` is tried first since its own
+# leading shape (`NAME LPAREN`) is a strict prefix-superset check away from
+# `undeclared_define`'s (`NAME NAME`) — trying the parenthesised form first
+# avoids a redundant failed attempt at `undeclared_define` on ordinary
+# declared input.
+define = declared_define
+       | undeclared_define ;
+
+declared_define = NAME LPAREN [ typed_param_list ] RPAREN COLON type_expr DEFINE expr ;
+
+typed_param_list = typed_param { COMMA typed_param } ;
+typed_param = NAME COLON type_expr ;
+
+undeclared_define = NAME NAME DEFINE expr ;
+
+# `x := e` (MA13 §4) — immediate assignment ONLY. Narrowed to a bare NAME
+# left-hand side, matching MA13's own single confirmed row literally (unlike
+# Derive's/Reduce's own `:=`, MA13 §4 never shows a `:=`-based function
+# definition form — that role belongs entirely to `==`, above). The
+# right-hand side is the fully general `expr`, which (since `assignment` is
+# itself one of `expr`'s own alternatives) gives a chained
+# `a := b := 5` right-associative reading FOR FREE, the identical
+# "RHS is `expr`, which loops back to `assignment`" trick
+# reduce.grammar's own header comment documents for its own `:=` — not
+# separately confirmed as real Axiom syntax by MA13, but costing nothing
+# extra to support and consistent with this grammar's uniform "everything is
+# `expr`-shaped" design (see `expr`'s own header comment above).
+assignment = NAME ASSIGN expr ;
+
+# `a : T` / `(a, b, c) : T` (MA13 §4) — declaration, restricting the domain a
+# name may hold. The left-hand side is deliberately narrow — a bare NAME or a
+# parenthesised, comma-separated list of bare NAMEs — matching MA13's own two
+# confirmed rows exactly; NOT a general `expr` the way `coercion`'s left-hand
+# side is (see `coercion`'s own comment below for why that asymmetry is
+# real and intentional, not an oversight).
+declaration = decl_target COLON type_expr ;
+
+decl_target = NAME
+            | LPAREN name_list RPAREN ;
+
+name_list = NAME { COMMA NAME } ;
+
+# `D has C` (MA13 §3/§4) — category-membership query. Deliberately its OWN
+# top-level `expr` alternative, NOT folded into the general arithmetic/
+# comparison cascade the way `coercion` (below) is: both of `has`'s operands
+# are always domain/category-shaped `type_expr`s per MA13 §3's own fixed
+# lookup-table design (`Polynomial(Integer) has Ring`, never an arbitrary
+# arithmetic value on either side) — every one of MA13's own worked `has`
+# examples appears as a standalone query, never nested inside a larger
+# arithmetic expression. This is a real, disclosed asymmetry with `coercion`
+# (whose left-hand side genuinely IS an arbitrary `expr`, MA13's own
+# `3 :: Fraction Integer` example coerces a plain literal, and nothing in
+# MA13 rules out `(a + b) :: Float`) — not a grammar-design inconsistency,
+# but two different constructs with two different confirmed operand shapes.
+has_query = type_expr "has" type_expr ;
+
+# =============================================================================
+# The ordinary arithmetic/comparison/coercion cascade (loosest -> tightest),
+# per MA13 §4's own precedence statement ("`^`/`**` (highest) -> `*`/`/` ->
+# `+`/`-` (lowest)") plus this crate's own placement of `comparison` and
+# `coercion` above it (mirroring derive.grammar's/reduce.grammar's own
+# placement of `comparison` above `additive`):
+# ---------------------------------------------------------------
+#   comparison       = ~= < <= > >=      (non-chaining -- one flat tier,
+#                                           mirroring reduce.grammar's own
+#                                           explicitly-disclosed non-chaining
+#                                           `comparison` simplification)
+#   coercion         ::                   (non-chaining; see below for why
+#                                           it sits BELOW comparison, i.e.
+#                                           binds TIGHTER)
+#   additive         + -
+#   multiplicative   * /
+#   unary            -                    (prefix; no unary `+`, matching
+#                                           Derive's/Reduce's identical
+#                                           asymmetry -- MA13 §4 lists only
+#                                           unary `-`)
+#   power            ^ **                 (right-associative; same operator,
+#                                           mirroring reduce.grammar's own
+#                                           CARET/POW collapse)
+#   postfix          f(...) / f a         (function application -- see
+#                                           this rule's own header comment
+#                                           for the paren-optional
+#                                           single-argument design)
+#   atom             literals, symbols, lists, ( ... ) / blocks
+# =============================================================================
+
+# Design decision: where `::` (coercion) binds, and why it is embedded in
+# this cascade while `has` (above) is not. `e :: T`'s left-hand side `e` is
+# confirmed to be an arbitrary expression (MA13's own worked example coerces
+# a bare literal, `3 :: Fraction Integer`, and nothing rules out coercing a
+# computed value, `(a + b) :: Float`) — so, unlike `has`, `coercion` belongs
+# INSIDE the general cascade, at a tier that lets it combine naturally with
+# arithmetic. It binds TIGHTER than `comparison` (so `x :: T = y` reads as
+# `(x :: T) = y` — comparing a coerced value against `y`, the only sensible
+# reading, since `T = y` alone is nonsensical) but LOOSER than `additive` (so
+# `a + b :: T` reads as `(a + b) :: T` — coercing the whole computed sum,
+# matching the natural "cast the value you just computed" intuition, rather
+# than the much stranger `a + (b :: T)`). Non-chaining (one optional
+# suffix), mirroring `comparison`'s own non-chaining shape immediately below.
+comparison = coercion [ ( EQ | NE | LE | LESS | GREATER | GE ) coercion ] ;
+
+coercion = additive [ COERCE type_expr ] ;
+
+additive       = multiplicative { ( PLUS | MINUS ) multiplicative } ;
+multiplicative = unary { ( TIMES | SLASH ) unary } ;
+
+# Prefix minus, self-recursive so a chain (`- - -5`) parses; the base case
+# dives into `power`. Binds looser than `power` (mirrors derive.grammar's/
+# reduce.grammar's identical `unary`/`power` split), so `-x^2` is
+# `Times[-1, Power[x, 2]]`, never `Power[Times[-1, x], 2]`.
+unary = MINUS unary | power ;
+
+# Exponentiation -- right-associative (MA13 §4's own precedence statement;
+# the recursive-descent shape gives this for free, RHS references `unary`,
+# which falls back to `power` absent a leading `-`, exactly
+# derive.grammar's/reduce.grammar's identical trick): `a^b^c` is
+# `Power[a, Power[b, c]]`. Both spellings (`^` CARET, `**` POW) are the SAME
+# operator, collapsed onto one production here (mirrors reduce.grammar's own
+# CARET/POW comment: "the parser, not the lexer, is where the two spellings
+# collapse").
+power = postfix [ ( CARET | POW ) unary ] ;
+
+# =============================================================================
+# Function application -- MA13 §4's confirmed `f(a, b)` AND paren-optional
+# single-argument `f a` (`factorial 7`, `ff z`) forms, unified into ONE
+# production (`call_args`'s own ordered choice), mirroring how
+# derive.grammar's/reduce.grammar's own single `postfix` production covers
+# every one of their own call-shaped uses. At most ONE call suffix per atom
+# (no `{ }` chaining the way derive.grammar's/reduce.grammar's own `postfix`
+# allows `f(x)(y)`) -- a deliberate, disclosed narrowing: MA13 confirms only
+# a SINGLE application per call (`factorial 7`, `ff z`, `f(a, b)`), never a
+# curried/chained one (`f(x)(y)`, `f a b`), and this grammar does not invent
+# multi-application syntax MA13 never shows.
+#
+# THE PAREN-OPTIONAL DISAMBIGUATION -- resolved structurally, with NO
+# lookahead predicate, mirroring idl.grammar's own "which production can
+# ever start on this token" reasoning for its own `/BOOLEAN`-vs-division
+# split: `call_args`'s second alternative is a single bare `atom` — NOT a
+# further `unary`/`power`/anything containing an OPERATOR. This means a
+# construct like `f -1` can NEVER be misread as "a call to `f` with the
+# negative literal `-1`": `atom` has no unary-minus alternative (only
+# `NUMBER | STRING | NAME | list_literal | group`), so `call_args`'s
+# atom-branch cannot start on a MINUS token at all, and `postfix` correctly
+# finds no call suffix at that position -- `f` parses alone, and the
+# outer `additive` tier is the ONLY thing that ever gets a chance to consume
+# the `-`, reading `f -1` as ordinary subtraction `f - 1`. This mirrors a
+# well-established convention in every language with both juxtaposition-
+# application and a unary/binary-overloaded `-` (Haskell's own `f -1` is
+# identically forced to parse as subtraction, for the identical structural
+# reason) -- not a gap, a correct and unsurprising resolution. The same
+# argument rules out any confusion with unary `+`, since MA13 §4 confirms no
+# unary `+` exists in this cut's grammar at all (only unary `-`), so `+` is
+# ALWAYS a binary operator and `f +1` is unambiguously `f + 1`.
+#
+# A bare NAME immediately followed by another bare NAME/NUMBER/STRING/list/
+# group with NO operator between them (`x y`) is therefore always read as a
+# CALL (`x(y)`) by this grammar -- whether `x` is actually callable is a
+# semantic question left to a future `axiom-runtime` (MA-13d), exactly as
+# idl.grammar leaves "is this NAME a known zero-arg procedure or a variable
+# to auto-display" to a future `idl-runtime`, not a gap this parser's CST
+# needs to paper over.
+postfix = atom [ call_args ] ;
+
+call_args = LPAREN [ arglist ] RPAREN
+          | atom ;
+
+arglist = expr { COMMA expr } ;
+
+atom = NUMBER
+     | STRING
+     | NAME
+     | list_literal
+     | group ;
+
+# `[a, b, c]` (MA13 §4) -- list literal, reusing the existing shared `List`
+# symbolic-ir handler at the lowering layer (MA13 §2/§5). Square brackets
+# only (mirroring maple.grammar's own `[a, b, c]`, NOT Reduce's curly
+# braces) -- axiom.tokens' own SECTION 2 comment confirms this bracket
+# choice. `[ elem_list ]` is optional so the empty list `[]` parses, mirroring
+# every sibling `*-parser`'s own optional-arglist convention.
+list_literal = LBRACKET [ elem_list ] RBRACKET ;
+elem_list = expr { COMMA expr } ;
+
+# =============================================================================
+# `( ... )` -- grouping AND the parenthesised, `;`-separated block
+# (MA13 §4's own TWO separate table rows: "grouping" and
+# "a parenthesised, semicolon-separated block; value is the last
+# expression's value"), unified into ONE production here, mirroring
+# derive.grammar's own `vector`/`row` unification of single-row vectors and
+# multi-row matrices: a `group` with exactly ONE `expr` child IS ordinary
+# grouping; a `group` with TWO OR MORE `expr` children (joined by `;`) IS a
+# block, its value the LAST child's value. A future `axiom-runtime` (MA-13d)
+# distinguishes the two the same way derive-runtime's own D-5 lowering
+# distinguishes a one-row vector from a multi-row matrix: by counting how
+# many `expr` children this rule actually matched, not by a grammar-level
+# distinction -- there is no separate `block` rule name in this grammar for
+# exactly that reason.
+# =============================================================================
+group = LPAREN expr { SEMI expr } RPAREN ;
+
+# =============================================================================
+# `type_expr` -- a domain/category-shaped expression, used everywhere MA13
+# §4's declaration (`:`), coercion (`::`), category-query (`has`), and
+# function-header type-annotation positions need one. Deliberately its OWN
+# rule, distinct from the ordinary `postfix`/`atom` cascade above, even
+# though the two are structurally close (both are "a NAME, optionally
+# applied to further arguments") -- giving type positions their own named
+# CST node is exactly the same "tag a semantically distinct grammar position
+# with its own rule name, even where the shape overlaps a general-purpose
+# production" discipline idl.grammar already applies to its own
+# `index_suffix`/`call_suffix` pair (both are "a bracketed argument list",
+# kept as two names for AST clarity). A future `axiom-runtime` can therefore
+# tell "this subtree is a type annotation" apart from "this subtree is an
+# ordinary value-producing call" by rule name alone, even on input like
+# `Polynomial(Integer)` that is byte-for-byte identical whichever position it
+# appears in -- a real, confirmed fact about Axiom's own design (MA13 §3:
+# domain construction reuses ordinary call syntax), not an accident of this
+# grammar.
+#
+# `type_ctor_args`'s own paren-optional second alternative is a single bare
+# NAME ONLY (never a further nested `type_expr` with its own optional args)
+# -- a deliberate, conservative narrowing, NOT a mirror of `type_expr`'s own
+# full recursive shape. MA13's only confirmed paren-optional example is the
+# simple two-level `Fraction Integer`; every RICHER nesting example MA13
+# shows (`List(Matrix(Polynomial(Complex(Fraction(Integer)))))`) uses FULLY
+# EXPLICIT parens at every level, never a paren-optional shorthand chained
+# more than once. Letting the paren-optional branch recurse into another
+# full `type_expr` (rather than a plain NAME) would, beyond being unconfirmed
+# syntax, ALSO reopen exactly the kind of "long chain of bare identifiers
+# with no delimiter, one recursion frame per identifier" adversarial shape
+# this grammar otherwise avoids everywhere else (`postfix`'s own
+# `call_args` has the identical bare-atom-only restriction, for the
+# identical reason) -- an adversarial `A A A A ... A` input of this shape
+# would cost one `type_expr`/`type_ctor_args` stack frame PER identifier with
+# no parenthesis needed to "pay" for each level, unlike every other
+# recursive shape in this grammar, which always costs at least one real
+# input character (a paren, a `-`, a `^`) per recursion level. `List
+# Fraction(Integer)` (paren-optional combined with a nested, EXPLICITLY
+# parenthesised argument) is consequently NOT accepted by this grammar --
+# write `List(Fraction(Integer))` instead (fully explicit parens, `type_expr`
+# first alternative, arbitrarily deep, and already covered by
+# `MAX_RULE_DEPTH` the same way ordinary `(((...)))` grouping is).
+# =============================================================================
+type_expr = NAME [ type_ctor_args ] ;
+
+type_ctor_args = LPAREN [ type_expr_list ] RPAREN
+               | NAME ;
+
+type_expr_list = type_expr { COMMA type_expr } ;

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -286,6 +286,7 @@ members = [
     "idl-repl",
     "idl-to-semantic-ir",
     "axiom-lexer",
+    "axiom-parser",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/axiom-parser/BUILD
+++ b/code/packages/rust/axiom-parser/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-axiom-parser -- --nocapture

--- a/code/packages/rust/axiom-parser/BUILD_windows
+++ b/code/packages/rust/axiom-parser/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-axiom-parser -- --nocapture

--- a/code/packages/rust/axiom-parser/CHANGELOG.md
+++ b/code/packages/rust/axiom-parser/CHANGELOG.md
@@ -1,0 +1,127 @@
+# Changelog
+
+## [0.1.0] - 2026-07-27
+
+### Added
+
+- Initial grammar-driven Rust Axiom parser (MA13 §6, task MA-13c), following
+  MA-13a's design-only kickoff spec
+  ([`MA13-axiom-language.md`](../../../specs/MA13-axiom-language.md)) and
+  MA-13b's `axiom-lexer` (merged, PR #8997).
+- `code/grammars/axiom/axiom.grammar`, implementing MA13 §4's full
+  consumer-view surface:
+  - The ordinary infix arithmetic/comparison cascade (loosest to tightest):
+    `comparison` (`= ~= < <= > >=`, non-chaining) → `coercion` (`::`,
+    non-chaining) → `additive` (`+ -`) → `multiplicative` (`* /`) → `unary`
+    (prefix `-`) → `power` (`^`/`**`, the same operator, right-associative)
+    → `postfix` (function application) → `atom`.
+  - `postfix`/`call_args`: `f(a, b)` and the paren-optional single-argument
+    form `f a` (`factorial 7`, `ff z`), unified into one production, with
+    the paren-optional branch restricted to a single bare `atom` — never a
+    further operator-led expression — so `f -1`/`f +1` unambiguously parse
+    as subtraction/addition, never a call with a signed-literal argument
+    (no lookahead predicate needed; a structural consequence of `atom`
+    having no unary-minus/-plus alternative).
+  - `assignment` (`x := e`, bare-`NAME` left-hand side) and `define`
+    (`f(x: T, ...): T == e` / `f x == e`, held-body function definition) as
+    two entirely separate productions — a genuine departure from
+    `derive-parser`'s/`reduce-parser`'s single shared `:=` production, since
+    Axiom's declared-function-definition form needs a typed parameter list
+    no ordinary call `arglist` can express. Both the declared form's
+    per-parameter type annotations and its return-type annotation are
+    REQUIRED (the narrower, spec-literal reading of MA13 §4's own single
+    confirmed row — no untyped-parenthesised or optional-return-type
+    variant is accepted).
+  - `if_expr` (`if p then e1 else e2`) — `else` MANDATORY in this cut (MA13
+    §4: "missing else — deferred"), unlike `reduce.grammar`'s/
+    `idl.grammar`'s own optional `else`.
+  - `group` (`( e1; e2; ...; eN )`): unifies plain grouping and the
+    parenthesised, `;`-separated block into ONE rule (distinguished by
+    child count at a later lowering layer), mirroring `derive.grammar`'s
+    own vector/matrix-row-counting convention.
+  - `declaration` (`a : T`, `(a, b, c) : T`) — left-hand side narrowed to a
+    bare `NAME` or parenthesised name-list, unlike `coercion`'s fully
+    general expression left-hand side (`e :: T`) — a real, disclosed
+    asymmetry: `has`'s and `declaration`'s operands are always
+    domain/category-shaped per MA13 §3's fixed lookup-table design, while
+    `coercion`'s left-hand side genuinely can be an arbitrary computed
+    value (MA13's own `3 :: Fraction Integer` example).
+  - `has_query` (`D has C`) — deliberately its OWN top-level `expr`
+    alternative, not folded into the arithmetic cascade the way `coercion`
+    is (both operands are always `type_expr`-shaped, never arithmetic
+    values, per every one of MA13's own worked examples).
+  - `type_expr`/`type_ctor_args` — a domain/category-shaped expression,
+    structurally close to `postfix`/`atom` (both are "a NAME, optionally
+    applied to further arguments" — Axiom's own domain construction reuses
+    ordinary call syntax, MA13 §3) but kept as its own named rule for CST
+    clarity, mirroring `idl-parser`'s `index_suffix`/`call_suffix` naming
+    discipline. The paren-optional constructor-argument shorthand
+    (`Fraction Integer`) is deliberately restricted to a single BARE `NAME`
+    (never a further nested `type_expr` with its own args) — a conservative
+    narrowing avoiding both unconfirmed syntax (MA13's only paren-optional
+    example is the simple two-level case; every richer nesting example uses
+    fully explicit parens) and an adversarial "long chain of bare
+    identifiers, one recursion frame per identifier, no delimiter to pay
+    for it" shape that every other recursive production in this grammar
+    avoids by costing at least one real input character per level.
+  - `program = expr` — parses exactly ONE top-level expression, not a
+    repeated multi-statement worksheet. `axiom.tokens` gives top-level
+    inputs no separator at all (no significant newline, unlike Derive; `;`
+    reserved exclusively for the parenthesised block, unlike Reduce's
+    `;`/`$`) — a direct, disclosed consequence of MA13 §5 framing Axiom as
+    a numbered, per-line interactive session (mirrored by a future
+    `axiom-repl`'s own step-counted prompt) rather than a batch worksheet.
+- `code/packages/rust/axiom-parser/`, wrapping the shared `GrammarParser`
+  (no hand-written parsing logic, per `lessons.md`'s
+  `feedback_no_handwritten_lexers_parsers`):
+  - `examples/regenerate_grammar.rs` — regenerates `src/_grammar.rs` from
+    `axiom.grammar`, mirroring `prolog-parser`'s own regen example.
+  - `MAX_RULE_DEPTH = 140`, independently measured (not assumed from a
+    sibling or from `parser::grammar_parser::DEFAULT_MAX_RULE_DEPTH`)
+    against four structurally distinct recursive shapes — parenthesised
+    grouping/block nesting, nested function-call arguments, a unary prefix
+    chain, and a power chain — via binary search on an uncapped parser, one
+    subprocess per data point, on a 2 MiB-stack worker thread, in a debug
+    build. Nesting-count floors: parens 27/28, calls 24/25, unary 201/202,
+    power 100/101. Rule-frame floors (converted via binary search over
+    `with_max_depth` against a fixed 5000-level input per shape): parens
+    282/283, calls **211/212** (the binding constraint — notably NOT
+    parenthesised grouping, unlike `derive-parser`/`reduce-parser`'s own
+    dominant shape), unary 212/213, power 213/214. `140` sits about 33.6%
+    below the binding 211 floor (comparable margin to `derive-parser`'s own
+    ~33%). Measured real-input headroom at 140 (capped parser, no crash
+    risk): parens/calls parse cleanly to 13 levels (14 trips), unary to 130
+    levels (131 trips), power to 65 levels (66 trips) — all well beyond any
+    hand-written Axiom expression. The measurement harness itself (a
+    throwaway `examples/depth_probe.rs` plus a shell binary-search script)
+    was not committed, matching `derive-parser`/`reduce-parser`/
+    `idl-parser`'s own precedent of not keeping a permanent measurement
+    tool.
+- `code/packages/rust/Cargo.toml` workspace registration (`axiom-parser`
+  added directly after `axiom-lexer`; the sibling `axiom-runtime`/
+  `axiom-repl`/`axiom-to-semantic-ir` crates do not exist yet — MA-13d/e,
+  separate follow-on tasks).
+- 58 unit tests + 1 doc test covering every grammar rule in MA13 §4's scope
+  table: every literal shape; both call forms (explicit-parens and
+  paren-optional) including the `f -1`/`f +1` disambiguation regression;
+  empty and non-empty list literals; arithmetic precedence/associativity
+  (including the `^`/`**` same-operator and right-associativity checks);
+  every comparison operator; `:=` including right-associative chaining;
+  both `==` definition forms including the "requires every parameter typed"
+  and "requires a return type" narrowing regressions and the
+  "`f x` alone is a call, `f x == e` is a definition" disambiguation;
+  `if`-`then`-`else` including the mandatory-`else` regression, dangling-else
+  resolution, and "usable as an expression"; the parenthesised block/group
+  unification (verified by counting `expr` children); plain and tuple
+  declarations, including a parameterized-domain type; coercion, including
+  the paren-optional type shorthand and both precedence-boundary checks
+  (binds tighter than comparison, looser than additive); `has` queries
+  (both of MA13's own true/false worked examples), including the
+  "unreachable as a bare arithmetic operand, but reachable through explicit
+  parens" pair; `type_expr`'s own paren-optional-argument-must-be-bare-name
+  restriction; `--` comments; syntax-error reporting including a panicking
+  and a `Result`-returning entry point; and a full depth-guard regression
+  suite (deep-input-returns-error-not-crash and cap-trips-before-native-
+  overflow on a default ~2 MiB stack thread, for all four measured shapes,
+  plus exact real-input headroom boundary tests pinned to the measured
+  values above).

--- a/code/packages/rust/axiom-parser/Cargo.toml
+++ b/code/packages/rust/axiom-parser/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "coding-adventures-axiom-parser"
+version = "0.1.0"
+edition = "2021"
+description = "Parser for Axiom, the strongly-typed CAS with a category/domain type system (MA13 MA-13c)"
+license = "MIT"
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }
+parser = { path = "../parser" }
+coding-adventures-axiom-lexer = { path = "../axiom-lexer" }

--- a/code/packages/rust/axiom-parser/README.md
+++ b/code/packages/rust/axiom-parser/README.md
@@ -1,0 +1,199 @@
+# coding-adventures-axiom-parser
+
+Axiom parser backed by `code/grammars/axiom/axiom.grammar`, compiled to Rust
+and statically linked into the crate.
+
+The runtime path does not read grammar files from disk, which keeps it
+suitable for a future WASM facade.
+
+## Where this fits
+
+Axiom (Scratchpad II, IBM Research, 1977; commercialized as Axiom in 1992 by
+Jenks & Sutor; today continued by OpenAxiom, FriCAS, and the independent
+Axiom project) is the strongly-typed computer algebra system whose
+category/domain type system is this repo's first symbolic-family (CAS)
+language to need a per-value type tag at all
+([`MA13-axiom-language.md`](../../../specs/MA13-axiom-language.md) §2). This
+is the third crate of Axiom's frontend — **MA-13c** — following:
+
+1. **MA-13a** — the design-only kickoff spec, fixing which Axiom this repo
+   targets (§1), confirming `symbolic-ir`/`symbolic-vm`/`cas-*` need no
+   changes for Axiom's arithmetic but carry no domain/category concept at
+   all (§2), and scoping the category/domain type system to a small, fixed,
+   **consumer-view-only** subset (§3) before any lexer/parser/runtime code
+   landed.
+2. **MA-13b** — [`axiom-lexer`](../axiom-lexer), the tokenizer.
+3. **MA-13c** — `axiom-parser` (this crate), the subject of this README.
+
+Next: **MA-13d** — `axiom-runtime` + `axiom-repl` (lowering this crate's CST
+to `symbolic_ir::IRNode` and evaluating with `symbolic_vm::VM`, plus the new
+`AxiomValue`/`AxiomDomain` layer MA13 §2/§3 fixes), then **MA-13e** —
+`axiom-to-semantic-ir`.
+
+## Scope
+
+Covers the MA-13-scoped consumer-view subset fixed by
+[MA13 §4](../../../specs/MA13-axiom-language.md#4-language-scope-the-historical-core):
+
+- Literals: integers, floats (`123`, `1.5`), strings (`"hello"`), symbols
+  (`x`, `foo`).
+- Function calls: `f(a, b)` **and** the paren-optional single-argument form
+  `f a` (`factorial 7`, `ff z`) — unified into one `postfix`/`call_args`
+  production. **No dedicated rational-literal token** — `1/3` is ordinary
+  `NUMBER SLASH NUMBER` division (inherited from `axiom-lexer`).
+- Lists: `[a, b, c]` (square brackets, reusing the shared `List`
+  symbolic-ir handler).
+- Arithmetic: `+ - * /`, both power spellings `^`/`**` (the SAME operator,
+  right-associative, tightest), left-associative `*`/`/`/`+`/`-`, unary `-`
+  only (no unary `+`).
+- Equality/comparison: `=` (lowers straight to Boolean `Equal` in this cut —
+  MA13 §3's own disclosed divergence from real Axiom's default `Equation`),
+  `~=` (Axiom's real not-equal spelling — **not** Maple's `<>` or Wolfram's
+  `!=`), `< <= > >=`.
+- `x := e` — immediate assignment (bare `NAME` left-hand side only).
+- `f(x: T, ...): T == e` (declared, typed) / `f x == e` (undeclared,
+  paren-optional single parameter, duck-typed) — held-body function
+  definition. Two entirely separate grammar productions from `:=`, unlike
+  Derive's/Reduce's own single shared assignment/definition operator — see
+  `axiom.grammar`'s own `define` rule comment for why.
+- `if p then e1 else e2` — `else` is **mandatory** in this cut (MA13 §4:
+  "missing else — deferred").
+- `( e1; e2; ...; eN )` — a parenthesised, `;`-separated block, value is the
+  last expression's value. Shares ONE grammar rule (`group`) with plain
+  `( ... )` grouping, distinguished by child count at a later lowering
+  layer, mirroring `derive.grammar`'s own vector/matrix unification.
+- `a : T`, `(a, b, c) : T` — declaration.
+- `e :: T` — coercion, including the paren-optional type shorthand
+  (`3 :: Fraction Integer`).
+- `D has C` — category-membership query (e.g.
+  `Polynomial(Integer) has Ring`).
+- `( … )` — grouping.
+
+Every one of these is `expr`-shaped and mutually nestable (an `if`-branch,
+an assignment's right-hand side, and a function body are all just `expr`) —
+see `axiom.grammar`'s own header comment for the full precedence cascade and
+every grammar-design decision (especially the paren-optional call form's
+disambiguation from a bare name followed by a binary operator, and why
+`has`/`declaration` sit outside the ordinary arithmetic cascade while
+`coercion` sits inside it).
+
+**Out of scope** (MA13 §4's deferred list, unchanged from `axiom-lexer`):
+user-defined categories/domains, `Join`, packages,
+symbolic-domain-parameterized generic functions, `Record`/`Union`/`Any`,
+`Matrix`/`SquareMatrix`/`Complex`, a genuine `Equation` domain, `macro`,
+bare-variable delayed `==`, block early-exit `=>`, piecewise/multi-clause
+function definitions, anonymous `+->` functions, list comprehensions,
+`for`/`while` loops, package-calling `$`, target-type `@`.
+
+## `program` parses exactly ONE top-level expression
+
+Unlike `derive-parser`/`reduce-parser` (which parse a whole multi-statement
+worksheet file, `program = { statement_line }`), `axiom.tokens` gives
+top-level Axiom inputs **no separator at all** — no significant newline
+(unlike Derive), no `;`/`$` (Axiom's `;` is reserved exclusively for the
+parenthesised block). This is a direct, disclosed consequence of MA13
+framing Axiom as a numbered, per-line interactive session (`(1) ->`,
+incrementing per computation step, mirrored by a future `axiom-repl`'s own
+numbered prompt, MA13 §5) rather than a batch worksheet — so `program = expr`
+parses exactly what one interactive input is ever confirmed to be, leaving
+"where does one REPL input end and the next begin" to that future
+`axiom-repl`. See `axiom.grammar`'s own header comment for the full
+reasoning.
+
+## `:=` vs `==` — two operators where Derive/Reduce need only one
+
+`derive-parser`'s/`reduce-parser`'s single `:=` production is shared,
+unmodified, between plain variable assignment and function definition (a
+later runtime disambiguates by inspecting the parsed left-hand side's
+shape). That trick does not transfer here: Axiom's **declared**
+function-definition form (`f(x: T, ...): T == e`) needs a parameter list of
+*typed* declarations (`x: T`), a shape no ordinary call's `arglist` (a plain
+comma-list of expressions) can express. So `assignment` (`:=`) and `define`
+(`==`) are two entirely separate productions with two entirely separate,
+narrowly-scoped confirmed left-hand-side shapes — this grammar does not
+invent any combination MA13 §4 does not literally show (no untyped
+parenthesised parameters, no optional return-type annotation).
+
+## The paren-optional call form's disambiguation
+
+`f a` (MA13's own confirmed `factorial 7`/`ff z` examples) is unified with
+`f(a, b)` into one `postfix`/`call_args` production, whose paren-optional
+branch matches a single bare `atom` — never a further operator-led
+expression. This means `f -1`/`f +1` can **never** be misread as a call with
+a negative/positive-literal argument: `atom` has no unary-minus (or `+`,
+which does not exist in this cut) alternative, so `call_args` cannot start
+on a `MINUS`/`PLUS` token at all, and `f - 1`/`f + 1` are unambiguously
+ordinary subtraction/addition — the same resolution Haskell's own
+juxtaposition-application gives its identically-overloaded `-`.
+
+## Usage
+
+```rust
+use coding_adventures_axiom_parser::parse_axiom;
+
+let ast = parse_axiom("power(x: Integer, n: NonNegativeInteger): Integer == x ** n");
+assert_eq!(ast.rule_name, "program");
+```
+
+A parsed declared function definition's shape (rule names, not a bespoke AST
+type — see below):
+
+```text
+program
+└─ expr
+   └─ define
+      └─ declared_define
+         ├─ NAME "power"
+         ├─ typed_param_list
+         │  ├─ typed_param (NAME "x", type_expr "Integer")
+         │  └─ typed_param (NAME "n", type_expr "NonNegativeInteger")
+         ├─ type_expr "Integer"                  <- the return type
+         └─ expr (power's held body: x ** n)
+```
+
+`parse_axiom` panics on a malformed source string; use `try_parse_axiom` for
+the `Result`-returning form, or `create_axiom_parser` directly if you need
+the raw `GrammarParser`.
+
+## No bespoke AST type — a generic `GrammarASTNode` CST, tagged by rule name
+
+Like every grammar-driven parser in this repo, this crate does not define
+its own AST enum. It returns the generic
+[`GrammarASTNode`](../parser/src/grammar_parser.rs) CST, whose `rule_name`
+field is what a future `axiom-runtime` (MA-13d) pattern-matches on. Type
+positions (`declaration`'s target type, `coercion`'s target type, `has`'s
+domain/category operands, a function header's parameter/return-type
+annotations) all parse through their own dedicated `type_expr` rule —
+structurally close to the ordinary `postfix`/`atom` call cascade (both are
+"a NAME, optionally applied to further arguments" — Axiom's own domain
+construction genuinely reuses ordinary call syntax, MA13 §3), but kept as
+its own named rule so a later pass can tell "this subtree is a type
+annotation" apart from "this subtree is an ordinary value-producing call"
+by rule name alone, mirroring `idl-parser`'s own `index_suffix`/
+`call_suffix` naming discipline for two structurally-similar-but-
+semantically-distinct bracketed-list positions.
+
+## Recursion-depth guard
+
+`MAX_RULE_DEPTH = 140`, independently measured against this grammar's own
+native-stack floor (not assumed from a sibling) across four structurally
+distinct recursive shapes — see `src/lib.rs`'s own `MAX_RULE_DEPTH` doc
+comment for the full measured-floor table and methodology.
+
+## Where this fits (pipeline)
+
+```text
+Axiom source
+   |
+   v
+axiom-lexer::tokenize_axiom        (MA-13b)
+   |
+   v
+axiom-parser::parse_axiom          (MA-13c, this crate)
+   |
+   v
+GrammarASTNode  <-  axiom-runtime + axiom-repl lower/evaluate this (MA-13d)
+   |
+   v
+axiom-to-semantic-ir                (MA-13e)
+```

--- a/code/packages/rust/axiom-parser/examples/regenerate_grammar.rs
+++ b/code/packages/rust/axiom-parser/examples/regenerate_grammar.rs
@@ -1,0 +1,45 @@
+//! Regenerate `src/_grammar.rs` from `code/grammars/axiom/axiom.grammar`.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run -p coding-adventures-axiom-parser --example regenerate_grammar
+//! ```
+//!
+//! This reads the canonical `axiom.grammar` (EBNF) and writes the compiled
+//! Rust embedding to `src/_grammar.rs`. The output is checked into the
+//! repository so downstream users do not need file I/O at startup — see
+//! this crate's own `src/lib.rs` doc comment. Mirrors `prolog-parser`'s own
+//! `examples/regenerate_grammar.rs`, adapted to this crate's grammar file.
+//!
+//! After editing `code/grammars/axiom/axiom.grammar`, re-run this example
+//! and commit the regenerated `src/_grammar.rs` alongside the `.grammar`
+//! change — the two must never drift (lessons.md's own "a `.grammar`/
+//! `.tokens` edit is not live" entry).
+
+use std::fs;
+use std::path::PathBuf;
+
+use grammar_tools::compiler::compile_parser_grammar;
+use grammar_tools::parser_grammar::parse_parser_grammar;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let grammars_dir = crate_root
+        .ancestors()
+        .nth(3)
+        .ok_or("could not locate the repo's `code/` parent")?
+        .join("grammars");
+    let grammar_path = grammars_dir.join("axiom").join("axiom.grammar");
+
+    let source = fs::read_to_string(&grammar_path)
+        .map_err(|e| format!("could not read {}: {}", grammar_path.display(), e))?;
+    let grammar = parse_parser_grammar(&source)?;
+
+    let rust_source = compile_parser_grammar(&grammar, "axiom.grammar");
+    let out = crate_root.join("src").join("_grammar.rs");
+    fs::write(&out, rust_source)?;
+
+    println!("wrote {} from {}", out.display(), grammar_path.display());
+    Ok(())
+}

--- a/code/packages/rust/axiom-parser/required_capabilities.json
+++ b/code/packages/rust/axiom-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/axiom-parser",
+  "capabilities": [],
+  "justification": "Pure computation. The Axiom grammar is embedded as generated Rust code; tokenizing and parsing need no filesystem, network, or process access."
+}

--- a/code/packages/rust/axiom-parser/src/_grammar.rs
+++ b/code/packages/rust/axiom-parser/src/_grammar.rs
@@ -1,0 +1,335 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: axiom.grammar
+// Regenerate with: grammar-tools compile-grammar axiom.grammar
+//
+// This file embeds a ParserGrammar as native Rust data structures.
+// Call `parser_grammar()` instead of reading and parsing the .grammar file.
+
+use grammar_tools::parser_grammar::{GrammarElement, GrammarRule, ParserGrammar};
+
+pub fn parser_grammar() -> ParserGrammar {
+    ParserGrammar {
+        rules: vec![
+        GrammarRule {
+            name: r#"program"#.to_string(),
+            body: GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            line_number: 108,
+        },
+        GrammarRule {
+            name: r#"expr"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"if_expr"#.to_string() },
+                GrammarElement::RuleReference { name: r#"define"#.to_string() },
+                GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
+                GrammarElement::RuleReference { name: r#"declaration"#.to_string() },
+                GrammarElement::RuleReference { name: r#"has_query"#.to_string() },
+                GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
+            ] },
+            line_number: 125,
+        },
+        GrammarRule {
+            name: r#"if_expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"if"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::Literal { value: r#"then"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::Literal { value: r#"else"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 138,
+        },
+        GrammarRule {
+            name: r#"define"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"declared_define"#.to_string() },
+                GrammarElement::RuleReference { name: r#"undeclared_define"#.to_string() },
+            ] },
+            line_number: 178,
+        },
+        GrammarRule {
+            name: r#"declared_define"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"typed_param_list"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                GrammarElement::RuleReference { name: r#"type_expr"#.to_string() },
+                GrammarElement::TokenReference { name: r#"DEFINE"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 181,
+        },
+        GrammarRule {
+            name: r#"typed_param_list"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"typed_param"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"typed_param"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 183,
+        },
+        GrammarRule {
+            name: r#"typed_param"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                GrammarElement::RuleReference { name: r#"type_expr"#.to_string() },
+            ] },
+            line_number: 184,
+        },
+        GrammarRule {
+            name: r#"undeclared_define"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::TokenReference { name: r#"DEFINE"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 186,
+        },
+        GrammarRule {
+            name: r#"assignment"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::TokenReference { name: r#"ASSIGN"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 200,
+        },
+        GrammarRule {
+            name: r#"declaration"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"decl_target"#.to_string() },
+                GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
+                GrammarElement::RuleReference { name: r#"type_expr"#.to_string() },
+            ] },
+            line_number: 208,
+        },
+        GrammarRule {
+            name: r#"decl_target"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"name_list"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                ] },
+            ] },
+            line_number: 210,
+        },
+        GrammarRule {
+            name: r#"name_list"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 213,
+        },
+        GrammarRule {
+            name: r#"has_query"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"type_expr"#.to_string() },
+                GrammarElement::Literal { value: r#"has"#.to_string() },
+                GrammarElement::RuleReference { name: r#"type_expr"#.to_string() },
+            ] },
+            line_number: 227,
+        },
+        GrammarRule {
+            name: r#"comparison"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"coercion"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"EQ"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"NE"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"LE"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"LESS"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"GREATER"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"GE"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"coercion"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 272,
+        },
+        GrammarRule {
+            name: r#"coercion"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COERCE"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"type_expr"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 274,
+        },
+        GrammarRule {
+            name: r#"additive"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"multiplicative"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"PLUS"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"multiplicative"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 276,
+        },
+        GrammarRule {
+            name: r#"multiplicative"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"TIMES"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"SLASH"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 277,
+        },
+        GrammarRule {
+            name: r#"unary"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                ] },
+                GrammarElement::RuleReference { name: r#"power"#.to_string() },
+            ] },
+            line_number: 283,
+        },
+        GrammarRule {
+            name: r#"power"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"postfix"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"CARET"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"POW"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 293,
+        },
+        GrammarRule {
+            name: r#"postfix"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"atom"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"call_args"#.to_string() }) },
+            ] },
+            line_number: 334,
+        },
+        GrammarRule {
+            name: r#"call_args"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"arglist"#.to_string() }) },
+                    GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                ] },
+                GrammarElement::RuleReference { name: r#"atom"#.to_string() },
+            ] },
+            line_number: 336,
+        },
+        GrammarRule {
+            name: r#"arglist"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 339,
+        },
+        GrammarRule {
+            name: r#"atom"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::RuleReference { name: r#"list_literal"#.to_string() },
+                GrammarElement::RuleReference { name: r#"group"#.to_string() },
+            ] },
+            line_number: 341,
+        },
+        GrammarRule {
+            name: r#"list_literal"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LBRACKET"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"elem_list"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
+            ] },
+            line_number: 353,
+        },
+        GrammarRule {
+            name: r#"elem_list"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 354,
+        },
+        GrammarRule {
+            name: r#"group"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"SEMI"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+            ] },
+            line_number: 371,
+        },
+        GrammarRule {
+            name: r#"type_expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"type_ctor_args"#.to_string() }) },
+            ] },
+            line_number: 416,
+        },
+        GrammarRule {
+            name: r#"type_ctor_args"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"type_expr_list"#.to_string() }) },
+                    GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                ] },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+            ] },
+            line_number: 418,
+        },
+        GrammarRule {
+            name: r#"type_expr_list"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"type_expr"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"type_expr"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 421,
+        },
+    ],
+        version: 1,
+    }
+}

--- a/code/packages/rust/axiom-parser/src/lib.rs
+++ b/code/packages/rust/axiom-parser/src/lib.rs
@@ -1,0 +1,788 @@
+//! # Axiom Parser — building a syntax tree for Axiom (the MA-13-scoped
+//! consumer-view subset).
+//!
+//! Turns the token stream from [`coding_adventures_axiom_lexer`] into a
+//! parse tree using the generic
+//! [`GrammarParser`](parser::grammar_parser::GrammarParser), driven by the
+//! embedded `axiom.grammar` (`src/_grammar.rs`). It hand-writes no parsing
+//! logic — a sibling of `derive-parser`/`reduce-parser`/`idl-parser`. See
+//! `code/specs/MA13-axiom-language.md` (MA-13a, the design-only kickoff
+//! this crate implements MA-13c of).
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! Axiom source
+//!    |
+//!    v
+//! coding_adventures_axiom_lexer::tokenize_axiom  ->  Vec<Token>   (MA-13b)
+//!    |
+//!    v
+//! parser::GrammarParser  (driven by the embedded axiom.grammar)   (MA-13c, this crate)
+//!    |
+//!    v
+//! GrammarASTNode  <- a future axiom-runtime (MA-13d) lowers this to
+//!                    symbolic_ir::IRNode + its own new AxiomValue/AxiomDomain
+//!                    layer (MA13 §2)
+//! ```
+//!
+//! ## What the tree captures
+//!
+//! Every Axiom expression in this cut parses down to ordinary infix/postfix
+//! operators over `head(args)`-shaped calls (closer in shape to this repo's
+//! Reduce/Derive/Maple CAS-family grammars than to any array-family grammar,
+//! MA13 §5), PLUS the three genuinely new productions MA13 §3 introduces —
+//! declaration (`:`, rule `declaration`), coercion (`::`, rule `coercion`),
+//! and category-membership query (`has`, rule `has_query`) — none of which
+//! any prior symbolic-family grammar in this repo has ever needed. See
+//! `code/grammars/axiom/axiom.grammar`'s own header comment for the full
+//! precedence cascade and every grammar-design decision this crate makes
+//! (most notably: `program` parses exactly ONE top-level expression, not a
+//! repeated multi-statement worksheet, since `axiom.tokens` gives top-level
+//! inputs no separator at all — see that file's own "WHY `program` IS A
+//! SINGLE EXPRESSION" section; and the paren-optional single-argument call
+//! form `f a`'s disambiguation from a bare name followed by a binary
+//! operator, e.g. `f -1`, — see `postfix`'s own comment there).
+//!
+//! ## `:=` vs `==` — two operators where Derive/Reduce need only one
+//!
+//! Unlike `derive-parser`/`reduce-parser`, whose single `:=` production is
+//! shared, unmodified, between plain variable assignment and function
+//! definition (disambiguated later, by a runtime inspecting the parsed
+//! left-hand side's shape), this crate's `assignment` (`:=`) and `define`
+//! (`==`) are two ENTIRELY SEPARATE grammar productions with two entirely
+//! separate confirmed left-hand-side shapes (MA13 §4): `assignment`'s
+//! left-hand side is always a bare `NAME`; `define`'s is always one of two
+//! fixed call/declaration shapes (`declared_define`/`undeclared_define`).
+//! This is a real, structural difference from Derive/Reduce's own design,
+//! not an inconsistency — see `axiom.grammar`'s own `define` rule comment
+//! for exactly why the "reuse whatever the general call production already
+//! parses" trick that works for Derive/Reduce does NOT transfer to Axiom's
+//! own declared-function-definition form (its typed parameter list has no
+//! analogue in an ordinary call's comma-list-of-expressions `arglist`).
+
+use coding_adventures_axiom_lexer::{tokenize_axiom, try_tokenize_axiom};
+use parser::grammar_parser::{GrammarASTNode, GrammarParser};
+mod _grammar;
+
+/// Recursion-depth cap for the Axiom [`GrammarParser`] — see
+/// [`GrammarParser::with_max_depth`] and
+/// [`parser::grammar_parser::DEFAULT_MAX_RULE_DEPTH`] for why the underlying
+/// guard exists at all (deep recursion through `parse_rule` can overflow the
+/// *native* thread stack — an uncatchable process abort — before this
+/// crate's own `Result`-returning entry points ever get a chance to report
+/// anything). `axiom-lexer` (MA-13b) has no recursion at all (it only
+/// tokenizes, see that crate's own doc comment); this is the FIRST Axiom
+/// crate with actual recursive descent, so this cap is added fresh here, not
+/// inherited from a sibling.
+///
+/// # Four recursion shapes, measured independently
+///
+/// Measured with the same methodology every sibling `*-parser` crate in this
+/// repo uses (per this repo's own `lessons.md` — "measure, don't assume one
+/// shape's floor bounds the others"): binary search, an *uncapped*
+/// `GrammarParser` (`max_depth = usize::MAX`), a `std::thread::spawn` worker
+/// with a fixed **2 MiB stack** (the same order of magnitude as a default
+/// thread's stack), one fresh **subprocess per data point** (a real
+/// native-stack overflow calls `process::abort()`, which kills the whole
+/// process — an in-process loop cannot survive past the first crash to
+/// report a clean number), in a **debug** build (`cargo test`'s own
+/// default, since debug frames are meaningfully larger than release
+/// frames). The probe harness used was a throwaway `examples/depth_probe.rs`
+/// (removed before this crate shipped, per this repo's own convention —
+/// `derive-parser`/`reduce-parser`/`idl-parser` do not keep a committed
+/// measurement tool either) driving `__uncapped_for_depth_probe` (also
+/// removed) through a small shell binary-search script; see this crate's
+/// `CHANGELOG.md` for the exact recorded methodology and results.
+///
+/// `axiom.grammar` has four structurally distinct self-referential shapes:
+///
+/// 1. **Parenthesised grouping/block nesting**, `((((…5…))))` — `group ->
+///    expr -> (if_expr/define/assignment/declaration/has_query all fail
+///    fast on the leading LPAREN) -> comparison -> coercion -> additive ->
+///    multiplicative -> unary -> power -> postfix -> atom -> group -> …` —
+///    cycles through the entire cascade every nesting level, the same
+///    dominant shape every prior CAS-family sibling here (`derive-parser`,
+///    `reduce-parser`) measured as their own binding constraint.
+/// 2. **Nested function-call arguments**, `f(f(f(…5…)))` — `postfix ->
+///    call_args -> arglist -> expr -> … -> postfix`, interposing two
+///    wrapper rule-frames (`call_args`, `arglist`) per level on top of
+///    `postfix`'s own re-entry.
+/// 3. **A unary prefix chain**, `- - - … 5` (a SPACE between every `-` is
+///    load-bearing — two adjacent `-` characters lex as the `--`
+///    line-comment opener, silently swallowing the rest of the line; this
+///    was caught directly when an unspaced first draft of the probe made
+///    every depth-guard test pass for the wrong reason — an empty token
+///    stream, not the cap, see `tests`'s own `unary_prefix_chain_source`
+///    comment) — `unary`'s own `MINUS unary | power` self-reference.
+/// 4. **A power chain**, `1^1^1^ … ^1` — `power`'s own
+///    `postfix [ (CARET|POW) unary ]` continuation (through `unary`, which
+///    falls back to `power` absent a leading `-`).
+///
+/// Every "flat chain of one operator" production written with EBNF `{ x }`
+/// repetition (`additive`, `multiplicative`, `typed_param_list`,
+/// `name_list`, `arglist`, `elem_list`, `type_expr_list`) costs *zero*
+/// native stack regardless of width — this is an already-established fact
+/// about [`parser::grammar_parser`]'s own `Repetition` arm (a plain
+/// `loop { ... }` where each iteration's `match_element` call returns
+/// before the next iteration begins), confirmed directly by reading that
+/// module and re-affirmed by every sibling `*-parser` crate's own
+/// `MAX_RULE_DEPTH` doc comment — not re-measured by a throwaway probe here.
+///
+/// Nesting-count floors (parses safely up to N, crashes at N+1), and the
+/// rule-frame-terms conversion (binary search over `with_max_depth` against
+/// a fixed 5000-level input of each shape, so the *cap itself* — not the
+/// input's own finite length — is always what triggers first):
+///
+/// | Shape | Nesting-count floor | Rule-frame floor |
+/// |---|---|---|
+/// | Parenthesised grouping | 27 safe / 28 crash | 282 safe / 283 crash |
+/// | Nested function calls | 24 safe / 25 crash | 211 safe / 212 crash |
+/// | Unary prefix chain | 201 safe / 202 crash | 212 safe / 213 crash |
+/// | Power chain | 100 safe / 101 crash | 213 safe / 214 crash |
+///
+/// The lowest rule-frame floor is nested function calls' **211** — NOT
+/// parenthesised grouping (282), even though grouping is the dominant
+/// binding constraint for `derive-parser`/`reduce-parser`. This mirrors the
+/// same "don't assume which shape binds" surprise every sibling
+/// `*-parser`'s own doc comment documents (`idl-parser`, `scilab-parser`,
+/// `maple-parser`, `reduce-parser`'s own cons-chain): `call_args`'s own
+/// `LPAREN [arglist] RPAREN` alternative interposes an extra `arglist`
+/// rule-frame beyond what plain `group`'s `LPAREN expr RPAREN` needs, and
+/// that extra frame's native-stack cost evidently outweighs grouping's own
+/// higher per-level *count* (~10.4 frames/level for grouping vs. ~8.8 for
+/// calls) enough to make nested calls the binding shape here.
+///
+/// `MAX_RULE_DEPTH` is set to **140** — about 33.6% below 211 (comparable
+/// margin to `derive-parser`'s own ~33%, `maple-parser`'s ~31.2%,
+/// `j-parser`'s ~30%, `idl-parser`'s ~30.2%), and therefore safely below the
+/// other three rule-frame floors (282, 212, 213) too.
+///
+/// Measured real-input headroom at `140` (using the CAPPED parser, i.e.
+/// [`create_axiom_parser`]/[`try_parse_axiom`], so no crash risk at all):
+/// parenthesised grouping and nested function calls each parse cleanly up
+/// to 13 levels (14 trips the cap); a unary prefix chain parses cleanly up
+/// to 130 levels (131 trips); a power chain parses cleanly up to 65 levels
+/// (66 trips) — all comfortably beyond anything a hand-written Axiom
+/// expression needs, and all four independently confirmed not to crash a
+/// default-stack thread even thousands of levels past the cap (see this
+/// crate's tests).
+const MAX_RULE_DEPTH: usize = 140;
+
+/// Create a [`GrammarParser`] wired to the Axiom grammar and the tokens of
+/// `source`, with the recursion-depth guard ([`MAX_RULE_DEPTH`]) enabled so
+/// pathologically deep nesting fails cleanly instead of overflowing the
+/// native stack.
+pub fn create_axiom_parser(source: &str) -> GrammarParser {
+    let tokens = tokenize_axiom(source);
+    GrammarParser::new(tokens, _grammar::parser_grammar()).with_max_depth(MAX_RULE_DEPTH)
+}
+
+/// Parse Axiom source text into a [`GrammarASTNode`] rooted at `program`.
+///
+/// # Panics
+///
+/// Panics on a lexical or syntax error. Use [`try_parse_axiom`] to handle
+/// errors.
+///
+/// # Example
+///
+/// ```
+/// use coding_adventures_axiom_parser::parse_axiom;
+/// let ast = parse_axiom("factorial 7");
+/// assert_eq!(ast.rule_name, "program");
+/// ```
+pub fn parse_axiom(source: &str) -> GrammarASTNode {
+    create_axiom_parser(source)
+        .parse()
+        .unwrap_or_else(|e| panic!("Axiom parse failed: {e}"))
+}
+
+/// Parse Axiom source text, returning a `Result` instead of panicking.
+pub fn try_parse_axiom(source: &str) -> Result<GrammarASTNode, String> {
+    let tokens = try_tokenize_axiom(source)?;
+    GrammarParser::new(tokens, _grammar::parser_grammar())
+        .with_max_depth(MAX_RULE_DEPTH)
+        .parse()
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parser::grammar_parser::ASTNodeOrToken;
+
+    fn contains_rule(node: &GrammarASTNode, name: &str) -> bool {
+        node.rule_name == name
+            || node.children.iter().any(|c| match c {
+                ASTNodeOrToken::Node(n) => contains_rule(n, name),
+                ASTNodeOrToken::Token(_) => false,
+            })
+    }
+
+    /// Find the first descendant node (or self) with the given rule name.
+    fn find_rule<'a>(node: &'a GrammarASTNode, name: &str) -> Option<&'a GrammarASTNode> {
+        if node.rule_name == name {
+            return Some(node);
+        }
+        for c in &node.children {
+            if let ASTNodeOrToken::Node(n) = c {
+                if let Some(found) = find_rule(n, name) {
+                    return Some(found);
+                }
+            }
+        }
+        None
+    }
+
+    fn parses(src: &str) -> bool {
+        try_parse_axiom(src).is_ok()
+    }
+
+    // --- program is a single top-level expression -------------------------
+
+    #[test]
+    fn program_is_the_root() {
+        assert_eq!(parse_axiom("1").rule_name, "program");
+    }
+
+    #[test]
+    fn a_bare_juxtaposed_pair_with_nothing_after_is_a_call_not_two_statements() {
+        // No top-level separator exists in this cut (see axiom.grammar's own
+        // header comment) -- `program = expr`, so trailing garbage after one
+        // full expression is a syntax error, not a silently-accepted second
+        // statement.
+        assert!(try_parse_axiom("a := 1 b := 2").is_err());
+    }
+
+    // --- Literals -----------------------------------------------------------
+
+    #[test]
+    fn integer_and_float_literals_parse() {
+        assert!(parses("42"));
+        assert!(parses("1.5"));
+    }
+
+    #[test]
+    fn string_literal_parses() {
+        assert!(parses("\"hello\""));
+    }
+
+    #[test]
+    fn symbol_parses() {
+        assert!(parses("x"));
+    }
+
+    // --- Function calls: f(a, b) and paren-optional single-argument f a ---
+
+    #[test]
+    fn explicit_paren_call_parses() {
+        let ast = parse_axiom("f(a, b)");
+        assert!(contains_rule(&ast, "postfix"));
+        assert!(contains_rule(&ast, "arglist"));
+    }
+
+    #[test]
+    fn paren_optional_single_argument_call_parses() {
+        // MA13 §4's own confirmed examples.
+        let ast = parse_axiom("factorial 7");
+        assert!(contains_rule(&ast, "postfix"));
+        assert!(contains_rule(&ast, "call_args"));
+        assert!(parses("ff z"));
+    }
+
+    #[test]
+    fn paren_optional_call_with_a_string_or_list_argument_parses() {
+        assert!(parses("f \"hello\""));
+        assert!(parses("f [1, 2, 3]"));
+    }
+
+    #[test]
+    fn call_with_no_arguments_parses() {
+        assert!(parses("f()"));
+    }
+
+    #[test]
+    fn nested_function_calls_parse() {
+        assert!(parses("f(g(x))"));
+    }
+
+    // --- The paren-optional call form does not swallow a following binary
+    // operator: `f -1` / `f +1` must read as subtraction/addition, never as
+    // a call with a negative/positive-literal argument (axiom.grammar's own
+    // "THE PAREN-OPTIONAL DISAMBIGUATION" comment).
+
+    #[test]
+    fn bare_name_followed_by_minus_number_is_subtraction_not_a_call() {
+        let ast = parse_axiom("f - 1");
+        assert!(contains_rule(&ast, "additive"));
+        // No call_args node should have consumed the MINUS as part of a
+        // negative-literal call argument.
+        assert!(!contains_rule(&ast, "call_args"));
+    }
+
+    #[test]
+    fn bare_name_followed_by_plus_number_is_addition_not_a_call() {
+        let ast = parse_axiom("f + 1");
+        assert!(contains_rule(&ast, "additive"));
+        assert!(!contains_rule(&ast, "call_args"));
+    }
+
+    // --- Lists ----------------------------------------------------------------
+
+    #[test]
+    fn list_literal_parses() {
+        let ast = parse_axiom("[a, b, c]");
+        assert!(contains_rule(&ast, "list_literal"));
+    }
+
+    #[test]
+    fn empty_list_literal_parses() {
+        assert!(parses("[]"));
+    }
+
+    // --- Arithmetic precedence and associativity ---------------------------
+
+    #[test]
+    fn arithmetic_precedence() {
+        let ast = parse_axiom("2 + 3 * 4 ^ 2");
+        assert!(contains_rule(&ast, "additive"));
+        assert!(contains_rule(&ast, "multiplicative"));
+        assert!(contains_rule(&ast, "power"));
+    }
+
+    #[test]
+    fn caret_and_double_star_are_the_same_operator() {
+        assert!(parses("a ^ b"));
+        assert!(parses("a ** b"));
+    }
+
+    #[test]
+    fn unary_minus_binds_looser_than_power() {
+        let ast = parse_axiom("-x^2");
+        assert!(contains_rule(&ast, "unary"));
+        assert!(contains_rule(&ast, "power"));
+    }
+
+    #[test]
+    fn power_is_right_associative_by_shape() {
+        assert!(parses("4^3^2"));
+    }
+
+    #[test]
+    fn multiplicative_and_additive_are_left_associative_by_shape() {
+        assert!(parses("1 - 2 - 3"));
+        assert!(parses("1 / 2 / 3"));
+    }
+
+    #[test]
+    fn grouping_parens_parse() {
+        let ast = parse_axiom("(1 + 2) * 3");
+        assert!(contains_rule(&ast, "group"));
+    }
+
+    // --- Equality / comparison ------------------------------------------------
+
+    #[test]
+    fn every_comparison_operator_parses() {
+        for op in ["=", "~=", "<", "<=", ">", ">="] {
+            let src = format!("a {op} b");
+            assert!(parses(&src), "`{src}` should parse");
+        }
+    }
+
+    #[test]
+    fn comparison_binds_looser_than_additive() {
+        let ast = parse_axiom("a + 1 = b - 1");
+        assert!(contains_rule(&ast, "comparison"));
+        assert!(contains_rule(&ast, "additive"));
+    }
+
+    // --- `:=` immediate assignment -------------------------------------------
+
+    #[test]
+    fn immediate_assignment_parses() {
+        let ast = parse_axiom("x := 5");
+        assert!(contains_rule(&ast, "assignment"));
+    }
+
+    #[test]
+    fn assignment_right_associates_by_shape() {
+        assert!(parses("a := b := 5"));
+    }
+
+    // --- `==` function definition: declared and undeclared forms ------------
+
+    #[test]
+    fn declared_function_definition_parses() {
+        let ast = parse_axiom("power(x: Integer, n: NonNegativeInteger): Integer == x ** n");
+        assert!(contains_rule(&ast, "declared_define"));
+        assert!(contains_rule(&ast, "typed_param_list"));
+    }
+
+    #[test]
+    fn declared_function_definition_with_no_parameters_parses() {
+        assert!(parses("pi(): Float == 3.14"));
+    }
+
+    #[test]
+    fn undeclared_function_definition_parses() {
+        let ast = parse_axiom("f x == x * x");
+        assert!(contains_rule(&ast, "undeclared_define"));
+    }
+
+    #[test]
+    fn undeclared_definition_with_no_parens_is_not_confused_with_a_plain_call() {
+        // `f x` alone (no `==`) is an ordinary call; `f x == e` is a
+        // definition -- both must parse, to two DIFFERENT rules.
+        let call_ast = parse_axiom("f x");
+        assert!(contains_rule(&call_ast, "postfix"));
+        assert!(!contains_rule(&call_ast, "undeclared_define"));
+
+        let def_ast = parse_axiom("f x == x");
+        assert!(contains_rule(&def_ast, "undeclared_define"));
+    }
+
+    #[test]
+    fn declared_define_requires_a_return_type_annotation() {
+        // MA13 §4's own row always shows the return-type annotation; this
+        // grammar takes the narrower, spec-literal reading and requires it.
+        assert!(try_parse_axiom("f(x: Integer) == x").is_err());
+    }
+
+    #[test]
+    fn declared_define_requires_every_parameter_to_be_typed() {
+        assert!(try_parse_axiom("f(x): Integer == x").is_err());
+    }
+
+    // --- `if p then e1 else e2` — `else` is MANDATORY in this cut -----------
+
+    #[test]
+    fn if_then_else_parses() {
+        let ast = parse_axiom("if a > 0 then 1 else -1");
+        assert!(contains_rule(&ast, "if_expr"));
+    }
+
+    #[test]
+    fn if_without_else_is_rejected() {
+        // MA13 §4: "missing else -- deferred" for this cut.
+        assert!(try_parse_axiom("if a > 0 then 1").is_err());
+    }
+
+    #[test]
+    fn if_is_usable_as_an_expression() {
+        let ast = parse_axiom("x := if a > 0 then 1 else -1");
+        assert!(contains_rule(&ast, "if_expr"));
+        assert!(contains_rule(&ast, "assignment"));
+    }
+
+    #[test]
+    fn dangling_else_attaches_to_the_nearest_if() {
+        assert!(parses("if a then if b then 1 else 2 else 3"));
+    }
+
+    // --- `( e1; e2; ...; eN )` parenthesised block ---------------------------
+
+    #[test]
+    fn parenthesised_block_parses_and_shares_the_group_rule_with_plain_grouping() {
+        let block_ast = parse_axiom("(a := 1; a + 1)");
+        let group = find_rule(&block_ast, "group").expect("group");
+        // Two `expr` children, joined by one SEMI -- a block, not plain
+        // grouping (axiom.grammar's own group-vs-block child-count design).
+        let expr_children = group
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "expr"))
+            .count();
+        assert_eq!(expr_children, 2);
+
+        let group_ast = parse_axiom("(1 + 2)");
+        let group2 = find_rule(&group_ast, "group").expect("group");
+        let expr_children2 = group2
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(n) if n.rule_name == "expr"))
+            .count();
+        assert_eq!(expr_children2, 1);
+    }
+
+    #[test]
+    fn block_with_three_statements_parses() {
+        assert!(parses("(a := 1; b := 2; a + b)"));
+    }
+
+    // --- Declaration: `a : T`, `(a, b, c) : T` -------------------------------
+
+    #[test]
+    fn plain_declaration_parses() {
+        let ast = parse_axiom("a : PositiveInteger");
+        assert!(contains_rule(&ast, "declaration"));
+    }
+
+    #[test]
+    fn tuple_declaration_parses() {
+        let ast = parse_axiom("(a, b, c) : Integer");
+        assert!(contains_rule(&ast, "declaration"));
+        assert!(contains_rule(&ast, "name_list"));
+    }
+
+    #[test]
+    fn declaration_type_can_be_a_parameterized_domain() {
+        let ast = parse_axiom("a : Fraction(Integer)");
+        assert!(contains_rule(&ast, "declaration"));
+        assert!(contains_rule(&ast, "type_expr"));
+    }
+
+    // --- Coercion: `e :: T` ---------------------------------------------------
+
+    #[test]
+    fn coercion_parses() {
+        let ast = parse_axiom("3 :: Fraction(Integer)");
+        assert!(contains_rule(&ast, "coercion"));
+    }
+
+    #[test]
+    fn coercion_type_accepts_the_paren_optional_shorthand() {
+        // MA13's own confirmed example: `3 :: Fraction Integer`.
+        let ast = parse_axiom("3 :: Fraction Integer");
+        assert!(contains_rule(&ast, "coercion"));
+        let type_expr = find_rule(&ast, "type_expr").expect("type_expr");
+        assert!(contains_rule(type_expr, "type_ctor_args"));
+    }
+
+    #[test]
+    fn coercion_left_hand_side_can_be_a_computed_expression() {
+        let ast = parse_axiom("(1 + 2) :: Float");
+        assert!(contains_rule(&ast, "coercion"));
+        assert!(contains_rule(&ast, "group"));
+    }
+
+    #[test]
+    fn coercion_binds_tighter_than_comparison() {
+        // `x :: T = y` must read as `(x :: T) = y` -- both `comparison` and
+        // `coercion` nodes must appear, with coercion nested UNDER comparison.
+        let ast = parse_axiom("x :: Integer = y");
+        let cmp = find_rule(&ast, "comparison").expect("comparison");
+        assert!(contains_rule(cmp, "coercion"));
+    }
+
+    #[test]
+    fn coercion_binds_looser_than_additive() {
+        // `a + b :: T` must read as `(a + b) :: T`.
+        let ast = parse_axiom("a + b :: Float");
+        let coerce = find_rule(&ast, "coercion").expect("coercion");
+        assert!(contains_rule(coerce, "additive"));
+    }
+
+    // --- `D has C` category-membership query ---------------------------------
+
+    #[test]
+    fn has_query_true_example_parses() {
+        // MA13's own worked example.
+        let ast = parse_axiom("Polynomial(Integer) has Ring");
+        assert!(contains_rule(&ast, "has_query"));
+    }
+
+    #[test]
+    fn has_query_false_example_parses() {
+        let ast = parse_axiom("List(Integer) has Ring");
+        assert!(contains_rule(&ast, "has_query"));
+    }
+
+    #[test]
+    fn has_query_is_not_directly_reachable_as_a_bare_arithmetic_operand() {
+        // `has` is deliberately its OWN top-level `expr` alternative, not
+        // folded into the general arithmetic cascade (axiom.grammar's own
+        // `has_query` comment) -- `additive`'s operand is `multiplicative`,
+        // never the full `expr`, so a BARE (unparenthesised) has-query
+        // cannot appear as an operand of `+`.
+        assert!(try_parse_axiom("1 + Integer has Ring").is_err());
+    }
+
+    #[test]
+    fn has_query_is_reachable_through_explicit_parens_like_every_other_expr_form() {
+        // `group = LPAREN expr { SEMI expr } RPAREN` wraps the FULL `expr`
+        // (deliberately -- the same "if/assignment/block are all usable as
+        // an expression" design every `expr`-shaped form in this grammar
+        // gets, see `expr`'s own header comment), so a has-query wrapped in
+        // explicit parens IS reachable as an arithmetic operand, the same
+        // way a parenthesised assignment or `if` would be.
+        let ast = parse_axiom("1 + (Integer has Ring)");
+        assert!(contains_rule(&ast, "has_query"));
+        assert!(contains_rule(&ast, "additive"));
+    }
+
+    #[test]
+    fn a_bare_type_expr_with_no_has_falls_through_to_an_ordinary_call() {
+        let ast = parse_axiom("Polynomial(Integer)");
+        assert!(contains_rule(&ast, "postfix"));
+        assert!(!contains_rule(&ast, "has_query"));
+    }
+
+    // --- type_expr's own paren-optional restriction (bare NAME only) --------
+
+    #[test]
+    fn type_ctor_paren_optional_argument_must_be_a_bare_name() {
+        // `List Fraction(Integer)` -- combining the paren-optional shorthand
+        // with a further explicitly-parenthesised argument -- is NOT
+        // accepted by this grammar (axiom.grammar's own `type_expr` comment);
+        // write `List(Fraction(Integer))` instead.
+        assert!(try_parse_axiom("a : List Fraction(Integer)").is_err());
+        assert!(parses("a : List(Fraction(Integer))"));
+    }
+
+    #[test]
+    fn deeply_nested_explicit_type_constructor_parses_up_to_the_depth_cap() {
+        assert!(parses("a : List(Matrix(Polynomial(Integer)))"));
+    }
+
+    // --- `--` comments are invisible to the parser (handled by the lexer) ---
+
+    #[test]
+    fn comments_are_skipped() {
+        assert!(parses("-- a comment\nx := 1 -- trailing"));
+    }
+
+    // --- Syntax errors are reported, not panics ------------------------------
+
+    #[test]
+    fn syntax_error_is_reported() {
+        assert!(try_parse_axiom("1 +").is_err());
+        assert!(try_parse_axiom("(1 + 2").is_err());
+        assert!(try_parse_axiom("has Ring").is_err());
+    }
+
+    #[test]
+    #[should_panic(expected = "Axiom parse failed")]
+    fn parse_axiom_panics_on_malformed_source() {
+        parse_axiom("1 +");
+    }
+
+    // -------------------------------------------------------------------
+    // Recursion-depth guard (DoS hardening) -- exercises all four
+    // independently-measured shapes documented on `MAX_RULE_DEPTH`.
+    // -------------------------------------------------------------------
+
+    fn nested_paren_source(n: usize) -> String {
+        format!("{}5{}", "(".repeat(n), ")".repeat(n))
+    }
+
+    fn nested_call_source(n: usize) -> String {
+        format!("{}5{}", "f(".repeat(n), ")".repeat(n))
+    }
+
+    fn unary_prefix_chain_source(n: usize) -> String {
+        // A SPACE between every `-` is load-bearing, not cosmetic: two
+        // adjacent MINUS characters with no space between them (`--`) is
+        // axiom.tokens' own line-comment opener (a `skip:` pattern, tried
+        // BEFORE ordinary token matching at every position -- see
+        // axiom-lexer's own doc comment) and would swallow the ENTIRE rest
+        // of the line as a comment, silently testing "zero tokens" instead
+        // of a genuine deep unary-chain -- this was caught directly: an
+        // earlier, unspaced version of this helper made every depth-guard
+        // test below pass for entirely the wrong reason (an empty token
+        // stream fails to parse regardless of `MAX_RULE_DEPTH`).
+        let mut s = "-"
+            .repeat(n)
+            .chars()
+            .map(|c| format!("{c} "))
+            .collect::<String>();
+        s.push('5');
+        s
+    }
+
+    fn power_chain_source(n: usize) -> String {
+        let mut s = String::from("1");
+        for _ in 0..n {
+            s.push_str("^1");
+        }
+        s
+    }
+
+    fn all_shape_sources(n: usize) -> Vec<String> {
+        vec![
+            nested_paren_source(n),
+            nested_call_source(n),
+            unary_prefix_chain_source(n),
+            power_chain_source(n),
+        ]
+    }
+
+    /// Deeply-nested input, for every measured shape, must produce a
+    /// recoverable error, not overflow the native stack. Parses 5000
+    /// levels -- far past `MAX_RULE_DEPTH` -- on a worker thread with a
+    /// generous 32 MiB stack, so the *guard* is what stops the recursion,
+    /// not the stack running out.
+    #[test]
+    fn test_deeply_nested_input_returns_error_not_overflow_for_every_shape() {
+        let sources = all_shape_sources(5000);
+        let handle = std::thread::Builder::new()
+            .name("axiom-parser-depth-guard-regression".to_string())
+            .stack_size(32 * 1024 * 1024)
+            .spawn(move || {
+                for src in sources {
+                    let result = try_parse_axiom(&src);
+                    assert!(
+                        result.is_err(),
+                        "deeply-nested input must fail with an error, not parse or crash"
+                    );
+                }
+            })
+            .expect("failed to spawn worker thread");
+        handle
+            .join()
+            .expect("depth guard must keep the worker thread from crashing");
+    }
+
+    /// A caller relying on `MAX_RULE_DEPTH` must have the guard trip
+    /// *before* the native stack overflows on a default-stack thread --
+    /// otherwise a production caller (or `cargo test`'s own per-test
+    /// thread) would still crash. Parses far-too-deep input, for every
+    /// shape, on a worker thread with **no** `stack_size` override (the
+    /// same ~2 MiB a default thread gets).
+    #[test]
+    fn test_cap_trips_before_overflow_on_default_stack_for_every_shape() {
+        let sources = all_shape_sources(5000);
+        let handle = std::thread::spawn(move || {
+            for src in sources {
+                let result = try_parse_axiom(&src);
+                assert!(result.is_err(), "deeply-nested input must error, not crash");
+            }
+        });
+        handle
+            .join()
+            .expect("MAX_RULE_DEPTH must trip BEFORE native overflow on the default stack");
+    }
+
+    /// Reasonable, hand-writable nesting for every shape stays well under
+    /// the cap.
+    #[test]
+    fn test_reasonable_nesting_stays_under_the_cap_for_every_shape() {
+        assert!(try_parse_axiom(&nested_paren_source(3)).is_ok());
+        assert!(try_parse_axiom(&nested_call_source(3)).is_ok());
+        assert!(try_parse_axiom(&unary_prefix_chain_source(5)).is_ok());
+        assert!(try_parse_axiom(&power_chain_source(5)).is_ok());
+    }
+
+    /// Input that nests *exactly up to* `MAX_RULE_DEPTH`'s measured
+    /// real-input headroom for every shape still parses cleanly, and one
+    /// level deeper cleanly trips the cap. These exact boundary counts were
+    /// found empirically by binary-searching `try_parse_axiom` (the CAPPED
+    /// public API, `MAX_RULE_DEPTH = 128`) against increasing nesting counts
+    /// for each shape -- see `MAX_RULE_DEPTH`'s own doc comment ("Measured
+    /// real-input headroom at `128`").
+    #[test]
+    fn test_headroom_boundary_for_every_shape() {
+        assert!(try_parse_axiom(&nested_paren_source(13)).is_ok());
+        assert!(try_parse_axiom(&nested_paren_source(14)).is_err());
+
+        assert!(try_parse_axiom(&nested_call_source(13)).is_ok());
+        assert!(try_parse_axiom(&nested_call_source(14)).is_err());
+
+        assert!(try_parse_axiom(&unary_prefix_chain_source(130)).is_ok());
+        assert!(try_parse_axiom(&unary_prefix_chain_source(131)).is_err());
+
+        assert!(try_parse_axiom(&power_chain_source(65)).is_ok());
+        assert!(try_parse_axiom(&power_chain_source(66)).is_err());
+    }
+}

--- a/code/packages/rust/axiom-parser/src/lib.rs
+++ b/code/packages/rust/axiom-parser/src/lib.rs
@@ -768,9 +768,9 @@ mod tests {
     /// real-input headroom for every shape still parses cleanly, and one
     /// level deeper cleanly trips the cap. These exact boundary counts were
     /// found empirically by binary-searching `try_parse_axiom` (the CAPPED
-    /// public API, `MAX_RULE_DEPTH = 128`) against increasing nesting counts
+    /// public API, `MAX_RULE_DEPTH = 140`) against increasing nesting counts
     /// for each shape -- see `MAX_RULE_DEPTH`'s own doc comment ("Measured
-    /// real-input headroom at `128`").
+    /// real-input headroom at `140`").
     #[test]
     fn test_headroom_boundary_for_every_shape() {
         assert!(try_parse_axiom(&nested_paren_source(13)).is_ok());


### PR DESCRIPTION
## Summary

Implements **MA-13c** — the parser for Axiom's MA13-scoped consumer-view subset — following [MA-13a's design-only kickoff spec](code/specs/MA13-axiom-language.md) and MA-13b's `axiom-lexer` (merged, PR #8997).

- `code/grammars/axiom/axiom.grammar` — the parser grammar, structured after `derive.grammar`/`reduce.grammar` (the closest CAS-family precedents, since Axiom lowers to `symbolic_ir`/`symbolic-vm` like Derive/Reduce/Maple, not to `array_runtime`), plus the three genuinely new productions MA13 §3 introduces: declaration (`:`), coercion (`::`), and category-membership query (`has`).
- `code/packages/rust/axiom-parser/` — wraps the shared `GrammarParser` (no hand-written parsing, per `feedback_no_handwritten_lexers_parsers`), with an independently-**measured** `MAX_RULE_DEPTH = 140` recursion-depth cap, 58 unit tests + 1 doc test (100% line coverage per `cargo tarpaulin`), README, CHANGELOG, and workspace registration.

## In / out of scope (per MA13 §4)

**In scope:** integer/float/string/symbol literals; `f(a, b)` and paren-optional `f a`; list literals `[a, b, c]`; the full arithmetic/comparison cascade (`^`/`**` highest, right-assoc; `*`/`/`; `+`/`-` lowest, left-assoc; unary `-` only); `:=` immediate assignment; `==` held-body function definition (declared `f(x: T, ...): T == e` and undeclared `f x == e`); `if p then e1 else e2` (mandatory `else`); `( e1; e2; ...; eN )` parenthesised block (unified with plain grouping); `a : T` / `(a, b, c) : T` declaration; `e :: T` coercion; `D has C` category query; `( … )` grouping.

**Out of scope** (unchanged from MA13/MA-13b): user-defined categories/domains, `Join`, packages, symbolic-domain-parameterized generics, `Record`/`Union`/`Any`, `Matrix`/`Complex`, a genuine `Equation` domain, `macro`, bare-variable delayed `==`, block early-exit `=>`, piecewise function definitions, anonymous `+->` functions, comprehensions, `for`/`while` loops, `$`/`@`.

## Grammar-design decisions worth flagging

1. **`program = expr`, not a repeated multi-statement worksheet.** Unlike `derive.grammar`/`reduce.grammar` (`program = { statement_line }`), `axiom.tokens` gives top-level inputs **no separator at all** (no significant newline, `;` reserved exclusively for the parenthesised block). This is a disclosed consequence of MA13 framing Axiom as a numbered, per-line interactive session (`(1) ->`) rather than a batch worksheet — `program` parses exactly one top-level expression, leaving "where does one REPL input end" to a future `axiom-repl` (MA-13d).
2. **`:=` and `==` are two entirely separate productions**, unlike Derive's/Reduce's single shared assignment/definition operator. Axiom's declared-function form needs a *typed* parameter list (`x: T`) no ordinary call `arglist` can express, so the "reuse whatever the general call production parses" trick doesn't transfer. Both the declared form's per-parameter types and its return-type annotation are **required** — the narrower, spec-literal reading of MA13's single confirmed row (no untyped-parenthesised or optional-return-type variant accepted).
3. **The paren-optional call form (`f a`) is restricted to a single bare `atom`**, never a further operator-led expression — so `f -1`/`f +1` unambiguously parse as subtraction/addition, never a call with a signed-literal argument (no lookahead predicate needed; `atom` structurally cannot start on `MINUS`/`PLUS`). This mirrors Haskell's identical resolution for its own juxtaposition-application vs. unary/binary `-`.
4. **`has`/`declaration` sit outside the ordinary arithmetic cascade; `coercion` sits inside it.** `has`'s and `declaration`'s operands are always domain/category-shaped (`type_expr`) per MA13's fixed lookup-table design; `coercion`'s left-hand side is confirmed to be an arbitrary expression (MA13's own `3 :: Fraction Integer` coerces a literal, and nothing rules out `(a + b) :: Float`).
5. **`type_expr`'s own paren-optional constructor shorthand is restricted to a single bare `NAME`** (never a further nested `type_expr` with its own args) — avoiding both unconfirmed syntax (MA13's only paren-optional example is the two-level `Fraction Integer`; richer nesting always uses fully explicit parens) and an adversarial "one recursion frame per bare identifier, no delimiter to pay for it" DoS shape. `List Fraction(Integer)` is therefore rejected; `List(Fraction(Integer))` (fully explicit parens) works.
6. **`MAX_RULE_DEPTH = 140`**, measured (not assumed) across four structurally distinct recursive shapes via binary search on an uncapped parser, subprocess-per-data-point, on a 2 MiB worker thread, in a debug build. The binding constraint turned out to be **nested function calls** (rule-frame floor 211/212) — notably *not* parenthesised grouping (282/283), which is the dominant shape for `derive-parser`/`reduce-parser`. 140 sits ~33.6% below that floor.

## Test plan

- [x] `cargo build -p coding-adventures-axiom-parser`
- [x] `cargo test -p coding-adventures-axiom-parser` — 58 unit tests + 1 doc test, all green
- [x] `cargo tarpaulin -p coding-adventures-axiom-parser` — 100% line coverage (11/11 in `lib.rs`, 2/2 in `_grammar.rs`)
- [x] `cargo clippy -p coding-adventures-axiom-parser --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p coding-adventures-axiom-parser -- --check` — clean (aside from the auto-generated `_grammar.rs`, which is intentionally left in its compiler-emitted style, per `lessons.md`)
- [x] Depth-guard regression tests confirmed to genuinely exercise the cap (not an empty-token-stream artifact — an earlier draft's unspaced unary-minus-chain helper collided with the `--` line-comment token; fixed by inserting spaces)
- [x] `cargo build --workspace` — confirmed the one encountered failure (`uefi`/`panic_impl` in `os-kernel`) is pre-existing on `origin/main` (verified via `git stash`), a documented host-un-buildable crate per `lessons.md`; unrelated to this change
- [x] Security review (sub-agent): **PASSED** — recursion-depth cap verified wired on every `GrammarParser` construction path in this crate; no unsafe code; no unchecked panics reachable from adversarial input; dev-only `examples/regenerate_grammar.rs` uses only fixed repo-relative paths (no traversal surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)