### PR TITLE
Add MOS sheet resistance support

### DIFF
--- a/code/packages/python/mosfet-models/CHANGELOG.md
+++ b/code/packages/python/mosfet-models/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [0.1.0] — Unreleased
 
 ### Added
+- `Level1Params.RSH` adds zero-default Berkeley drain/source sheet resistance
+  with finite, non-negative validation.
 - `Level1Params.RS` adds the zero-default Berkeley external source resistance
   parameter with finite, non-negative validation.
 - `Level1Params.RD` adds the zero-default Berkeley external drain resistance

--- a/code/packages/python/mosfet-models/README.md
+++ b/code/packages/python/mosfet-models/README.md
@@ -27,7 +27,8 @@ print(r.Id, r.gm, r.gds, r.region)
   diffusion through `L_eff = L - 2*LD`, `PB` / `MJ` / `FC` bulk-junction
   depletion shaping, Berkeley-default `TOX` gate oxide thickness for intrinsic
   Meyer capacitance through `Cox = epsilon_ox / TOX`, zero-default `RD` / `RS`
-  external drain/source resistance, and `KF` / `AF` flicker noise.
+  external drain/source resistance, zero-default `RSH` sheet resistance, and
+  `KF` / `AF` flicker noise.
 - `evaluate_level1(params, V_GS, V_DS, V_BS, T)`: returns `MosResult` with Id, gm, gds, gmb, Cgs/Cgd/Cgb/Cbs/Cbd, region.
 - Region detection: cutoff (subthreshold-aware), triode, saturation.
 - Body effect via gamma * (sqrt(PHI-V_BS) - sqrt(PHI)) shift.

--- a/code/packages/python/mosfet-models/src/mosfet_models/level1.py
+++ b/code/packages/python/mosfet-models/src/mosfet_models/level1.py
@@ -31,6 +31,7 @@ class Level1Params:
     TOX: float = 1e-7  # gate oxide thickness (m)
     RD: float = 0.0  # external drain resistance (ohm)
     RS: float = 0.0  # external source resistance (ohm)
+    RSH: float = 0.0  # drain/source sheet resistance (ohm per square)
     IS: float = 1e-15  # saturation current (A)
     N_SUB: float = 1.4  # subthreshold slope factor
     T_NOM: float = 300.15  # nominal temperature (K)
