### PR TITLE
Add MOS drain square support

### DIFF
--- a/code/packages/python/mosfet-models/CHANGELOG.md
+++ b/code/packages/python/mosfet-models/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [0.1.0] — Unreleased
 
 ### Added
+- `Level1Params.NRD` adds the Berkeley drain diffusion square count, defaulting
+  to one with finite, non-negative validation.
 - `Level1Params.RSH` adds zero-default Berkeley drain/source sheet resistance
   with finite, non-negative validation.
 - `Level1Params.RS` adds the zero-default Berkeley external source resistance

--- a/code/packages/python/mosfet-models/README.md
+++ b/code/packages/python/mosfet-models/README.md
@@ -27,8 +27,8 @@ print(r.Id, r.gm, r.gds, r.region)
   diffusion through `L_eff = L - 2*LD`, `PB` / `MJ` / `FC` bulk-junction
   depletion shaping, Berkeley-default `TOX` gate oxide thickness for intrinsic
   Meyer capacitance through `Cox = epsilon_ox / TOX`, zero-default `RD` / `RS`
-  external drain/source resistance, zero-default `RSH` sheet resistance, and
-  `KF` / `AF` flicker noise.
+  external drain/source resistance, zero-default `RSH` sheet resistance,
+  one-default `NRD` drain diffusion square count, and `KF` / `AF` flicker noise.
 - `evaluate_level1(params, V_GS, V_DS, V_BS, T)`: returns `MosResult` with Id, gm, gds, gmb, Cgs/Cgd/Cgb/Cbs/Cbd, region.
 - Region detection: cutoff (subthreshold-aware), triode, saturation.
 - Body effect via gamma * (sqrt(PHI-V_BS) - sqrt(PHI)) shift.

--- a/code/packages/python/mosfet-models/src/mosfet_models/level1.py
+++ b/code/packages/python/mosfet-models/src/mosfet_models/level1.py
@@ -32,6 +32,7 @@ class Level1Params:
     RD: float = 0.0  # external drain resistance (ohm)
     RS: float = 0.0  # external source resistance (ohm)
     RSH: float = 0.0  # drain/source sheet resistance (ohm per square)
+    NRD: float = 1.0  # number of drain diffusion squares
     IS: float = 1e-15  # saturation current (A)
     N_SUB: float = 1.4  # subthreshold slope factor
     T_NOM: float = 300.15  # nominal temperature (K)
