### PR TITLE
feat(semantic-ir-to-c): OOP mirror slice 2 — instance methods (0.14.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.14.0 — OOP mirror slice 2: instance methods
+
+Instance-method definition and dispatch — the second slice of the C OOP mirror.
+
+- `__def_method__("Class", "m", MakeClosure(fn))` registers a method: it inserts
+  the closure into an explicit `(class, method) → closure` table
+  (`_sir_def_method`, keyed on the interned class + method).
+- `__method__(recv, "m", args…)` dispatches: `_sir_call_method` resolves
+  `(recv's class, "m")` in the table and applies the closure to the args; a
+  non-instance receiver or an unresolved method is a (rescuable) `NoMethodError`.
+
+**Anti-RCE by construction.** Dispatch is an **explicit data lookup** on the
+`(class, method)` key — never reflection on a source-derived string (the SIR24
+§Security invariant). A user method literally named `system`/`eval` is only ever
+a table KEY; an unknown method is a controlled `NoMethodError`, never a jump.
+(Class/method names emit as quoted C string literals, so there is no injection
+surface either.)
+
+**Totality / clean rejection.** A `__method__` dispatch to a name the module
+never registers via `__def_method__` is a **built-in method call** (`.length`,
+`.upcase`, … — the separate Collections batch) and is rejected cleanly, not
+compiled to a runtime `NoMethodError`: a first pass collects the registered
+method names (a thread-local allowlist), and the scan validates each dispatch. A
+malformed `__def_method__` (not `[StrLit, StrLit, MakeClosure]`) or `__method__`,
+and a `__def_method__`/`__method__` with a control-flow argument (which the
+compound emit path cannot render), are also rejected. `self`/`@ivars` are the
+next slice, so method bodies here don't yet reference the instance.
+
 ## 0.13.0 — OOP mirror slice 1: instance runtime + empty class + constants
 
 Accepts `Feature::Classes` + `Feature::Constants` — the first slice of the C

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -107,7 +107,13 @@ mirror **slice 1** — `Classes` + `Constants`: an empty class
 (`class Foo; end` → a comment), construction (`Foo.new` → `_sir_new_instance`, a
 new `SIR_INSTANCE` box stored inline in the union that prints `#<Foo>`), and
 constants (`PI = 3` / `PI` → a runtime `_sir_const_set` / `_sir_const_get`
-table).  Class/constant names are quoted C string literals (no injection).
+table).  Class/constant names are quoted C string literals (no injection).  And
+**slice 2** — instance methods: `__def_method__` registers a `(class, method) →
+closure` into an explicit table (`_sir_def_method`), and `__method__` dispatches
+via `_sir_call_method` (resolve `(recv's class, method)`, apply the closure; miss
+→ `NoMethodError`).  Dispatch is an explicit data lookup — **never reflection** on
+a source string — so it is anti-RCE by construction; a dispatch to an
+un-registered (built-in) method is rejected cleanly (the Collections batch).
 
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
 `Intrinsics`, `NDArrays`, the rest of OOP (instance methods, `@ivars`,

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -11,7 +11,7 @@
 //! See [SIR24](../../../specs/SIR24-semantic-ir-to-c.md) for the design.
 
 use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 
 use semantic_ir::{Block, Expr, Function, Global, IntSpec, IntWidth, Module, Scope, Span, Stmt};
@@ -1325,6 +1325,40 @@ fn emit_builtin_simple(out: &mut String, name: &str, args: &[Expr], indent: usiz
         }
         return;
     }
