### PR TITLE
feat(semantic-ir-to-c): OOP mirror slice 1 — instance runtime + empty class + constants (0.13.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.13.0 — OOP mirror slice 1: instance runtime + empty class + constants
+
+Accepts `Feature::Classes` + `Feature::Constants` — the first slice of the C
+backend's OOP mirror (the Ruby backend just finished the full 7-slice arc). This
+slice is the **instance-runtime foundation**:
+
+- A new `SIR_INSTANCE` value tag + `struct SirInstance { const char *sir_class; }`
+  stored **inline in the `SirValue` union** — unlike the Go/Rust backends (which
+  hold an integer id into a side-table because their value type is `Copy`), the
+  C pointer IS the handle, so pointer-identity is object identity (no id table).
+- `class Foo; end` → `Stmt::ClassDef` → a comment: a class is just a NAME in the
+  C runtime (an instance carries its class string; there is no class object).
+- `Foo.new` → `_sir_new_instance("Foo")`, printing `#<Foo>` (deterministic — no
+  address, so tests can assert on it). `_sir_value_eq` gains a `SIR_INSTANCE` arm
+  (pointer identity, Ruby's default `==` on an object).
+- **Constants** ride in (entangled: the frontend records `Constants` for any
+  `Foo.new`, since the receiver is a constant). `PI = 3` / `PI` →
+  `_sir_const_set` / `_sir_const_get` over a tiny runtime name→value table; an
+  undefined constant raises a rescuable `NameError`. Class/constant names are
+  emitted as **quoted C string literals** (no injection, as with rescue types).
+
+**Deferred, rejected cleanly** (each a later slice): `__new__` with constructor
+arguments (needs `initialize`), a `class << self` singleton, the OOP method
+builtins (`__def_method__` / `__method__` / …), and — via their still-unaccepted
+features — `@ivars`, `@@class vars`, method-resolving inheritance, and modules.
+
 ## 0.12.0 — exceptions (SIR17)
 
 Accepts `Feature::Exceptions`. C has no stack unwinding, so `begin … rescue …

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -102,12 +102,19 @@ producing a plain positional C call (omitted optional keywords filled with
 handler stack (a `SIR_ERROR` value, a baked-in exception-class ancestry table
 for `rescue`-by-class matching, and a two-handler structure so `ensure` runs
 even when a rescue body raises). Rescue-type names are emitted as quoted string
-literals (no injection). `raise SomeClass` (needs `Constants`) and `retry` are
-deferred, rejected cleanly.
+literals (no injection); `retry` is deferred, rejected cleanly. And the OOP
+mirror **slice 1** — `Classes` + `Constants`: an empty class
+(`class Foo; end` → a comment), construction (`Foo.new` → `_sir_new_instance`, a
+new `SIR_INSTANCE` box stored inline in the union that prints `#<Foo>`), and
+constants (`PI = 3` / `PI` → a runtime `_sir_const_set` / `_sir_const_get`
+table).  Class/constant names are quoted C string literals (no injection).
 
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
-`Intrinsics`, `NDArrays`, `Constants`/OOP, and every
-other not-yet-wired feature until its batch lands.  `Bignum` stays rejected
+`Intrinsics`, `NDArrays`, the rest of OOP (instance methods, `@ivars`,
+`@@class vars`, inheritance dispatch, class methods, modules — later mirror
+slices, so `__new__` with constructor args, `__def_method__`/`__method__`, a
+`class << self` singleton, and `@`/`@@` scopes are all refused for now), and
+every other not-yet-wired feature until its batch lands.  `Bignum` stays rejected
 until a bignum runtime ships — a module needing arbitrary precision is refused,
 never silently truncated.
 

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -399,9 +399,31 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         // SIR16 re-binding: the target `SirValue` is already declared (by an
         // earlier `LetStarBinding`), so this reuses `emit_assign` (which handles
         // a simple value or a compound `If`/`Convert`).
-        Stmt::Assign { name, value, .. } => {
-            let n = sanitize_ident(name);
-            emit_assign(out, &n, value, indent);
+        Stmt::Assign {
+            name, scope, value, ..
+        } => {
+            if matches!(scope, Scope::Const) {
+                // OOP slice 1: a `Scope::Const` definition (`PI = 3`) writes the
+                // runtime constant table.  The name is a QUOTED C string literal
+                // (no injection).  A compound value is hoisted into a temp first.
+                if is_simple(value) {
+                    let _ = write!(out, "{pad}(void)_sir_const_set({}, ", quote_c_string(name));
+                    emit_expr(out, value, indent);
+                    out.push_str(");\n");
+                } else {
+                    let tmp = format!("_sir_t{}", fresh_id());
+                    let _ = writeln!(out, "{pad}SirValue {tmp};");
+                    emit_assign(out, &tmp, value, indent);
+                    let _ = writeln!(
+                        out,
+                        "{pad}(void)_sir_const_set({}, {tmp});",
+                        quote_c_string(name)
+                    );
+                }
+            } else {
+                let n = sanitize_ident(name);
+                emit_assign(out, &n, value, indent);
+            }
         }
         // SIR16 loop.  Portable shape that re-evaluates a possibly-compound
         // condition every iteration:
@@ -670,6 +692,15 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
                 "{p1}if (_sir_esc{id}) {{ (void)_sir_raise(_sir_pend{id}); }}"
             );
             let _ = writeln!(out, "{pad}}}");
+        }
+        // OOP slice 1: an empty base class declaration.  A class is just a NAME
+        // in the C runtime (an instance carries its class string; there is no
+        // class object), so the declaration emits only a comment.  `superclass`
+        // is irrelevant without method dispatch (a later slice); a non-empty body
+        // observes the unaccepted `ClassVars` feature and is rejected by the
+        // capability check before emit.
+        Stmt::ClassDef { .. } => {
+            let _ = writeln!(out, "{pad}/* class declaration (no class object) */");
         }
         other => unreachable!("C backend reached unsupported statement: {other:?}"),
     }
