### PR TITLE
Add MOS source square support

### DIFF
--- a/code/packages/python/mosfet-models/CHANGELOG.md
+++ b/code/packages/python/mosfet-models/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [0.1.0] — Unreleased
 
 ### Added
+- `Level1Params.NRS` adds the Berkeley source diffusion square count, defaulting
+  to one with finite, non-negative validation.
 - `Level1Params.NRD` adds the Berkeley drain diffusion square count, defaulting
   to one with finite, non-negative validation.
 - `Level1Params.RSH` adds zero-default Berkeley drain/source sheet resistance

--- a/code/packages/python/mosfet-models/README.md
+++ b/code/packages/python/mosfet-models/README.md
@@ -28,7 +28,8 @@ print(r.Id, r.gm, r.gds, r.region)
   depletion shaping, Berkeley-default `TOX` gate oxide thickness for intrinsic
   Meyer capacitance through `Cox = epsilon_ox / TOX`, zero-default `RD` / `RS`
   external drain/source resistance, zero-default `RSH` sheet resistance,
-  one-default `NRD` drain diffusion square count, and `KF` / `AF` flicker noise.
+  one-default `NRD` / `NRS` drain/source diffusion square counts, and `KF` /
+  `AF` flicker noise.
 - `evaluate_level1(params, V_GS, V_DS, V_BS, T)`: returns `MosResult` with Id, gm, gds, gmb, Cgs/Cgd/Cgb/Cbs/Cbd, region.
 - Region detection: cutoff (subthreshold-aware), triode, saturation.
 - Body effect via gamma * (sqrt(PHI-V_BS) - sqrt(PHI)) shift.

--- a/code/packages/python/mosfet-models/src/mosfet_models/level1.py
+++ b/code/packages/python/mosfet-models/src/mosfet_models/level1.py
@@ -33,6 +33,7 @@ class Level1Params:
     RS: float = 0.0  # external source resistance (ohm)
     RSH: float = 0.0  # drain/source sheet resistance (ohm per square)
     NRD: float = 1.0  # number of drain diffusion squares
+    NRS: float = 1.0  # number of source diffusion squares
     IS: float = 1e-15  # saturation current (A)
     N_SUB: float = 1.4  # subthreshold slope factor
     T_NOM: float = 300.15  # nominal temperature (K)
