### PR TITLE
feat(constant-fold): fold Math.fround(n) at a float32 fixed point (0.110.0)

### DIFF
--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.110.0] - 2026-07-24
+
+### Added - Math.fround(n) at a float32 fixed point
+
+`Math.fround(x)` (ECMAScript §21.3.2.19) rounds `x` to the nearest float32 and
+widens back to a double — exactly Rust's `x as f32 as f64`, so the round-trip is
+bit-for-bit reproducible (no `powf`-style last-ULP hazard). The reference
+compiler folds `Math.fround(x)` ONLY when `x` is already an exact float32 — a
+fixed point where `fround(x) === x` and the fold changes nothing:
+
+```text
+  Math.fround(1.5)      -> 1.5      (exactly a float32)
+  Math.fround(-2.5)     -> -2.5
+  Math.fround(0)        -> 0
+  Math.fround(1.1)      -> Math.fround(1.1)      (rounds; DECLINED)
+  Math.fround(16777217) -> Math.fround(16777217) (2^24+1; rounds; DECLINED)
+```
+
+We mirror that: fold only when `x.is_finite() && (x as f32 as f64) == x`, and
+DECLINE a `-0` fixed point (`-0` has no numeric-literal token — the same
+negative-zero care as the Math.abs/floor block). `NaN`/`Infinity` are
+identifiers, never numeric literals, so they never reach the numeric-literal
+handler; the `is_finite` guard is defense-in-depth. Only the bare-global
+`Math.fround` callee with exactly one numeric-literal argument folds.
+
+This closes the `fround` half of the Math static-fold task; `Math.pow` remains
+declined (unsound to fold via `powf`; a safe pow needs integer-exponent-only
+exact arithmetic).
+
 ## [0.109.0] - 2026-07-22
 
 ### Added - fold `Math.clz32(n)` and `Math.imul(a, b)` on numeric literals

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.109.0"
+version = "0.110.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -2807,6 +2807,58 @@ fn fold_call(c: &CallExpression, st: &mut FoldState) -> Expression {
                     }
                 }
 
+                // ---- Math.fround(n) → n, ONLY at a float32 fixed point ----
+                //
+                // `Math.fround(x)` (ECMAScript §21.3.2.19) rounds `x` to the
+                // nearest IEEE-754 *single-precision* (float32) value, then widens
+                // back to a double. That is EXACTLY Rust's `x as f32 as f64`, so
+                // the round-trip is bit-for-bit reproducible with no `powf`-style
+                // last-ULP hazard.
+                //
+                // The reference compiler folds `Math.fround(x)` ONLY when `x` is
+                // already an exact float32 — i.e. a *fixed point* of the round
+                // trip, where `fround(x) === x` and the fold changes nothing:
+                //
+                //   Math.fround(1.5)      → 1.5     (1.5 is exactly a float32)
+                //   Math.fround(-2.5)     → -2.5
+                //   Math.fround(0)        → 0
+                //   Math.fround(1.1)      → Math.fround(1.1)   (1.1 rounds — DECLINED)
+                //   Math.fround(16777217) → Math.fround(16777217)  (2^24+1 rounds)
+                //
+                // When `fround(x) !== x` the reference LEAVES the call intact (the
+                // rounded constant is no shorter and would change the printed
+                // value), so we mirror that by folding only the fixed point and
+                // declining everything else. The gate `x as f32 as f64 == x`
+                // captures exactly the exact-float32 doubles.
+                //
+                // Scope guards (each keeps us strictly inside the reference's
+                // behaviour and away from unspellable tokens):
+                //   * bare-global `Math.fround` callee, exactly ONE argument, and
+                //     that argument is a NUMERIC LITERAL (no ToNumber side effect);
+                //   * `x.is_finite()` — `NaN`/`Infinity` are identifiers, never
+                //     numeric literals, so they cannot reach here from source; the
+                //     guard is defense-in-depth against a pre-folded infinity;
+                //   * a `-0` fixed point is DECLINED (`-0` has no numeric-literal
+                //     token; declining is always safe), mirroring the negative-zero
+                //     care in the Math.abs/floor block above.
+                if obj.name == "Math"
+                    && prop.name == "fround"
+                    && arguments.len() == 1
+                {
+                    if let Expression::NumericLiteral(n) = &arguments[0] {
+                        let x = n.value;
+                        let is_float32_fixed_point = x.is_finite() && (x as f32 as f64) == x;
+                        let neg_zero = x == 0.0 && x.is_sign_negative();
+                        if is_float32_fixed_point && !neg_zero {
+                            let parent = c.cv.clone();
+                            let before = format!("Math.fround({x})");
+                            let after = format_js_number(x);
+                            let new_cv = st.fork_cv(&parent, &before, &after);
+                            return stamp_literal_cv(FoldedLiteral::Number(x), new_cv);
+                        }
+                    }
+                }
+
                 // ---- Object.fromEntries([[k, v], …]) → object literal ----
                 //
                 // `Object.fromEntries` (ECMAScript §20.1.2.7) is the inverse of
