### PR TITLE
feat(adj-formula-stdlib): magnetic-flux-density-conversions — NIST SP 811 B.9 gauss/gamma→tesla exact factors (RS-5 table)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -674,6 +674,49 @@ fn shipped_kinematic_viscosity_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b14) Shipped table — reference/magnetic-flux-density-conversions.adj resolves via
+//       import (a NEW dimension: magnetic flux density → tesla, the EXACT SP 811 B.9
+//       boldface factors gauss and gamma), and a unit with no row (`kilogauss`)
+//       abstains.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_magnetic_flux_density_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_mfd");
+    let src = stdlib().join("reference/magnetic-flux-density-conversions.adj");
+    std::fs::copy(&src, dir.join("magnetic-flux-density-conversions.adj"))
+        .expect("copy shipped magnetic-flux-density-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"magnetic-flux-density-conversions.adj\"\n\
+         ? magnetic_flux_density_to_teslas(gauss, $v)\n\
+         ? magnetic_flux_density_to_teslas(gamma, $v)\n\
+         ? magnetic_flux_density_to_teslas(kilogauss, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 magnetic-flux-density exact factors resolve, character-for-
+    // character from the table (boldface = exact; scientific notation to plain decimal).
+    assert!(out.contains("\"v\":\"0.0001\""), "gauss = 0.0001 T: {out}");
+    assert!(
+        out.contains("\"v\":\"0.000000001\""),
+        "gamma = 0.000000001 T: {out}"
+    );
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `kilogauss` has no row in this base-unit table, so the engine abstains rather than
+    // inventing a factor the table does not carry.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a unit with no row abstains, never a fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/magnetic-flux-density-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/magnetic-flux-density-conversions.adj
@@ -1,0 +1,58 @@
+% ============================================================================
+% magnetic-flux-density-conversions — magnetic-flux-density-unit → tesla factors
+% (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of `dynamic-viscosity-conversions.adj` and
+% `kinematic-viscosity-conversions.adj`: a native tabular relation ingested VERBATIM
+% from a published NIST conversion table. Each row states the factor converting one
+% magnetic-flux-density unit to the SI coherent unit of magnetic flux density, the
+% tesla (T):
+%
+%     ? magnetic_flux_density_to_teslas(gauss, $v)   % 0.0001
+%     ? magnetic_flux_density_to_teslas(gamma, $v)   % 0.000000001
+%
+% This is a NEW dimension alongside the length/mass/area/volume/time/speed/energy/
+% pressure/force/acceleration/dynamic-viscosity/kinematic-viscosity tables: where
+% those normalise their own quantity, this one normalises a MAGNETIC FLUX DENSITY (the
+% strength of a magnetic field, one tesla being one weber per square metre). Put a
+% field given in the CGS gauss into SI first, then reason (write-once-use-many). Why a
+% `table` and not several hand-written `relate` clauses: this is exactly the shape
+% reference data comes in — a published table, not prose. The citable artifact IS the
+% NIST conversion-factors table at the `locator` below; every factor here is a CELL of
+% NIST Special Publication 811, Appendix B.9 ("Factors for units listed
+% alphabetically"), and the whole table is defended by one provenance envelope rather
+% than repeating `source`/`locator`/`trust` on every row. Each `row` lowers to a ground
+% relation `magnetic_flux_density_to_teslas(unit, teslas)`, so the exact lookup above is
+% the ordinary SLD binding query — the engine returns the factor WITH this table's
+% citation as its proof, on the CPU, with zero model calls.
+%
+% HONESTY NOTE: NIST SP 811 B.9 prints these two magnetic-flux-density factors in
+% BOLDFACE, its convention for factors that are EXACT by definition, transcribed here
+% as the plain decimal number of teslas each unit names:
+%
+%     gauss (Gs, G)   1.0 E-04  →  0.0001
+%     gamma           1.0 E-09  →  0.000000001
+%
+% These two are exact because both are coherent CGS-Gaussian / customary magnetic units
+% defined as exact powers of ten of the tesla — one gauss is exactly 10⁻⁴ T, and one
+% gamma is exactly 10⁻⁹ T (i.e. exactly one nanotesla). Both terminate; nothing here is
+% a rounded measurement. This table's scope is precisely those two base units NIST lists
+% for magnetic flux density; a unit with NO row — e.g. a `kilogauss` — ABSTAINS rather
+% than returning a factor the table does not carry. The only claim this table makes is
+% "these are the exact factors NIST SP 811 B.9 prints", which is exactly what a
+% byte-check against the cited table verifies. `trust authoritative` — a primary,
+% re-fetchable standards reference. (See ADJ-TABLES.md; and
+% feedback_nothing_human_authored — every factor is a verbatim cell of the cited table,
+% nothing asserted from memory.)
+% ============================================================================
+
+table magnetic_flux_density_to_teslas {
+    columns unit, teslas
+
+    row (gauss, 0.0001)
+    row (gamma, 0.000000001)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/magnetic-flux-density-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/magnetic-flux-density-conversions.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% magnetic-flux-density-conversions.query.adj — a worked lookup over the
+% magnetic-flux-density table.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a "how many tesla is
+% one gauss?" question: it states no conversion fact — it only `import`s the grounded
+% table and asks binding queries. The native adj-lang engine resolves each `?` against
+% the table's rows (lowered to `magnetic_flux_density_to_teslas` relations) and returns
+% the binding + the table's source/locator/trust. A unit not in the table abstains
+% honestly — the engine never invents a factor (e.g. a `kilogauss`, which this table
+% does not carry a row for).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli magnetic-flux-density-conversions.query.adj
+% ============================================================================
+
+import "magnetic-flux-density-conversions.adj"
+
+? magnetic_flux_density_to_teslas(gauss, $v)      % expect 0.0001
+? magnetic_flux_density_to_teslas(gamma, $v)      % expect 0.000000001
+? magnetic_flux_density_to_teslas(kilogauss, $v)  % expect abstain — no row


### PR DESCRIPTION
## What

Adds `reference/magnetic-flux-density-conversions.adj` — a native RS-5 `table` for a **new dimension**, magnetic flux density → the SI **tesla (T)** — a sibling of the viscosity / length / mass / area / volume / time / speed / energy / pressure / force / acceleration conversion tables. Two rows, **both exact** (NIST prints them boldface = exact by definition), transcribed **verbatim** from NIST Special Publication 811, Appendix B.9 ("Factors for units listed alphabetically"):

| unit | NIST B.9 factor | tesla |
|---|---|---|
| gauss (Gs, G) | **1.0 E-04** | 0.0001 |
| gamma | **1.0 E-09** | 0.000000001 |

Each `row` lowers to a ground relation `magnetic_flux_density_to_teslas(unit, teslas)`, so an exact lookup is the ordinary SLD binding query — the engine returns the factor **with the table's one provenance envelope** (`source`/`locator`/`trust authoritative`), on the CPU, zero model calls.

## Honesty / abstention

Both factors are exact because gauss and gamma are defined as exact powers of ten of the tesla — one gauss is exactly 10⁻⁴ T, one gamma exactly 10⁻⁹ T (one nanotesla). This table's scope is those two base units NIST lists; a unit with **no row** — e.g. a `kilogauss` — **abstains** rather than returning a factor the table does not carry. The only claim the table makes is "these are the exact factors NIST SP 811 B.9 prints" — which a byte-check against the cited page verifies.

## Files

- `reference/magnetic-flux-density-conversions.adj` — the grounded RS-5 table
- `reference/magnetic-flux-density-conversions.query.adj` — worked lookups (gauss → 0.0001, gamma → 0.000000001, and an abstaining miss)
- `adj-lang-cli/tests/rs5_table_e2e.rs` — new **(b14)** block on the shared table anchor, driving the built CLI against the shipped table

## Verification

- `cargo test -p adj-lang-cli --test rs5_table_e2e` → **19/19 pass** (new block asserts exact `0.0001` / `0.000000001`, the NIST B.9 locator on the answer, and abstention on the no-row unit)
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean
- Shipped query run through the CLI → `0.0001` / `0.000000001` exact, `abstained:true` on the no-row unit, NIST B.9 locator carried
- NUL-scan: 0 bytes in all touched files
- Byte-verified verbatim against NIST SP 811 B.9 (gauss `1.0 E-04`, gamma `1.0 E-09`, both boldface/exact)
- Data + test only — **no version bump**
- `/security-review` → PASSED (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)