@@ -134,6 +135,8 @@ def evaluate_level1(
         raise ValueError("MOSFET RSH must be finite and non-negative")
     if not isfinite(p.NRD) or p.NRD < 0.0:
         raise ValueError("MOSFET NRD must be finite and non-negative")
+    if not isfinite(p.NRS) or p.NRS < 0.0:
+        raise ValueError("MOSFET NRS must be finite and non-negative")
     beta = p.KP * (p.W / effective_length)
 
     # Threshold with body effect. The formula is well-defined whenever

--- a/code/packages/python/mosfet-models/tests/test_models.py
+++ b/code/packages/python/mosfet-models/tests/test_models.py
@@ -199,6 +199,14 @@ def test_drain_squares_rejects_negative_value():
         evaluate_level1(Level1Params(NRD=-1.0), V_GS=1.8, V_DS=1.8)
 
 
+def test_source_squares_rejects_negative_value():
+    with pytest.raises(
+        ValueError,
+        match="MOSFET NRS must be finite and non-negative",
+    ):
+        evaluate_level1(Level1Params(NRS=-1.0), V_GS=1.8, V_DS=1.8)
+
+
 def test_overlap_and_bulk_capacitances_are_reported():
     p = Level1Params(
         W=2e-6,

--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add the Level-1 MOS `NRS` instance parameter. It defaults to one and scales
+  the `RSH` source fallback while preserving explicit positive `RS` precedence,
+  intrinsic-node stamping, and `:RS` Johnson noise.
 - Add the Level-1 MOS `NRD` instance parameter. It defaults to one and scales
   the `RSH` drain fallback while preserving explicit positive `RD` precedence,
   intrinsic-node stamping, and `:RD` Johnson noise.

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -99,8 +99,9 @@ node, routes the channel and drain-side capacitances through it, and contributes
 `RS` defaults to zero ohms. A finite positive value inserts an intrinsic source
 node, routes the channel and source-side capacitances through it, and contributes
 `4kT/RS` thermal noise.
-`RSH` defaults to zero ohms per square. `NRD` defaults to one drain square, so
-the drain fallback is `RSH * NRD`; an explicit positive `RD` takes precedence.
+`RSH` defaults to zero ohms per square. `NRD` and `NRS` default to one drain
+and source square, so the fallbacks are `RSH * NRD` and `RSH * NRS`; explicit
+positive `RD` / `RS` values take precedence.
 The source fallback remains one square until the matching source-geometry slice.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -9089,6 +9089,7 @@ def _mosfet_source_resistance(el: Mosfet) -> float:
         source_resistance
         if source_resistance > 0.0
         else float(getattr(params, "RSH", 0.0))
+        * float(getattr(params, "NRS", 1.0))
     )
 
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -789,6 +789,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(75.0) == mos_model.model.model.params.RS
     assert pytest.approx(50.0) == mos_model.model.model.params.RSH
     assert pytest.approx(1.0) == mos_model.model.model.params.NRD
+    assert pytest.approx(1.0) == mos_model.model.model.params.NRS
     assert pytest.approx(25.0e-9) == mos_model.model.model.params.TOX
     assert pytest.approx(2.0e-24) == mos_model.model.model.params.KF
     assert pytest.approx(1.4) == mos_model.model.model.params.AF
@@ -960,7 +961,7 @@ def test_dc_mosfet_sheet_resistance_biases_both_intrinsic_terminals() -> None:
         "0",
         MOSFET(
             MosfetType.NMOS,
-            Level1Model(Level1Params(RSH=1_000.0, NRD=2.0)),
+            Level1Model(Level1Params(RSH=1_000.0, NRD=2.0, NRS=3.0)),
         ),
     ))
 
@@ -2083,6 +2084,30 @@ def test_mosfet_rejects_invalid_drain_squares(
         dc_op(circuit)
 
 
+@pytest.mark.parametrize("source_squares", [float("nan"), -1.0])
+def test_mosfet_rejects_invalid_source_squares(
+    source_squares: float,
+) -> None:
+    circuit = Circuit()
+    circuit.add(Mosfet(
+        "Mbad",
+        "drain",
+        "gate",
+        "0",
+        "0",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(Level1Params(NRS=source_squares)),
+        ),
+    ))
+
+    with pytest.raises(
+        ValueError,
+        match="MOSFET NRS must be finite and non-negative",
+    ):
+        dc_op(circuit)
+
+
 def test_transient_diode_transit_time_holds_forward_charge_on_turnoff() -> None:
     def run(transit_time: float) -> TransientResult:
         circuit = Circuit()
@@ -3028,6 +3053,7 @@ def test_subcircuit_expansion_preserves_mos_geometry():
                             RS=75.0,
                             RSH=50.0,
                             NRD=2.0,
+                            NRS=3.0,
                             TOX=25.0e-9,
                         )
                     ),
@@ -3048,6 +3074,7 @@ def test_subcircuit_expansion_preserves_mos_geometry():
     assert pytest.approx(75.0) == expanded.model.model.params.RS
     assert pytest.approx(50.0) == expanded.model.model.params.RSH
     assert pytest.approx(2.0) == expanded.model.model.params.NRD
+    assert pytest.approx(3.0) == expanded.model.model.params.NRS
     assert pytest.approx(25.0e-9) == expanded.model.model.params.TOX
 
 