@@ -1255,10 +1286,15 @@ fn emit_var_ref(out: &mut String, name: &str, scope: Scope) {
         Scope::Builtin => {
             let _ = write!(out, "_sir_builtin_closure({})", quote_c_string(name));
         }
-        // SIR17+ scopes (Instance / ClassVar / Const) belong to features the
-        // v0 backend does not accept, so the capability check rejects such
-        // modules before emit.  Unreachable.
-        other => unreachable!("v0 C backend reached unsupported var scope: {other:?}"),
+        // OOP slice 1: a `Scope::Const` reference (`PI`, `Foo::Bar`) reads the
+        // runtime constant table.  The name is a QUOTED C string literal (no
+        // injection); an undefined constant raises `NameError` at runtime.
+        Scope::Const => {
+            let _ = write!(out, "_sir_const_get({})", quote_c_string(name));
+        }
+        // `Instance` / `ClassVar` belong to features the backend does not yet
+        // accept, so the capability check rejects such modules before emit.
+        other => unreachable!("C backend reached unsupported var scope: {other:?}"),
     }
 }
 
@@ -1274,6 +1310,18 @@ fn emit_builtin_simple(out: &mut String, name: &str, args: &[Expr], indent: usiz
             out.push_str("_sir_raise_value(");
             emit_expr(out, &args[0], indent);
             out.push(')');
+        }
+        return;
+    }
+    // OOP slice 1: `Foo.new` → `_sir_new_instance("Foo")`.  `args[0]` is the class
+    // name (a `StrLit`), emitted as a QUOTED C string literal (no injection); the
+    // scan guarantees exactly one `StrLit` arg (constructor args need `initialize`,
+    // a later slice), so this arm never reaches the compound path.
+    if name == "__new__" {
+        if let Some(Expr::StrLit { value, .. }) = args.first() {
+            let _ = write!(out, "_sir_new_instance({})", quote_c_string(value));
+        } else {
+            let _ = write!(out, "_sir_unknown_builtin({})", quote_c_string(name));
         }
         return;
     }
