### PR TITLE
feat(semantic-ir-to-ruby): classes slice 7 — modules/mixins (OOP arc complete) (0.17.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.17.0 — classes slice 7: modules / mixins (OOP arc complete)
+
+Accepts `Feature::Modules` — module definitions and `include`/`extend` mixins.
+This is the **last OOP slice**: the Ruby backend now covers the full class/module
+surface (classes, constants, instance & class methods, `@ivars`, `@@class vars`,
+inheritance + `super`, and now modules).
+
+- `module M; …; end` → `Object.const_set(:M, Module.new)` (reflective, like a
+  class — a native `module` block is illegal inside the `main` method).
+- `include M` (in a class) → `__include__("Class", "M")` → `(Class).include(M)`.
+- `extend M` → `__extend__("Class", "M")` → `(Class).extend(M)`.
+
+**Module methods reuse existing machinery.** A module's methods are hoisted and
+registered with the SAME `__def_method__` protocol as class methods (slice 2):
+`Module#define_method` installs each as `:sir_um_<m>`, and once a class `include`s
+the module they resolve through the ancestry via the existing
+`__method__`/`public_send` dispatch — so this slice adds **no new method
+machinery**, only the `ModuleDef` declaration and the two native mixin builtins.
+`include` adds instance methods; `extend` adds singleton (class) methods.
+
+**Injection safety.** The module name (`const_set`) and both mixin operands (the
+class and the module, emitted verbatim as bare constants in `.include`/`.extend`)
+are validated as constant paths in the co-total scan. A non-empty module body
+(class-level code) is deferred — a method-only module has an empty body.
+
+**OOP arc complete** for the Ruby backend. Remaining not-yet-wired features are
+the built-in **collection-method** catalog, `TailCalls`, `Intrinsics`,
+`NDArrays`, and array-pattern destructuring.
+
 ## 0.16.0 — classes slice 6: class variables (@@x)
 
 Accepts `Feature::ClassVars` — `@@` class variables.

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/README.md
+++ b/code/packages/rust/semantic-ir-to-ruby/README.md
@@ -97,12 +97,17 @@ independent class-method allowlist so a built-in class-method call rejects clean
 `sir_cvar_owner(self).class_variable_get/set(:"@@x")` (the owner is the class in
 both instance- and class-method contexts, so they share one `@@x`), and a
 class-body `@@x = init` — the first accepted non-empty class body — writes on the
-class by name; each `@@`-name validated (no injection).
+class by name; each `@@`-name validated (no injection). **Modules / mixins**
+(slice 7, completing the OOP arc): `module M; …; end` → `Object.const_set(:M,
+Module.new)`, and `include M` / `extend M` → native `(Class).include(M)` /
+`(Class).extend(M)` (both operands validated) — a module's methods reuse the
+existing `__def_method__` registration, so a mixed-in method resolves through the
+ancestry with no new machinery.
 Rejects `TailCalls`, `Intrinsics`, and every not-yet-wired feature (array
 indexing / slicing via `IndexGet` — `NDArrays`; array-pattern destructuring;
-built-in collection methods; and the last of OOP — modules — plus a namespaced
-class/constant definition or other class-body content) until its slice lands —
-each a clean, source-positioned `UnsupportedFeature`.
+built-in collection methods; plus a namespaced class/constant definition or a
+non-`@@x`-init class/module body) until its slice lands — each a clean,
+source-positioned `UnsupportedFeature`.
 
 ## Verification
 

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -107,6 +107,12 @@ const SUPPORTED_BUILTINS: &[&str] = &[
     // keeping dispatch CLOSED (anti-RCE).
     "__def_class_method__",
     "__class_method__",
+    // OOP classes slice 7 (modules / mixins): `include M` / `extend M` render as
+    // Ruby's native `Class.include(Module)` / `Class.extend(Module)`.  Both
+    // operands are bare constant references (validated).  A module's own methods
+    // are hoisted + registered via `__def_method__`, reusing the slice-2 machinery.
+    "__include__",
+    "__extend__",
 ];
 
 /// Emit a complete self-contained Ruby source file for `m`.