@@ -8287,7 +8314,7 @@ def test_noise_mosfet_rs_adds_thermal_noise() -> None:
         "0",
         MOSFET(
             MosfetType.NMOS,
-            Level1Model(Level1Params(RS=250.0)),
+            Level1Model(Level1Params(RS=250.0, RSH=100.0, NRS=10.0)),
         ),
     ))
 
@@ -8313,12 +8340,12 @@ def test_noise_mosfet_rsh_adds_both_terminal_noise_sources() -> None:
         "0",
         MOSFET(
             MosfetType.NMOS,
-            Level1Model(Level1Params(RSH=250.0, NRD=2.0)),
+            Level1Model(Level1Params(RSH=250.0, NRD=2.0, NRS=3.0)),
         ),
     ))
 
     entries = noise_ac(circuit, "out", "Vgate", freqs=[1_000.0]).points[0].entries
-    for name, resistance in (("M1:RD", 500.0), ("M1:RS", 250.0)):
+    for name, resistance in (("M1:RD", 500.0), ("M1:RS", 750.0)):
         entry = next(
             candidate
             for candidate in entries

--- a/code/packages/rust/mosfet-models/CHANGELOG.md
+++ b/code/packages/rust/mosfet-models/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `Level1Params::nrs` adds the Berkeley source diffusion square count,
+  defaulting to one with finite, non-negative validation.
 - `Level1Params::nrd` adds the Berkeley drain diffusion square count, defaulting
   to one with finite, non-negative validation.
 - `Level1Params::rsh` adds zero-default Berkeley drain/source sheet resistance

--- a/code/packages/rust/mosfet-models/README.md
+++ b/code/packages/rust/mosfet-models/README.md
@@ -29,8 +29,8 @@ and must leave a positive effective channel length. `TOX` defaults to
 `100 nm`, must be positive, and derives intrinsic Meyer gate capacitance from
 `Cox = epsilon_ox / TOX`. `RD`, `RS`, and `RSH` are finite, non-negative
 external drain, source, and sheet-resistance parameters for engine topology and
-default to zero ohms. `NRD` is the finite, non-negative drain diffusion square
-count and defaults to one.
+default to zero ohms. `NRD` and `NRS` are finite, non-negative drain/source
+diffusion square counts and default to one.
 
 ## Usage
 

--- a/code/packages/rust/mosfet-models/src/lib.rs
+++ b/code/packages/rust/mosfet-models/src/lib.rs
@@ -44,6 +44,7 @@ const OXIDE_PERMITTIVITY: f64 = 3.453_133e-11;
 /// | RS        | Source resistance (ohm)             | 0        |
 /// | RSH       | Drain/source sheet resistance (ohm) | 0        |
 /// | NRD       | Number of drain squares              | 1        |
+/// | NRS       | Number of source squares             | 1        |
 /// | IS        | Drain–body saturation current (A)  | 1 fA     |
 /// | N_SUB     | Subthreshold slope factor          | 1.4      |
 /// | T_NOM     | Nominal temperature (K)            | 300.15   |
@@ -77,6 +78,8 @@ pub struct Level1Params {
     pub rsh: f64,
     /// Number of squares in the drain diffusion.
     pub nrd: f64,
+    /// Number of squares in the source diffusion.
+    pub nrs: f64,
     /// Drain–body saturation current [A] (used for subthreshold floor).
     pub is: f64,
     /// Subthreshold slope factor n.  Subthreshold current ∝ exp(V_OV / (n V_T)).
@@ -123,6 +126,7 @@ impl Default for Level1Params {
             rs: 0.0,
             rsh: 0.0,
             nrd: 1.0,
+            nrs: 1.0,
             is: 1e-15,
             n_sub: 1.4,
             t_nom: 300.15,
@@ -275,6 +279,10 @@ pub fn evaluate_level1(
     assert!(
         p.nrd.is_finite() && p.nrd >= 0.0,
         "MOSFET NRD must be finite and non-negative"
+    );
+    assert!(
+        p.nrs.is_finite() && p.nrs >= 0.0,
+        "MOSFET NRS must be finite and non-negative"
     );
     let beta = p.kp * (p.w / effective_length);
 

--- a/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
+++ b/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
@@ -16,6 +16,7 @@ fn test_default_params() {
     assert!((p.l - 130e-9).abs() < 1e-15);
     assert_eq!(p.ld, 0.0);
     assert_eq!(p.nrd, 1.0);
+    assert_eq!(p.nrs, 1.0);
     assert_eq!(p.kf, 0.0);
     assert_eq!(p.af, 1.0);
     assert!(p.subthreshold_enable);
@@ -216,6 +217,21 @@ fn test_drain_squares_rejects_negative_value() {
     let _ = evaluate_level1(
         &Level1Params {
             nrd: -1.0,
+            ..Level1Params::default()
+        },
+        1.8,
+        1.8,
+        0.0,
+        300.15,
+    );
+}
+
+#[test]
+#[should_panic(expected = "MOSFET NRS must be finite and non-negative")]
+fn test_source_squares_rejects_negative_value() {
+    let _ = evaluate_level1(
+        &Level1Params {
+            nrs: -1.0,
             ..Level1Params::default()
         },
         1.8,

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add the Level-1 MOS `NRS` instance parameter. It defaults to one and scales
+  the `RSH` source fallback while preserving explicit positive `RS` precedence,
+  intrinsic-node stamping, and `:RS` Johnson noise.
 - Add the Level-1 MOS `NRD` instance parameter. It defaults to one and scales
   the `RSH` drain fallback while preserving explicit positive `RD` precedence,
   intrinsic-node stamping, and `:RD` Johnson noise.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -140,8 +140,9 @@ node, routes the channel and drain-side capacitances through it, and contributes
 `RS` defaults to zero ohms. A finite positive value inserts an intrinsic source
 node, routes the channel and source-side capacitances through it, and contributes
 `4kT/RS` thermal noise.
-`RSH` defaults to zero ohms per square. `NRD` defaults to one drain square, so
-the drain fallback is `RSH * NRD`; an explicit positive `RD` takes precedence.
+`RSH` defaults to zero ohms per square. `NRD` and `NRS` default to one drain
+and source square, so the fallbacks are `RSH * NRD` and `RSH * NRS`; explicit
+positive `RD` / `RS` values take precedence.
 The source fallback remains one square until the matching source-geometry slice.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3613,6 +3613,7 @@ pub struct MosfetLevel1Params {
     pub source_resistance: f64,
     pub sheet_resistance: f64,
     pub drain_squares: f64,
+    pub source_squares: f64,
     pub saturation_current: f64,
     pub n_sub: f64,
     pub t_nom: f64,
@@ -3644,6 +3645,7 @@ impl Default for MosfetLevel1Params {
             source_resistance: 0.0,
             sheet_resistance: 0.0,
             drain_squares: 1.0,
+            source_squares: 1.0,
             saturation_current: 1.0e-15,
             n_sub: 1.4,
             t_nom: 300.15,
@@ -24969,7 +24971,7 @@ fn mosfet_source_resistance(mosfet: &Mosfet) -> f64 {
     if mosfet.params.source_resistance > 0.0 {
         mosfet.params.source_resistance
     } else {
-        mosfet.params.sheet_resistance
+        mosfet.params.sheet_resistance * mosfet.params.source_squares
     }
 }
 
@@ -25666,6 +25668,7 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         ("RS", params.source_resistance),
         ("RSH", params.sheet_resistance),
         ("NRD", params.drain_squares),
+        ("NRS", params.source_squares),
         ("TOX", params.oxide_thickness),
         ("IS", params.saturation_current),
         ("N_SUB", params.n_sub),
@@ -25730,6 +25733,12 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: mosfet.name.clone(),
             reason: "MOSFET NRD must be non-negative".to_string(),
+        });
+    }
+    if params.source_squares < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET NRS must be non-negative".to_string(),
         });
     }
     if params.oxide_thickness <= 0.0 {

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -631,6 +631,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(mos_model.params.source_resistance, 75.0);
     assert_close(mos_model.params.sheet_resistance, 50.0);
     assert_close(mos_model.params.drain_squares, 1.0);
+    assert_close(mos_model.params.source_squares, 1.0);
     assert_close(mos_model.params.oxide_thickness, 25.0e-9);
     assert_close(mos_model.params.flicker_noise_coefficient, 2.0e-24);
     assert_close(mos_model.params.flicker_noise_exponent, 1.4);
@@ -1681,6 +1682,7 @@ fn dc_mosfet_sheet_resistance_biases_both_intrinsic_terminals() {
         MosfetLevel1Params {
             sheet_resistance: 1_000.0,
             drain_squares: 2.0,
+            source_squares: 3.0,
             ..MosfetLevel1Params::default()
         },
     )));
@@ -1796,6 +1798,7 @@ fn subcircuit_expansion_preserves_mos_geometry() {
             source_resistance: 75.0,
             sheet_resistance: 50.0,
             drain_squares: 2.0,
+            source_squares: 3.0,
             oxide_thickness: 25.0e-9,
             ..MosfetLevel1Params::default()
         },
@@ -1840,6 +1843,7 @@ fn subcircuit_expansion_preserves_mos_geometry() {
     assert_close(expanded.params.source_resistance, 75.0);
     assert_close(expanded.params.sheet_resistance, 50.0);
     assert_close(expanded.params.drain_squares, 2.0);
+    assert_close(expanded.params.source_squares, 3.0);
     assert_close(expanded.params.oxide_thickness, 25.0e-9);
 }
 
@@ -4011,6 +4015,38 @@ fn dc_mosfet_rejects_invalid_drain_squares() {
                     "MOSFET NRD must be non-negative".to_string()
                 } else {
                     "MOSFET NRD must be finite".to_string()
+                },
+            }
+        );
+    }
+}
+
+#[test]
+fn dc_mosfet_rejects_invalid_source_squares() {
+    for source_squares in [f64::NAN, -1.0] {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "Mbad",
+            "drain",
+            "gate",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                source_squares,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+
+        let err = dc_op(&circuit).unwrap_err();
+        assert_eq!(
+            err,
+            SpiceError::InvalidElement {
+                name: "Mbad".to_string(),
+                reason: if source_squares.is_finite() {
+                    "MOSFET NRS must be non-negative".to_string()
+                } else {
+                    "MOSFET NRS must be finite".to_string()
                 },
             }
         );

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -591,6 +591,8 @@ fn mosfet_source_resistance_emits_thermal_noise() {
         MosfetType::Nmos,
         MosfetLevel1Params {
             source_resistance: 250.0,
+            sheet_resistance: 100.0,
+            source_squares: 10.0,
             ..MosfetLevel1Params::default()
         },
     )));