@@ -131,6 +132,8 @@ def evaluate_level1(
         raise ValueError("MOSFET RS must be finite and non-negative")
     if not isfinite(p.RSH) or p.RSH < 0.0:
         raise ValueError("MOSFET RSH must be finite and non-negative")
+    if not isfinite(p.NRD) or p.NRD < 0.0:
+        raise ValueError("MOSFET NRD must be finite and non-negative")
     beta = p.KP * (p.W / effective_length)
 
     # Threshold with body effect. The formula is well-defined whenever

--- a/code/packages/python/mosfet-models/tests/test_models.py
+++ b/code/packages/python/mosfet-models/tests/test_models.py
@@ -191,6 +191,14 @@ def test_sheet_resistance_rejects_negative_value():
         evaluate_level1(Level1Params(RSH=-1.0), V_GS=1.8, V_DS=1.8)
 
 
+def test_drain_squares_rejects_negative_value():
+    with pytest.raises(
+        ValueError,
+        match="MOSFET NRD must be finite and non-negative",
+    ):
+        evaluate_level1(Level1Params(NRD=-1.0), V_GS=1.8, V_DS=1.8)
+
+
 def test_overlap_and_bulk_capacitances_are_reported():
     p = Level1Params(
         W=2e-6,

--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add the Level-1 MOS `NRD` instance parameter. It defaults to one and scales
+  the `RSH` drain fallback while preserving explicit positive `RD` precedence,
+  intrinsic-node stamping, and `:RD` Johnson noise.
 - Add Level-1 MOS model-card `RSH` support. A positive sheet resistance supplies
   the default one-square drain/source terminal resistances when `RD` / `RS`
   remain zero, reusing intrinsic-node stamping and terminal Johnson noise.

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -99,9 +99,9 @@ node, routes the channel and drain-side capacitances through it, and contributes
 `RS` defaults to zero ohms. A finite positive value inserts an intrinsic source
 node, routes the channel and source-side capacitances through it, and contributes
 `4kT/RS` thermal noise.
-`RSH` defaults to zero ohms per square. With the default one-square terminal
-geometry, it supplies both terminal resistances wherever `RD` or `RS` remains
-zero; an explicit positive terminal resistance takes precedence.
+`RSH` defaults to zero ohms per square. `NRD` defaults to one drain square, so
+the drain fallback is `RSH * NRD`; an explicit positive `RD` takes precedence.
+The source fallback remains one square until the matching source-geometry slice.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -9069,6 +9069,7 @@ def _mosfet_drain_resistance(el: Mosfet) -> float:
         drain_resistance
         if drain_resistance > 0.0
         else float(getattr(params, "RSH", 0.0))
+        * float(getattr(params, "NRD", 1.0))
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -788,6 +788,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(125.0) == mos_model.model.model.params.RD
     assert pytest.approx(75.0) == mos_model.model.model.params.RS
     assert pytest.approx(50.0) == mos_model.model.model.params.RSH
+    assert pytest.approx(1.0) == mos_model.model.model.params.NRD
     assert pytest.approx(25.0e-9) == mos_model.model.model.params.TOX
     assert pytest.approx(2.0e-24) == mos_model.model.model.params.KF
     assert pytest.approx(1.4) == mos_model.model.model.params.AF
@@ -959,7 +960,7 @@ def test_dc_mosfet_sheet_resistance_biases_both_intrinsic_terminals() -> None:
         "0",
         MOSFET(
             MosfetType.NMOS,
-            Level1Model(Level1Params(RSH=1_000.0)),
+            Level1Model(Level1Params(RSH=1_000.0, NRD=2.0)),
         ),
     ))
 
@@ -2058,6 +2059,30 @@ def test_mosfet_rejects_invalid_sheet_resistance(
         dc_op(circuit)
 
 
+@pytest.mark.parametrize("drain_squares", [float("nan"), -1.0])
+def test_mosfet_rejects_invalid_drain_squares(
+    drain_squares: float,
+) -> None:
+    circuit = Circuit()
+    circuit.add(Mosfet(
+        "Mbad",
+        "drain",
+        "gate",
+        "0",
+        "0",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(Level1Params(NRD=drain_squares)),
+        ),
+    ))
+
+    with pytest.raises(
+        ValueError,
+        match="MOSFET NRD must be finite and non-negative",
+    ):
+        dc_op(circuit)
+
+
 def test_transient_diode_transit_time_holds_forward_charge_on_turnoff() -> None:
     def run(transit_time: float) -> TransientResult:
         circuit = Circuit()
@@ -3002,6 +3027,7 @@ def test_subcircuit_expansion_preserves_mos_geometry():
                             RD=125.0,
                             RS=75.0,
                             RSH=50.0,
+                            NRD=2.0,
                             TOX=25.0e-9,
                         )
                     ),
@@ -3021,6 +3047,7 @@ def test_subcircuit_expansion_preserves_mos_geometry():
     assert pytest.approx(125.0) == expanded.model.model.params.RD
     assert pytest.approx(75.0) == expanded.model.model.params.RS
     assert pytest.approx(50.0) == expanded.model.model.params.RSH
+    assert pytest.approx(2.0) == expanded.model.model.params.NRD
     assert pytest.approx(25.0e-9) == expanded.model.model.params.TOX
 
 
@@ -8286,19 +8313,19 @@ def test_noise_mosfet_rsh_adds_both_terminal_noise_sources() -> None:
         "0",
         MOSFET(
             MosfetType.NMOS,
-            Level1Model(Level1Params(RSH=250.0)),
+            Level1Model(Level1Params(RSH=250.0, NRD=2.0)),
         ),
     ))
 
     entries = noise_ac(circuit, "out", "Vgate", freqs=[1_000.0]).points[0].entries