@@ -566,13 +572,36 @@ impl Scan {
         // obligates handling it too, or a hand-built module carrying it would
         // pass validation + the capability check and reach the emitter's
         // `unreachable!` (a DoS).  It is deferred to a later OOP slice; reject it
-        // cleanly here.  (`Stmt::ModuleDef` is NOT handled here because it
-        // observes the unaccepted `Feature::Modules`, so the capability check
-        // rejects such a module before this scan.)
+        // cleanly here.
         Stmt::SingletonClassDef { span, .. } => Some(ScanHit::Unsupported(
             "a singleton class (`class << self`)".to_string(),
             span.clone(),
         )),
+        // A `Stmt::ModuleDef` (`module M; end`, `Feature::Modules`, OOP slice 7) —
+        // the sole observer of `Feature::Modules`, so accepting it obligates
+        // handling `ModuleDef` here (else it would reach the emitter's
+        // `unreachable!`).  Emitted as `Object.const_set(:M, Module.new)`, so
+        // validate the name as a single-segment constant (like a `ClassDef`); a
+        // non-empty module body (class-level code) is deferred — a method-only
+        // module has an EMPTY body (its methods are hoisted + registered via
+        // `__def_method__`).
+        Stmt::ModuleDef { name, body, span } => {
+            if !is_valid_constant_path(name) {
+                Some(ScanHit::ConstantName(name.clone(), span.clone()))
+            } else if name.contains("::") {
+                Some(ScanHit::Unsupported(
+                    "a namespaced module name (`module Foo::Bar`)".to_string(),
+                    span.clone(),
+                ))
+            } else if !body.is_empty() {
+                Some(ScanHit::Unsupported(
+                    "a non-empty module body (class-level code)".to_string(),
+                    span.clone(),
+                ))
+            } else {
+                None
+            }
+        }
         _ => None,
     }
     }
@@ -749,6 +778,26 @@ impl Scan {
                                 ),
                                 mspan.clone(),
                             ));
+                        }
+                    }
+                    _ => return Some(ScanHit::Builtin(name.clone(), span.clone())),
+                }
+            }
+            // `__include__("Class", "Module")` / `__extend__(…)` (OOP slice 7) mix
+            // a module into a class: `(<Class>).include(<Module>)`.  BOTH operands
+            // are emitted verbatim as bare constant references, so validate each as
+            // a constant path here (injection guard).
+            if name == "__include__" || name == "__extend__" {
+                match (args.first(), args.get(1)) {
+                    (
+                        Some(Expr::StrLit { value: cls, span: cspan }),
+                        Some(Expr::StrLit { value: m, span: mspan }),
+                    ) => {
+                        if !is_valid_constant_path(cls) {
+                            return Some(ScanHit::ConstantName(cls.clone(), cspan.clone()));
+                        }
+                        if !is_valid_constant_path(m) {
+                            return Some(ScanHit::ConstantName(m.clone(), mspan.clone()));
                         }
                     }
                     _ => return Some(ScanHit::Builtin(name.clone(), span.clone())),
@@ -1149,8 +1198,16 @@ fn emit_stmt(s: &Stmt) -> String {
             }
             s
         }
-        // Other not-yet-supported statements (e.g. index-set, module/singleton
-        // defs) are rejected by the capability check / scan before emit.
+        // OOP classes slice 7: a `module M; end` — defined REFLECTIVELY like a
+        // class (`const_set` is legal anywhere; a native `module` block is a Ruby
+        // error inside the `main` method), naming the module `M`.  The scan
+        // guarantees a single-segment constant name and an empty body, so this is
+        // a bare `Object.const_set(:M, Module.new)`.  Its methods are hoisted and
+        // registered separately with `__def_method__` (reusing slice-2 machinery),
+        // and a class mixes it in with the native `include`/`extend` below.
+        Stmt::ModuleDef { name, .. } => format!("Object.const_set(:{name}, Module.new)"),
+        // Other not-yet-supported statements (e.g. index-set, singleton defs) are
+        // rejected by the capability check / scan before emit.
         other => unreachable!("Ruby backend reached unsupported statement: {other:?}"),
     }
 }
@@ -1517,6 +1574,13 @@ fn emit_builtin(name: &str, args: &[Expr]) -> String {
             parts.extend_from_slice(&a[2..]);
             format!("({class}).public_send({})", parts.join(", "))
         }
+        // OOP classes slice 7 — mix a module into a class.  `args[0]` = the class,
+        // `args[1]` = the module, BOTH bare validated constants.  `include` adds
+        // the module's methods as INSTANCE methods (resolved through the ancestry
+        // by the existing `__method__`/`public_send` dispatch); `extend` adds them
+        // as SINGLETON (class) methods.  Native Ruby — no runtime helper.
+        "__include__" => format!("({}).include({})", str_arg(args, 0), str_arg(args, 1)),
+        "__extend__" => format!("({}).extend({})", str_arg(args, 0), str_arg(args, 1)),
         // Unreachable: first_scan_issue rejected anything else.
         other => unreachable!("v0 Ruby backend reached unsupported builtin: {other}"),
     }