+    // OOP slice 2: register an instance method.  `args = [StrLit(class),
+    // StrLit(method), MakeClosure(fn)]`.  Class/method are QUOTED C string
+    // literals (no injection); the closure is emitted as a `_sir_make_closure`.
+    if name == "__def_method__" {
+        if let (Some(Expr::StrLit { value: cls, .. }), Some(Expr::StrLit { value: m, .. }), Some(clo)) =
+            (args.first(), args.get(1), args.get(2))
+        {
+            let _ = write!(out, "_sir_def_method({}, {}, ", quote_c_string(cls), quote_c_string(m));
+            emit_expr(out, clo, indent);
+            out.push(')');
+        } else {
+            let _ = write!(out, "_sir_unknown_builtin({})", quote_c_string(name));
+        }
+        return;
+    }
+    // OOP slice 2: dispatch an instance method.  `args = [recv, StrLit(method),
+    // call-args…]`.  The method name is a QUOTED C string literal; dispatch is an
+    // explicit `(class,method)` table lookup (anti-RCE — never reflection).
+    if name == "__method__" {
+        if let (Some(recv), Some(Expr::StrLit { value: m, .. })) = (args.first(), args.get(1)) {
+            let call_args = &args[2..];
+            out.push_str("_sir_call_method(");
+            emit_expr(out, recv, indent);
+            let _ = write!(out, ", {}, {}", quote_c_string(m), call_args.len());
+            for a in call_args {
+                out.push_str(", ");
+                emit_expr(out, a, indent);
+            }
+            out.push(')');
+        } else {
+            let _ = write!(out, "_sir_unknown_builtin({})", quote_c_string(name));
+        }
+        return;
+    }
     // Variadic-shaped builtins take (count, args...).
     if let Some(helper) = variadic_helper(name) {
         let _ = write!(out, "{}({}", helper, args.len());
@@ -1364,10 +1398,12 @@ fn emit_builtin_with_names(out: &mut String, name: &str, names: &[String]) {
         }
         return;
     }
