### PR TITLE
feat(adj-formula-stdlib): illuminance-conversions — NIST SP 811 B.9 phot→lux exact factor (RS-5 table)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -717,6 +717,45 @@ fn shipped_magnetic_flux_density_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b15) Shipped table — reference/illuminance-conversions.adj resolves via import (a
+//       NEW dimension: illuminance → lux, the EXACT SP 811 B.9 boldface CGS factor
+//       phot), and a non-exact customary unit (`footcandle`) — a rounded factor with no
+//       row — abstains.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_illuminance_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_illum");
+    let src = stdlib().join("reference/illuminance-conversions.adj");
+    std::fs::copy(&src, dir.join("illuminance-conversions.adj"))
+        .expect("copy shipped illuminance-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"illuminance-conversions.adj\"\n\
+         ? illuminance_to_lux(phot, $v)\n\
+         ? illuminance_to_lux(footcandle, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 "Illuminance" exact factor resolves, character-for-character
+    // from the table (boldface = exact; scientific notation to plain decimal).
+    assert!(out.contains("\"v\":\"10000\""), "phot = 10000 lx: {out}");
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `footcandle` is a NIST customary row printed as a ROUNDED (non-boldface) factor —
+    // not an exact row here, so the engine abstains rather than committing to a rounded
+    // value.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a non-exact unit abstains, never a fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/illuminance-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/illuminance-conversions.adj
@@ -1,0 +1,53 @@
+% ============================================================================
+% illuminance-conversions — illuminance-unit → lux factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of `magnetic-flux-density-conversions.adj` and the other
+% NIST-cited conversion tables: a native tabular relation ingested VERBATIM from a
+% published NIST conversion table. The row states the factor converting the CGS
+% illuminance unit to the SI coherent unit of illuminance, the lux (lx):
+%
+%     ? illuminance_to_lux(phot, $v)   % 10000
+%
+% This is a NEW dimension alongside the length/mass/area/volume/time/speed/energy/
+% pressure/force/acceleration/dynamic-viscosity/kinematic-viscosity/magnetic-flux-
+% density tables: where those normalise their own quantity, this one normalises an
+% ILLUMINANCE (luminous flux per unit area, one lux being one lumen per square metre).
+% Put a light level given in the CGS phot into SI first, then reason (write-once-
+% use-many). Why a `table` and not a hand-written `relate` clause: this is exactly the
+% shape reference data comes in — a published table, not prose. The citable artifact IS
+% the NIST conversion-factors table at the `locator` below; the factor here is a CELL of
+% NIST Special Publication 811, Appendix B.9 ("Factors for units listed
+% alphabetically"), defended by one provenance envelope. Each `row` lowers to a ground
+% relation `illuminance_to_lux(unit, lux)`, so the exact lookup above is the ordinary SLD
+% binding query — the engine returns the factor WITH this table's citation as its proof,
+% on the CPU, with zero model calls.
+%
+% HONESTY NOTE (like force-/viscosity-conversions, only the EXACT defined factor gets a
+% row, not the rounded ones): NIST SP 811 B.9 prints the "phot" illuminance factor in
+% BOLDFACE, its convention for factors that are EXACT by definition, transcribed here as
+% the plain decimal number of lux it names:
+%
+%     phot (ph)   1.0 E+04  →  10000
+%
+% This is exact because the phot is a coherent CGS unit — one phot is one lumen per
+% square centimetre, i.e. exactly 10⁴ lux. It terminates; nothing here is a rounded
+% measurement. NIST's other illuminance rows are customary units whose factors NIST
+% prints in plain (non-boldface) type as ROUNDED values — e.g. the "footcandle" (lumen
+% per square foot) at 1.076 391 E+01 lux — so they are NOT given rows here; a
+% `? illuminance_to_lux(footcandle, $v)` ABSTAINS rather than committing to a rounded
+% factor. The only claim this table makes is "this is the exact factor NIST SP 811 B.9
+% prints" — which is exactly what a byte-check against the cited table verifies.
+% `trust authoritative` — a primary, re-fetchable standards reference. (See
+% ADJ-TABLES.md; and feedback_nothing_human_authored — the factor is a verbatim cell of
+% the cited table, nothing asserted from memory.)
+% ============================================================================
+
+table illuminance_to_lux {
+    columns unit, lux
+
+    row (phot, 10000)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/illuminance-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/illuminance-conversions.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% illuminance-conversions.query.adj — a worked lookup over the illuminance table.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a "how many lux is one
+% phot?" question: it states no conversion fact — it only `import`s the grounded table
+% and asks binding queries. The native adj-lang engine resolves each `?` against the
+% table's row (lowered to an `illuminance_to_lux` relation) and returns the binding + the
+% table's source/locator/trust. A unit not in the table abstains honestly — the engine
+% never invents a factor (notably NIST's non-exact customary rows, e.g. the footcandle,
+% which is rounded and therefore gets no row).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli illuminance-conversions.query.adj
+% ============================================================================
+
+import "illuminance-conversions.adj"
+
+? illuminance_to_lux(phot, $v)       % expect 10000
+? illuminance_to_lux(footcandle, $v) % expect abstain — non-exact, no row


### PR DESCRIPTION
## What

Adds `reference/illuminance-conversions.adj` — a native RS-5 `table` for a **new dimension**, illuminance → the SI **lux (lx)** — a sibling of the viscosity / magnetic-flux-density / length / mass / area / volume / time / speed / energy / pressure / force / acceleration conversion tables. One row, **exact** (NIST prints it boldface = exact by definition), transcribed **verbatim** from NIST Special Publication 811, Appendix B.9 ("Factors for units listed alphabetically"):

| unit | NIST B.9 factor | lux |
|---|---|---|
| phot (ph) | **1.0 E+04** | 10000 |

The row lowers to a ground relation `illuminance_to_lux(unit, lux)`, so an exact lookup is the ordinary SLD binding query — the engine returns the factor **with the table's one provenance envelope** (`source`/`locator`/`trust authoritative`), on the CPU, zero model calls.

## Honesty / abstention

The phot is exact because it is a coherent CGS unit — one phot is one lumen per square centimetre, i.e. exactly 10⁴ lux. NIST's other illuminance rows are customary units printed as **rounded** (non-boldface) factors — e.g. the **footcandle** (lumen per square foot) at `1.076 391 E+01` lux — so they get **no row** here; a `? illuminance_to_lux(footcandle, $v)` **abstains** rather than committing to a rounded value. The only claim the table makes is "this is the exact factor NIST SP 811 B.9 prints" — which a byte-check against the cited page verifies.

## Files

- `reference/illuminance-conversions.adj` — the grounded RS-5 table
- `reference/illuminance-conversions.query.adj` — worked lookup (phot → 10000, and an abstaining footcandle)
- `adj-lang-cli/tests/rs5_table_e2e.rs` — new **(b15)** block on the shared table anchor, driving the built CLI against the shipped table

## Verification

- `cargo test -p adj-lang-cli --test rs5_table_e2e` → **20/20 pass** (new block asserts exact `10000`, the NIST B.9 locator on the answer, and abstention on the non-exact unit)
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean
- Shipped query run through the CLI → `10000` exact, `abstained:true` on the footcandle, NIST B.9 locator carried
- NUL-scan: 0 bytes in all touched files
- Byte-verified verbatim against NIST SP 811 B.9 (phot `1.0 E+04`, boldface/exact)
- Data + test only — **no version bump**
- `/security-review` → PASSED (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)