-    for name in ("M1:RD", "M1:RS"):
+    for name, resistance in (("M1:RD", 500.0), ("M1:RS", 250.0)):
         entry = next(
             candidate
             for candidate in entries
             if candidate.element_name == name and candidate.noise_type == "thermal"
         )
         assert entry.source_psd == pytest.approx(
-            4.0 * 1.380_649e-23 * 300.0 / 250.0
+            4.0 * 1.380_649e-23 * 300.0 / resistance
         )
 
 

--- a/code/packages/rust/mosfet-models/CHANGELOG.md
+++ b/code/packages/rust/mosfet-models/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `Level1Params::nrd` adds the Berkeley drain diffusion square count, defaulting
+  to one with finite, non-negative validation.
 - `Level1Params::rsh` adds zero-default Berkeley drain/source sheet resistance
   with finite, non-negative validation.
 - `Level1Params::rs` adds the zero-default Berkeley external source resistance

--- a/code/packages/rust/mosfet-models/README.md
+++ b/code/packages/rust/mosfet-models/README.md
@@ -29,7 +29,8 @@ and must leave a positive effective channel length. `TOX` defaults to
 `100 nm`, must be positive, and derives intrinsic Meyer gate capacitance from
 `Cox = epsilon_ox / TOX`. `RD`, `RS`, and `RSH` are finite, non-negative
 external drain, source, and sheet-resistance parameters for engine topology and
-default to zero ohms.
+default to zero ohms. `NRD` is the finite, non-negative drain diffusion square
+count and defaults to one.
 
 ## Usage
 

--- a/code/packages/rust/mosfet-models/src/lib.rs
+++ b/code/packages/rust/mosfet-models/src/lib.rs
@@ -43,6 +43,7 @@ const OXIDE_PERMITTIVITY: f64 = 3.453_133e-11;
 /// | RD        | Drain resistance (ohm)              | 0        |
 /// | RS        | Source resistance (ohm)             | 0        |
 /// | RSH       | Drain/source sheet resistance (ohm) | 0        |
+/// | NRD       | Number of drain squares              | 1        |
 /// | IS        | Drain–body saturation current (A)  | 1 fA     |
 /// | N_SUB     | Subthreshold slope factor          | 1.4      |
 /// | T_NOM     | Nominal temperature (K)            | 300.15   |