@@ -1314,6 +1362,13 @@ fn emit_builtin_with_names(out: &mut String, name: &str, names: &[String]) {
         } else {
             let _ = write!(out, "_sir_raise_value({})", names[0]);
         }
+        return;
+    }
+    // `__new__`'s single `StrLit` class-name arg is always simple, so the call is
+    // never hoisted to the compound path — this arm is unreachable, but emit a
+    // clear marker rather than a wrong `_sir_str`-based construction.
+    if name == "__new__" {
+        let _ = write!(out, "_sir_unknown_builtin({})", quote_c_string(name));
         return;
     }
     if let Some(helper) = variadic_helper(name) {
@@ -1370,7 +1425,10 @@ fn variadic_helper(name: &str) -> Option<&'static str> {
 fn is_supported_builtin(name: &str) -> bool {
     variadic_helper(name).is_some()
         || fixed_helper(name).is_some()
-        || matches!(name, "and" | "or" | "raise")
+        // OOP slice 1: `__new__` constructs an instance.  (The other OOP builtins
+        // — `__def_method__`/`__method__`/`__super__`/… — stay unsupported, so a
+        // method-bearing class is rejected up front.)
+        || matches!(name, "and" | "or" | "raise" | "__new__")
 }
 
 /// The first `BuiltinCall` whose name the v0 emitter cannot lower, if any.  A
@@ -1463,6 +1521,15 @@ fn scan_stmt_for_builtin(s: &Stmt) -> Option<(String, Span)> {
                     .as_ref()
                     .and_then(|e| e.iter().find_map(scan_stmt_for_builtin))
             }),
+        // OOP slice 1: a `Stmt::SingletonClassDef` (`class << self`) ALSO observes
+        // `Feature::Classes`, so accepting `Classes` obligates rejecting it here —
+        // else it reaches the emitter's `unreachable!` (a DoS on a hand-built
+        // module).  Deferred to a later slice.  (`Stmt::ClassDef` is NOT rejected
+        // — it emits a comment; `Stmt::ModuleDef` observes the unaccepted
+        // `Feature::Modules`, so the capability check rejects it before this scan.)
+        Stmt::SingletonClassDef { span, .. } => {
+            Some(("class << self (singleton class)".to_string(), span.clone()))
+        }
         _ => None,
     }
 }
@@ -1474,6 +1541,18 @@ fn scan_expr_for_builtin(e: &Expr) -> Option<(String, Span)> {
         } => {
             if !is_supported_builtin(name) {
                 return Some((name.clone(), span.clone()));
+            }
+            // OOP slice 1: `__new__` must be `[StrLit(class)]` — exactly one
+            // constant class name, no constructor arguments (those need
+            // `initialize`, a later slice).  Anything else is rejected cleanly so
+            // the emitter's single-`StrLit` assumption holds.
+            if name == "__new__"
+                && !matches!(args.as_slice(), [Expr::StrLit { .. }])
+            {
+                return Some((
+                    "__new__ with constructor arguments or a non-constant class name".to_string(),
+                    span.clone(),
+                ));
             }
             args.iter().find_map(scan_expr_for_builtin)
         }

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -1530,6 +1530,17 @@ fn scan_stmt_for_builtin(s: &Stmt) -> Option<(String, Span)> {
         Stmt::SingletonClassDef { span, .. } => {
             Some(("class << self (singleton class)".to_string(), span.clone()))
         }
+        // OOP slice 1: a `Stmt::ClassDef` emits only a comment (the empty base
+        // class is a bare name), so REJECT the two shapes that comment would
+        // silently drop — a superclass (inheritance dispatch is a later slice)
+        // and a non-empty body (class-level code / `@@x` initializers) — rather
+        // than mis-emit.  The empty base class passes through.
+        Stmt::ClassDef {
+            superclass, body, span, ..
+        } if superclass.is_some() || !body.is_empty() => Some((
+            "a class with a superclass or a non-empty body (later OOP slices)".to_string(),
+            span.clone(),
+        )),
         _ => None,
     }
 }