--- a/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
@@ -213,6 +213,20 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // runs where `self` is `main`, not the class.  Every `@@`-name is validated as
     // `@@<identifier>` in the co-total scan (no injection).
     Feature::ClassVars,
+    // ── OOP classes, slice 7: modules / mixins (the last OOP slice) ──────
+    // `Feature::Modules` is observed by a `Stmt::ModuleDef` (the sole observer).
+    //   `module M; …; end` → `Object.const_set(:M, Module.new)`
+    //   `include M` (in a class) → `__include__("Class", "M")` → `Class.include(M)`
+    //   `extend M`             → `__extend__("Class", "M")`  → `Class.extend(M)`
+    // A module's own methods are HOISTED and registered with the SAME
+    // `__def_method__` protocol as class methods (slice 2), so `Module#define_method`
+    // installs them and, once a class `include`s the module, they resolve through
+    // the ancestry via the existing `__method__`/`public_send` dispatch — no new
+    // method machinery.  This slice adds only the `ModuleDef` declaration and the
+    // native `include`/`extend` mixins (both operands validated as constant
+    // references, no injection).  A non-empty module body is deferred (a
+    // method-only module has an empty body — its methods are hoisted).
+    Feature::Modules,
 ];
 
 impl Backend for RubyBackend {

--- a/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
@@ -1693,6 +1693,7 @@ fn method_module_fns(stmts: Vec<Stmt>, extra: Vec<Function>) -> Module {
             Feature::Constants,
             Feature::Strings,
             Feature::Closures,
+            Feature::Modules,
         ]),
         imports: vec![],
         exports: vec![],