@@ -74,6 +75,8 @@ pub struct Level1Params {
     pub rs: f64,
     /// Drain/source sheet resistance [ohm per square].
     pub rsh: f64,
+    /// Number of squares in the drain diffusion.
+    pub nrd: f64,
     /// Drain–body saturation current [A] (used for subthreshold floor).
     pub is: f64,
     /// Subthreshold slope factor n.  Subthreshold current ∝ exp(V_OV / (n V_T)).
@@ -119,6 +122,7 @@ impl Default for Level1Params {
             rd: 0.0,
             rs: 0.0,
             rsh: 0.0,
+            nrd: 1.0,
             is: 1e-15,
             n_sub: 1.4,
             t_nom: 300.15,
@@ -267,6 +271,10 @@ pub fn evaluate_level1(
     assert!(
         p.rsh.is_finite() && p.rsh >= 0.0,
         "MOSFET RSH must be finite and non-negative"
+    );
+    assert!(
+        p.nrd.is_finite() && p.nrd >= 0.0,
+        "MOSFET NRD must be finite and non-negative"
     );
     let beta = p.kp * (p.w / effective_length);
 

--- a/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
+++ b/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
@@ -15,6 +15,7 @@ fn test_default_params() {
     assert_eq!(p.w, 1e-6);
     assert!((p.l - 130e-9).abs() < 1e-15);
     assert_eq!(p.ld, 0.0);
+    assert_eq!(p.nrd, 1.0);
     assert_eq!(p.kf, 0.0);
     assert_eq!(p.af, 1.0);
     assert!(p.subthreshold_enable);
@@ -200,6 +201,21 @@ fn test_sheet_resistance_rejects_negative_value() {
     evaluate_level1(
         &Level1Params {
             rsh: -1.0,
+            ..Level1Params::default()
+        },
+        1.8,
+        1.8,
+        0.0,
+        300.15,
+    );
+}
+
+#[test]
+#[should_panic(expected = "MOSFET NRD must be finite and non-negative")]
+fn test_drain_squares_rejects_negative_value() {
+    let _ = evaluate_level1(
+        &Level1Params {
+            nrd: -1.0,
             ..Level1Params::default()
         },
         1.8,

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add the Level-1 MOS `NRD` instance parameter. It defaults to one and scales
+  the `RSH` drain fallback while preserving explicit positive `RD` precedence,
+  intrinsic-node stamping, and `:RD` Johnson noise.
 - Add Level-1 MOS model-card `RSH` support. A positive sheet resistance supplies
   the default one-square drain/source terminal resistances when `RD` / `RS`
   remain zero, reusing intrinsic-node stamping and terminal Johnson noise.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -140,9 +140,9 @@ node, routes the channel and drain-side capacitances through it, and contributes
 `RS` defaults to zero ohms. A finite positive value inserts an intrinsic source
 node, routes the channel and source-side capacitances through it, and contributes
 `4kT/RS` thermal noise.
-`RSH` defaults to zero ohms per square. With the default one-square terminal
-geometry, it supplies both terminal resistances wherever `RD` or `RS` remains
-zero; an explicit positive terminal resistance takes precedence.
+`RSH` defaults to zero ohms per square. `NRD` defaults to one drain square, so
+the drain fallback is `RSH * NRD`; an explicit positive `RD` takes precedence.
+The source fallback remains one square until the matching source-geometry slice.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3612,6 +3612,7 @@ pub struct MosfetLevel1Params {
     pub drain_resistance: f64,
     pub source_resistance: f64,
     pub sheet_resistance: f64,
+    pub drain_squares: f64,
     pub saturation_current: f64,
     pub n_sub: f64,
     pub t_nom: f64,
@@ -3642,6 +3643,7 @@ impl Default for MosfetLevel1Params {
             drain_resistance: 0.0,
             source_resistance: 0.0,
             sheet_resistance: 0.0,
+            drain_squares: 1.0,
             saturation_current: 1.0e-15,
             n_sub: 1.4,
             t_nom: 300.15,
@@ -24959,7 +24961,7 @@ fn mosfet_drain_resistance(mosfet: &Mosfet) -> f64 {
     if mosfet.params.drain_resistance > 0.0 {
         mosfet.params.drain_resistance
     } else {
-        mosfet.params.sheet_resistance
+        mosfet.params.sheet_resistance * mosfet.params.drain_squares
     }
 }
 
@@ -25663,6 +25665,7 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         ("RD", params.drain_resistance),
         ("RS", params.source_resistance),
         ("RSH", params.sheet_resistance),
+        ("NRD", params.drain_squares),
         ("TOX", params.oxide_thickness),
         ("IS", params.saturation_current),
         ("N_SUB", params.n_sub),
@@ -25721,6 +25724,12 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: mosfet.name.clone(),
             reason: "MOSFET RSH must be non-negative".to_string(),
+        });
+    }
+    if params.drain_squares < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET NRD must be non-negative".to_string(),
         });
     }
     if params.oxide_thickness <= 0.0 {

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -630,6 +630,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(mos_model.params.drain_resistance, 125.0);
     assert_close(mos_model.params.source_resistance, 75.0);
     assert_close(mos_model.params.sheet_resistance, 50.0);
+    assert_close(mos_model.params.drain_squares, 1.0);
     assert_close(mos_model.params.oxide_thickness, 25.0e-9);
     assert_close(mos_model.params.flicker_noise_coefficient, 2.0e-24);
     assert_close(mos_model.params.flicker_noise_exponent, 1.4);
@@ -1679,6 +1680,7 @@ fn dc_mosfet_sheet_resistance_biases_both_intrinsic_terminals() {
         MosfetType::Nmos,
         MosfetLevel1Params {
             sheet_resistance: 1_000.0,
+            drain_squares: 2.0,
             ..MosfetLevel1Params::default()
         },
     )));
@@ -1793,6 +1795,7 @@ fn subcircuit_expansion_preserves_mos_geometry() {
             drain_resistance: 125.0,
             source_resistance: 75.0,
             sheet_resistance: 50.0,
+            drain_squares: 2.0,
             oxide_thickness: 25.0e-9,
             ..MosfetLevel1Params::default()
         },
@@ -1836,6 +1839,7 @@ fn subcircuit_expansion_preserves_mos_geometry() {
     assert_close(expanded.params.drain_resistance, 125.0);
     assert_close(expanded.params.source_resistance, 75.0);
     assert_close(expanded.params.sheet_resistance, 50.0);
+    assert_close(expanded.params.drain_squares, 2.0);
     assert_close(expanded.params.oxide_thickness, 25.0e-9);
 }
 
@@ -3975,6 +3979,38 @@ fn dc_mosfet_rejects_invalid_sheet_resistance() {
                     "MOSFET RSH must be non-negative".to_string()
                 } else {
                     "MOSFET RSH must be finite".to_string()
+                },
+            }
+        );
+    }
+}
+
+#[test]
+fn dc_mosfet_rejects_invalid_drain_squares() {
+    for drain_squares in [f64::NAN, -1.0] {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "Mbad",
+            "drain",
+            "gate",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                drain_squares,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+
+        let err = dc_op(&circuit).unwrap_err();
+        assert_eq!(
+            err,
+            SpiceError::InvalidElement {
+                name: "Mbad".to_string(),
+                reason: if drain_squares.is_finite() {
+                    "MOSFET NRD must be non-negative".to_string()
+                } else {
+                    "MOSFET NRD must be finite".to_string()
                 },
             }
         );

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -629,12 +629,13 @@ fn mosfet_sheet_resistance_emits_both_terminal_noise_sources() {
         MosfetType::Nmos,
         MosfetLevel1Params {
             sheet_resistance: 250.0,
+            drain_squares: 2.0,
             ..MosfetLevel1Params::default()
         },
     )));
 
     let result = noise_ac(&circuit, "out", "Vgate", &[1_000.0], 300.0).unwrap();