-    // `__new__`'s single `StrLit` class-name arg is always simple, so the call is
-    // never hoisted to the compound path — this arm is unreachable, but emit a
-    // clear marker rather than a wrong `_sir_str`-based construction.
-    if name == "__new__" {
+    // `__new__`/`__def_method__`/`__method__` carry a `StrLit` class/method name
+    // (and a `MakeClosure`) that must stay a raw C literal, which the compound
+    // (already-emitted `names`) path cannot recover.  The scan rejects any such
+    // call that is not `is_simple` (a control-flow argument), so these arms are
+    // unreachable — emit a clear marker rather than a wrong construction.
+    if matches!(name, "__new__" | "__def_method__" | "__method__") {
         let _ = write!(out, "_sir_unknown_builtin({})", quote_c_string(name));
         return;
     }
@@ -1425,19 +1461,160 @@ fn variadic_helper(name: &str) -> Option<&'static str> {
 fn is_supported_builtin(name: &str) -> bool {
     variadic_helper(name).is_some()
         || fixed_helper(name).is_some()
-        // OOP slice 1: `__new__` constructs an instance.  (The other OOP builtins
-        // — `__def_method__`/`__method__`/`__super__`/… — stay unsupported, so a
-        // method-bearing class is rejected up front.)
-        || matches!(name, "and" | "or" | "raise" | "__new__")
+        // OOP slice 1 `__new__` (construct an instance) + slice 2 instance
+        // methods: `__def_method__` (register a `(class,method)` closure) and
+        // `__method__` (dispatch it).  (`__super__`/`__self__`/`__class_method__`/
+        // … stay unsupported — later slices.)
+        || matches!(name, "and" | "or" | "raise" | "__new__" | "__def_method__" | "__method__")
 }
 
-/// The first `BuiltinCall` whose name the v0 emitter cannot lower, if any.  A
-/// structural gate (the C analogue of the Go backend's `check_exception_soundness`):
-/// some builtins — notably `__method__` — are not gated by an *unaccepted
-/// feature*, so a module can pass the capability check yet still contain a
-/// builtin this v0 has no lowering for.  Reporting it lets `compile` reject
-/// cleanly.
+// The structural gate below (`first_unsupported_builtin`) reports the first
+// `BuiltinCall` the v0 emitter cannot lower — some builtins (notably `__method__`)
+// are not gated by an unaccepted feature, so a module can pass the capability
+// check yet still contain an unlowerable builtin — plus the out-of-slice OOP
+// shapes.  The thread-local below carries its `__method__` allowlist.
+thread_local! {
+    // The set of method names the module registers via `__def_method__` — the
+    // CLOSED set that `__method__` dispatch may target (OOP slice 2). A dispatch to
+    // any OTHER name is a built-in-method call (the Collections batch), rejected
+    // until then. Populated once per `first_unsupported_builtin` run (compilation
+    // is single-threaded per module), read in the scan. (Dispatch is already
+    // anti-RCE by construction — an explicit (class,method) table lookup — so this
+    // allowlist is purely for clean COMPILE-TIME rejection.)
+    static DEFINED_METHODS: RefCell<HashSet<String>> = RefCell::new(HashSet::new());
+}
+
+/// Collect the `__def_method__("Class", "m", …)` method names anywhere in `m`
+/// (a full recursive walk, so a dispatch is never wrongly rejected for a
+/// registration nested in a loop/branch/closure).
+fn collect_defined_methods(m: &Module, out: &mut HashSet<String>) {
+    fn from_expr(e: &Expr, out: &mut HashSet<String>) {
+        match e {
+            Expr::BuiltinCall { name, args, .. } => {
+                if name == "__def_method__" {
+                    if let Some(Expr::StrLit { value, .. }) = args.get(1) {
+                        out.insert(value.clone());
+                    }
+                }
+                args.iter().for_each(|a| from_expr(a, out));
+            }
+            Expr::DirectCall { args, .. } => args.iter().for_each(|a| from_expr(a, out)),
+            Expr::IndirectCall { target, args, .. } => {
+                from_expr(target, out);
+                args.iter().for_each(|a| from_expr(a, out));
+            }
+            Expr::KeywordArg { value, .. } => from_expr(value, out),
+            Expr::If {
+                cond,
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                from_expr(cond, out);
+                from_block(then_branch, out);
+                from_block(else_branch, out);
+            }
+            Expr::Block(b) => from_block(b, out),
+            Expr::MakeClosure { captures, .. } => {
+                captures.iter().for_each(|c| from_expr(&c.value, out))
+            }
+            Expr::Convert { value, .. } => from_expr(value, out),
+            Expr::SeqLit { items, .. } => items.iter().for_each(|i| from_expr(i, out)),
+            Expr::SeqIndex { seq, index, .. } => {
+                from_expr(seq, out);
+                from_expr(index, out);
+            }
+            Expr::SeqLen { seq, .. } => from_expr(seq, out),
+            Expr::MapLit { entries, .. } => entries.iter().for_each(|e| {
+                from_expr(&e.key, out);
+                from_expr(&e.value, out);
+            }),
+            Expr::MapGet { map, key, .. } => {
+                from_expr(map, out);
+                from_expr(key, out);
+            }
+            Expr::LogicalAnd { lhs, rhs, .. } | Expr::LogicalOr { lhs, rhs, .. } => {
+                from_expr(lhs, out);
+                from_expr(rhs, out);
+            }
+            _ => {}
+        }
+    }
+    fn from_stmt(s: &Stmt, out: &mut HashSet<String>) {
+        match s {
+            Stmt::LetBinding { value, .. }
+            | Stmt::LetStarBinding { value, .. }
+            | Stmt::ExprStmt { expr: value, .. }
+            | Stmt::Assign { value, .. } => from_expr(value, out),
+            Stmt::While { cond, body, .. } => {
+                from_expr(cond, out);
+                from_block(body, out);
+            }
+            Stmt::ForRange {
+                start,
+                stop,
+                step,
+                body,
+                ..
+            } => {
+                from_expr(start, out);
+                from_expr(stop, out);
+                from_expr(step, out);
+                from_block(body, out);
+            }
+            Stmt::ForEach { iter, body, .. } => {
+                from_expr(iter, out);
+                from_block(body, out);
+            }
+            Stmt::SeqSet {
+                seq, index, value, ..
+            } => {
+                from_expr(seq, out);
+                from_expr(index, out);
+                from_expr(value, out);
+            }
+            Stmt::MapSet {
+                map, key, value, ..
+            } => {
+                from_expr(map, out);
+                from_expr(key, out);
+                from_expr(value, out);
+            }
+            Stmt::TryCatch {
+                body,
+                rescues,
+                ensure_body,
+                ..
+            } => {
+                body.iter().for_each(|s| from_stmt(s, out));
+                rescues
+                    .iter()
+                    .for_each(|rc| rc.body.iter().for_each(|s| from_stmt(s, out)));
+                if let Some(e) = ensure_body {
+                    e.iter().for_each(|s| from_stmt(s, out));
+                }
+            }
+            _ => {}
+        }
+    }
+    fn from_block(b: &Block, out: &mut HashSet<String>) {
+        b.stmts.iter().for_each(|s| from_stmt(s, out));
+        from_expr(&b.value, out);
+    }
+    for f in &m.functions {
+        for p in &f.params {
+            if let Some(d) = &p.default {
+                from_expr(d, out);
+            }
+        }
+        from_block(&f.body, out);
+    }
+}
+
 pub fn first_unsupported_builtin(m: &Module) -> Option<(String, Span)> {
+    let mut defined = HashSet::new();
+    collect_defined_methods(m, &mut defined);
+    DEFINED_METHODS.with(|d| *d.borrow_mut() = defined);
     for f in &m.functions {
         // A SIR19 parameter default is an expression the prologue evaluates at
         // call time, so a deferred builtin nested in one must be pre-checked
@@ -1564,6 +1741,51 @@ fn scan_expr_for_builtin(e: &Expr) -> Option<(String, Span)> {
                     "__new__ with constructor arguments or a non-constant class name".to_string(),
                     span.clone(),
                 ));
+            }
+            // OOP slice 2: `__def_method__` must be `[StrLit(class), StrLit(method),
+            // MakeClosure]` — the emitter reads all three; a malformed shape would
+            // otherwise emit a runtime-failing marker instead of rejecting.
+            if name == "__def_method__"
+                && !matches!(
+                    args.as_slice(),
+                    [Expr::StrLit { .. }, Expr::StrLit { .. }, Expr::MakeClosure { .. }]
+                )
+            {
+                return Some(("a malformed __def_method__ registration".to_string(), span.clone()));
+            }
+            // `__method__` must have a receiver and a `StrLit` method name.
+            if name == "__method__"
+                && !matches!((args.first(), args.get(1)), (Some(_), Some(Expr::StrLit { .. })))
+            {
+                return Some(("a malformed __method__ dispatch".to_string(), span.clone()));
+            }
+            // `__def_method__`/`__method__` carry a `StrLit` class/method name that
+            // must stay a raw C literal.  The compound (control-flow-argument) path
+            // cannot recover it, so reject a call that is not `is_simple` —
+            // deferred, not mis-emitted.
+            if matches!(name.as_str(), "__def_method__" | "__method__") && !is_simple(e) {
+                return Some((
+                    format!("a `{name}` call with a control-flow argument"),
+                    span.clone(),
+                ));
+            }
+            // `__method__(recv, "m", …)` dispatch to a method the module never
+            // registers via `__def_method__` is a BUILT-IN method call (the
+            // Collections batch) — rejected cleanly (dispatch is already anti-RCE
+            // by construction; this preserves clean compile-time rejection).
+            if name == "__method__" {
+                if let Some(Expr::StrLit { value, .. }) = args.get(1) {
+                    let known = DEFINED_METHODS.with(|d| d.borrow().contains(value));
+                    if !known {
+                        return Some((
+                            format!(
+                                "a call to the built-in method `{value}` (only \
+                                 user-defined methods dispatch this slice)"
+                            ),
+                            span.clone(),
+                        ));
+                    }
+                }
             }
             args.iter().find_map(scan_expr_for_builtin)
         }

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -1013,6 +1013,73 @@ SirValue _sir_const_get(const char *name) {
     return _sir_raise(_sir_error("NameError", _sir_str(_sir_cat("uninitialized constant ", name))));
 }
 