@@ -128,6 +129,8 @@ def evaluate_level1(
         raise ValueError("MOSFET RD must be finite and non-negative")
     if not isfinite(p.RS) or p.RS < 0.0:
         raise ValueError("MOSFET RS must be finite and non-negative")
+    if not isfinite(p.RSH) or p.RSH < 0.0:
+        raise ValueError("MOSFET RSH must be finite and non-negative")
     beta = p.KP * (p.W / effective_length)
 
     # Threshold with body effect. The formula is well-defined whenever

--- a/code/packages/python/mosfet-models/tests/test_models.py
+++ b/code/packages/python/mosfet-models/tests/test_models.py
@@ -183,6 +183,14 @@ def test_source_resistance_rejects_negative_value():
         evaluate_level1(Level1Params(RS=-1.0), V_GS=1.8, V_DS=1.8)
 
 
+def test_sheet_resistance_rejects_negative_value():
+    with pytest.raises(
+        ValueError,
+        match="MOSFET RSH must be finite and non-negative",
+    ):
+        evaluate_level1(Level1Params(RSH=-1.0), V_GS=1.8, V_DS=1.8)
+
+
 def test_overlap_and_bulk_capacitances_are_reported():
     p = Level1Params(
         W=2e-6,

--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add Level-1 MOS model-card `RSH` support. A positive sheet resistance supplies
+  the default one-square drain/source terminal resistances when `RD` / `RS`
+  remain zero, reusing intrinsic-node stamping and terminal Johnson noise.
 - Add Level-1 MOS model-card `RS` support. Nonzero values create an intrinsic
   source node, stamp the external resistor in DC, TF, AC, and transient
   analyses, route source-side capacitances through it, and emit `:RS` Johnson

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -99,6 +99,9 @@ node, routes the channel and drain-side capacitances through it, and contributes
 `RS` defaults to zero ohms. A finite positive value inserts an intrinsic source
 node, routes the channel and source-side capacitances through it, and contributes
 `4kT/RS` thermal noise.
+`RSH` defaults to zero ohms per square. With the default one-square terminal
+geometry, it supplies both terminal resistances wherever `RD` or `RS` remains
+zero; an explicit positive terminal resistance takes precedence.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -9064,7 +9064,12 @@ def _mosfet_drain_body_charge_state_name(el: Mosfet) -> str:
 
 def _mosfet_drain_resistance(el: Mosfet) -> float:
     params = getattr(getattr(el.model, "model", None), "params", None)
-    return float(getattr(params, "RD", 0.0))
+    drain_resistance = float(getattr(params, "RD", 0.0))
+    return (
+        drain_resistance
+        if drain_resistance > 0.0
+        else float(getattr(params, "RSH", 0.0))
+    )
 
 
 def _mosfet_intrinsic_drain_node(el: Mosfet) -> str:
@@ -9078,7 +9083,12 @@ def _mosfet_intrinsic_drain_node(el: Mosfet) -> str:
 
 def _mosfet_source_resistance(el: Mosfet) -> float:
     params = getattr(getattr(el.model, "model", None), "params", None)
-    return float(getattr(params, "RS", 0.0))
+    source_resistance = float(getattr(params, "RS", 0.0))
+    return (
+        source_resistance
+        if source_resistance > 0.0
+        else float(getattr(params, "RSH", 0.0))
+    )
 
 
 def _mosfet_intrinsic_source_node(el: Mosfet) -> str:

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -311,8 +311,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "PNP": (41, 58, 13, 4),
     "NJF": (22, 30, 7, 3),
     "PJF": (22, 30, 7, 3),
-    "NMOS": (25, 32, 6, 3),
-    "PMOS": (25, 32, 6, 3),
+    "NMOS": (26, 33, 6, 3),
+    "PMOS": (26, 33, 6, 3),
 }
 
 
@@ -467,6 +467,7 @@ _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
     "TOX": "TOX",
     "RD": "RD",
     "RS": "RS",
+    "RSH": "RSH",
     "IS": "IS",
     "NSUB": "N_SUB",
     "N_SUB": "N_SUB",
@@ -1075,6 +1076,7 @@ def mosfet_from_model_card(
         TOX=p.get("TOX", defaults.TOX),
         RD=p.get("RD", defaults.RD),
         RS=p.get("RS", defaults.RS),
+        RSH=p.get("RSH", defaults.RSH),
         IS=p.get("IS", defaults.IS),
         N_SUB=p.get("N_SUB", defaults.N_SUB),
         T_NOM=p.get("T_NOM", defaults.T_NOM),

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -408,7 +408,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 191
+    assert len(coverage) == 193
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -423,7 +423,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tAF\tAF\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 191
+    assert len(records) == 193
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -446,8 +446,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert summary[0].max_alias_count == 3
     assert summary[0].aliased_parameters == ("IS", "VT", "CJO", "VJ", "M")
     assert summary[5].kind == "NMOS"
-    assert summary[5].canonical_parameter_count == 25
-    assert summary[5].accepted_name_count == 32
+    assert summary[5].canonical_parameter_count == 26
+    assert summary[5].accepted_name_count == 33
     assert summary[5].aliased_parameter_count == 6
     assert summary[5].max_alias_count == 3
     assert summary[5].aliased_parameters == (
@@ -469,7 +469,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert table.splitlines()[1] == "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M"
     assert (
         table.splitlines()[-1]
-        == "PMOS\t25\t32\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        == "PMOS\t26\t33\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
     )
     records = model_card_supported_parameter_coverage_summary_records()
     assert len(records) == 7
@@ -497,9 +497,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 191
-    assert report.expected_canonical_parameter_count == 191
-    assert report.accepted_name_count == 261
+    assert report.canonical_parameter_count == 193
+    assert report.expected_canonical_parameter_count == 193
+    assert report.accepted_name_count == 263
     assert report.aliased_parameter_count == 57
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -507,7 +507,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t191\t191\t261\t57\t4\t0"
+        "true\t7\t7\t193\t193\t263\t57\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -535,15 +535,15 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 190
-    assert report.accepted_name_count == 258
+    assert report.canonical_parameter_count == 192
+    assert report.accepted_name_count == 260
     assert report.aliased_parameter_count == 56
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
     assert report.issues[0].field == "canonical_parameter_count"
     assert report.issues[0].message == (
-        "expected NMOS to expose 25 canonical supported parameters, found 24"
+        "expected NMOS to expose 26 canonical supported parameters, found 25"
     )
     assert report.issues[-1].field == "max_alias_count"
     assert report.issues[-1].message == "expected NMOS max alias count 3, found 2"
@@ -551,12 +551,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t190\t191\t258\t56\t4\t4\n"
+        "false\t7\t7\t192\t193\t260\t56\t4\t4\n"
         "kind\tfield\tmessage\n"
-        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 25 canonical "
-        "supported parameters, found 24\n"
-        "NMOS\taccepted_name_count\texpected NMOS to expose 32 accepted model-card "
-        "names, found 29\n"
+        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 26 canonical "
+        "supported parameters, found 25\n"
+        "NMOS\taccepted_name_count\texpected NMOS to expose 33 accepted model-card "
+        "names, found 30\n"
         "NMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing "
         "parameters, found 5\n"
         "NMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
@@ -565,12 +565,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
     assert records[0] == {
         "kind": "NMOS",
         "field": "canonical_parameter_count",
-        "message": "expected NMOS to expose 25 canonical supported parameters, found 24",
+        "message": "expected NMOS to expose 26 canonical supported parameters, found 25",
     }
     assert format_model_card_supported_parameter_coverage_gate_issue_csv(report).startswith(
         "kind,field,message\n"
-        'NMOS,canonical_parameter_count,"expected NMOS to expose 25 canonical '
-        'supported parameters, found 24"\n'
+        'NMOS,canonical_parameter_count,"expected NMOS to expose 26 canonical '
+        'supported parameters, found 25"\n'
     )
     assert (
         json.loads(format_model_card_supported_parameter_coverage_gate_issue_json(report))
@@ -750,6 +750,7 @@ def test_model_card_aliases_build_device_instances() -> None:
             "LD": 50.0e-9,
             "RD": 125.0,
             "RS": 75.0,
+            "RSH": 50.0,
             "TOX": 25.0e-9,
             "KF": 2.0e-24,
             "AF": 1.4,
@@ -768,6 +769,7 @@ def test_model_card_aliases_build_device_instances() -> None:
         "LD": 50.0e-9,
         "RD": 125.0,
         "RS": 75.0,
+        "RSH": 50.0,
         "TOX": 25.0e-9,
         "KF": 2.0e-24,
         "AF": 1.4,
@@ -785,6 +787,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(50.0e-9) == mos_model.model.model.params.LD
     assert pytest.approx(125.0) == mos_model.model.model.params.RD
     assert pytest.approx(75.0) == mos_model.model.model.params.RS
+    assert pytest.approx(50.0) == mos_model.model.model.params.RSH
     assert pytest.approx(25.0e-9) == mos_model.model.model.params.TOX
     assert pytest.approx(2.0e-24) == mos_model.model.model.params.KF
     assert pytest.approx(1.4) == mos_model.model.model.params.AF
@@ -941,6 +944,27 @@ def test_dc_mosfet_source_resistance_raises_intrinsic_source_voltage() -> None:
     ))
 
     result = dc_op(circuit)
+    assert result.node_voltages["__spice_M1_source"] > 0.0
+
+
+def test_dc_mosfet_sheet_resistance_biases_both_intrinsic_terminals() -> None:
+    circuit = Circuit()
+    circuit.add(VoltageSource("Vdrain", "drain", "0", 5.0))
+    circuit.add(VoltageSource("Vgate", "gate", "0", 3.0))
+    circuit.add(Mosfet(
+        "M1",
+        "drain",
+        "gate",
+        "0",
+        "0",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(Level1Params(RSH=1_000.0)),
+        ),
+    ))
+
+    result = dc_op(circuit)
+    assert result.node_voltages["__spice_M1_drain"] < 5.0
     assert result.node_voltages["__spice_M1_source"] > 0.0
 
 
@@ -2010,6 +2034,30 @@ def test_mosfet_rejects_invalid_source_resistance(
         dc_op(circuit)
 
 
+@pytest.mark.parametrize("sheet_resistance", [float("nan"), -1.0])
+def test_mosfet_rejects_invalid_sheet_resistance(
+    sheet_resistance: float,
+) -> None:
+    circuit = Circuit()
+    circuit.add(Mosfet(
+        "Mbad",
+        "drain",
+        "gate",
+        "0",
+        "0",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(Level1Params(RSH=sheet_resistance)),
+        ),
+    ))
+
+    with pytest.raises(
+        ValueError,
+        match="MOSFET RSH must be finite and non-negative",
+    ):
+        dc_op(circuit)
+
+
 def test_transient_diode_transit_time_holds_forward_charge_on_turnoff() -> None:
     def run(transit_time: float) -> TransientResult:
         circuit = Circuit()
@@ -2953,6 +3001,7 @@ def test_subcircuit_expansion_preserves_mos_geometry():
                             LD=0.1e-6,
                             RD=125.0,
                             RS=75.0,
+                            RSH=50.0,
                             TOX=25.0e-9,
                         )
                     ),
@@ -2971,6 +3020,7 @@ def test_subcircuit_expansion_preserves_mos_geometry():
     assert pytest.approx(0.1e-6) == expanded.model.model.params.LD
     assert pytest.approx(125.0) == expanded.model.model.params.RD
     assert pytest.approx(75.0) == expanded.model.model.params.RS
+    assert pytest.approx(50.0) == expanded.model.model.params.RSH
     assert pytest.approx(25.0e-9) == expanded.model.model.params.TOX
 
 
@@ -8221,6 +8271,35 @@ def test_noise_mosfet_rs_adds_thermal_noise() -> None:
         if entry.element_name == "M1:RS" and entry.noise_type == "thermal"
     )
     assert rs.source_psd == pytest.approx(4.0 * 1.380_649e-23 * 300.0 / 250.0)
+
+
+def test_noise_mosfet_rsh_adds_both_terminal_noise_sources() -> None:
+    circuit = Circuit()
+    circuit.add(VoltageSource("Vdd", "vdd", "0", 5.0))
+    circuit.add(VoltageSource("Vgate", "gate", "0", 3.0))
+    circuit.add(Resistor("Rload", "vdd", "out", 1_000.0))
+    circuit.add(Mosfet(
+        "M1",
+        "out",
+        "gate",
+        "0",
+        "0",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(Level1Params(RSH=250.0)),
+        ),
+    ))
+
+    entries = noise_ac(circuit, "out", "Vgate", freqs=[1_000.0]).points[0].entries
+    for name in ("M1:RD", "M1:RS"):
+        entry = next(
+            candidate
+            for candidate in entries
+            if candidate.element_name == name and candidate.noise_type == "thermal"
+        )
+        assert entry.source_psd == pytest.approx(
+            4.0 * 1.380_649e-23 * 300.0 / 250.0
+        )
 
 
 def test_noise_jfet_rs_adds_thermal_noise() -> None:

--- a/code/packages/rust/mosfet-models/CHANGELOG.md
+++ b/code/packages/rust/mosfet-models/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `Level1Params::rsh` adds zero-default Berkeley drain/source sheet resistance
+  with finite, non-negative validation.
 - `Level1Params::rs` adds the zero-default Berkeley external source resistance
   parameter with finite, non-negative validation.
 - `Level1Params::rd` adds the zero-default Berkeley external drain resistance

--- a/code/packages/rust/mosfet-models/README.md
+++ b/code/packages/rust/mosfet-models/README.md
@@ -27,8 +27,9 @@ This crate implements the classical square-law MOSFET model used in introductory
 where β = KP × W/(L − 2LD) and V_OV = V_GS − V_t. `LD` defaults to zero
 and must leave a positive effective channel length. `TOX` defaults to
 `100 nm`, must be positive, and derives intrinsic Meyer gate capacitance from
-`Cox = epsilon_ox / TOX`. `RD` and `RS` are finite, non-negative external drain
-and source resistance parameters for engine topology and default to zero ohms.
+`Cox = epsilon_ox / TOX`. `RD`, `RS`, and `RSH` are finite, non-negative
+external drain, source, and sheet-resistance parameters for engine topology and
+default to zero ohms.
 
 ## Usage
 

--- a/code/packages/rust/mosfet-models/src/lib.rs
+++ b/code/packages/rust/mosfet-models/src/lib.rs
@@ -42,6 +42,7 @@ const OXIDE_PERMITTIVITY: f64 = 3.453_133e-11;
 /// | TOX       | Gate oxide thickness (m)           | 100 nm   |
 /// | RD        | Drain resistance (ohm)              | 0        |
 /// | RS        | Source resistance (ohm)             | 0        |
+/// | RSH       | Drain/source sheet resistance (ohm) | 0        |
 /// | IS        | Drain–body saturation current (A)  | 1 fA     |
 /// | N_SUB     | Subthreshold slope factor          | 1.4      |
 /// | T_NOM     | Nominal temperature (K)            | 300.15   |
