### PR TITLE
feat(adj-formula-stdlib): pulse-pressure — PP = SBP − DBP 3-way inverter (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_pulse_pressure_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_pulse_pressure_e2e.rs
@@ -1,0 +1,141 @@
+//! End-to-end tests for the `clinical/pulse-pressure.adj` library — the definition of
+//! pulse pressure (PP = SBP − DBP) and its two exact rearrangements (SBP = PP + DBP,
+//! DBP = SBP − PP) — driven through the built CLI binary against the SHIPPED stdlib.
+//! Each proves the same invariant as the other formula libraries: a consumer states NO
+//! arithmetic; it imports the grounded library, binds the pressures with `observe`, and
+//! the engine applies the cited definition on the CPU, computing the EXACT value and
+//! rendering the definition's citation and trust tier in the `derived` section (the
+//! auditable answer). The three formulas INVERT around the worked case SBP = 120 mmHg,
+//! DBP = 80 mmHg: 120 − 80 = 40, and both 40 + 80 = 120 and 120 − 40 = 80 recover the
+//! inputs.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped pulse-pressure library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_pulse_pressure_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/pulse-pressure.adj")
+        .canonicalize()
+        .expect("shipped pulse-pressure.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_pp_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_pulse_pressure_lib()).unwrap();
+    std::fs::write(dir.join("pulse-pressure.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// pulse_pressure — the definition: the systolic minus the diastolic.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_pulse_pressure_library_and_computes_definition_with_citation() {
+    let dir = scratch("def");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"pulse-pressure.adj\"\n\
+         observe systolic_pressure(120)\n\
+         observe diastolic_pressure(80)\n\
+         ? pulse_pressure(systolic_pressure, diastolic_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied definition's result: 120 − 80 = 40.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"pulse_pressure\"") && s.contains("\"value\":40"),
+        "pulse_pressure(120, 80) = 40: {s}"
+    );
+    // … AND the OpenStax/LibreTexts citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("med.libretexts.org"),
+        "applied definition carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// systolic_pressure — the same definition solved for SBP: PP + DBP, which INVERTS the
+// pulse pressure just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_systolic_as_pulse_pressure_plus_diastolic_with_citation() {
+    let dir = scratch("sbp");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"pulse-pressure.adj\"\n\
+         observe pulse_pressure(40)\n\
+         observe diastolic_pressure(80)\n\
+         ? systolic_pressure(pulse_pressure, diastolic_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 40 + 80 = 120, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"systolic_pressure\"") && s.contains("\"value\":120"),
+        "systolic_pressure(40, 80) = 120: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("med.libretexts.org"),
+        "systolic_pressure carries its LibreTexts citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// diastolic_pressure — the same definition solved for DBP: SBP − PP, the third exact
+// reading of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_diastolic_as_systolic_minus_pulse_pressure_with_citation() {
+    let dir = scratch("dbp");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"pulse-pressure.adj\"\n\
+         observe systolic_pressure(120)\n\
+         observe pulse_pressure(40)\n\
+         ? diastolic_pressure(systolic_pressure, pulse_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 120 − 40 = 80, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"diastolic_pressure\"") && s.contains("\"value\":80"),
+        "diastolic_pressure(120, 40) = 80: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("med.libretexts.org"),
+        "diastolic_pressure carries its LibreTexts citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/pulse-pressure.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/pulse-pressure.adj
@@ -1,0 +1,101 @@
+% ============================================================================
+% pulse-pressure.adj — the definition of pulse pressure (PP = SBP − DBP) in the
+% ADJ standard library.
+% ============================================================================
+% The pulse-pressure entry of the *clinical* track, a hemodynamics sibling of
+% `mean-arterial-pressure.adj` and `cardiac-output.adj`: the foundational
+% blood-pressure definition a first course states as PULSE PRESSURE IS THE DIFFERENCE
+% BETWEEN THE SYSTOLIC PRESSURE AND THE DIASTOLIC PRESSURE — as an importable,
+% byte-provenanced, PARAMETERIZED `formula`, together with its two exact rearrangements
+% (the systolic a pulse pressure implies for a diastolic, and the diastolic it implies
+% for a systolic). As with every compute library, a consumer states NO arithmetic: it
+% `import`s this file, binds the measured pressures from its own byte-provenance
+% decomposition, and asks the engine to APPLY the cited definition on the CPU. Zero math
+% is performed by the model; the engine computes each value EXACTLY, carrying the
+% definition's citation.
+%
+%     import "pulse-pressure.adj"
+%     observe systolic_pressure(120)     % "…120 mmHg systolic…"  (span cited by the model)
+%     observe diastolic_pressure(80)     % "…80 mmHg diastolic…"  (span cited by the model)
+%     ? pulse_pressure(systolic_pressure, diastolic_pressure)
+%                                          % engine → 40, carrying PP = SBP − DBP
+%
+% All three formulas are EXACT over their parameters (a difference and two sums/
+% differences of measured quantities); there is no separately grounded physiological
+% constant, so every value the engine returns is exact. The three COMPOSE and invert
+% cleanly around the worked case SBP = 120 mmHg, DBP = 80 mmHg (PP = 120 − 80 = 40 mmHg):
+% the `pulse_pressure` a consumer computes from a systolic and diastolic is exactly the
+% `pulse_pressure` the `systolic_pressure` formula adds back to that diastolic to recover
+% the systolic, and exactly the `pulse_pressure` the `diastolic_pressure` formula
+% subtracts from that systolic to recover the diastolic.
+%
+%   pulse_pressure(systolic, diastolic)         = systolic - diastolic       % PP = SBP − DBP  (definition)
+%   systolic_pressure(pulse_pressure, diastolic) = pulse_pressure + diastolic  % SBP = PP + DBP  (same def, solved for SBP)
+%   diastolic_pressure(systolic, pulse_pressure) = systolic - pulse_pressure   % DBP = SBP − PP  (same def, solved for DBP)
+%
+% NOTE: the pressures must be in the same unit (millimetres of mercury, mmHg, by
+% clinical convention); the pulse pressure then comes out in that same unit. This
+% library computes the exact value over whatever consistent unit it is given.
+%
+% All three formulas are defended by the SAME definitional sentence — "As shown in
+% Figure 20.10, the difference between the systolic pressure and the diastolic pressure
+% is the pulse pressure." — because that one definition (pulse pressure IS the
+% systolic-minus-diastolic difference) sanctions the relation read every way (PP from
+% SBP and DBP, SBP from PP and DBP, or DBP from SBP and PP). The quote is transcribed
+% verbatim from the OpenStax Anatomy and Physiology 2e "Blood Flow, Blood Pressure, and
+% Resistance" chapter on Medicine LibreTexts (the same primary reference the
+% mean-arterial-pressure library draws on — pulse pressure is the very quantity MAP's
+% one-third term acts on), so each `formula` carries the provenance envelope every
+% shipped grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the definitional sentence is a verbatim span of the
+% cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable hemodynamic quantity the definition
+% ranges over, and each result is the derived quantity. `systolic_pressure`,
+% `diastolic_pressure` and `pulse_pressure` each appear BOTH as a derived result and as
+% an input (of the other formulas), so each is a single dictionary term used in both
+% roles. The `surface` lists are the everyday names a decomposer maps onto the canonical
+% term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary pulse_pressure_vocab {
+    define systolic_pressure  : finding  surface "systolic pressure", "systolic BP", "SBP"   % millimetres of mercury (mmHg)
+    define diastolic_pressure : finding  surface "diastolic pressure", "diastolic BP", "DBP"  % millimetres of mercury (mmHg)
+    define pulse_pressure     : finding  surface "pulse pressure", "PP"                        % millimetres of mercury (mmHg)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable `let` over its
+% formal parameters, bound at apply time, and each carries the definitional quote from
+% OpenStax A&P on LibreTexts (a quote is required on a shipped formula). One is a
+% difference and two are a sum and a difference, so the engine returns each value
+% EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook pulse_pressure_laws {
+    use pulse_pressure_vocab
+
+    % Pulse pressure — the difference between the systolic and diastolic pressures.
+    % OpenStax defines pulse pressure as the systolic-minus-diastolic difference, i.e.
+    % PP = SBP − DBP.
+    formula pulse_pressure(systolic_pressure, diastolic_pressure) = systolic_pressure - diastolic_pressure
+        source "As shown in Figure 20.10, the difference between the systolic pressure and the diastolic pressure is the pulse pressure."
+        locator "https://med.libretexts.org/Bookshelves/Anatomy_and_Physiology/Anatomy_and_Physiology_2e_(OpenStax)/04:_Fluids_and_Transport/20:_The_Cardiovascular_System_-_Blood_Vessels_and_Circulation/20.03:_Blood_Flow_Blood_Pressure_and_Resistance"
+        trust authoritative
+
+    % Systolic pressure — the same definition solved for the systolic a pulse pressure
+    % implies for a diastolic (SBP = PP + DBP). Defended by the SAME definitional
+    % sentence, read the other way.
+    formula systolic_pressure(pulse_pressure, diastolic_pressure) = pulse_pressure + diastolic_pressure
+        source "As shown in Figure 20.10, the difference between the systolic pressure and the diastolic pressure is the pulse pressure."
+        locator "https://med.libretexts.org/Bookshelves/Anatomy_and_Physiology/Anatomy_and_Physiology_2e_(OpenStax)/04:_Fluids_and_Transport/20:_The_Cardiovascular_System_-_Blood_Vessels_and_Circulation/20.03:_Blood_Flow_Blood_Pressure_and_Resistance"
+        trust authoritative
+
+    % Diastolic pressure — the same definition solved for the diastolic a pulse pressure
+    % implies for a systolic (DBP = SBP − PP). Again the SAME definitional sentence, read
+    % the third way.
+    formula diastolic_pressure(systolic_pressure, pulse_pressure) = systolic_pressure - pulse_pressure
+        source "As shown in Figure 20.10, the difference between the systolic pressure and the diastolic pressure is the pulse pressure."
+        locator "https://med.libretexts.org/Bookshelves/Anatomy_and_Physiology/Anatomy_and_Physiology_2e_(OpenStax)/04:_Fluids_and_Transport/20:_The_Cardiovascular_System_-_Blood_Vessels_and_Circulation/20.03:_Blood_Flow_Blood_Pressure_and_Resistance"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/pulse-pressure.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/pulse-pressure.query.adj
@@ -1,0 +1,33 @@
+% ============================================================================
+% pulse-pressure.query.adj — worked examples over the clinical pulse-pressure library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a pulse-pressure
+% question: it states NO arithmetic and NO definition — it only `import`s the grounded
+% library, `observe`s the pressures it decomposed from the prompt (each a
+% byte-provenanced span, elided here), and asks the engine to APPLY the cited
+% definition. The native adj-lang engine binds the parameters, computes each value
+% EXACTLY on the CPU, and returns it with the definition's source/locator/trust.
+%
+% The three questions INVERT: a blood pressure of 120/80 mmHg has a pulse pressure of
+% 120 − 80 = 40 mmHg; that 40 mmHg pulse pressure at the same 80 mmHg diastolic is
+% exactly what the systolic formula adds back to recover the 120 mmHg systolic, and that
+% 40 mmHg at the same 120 mmHg systolic is exactly what the diastolic formula subtracts
+% to recover the 80 mmHg diastolic.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli pulse-pressure.query.adj
+% ============================================================================
+
+import "pulse-pressure.adj"
+
+% 120/80 mmHg: pulse pressure = 120 − 80.
+observe systolic_pressure(120)
+observe diastolic_pressure(80)
+? pulse_pressure(systolic_pressure, diastolic_pressure)   % expect 40   (definition: PP = SBP − DBP)
+
+% That 40 mmHg pulse pressure for the same 80 mmHg diastolic: systolic = 40 + 80.
+observe pulse_pressure(40)
+? systolic_pressure(pulse_pressure, diastolic_pressure)    % expect 120  (same definition, solved for SBP = PP + DBP)
+
+% That 40 mmHg pulse pressure at the same 120 mmHg systolic: diastolic = 120 − 40.
+? diastolic_pressure(systolic_pressure, pulse_pressure)    % expect 80   (same definition, solved for DBP = SBP − PP)


### PR DESCRIPTION
## What

Adds the clinical **pulse-pressure** library — a hemodynamics sibling of `mean-arterial-pressure.adj` and `cardiac-output.adj`. Pulse pressure is the difference between the systolic and diastolic pressures, shipped as a byte-provenanced, parameterized `formula` together with its two exact rearrangements:

| formula | body | reading |
|---|---|---|
| `pulse_pressure(systolic, diastolic)` | `systolic − diastolic` | PP = SBP − DBP  (definition) |
| `systolic_pressure(pulse_pressure, diastolic)` | `pulse_pressure + diastolic` | SBP = PP + DBP |
| `diastolic_pressure(systolic, pulse_pressure)` | `systolic − pulse_pressure` | DBP = SBP − PP |

A consumer states **no arithmetic** — it imports the grounded library, `observe`s the measured pressures from its own byte-provenance decomposition, and the engine applies the cited definition on the CPU, **exact**, carrying the definition's `source`/`locator`/`trust`.

## Grounding

There is no separately grounded physiological constant here, so every value is exact. All three formulas carry the **verbatim** OpenStax Anatomy & Physiology 2e definitional sentence — "As shown in Figure 20.10, the difference between the systolic pressure and the diastolic pressure is the pulse pressure." — from the "Blood Flow, Blood Pressure, and Resistance" chapter on Medicine LibreTexts (the same primary reference the mean-arterial-pressure library draws on; pulse pressure is the very quantity MAP's one-third term acts on). `trust authoritative`; byte-verified against the cited page.

The three **INVERT** around the worked case SBP=120 mmHg, DBP=80 mmHg → PP=40 mmHg → recovers SBP=120 and DBP=80.

## Files

- `clinical/pulse-pressure.adj` — the grounded 3-way formula library
- `clinical/pulse-pressure.query.adj` — worked inverting lookups (40 / 120 / 80)
- `adj-lang-cli/tests/formula_pulse_pressure_e2e.rs` — 3 dedicated e2e tests driving the built CLI against the shipped library

## Verification

- `cargo test -p adj-lang-cli --test formula_pulse_pressure_e2e` → **3/3 pass** (assert exact 40/120/80 + `trust authoritative` + `med.libretexts.org` on each answer)
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean
- Shipped query run through the CLI → `40` / `120` / `80` exact, each carrying `trust authoritative` and the LibreTexts locator
- NUL-scan: 0 bytes in all three files
- Data + test only — **no version bump**
- `/security-review` → PASSED (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)