@@ -12791,6 +12843,51 @@ mod tests {
             assert!(!changed, "a -0 result must not fold (no -0 literal spelling)");
             assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
         }
+    }
+
+    #[test]
+    fn fold_math_fround_fixed_point() {
+        // Math.fround folds ONLY at a float32 fixed point (fround(x) === x), and
+        // then leaves the value unchanged. Every dyadic rational with a small
+        // enough denominator and exponent is exactly representable in float32.
+        assert_eq!(folded_number(math_call("fround", vec![num(1.5, None)])), 1.5);
+        assert_eq!(folded_number(math_call("fround", vec![num(-2.5, None)])), -2.5);
+        assert_eq!(folded_number(math_call("fround", vec![num(0.0, None)])), 0.0);
+        assert_eq!(folded_number(math_call("fround", vec![num(0.5, None)])), 0.5);
+        assert_eq!(folded_number(math_call("fround", vec![num(0.25, None)])), 0.25);
+        // Any integer up to 2^24 is exactly a float32.
+        assert_eq!(
+            folded_number(math_call("fround", vec![num(16777216.0, None)])),
+            16777216.0
+        );
+    }
+
+    #[test]
+    fn fold_math_fround_declines_non_float32() {
+        // A double that is NOT already a float32 would be CHANGED by fround, so
+        // the reference (and we) leave the call intact.
+        let cases = [
+            math_call("fround", vec![num(1.1, None)]),        // rounds
+            math_call("fround", vec![num(0.1, None)]),        // rounds
+            math_call("fround", vec![num(16777217.0, None)]), // 2^24+1, rounds
+        ];
+        for c in cases {
+            let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+            assert!(!changed, "a non-float32 double must not fold via fround");
+            assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
+        }
+    }
+
+    #[test]
+    fn fold_math_fround_declines_negative_zero() {
+        // fround(-0) === -0, but -0 has no numeric-literal spelling, so decline
+        // (matching the Math.abs/floor negative-zero policy). `-0` also cannot
+        // reach here from source — it parses as unary minus on `0` — so this
+        // guards only a hypothetically pre-folded -0 literal.
+        let c = math_call("fround", vec![num(-0.0, None)]);
+        let (out, _, changed, _) = run_pass(program_with_expr(c, true));
+        assert!(!changed, "a -0 fround fixed point must not fold");
+        assert!(matches!(extract_expr(&out), Expression::CallExpression(_)));
     }
 
     #[test]

--- a/code/programs/rust/closurec/tests/diff/simple-fold-math-fround/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-math-fround/README.md
@@ -1,0 +1,20 @@
+# simple-fold-math-fround
+
+End-to-end oracle for static `Math.fround(n)` folding in
+`closure-pass-constant-fold` (0.110.0).
+
+`Math.fround(x)` rounds `x` to the nearest float32 and widens back to a double
+(`x as f32 as f64`). The fold fires ONLY at a float32 fixed point
+(`fround(x) === x`), leaving the value unchanged; a double that fround would
+change (`1.1`, `2^24+1`), a non-global receiver (`m.fround`), a `-0` fixed
+point, and `NaN`/`Infinity` (which are identifiers, not numeric literals) are
+all declined.
+
+## Expected output
+
+```text
+var a=1.5,b=-2.5,c=.25,d=16777216,e=Math.fround(1.1),f=Math.fround(16777217),g=m.fround(1.5);report(a,b,c,d,e,f,g);
+```
+
+Byte-identical to the reference Closure Compiler (`v20260712`,
+`SIMPLE_OPTIMIZATIONS`, `ECMASCRIPT_2020`, `NO_TRANSPILE`), verified with `xxd`.

--- a/code/programs/rust/closurec/tests/diff/simple-fold-math-fround/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-math-fround/expected.stdout
@@ -1,0 +1,1 @@
+var a=1.5,b=-2.5,c=.25,d=16777216,e=Math.fround(1.1),f=Math.fround(16777217),g=m.fround(1.5);report(a,b,c,d,e,f,g);