@@ -71,6 +72,8 @@ pub struct Level1Params {
     pub rd: f64,
     /// External source resistance [ohm].
     pub rs: f64,
+    /// Drain/source sheet resistance [ohm per square].
+    pub rsh: f64,
     /// Drain–body saturation current [A] (used for subthreshold floor).
     pub is: f64,
     /// Subthreshold slope factor n.  Subthreshold current ∝ exp(V_OV / (n V_T)).
@@ -115,6 +118,7 @@ impl Default for Level1Params {
             tox: 1.0e-7,
             rd: 0.0,
             rs: 0.0,
+            rsh: 0.0,
             is: 1e-15,
             n_sub: 1.4,
             t_nom: 300.15,
@@ -259,6 +263,10 @@ pub fn evaluate_level1(
     assert!(
         p.rs.is_finite() && p.rs >= 0.0,
         "MOSFET RS must be finite and non-negative"
+    );
+    assert!(
+        p.rsh.is_finite() && p.rsh >= 0.0,
+        "MOSFET RSH must be finite and non-negative"
     );
     let beta = p.kp * (p.w / effective_length);
 

--- a/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
+++ b/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
@@ -194,6 +194,21 @@ fn test_source_resistance_rejects_negative_value() {
     );
 }
 
+#[test]
+#[should_panic(expected = "MOSFET RSH must be finite and non-negative")]
+fn test_sheet_resistance_rejects_negative_value() {
+    evaluate_level1(
+        &Level1Params {
+            rsh: -1.0,
+            ..Level1Params::default()
+        },
+        1.8,
+        1.8,
+        0.0,
+        300.15,
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Body effect
 // ---------------------------------------------------------------------------

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add Level-1 MOS model-card `RSH` support. A positive sheet resistance supplies
+  the default one-square drain/source terminal resistances when `RD` / `RS`
+  remain zero, reusing intrinsic-node stamping and terminal Johnson noise.
 - Add Level-1 MOS model-card `RS` support. Nonzero values create an intrinsic
   source node, stamp the external resistor in DC, TF, AC, and transient
   analyses, route source-side capacitances through it, and emit `:RS` Johnson

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -140,6 +140,9 @@ node, routes the channel and drain-side capacitances through it, and contributes
 `RS` defaults to zero ohms. A finite positive value inserts an intrinsic source
 node, routes the channel and source-side capacitances through it, and contributes
 `4kT/RS` thermal noise.
+`RSH` defaults to zero ohms per square. With the default one-square terminal
+geometry, it supplies both terminal resistances wherever `RD` or `RS` remains
+zero; an explicit positive terminal resistance takes precedence.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3611,6 +3611,7 @@ pub struct MosfetLevel1Params {
     pub oxide_thickness: f64,
     pub drain_resistance: f64,
     pub source_resistance: f64,
+    pub sheet_resistance: f64,
     pub saturation_current: f64,
     pub n_sub: f64,
     pub t_nom: f64,
@@ -3640,6 +3641,7 @@ impl Default for MosfetLevel1Params {
             oxide_thickness: 1.0e-7,
             drain_resistance: 0.0,
             source_resistance: 0.0,
+            sheet_resistance: 0.0,
             saturation_current: 1.0e-15,
             n_sub: 1.4,
             t_nom: 300.15,
@@ -3996,8 +3998,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     (ModelCardKind::Pnp, 41, 58, 13, 4),
     (ModelCardKind::Njf, 22, 30, 7, 3),
     (ModelCardKind::Pjf, 22, 30, 7, 3),
-    (ModelCardKind::Nmos, 25, 32, 6, 3),
-    (ModelCardKind::Pmos, 25, 32, 6, 3),
+    (ModelCardKind::Nmos, 26, 33, 6, 3),
+    (ModelCardKind::Pmos, 26, 33, 6, 3),
 ];
 const DIODE_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IS", "IS"),
@@ -4130,6 +4132,7 @@ const MOS_LEVEL1_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("TOX", "TOX"),
     ("RD", "RD"),
     ("RS", "RS"),
+    ("RSH", "RSH"),
     ("IS", "IS"),
     ("NSUB", "N_SUB"),
     ("N_SUB", "N_SUB"),
@@ -4917,6 +4920,9 @@ pub fn mosfet_from_model_card(
     }
     if let Some(value) = model.parameters.get("RS") {
         params.source_resistance = *value;
+    }
+    if let Some(value) = model.parameters.get("RSH") {
+        params.sheet_resistance = *value;
     }
     if let Some(value) = model.parameters.get("IS") {
         params.saturation_current = *value;
@@ -22332,10 +22338,10 @@ fn collect_node_indices(circuit: &Circuit) -> HashMap<String, usize> {
                 insert_node(&mut names, &mosfet.gate);
                 insert_node(&mut names, &mosfet.source);
                 insert_node(&mut names, &mosfet.body);
-                if mosfet.params.drain_resistance > 0.0 {
+                if mosfet_drain_resistance(mosfet) > 0.0 {
                     insert_node(&mut names, &mosfet_intrinsic_drain_node(mosfet));
                 }
-                if mosfet.params.source_resistance > 0.0 {
+                if mosfet_source_resistance(mosfet) > 0.0 {
                     insert_node(&mut names, &mosfet_intrinsic_source_node(mosfet));
                 }
             }
@@ -22845,25 +22851,25 @@ fn collect_noise_sources(
                         frequency_exponent: 1.0,
                     });
                 }
-                if mosfet.params.drain_resistance > 0.0 {
+                let drain_resistance = mosfet_drain_resistance(mosfet);
+                if drain_resistance > 0.0 {
                     sources.push(NoiseSource {
                         element_name: format!("{}:RD", mosfet.name),
                         noise_type: NoiseType::Thermal,
                         positive: node_index(node_indices, &mosfet.drain),
                         negative: drain,
-                        source_psd: 4.0 * BOLTZMANN * temperature_kelvin
-                            / mosfet.params.drain_resistance,
+                        source_psd: 4.0 * BOLTZMANN * temperature_kelvin / drain_resistance,
                         frequency_exponent: 0.0,
                     });
                 }
-                if mosfet.params.source_resistance > 0.0 {
+                let source_resistance = mosfet_source_resistance(mosfet);
+                if source_resistance > 0.0 {
                     sources.push(NoiseSource {
                         element_name: format!("{}:RS", mosfet.name),
                         noise_type: NoiseType::Thermal,
                         positive: node_index(node_indices, &mosfet.source),
                         negative: source,
-                        source_psd: 4.0 * BOLTZMANN * temperature_kelvin
-                            / mosfet.params.source_resistance,
+                        source_psd: 4.0 * BOLTZMANN * temperature_kelvin / source_resistance,
                         frequency_exponent: 0.0,
                     });
                 }
@@ -24190,20 +24196,22 @@ fn stamp_mosfet(
     stamp_transconductance(matrix, drain, source, body, source, result.gmb);
     stamp_equivalent_current_source(rhs, drain, source, equivalent_current);
     stamp_mosfet_charge(mosfet, capacitor_states, node_indices, matrix, rhs)?;
-    if mosfet.params.drain_resistance > 0.0 {
+    let drain_resistance = mosfet_drain_resistance(mosfet);
+    if drain_resistance > 0.0 {
         stamp_conductance(
             matrix,
             node_index(node_indices, &mosfet.drain),
             drain,
-            1.0 / mosfet.params.drain_resistance,
+            1.0 / drain_resistance,
         );
     }
-    if mosfet.params.source_resistance > 0.0 {
+    let source_resistance = mosfet_source_resistance(mosfet);
+    if source_resistance > 0.0 {
         stamp_conductance(
             matrix,
             node_index(node_indices, &mosfet.source),
             source,
-            1.0 / mosfet.params.source_resistance,
+            1.0 / source_resistance,
         );
     }
     Ok(())
@@ -24385,20 +24393,22 @@ fn stamp_mosfet_small_signal(
     stamp_conductance(matrix, drain, source, result.gds);
     stamp_transconductance(matrix, drain, source, gate, source, result.gm);
     stamp_transconductance(matrix, drain, source, body, source, result.gmb);
-    if mosfet.params.drain_resistance > 0.0 {
+    let drain_resistance = mosfet_drain_resistance(mosfet);
+    if drain_resistance > 0.0 {
         stamp_conductance(
             matrix,
             node_index(node_indices, &mosfet.drain),
             drain,
-            1.0 / mosfet.params.drain_resistance,
+            1.0 / drain_resistance,
         );
     }
-    if mosfet.params.source_resistance > 0.0 {
+    let source_resistance = mosfet_source_resistance(mosfet);
+    if source_resistance > 0.0 {
         stamp_conductance(
             matrix,
             node_index(node_indices, &mosfet.source),
             source,
-            1.0 / mosfet.params.source_resistance,
+            1.0 / source_resistance,
         );
     }
     Ok(())
@@ -24495,20 +24505,22 @@ fn stamp_ac_mosfet_small_signal(
         source,
         Complex::new(result.gmb, 0.0),
     );
-    if mosfet.params.drain_resistance > 0.0 {
+    let drain_resistance = mosfet_drain_resistance(mosfet);
+    if drain_resistance > 0.0 {
         stamp_complex_conductance(
             matrix,
             node_index(node_indices, &mosfet.drain),
             drain,
-            Complex::new(1.0 / mosfet.params.drain_resistance, 0.0),
+            Complex::new(1.0 / drain_resistance, 0.0),
         );
     }
-    if mosfet.params.source_resistance > 0.0 {
+    let source_resistance = mosfet_source_resistance(mosfet);
+    if source_resistance > 0.0 {
         stamp_complex_conductance(
             matrix,
             node_index(node_indices, &mosfet.source),
             source,
-            Complex::new(1.0 / mosfet.params.source_resistance, 0.0),
+            Complex::new(1.0 / source_resistance, 0.0),
         );
     }
     Ok(())
@@ -24926,7 +24938,8 @@ fn jfet_intrinsic_source_node(jfet: &Jfet) -> String {
 }
 
 fn mosfet_intrinsic_drain_node(mosfet: &Mosfet) -> String {
-    if !mosfet.params.drain_resistance.is_finite() || mosfet.params.drain_resistance <= 0.0 {
+    let drain_resistance = mosfet_drain_resistance(mosfet);
+    if !drain_resistance.is_finite() || drain_resistance <= 0.0 {
         mosfet.drain.clone()
     } else {
         format!("__spice_{}_drain", mosfet.name)
@@ -24934,10 +24947,27 @@ fn mosfet_intrinsic_drain_node(mosfet: &Mosfet) -> String {
 }
 
 fn mosfet_intrinsic_source_node(mosfet: &Mosfet) -> String {
-    if !mosfet.params.source_resistance.is_finite() || mosfet.params.source_resistance <= 0.0 {
+    let source_resistance = mosfet_source_resistance(mosfet);
+    if !source_resistance.is_finite() || source_resistance <= 0.0 {
         mosfet.source.clone()
     } else {
         format!("__spice_{}_source", mosfet.name)
+    }
+}
+
+fn mosfet_drain_resistance(mosfet: &Mosfet) -> f64 {
+    if mosfet.params.drain_resistance > 0.0 {
+        mosfet.params.drain_resistance
+    } else {
+        mosfet.params.sheet_resistance
+    }
+}
+
+fn mosfet_source_resistance(mosfet: &Mosfet) -> f64 {
+    if mosfet.params.source_resistance > 0.0 {
+        mosfet.params.source_resistance
+    } else {
+        mosfet.params.sheet_resistance
     }
 }
 
@@ -25632,6 +25662,7 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         ("LD", params.lateral_diffusion_length),
         ("RD", params.drain_resistance),
         ("RS", params.source_resistance),
+        ("RSH", params.sheet_resistance),
         ("TOX", params.oxide_thickness),
         ("IS", params.saturation_current),
         ("N_SUB", params.n_sub),
@@ -25684,6 +25715,12 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: mosfet.name.clone(),
             reason: "MOSFET RS must be non-negative".to_string(),
+        });
+    }
+    if params.sheet_resistance < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET RSH must be non-negative".to_string(),
         });
     }
     if params.oxide_thickness <= 0.0 {

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -95,7 +95,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 191);
+    assert_eq!(coverage.len(), 193);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -114,7 +114,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tAF\tAF\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 191);
+    assert_eq!(records.len(), 193);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -147,8 +147,8 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         vec!["IS", "VT", "CJO", "VJ", "M"]
     );
     assert_eq!(summary[5].kind, ModelCardKind::Nmos);
-    assert_eq!(summary[5].canonical_parameter_count, 25);
-    assert_eq!(summary[5].accepted_name_count, 32);
+    assert_eq!(summary[5].canonical_parameter_count, 26);
+    assert_eq!(summary[5].accepted_name_count, 33);
     assert_eq!(summary[5].aliased_parameter_count, 6);
     assert_eq!(summary[5].max_alias_count, 3);
     assert_eq!(
@@ -166,7 +166,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     assert_eq!(lines[1], "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\t25\t32\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        &"PMOS\t26\t33\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
     );
     let records = model_card_supported_parameter_coverage_summary_records();
     assert_eq!(records.len(), 7);
@@ -184,7 +184,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         "[{\"kind\":\"D\",\"canonical_parameter_count\":\"15\",\"accepted_name_count\":\"21\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
     ));
     assert!(json.ends_with(
-        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"25\",\"accepted_name_count\":\"32\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
+        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"26\",\"accepted_name_count\":\"33\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
     ));
 }
 
@@ -195,15 +195,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 191);
-    assert_eq!(report.expected_canonical_parameter_count, 191);
-    assert_eq!(report.accepted_name_count, 261);
+    assert_eq!(report.canonical_parameter_count, 193);
+    assert_eq!(report.expected_canonical_parameter_count, 193);
+    assert_eq!(report.accepted_name_count, 263);
     assert_eq!(report.aliased_parameter_count, 57);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t191\t191\t261\t57\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t193\t193\t263\t57\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -230,8 +230,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 190);
-    assert_eq!(report.accepted_name_count, 258);
+    assert_eq!(report.canonical_parameter_count, 192);
+    assert_eq!(report.accepted_name_count, 260);
     assert_eq!(report.aliased_parameter_count, 56);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -239,7 +239,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     assert_eq!(report.issues[0].field, "canonical_parameter_count");
     assert_eq!(
         report.issues[0].message,
-        "expected NMOS to expose 25 canonical supported parameters, found 24"
+        "expected NMOS to expose 26 canonical supported parameters, found 25"
     );
     assert_eq!(report.issues.last().unwrap().field, "max_alias_count");
     assert_eq!(
@@ -248,20 +248,20 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t190\t191\t258\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 25 canonical supported parameters, found 24\nNMOS\taccepted_name_count\texpected NMOS to expose 32 accepted model-card names, found 29\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t192\t193\t260\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 26 canonical supported parameters, found 25\nNMOS\taccepted_name_count\texpected NMOS to expose 33 accepted model-card names, found 30\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
     assert_eq!(records[0]["field"], "canonical_parameter_count");
     assert_eq!(
         records[0]["message"],
-        "expected NMOS to expose 25 canonical supported parameters, found 24"
+        "expected NMOS to expose 26 canonical supported parameters, found 25"
     );
     assert!(format_model_card_supported_parameter_coverage_gate_issue_csv(&report).starts_with(
-        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 25 canonical supported parameters, found 24\"\n"
+        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 26 canonical supported parameters, found 25\"\n"
     ));
     assert!(format_model_card_supported_parameter_coverage_gate_issue_json(&report).starts_with(
-        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 25 canonical supported parameters, found 24\"}"
+        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 26 canonical supported parameters, found 25\"}"
     ));
 }
 
@@ -283,8 +283,8 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(dashboard[0].issue_count, 0);
     assert!(dashboard[0].issue_fields.is_empty());
     assert_eq!(dashboard[5].kind, ModelCardKind::Nmos);
-    assert_eq!(dashboard[5].canonical_parameter_count, 25);
-    assert_eq!(dashboard[5].accepted_name_count, 32);
+    assert_eq!(dashboard[5].canonical_parameter_count, 26);
+    assert_eq!(dashboard[5].accepted_name_count, 33);
     assert_eq!(dashboard[5].issue_count, 0);
 
     let table = format_model_card_supported_parameter_coverage_dashboard_table(&coverage);
@@ -296,7 +296,7 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(lines[1], "D\ttrue\t15\t15\t21\t21\t5\t5\t3\t3\t0\t");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\ttrue\t25\t25\t32\t32\t6\t6\t3\t3\t0\t"
+        &"PMOS\ttrue\t26\t26\t33\t33\t6\t6\t3\t3\t0\t"
     );
     let records = model_card_supported_parameter_coverage_dashboard_records(&coverage);
     assert_eq!(records.len(), 7);
@@ -328,10 +328,10 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         .unwrap();
 
     assert!(!nmos.passed);
-    assert_eq!(nmos.canonical_parameter_count, 24);
-    assert_eq!(nmos.expected_canonical_parameter_count, 25);
-    assert_eq!(nmos.accepted_name_count, 29);
-    assert_eq!(nmos.expected_accepted_name_count, 32);
+    assert_eq!(nmos.canonical_parameter_count, 25);
+    assert_eq!(nmos.expected_canonical_parameter_count, 26);
+    assert_eq!(nmos.accepted_name_count, 30);
+    assert_eq!(nmos.expected_accepted_name_count, 33);
     assert_eq!(nmos.aliased_parameter_count, 5);
     assert_eq!(nmos.expected_aliased_parameter_count, 6);
     assert_eq!(nmos.max_alias_count, 2);
@@ -347,7 +347,7 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         ]
     );
     assert!(format_model_card_supported_parameter_coverage_dashboard_table(&coverage).contains(
-        "NMOS\tfalse\t24\t25\t29\t32\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
+        "NMOS\tfalse\t25\t26\t30\t33\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
     ));
 }
 
@@ -596,6 +596,7 @@ fn model_card_aliases_build_device_instances() {
             ("LD", 50.0e-9),
             ("RD", 125.0),
             ("RS", 75.0),
+            ("RSH", 50.0),
             ("TOX", 25.0e-9),
             ("KF", 2.0e-24),
             ("AF", 1.4),
@@ -613,6 +614,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*mos_card.parameters.get("LD").unwrap(), 50.0e-9);
     assert_close(*mos_card.parameters.get("RD").unwrap(), 125.0);
     assert_close(*mos_card.parameters.get("RS").unwrap(), 75.0);
+    assert_close(*mos_card.parameters.get("RSH").unwrap(), 50.0);
     assert_close(*mos_card.parameters.get("TOX").unwrap(), 25.0e-9);
     assert_close(*mos_card.parameters.get("KF").unwrap(), 2.0e-24);
     assert_close(*mos_card.parameters.get("AF").unwrap(), 1.4);
@@ -627,6 +629,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(mos_model.params.lateral_diffusion_length, 50.0e-9);
     assert_close(mos_model.params.drain_resistance, 125.0);
     assert_close(mos_model.params.source_resistance, 75.0);
+    assert_close(mos_model.params.sheet_resistance, 50.0);
     assert_close(mos_model.params.oxide_thickness, 25.0e-9);
     assert_close(mos_model.params.flicker_noise_coefficient, 2.0e-24);
     assert_close(mos_model.params.flicker_noise_exponent, 1.4);
@@ -1659,6 +1662,33 @@ fn dc_mosfet_source_resistance_raises_intrinsic_source_voltage() {
 }
 
 #[test]
+fn dc_mosfet_sheet_resistance_biases_both_intrinsic_terminals() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vdrain", "drain", "0", 5.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 3.0,
+    )));
+    circuit.add(Element::Mosfet(Mosfet::with_model(
+        "M1",
+        "drain",
+        "gate",
+        "0",
+        "0",
+        MosfetType::Nmos,
+        MosfetLevel1Params {
+            sheet_resistance: 1_000.0,
+            ..MosfetLevel1Params::default()
+        },
+    )));
+
+    let result = dc_op(&circuit).unwrap();
+    assert!(result.node_voltages["__spice_M1_drain"] < 5.0);
+    assert!(result.node_voltages["__spice_M1_source"] > 0.0);
+}
+
+#[test]
 fn dc_jfet_source_resistance_raises_intrinsic_source_voltage() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(
@@ -1762,6 +1792,7 @@ fn subcircuit_expansion_preserves_mos_geometry() {
             lateral_diffusion_length: 0.1e-6,
             drain_resistance: 125.0,
             source_resistance: 75.0,
+            sheet_resistance: 50.0,
             oxide_thickness: 25.0e-9,
             ..MosfetLevel1Params::default()
         },
@@ -1804,6 +1835,7 @@ fn subcircuit_expansion_preserves_mos_geometry() {
     assert_close(expanded.params.lateral_diffusion_length, 0.1e-6);
     assert_close(expanded.params.drain_resistance, 125.0);
     assert_close(expanded.params.source_resistance, 75.0);
+    assert_close(expanded.params.sheet_resistance, 50.0);
     assert_close(expanded.params.oxide_thickness, 25.0e-9);
 }
 
@@ -3911,6 +3943,38 @@ fn dc_mosfet_rejects_invalid_source_resistance() {
                     "MOSFET RS must be non-negative".to_string()
                 } else {
                     "MOSFET RS must be finite".to_string()
+                },
+            }
+        );
+    }
+}
+
+#[test]
+fn dc_mosfet_rejects_invalid_sheet_resistance() {
+    for sheet_resistance in [f64::NAN, -1.0] {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "Mbad",
+            "drain",
+            "gate",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                sheet_resistance,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+
+        let err = dc_op(&circuit).unwrap_err();
+        assert_eq!(
+            err,
+            SpiceError::InvalidElement {
+                name: "Mbad".to_string(),
+                reason: if sheet_resistance.is_finite() {
+                    "MOSFET RSH must be non-negative".to_string()
+                } else {
+                    "MOSFET RSH must be finite".to_string()
                 },
             }
         );

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -609,6 +609,46 @@ fn mosfet_source_resistance_emits_thermal_noise() {
 }
 
 #[test]
+fn mosfet_sheet_resistance_emits_both_terminal_noise_sources() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vdd", "vdd", "0", 5.0,
+    )));
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vgate", "gate", "0", 3.0,
+    )));
+    circuit.add(Element::Resistor(Resistor::new(
+        "Rload", "vdd", "out", 1_000.0,
+    )));
+    circuit.add(Element::Mosfet(Mosfet::with_model(
+        "M1",
+        "out",
+        "gate",
+        "0",
+        "0",
+        MosfetType::Nmos,
+        MosfetLevel1Params {
+            sheet_resistance: 250.0,
+            ..MosfetLevel1Params::default()
+        },
+    )));
+
+    let result = noise_ac(&circuit, "out", "Vgate", &[1_000.0], 300.0).unwrap();
+    for name in ["M1:RD", "M1:RS"] {
+        let entry = result.points[0]
+            .entries
+            .iter()
+            .find(|entry| entry.element_name == name && entry.noise_type == NoiseType::Thermal)
+            .unwrap();
+        assert_close(
+            entry.source_psd,
+            4.0 * 1.380_649e-23 * 300.0 / 250.0,
+            1.0e-30,
+        );
+    }
+}
+
+#[test]
 fn jfet_source_resistance_emits_thermal_noise() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add Level-1 MOS model-card `RSH` support. A positive sheet resistance supplies