@@ -630,12 +632,13 @@ fn mosfet_sheet_resistance_emits_both_terminal_noise_sources() {
         MosfetLevel1Params {
             sheet_resistance: 250.0,
             drain_squares: 2.0,
+            source_squares: 3.0,
             ..MosfetLevel1Params::default()
         },
     )));
 
     let result = noise_ac(&circuit, "out", "Vgate", &[1_000.0], 300.0).unwrap();
-    for (name, resistance) in [("M1:RD", 500.0), ("M1:RS", 250.0)] {
+    for (name, resistance) in [("M1:RD", 500.0), ("M1:RS", 750.0)] {
         let entry = result.points[0]
             .entries
             .iter()

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Parse Level-1 MOS instance `NRS=<squares>` into the engine parameter bundle
+  so netlist-driven source resistance uses `RSH * NRS`.
 - Parse Level-1 MOS model `RSH` and instance `NRD=<squares>` into the engine
   parameter bundle so netlist-driven drain resistance uses `RSH * NRD`.
 - Add Berkeley SPICE app-deck shell dashboard dispatch queue lane tab panel

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -760,7 +760,7 @@ parameters, `.model <name> NPN|PNP(...)` BJT cards with `IS`, `BF` /
 `.model <name> NMOS|PMOS(...)` Level-1 MOSFET
 cards with common SPICE aliases (`VT0` / `VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
 `W`, `L`, `RSH`, `IS`, `N_SUB` / `NSUB`, `T_NOM` / `TNOM`, `CGSO`, `CGDO`,
-`CGBO`, `CBS`, and `CBD`), MOS instance `NRD=<squares>`, SPICE engineering
+`CGBO`, `CBS`, and `CBD`), MOS instance `NRD=<squares>` / `NRS=<squares>`, SPICE engineering
 suffixes, capacitor `IC=<voltage>` and inductor `IC=<current>` initial
 conditions, independent-source `AC <magnitude> [phase]` forms,
 PWL/PULSE/SIN/EXP source forms, comments, `.end`, `.subckt` / `X` instance

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1902,6 +1902,9 @@ fn build_mosfet_params(
     if let Some(value) = instance_params.get("NRD") {
         params.drain_squares = *value;
     }
+    if let Some(value) = instance_params.get("NRS") {
+        params.source_squares = *value;
+    }
     params
 }
 

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1362,7 +1362,7 @@ fn parses_mosfet_models_into_operating_point_circuits() {
 .model nch NMOS(VTO=0.45 KP=250u LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n RSH=250 NSUB=1.5 TNOM=300 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p)
 Vdd vdd 0 DC 5
 Vgate gate 0 DC 2.5
-M1 vdd gate out 0 nch W=4u L=200n NRD=2
+M1 vdd gate out 0 nch W=4u L=200n NRD=2 NRS=3
 Rload out 0 1k
 .op
 "#,
@@ -1394,6 +1394,7 @@ Rload out 0 1k
     assert_close(mosfet.params.l, 200.0e-9);
     assert_close(mosfet.params.sheet_resistance, 250.0);
     assert_close(mosfet.params.drain_squares, 2.0);
+    assert_close(mosfet.params.source_squares, 3.0);
     assert_close(mosfet.params.n_sub, 1.5);
     assert_close(mosfet.params.t_nom, 300.0);
     assert_close(mosfet.params.gate_source_overlap_capacitance, 3.0e-12);

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add the Level-1 MOS `NRS` instance parameter. It defaults to one and scales
+  the `RSH` source fallback while preserving explicit positive `RS` precedence,
+  intrinsic-node stamping, and `:RS` Johnson noise.
 - Add the Level-1 MOS `NRD` instance parameter. It defaults to one and scales
   the `RSH` drain fallback while preserving explicit positive `RD` precedence,
   intrinsic-node stamping, and `:RD` Johnson noise.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -91,8 +91,9 @@ node, routes the channel and drain-side capacitances through it, and contributes
 `RS` defaults to zero ohms. A finite positive value inserts an intrinsic source
 node, routes the channel and source-side capacitances through it, and contributes
 `4kT/RS` thermal noise.
-`RSH` defaults to zero ohms per square. `NRD` defaults to one drain square, so
-the drain fallback is `RSH * NRD`; an explicit positive `RD` takes precedence.
+`RSH` defaults to zero ohms per square. `NRD` and `NRS` default to one drain
+and source square, so the fallbacks are `RSH * NRD` and `RSH * NRS`; explicit
+positive `RD` / `RS` values take precedence.
 The source fallback remains one square until the matching source-geometry slice.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1781,6 +1781,7 @@ export interface MosfetLevel1Params {
   readonly RS: number;
   readonly RSH: number;
   readonly NRD: number;
+  readonly NRS: number;
   readonly IS: number;
   readonly N_SUB: number;
   readonly T_NOM: number;
@@ -8042,6 +8043,7 @@ export function defaultMosfetLevel1Params(): MosfetLevel1Params {
     RS: 0.0,
     RSH: 0.0,
     NRD: 1.0,
+    NRS: 1.0,
     IS: 1.0e-15,
     N_SUB: 1.4,
     T_NOM: 300.15,
@@ -20819,7 +20821,9 @@ function mosfetDrainResistance(element: Mosfet): number {
 }
 
 function mosfetSourceResistance(element: Mosfet): number {
-  return element.params.RS > 0.0 ? element.params.RS : element.params.RSH;
+  return element.params.RS > 0.0
+    ? element.params.RS
+    : element.params.RSH * element.params.NRS;
 }
 
 function jfetChargeStateVoltage(
@@ -21130,6 +21134,9 @@ function validateMosfet(element: Mosfet): void {
   }
   if (params.NRD < 0.0) {
     throw invalidElement(element.name, "MOSFET NRD must be non-negative");
+  }
+  if (params.NRS < 0.0) {
+    throw invalidElement(element.name, "MOSFET NRS must be non-negative");
   }
   if (params.TOX <= 0.0) {
     throw invalidElement(element.name, "MOSFET TOX must be positive");

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -457,6 +457,7 @@ describe("dcOp", () => {
     expectClose(mosModel.params.RS, 75.0);
     expectClose(mosModel.params.RSH, 50.0);
     expectClose(mosModel.params.NRD, 1.0);
+    expectClose(mosModel.params.NRS, 1.0);
     expectClose(mosModel.params.TOX, 25.0e-9);
     expectClose(mosModel.params.KF, 2.0e-24);
     expectClose(mosModel.params.AF, 1.4);
@@ -1183,6 +1184,7 @@ describe("dcOp", () => {
     circuit.add(mosfet("M1", "drain", "gate", "0", "0", "NMOS", {
       RSH: 1_000.0,
       NRD: 2.0,
+      NRS: 3.0,
     }));
 
     const result = dcOp(circuit);
@@ -1258,6 +1260,7 @@ describe("dcOp", () => {
           RS: 75.0,
           RSH: 50.0,
           NRD: 2.0,
+          NRS: 3.0,
           TOX: 25.0e-9,
         }),
       ]),
@@ -1274,6 +1277,7 @@ describe("dcOp", () => {
     expectClose(expanded!.params.RS, 75.0);
     expectClose(expanded!.params.RSH, 50.0);
     expectClose(expanded!.params.NRD, 2.0);
+    expectClose(expanded!.params.NRS, 3.0);
     expectClose(expanded!.params.TOX, 25.0e-9);
   });
 
@@ -2537,6 +2541,20 @@ describe("dcOp", () => {
         Number.isFinite(drainSquares)
           ? "MOSFET NRD must be non-negative"
           : "MOSFET NRD must be finite",
+      );
+    }
+  });
+
+  it("rejects invalid MOSFET source square counts", () => {
+    for (const sourceSquares of [Number.NaN, -1.0]) {
+      const circuit = new Circuit();
+      circuit.add(mosfet("Mbad", "drain", "gate", "0", "0", "NMOS", {
+        NRS: sourceSquares,
+      }));
+      expect(() => dcOp(circuit)).toThrowError(
+        Number.isFinite(sourceSquares)
+          ? "MOSFET NRS must be non-negative"
+          : "MOSFET NRS must be finite",
       );
     }
   });

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -191,7 +191,11 @@ describe("noiseAc", () => {
     circuit.add(voltageSource("Vdd", "vdd", "0", 5.0));
     circuit.add(voltageSource("Vgate", "gate", "0", 3.0));
     circuit.add(resistor("Rload", "vdd", "out", 1_000.0));
-    circuit.add(mosfet("M1", "out", "gate", "0", "0", "NMOS", { RS: 250.0 }));
+    circuit.add(mosfet("M1", "out", "gate", "0", "0", "NMOS", {
+      RS: 250.0,
+      RSH: 100.0,
+      NRS: 10.0,
+    }));
 
     const entry = noiseAc(circuit, "out", "Vgate", [1_000.0], 300.0).points[0]!.entries
       .find((candidate) =>
@@ -211,10 +215,11 @@ describe("noiseAc", () => {
     circuit.add(mosfet("M1", "out", "gate", "0", "0", "NMOS", {
       RSH: 250.0,
       NRD: 2.0,
+      NRS: 3.0,
     }));
 
     const entries = noiseAc(circuit, "out", "Vgate", [1_000.0], 300.0).points[0]!.entries;
-    for (const [name, resistance] of [["M1:RD", 500.0], ["M1:RS", 250.0]] as const) {
+    for (const [name, resistance] of [["M1:RD", 500.0], ["M1:RS", 750.0]] as const) {
       const entry = entries.find((candidate) =>
         candidate.elementName === name && candidate.noiseType === "thermal"
       );

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,16 +33,16 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS drain diffusion squares.
+1. Cross-language Level-1 MOS source diffusion squares.
    - Status: current PR completion candidate.
-   - Add the Berkeley Level-1 MOS `NRD` instance parameter in Rust, Python, and
-     TypeScript, defaulting to one drain diffusion square.
-   - When explicit `RD` remains zero, use `RSH * NRD` for the drain resistance;
-     positive explicit `RD` continues to take precedence.
-   - Reuse the existing intrinsic drain topology in DC, TF, AC, transient, and
-     noise analyses, preserve `NRD` through hierarchy and cloning, enforce
+   - Add the Berkeley Level-1 MOS `NRS` instance parameter in Rust, Python, and
+     TypeScript, defaulting to one source diffusion square.
+   - When explicit `RS` remains zero, use `RSH * NRS` for the source resistance;
+     positive explicit `RS` continues to take precedence.
+   - Reuse the existing intrinsic source topology in DC, TF, AC, transient, and
+     noise analyses, preserve `NRS` through hierarchy and cloning, enforce
      finite non-negative validation, and keep the model-card coverage gate at
-     193 canonical rows because `NRD` is an instance parameter.
+     193 canonical rows because `NRS` is an instance parameter.
 
 ## Completed Slices
 
@@ -3462,6 +3462,16 @@ the Rust, Python, and TypeScript surfaces together.
      transfer-function, and noise analyses, hierarchy preserves `RSH`, finite
      non-negative validation is shared, and the supported-parameter release
      gate now covers 193 canonical rows.
+
+272. Cross-language Level-1 MOS drain diffusion squares.
+   - Status: completed in PR 9029.
+   - Rust, Python, and TypeScript Level-1 MOS instances now accept `NRD`,
+     defaulting to one drain diffusion square.
+   - When explicit `RD` remains zero, `RSH * NRD` supplies the drain
+     resistance across DC, TF, AC, transient, and noise analyses; hierarchy and
+     cloning preserve `NRD`, finite non-negative validation is shared, and the
+     model-card coverage gate remains at 193 canonical rows because `NRD` is
+     an instance parameter.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add the Berkeley Level-1 MOS `NRS` instance parameter across Rust, Python, and TypeScript
- scale the source-side `RSH` fallback by `NRS` while preserving explicit positive `RS` precedence and existing intrinsic-source topology
- parse `NRS=<squares>` in the Rust netlist parser and cover defaults, validation, hierarchy, DC, and noise behavior
- reconcile the SPICE completion plan after #9029

## Verification
- `cargo fmt -p mosfet-models -p spice-engine -- --check`
- `cargo test -p mosfet-models -p spice-engine -p spice-netlist-parser`
- Python Ruff for both touched packages (`--ignore SIM108,F841`)
- Python pytest: 679 passed
- TypeScript Vitest: 388 passed
- TypeScript build
- `git diff --check`