+/* ---- OOP: instance-method table & dispatch ------------------ */
+
+/* An EXPLICIT (class, method) -> closure table, populated by emitted
+ * `__def_method__` registrations.  Dispatch (`__method__`) is a DATA lookup on
+ * the (interned class, interned method) key — NEVER reflection on a
+ * source-derived string — so a user method literally named `system`/`eval` is
+ * only ever a table KEY, and an unresolved method is a controlled `NoMethodError`
+ * (the anti-RCE invariant, SIR24 §Security #2).  Keys are interned, so the scan
+ * is a pointer compare.  (Slice 2: a flat table; inheritance walks the ancestry
+ * in a later slice.) */
+#define SIR_METHOD_MAX 8192
+static struct { const char *cls; const char *method; SirValue fn; } _sir_method_tab[SIR_METHOD_MAX];
+static int _sir_method_n = 0;
+
+SirValue _sir_def_method(const char *cls, const char *method, SirValue fn) {
+    const char *c = _sir_intern(cls), *m = _sir_intern(method);
+    int i;
+    for (i = 0; i < _sir_method_n; i++) {
+        if (_sir_method_tab[i].cls == c && _sir_method_tab[i].method == m) {
+            _sir_method_tab[i].fn = fn;
+            return fn;
+        }
+    }
+    if (_sir_method_n < SIR_METHOD_MAX) {
+        _sir_method_tab[_sir_method_n].cls = c;
+        _sir_method_tab[_sir_method_n].method = m;
+        _sir_method_tab[_sir_method_n].fn = fn;
+        _sir_method_n++;
+    }
+    return fn;
+}
+
+/* Look up `(cls, method)` -> closure, or a `SIR_NIL` sentinel on a miss. */
+static SirValue _sir_lookup_method(const char *cls, const char *method) {
+    const char *c = _sir_intern(cls), *m = _sir_intern(method);
+    int i;
+    for (i = 0; i < _sir_method_n; i++) {
+        if (_sir_method_tab[i].cls == c && _sir_method_tab[i].method == m) {
+            return _sir_method_tab[i].fn;
+        }
+    }
+    return _sir_nil();
+}
+
+/* Dispatch an instance method: resolve `(recv's class, method)` and apply the
+ * closure to the args.  A non-instance receiver or an unresolved method is a
+ * (rescuable) `NoMethodError`. */
+SirValue _sir_call_method(SirValue recv, const char *method, int argc, ...) {
+    va_list ap;
+    SirValue *args, fn, r;
+    if (recv.tag != SIR_INSTANCE) {
+        return _sir_raise(_sir_error(
+            "NoMethodError", _sir_str(_sir_cat("undefined method for a non-object receiver: ", method))));
+    }
+    fn = _sir_lookup_method(recv.as.inst->sir_class, method);
+    if (fn.tag != SIR_CLOSURE) {
+        return _sir_raise(
+            _sir_error("NoMethodError", _sir_str(_sir_cat("undefined method ", method))));
+    }
+    va_start(ap, argc);
+    args = _sir_va_collect(argc, ap);
+    va_end(ap);
+    r = fn.as.clo->fn(fn.as.clo->caps, args, argc);
+    if (args) free(args);
+    return r;
+}
+
 SirValue _sir_print_v(SirValue *xs, int n) {
     int i;
     for (i = 0; i < n; i++) _sir_fmt(stdout, xs[i]);

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_classes.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_classes.rs
@@ -176,7 +176,8 @@ fn deferred_oop_shapes_are_rejected_cleanly() {
         ),
         "__new__ with ctor args must be rejected"
     );