--- a/code/programs/rust/closurec/tests/diff/simple-fold-math-fround/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-math-fround/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-fold-math-fround/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-fold-math-fround/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-fold-math-fround/input/a.js
@@ -1,0 +1,27 @@
+// SIMPLE-level static Math.fround(n) fold -> numeric literal, ONLY at a
+// float32 fixed point (constant-fold 0.110.0).
+//
+// Math.fround(x) (ECMAScript 21.3.2.19) rounds x to the nearest float32 and
+// widens back to a double -- exactly `x as f32 as f64`, so the round-trip is
+// bit-for-bit reproducible. The reference compiler folds ONLY when x is already
+// an exact float32 (fround(x) === x), leaving the value unchanged:
+//   * Math.fround(1.5)      -> 1.5        (1.5 is exactly a float32)
+//   * Math.fround(-2.5)     -> -2.5
+//   * Math.fround(0.25)     -> .25
+//   * Math.fround(16777216) -> 16777216   (2^24 is exactly a float32)
+//   * Math.fround(1.1)      -> DECLINED    (1.1 is not a float32; fround changes it)
+//   * Math.fround(16777217) -> DECLINED    (2^24+1 rounds down to 2^24)
+//   * m.fround(1.5)         -> DECLINED    (only the bare global Math folds)
+//
+// A -0 fixed point is also DECLINED (no numeric-literal spelling), and NaN /
+// Infinity never reach the numeric-literal handler (they are identifiers, not
+// numeric literals). Those are covered by unit tests, not shown here so the
+// fixture stays byte-identical to the reference compiler.
+var a = Math.fround(1.5);
+var b = Math.fround(-2.5);
+var c = Math.fround(0.25);
+var d = Math.fround(16777216);
+var e = Math.fround(1.1);
+var f = Math.fround(16777217);
+var g = m.fround(1.5);
+report(a, b, c, d, e, f, g);

--- a/code/programs/rust/closurec/tests/diff_simple_fold_math_fround.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_fold_math_fround.rs
@@ -1,0 +1,52 @@
+//! Integration test for the `tests/diff/simple-fold-math-fround/` fixture.
+//!
+//! End-to-end oracle for static `Math.fround(...)` folding in
+//! `closure-pass-constant-fold`: when the single argument is a numeric literal
+//! that is already an exact float32 (a fixed point, `fround(x) === x`) the call
+//! collapses to that numeric literal, unchanged. A double that fround would
+//! change (`Math.fround(1.1)`, `Math.fround(16777217)`) and a non-global
+//! receiver (`m.fround(1.5)`) are declined.
+//!
+//! At SIMPLE the fixture optimizes to:
+//!
+//! ```text
+//! var a=1.5,b=-2.5,c=.25,d=16777216,e=Math.fround(1.1),f=Math.fround(16777217),g=m.fround(1.5);report(a,b,c,d,e,f,g);
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-fold-math-fround/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_fold_math_fround_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-fold-math-fround/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}


### PR DESCRIPTION
## What

`constant-fold` (0.110.0): fold `Math.fround(n)` to a numeric literal, but **only at a float32 fixed point** — the fround half of the Math.pow/fround item (#221).

`Math.fround(x)` (ECMAScript §21.3.2.19) rounds `x` to the nearest IEEE-754 single-precision (float32) value and widens back to a double — exactly Rust's `x as f32 as f64`, so the round-trip is bit-for-bit reproducible with **no `powf`-style last-ULP hazard** (which is why `Math.pow` remains declined).

The reference compiler folds `Math.fround(x)` only when `x` is already an exact float32 — a fixed point where `fround(x) === x`:

```text
Math.fround(1.5)      -> 1.5        (exactly a float32)
Math.fround(-2.5)     -> -2.5
Math.fround(0.25)     -> .25
Math.fround(16777216) -> 16777216   (2^24 is exactly a float32)
Math.fround(1.1)      -> Math.fround(1.1)        (DECLINED — 1.1 rounds)
Math.fround(16777217) -> Math.fround(16777217)   (DECLINED — 2^24+1 rounds)
```

When `fround(x) !== x` the reference leaves the call intact (the rounded constant is no shorter and would change the printed value), so we decline. The gate `x.is_finite() && (x as f32 as f64) == x` captures exactly the exact-float32 doubles.

## Guards

- Bare-global `Math.fround` callee, exactly one **numeric-literal** argument (no ToNumber side effect).
- A `-0` fixed point is declined (`-0` has no numeric-literal spelling) — same negative-zero care as the Math.abs/floor block.
- `NaN`/`Infinity` are identifiers, never numeric literals, so they never reach the handler (plus an `is_finite` guard as defense-in-depth).

## Verification

- 410 constant-fold unit tests (3 new: fixed-point fold, declines-non-float32, declines-negative-zero), zero regressions.
- New closurec e2e fixture `simple-fold-math-fround`, byte-identical to the oracle jar (`v20260712`, `SIMPLE`, `ECMASCRIPT_2020`, `NO_TRANSPILE`), verified with `xxd` — covers fold, two declines, and non-global-receiver decline.
- Full closurec suite: **161 suites / 958 tests, zero failures, zero drift.**
- `cargo clippy -- -D warnings` clean in both workspaces.
- Inline security review: **PASSED** — the float→float `as` cast is total (no UB/panic on any f64 incl. subnormals/large values), the fold is semantics-preserving, and there is no panic path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