--- a/code/packages/rust/semantic-ir-to-c/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/lib.rs
@@ -147,6 +147,25 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // `Const` reference → observes `Feature::Constants` (unaccepted) → rejected;
     // `retry` is not yet lowered (rejected by the builtin gate) — both deferred.
     Feature::Exceptions,
+    // ── OOP mirror, slice 1: instance runtime + empty class + constants ──
+    // Mirrors the Ruby backend's OOP slice 1.  `Feature::Classes` +
+    // `Feature::Constants` are ENTANGLED: the frontend records `Constants` for
+    // any `Foo.new` (the receiver is a constant), so an instantiable class needs
+    // both.  This slice accepts:
+    //   `class Foo; end`  → `Stmt::ClassDef` → a comment (a class is just a NAME
+    //                        in the C runtime — an instance carries its class
+    //                        string; there is no class object).
+    //   `Foo.new`         → `BuiltinCall("__new__", [StrLit("Foo")])` →
+    //                        `_sir_new_instance("Foo")` (a `SIR_INSTANCE` box).
+    //   `PI = 3` / `PI`   → a `Scope::Const` `Assign`/`VarRef` → a tiny runtime
+    //                        constant table (`_sir_const_set`/`_sir_const_get`).
+    // Names are emitted as QUOTED C string literals (no injection, as with rescue
+    // types).  Deferred to later slices (rejected cleanly): `__new__` with
+    // constructor arguments (needs `initialize`), a `class << self` singleton, the
+    // OOP method builtins (`__def_method__`/`__method__`/…), and — via their own
+    // unaccepted features — `@ivars`/`@@cvars`/inheritance-dispatch/modules.
+    Feature::Classes,
+    Feature::Constants,
 ];
 
 impl Backend for CBackend {

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -51,7 +51,13 @@ typedef enum {
     SIR_MISSING,
     /* A SIR17 exception value (`raise`d and `rescue`d) — a class name plus an
      * optional message. */
-    SIR_ERROR
+    SIR_ERROR,
+    /* A SIR OOP instance (`Foo.new`) — a heap object carrying its class name.
+     * Unlike the Go/Rust backends (which hold an integer id into a side-table
+     * because their value type is `Copy`), C stores the `SirInstance *` INLINE in
+     * the union: the pointer IS the handle, so pointer-identity is object
+     * identity.  A dedicated tag means no built-in-type helper mis-handles it. */
+    SIR_INSTANCE
 } SirTag;
 
 typedef struct SirValue SirValue;
@@ -60,6 +66,7 @@ typedef struct SirClosure SirClosure;
 typedef struct SirSeq SirSeq;
 typedef struct SirMap SirMap;
 typedef struct SirError SirError;
+typedef struct SirInstance SirInstance;
 
 struct SirValue {
     SirTag tag;
@@ -73,6 +80,7 @@ struct SirValue {
         SirSeq *seq;      /* SIR_SEQ */
         SirMap *map;      /* SIR_MAP */
         SirError *err;    /* SIR_ERROR */
+        SirInstance *inst;/* SIR_INSTANCE */
     } as;
 };
 
@@ -83,6 +91,11 @@ struct SirPair { SirValue car; SirValue cdr; };
  * `rescue` clause via the baked-in ancestry table.  `msg` is the message (a
  * `SIR_STR`, or nil for a bare `raise Class` — then the class name is shown). */
 struct SirError { const char *sir_class; SirValue msg; };
+
+/* A SIR OOP instance.  `sir_class` is the interned class name (`"Foo"`); it is
+ * how method dispatch (later slices) keys the method table and how the ancestry
+ * walk finds the superclass.  Instance variables (`@x`) join in a later slice. */
+struct SirInstance { const char *sir_class; };
 
 /* A SIR16 sequence (`[1, 2, 3]`) — a heap-boxed dynamic array. `items` points
  * at `len` `SirValue`s (arena-allocated, never freed like every other heap
@@ -155,6 +168,40 @@ SirValue _sir_int(int64_t i)   { SirValue v; v.tag = SIR_INT;  v.as.i = i;   ret
 SirValue _sir_float(double f)  { SirValue v; v.tag = SIR_FLOAT; v.as.f = f;  return v; }
 SirValue _sir_str(const char *s) { SirValue v; v.tag = SIR_STR; v.as.s = s;  return v; }
 SirValue _sir_sym(const char *s) { SirValue v; v.tag = SIR_SYM; v.as.s = _sir_intern(s); return v; }
+
+/* ---- OOP: instances & constants ----------------------------- */
+
+/* Construct a fresh instance of class `cls` (`Foo.new`).  The class name is
+ * interned so later method dispatch keys the method table by pointer/`strcmp`.
+ * Arena-allocated, never freed (like every heap box). */
+SirValue _sir_new_instance(const char *cls) {
+    SirInstance *o = (SirInstance *)_sir_alloc(sizeof(SirInstance));
+    o->sir_class = _sir_intern(cls);
+    { SirValue v; v.tag = SIR_INSTANCE; v.as.inst = o; return v; }
+}
+
+/* A SIR constant (`PI = 3`, referenced as `PI`).  Ruby constants are named,
+ * top-level, and set-once-at-runtime; C has no such construct, so a tiny
+ * name -> value table backs them.  The name is an interned string emitted from a
+ * quoted C string literal (no injection).  A read of an undefined constant is a
+ * `NameError` (matching Ruby), routed through the existing exception path. */
+#define SIR_CONST_MAX 4096
+static struct { const char *name; SirValue val; } _sir_const_tab[SIR_CONST_MAX];
+static int _sir_const_n = 0;
+
+SirValue _sir_const_set(const char *name, SirValue v) {
+    const char *n = _sir_intern(name);
+    int i;
+    for (i = 0; i < _sir_const_n; i++) {
+        if (_sir_const_tab[i].name == n) { _sir_const_tab[i].val = v; return v; }
+    }
+    if (_sir_const_n < SIR_CONST_MAX) {
+        _sir_const_tab[_sir_const_n].name = n;
+        _sir_const_tab[_sir_const_n].val = v;
+        _sir_const_n++;
+    }
+    return v;
+}
 
 /* The SIR19 "argument omitted" sentinel (see `SIR_MISSING`).  `_sir_missing()`
  * is passed at a call site for each trailing defaulted parameter left off; the
@@ -437,6 +484,10 @@ int _sir_value_eq_d(SirValue a, SirValue b, int depth) {
          * default `==` is object identity), so a `rescue => e` binding compares
          * equal to itself. */
         case SIR_ERROR:   return a.as.err == b.as.err;
+        /* Two instances are equal only when they are the SAME object (Ruby's
+         * default `==` on a user object is identity) — the inline pointer IS the
+         * identity, so this is a plain pointer compare. */
+        case SIR_INSTANCE: return a.as.inst == b.as.inst;
         default:          return 0;
     }
 }