-    for name in ["M1:RD", "M1:RS"] {
+    for (name, resistance) in [("M1:RD", 500.0), ("M1:RS", 250.0)] {
         let entry = result.points[0]
             .entries
             .iter()
@@ -642,7 +643,7 @@ fn mosfet_sheet_resistance_emits_both_terminal_noise_sources() {
             .unwrap();
         assert_close(
             entry.source_psd,
-            4.0 * 1.380_649e-23 * 300.0 / 250.0,
+            4.0 * 1.380_649e-23 * 300.0 / resistance,
             1.0e-30,
         );
     }

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Parse Level-1 MOS model `RSH` and instance `NRD=<squares>` into the engine
+  parameter bundle so netlist-driven drain resistance uses `RSH * NRD`.
 - Add Berkeley SPICE app-deck shell dashboard dispatch queue lane tab panel
   card action menu group shortcut command palette search invocation receipt
   notification stack summary product handoff delivery package embed runtime

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -759,8 +759,8 @@ parameters, `.model <name> NPN|PNP(...)` BJT cards with `IS`, `BF` /
 `BETA_F`, `VT`, `CJE`, `CJC`, `TF`, and `TR` parameters,
 `.model <name> NMOS|PMOS(...)` Level-1 MOSFET
 cards with common SPICE aliases (`VT0` / `VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
-`W`, `L`, `IS`, `N_SUB` / `NSUB`, `T_NOM` / `TNOM`, `CGSO`, `CGDO`, `CGBO`,
-`CBS`, and `CBD`), SPICE engineering
+`W`, `L`, `RSH`, `IS`, `N_SUB` / `NSUB`, `T_NOM` / `TNOM`, `CGSO`, `CGDO`,
+`CGBO`, `CBS`, and `CBD`), MOS instance `NRD=<squares>`, SPICE engineering
 suffixes, capacitor `IC=<voltage>` and inductor `IC=<current>` initial
 conditions, independent-source `AC <magnitude> [phase]` forms,
 PWL/PULSE/SIN/EXP source forms, comments, `.end`, `.subckt` / `X` instance

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1899,6 +1899,9 @@ fn build_mosfet_params(
     for (name, value) in model.params.iter().chain(instance_params.iter()) {
         apply_mosfet_param(&mut params, name, *value);
     }
+    if let Some(value) = instance_params.get("NRD") {
+        params.drain_squares = *value;
+    }
     params
 }
 
@@ -1911,6 +1914,7 @@ fn apply_mosfet_param(params: &mut MosfetLevel1Params, name: &str, value: f64) {
         "PHI" => params.phi = value,
         "W" => params.w = value,
         "L" => params.l = value,
+        "RSH" => params.sheet_resistance = value,
         "IS" => params.saturation_current = value,
         "N_SUB" | "NSUB" | "N" => params.n_sub = value,
         "T_NOM" | "TNOM" => params.t_nom = value,

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1359,10 +1359,10 @@ Jpull drain gate source pch
 fn parses_mosfet_models_into_operating_point_circuits() {
     let parsed = parse_netlist(
         r#"
-.model nch NMOS(VTO=0.45 KP=250u LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n NSUB=1.5 TNOM=300 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p)
+.model nch NMOS(VTO=0.45 KP=250u LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n RSH=250 NSUB=1.5 TNOM=300 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p)
 Vdd vdd 0 DC 5
 Vgate gate 0 DC 2.5
-M1 vdd gate out 0 nch W=4u L=200n
+M1 vdd gate out 0 nch W=4u L=200n NRD=2
 Rload out 0 1k
 .op
 "#,
@@ -1392,6 +1392,8 @@ Rload out 0 1k
     assert_close(mosfet.params.phi, 0.8);
     assert_close(mosfet.params.w, 4.0e-6);
     assert_close(mosfet.params.l, 200.0e-9);
+    assert_close(mosfet.params.sheet_resistance, 250.0);
+    assert_close(mosfet.params.drain_squares, 2.0);
     assert_close(mosfet.params.n_sub, 1.5);
     assert_close(mosfet.params.t_nom, 300.0);
     assert_close(mosfet.params.gate_source_overlap_capacitance, 3.0e-12);

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add the Level-1 MOS `NRD` instance parameter. It defaults to one and scales
+  the `RSH` drain fallback while preserving explicit positive `RD` precedence,
+  intrinsic-node stamping, and `:RD` Johnson noise.
 - Add Level-1 MOS model-card `RSH` support. A positive sheet resistance supplies
   the default one-square drain/source terminal resistances when `RD` / `RS`
   remain zero, reusing intrinsic-node stamping and terminal Johnson noise.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -91,9 +91,9 @@ node, routes the channel and drain-side capacitances through it, and contributes
 `RS` defaults to zero ohms. A finite positive value inserts an intrinsic source
 node, routes the channel and source-side capacitances through it, and contributes
 `4kT/RS` thermal noise.
-`RSH` defaults to zero ohms per square. With the default one-square terminal
-geometry, it supplies both terminal resistances wherever `RD` or `RS` remains
-zero; an explicit positive terminal resistance takes precedence.
+`RSH` defaults to zero ohms per square. `NRD` defaults to one drain square, so
+the drain fallback is `RSH * NRD`; an explicit positive `RD` takes precedence.
+The source fallback remains one square until the matching source-geometry slice.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1780,6 +1780,7 @@ export interface MosfetLevel1Params {
   readonly RD: number;
   readonly RS: number;
   readonly RSH: number;
+  readonly NRD: number;
   readonly IS: number;
   readonly N_SUB: number;
   readonly T_NOM: number;
@@ -8040,6 +8041,7 @@ export function defaultMosfetLevel1Params(): MosfetLevel1Params {
     RD: 0.0,
     RS: 0.0,
     RSH: 0.0,
+    NRD: 1.0,
     IS: 1.0e-15,
     N_SUB: 1.4,
     T_NOM: 300.15,
@@ -20811,7 +20813,9 @@ function mosfetIntrinsicSourceNode(element: Mosfet): string {
 }
 
 function mosfetDrainResistance(element: Mosfet): number {
-  return element.params.RD > 0.0 ? element.params.RD : element.params.RSH;
+  return element.params.RD > 0.0
+    ? element.params.RD
+    : element.params.RSH * element.params.NRD;
 }
 
 function mosfetSourceResistance(element: Mosfet): number {
@@ -21123,6 +21127,9 @@ function validateMosfet(element: Mosfet): void {
   }
   if (params.RSH < 0.0) {
     throw invalidElement(element.name, "MOSFET RSH must be non-negative");
+  }
+  if (params.NRD < 0.0) {
+    throw invalidElement(element.name, "MOSFET NRD must be non-negative");
   }
   if (params.TOX <= 0.0) {
     throw invalidElement(element.name, "MOSFET TOX must be positive");

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -456,6 +456,7 @@ describe("dcOp", () => {
     expectClose(mosModel.params.RD, 125.0);
     expectClose(mosModel.params.RS, 75.0);
     expectClose(mosModel.params.RSH, 50.0);
+    expectClose(mosModel.params.NRD, 1.0);
     expectClose(mosModel.params.TOX, 25.0e-9);
     expectClose(mosModel.params.KF, 2.0e-24);
     expectClose(mosModel.params.AF, 1.4);
@@ -1181,6 +1182,7 @@ describe("dcOp", () => {
     circuit.add(voltageSource("Vgate", "gate", "0", 3.0));
     circuit.add(mosfet("M1", "drain", "gate", "0", "0", "NMOS", {
       RSH: 1_000.0,
+      NRD: 2.0,
     }));
 
     const result = dcOp(circuit);
@@ -1255,6 +1257,7 @@ describe("dcOp", () => {
           RD: 125.0,
           RS: 75.0,
           RSH: 50.0,
+          NRD: 2.0,
           TOX: 25.0e-9,
         }),
       ]),
@@ -1270,6 +1273,7 @@ describe("dcOp", () => {
     expectClose(expanded!.params.RD, 125.0);
     expectClose(expanded!.params.RS, 75.0);
     expectClose(expanded!.params.RSH, 50.0);
+    expectClose(expanded!.params.NRD, 2.0);
     expectClose(expanded!.params.TOX, 25.0e-9);
   });
 
@@ -2519,6 +2523,20 @@ describe("dcOp", () => {
         Number.isFinite(sheetResistance)
           ? "MOSFET RSH must be non-negative"
           : "MOSFET RSH must be finite",
+      );
+    }
+  });
+
+  it("rejects invalid MOSFET drain square counts", () => {
+    for (const drainSquares of [Number.NaN, -1.0]) {
+      const circuit = new Circuit();
+      circuit.add(mosfet("Mbad", "drain", "gate", "0", "0", "NMOS", {
+        NRD: drainSquares,
+      }));
+      expect(() => dcOp(circuit)).toThrowError(
+        Number.isFinite(drainSquares)
+          ? "MOSFET NRD must be non-negative"
+          : "MOSFET NRD must be finite",
       );
     }
   });

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -208,15 +208,18 @@ describe("noiseAc", () => {
     circuit.add(voltageSource("Vdd", "vdd", "0", 5.0));
     circuit.add(voltageSource("Vgate", "gate", "0", 3.0));
     circuit.add(resistor("Rload", "vdd", "out", 1_000.0));
-    circuit.add(mosfet("M1", "out", "gate", "0", "0", "NMOS", { RSH: 250.0 }));
+    circuit.add(mosfet("M1", "out", "gate", "0", "0", "NMOS", {
+      RSH: 250.0,
+      NRD: 2.0,
+    }));
 
     const entries = noiseAc(circuit, "out", "Vgate", [1_000.0], 300.0).points[0]!.entries;
-    for (const name of ["M1:RD", "M1:RS"]) {
+    for (const [name, resistance] of [["M1:RD", 500.0], ["M1:RS", 250.0]] as const) {
       const entry = entries.find((candidate) =>
         candidate.elementName === name && candidate.noiseType === "thermal"
       );
       expect(entry?.sourcePsd).toBeCloseTo(
-        4.0 * 1.380_649e-23 * 300.0 / 250.0,
+        4.0 * 1.380_649e-23 * 300.0 / resistance,
         30,
       );
     }

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,17 +33,16 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS sheet resistance.
+1. Cross-language Level-1 MOS drain diffusion squares.
    - Status: current PR completion candidate.
-   - Add Berkeley Level-1 MOS `RSH` model-card support in Rust, Python, and
-     TypeScript, defaulting to zero ohms per square.
-   - With the current default one-square drain/source geometry, use `RSH` for
-     each terminal whose explicit `RD` or `RS` remains zero; positive explicit
-     terminal resistance takes precedence.
-   - Reuse the intrinsic terminal topology in DC, TF, AC, transient, and noise
-     analyses, preserve `RSH` through hierarchy and cloning, enforce finite
-     non-negative validation, and extend the supported-parameter coverage gate
-     from 191 to 193 canonical rows.
+   - Add the Berkeley Level-1 MOS `NRD` instance parameter in Rust, Python, and
+     TypeScript, defaulting to one drain diffusion square.
+   - When explicit `RD` remains zero, use `RSH * NRD` for the drain resistance;
+     positive explicit `RD` continues to take precedence.
+   - Reuse the existing intrinsic drain topology in DC, TF, AC, transient, and
+     noise analyses, preserve `NRD` through hierarchy and cloning, enforce
+     finite non-negative validation, and keep the model-card coverage gate at
+     193 canonical rows because `NRD` is an instance parameter.
 
 ## Completed Slices
 
@@ -3453,6 +3452,16 @@ the Rust, Python, and TypeScript surfaces together.
      shared across analyses, source-side capacitances terminate at the intrinsic
      node, and the supported-parameter release gate now covers 191 canonical
      rows.
+
+271. Cross-language Level-1 MOS sheet resistance.
+   - Status: completed in PR 9026.
+   - Rust, Python, and TypeScript Level-1 MOS model cards now accept `RSH`,
+     defaulting to zero ohms per square and supplying one-square drain/source
+     terminal resistances wherever explicit `RD` / `RS` remains zero.
+   - The shared intrinsic terminal topology covers DC, transient, AC,
+     transfer-function, and noise analyses, hierarchy preserves `RSH`, finite
+     non-negative validation is shared, and the supported-parameter release
+     gate now covers 193 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley Level-1 MOS `NRD` drain diffusion squares across Rust, Python, and TypeScript, defaulting to one
- scale the `RSH` drain fallback as `RSH * NRD` while preserving explicit positive `RD` precedence across DC, transient, TF, AC, and noise
- parse model `RSH` plus instance `NRD` in the Rust grammar-backed netlist path and reconcile the SPICE completion plan

## Verification
- `cargo fmt -p mosfet-models -p spice-engine -- --check`
- `cargo test -p mosfet-models -p spice-engine -p spice-netlist-parser`
- Python `ruff check --ignore SIM108,F841` for both touched packages
- Python `pytest` for both touched packages: 676 passed
- TypeScript `npm run build`
- TypeScript `npm test`: 387 passed