@@ -2328,4 +2329,109 @@ fn a_non_double_at_classvar_name_is_rejected() {
     assert!(compile(&classvar_module(vec![classvar_assign("@n", ilit(1))])).is_err(), "single @");
     assert!(compile(&classvar_module(vec![classvar_assign("@@", ilit(1))])).is_err(), "bare @@");
     assert!(compile(&classvar_module(vec![classvar_assign("@@1x", ilit(1))])).is_err(), "@@ + digit");
+}
+
+// ── OOP classes slice 7 — modules / mixins (the LAST OOP slice) ─────────────
+//
+// `module M; def m;…;end; end` lowers to a `Stmt::ModuleDef` + a hoisted `M__m`
+// function + `__def_method__("M", "m", closure)` (the SAME registration as a
+// class), and `include M` (in a class) to `__include__("Class", "M")`. Rendered
+// as `Object.const_set(:M, Module.new)`, `Object.const_set(:Class, Class.new)`,
+// `M.define_method(:sir_um_m, &closure)` (existing slice-2 path — `Module` has
+// `define_method`), and `(Class).include(M)`. A mixed-in method then resolves
+// through the ancestry via the existing `__method__`/`public_send` dispatch — so
+// module methods need NO new machinery.
+
+fn moduledef(name: &str, body: Vec<Stmt>) -> Stmt {
+    Stmt::ModuleDef { name: name.into(), body, span: s2() }
+}
+fn mixin_call(builtin: &str, class: &str, module: &str) -> Expr {
+    Expr::BuiltinCall {
+        name: builtin.into(),
+        args: vec![strlit(class), strlit(module)],
+        effects: EffectSet::PURE,
+        span: s2(),
+    }
+}
+
+// ---- positive, through the real frontend + interpreter --------------------
+
+#[test]
+fn e2e_module_mixed_into_a_class() {
+    // `module Greet; def hello; …; end; end; class Person; include Greet; end` —
+    // a `Person` instance answers the module's method.
+    let rb = ruby_to_ruby(
+        "module Greet\n  def hello\n    puts \"hi\"\n  end\nend\n\
+         class Person\n  include Greet\nend\nPerson.new.hello\n",
+    );
+    assert!(rb.contains("Object.const_set(:Greet, Module.new)"), "module decl:\n{rb}");
+    assert!(rb.contains("(Person).include(Greet)"), "native include:\n{rb}");
+    assert!(rb.contains("Greet.define_method(:sir_um_hello"), "module method via slice-2 path:\n{rb}");
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "hi"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn e2e_one_module_shared_by_two_classes() {
+    // The same module mixed into two classes — both share its method.
+    let rb = ruby_to_ruby(
+        "module Named\n  def label\n    \"L\"\n  end\nend\n\
+         class A\n  include Named\nend\nclass B\n  include Named\nend\n\
+         puts A.new.label\nputs B.new.label\n",
+    );
+    match run_ruby(&rb) {
+        Some(out) => assert_eq!(out, "L\nL"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+// ---- hand-built: emit shape + injection + totality ------------------------
+
+#[test]
+fn module_and_extend_emit_natively() {
+    let m = method_module(vec![
+        moduledef("Mod", vec![]),
+        classdef("Cls", None, vec![]),
+        puts(mixin_call("__extend__", "Cls", "Mod")),
+    ]);
+    let rb = compile(&m).expect("module + extend compiles").source;
+    assert!(rb.contains("Object.const_set(:Mod, Module.new)"), "module:\n{rb}");
+    assert!(rb.contains("(Cls).extend(Mod)"), "native extend:\n{rb}");
+}
+
+#[test]
+fn an_injectable_module_name_is_rejected() {
+    let m = method_module(vec![moduledef("Mod\n  system('x')", vec![])]);
+    let err = compile(&m).expect_err("an injectable module name must be rejected");
+    assert_eq!(err.kind, semantic_ir::BackendErrorKind::UnsupportedFeature);
+}
+
+#[test]
+fn an_injectable_include_operand_is_rejected() {
+    // Both the class and the module operand are emitted verbatim — a crafted
+    // either must be rejected.
+    let bad_class = method_module(vec![puts(mixin_call("__include__", "Cls\n system('x')", "Mod"))]);
+    assert!(compile(&bad_class).is_err(), "injectable include class must be rejected");
+    let bad_mod = method_module(vec![puts(mixin_call("__include__", "Cls", "Mod\n system('x')"))]);
+    assert!(compile(&bad_mod).is_err(), "injectable include module must be rejected");
+}
+
+#[test]
+fn a_malformed_include_missing_the_module_is_rejected() {
+    let bad = Expr::BuiltinCall {
+        name: "__include__".into(),
+        args: vec![strlit("Cls")], // no module operand
+        effects: EffectSet::PURE,
+        span: s2(),
+    };
+    let m = method_module(vec![puts(bad)]);
+    assert!(compile(&m).is_err(), "a malformed __include__ must be rejected");
+}
+
+#[test]
+fn a_non_empty_module_body_is_rejected() {
+    let m = method_module(vec![moduledef("Mod", vec![puts(strlit("side effect"))])]);
+    assert!(compile(&m).is_err(), "a non-empty module body must be rejected");
 }

--- a/code/specs/SIR25-semantic-ir-to-ruby.md
+++ b/code/specs/SIR25-semantic-ir-to-ruby.md
@@ -150,9 +150,19 @@ holding ONLY such initializers) instead writes on the class by name
 `@@`-name is validated as `@@<identifier>` and emitted as a quoted symbol (no
 injection); `emit_var_ref` now matches every `Scope` exhaustively.
 
+The seventh OOP slice (0.17.0) **completes the arc** with modules / mixins.
+`module M; …; end` (`Stmt::ModuleDef`, `Feature::Modules`) → `Object.const_set(:M,
+Module.new)`, and `include M` / `extend M` → `__include__` / `__extend__` →
+native `(Class).include(M)` / `(Class).extend(M)` (both operands validated
+constants). A module's methods are hoisted and registered with the SAME
+`__def_method__` protocol as a class (`Module#define_method`), so once a class
+`include`s the module they resolve through the ancestry via the existing
+`__method__` / `public_send` dispatch — no new method machinery. The Ruby backend
+now covers the full class/module surface.
+
 **Still rejects** `TailCalls`, `Intrinsics`, `NDArrays`, and every not-yet-landed
-feature — including the last of OOP, modules (`__include__` / `__extend__`); plus
-a malformed `__def_method__` / `__def_class_method__`, a class body with content
+feature — the built-in **collection-method** catalog; plus a malformed
+`__def_method__` / `__def_class_method__`, a class or module body with content
 other than `@@x` initializers, a namespaced (`Foo::Bar`) class/constant
 *definition* (`const_set` names one namespace), and a **singleton class**
 (`class << self` —
@@ -205,6 +215,9 @@ or temporaries:
 | `BuiltinCall("__class_method__", [class, m, args…])` | `(<class>).public_send(:sir_um_<m>, <args>)` — class-name-receiver dispatch (allowlisted, anti-RCE) |
 | `VarRef { ClassVar }` / `Assign { ClassVar }` (method body) | `sir_cvar_owner(self).class_variable_get/set(:"@@x", …)` — owner is the class in both contexts |
 | `Assign { ClassVar }` (class body) | `<Class>.class_variable_set(:"@@x", <init>)` — the only accepted non-empty class-body content |
+| `ModuleDef { name }` | `Object.const_set(:<name>, Module.new)` — reflective module declaration |
+| `BuiltinCall("__include__", [class, module])` | `(<class>).include(<module>)` — native mixin (both validated constants) |
+| `BuiltinCall("__extend__", [class, module])` | `(<class>).extend(<module>)` — native singleton-method mixin |
 | `If` | `(if sir_truthy(<cond>) then <then> else <else> end)` |
 | `LogicalAnd { lhs, rhs }` | `(<lhs> && <rhs>)` — native short-circuit, yields the deciding operand |
 | `LogicalOr { lhs, rhs }` | `(<lhs> \|\| <rhs>)` — native short-circuit, yields the deciding operand |
@@ -308,11 +321,11 @@ growing `ACCEPTED_FEATURES`, the runtime, and the conformance corpus in lockstep
    landed 0.13), **inheritance** + `super` (`Class.new(Super)` + an explicit
    ancestry walk, landed 0.14), class **methods** (`def self.m`, native
    `define_singleton_method`, landed 0.15), class **variables** (`@@x` via
-   `class_variable_get/set`, landed 0.16), then **modules**/mixins (the last
-   slice).
+   `class_variable_get/set`, landed 0.16), and **modules**/mixins (native
+   `include`/`extend`, landed 0.17 — OOP arc complete).
 6. **Collections** — the `__method__` catalog for built-in `String`/`Array`/
-   `Hash`/numeric methods (Ruby methods are largely native), sharing the same
-   `__method__` dispatch surface as OOP.
+   `Hash`/numeric methods (Ruby methods are largely native), the remaining large
+   batch, sharing the same `__method__` dispatch surface as OOP.
 
 ## Out of scope (v0)
 


### PR DESCRIPTION
## What

The **final OOP slice**: module definitions and `include`/`extend` mixins. Bumps `semantic-ir-to-ruby` 0.16.0 → 0.17.0 and **completes the Ruby OOP arc** — the backend now covers the full class/module surface (classes, constants, instance & class methods, `@ivars`, `@@class vars`, inheritance + `super`, modules).

- `module M; …; end` → `Stmt::ModuleDef` → `Object.const_set(:M, Module.new)`.
- `include M` (in a class) → `__include__("Class", "M")` → `(Class).include(M)`.
- `extend M` → `__extend__("Class", "M")` → `(Class).extend(M)`.

## Module methods reuse existing machinery

A module's methods are hoisted and registered with the **same** `__def_method__` protocol as class methods (slice 2): `Module#define_method` installs each as `:sir_um_<m>`, and once a class `include`s the module they resolve through the ancestry via the existing `__method__`/`public_send` dispatch. So this slice adds **no new method machinery** — only the `ModuleDef` declaration and the two native mixin builtins. `include` adds instance methods; `extend` adds singleton (class) methods. Verified end-to-end: a module mixed into a class (`Person.new.hello`) and one module shared by two classes.

## Injection safety & totality

`ModuleDef` is the sole observer of `Feature::Modules`, so accepting it obligates handling `ModuleDef` (present in both `emit_stmt` and the scan — no reachable `unreachable!`). The three new verbatim-constant emits — the module name (`const_set`) and both mixin operands (class + module in `.include`/`.extend`) — are each validated as constant paths in the co-total scan; `str_arg` is guaranteed `StrLit` by the scan; a non-empty module body is deferred.

## Security review

A read-only security sub-agent reviewed the diff with injection + totality as the focus and returned **PASSED — no vulnerabilities**: all three verbatim sites are guarded co-totally, a crafted name/operand is rejected, `include`/`extend` operands can only be validated constants (no reflection sink), and there's no reachable panic.

## Tests

118 tests pass (new: frontend+interpreter e2e for a module mixed into a class and a module shared by two classes; hand-built for the module/extend emit shape, an injectable module name, injectable include operands, a malformed `__include__`, and a non-empty module body). `cargo clippy` clean. CHANGELOG, README, and SIR25 spec (node table, prose, roadmap — OOP arc marked complete, Collections is next) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)