@@ -825,6 +876,11 @@ void _sir_fmt(FILE *out, SirValue v) {
             if (v.as.err->msg.tag == SIR_NIL) fputs(v.as.err->sir_class, out);
             else _sir_fmt(out, v.as.err->msg);
             break;
+        /* An instance prints as `#<Foo>` (its class name).  Deterministic — no
+         * address — so tests can assert on it (Ruby's default `#<Foo:0x…>` would
+         * embed a non-reproducible pointer). */
+        case SIR_INSTANCE:
+            fputs("#<", out); fputs(v.as.inst->sir_class, out); fputc('>', out); break;
         default: break;
     }
     _sir_fmt_depth--;
@@ -943,6 +999,18 @@ SirValue _sir_raise(SirValue exc) {
 SirValue _sir_raise_value(SirValue v) {
     if (v.tag == SIR_ERROR) return _sir_raise(v);
     return _sir_raise(_sir_error("RuntimeError", v));
+}
+
+/* Read a SIR constant by name (`_sir_const_set` populated it).  A read of an
+ * undefined constant raises `NameError` — a rescuable exception (matching Ruby's
+ * `uninitialized constant`), not a hard exit. */
+SirValue _sir_const_get(const char *name) {
+    const char *n = _sir_intern(name);
+    int i;
+    for (i = 0; i < _sir_const_n; i++) {
+        if (_sir_const_tab[i].name == n) return _sir_const_tab[i].val;
+    }
+    return _sir_raise(_sir_error("NameError", _sir_str(_sir_cat("uninitialized constant ", name))));
 }
 
 SirValue _sir_print_v(SirValue *xs, int n) {

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_classes.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_classes.rs
@@ -1,0 +1,206 @@
+//! Execution proof for the OOP mirror slice 1 (classes + constants) on the C
+//! backend — hand-build producer-agnostic modules, emit C, compile with a real
+//! cc, run, assert stdout.  Skips gracefully when no `cc` is present.
+//!
+//! Slice 1 = the instance runtime foundation: an empty class (`class Foo; end`),
+//! construction (`Foo.new` → a `SIR_INSTANCE` box printing `#<Foo>`), and the
+//! entangled constants (`PI = 3` via a runtime const table).
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Scope, Span,
+    Stmt, CURRENT_SIR_VERSION,
+};
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    for cand in ["cc", "clang", "gcc"] {
+        if Command::new(cand)
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+        {
+            return Some(cand.to_string());
+        }
+    }
+    None
+}
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn run(module: &Module) -> Option<String> {
+    let cc = find_cc()?;
+    let artifact = semantic_ir_to_c::compile(module).expect("C backend compile (no panic)");
+    let dir = std::env::temp_dir();
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let stem = format!("sirc_cls_{}_{}", std::process::id(), n);
+    let cpath: PathBuf = dir.join(format!("{stem}.c"));
+    let exe: PathBuf = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::File::create(&cpath)
+        .and_then(|mut f| f.write_all(artifact.source.as_bytes()))
+        .expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-Werror=unused-variable", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        artifact.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "program exited non-zero");
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+fn s() -> Span {
+    Span::synthetic()
+}
+fn strlit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+fn bc(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+fn puts(arg: Expr) -> Stmt {
+    Stmt::ExprStmt { expr: bc("puts", vec![arg]), span: s() }
+}
+fn local(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
+}
+fn module(stmts: Vec<Stmt>, feats: &[Feature]) -> Module {
+    Module {
+        name: "clsprog".into(),
+        manifest: FeatureManifest::from_features(feats),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+#[test]
+fn empty_class_new_prints_the_instance() {
+    // `class Foo; end; x = Foo.new; puts x` → `#<Foo>` (deterministic — no address).
+    let m = module(
+        vec![
+            Stmt::ClassDef { name: "Foo".into(), superclass: None, body: vec![], span: s() },
+            Stmt::LetBinding { name: "x".into(), sir_type: None, value: bc("__new__", vec![strlit("Foo")]), span: s() },
+            puts(local("x")),
+        ],
+        &[Feature::Classes, Feature::Constants, Feature::Strings],
+    );
+    match run(&m) {
+        Some(out) => assert_eq!(out, "#<Foo>\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn constant_set_and_get() {
+    // `PI = 3; puts PI` → `3` (runtime const table).
+    let m = module(
+        vec![
+            Stmt::Assign { name: "PI".into(), scope: Scope::Const, value: ilit(3), span: s() },
+            puts(Expr::VarRef { name: "PI".into(), scope: Scope::Const, span: s() }),
+        ],
+        &[Feature::Constants, Feature::MutableBindings],
+    );
+    match run(&m) {
+        Some(out) => assert_eq!(out, "3\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn two_instances_are_distinct_by_identity() {
+    // Two `Foo.new`s are distinct objects: `==` is identity, so `a == b` is false
+    // (printed via an int so the assertion is display-convention-independent).
+    let m = module(
+        vec![
+            Stmt::ClassDef { name: "Foo".into(), superclass: None, body: vec![], span: s() },
+            Stmt::LetBinding { name: "a".into(), sir_type: None, value: bc("__new__", vec![strlit("Foo")]), span: s() },
+            Stmt::LetBinding { name: "b".into(), sir_type: None, value: bc("__new__", vec![strlit("Foo")]), span: s() },
+            puts(bc("==", vec![local("a"), local("a")])),
+            puts(bc("==", vec![local("a"), local("b")])),
+        ],
+        &[Feature::Classes, Feature::Constants, Feature::Strings],
+    );
+    match run(&m) {
+        // `a==a` true, `a==b` false — Ruby display convention off (module not
+        // tagged source_language=ruby), so booleans print `#t`/`#f`.
+        Some(out) => assert_eq!(out, "#t\n#f\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+// ---- rejection (deferred shapes rejected cleanly, never a panic) ----------
+
+fn rejects(stmts: Vec<Stmt>, feats: &[Feature]) -> bool {
+    semantic_ir_to_c::compile(&module(stmts, feats)).is_err()
+}
+
+#[test]
+fn deferred_oop_shapes_are_rejected_cleanly() {
+    // `__new__` with a constructor argument (needs `initialize`, a later slice).
+    assert!(
+        rejects(
+            vec![puts(bc("__new__", vec![strlit("Foo"), ilit(1)]))],
+            &[Feature::Classes, Feature::Constants, Feature::Strings]
+        ),
+        "__new__ with ctor args must be rejected"
+    );
+    // A method-bearing class surfaces `__def_method__` (an unsupported builtin).
+    assert!(
+        rejects(
+            vec![
+                Stmt::ClassDef { name: "Foo".into(), superclass: None, body: vec![], span: s() },
+                puts(bc("__def_method__", vec![strlit("Foo"), strlit("m")])),
+            ],
+            &[Feature::Classes, Feature::Constants, Feature::Strings]
+        ),
+        "__def_method__ must be rejected"
+    );
+    // A `class << self` singleton (also observes Feature::Classes).
+    assert!(
+        rejects(
+            vec![Stmt::SingletonClassDef { target: "self".into(), body: vec![], span: s() }],
+            &[Feature::Classes]
+        ),
+        "singleton class must be rejected"
+    );
+    // An instance-method dispatch (`__method__`) is a later slice.
+    assert!(
+        rejects(
+            vec![puts(bc("__method__", vec![bc("__new__", vec![strlit("Foo")]), strlit("m")]))],
+            &[Feature::Classes, Feature::Constants, Feature::Strings]
+        ),
+        "__method__ dispatch must be rejected"
+    );
+}

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_classes.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_classes.rs
@@ -203,4 +203,28 @@ fn deferred_oop_shapes_are_rejected_cleanly() {
         ),
         "__method__ dispatch must be rejected"
     );
+    // A superclass (inheritance dispatch is a later slice) — the empty-class
+    // comment emit would otherwise silently drop the link.
+    assert!(
+        rejects(
+            vec![Stmt::ClassDef { name: "Dog".into(), superclass: Some("Animal".into()), body: vec![], span: s() }],
+            &[Feature::Classes]
+        ),
+        "a superclass must be rejected"
+    );
+    // A non-empty class body (its content would be silently dropped by the
+    // comment emit) — here a `Const`-assign body stmt (an accepted feature, so it
+    // passes the manifest gate and must be caught by the scan, not dropped).
+    assert!(
+        rejects(
+            vec![Stmt::ClassDef {
+                name: "Foo".into(),
+                superclass: None,
+                body: vec![Stmt::Assign { name: "PI".into(), scope: Scope::Const, value: ilit(3), span: s() }],
+                span: s(),
+            }],
+            &[Feature::Classes, Feature::Constants]
+        ),
+        "a non-empty class body must be rejected"
+    );
 }

--- a/code/packages/rust/semantic-ir-to-c/tests/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/emit.rs
@@ -114,13 +114,14 @@ fn self_contained_no_external_headers() {
 
 #[test]
 fn unaccepted_feature_is_rejected_cleanly() {
-    // An (empty) class declaration declares Feature::Classes, which this
-    // backend does not accept. (Arrays now declare the accepted Sequences
-    // feature and hashes the accepted Maps feature, so neither exercises the
-    // rejection path any longer — a class still does. A class is a declaration,
-    // so — unlike a `true && false` short-circuit — it is not folded away.)
-    let m = lower_ruby("class Foo\nend");
-    let err = compile(&m).expect_err("backend rejects Classes");
+    // A `module` declaration declares Feature::Modules, which this backend does
+    // not accept. (Arrays/hashes declare the accepted Sequences/Maps features,
+    // and an empty `class` now declares the accepted Classes feature — the OOP
+    // mirror slice 1 — so none of those exercise the rejection path any longer. A
+    // module is the last OOP feature, still unaccepted, and — being a declaration
+    // — is not folded away like a `true && false` short-circuit.)
+    let m = lower_ruby("module Foo\nend");
+    let err = compile(&m).expect_err("backend rejects Modules");
     assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
 }
 


### PR DESCRIPTION
## What

The **first slice of the C backend's OOP mirror** — the instance-runtime foundation. The Ruby backend just finished the full 7-slice OOP arc; this begins bringing C (the sole OOP laggard) to parity. Bumps `semantic-ir-to-c` 0.12.0 → 0.13.0, accepting `Feature::Classes` + `Feature::Constants` (entangled — the frontend records `Constants` for any `Foo.new`, since the receiver is a constant).

## Runtime

- A new `SIR_INSTANCE` value tag + `struct SirInstance { const char *sir_class; }` stored **inline in the `SirValue` union**. Unlike the Go/Rust backends (which hold an integer id into a side-table because their value type is `Copy`), the C pointer *is* the handle — pointer-identity is object identity, so **no id table** is needed.
- `_sir_new_instance(cls)` constructs it; `_sir_fmt` prints `#<Foo>` (deterministic — no address, so tests can assert); `_sir_value_eq` gains a `SIR_INSTANCE` arm (pointer identity, Ruby's default object `==`).
- Constants: a tiny name→value table `_sir_const_set`/`_sir_const_get`; an undefined constant raises a rescuable `NameError` via the existing exception path.

## Emit

- `class Foo; end` → a C comment (a class is just a NAME in the C runtime; an instance carries its class string, there is no class object).
- `Foo.new` → `_sir_new_instance("Foo")`; `Scope::Const` ref → `_sir_const_get`; `Const` assign → `_sir_const_set`. Class/constant names emit as **quoted C string literals** (`quote_c_string`, trigraph-safe) — so, unlike Ruby's bare-constant emit, there's no injection surface from names, and the `ClassDef` comment is a fixed string (the class name is not embedded, so no `*/` break-out).
- **Totality**: rejects `__new__` with constructor args (needs `initialize`), a `class << self` singleton (also observes `Classes`), a superclass or non-empty class body (would be silently dropped by the comment emit), and every other OOP builtin (`__def_method__`/`__method__`/…); `ModuleDef`/`@ivars`/`@@cvars` are gate-rejected via their unaccepted features.

## Security review

A read-only security sub-agent reviewed the diff with **C memory safety** as the primary focus and returned **PASSED — no vulnerabilities**: `_sir_new_instance`/`_sir_const_set`/`_sir_const_get` are bounds-checked (past-cap is a bounded no-op), `_sir_fmt` uses `fputs` (no format-string exposure) on the non-NULL interned class name, `_sir_value_eq` is a guarded pointer compare, names are `quote_c_string`-safe, and no emit arm can reach a Rust panic/OOB. A non-security note (the comment emit would drop a class body/superclass) was addressed in a follow-up commit (reject them in the scan).

## Tests

`tests/compile_and_run_classes.rs` (4 tests, compiled + run through a real `cc`): the instance prints `#<Foo>`, `PI = 3; puts PI` → `3`, two `Foo.new` are distinct by identity, and 6 deferred-shape rejections. The stale `unaccepted_feature_is_rejected_cleanly` test now uses a `module` (Classes is accepted). All 14 C test files pass; `cargo clippy` clean. CHANGELOG, README, SIR24 spec (roadmap) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)