+  the default one-square drain/source terminal resistances when `RD` / `RS`
+  remain zero, reusing intrinsic-node stamping and terminal Johnson noise.
 - Add Level-1 MOS model-card `RS` support. Nonzero values create an intrinsic
   source node, stamp the external resistor in DC, TF, AC, and transient
   analyses, route source-side capacitances through it, and emit `:RS` Johnson

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -91,6 +91,9 @@ node, routes the channel and drain-side capacitances through it, and contributes
 `RS` defaults to zero ohms. A finite positive value inserts an intrinsic source
 node, routes the channel and source-side capacitances through it, and contributes
 `4kT/RS` thermal noise.
+`RSH` defaults to zero ohms per square. With the default one-square terminal
+geometry, it supplies both terminal resistances wherever `RD` or `RS` remains
+zero; an explicit positive terminal resistance takes precedence.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1779,6 +1779,7 @@ export interface MosfetLevel1Params {
   readonly TOX: number;
   readonly RD: number;
   readonly RS: number;
+  readonly RSH: number;
   readonly IS: number;
   readonly N_SUB: number;
   readonly T_NOM: number;
@@ -2051,8 +2052,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   PNP: [41, 58, 13, 4],
   NJF: [22, 30, 7, 3],
   PJF: [22, 30, 7, 3],
-  NMOS: [25, 32, 6, 3],
-  PMOS: [25, 32, 6, 3],
+  NMOS: [26, 33, 6, 3],
+  PMOS: [26, 33, 6, 3],
 };
 
 export interface Vccs {
@@ -8038,6 +8039,7 @@ export function defaultMosfetLevel1Params(): MosfetLevel1Params {
     TOX: 1.0e-7,
     RD: 0.0,
     RS: 0.0,
+    RSH: 0.0,
     IS: 1.0e-15,
     N_SUB: 1.4,
     T_NOM: 300.15,
@@ -8227,6 +8229,7 @@ const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   TOX: "TOX",
   RD: "RD",
   RS: "RS",
+  RSH: "RSH",
   IS: "IS",
   NSUB: "N_SUB",
   N_SUB: "N_SUB",
@@ -8803,6 +8806,7 @@ export function mosfetFromModelCard(
     ...(p.TOX !== undefined ? { TOX: p.TOX } : {}),
     ...(p.RD !== undefined ? { RD: p.RD } : {}),
     ...(p.RS !== undefined ? { RS: p.RS } : {}),
+    ...(p.RSH !== undefined ? { RSH: p.RSH } : {}),
     ...(p.IS !== undefined ? { IS: p.IS } : {}),
     ...(p.N_SUB !== undefined ? { N_SUB: p.N_SUB } : {}),
     ...(p.T_NOM !== undefined ? { T_NOM: p.T_NOM } : {}),
@@ -18572,10 +18576,10 @@ function collectNodeIndices(circuit: Circuit): Map<string, number> {
         insertNode(names, element.gate);
         insertNode(names, element.source);
         insertNode(names, element.body);
-        if (element.params.RD > 0.0) {
+        if (mosfetDrainResistance(element) > 0.0) {
           insertNode(names, mosfetIntrinsicDrainNode(element));
         }
-        if (element.params.RS > 0.0) {
+        if (mosfetSourceResistance(element) > 0.0) {
           insertNode(names, mosfetIntrinsicSourceNode(element));
         }
         break;
@@ -19008,23 +19012,25 @@ function collectNoiseSources(
           frequencyExponent: 1.0,
         });
       }
-      if (element.params.RD > 0.0) {
+      const drainResistance = mosfetDrainResistance(element);
+      if (drainResistance > 0.0) {
         sources.push({
           elementName: `${element.name}:RD`,
           noiseType: "thermal",
           positive: nodeIndex(nodeIndices, element.drain),
           negative: drain,
-          sourcePsd: 4.0 * BOLTZMANN * temperatureKelvin / element.params.RD,
+          sourcePsd: 4.0 * BOLTZMANN * temperatureKelvin / drainResistance,
           frequencyExponent: 0.0,
         });
       }
-      if (element.params.RS > 0.0) {
+      const sourceResistance = mosfetSourceResistance(element);
+      if (sourceResistance > 0.0) {
         sources.push({
           elementName: `${element.name}:RS`,
           noiseType: "thermal",
           positive: nodeIndex(nodeIndices, element.source),
           negative: source,
-          sourcePsd: 4.0 * BOLTZMANN * temperatureKelvin / element.params.RS,
+          sourcePsd: 4.0 * BOLTZMANN * temperatureKelvin / sourceResistance,
           frequencyExponent: 0.0,
         });
       }
@@ -20217,20 +20223,22 @@ function stampMosfet(
   stampTransconductance(matrix, drain, source, body, source, result.gmb);
   stampCurrentSourceEquivalent(rhs, drain, source, equivalentCurrent);
   stampMosfetCharge(element, capacitorStates, nodeIndices, matrix, rhs);
-  if (element.params.RD > 0.0) {
+  const drainResistance = mosfetDrainResistance(element);
+  if (drainResistance > 0.0) {
     stampConductance(
       matrix,
       nodeIndex(nodeIndices, element.drain),
       drain,
-      1.0 / element.params.RD,
+      1.0 / drainResistance,
     );
   }
-  if (element.params.RS > 0.0) {
+  const sourceResistance = mosfetSourceResistance(element);
+  if (sourceResistance > 0.0) {
     stampConductance(
       matrix,
       nodeIndex(nodeIndices, element.source),
       source,
-      1.0 / element.params.RS,
+      1.0 / sourceResistance,
     );
   }
 }
@@ -20789,15 +20797,25 @@ function jfetIntrinsicSourceNode(element: Jfet): string {
 }
 
 function mosfetIntrinsicDrainNode(element: Mosfet): string {
-  return !Number.isFinite(element.params.RD) || element.params.RD <= 0.0
+  const drainResistance = mosfetDrainResistance(element);
+  return !Number.isFinite(drainResistance) || drainResistance <= 0.0
     ? element.drain
     : `__spice_${element.name}_drain`;
 }
 
 function mosfetIntrinsicSourceNode(element: Mosfet): string {
-  return !Number.isFinite(element.params.RS) || element.params.RS <= 0.0
+  const sourceResistance = mosfetSourceResistance(element);
+  return !Number.isFinite(sourceResistance) || sourceResistance <= 0.0
     ? element.source
     : `__spice_${element.name}_source`;
+}
+
+function mosfetDrainResistance(element: Mosfet): number {
+  return element.params.RD > 0.0 ? element.params.RD : element.params.RSH;
+}
+
+function mosfetSourceResistance(element: Mosfet): number {
+  return element.params.RS > 0.0 ? element.params.RS : element.params.RSH;
 }
 
 function jfetChargeStateVoltage(
@@ -21102,6 +21120,9 @@ function validateMosfet(element: Mosfet): void {
   }
   if (params.RS < 0.0) {
     throw invalidElement(element.name, "MOSFET RS must be non-negative");
+  }
+  if (params.RSH < 0.0) {
+    throw invalidElement(element.name, "MOSFET RSH must be non-negative");
   }
   if (params.TOX <= 0.0) {
     throw invalidElement(element.name, "MOSFET TOX must be positive");
@@ -22537,20 +22558,22 @@ function stampMosfetSmallSignal(
   stampConductance(matrix, drain, source, result.gds);
   stampTransconductance(matrix, drain, source, gate, source, result.gm);
   stampTransconductance(matrix, drain, source, body, source, result.gmb);
-  if (element.params.RD > 0.0) {
+  const drainResistance = mosfetDrainResistance(element);
+  if (drainResistance > 0.0) {
     stampConductance(
       matrix,
       nodeIndex(nodeIndices, element.drain),
       drain,
-      1.0 / element.params.RD,
+      1.0 / drainResistance,
     );
   }
-  if (element.params.RS > 0.0) {
+  const sourceResistance = mosfetSourceResistance(element);
+  if (sourceResistance > 0.0) {
     stampConductance(
       matrix,
       nodeIndex(nodeIndices, element.source),
       source,
-      1.0 / element.params.RS,
+      1.0 / sourceResistance,
     );
   }
 }
@@ -23312,20 +23335,22 @@ function stampAcMosfetSmallSignal(
     source,
     complex(result.gmb, 0.0),
   );
-  if (element.params.RD > 0.0) {
+  const drainResistance = mosfetDrainResistance(element);
+  if (drainResistance > 0.0) {
     stampComplexConductance(
       matrix,
       nodeIndex(nodeIndices, element.drain),
       drain,
-      complex(1.0 / element.params.RD, 0.0),
+      complex(1.0 / drainResistance, 0.0),
     );
   }
-  if (element.params.RS > 0.0) {
+  const sourceResistance = mosfetSourceResistance(element);
+  if (sourceResistance > 0.0) {
     stampComplexConductance(
       matrix,
       nodeIndex(nodeIndices, element.source),
       source,
-      complex(1.0 / element.params.RS, 0.0),
+      complex(1.0 / sourceResistance, 0.0),
     );
   }
 }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -121,7 +121,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(191);
+    expect(coverage).toHaveLength(193);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -141,7 +141,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tAF\tAF\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(191);
+    expect(records).toHaveLength(193);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -167,8 +167,8 @@ describe("dcOp", () => {
     });
     expect(summary[5]).toStrictEqual({
       kind: "NMOS",
-      canonicalParameterCount: 25,
-      acceptedNameCount: 32,
+      canonicalParameterCount: 26,
+      acceptedNameCount: 33,
       aliasedParameterCount: 6,
       maxAliasCount: 3,
       aliasedParameters: ["VT0", "LAMBDA", "N_SUB", "T_NOM", "CBS", "CBD"],
@@ -181,7 +181,7 @@ describe("dcOp", () => {
     );
     expect(table.split("\n")[1]).toBe("D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     expect(table.split("\n").at(-1)).toBe(
-      "PMOS\t25\t32\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
+      "PMOS\t26\t33\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
     );
     const records = modelCardSupportedParameterCoverageSummaryRecords();
     expect(records).toHaveLength(7);
@@ -206,15 +206,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 191,
-      expectedCanonicalParameterCount: 191,
-      acceptedNameCount: 261,
+      canonicalParameterCount: 193,
+      expectedCanonicalParameterCount: 193,
+      acceptedNameCount: 263,
       aliasedParameterCount: 57,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t191\t191\t261\t57\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t193\t193\t263\t57\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -237,15 +237,15 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(190);
-    expect(report.acceptedNameCount).toBe(258);
+    expect(report.canonicalParameterCount).toBe(192);
+    expect(report.acceptedNameCount).toBe(260);
     expect(report.aliasedParameterCount).toBe(56);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 25 canonical supported parameters, found 24",
+      message: "expected NMOS to expose 26 canonical supported parameters, found 25",
     });
     expect(report.issues.at(-1)).toStrictEqual({
       kind: "NMOS",
@@ -253,16 +253,16 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t190\t191\t258\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 25 canonical supported parameters, found 24\nNMOS\taccepted_name_count\texpected NMOS to expose 32 accepted model-card names, found 29\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t192\t193\t260\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 26 canonical supported parameters, found 25\nNMOS\taccepted_name_count\texpected NMOS to expose 33 accepted model-card names, found 30\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 25 canonical supported parameters, found 24",
+      message: "expected NMOS to expose 26 canonical supported parameters, found 25",
     });
     expect(formatModelCardSupportedParameterCoverageGateIssueCsv(report)).toMatch(
-      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 25 canonical supported parameters, found 24"\n/,
+      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 26 canonical supported parameters, found 25"\n/,
     );
     expect(JSON.parse(formatModelCardSupportedParameterCoverageGateIssueJson(report))).toStrictEqual(
       records,
@@ -421,6 +421,7 @@ describe("dcOp", () => {
       LD: 50.0e-9,
       RD: 125.0,
       RS: 75.0,
+      RSH: 50.0,
       TOX: 25.0e-9,
       KF: 2.0e-24,
       AF: 1.4,
@@ -438,6 +439,7 @@ describe("dcOp", () => {
       LD: 50.0e-9,
       RD: 125.0,
       RS: 75.0,
+      RSH: 50.0,
       TOX: 25.0e-9,
       KF: 2.0e-24,
       AF: 1.4,
@@ -453,6 +455,7 @@ describe("dcOp", () => {
     expectClose(mosModel.params.LD, 50.0e-9);
     expectClose(mosModel.params.RD, 125.0);
     expectClose(mosModel.params.RS, 75.0);
+    expectClose(mosModel.params.RSH, 50.0);
     expectClose(mosModel.params.TOX, 25.0e-9);
     expectClose(mosModel.params.KF, 2.0e-24);
     expectClose(mosModel.params.AF, 1.4);
@@ -1172,6 +1175,19 @@ describe("dcOp", () => {
     expect(result.nodeVoltages.get("__spice_M1_source")!).toBeGreaterThan(0.0);
   });
 
+  it("biases both intrinsic MOSFET terminals through RSH", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vdrain", "drain", "0", 5.0));
+    circuit.add(voltageSource("Vgate", "gate", "0", 3.0));
+    circuit.add(mosfet("M1", "drain", "gate", "0", "0", "NMOS", {
+      RSH: 1_000.0,
+    }));
+
+    const result = dcOp(circuit);
+    expect(result.nodeVoltages.get("__spice_M1_drain")!).toBeLessThan(5.0);
+    expect(result.nodeVoltages.get("__spice_M1_source")!).toBeGreaterThan(0.0);
+  });
+
   it("raises the intrinsic JFET source voltage across RS", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vdrain", "drain", "0", 5.0));
@@ -1238,6 +1254,7 @@ describe("dcOp", () => {
           LD: 0.1e-6,
           RD: 125.0,
           RS: 75.0,
+          RSH: 50.0,
           TOX: 25.0e-9,
         }),
       ]),
@@ -1252,6 +1269,7 @@ describe("dcOp", () => {
     expectClose(expanded!.params.LD, 0.1e-6);
     expectClose(expanded!.params.RD, 125.0);
     expectClose(expanded!.params.RS, 75.0);
+    expectClose(expanded!.params.RSH, 50.0);
     expectClose(expanded!.params.TOX, 25.0e-9);
   });
 
@@ -2487,6 +2505,20 @@ describe("dcOp", () => {
         Number.isFinite(sourceResistance)
           ? "MOSFET RS must be non-negative"
           : "MOSFET RS must be finite",
+      );
+    }
+  });
+
+  it("rejects invalid MOSFET sheet resistances", () => {
+    for (const sheetResistance of [Number.NaN, -1.0]) {
+      const circuit = new Circuit();
+      circuit.add(mosfet("Mbad", "drain", "gate", "0", "0", "NMOS", {
+        RSH: sheetResistance,
+      }));
+      expect(() => dcOp(circuit)).toThrowError(
+        Number.isFinite(sheetResistance)
+          ? "MOSFET RSH must be non-negative"
+          : "MOSFET RSH must be finite",
       );
     }
   });

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -203,6 +203,25 @@ describe("noiseAc", () => {
     );
   });
 
+  it("emits both MOSFET terminal noise sources from RSH", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vdd", "vdd", "0", 5.0));
+    circuit.add(voltageSource("Vgate", "gate", "0", 3.0));
+    circuit.add(resistor("Rload", "vdd", "out", 1_000.0));
+    circuit.add(mosfet("M1", "out", "gate", "0", "0", "NMOS", { RSH: 250.0 }));
+
+    const entries = noiseAc(circuit, "out", "Vgate", [1_000.0], 300.0).points[0]!.entries;
+    for (const name of ["M1:RD", "M1:RS"]) {
+      const entry = entries.find((candidate) =>
+        candidate.elementName === name && candidate.noiseType === "thermal"
+      );
+      expect(entry?.sourcePsd).toBeCloseTo(
+        4.0 * 1.380_649e-23 * 300.0 / 250.0,
+        30,
+      );
+    }
+  });
+
   it("emits JFET source-resistance thermal noise", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vdd", "vdd", "0", 5.0));

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,17 +33,17 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS source resistance.
+1. Cross-language Level-1 MOS sheet resistance.
    - Status: current PR completion candidate.
-   - Add Berkeley Level-1 MOS `RS` model-card support in Rust, Python, and
-     TypeScript, defaulting to zero ohms.
-   - For positive values, create an intrinsic source node, stamp the external
-     resistor in DC, TF, AC, and transient analyses, and route the channel plus
-     source-side capacitances through the intrinsic node.
-   - Preserve `RS` through hierarchy and cloning, require a finite non-negative
-     value, emit the resistor's `4kT/RS` Johnson noise as `<name>:RS`, and
-     extend the supported-parameter coverage gate from 189 to 191 canonical
-     rows.
+   - Add Berkeley Level-1 MOS `RSH` model-card support in Rust, Python, and
+     TypeScript, defaulting to zero ohms per square.
+   - With the current default one-square drain/source geometry, use `RSH` for
+     each terminal whose explicit `RD` or `RS` remains zero; positive explicit
+     terminal resistance takes precedence.
+   - Reuse the intrinsic terminal topology in DC, TF, AC, transient, and noise
+     analyses, preserve `RSH` through hierarchy and cloning, enforce finite
+     non-negative validation, and extend the supported-parameter coverage gate
+     from 191 to 193 canonical rows.
 
 ## Completed Slices
 
@@ -3442,6 +3442,16 @@ the Rust, Python, and TypeScript surfaces together.
    - Hierarchy and cloning preserve `RD`, finite non-negative validation is
      shared across analyses, drain-side capacitances terminate at the intrinsic
      node, and the supported-parameter release gate now covers 189 canonical
+     rows.
+
+270. Cross-language Level-1 MOS source resistance.
+   - Status: completed in PR 9020.
+   - Rust, Python, and TypeScript Level-1 MOS model cards now accept `RS`,
+     defaulting to zero, and create an intrinsic source node for positive values
+     across DC, transient, AC, transfer-function, and noise analyses.
+   - Hierarchy and cloning preserve `RS`, finite non-negative validation is
+     shared across analyses, source-side capacitances terminate at the intrinsic
+     node, and the supported-parameter release gate now covers 191 canonical
      rows.
 
 ## Backlog


### PR DESCRIPTION
## Summary
- add Berkeley Level-1 MOS `RSH` model-card support across Rust, Python, and TypeScript
- use one default square at each terminal when explicit `RD` or `RS` is zero, preserving explicit-resistance precedence across DC, transient, TF, AC, and noise
- validate and preserve `RSH`, extend model-card coverage gates, and reconcile the SPICE completion plan

## Verification
- `cargo fmt -p mosfet-models -p spice-engine -- --check`
- `cargo test -p mosfet-models -p spice-engine`
- Python `ruff check --ignore SIM108,F841` for both touched packages
- Python `pytest` for both touched packages: 673 passed
- TypeScript `npm run build`
- TypeScript `npm test`: 386 passed