-    // A method-bearing class surfaces `__def_method__` (an unsupported builtin).
+    // A MALFORMED `__def_method__` (no closure) — a well-formed one is now
+    // supported (slice 2), but a missing closure must reject, not mis-emit.
     assert!(
         rejects(
             vec![
@@ -185,7 +186,7 @@ fn deferred_oop_shapes_are_rejected_cleanly() {
             ],
             &[Feature::Classes, Feature::Constants, Feature::Strings]
         ),
-        "__def_method__ must be rejected"
+        "a malformed __def_method__ must be rejected"
     );
     // A `class << self` singleton (also observes Feature::Classes).
     assert!(
@@ -195,13 +196,14 @@ fn deferred_oop_shapes_are_rejected_cleanly() {
         ),
         "singleton class must be rejected"
     );
-    // An instance-method dispatch (`__method__`) is a later slice.
+    // A `__method__` dispatch to a method the module never registers is a
+    // built-in method call (the Collections batch) — rejected cleanly.
     assert!(
         rejects(
             vec![puts(bc("__method__", vec![bc("__new__", vec![strlit("Foo")]), strlit("m")]))],
             &[Feature::Classes, Feature::Constants, Feature::Strings]
         ),
-        "__method__ dispatch must be rejected"
+        "an unregistered (built-in) __method__ dispatch must be rejected"
     );
     // A superclass (inheritance dispatch is a later slice) — the empty-class
     // comment emit would otherwise silently drop the link.

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_methods.rs
@@ -1,0 +1,84 @@
+//! Execution proof for OOP mirror slice 2 (instance methods) on the C backend —
+//! lower REAL Ruby source, emit C, compile with a real cc, run, assert stdout.
+//! Skips gracefully when no `cc` is present.
+//!
+//! A method-bearing class lowers to a hoisted function + `__def_method__`
+//! (registering a `(class,method)` closure) + `__method__` (dispatching it). The
+//! dispatch is an explicit table lookup — never reflection.
+
+use std::process::Command;
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    ["cc", "clang", "gcc"]
+        .iter()
+        .find(|c| {
+            Command::new(c)
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        })
+        .map(|s| s.to_string())
+}
+
+/// Lower `src` (Ruby) → C, compile + run, return stdout (or None if no cc).
+fn run_ruby(src: &str) -> Option<String> {
+    let cc = find_cc()?;
+    let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
+    let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
+    let dir = std::env::temp_dir();
+    let stem = format!("sirc_meth_{}_{}", std::process::id(), src.len());
+    let cpath = dir.join(format!("{stem}.c"));
+    let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::write(&cpath, &art.source).expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        art.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "program exited non-zero");
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn instance_method_call() {
+    // `class Greeter; def greet; puts "hi"; end; end; Greeter.new.greet` → "hi".
+    match run_ruby("class Greeter\n  def greet\n    puts \"hi\"\n  end\nend\nGreeter.new.greet\n") {
+        Some(out) => assert_eq!(out, "hi\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn instance_method_with_args_and_return() {
+    // A method with parameters and a return value used by the caller.
+    match run_ruby("class Adder\n  def add(a, b)\n    a + b\n  end\nend\nputs Adder.new.add(2, 3)\n") {
+        Some(out) => assert_eq!(out, "5\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn two_methods_on_one_class() {
+    // Two methods on the same class, both dispatched on a stored instance.
+    match run_ruby(
+        "class Point\n  def x\n    10\n  end\n  def y\n    20\n  end\nend\n\
+         p = Point.new\nputs p.x\nputs p.y\n",
+    ) {
+        Some(out) => assert_eq!(out, "10\n20\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}

--- a/code/packages/rust/semantic-ir-to-c/tests/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/emit.rs
@@ -141,17 +141,18 @@ fn string_literals_are_trigraph_safe() {
 }
 
 #[test]
-fn method_dispatch_is_rejected_in_v0() {
-    // `"hi".length` lowers to the `__method__` collection-dispatch builtin.
-    // It is not gated by an unaccepted *feature* (its receiver is a String,
-    // which v0 accepts), so the structural builtin gate must reject it rather
-    // than emit a call that fails at runtime.
+fn builtin_method_dispatch_is_rejected() {
+    // `"hi".length` lowers to a `__method__` dispatch to `length` — a BUILT-IN
+    // method the module never registers via `__def_method__`.  OOP slice 2 now
+    // lowers user-defined instance methods, but a built-in method call is the
+    // separate Collections batch, so the allowlist rejects it cleanly (rather
+    // than emitting a call that `NoMethodError`s at runtime).
     let m = lower_ruby("puts \"hi\".length");
-    let err = compile(&m).expect_err("v0 rejects __method__ dispatch");
+    let err = compile(&m).expect_err("rejects a built-in method dispatch");
     assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
     assert!(
-        err.message.contains("__method__"),
-        "names the builtin: {}",
+        err.message.contains("length"),
+        "names the built-in method: {}",
         err.message
     );
 }


### PR DESCRIPTION
## What

Instance-method definition and dispatch — the **second slice of the C OOP mirror** (after slice 1's instance runtime). Bumps `semantic-ir-to-c` 0.13.0 → 0.14.0. The C backend now matches Ruby's first two OOP slices (classes+constants, instance methods).

- `__def_method__("C", "m", MakeClosure(fn))` → `_sir_def_method`: inserts the closure into an explicit `(class, method) → closure` table (interned keys).
- `__method__(recv, "m", args…)` → `_sir_call_method`: resolves `(recv's class, "m")` and applies the closure to the args; a non-instance receiver or an unresolved method is a (rescuable) `NoMethodError`.

## Anti-RCE by construction

Dispatch is an **explicit data lookup** on the `(class, method)` interned key — never reflection on a source-derived string (the SIR24 §Security invariant). The stored closure's function pointer comes from a compiler-emitted `MakeClosure` in the same module, so a crafted method *name* is only ever a table key → `NoMethodError` on a miss, never a jump. No `sir_um_`-style prefix trick is needed (unlike Ruby's native `public_send`) — the closed table *is* the guarantee. Class/method names emit as quoted C string literals (no injection surface either).

## Totality / clean rejection

A `__method__` dispatch to a name the module never registers is a **built-in method call** (`.length`/`.upcase` — the Collections batch) and is rejected cleanly, not compiled to a runtime `NoMethodError`: a first pass collects the registered method names (a thread-local allowlist), and the scan validates each dispatch. A malformed `__def_method__` (not `[StrLit, StrLit, MakeClosure]`) or `__method__`, and a `__def_method__`/`__method__` with a control-flow argument (which the compound emit path can't render as a raw C name), are also rejected. `self`/`@ivars` are the next slice, so method bodies here don't yet reference the instance.

## Security review

A read-only security sub-agent reviewed the diff with **C memory safety** as the primary focus and returned **PASSED — no vulnerabilities**: the method table is bounds-checked (past-cap no-op), `_sir_call_method` tag-guards every deref (`recv.tag == SIR_INSTANCE` before `recv.as.inst`, `fn.tag == SIR_CLOSURE` before `fn.as.clo->fn`), varargs match and free symmetrically (the vetted `_sir_apply` pattern), dispatch is a non-reflective interned-key lookup, and the scan makes the emit arms total.

## Tests

`tests/compile_and_run_methods.rs` (3 frontend + `cc` e2e tests: a no-arg method call → "hi", a method with args + return → 5, two methods on one class → "10\n20"). Updated slice-1 rejection tests (a malformed `__def_method__` and an unregistered `__method__` still reject) and the stale `method_dispatch_is_rejected_in_v0` emit test (a built-in `.length` is still rejected, now by the allowlist). All 15 C test files pass; `cargo clippy` clean. CHANGELOG, README, SIR24 spec (roadmap) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)