### PR TITLE
feat(adj-formula-stdlib): anion-gap — StatPearls (Na+K)−(Cl+HCO3) definition library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_anion_gap_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_anion_gap_e2e.rs
@@ -1,0 +1,150 @@
+//! End-to-end tests for the `clinical/anion-gap.adj` library — the definition of the
+//! serum anion gap (AG = (Na + K) - (Cl + HCO3)) and its two exact rearrangements
+//! (Na = AG + Cl + HCO3 - K, HCO3 = Na + K - Cl - AG) — driven through the built CLI
+//! binary against the SHIPPED stdlib. Each proves the same invariant as the other formula
+//! libraries: a consumer states NO arithmetic; it imports the grounded library, binds the
+//! electrolytes with `observe`, and the engine applies the cited definition on the CPU,
+//! computing the EXACT value and rendering the definition's citation and trust tier in the
+//! `derived` section (the auditable answer). The three formulas INVERT around the worked
+//! case Na = 140, K = 5, Cl = 100, HCO3 = 25 mEq/L: (140 + 5) - (100 + 25) = 20, and both
+//! 20 + 100 + 25 - 5 = 140 and 140 + 5 - 100 - 20 = 25 recover the inputs.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped anion-gap library, resolved from this crate's manifest dir
+/// so the test is location-independent.
+fn shipped_anion_gap_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/anion-gap.adj")
+        .canonicalize()
+        .expect("shipped anion-gap.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_ag_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_anion_gap_lib()).unwrap();
+    std::fs::write(dir.join("anion-gap.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// anion_gap — the definition: the measured cations (Na + K) minus the measured anions
+// (Cl + HCO3).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_anion_gap_library_and_computes_definition_with_citation() {
+    let dir = scratch("def");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"anion-gap.adj\"\n\
+         observe sodium(140)\n\
+         observe potassium(5)\n\
+         observe chloride(100)\n\
+         observe bicarbonate(25)\n\
+         ? anion_gap(sodium, potassium, chloride, bicarbonate)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied definition's result:
+    // (140 + 5) - (100 + 25) = 20.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"anion_gap\"") && s.contains("\"value\":20"),
+        "anion_gap(140, 5, 100, 25) = 20: {s}"
+    );
+    // … AND the StatPearls/NCBI Bookshelf citation and trust tier, so the answer is
+    // auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied definition carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// sodium — the same definition solved for Na: AG + Cl + HCO3 - K, which INVERTS the anion
+// gap just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_sodium_from_anion_gap_and_the_other_electrolytes_with_citation() {
+    let dir = scratch("na");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"anion-gap.adj\"\n\
+         observe anion_gap(20)\n\
+         observe potassium(5)\n\
+         observe chloride(100)\n\
+         observe bicarbonate(25)\n\
+         ? sodium(anion_gap, potassium, chloride, bicarbonate)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 20 + 100 + 25 - 5 = 140, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"sodium\"") && s.contains("\"value\":140"),
+        "sodium(20, 5, 100, 25) = 140: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "sodium carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// bicarbonate — the same definition solved for HCO3: Na + K - Cl - AG, the third exact
+// reading of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_bicarbonate_from_anion_gap_and_the_other_electrolytes_with_citation() {
+    let dir = scratch("hco3");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"anion-gap.adj\"\n\
+         observe sodium(140)\n\
+         observe potassium(5)\n\
+         observe chloride(100)\n\
+         observe anion_gap(20)\n\
+         ? bicarbonate(sodium, potassium, chloride, anion_gap)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 140 + 5 - 100 - 20 = 25, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"bicarbonate\"") && s.contains("\"value\":25"),
+        "bicarbonate(140, 5, 100, 20) = 25: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "bicarbonate carries its StatPearls citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/anion-gap.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/anion-gap.adj
@@ -1,0 +1,106 @@
+% ============================================================================
+% anion-gap.adj — the definition of the serum anion gap
+% (AG = (Na + K) − (Cl + HCO3)) in the ADJ standard library.
+% ============================================================================
+% The anion-gap entry of the *clinical* track, an acid–base sibling of
+% `mean-arterial-pressure.adj`, `pulse-pressure.adj` and `cardiac-output.adj`: the
+% foundational electrolyte relationship a first course states as THE ANION GAP IS THE
+% DIFFERENCE BETWEEN THE MEASURED CATIONS (Na, K) AND THE MEASURED ANIONS (Cl, HCO3) — as
+% an importable, byte-provenanced, PARAMETERIZED `formula`, together with two exact
+% rearrangements (the sodium the other three imply, and the bicarbonate the other three
+% imply). As with every compute library, a consumer states NO arithmetic: it `import`s
+% this file, binds the measured electrolytes from its own byte-provenance decomposition,
+% and asks the engine to APPLY the cited definition on the CPU. Zero math is performed by
+% the model; the engine computes each value EXACTLY, carrying the definition's citation.
+%
+%     import "anion-gap.adj"
+%     observe sodium(140)        % "…Na 140 mEq/L…"      (span cited by the model)
+%     observe potassium(5)       % "…K 5 mEq/L…"         (span cited by the model)
+%     observe chloride(100)      % "…Cl 100 mEq/L…"      (span cited by the model)
+%     observe bicarbonate(25)    % "…HCO3 25 mEq/L…"     (span cited by the model)
+%     ? anion_gap(sodium, potassium, chloride, bicarbonate)
+%                                  % engine → 20, carrying AG = (Na + K) − (Cl + HCO3)
+%
+% All three formulas are EXACT over their parameters (sums and differences of measured
+% quantities); there is no separately grounded physiological constant, so every value the
+% engine returns is exact. The three COMPOSE and invert cleanly around the worked case
+% Na = 140, K = 5, Cl = 100, HCO3 = 25 mEq/L (AG = (140 + 5) − (100 + 25) = 20 mEq/L): the
+% `anion_gap` a consumer computes from the four electrolytes is exactly the `anion_gap`
+% the `sodium` formula moves to the other side to recover the sodium, and exactly the
+% `anion_gap` the `bicarbonate` formula moves to the other side to recover the
+% bicarbonate.
+%
+%   anion_gap(sodium, potassium, chloride, bicarbonate) = sodium + potassium - (chloride + bicarbonate)
+%                                                                 % AG = (Na + K) − (Cl + HCO3)   (definition)
+%   sodium(anion_gap, potassium, chloride, bicarbonate) = anion_gap + chloride + bicarbonate - potassium
+%                                                                 % Na = AG + Cl + HCO3 − K        (same def, solved for Na)
+%   bicarbonate(sodium, potassium, chloride, anion_gap) = sodium + potassium - chloride - anion_gap
+%                                                                 % HCO3 = Na + K − Cl − AG        (same def, solved for HCO3)
+%
+% NOTE: the electrolytes must be in the same unit (milliequivalents per litre, mEq/L, by
+% clinical convention — numerically equal to mmol/L for these monovalent ions); the anion
+% gap then comes out in that same unit. This library computes the exact value over
+% whatever consistent unit it is given. This is the potassium-INCLUSIVE form the cited
+% source states; a laboratory that omits potassium simply observes it as 0.
+%
+% All three formulas are defended by the SAME definitional sentence — "Using the results
+% of the comprehensive metabolic panel (CMP), the anion gap is the difference between
+% measured cations (positively charged ions like Na+ and K+) and measured anions
+% (negatively charged ions like Cl- and HCO3-)." — because that one definition (the anion
+% gap IS the cations-minus-anions difference) sanctions the relation read every way (AG
+% from the four electrolytes, Na from AG and the rest, or HCO3 from AG and the rest). The
+% quote is transcribed verbatim from the StatPearls "Biochemistry, Anion Gap" article on
+% the NCBI Bookshelf, so each `formula` carries the provenance envelope every shipped
+% grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the definitional sentence is a verbatim span of the
+% cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable serum electrolyte the definition ranges
+% over, and each result is a derived quantity. `sodium`, `bicarbonate` and `anion_gap`
+% each appear BOTH as a derived result and as an input (of the other formulas), so each is
+% a single dictionary term used in both roles. The `surface` lists are the everyday names
+% a decomposer maps onto the canonical term; the trailing comment records the intended
+% unit.
+% ----------------------------------------------------------------------------
+dictionary anion_gap_vocab {
+    define sodium      : finding  surface "sodium", "Na", "Na+"                          % milliequivalents per litre (mEq/L)
+    define potassium   : finding  surface "potassium", "K", "K+"                         % milliequivalents per litre (mEq/L)
+    define chloride    : finding  surface "chloride", "Cl", "Cl-"                        % milliequivalents per litre (mEq/L)
+    define bicarbonate : finding  surface "bicarbonate", "HCO3", "HCO3-", "total CO2"    % milliequivalents per litre (mEq/L)
+    define anion_gap   : finding  surface "anion gap", "AG"                              % milliequivalents per litre (mEq/L)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable `let` over its
+% formal parameters, bound at apply time, and each carries the definitional quote from
+% StatPearls on the NCBI Bookshelf (a quote is required on a shipped formula). Each is a
+% sum-and-difference of measured quantities, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook anion_gap_laws {
+    use anion_gap_vocab
+
+    % Anion gap — the difference between the measured cations (Na + K) and the measured
+    % anions (Cl + HCO3), i.e. AG = (Na + K) − (Cl + HCO3).
+    formula anion_gap(sodium, potassium, chloride, bicarbonate) = sodium + potassium - (chloride + bicarbonate)
+        source "Using the results of the comprehensive metabolic panel (CMP), the anion gap is the difference between measured cations (positively charged ions like Na+ and K+) and measured anions (negatively charged ions like Cl- and HCO3-)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK539757/"
+        trust authoritative
+
+    % Sodium — the same definition solved for the sodium the anion gap and the other three
+    % electrolytes imply (Na = AG + Cl + HCO3 − K). Defended by the SAME definitional
+    % sentence, read the other way.
+    formula sodium(anion_gap, potassium, chloride, bicarbonate) = anion_gap + chloride + bicarbonate - potassium
+        source "Using the results of the comprehensive metabolic panel (CMP), the anion gap is the difference between measured cations (positively charged ions like Na+ and K+) and measured anions (negatively charged ions like Cl- and HCO3-)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK539757/"
+        trust authoritative
+
+    % Bicarbonate — the same definition solved for the bicarbonate the anion gap and the
+    % other three electrolytes imply (HCO3 = Na + K − Cl − AG). Again the SAME definitional
+    % sentence, read the third way.
+    formula bicarbonate(sodium, potassium, chloride, anion_gap) = sodium + potassium - chloride - anion_gap
+        source "Using the results of the comprehensive metabolic panel (CMP), the anion gap is the difference between measured cations (positively charged ions like Na+ and K+) and measured anions (negatively charged ions like Cl- and HCO3-)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK539757/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/anion-gap.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/anion-gap.query.adj
@@ -1,0 +1,35 @@
+% ============================================================================
+% anion-gap.query.adj — worked examples over the clinical anion-gap library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER an anion-gap question: it
+% states NO arithmetic and NO definition — it only `import`s the grounded library,
+% `observe`s the electrolytes it decomposed from the prompt (each a byte-provenanced span,
+% elided here), and asks the engine to APPLY the cited definition. The native adj-lang
+% engine binds the parameters, computes each value EXACTLY on the CPU, and returns it with
+% the definition's source/locator/trust.
+%
+% The three questions INVERT: a comprehensive metabolic panel with Na 140, K 5, Cl 100,
+% HCO3 25 mEq/L has an anion gap of (140 + 5) − (100 + 25) = 20 mEq/L; that 20 mEq/L anion
+% gap with the same K, Cl and HCO3 is exactly what the sodium formula recovers the 140
+% mEq/L sodium from, and that 20 mEq/L anion gap with the same Na, K and Cl is exactly
+% what the bicarbonate formula recovers the 25 mEq/L bicarbonate from.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli anion-gap.query.adj
+% ============================================================================
+
+import "anion-gap.adj"
+
+% Na 140, K 5, Cl 100, HCO3 25 mEq/L: anion gap = (140 + 5) − (100 + 25).
+observe sodium(140)
+observe potassium(5)
+observe chloride(100)
+observe bicarbonate(25)
+? anion_gap(sodium, potassium, chloride, bicarbonate)     % expect 20   (definition: AG = (Na + K) − (Cl + HCO3))
+
+% That 20 mEq/L anion gap with the same K, Cl and HCO3: sodium = 20 + 100 + 25 − 5.
+observe anion_gap(20)
+? sodium(anion_gap, potassium, chloride, bicarbonate)      % expect 140  (same definition, solved for Na = AG + Cl + HCO3 − K)
+
+% That 20 mEq/L anion gap with the same Na, K and Cl: bicarbonate = 140 + 5 − 100 − 20.
+? bicarbonate(sodium, potassium, chloride, anion_gap)      % expect 25   (same definition, solved for HCO3 = Na + K − Cl − AG)


### PR DESCRIPTION
## What

Adds the **serum anion gap** to the clinical formula-library track of `adj-formula-stdlib`: a byte-provenanced, importable `formulabook` grounding the definition **AG = (Na + K) − (Cl + HCO3)** and its two exact algebraic rearrangements, each defended by the same verbatim source sentence.

A consumer states **NO arithmetic**: it `import`s the library, `observe`s the measured electrolytes it decomposed from the prompt (each a byte-provenanced span), and the engine **applies the cited definition on the CPU, EXACT** (BigRational), carrying `source`/`locator`/`trust` into the auditable `derived` section. Zero math is performed by the model.

## The three grounded formulas (one definition, read three ways)

| formula | reading |
|---|---|
| `anion_gap(sodium, potassium, chloride, bicarbonate) = sodium + potassium - (chloride + bicarbonate)` | AG = (Na + K) − (Cl + HCO3) — definition |
| `sodium(anion_gap, potassium, chloride, bicarbonate) = anion_gap + chloride + bicarbonate - potassium` | Na = AG + Cl + HCO3 − K |
| `bicarbonate(sodium, potassium, chloride, anion_gap) = sodium + potassium - chloride - anion_gap` | HCO3 = Na + K − Cl − AG |

They compose and invert cleanly around the worked case **Na 140, K 5, Cl 100, HCO3 25 mEq/L → AG = 145 − 125 = 20 mEq/L**.

## Provenance

All three formulas carry the SAME verbatim definitional sentence, transcribed from the StatPearls *"Biochemistry, Anion Gap"* article on the NCBI Bookshelf:

> "Using the results of the comprehensive metabolic panel (CMP), the anion gap is the difference between measured cations (positively charged ions like Na+ and K+) and measured anions (negatively charged ions like Cl- and HCO3-)."

`locator https://www.ncbi.nlm.nih.gov/books/NBK539757/` · `trust authoritative`. This is the potassium-INCLUSIVE form the cited source states (a lab that omits K simply observes it as 0). Nothing is asserted from memory — the definition is a verbatim span of the cited page.

## Files (data + one dedicated e2e test only; no version bump)

- `clinical/anion-gap.adj` — dictionary + formulabook (3 grounded formulas)
- `clinical/anion-gap.query.adj` — worked, inverting query triple over the library
- `adj-lang-cli/tests/formula_anion_gap_e2e.rs` — 3 e2e tests through the built CLI against the shipped stdlib: exact value (20 / 140 / 25) + `trust authoritative` + `ncbi.nlm.nih.gov` locator in the derived section

## Verification

- Shipped query renders 20 / 140 / 25 exact (BigRational 20/1 etc.); derivation tree (140+5)−(100+25)=20
- `cargo test -p adj-lang-cli --test formula_anion_gap_e2e` → **3/3 pass**
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean
- New source files NUL-scan 0
- `/security-review` → PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)