### PR TITLE
Add MOS drain diffusion area capacitance

### DIFF
--- a/code/packages/python/mosfet-models/CHANGELOG.md
+++ b/code/packages/python/mosfet-models/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [0.1.0] — Unreleased
 
 ### Added
+- `Level1Params.AD` and `Level1Params.CJ` add zero-default Berkeley drain
+  diffusion area and bottom-junction capacitance density, contributing
+  `CJ * AD` to the zero-bias drain-body capacitance.
 - `Level1Params.NRS` adds the Berkeley source diffusion square count, defaulting
   to one with finite, non-negative validation.
 - `Level1Params.NRD` adds the Berkeley drain diffusion square count, defaulting

--- a/code/packages/python/mosfet-models/README.md
+++ b/code/packages/python/mosfet-models/README.md
@@ -28,8 +28,9 @@ print(r.Id, r.gm, r.gds, r.region)
   depletion shaping, Berkeley-default `TOX` gate oxide thickness for intrinsic
   Meyer capacitance through `Cox = epsilon_ox / TOX`, zero-default `RD` / `RS`
   external drain/source resistance, zero-default `RSH` sheet resistance,
-  one-default `NRD` / `NRS` drain/source diffusion square counts, and `KF` /
-  `AF` flicker noise.
+  one-default `NRD` / `NRS` drain/source diffusion square counts, zero-default
+  drain diffusion area `AD` and bottom-junction capacitance density `CJ`
+  contributing `CJ * AD` to `CBD`, and `KF` / `AF` flicker noise.
 - `evaluate_level1(params, V_GS, V_DS, V_BS, T)`: returns `MosResult` with Id, gm, gds, gmb, Cgs/Cgd/Cgb/Cbs/Cbd, region.
 - Region detection: cutoff (subthreshold-aware), triode, saturation.
 - Body effect via gamma * (sqrt(PHI-V_BS) - sqrt(PHI)) shift.

--- a/code/packages/python/mosfet-models/src/mosfet_models/level1.py
+++ b/code/packages/python/mosfet-models/src/mosfet_models/level1.py
@@ -34,6 +34,8 @@ class Level1Params:
     RSH: float = 0.0  # drain/source sheet resistance (ohm per square)
     NRD: float = 1.0  # number of drain diffusion squares
     NRS: float = 1.0  # number of source diffusion squares
+    AD: float = 0.0  # drain diffusion area (m^2)
+    CJ: float = 0.0  # bottom junction capacitance per area (F/m^2)
     IS: float = 1e-15  # saturation current (A)
     N_SUB: float = 1.4  # subthreshold slope factor
     T_NOM: float = 300.15  # nominal temperature (K)
@@ -137,6 +139,10 @@ def evaluate_level1(
         raise ValueError("MOSFET NRD must be finite and non-negative")
     if not isfinite(p.NRS) or p.NRS < 0.0:
         raise ValueError("MOSFET NRS must be finite and non-negative")
+    if not isfinite(p.AD) or p.AD < 0.0:
+        raise ValueError("MOSFET AD must be finite and non-negative")
+    if not isfinite(p.CJ) or p.CJ < 0.0:
+        raise ValueError("MOSFET CJ must be finite and non-negative")
     beta = p.KP * (p.W / effective_length)
 
     # Threshold with body effect. The formula is well-defined whenever
@@ -159,7 +165,13 @@ def evaluate_level1(
     Cgd_intrinsic = 0.0
     Cgb_intrinsic = 0.0
     Cbs_bulk = bulk_junction_capacitance(p.CBS, V_BS, p.PB, p.MJ, p.FC)
-    Cbd_bulk = bulk_junction_capacitance(p.CBD, V_BS - V_DS, p.PB, p.MJ, p.FC)
+    Cbd_bulk = bulk_junction_capacitance(
+        p.CBD + p.CJ * p.AD,
+        V_BS - V_DS,
+        p.PB,
+        p.MJ,
+        p.FC,
+    )
 
     if V_OV <= 0:
         # Cutoff — optionally subthreshold.

--- a/code/packages/python/mosfet-models/tests/test_models.py
+++ b/code/packages/python/mosfet-models/tests/test_models.py
@@ -207,6 +207,27 @@ def test_source_squares_rejects_negative_value():
         evaluate_level1(Level1Params(NRS=-1.0), V_GS=1.8, V_DS=1.8)
 
 
+def test_drain_area_scales_bottom_junction_capacitance():
+    result = evaluate_level1(
+        Level1Params(CBD=1.0e-12, CJ=2.0e-3, AD=3.0e-9, MJ=0.0),
+        V_GS=1.8,
+        V_DS=0.0,
+    )
+    assert result.Cbd == pytest.approx(7.0e-12)
+
+
+@pytest.mark.parametrize(
+    ("params", "message"),
+    [
+        (Level1Params(AD=-1.0), "MOSFET AD must be finite and non-negative"),
+        (Level1Params(CJ=-1.0), "MOSFET CJ must be finite and non-negative"),
+    ],
+)
+def test_drain_geometry_rejects_negative_values(params, message):
+    with pytest.raises(ValueError, match=message):
+        evaluate_level1(params, V_GS=1.8, V_DS=1.8)
+
+
 def test_overlap_and_bulk_capacitances_are_reported():
     p = Level1Params(
         W=2e-6,

--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add the Level-1 MOS `AD` instance parameter and model-card `CJ` density.
+  Their product augments `CBD` in AC and transient drain-body capacitance.
 - Add the Level-1 MOS `NRS` instance parameter. It defaults to one and scales
   the `RSH` source fallback while preserving explicit positive `RS` precedence,
   intrinsic-node stamping, and `:RS` Johnson noise.

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -102,7 +102,9 @@ node, routes the channel and source-side capacitances through it, and contribute
 `RSH` defaults to zero ohms per square. `NRD` and `NRS` default to one drain
 and source square, so the fallbacks are `RSH * NRD` and `RSH * NRS`; explicit
 positive `RD` / `RS` values take precedence.
-The source fallback remains one square until the matching source-geometry slice.
+`AD` and model-card `CJ` default to zero, are finite and non-negative, and add
+`CJ * AD` to the zero-bias drain-body capacitance `CBD` in AC and transient
+analysis.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -9113,7 +9113,9 @@ def _mosfet_charge_state_specs(el: Mosfet) -> list[tuple[str, str, str, float]]:
     cgd = getattr(params, "CGDO", 0.0) * width
     cgb = getattr(params, "CGBO", 0.0) * length
     cbs = getattr(params, "CBS", 0.0)
-    cbd = getattr(params, "CBD", 0.0)
+    cbd = getattr(params, "CBD", 0.0) + (
+        getattr(params, "CJ", 0.0) * getattr(params, "AD", 0.0)
+    )
     if cgs > 0.0:
         specs.append(
             (

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -311,8 +311,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "PNP": (41, 58, 13, 4),
     "NJF": (22, 30, 7, 3),
     "PJF": (22, 30, 7, 3),
-    "NMOS": (26, 33, 6, 3),
-    "PMOS": (26, 33, 6, 3),
+    "NMOS": (27, 34, 6, 3),
+    "PMOS": (27, 34, 6, 3),
 }
 
 
@@ -480,6 +480,7 @@ _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
     "CJS": "CBS",
     "CBD": "CBD",
     "CJD": "CBD",
+    "CJ": "CJ",
     "PB": "PB",
     "MJ": "MJ",
     "FC": "FC",
@@ -1085,6 +1086,7 @@ def mosfet_from_model_card(
         CGBO=p.get("CGBO", defaults.CGBO),
         CBS=p.get("CBS", defaults.CBS),
         CBD=p.get("CBD", defaults.CBD),
+        CJ=p.get("CJ", defaults.CJ),
         PB=p.get("PB", defaults.PB),
         MJ=p.get("MJ", defaults.MJ),
         FC=p.get("FC", defaults.FC),

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -408,7 +408,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 193
+    assert len(coverage) == 195
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -423,7 +423,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tAF\tAF\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 193
+    assert len(records) == 195
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -446,8 +446,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert summary[0].max_alias_count == 3
     assert summary[0].aliased_parameters == ("IS", "VT", "CJO", "VJ", "M")
     assert summary[5].kind == "NMOS"
-    assert summary[5].canonical_parameter_count == 26
-    assert summary[5].accepted_name_count == 33
+    assert summary[5].canonical_parameter_count == 27
+    assert summary[5].accepted_name_count == 34
     assert summary[5].aliased_parameter_count == 6
     assert summary[5].max_alias_count == 3
     assert summary[5].aliased_parameters == (
@@ -469,7 +469,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert table.splitlines()[1] == "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M"
     assert (
         table.splitlines()[-1]
-        == "PMOS\t26\t33\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        == "PMOS\t27\t34\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
     )
     records = model_card_supported_parameter_coverage_summary_records()
     assert len(records) == 7
@@ -497,9 +497,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 193
-    assert report.expected_canonical_parameter_count == 193
-    assert report.accepted_name_count == 263
+    assert report.canonical_parameter_count == 195
+    assert report.expected_canonical_parameter_count == 195
+    assert report.accepted_name_count == 265
     assert report.aliased_parameter_count == 57
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -507,7 +507,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t193\t193\t263\t57\t4\t0"
+        "true\t7\t7\t195\t195\t265\t57\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -535,15 +535,15 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 192
-    assert report.accepted_name_count == 260
+    assert report.canonical_parameter_count == 194
+    assert report.accepted_name_count == 262
     assert report.aliased_parameter_count == 56
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
     assert report.issues[0].field == "canonical_parameter_count"
     assert report.issues[0].message == (
-        "expected NMOS to expose 26 canonical supported parameters, found 25"
+        "expected NMOS to expose 27 canonical supported parameters, found 26"
     )
     assert report.issues[-1].field == "max_alias_count"
     assert report.issues[-1].message == "expected NMOS max alias count 3, found 2"
@@ -551,12 +551,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t192\t193\t260\t56\t4\t4\n"
+        "false\t7\t7\t194\t195\t262\t56\t4\t4\n"
         "kind\tfield\tmessage\n"
-        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 26 canonical "
-        "supported parameters, found 25\n"
-        "NMOS\taccepted_name_count\texpected NMOS to expose 33 accepted model-card "
-        "names, found 30\n"
+        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 27 canonical "
+        "supported parameters, found 26\n"
+        "NMOS\taccepted_name_count\texpected NMOS to expose 34 accepted model-card "
+        "names, found 31\n"
         "NMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing "
         "parameters, found 5\n"
         "NMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
@@ -565,12 +565,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
     assert records[0] == {
         "kind": "NMOS",
         "field": "canonical_parameter_count",
-        "message": "expected NMOS to expose 26 canonical supported parameters, found 25",
+        "message": "expected NMOS to expose 27 canonical supported parameters, found 26",
     }
     assert format_model_card_supported_parameter_coverage_gate_issue_csv(report).startswith(
         "kind,field,message\n"
-        'NMOS,canonical_parameter_count,"expected NMOS to expose 26 canonical '
-        'supported parameters, found 25"\n'
+        'NMOS,canonical_parameter_count,"expected NMOS to expose 27 canonical '
+        'supported parameters, found 26"\n'
     )
     assert (
         json.loads(format_model_card_supported_parameter_coverage_gate_issue_json(report))
@@ -751,6 +751,7 @@ def test_model_card_aliases_build_device_instances() -> None:
             "RD": 125.0,
             "RS": 75.0,
             "RSH": 50.0,
+            "CJ": 2.0e-3,
             "TOX": 25.0e-9,
             "KF": 2.0e-24,
             "AF": 1.4,
@@ -770,6 +771,7 @@ def test_model_card_aliases_build_device_instances() -> None:
         "RD": 125.0,
         "RS": 75.0,
         "RSH": 50.0,
+        "CJ": 2.0e-3,
         "TOX": 25.0e-9,
         "KF": 2.0e-24,
         "AF": 1.4,
@@ -790,6 +792,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(50.0) == mos_model.model.model.params.RSH
     assert pytest.approx(1.0) == mos_model.model.model.params.NRD
     assert pytest.approx(1.0) == mos_model.model.model.params.NRS
+    assert pytest.approx(2.0e-3) == mos_model.model.model.params.CJ
     assert pytest.approx(25.0e-9) == mos_model.model.model.params.TOX
     assert pytest.approx(2.0e-24) == mos_model.model.model.params.KF
     assert pytest.approx(1.4) == mos_model.model.model.params.AF
@@ -1793,8 +1796,8 @@ def test_transient_mosfet_overlap_capacitance_slows_gate_step() -> None:
     assert charged_first < uncharged_first
 
 
-def test_transient_mosfet_bulk_junction_capacitance_slows_drain_step() -> None:
-    def run(cbd: float) -> TransientResult:
+def test_transient_mosfet_drain_area_scales_bottom_junction_capacitance() -> None:
+    def run(cj: float, ad: float) -> TransientResult:
         circuit = Circuit()
         circuit.add(VoltageSource(
             "Vstep",
@@ -1812,13 +1815,13 @@ def test_transient_mosfet_bulk_junction_capacitance_slows_drain_step() -> None:
             "0",
             MOSFET(
                 MosfetType.NMOS,
-                Level1Model(Level1Params(KP=1.0e-12, W=1.0, L=1.0, CBD=cbd)),
+                Level1Model(Level1Params(KP=1.0e-12, W=1.0, L=1.0, CJ=cj, AD=ad)),
             ),
         ))
         return transient(circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler")
 
-    uncharged = run(0.0)
-    charged = run(1.0e-9)
+    uncharged = run(0.0, 0.0)
+    charged = run(0.5, 2.0e-9)
 
     assert uncharged.converged
     assert charged.converged
@@ -2104,6 +2107,52 @@ def test_mosfet_rejects_invalid_source_squares(
     with pytest.raises(
         ValueError,
         match="MOSFET NRS must be finite and non-negative",
+    ):
+        dc_op(circuit)
+
+
+@pytest.mark.parametrize("drain_area", [float("nan"), -1.0])
+def test_mosfet_rejects_invalid_drain_area(drain_area: float) -> None:
+    circuit = Circuit()
+    circuit.add(Mosfet(
+        "Mbad",
+        "drain",
+        "gate",
+        "0",
+        "0",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(Level1Params(AD=drain_area)),
+        ),
+    ))
+
+    with pytest.raises(
+        ValueError,
+        match="MOSFET AD must be finite and non-negative",
+    ):
+        dc_op(circuit)
+
+
+@pytest.mark.parametrize("bottom_junction_capacitance", [float("nan"), -1.0])
+def test_mosfet_rejects_invalid_bottom_junction_capacitance(
+    bottom_junction_capacitance: float,
+) -> None:
+    circuit = Circuit()
+    circuit.add(Mosfet(
+        "Mbad",
+        "drain",
+        "gate",
+        "0",
+        "0",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(Level1Params(CJ=bottom_junction_capacitance)),
+        ),
+    ))
+
+    with pytest.raises(
+        ValueError,
+        match="MOSFET CJ must be finite and non-negative",
     ):
         dc_op(circuit)
 
@@ -3054,6 +3103,8 @@ def test_subcircuit_expansion_preserves_mos_geometry():
                             RSH=50.0,
                             NRD=2.0,
                             NRS=3.0,
+                            AD=4.0e-12,
+                            CJ=2.0e-3,
                             TOX=25.0e-9,
                         )
                     ),
@@ -3075,6 +3126,8 @@ def test_subcircuit_expansion_preserves_mos_geometry():
     assert pytest.approx(50.0) == expanded.model.model.params.RSH
     assert pytest.approx(2.0) == expanded.model.model.params.NRD
     assert pytest.approx(3.0) == expanded.model.model.params.NRS
+    assert pytest.approx(4.0e-12) == expanded.model.model.params.AD
+    assert pytest.approx(2.0e-3) == expanded.model.model.params.CJ
     assert pytest.approx(25.0e-9) == expanded.model.model.params.TOX
 
 
@@ -5747,6 +5800,41 @@ def test_ac_mosfet_overlap_capacitance_shunts_high_frequency_gate_drive():
 
     assert without_capacitance > 0.9
     assert with_capacitance < without_capacitance / 100.0
+
+
+def test_ac_mosfet_drain_area_scales_bottom_junction_capacitance():
+    def drain_amplitude(cj: float, ad: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vac", "in", "0", 0.0, ac=AcSource(1.0)))
+        circuit.add(Resistor("Rin", "in", "drain", 1000.0))
+        circuit.add(Mosfet(
+            "M1",
+            "drain",
+            "0",
+            "0",
+            "0",
+            MOSFET(
+                MosfetType.NMOS,
+                Level1Model(
+                    Level1Params(
+                        KP=1.0e-12,
+                        W=1.0,
+                        L=1.0,
+                        TOX=1.0e9,
+                        CJ=cj,
+                        AD=ad,
+                    )
+                ),
+            ),
+        ))
+        result = ac_sweep(circuit, f_start=100000.0, f_stop=100000.0, n_points=1)
+        return abs(result.points[0].node_voltages["drain"])
+
+    without_area_capacitance = drain_amplitude(0.5, 0.0)
+    with_area_capacitance = drain_amplitude(0.5, 2.0e-6)
+
+    assert without_area_capacitance > 0.9
+    assert with_area_capacitance < without_area_capacitance / 100.0
 
 
 def test_ac_mosfet_oxide_thickness_scales_intrinsic_gate_capacitance():

--- a/code/packages/rust/mosfet-models/CHANGELOG.md
+++ b/code/packages/rust/mosfet-models/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- `Level1Params::ad` and `Level1Params::cj` add zero-default Berkeley drain
+  diffusion area and bottom-junction capacitance density, contributing
+  `CJ * AD` to the zero-bias drain-body capacitance.
 - `Level1Params::nrs` adds the Berkeley source diffusion square count,
   defaulting to one with finite, non-negative validation.
 - `Level1Params::nrd` adds the Berkeley drain diffusion square count, defaulting

--- a/code/packages/rust/mosfet-models/README.md
+++ b/code/packages/rust/mosfet-models/README.md
@@ -8,7 +8,8 @@ This crate implements the classical square-law MOSFET model used in introductory
 
 - **`Level1Params`** — Level-1 geometry, DC, capacitance, temperature, and
   noise parameters, including zero-default `LD` lateral diffusion,
-  Berkeley-default `TOX` gate oxide thickness, `KF` flicker noise, and a
+  Berkeley-default `TOX` gate oxide thickness, drain diffusion area `AD`,
+  bottom-junction capacitance density `CJ`, `KF` flicker noise, and a
   unit-default `AF` exponent.
 - **`evaluate_level1`** — core I-V evaluation returning `MosResult` with `Id`, `gm`, `gds`, `gmb`, gate/body capacitances, and the operating `Region`.
 - **`Region`** — `Cutoff`, `Subthreshold`, `Triode`, `Saturation`.
@@ -31,6 +32,8 @@ and must leave a positive effective channel length. `TOX` defaults to
 external drain, source, and sheet-resistance parameters for engine topology and
 default to zero ohms. `NRD` and `NRS` are finite, non-negative drain/source
 diffusion square counts and default to one.
+`AD` and `CJ` are finite, non-negative and default to zero; together they add
+`CJ * AD` to the zero-bias drain-body capacitance `CBD`.
 
 ## Usage
 

--- a/code/packages/rust/mosfet-models/src/lib.rs
+++ b/code/packages/rust/mosfet-models/src/lib.rs
@@ -45,6 +45,8 @@ const OXIDE_PERMITTIVITY: f64 = 3.453_133e-11;
 /// | RSH       | Drain/source sheet resistance (ohm) | 0        |
 /// | NRD       | Number of drain squares              | 1        |
 /// | NRS       | Number of source squares             | 1        |
+/// | AD        | Drain diffusion area (m²)             | 0        |
+/// | CJ        | Bottom junction capacitance (F/m²)    | 0        |
 /// | IS        | Drain–body saturation current (A)  | 1 fA     |
 /// | N_SUB     | Subthreshold slope factor          | 1.4      |
 /// | T_NOM     | Nominal temperature (K)            | 300.15   |
@@ -80,6 +82,10 @@ pub struct Level1Params {
     pub nrd: f64,
     /// Number of squares in the source diffusion.
     pub nrs: f64,
+    /// Drain diffusion area [m²].
+    pub ad: f64,
+    /// Bottom junction capacitance per unit area [F/m²].
+    pub cj: f64,
     /// Drain–body saturation current [A] (used for subthreshold floor).
     pub is: f64,
     /// Subthreshold slope factor n.  Subthreshold current ∝ exp(V_OV / (n V_T)).
@@ -127,6 +133,8 @@ impl Default for Level1Params {
             rsh: 0.0,
             nrd: 1.0,
             nrs: 1.0,
+            ad: 0.0,
+            cj: 0.0,
             is: 1e-15,
             n_sub: 1.4,
             t_nom: 300.15,
@@ -284,6 +292,14 @@ pub fn evaluate_level1(
         p.nrs.is_finite() && p.nrs >= 0.0,
         "MOSFET NRS must be finite and non-negative"
     );
+    assert!(
+        p.ad.is_finite() && p.ad >= 0.0,
+        "MOSFET AD must be finite and non-negative"
+    );
+    assert!(
+        p.cj.is_finite() && p.cj >= 0.0,
+        "MOSFET CJ must be finite and non-negative"
+    );
     let beta = p.kp * (p.w / effective_length);
 
     // Threshold with body effect.
@@ -306,7 +322,7 @@ pub fn evaluate_level1(
     // Meyer gate-to-channel capacitance, partitioned by operating region below.
     let channel_capacitance = p.w * effective_length * (OXIDE_PERMITTIVITY / p.tox);
     let cbs_bulk = bulk_junction_capacitance(p.cbs, v_bs, p.pb, p.mj, p.fc);
-    let cbd_bulk = bulk_junction_capacitance(p.cbd, v_bs - v_ds, p.pb, p.mj, p.fc);
+    let cbd_bulk = bulk_junction_capacitance(p.cbd + p.cj * p.ad, v_bs - v_ds, p.pb, p.mj, p.fc);
 
     // -----------------------------------------------------------------------
     // Cutoff / subthreshold

--- a/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
+++ b/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
@@ -17,6 +17,8 @@ fn test_default_params() {
     assert_eq!(p.ld, 0.0);
     assert_eq!(p.nrd, 1.0);
     assert_eq!(p.nrs, 1.0);
+    assert_eq!(p.ad, 0.0);
+    assert_eq!(p.cj, 0.0);
     assert_eq!(p.kf, 0.0);
     assert_eq!(p.af, 1.0);
     assert!(p.subthreshold_enable);
@@ -232,6 +234,54 @@ fn test_source_squares_rejects_negative_value() {
     let _ = evaluate_level1(
         &Level1Params {
             nrs: -1.0,
+            ..Level1Params::default()
+        },
+        1.8,
+        1.8,
+        0.0,
+        300.15,
+    );
+}
+
+#[test]
+fn test_drain_area_scales_bottom_junction_capacitance() {
+    let result = evaluate_level1(
+        &Level1Params {
+            cbd: 1.0e-12,
+            cj: 2.0e-3,
+            ad: 3.0e-9,
+            mj: 0.0,
+            ..Level1Params::default()
+        },
+        1.8,
+        0.0,
+        0.0,
+        300.15,
+    );
+    assert!((result.cbd - 7.0e-12).abs() < 1.0e-24);
+}
+
+#[test]
+#[should_panic(expected = "MOSFET AD must be finite and non-negative")]
+fn test_drain_area_rejects_negative_value() {
+    let _ = evaluate_level1(
+        &Level1Params {
+            ad: -1.0,
+            ..Level1Params::default()
+        },
+        1.8,
+        1.8,
+        0.0,
+        300.15,
+    );
+}
+
+#[test]
+#[should_panic(expected = "MOSFET CJ must be finite and non-negative")]
+fn test_bottom_junction_capacitance_rejects_negative_value() {
+    let _ = evaluate_level1(
+        &Level1Params {
+            cj: -1.0,
             ..Level1Params::default()
         },
         1.8,

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add the Level-1 MOS `AD` instance parameter and model-card `CJ` density.
+  Their product augments `CBD` in AC and transient drain-body capacitance.
 - Add the Level-1 MOS `NRS` instance parameter. It defaults to one and scales
   the `RSH` source fallback while preserving explicit positive `RS` precedence,
   intrinsic-node stamping, and `:RS` Johnson noise.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -143,7 +143,9 @@ node, routes the channel and source-side capacitances through it, and contribute
 `RSH` defaults to zero ohms per square. `NRD` and `NRS` default to one drain
 and source square, so the fallbacks are `RSH * NRD` and `RSH * NRS`; explicit
 positive `RD` / `RS` values take precedence.
-The source fallback remains one square until the matching source-geometry slice.
+`AD` and model-card `CJ` default to zero, are finite and non-negative, and add
+`CJ * AD` to the zero-bias drain-body capacitance `CBD` in AC and transient
+analysis.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3614,6 +3614,8 @@ pub struct MosfetLevel1Params {
     pub sheet_resistance: f64,
     pub drain_squares: f64,
     pub source_squares: f64,
+    pub drain_area: f64,
+    pub bottom_junction_capacitance: f64,
     pub saturation_current: f64,
     pub n_sub: f64,
     pub t_nom: f64,
@@ -3646,6 +3648,8 @@ impl Default for MosfetLevel1Params {
             sheet_resistance: 0.0,
             drain_squares: 1.0,
             source_squares: 1.0,
+            drain_area: 0.0,
+            bottom_junction_capacitance: 0.0,
             saturation_current: 1.0e-15,
             n_sub: 1.4,
             t_nom: 300.15,
@@ -4002,8 +4006,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     (ModelCardKind::Pnp, 41, 58, 13, 4),
     (ModelCardKind::Njf, 22, 30, 7, 3),
     (ModelCardKind::Pjf, 22, 30, 7, 3),
-    (ModelCardKind::Nmos, 26, 33, 6, 3),
-    (ModelCardKind::Pmos, 26, 33, 6, 3),
+    (ModelCardKind::Nmos, 27, 34, 6, 3),
+    (ModelCardKind::Pmos, 27, 34, 6, 3),
 ];
 const DIODE_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IS", "IS"),
@@ -4149,6 +4153,7 @@ const MOS_LEVEL1_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("CJS", "CBS"),
     ("CBD", "CBD"),
     ("CJD", "CBD"),
+    ("CJ", "CJ"),
     ("PB", "PB"),
     ("MJ", "MJ"),
     ("FC", "FC"),
@@ -4951,6 +4956,9 @@ pub fn mosfet_from_model_card(
     }
     if let Some(value) = model.parameters.get("CBD") {
         params.drain_bulk_capacitance = *value;
+    }
+    if let Some(value) = model.parameters.get("CJ") {
+        params.bottom_junction_capacitance = *value;
     }
     if let Some(value) = model.parameters.get("PB") {
         params.bulk_junction_potential = *value;
@@ -24306,7 +24314,7 @@ fn evaluate_nmos_level1(
         params.forward_bias_depletion_coefficient,
     );
     let cbd_bulk = mosfet_bulk_junction_capacitance(
-        params.drain_bulk_capacitance,
+        params.drain_bulk_capacitance + params.bottom_junction_capacitance * params.drain_area,
         vbs - vds,
         params.bulk_junction_potential,
         params.bulk_junction_grading_coefficient,
@@ -25038,7 +25046,8 @@ fn mosfet_charge_state_specs(mosfet: &Mosfet) -> Vec<MosfetChargeStateSpec> {
     let gate_drain_capacitance = params.gate_drain_overlap_capacitance * params.w;
     let gate_body_capacitance = params.gate_bulk_overlap_capacitance * params.l;
     let source_body_capacitance = params.source_bulk_capacitance;
-    let drain_body_capacitance = params.drain_bulk_capacitance;
+    let drain_body_capacitance =
+        params.drain_bulk_capacitance + params.bottom_junction_capacitance * params.drain_area;
     if gate_source_capacitance > 0.0 {
         specs.push(MosfetChargeStateSpec {
             name: mosfet_gate_source_charge_state_name(mosfet),
@@ -25669,6 +25678,8 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         ("RSH", params.sheet_resistance),
         ("NRD", params.drain_squares),
         ("NRS", params.source_squares),
+        ("AD", params.drain_area),
+        ("CJ", params.bottom_junction_capacitance),
         ("TOX", params.oxide_thickness),
         ("IS", params.saturation_current),
         ("N_SUB", params.n_sub),
@@ -25739,6 +25750,18 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: mosfet.name.clone(),
             reason: "MOSFET NRS must be non-negative".to_string(),
+        });
+    }
+    if params.drain_area < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET AD must be non-negative".to_string(),
+        });
+    }
+    if params.bottom_junction_capacitance < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET CJ must be non-negative".to_string(),
         });
     }
     if params.oxide_thickness <= 0.0 {

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -1356,6 +1356,47 @@ fn ac_mosfet_overlap_capacitance_shunts_high_frequency_gate_drive() {
 }
 
 #[test]
+fn ac_mosfet_drain_area_scales_bottom_junction_capacitance() {
+    fn drain_amplitude(bottom_junction_capacitance: f64, drain_area: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "in", "0", 0.0, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "drain", 1_000.0,
+        )));
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "M1",
+            "drain",
+            "0",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                kp: 1.0e-12,
+                w: 1.0,
+                l: 1.0,
+                oxide_thickness: 1.0e9,
+                drain_area,
+                bottom_junction_capacitance,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+
+        ac_sweep(&circuit, 100_000.0, 100_000.0, 1).unwrap()[0]
+            .voltage("drain")
+            .unwrap()
+            .abs()
+    }
+
+    let without_area_capacitance = drain_amplitude(0.5, 0.0);
+    let with_area_capacitance = drain_amplitude(0.5, 2.0e-6);
+
+    assert!(without_area_capacitance > 0.9);
+    assert!(with_area_capacitance < without_area_capacitance / 100.0);
+}
+
+#[test]
 fn ac_mosfet_oxide_thickness_scales_intrinsic_gate_capacitance() {
     let gate_amplitude = |oxide_thickness| {
         let mut circuit = Circuit::new();

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -95,7 +95,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 193);
+    assert_eq!(coverage.len(), 195);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -114,7 +114,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tAF\tAF\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 193);
+    assert_eq!(records.len(), 195);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -147,8 +147,8 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         vec!["IS", "VT", "CJO", "VJ", "M"]
     );
     assert_eq!(summary[5].kind, ModelCardKind::Nmos);
-    assert_eq!(summary[5].canonical_parameter_count, 26);
-    assert_eq!(summary[5].accepted_name_count, 33);
+    assert_eq!(summary[5].canonical_parameter_count, 27);
+    assert_eq!(summary[5].accepted_name_count, 34);
     assert_eq!(summary[5].aliased_parameter_count, 6);
     assert_eq!(summary[5].max_alias_count, 3);
     assert_eq!(
@@ -166,7 +166,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     assert_eq!(lines[1], "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\t26\t33\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        &"PMOS\t27\t34\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
     );
     let records = model_card_supported_parameter_coverage_summary_records();
     assert_eq!(records.len(), 7);
@@ -184,7 +184,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         "[{\"kind\":\"D\",\"canonical_parameter_count\":\"15\",\"accepted_name_count\":\"21\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
     ));
     assert!(json.ends_with(
-        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"26\",\"accepted_name_count\":\"33\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
+        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"27\",\"accepted_name_count\":\"34\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
     ));
 }
 
@@ -195,15 +195,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 193);
-    assert_eq!(report.expected_canonical_parameter_count, 193);
-    assert_eq!(report.accepted_name_count, 263);
+    assert_eq!(report.canonical_parameter_count, 195);
+    assert_eq!(report.expected_canonical_parameter_count, 195);
+    assert_eq!(report.accepted_name_count, 265);
     assert_eq!(report.aliased_parameter_count, 57);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t193\t193\t263\t57\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t195\t195\t265\t57\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -230,8 +230,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 192);
-    assert_eq!(report.accepted_name_count, 260);
+    assert_eq!(report.canonical_parameter_count, 194);
+    assert_eq!(report.accepted_name_count, 262);
     assert_eq!(report.aliased_parameter_count, 56);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -239,7 +239,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     assert_eq!(report.issues[0].field, "canonical_parameter_count");
     assert_eq!(
         report.issues[0].message,
-        "expected NMOS to expose 26 canonical supported parameters, found 25"
+        "expected NMOS to expose 27 canonical supported parameters, found 26"
     );
     assert_eq!(report.issues.last().unwrap().field, "max_alias_count");
     assert_eq!(
@@ -248,20 +248,20 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t192\t193\t260\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 26 canonical supported parameters, found 25\nNMOS\taccepted_name_count\texpected NMOS to expose 33 accepted model-card names, found 30\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t194\t195\t262\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 27 canonical supported parameters, found 26\nNMOS\taccepted_name_count\texpected NMOS to expose 34 accepted model-card names, found 31\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
     assert_eq!(records[0]["field"], "canonical_parameter_count");
     assert_eq!(
         records[0]["message"],
-        "expected NMOS to expose 26 canonical supported parameters, found 25"
+        "expected NMOS to expose 27 canonical supported parameters, found 26"
     );
     assert!(format_model_card_supported_parameter_coverage_gate_issue_csv(&report).starts_with(
-        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 26 canonical supported parameters, found 25\"\n"
+        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 27 canonical supported parameters, found 26\"\n"
     ));
     assert!(format_model_card_supported_parameter_coverage_gate_issue_json(&report).starts_with(
-        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 26 canonical supported parameters, found 25\"}"
+        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 27 canonical supported parameters, found 26\"}"
     ));
 }
 
@@ -283,8 +283,8 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(dashboard[0].issue_count, 0);
     assert!(dashboard[0].issue_fields.is_empty());
     assert_eq!(dashboard[5].kind, ModelCardKind::Nmos);
-    assert_eq!(dashboard[5].canonical_parameter_count, 26);
-    assert_eq!(dashboard[5].accepted_name_count, 33);
+    assert_eq!(dashboard[5].canonical_parameter_count, 27);
+    assert_eq!(dashboard[5].accepted_name_count, 34);
     assert_eq!(dashboard[5].issue_count, 0);
 
     let table = format_model_card_supported_parameter_coverage_dashboard_table(&coverage);
@@ -296,7 +296,7 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(lines[1], "D\ttrue\t15\t15\t21\t21\t5\t5\t3\t3\t0\t");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\ttrue\t26\t26\t33\t33\t6\t6\t3\t3\t0\t"
+        &"PMOS\ttrue\t27\t27\t34\t34\t6\t6\t3\t3\t0\t"
     );
     let records = model_card_supported_parameter_coverage_dashboard_records(&coverage);
     assert_eq!(records.len(), 7);
@@ -328,10 +328,10 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         .unwrap();
 
     assert!(!nmos.passed);
-    assert_eq!(nmos.canonical_parameter_count, 25);
-    assert_eq!(nmos.expected_canonical_parameter_count, 26);
-    assert_eq!(nmos.accepted_name_count, 30);
-    assert_eq!(nmos.expected_accepted_name_count, 33);
+    assert_eq!(nmos.canonical_parameter_count, 26);
+    assert_eq!(nmos.expected_canonical_parameter_count, 27);
+    assert_eq!(nmos.accepted_name_count, 31);
+    assert_eq!(nmos.expected_accepted_name_count, 34);
     assert_eq!(nmos.aliased_parameter_count, 5);
     assert_eq!(nmos.expected_aliased_parameter_count, 6);
     assert_eq!(nmos.max_alias_count, 2);
@@ -347,7 +347,7 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         ]
     );
     assert!(format_model_card_supported_parameter_coverage_dashboard_table(&coverage).contains(
-        "NMOS\tfalse\t25\t26\t30\t33\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
+        "NMOS\tfalse\t26\t27\t31\t34\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
     ));
 }
 
@@ -597,6 +597,7 @@ fn model_card_aliases_build_device_instances() {
             ("RD", 125.0),
             ("RS", 75.0),
             ("RSH", 50.0),
+            ("CJ", 2.0e-3),
             ("TOX", 25.0e-9),
             ("KF", 2.0e-24),
             ("AF", 1.4),
@@ -615,6 +616,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*mos_card.parameters.get("RD").unwrap(), 125.0);
     assert_close(*mos_card.parameters.get("RS").unwrap(), 75.0);
     assert_close(*mos_card.parameters.get("RSH").unwrap(), 50.0);
+    assert_close(*mos_card.parameters.get("CJ").unwrap(), 2.0e-3);
     assert_close(*mos_card.parameters.get("TOX").unwrap(), 25.0e-9);
     assert_close(*mos_card.parameters.get("KF").unwrap(), 2.0e-24);
     assert_close(*mos_card.parameters.get("AF").unwrap(), 1.4);
@@ -632,6 +634,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(mos_model.params.sheet_resistance, 50.0);
     assert_close(mos_model.params.drain_squares, 1.0);
     assert_close(mos_model.params.source_squares, 1.0);
+    assert_close(mos_model.params.bottom_junction_capacitance, 2.0e-3);
     assert_close(mos_model.params.oxide_thickness, 25.0e-9);
     assert_close(mos_model.params.flicker_noise_coefficient, 2.0e-24);
     assert_close(mos_model.params.flicker_noise_exponent, 1.4);
@@ -1799,6 +1802,8 @@ fn subcircuit_expansion_preserves_mos_geometry() {
             sheet_resistance: 50.0,
             drain_squares: 2.0,
             source_squares: 3.0,
+            drain_area: 4.0e-12,
+            bottom_junction_capacitance: 2.0e-3,
             oxide_thickness: 25.0e-9,
             ..MosfetLevel1Params::default()
         },
@@ -1844,6 +1849,8 @@ fn subcircuit_expansion_preserves_mos_geometry() {
     assert_close(expanded.params.sheet_resistance, 50.0);
     assert_close(expanded.params.drain_squares, 2.0);
     assert_close(expanded.params.source_squares, 3.0);
+    assert_close(expanded.params.drain_area, 4.0e-12);
+    assert_close(expanded.params.bottom_junction_capacitance, 2.0e-3);
     assert_close(expanded.params.oxide_thickness, 25.0e-9);
 }
 
@@ -4047,6 +4054,70 @@ fn dc_mosfet_rejects_invalid_source_squares() {
                     "MOSFET NRS must be non-negative".to_string()
                 } else {
                     "MOSFET NRS must be finite".to_string()
+                },
+            }
+        );
+    }
+}
+
+#[test]
+fn dc_mosfet_rejects_invalid_drain_area() {
+    for drain_area in [f64::NAN, -1.0] {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "Mbad",
+            "drain",
+            "gate",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                drain_area,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+
+        let err = dc_op(&circuit).unwrap_err();
+        assert_eq!(
+            err,
+            SpiceError::InvalidElement {
+                name: "Mbad".to_string(),
+                reason: if drain_area.is_finite() {
+                    "MOSFET AD must be non-negative".to_string()
+                } else {
+                    "MOSFET AD must be finite".to_string()
+                },
+            }
+        );
+    }
+}
+
+#[test]
+fn dc_mosfet_rejects_invalid_bottom_junction_capacitance() {
+    for bottom_junction_capacitance in [f64::NAN, -1.0] {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "Mbad",
+            "drain",
+            "gate",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                bottom_junction_capacitance,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+
+        let err = dc_op(&circuit).unwrap_err();
+        assert_eq!(
+            err,
+            SpiceError::InvalidElement {
+                name: "Mbad".to_string(),
+                reason: if bottom_junction_capacitance.is_finite() {
+                    "MOSFET CJ must be non-negative".to_string()
+                } else {
+                    "MOSFET CJ must be finite".to_string()
                 },
             }
         );

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -421,8 +421,8 @@ fn transient_mosfet_overlap_capacitance_slows_gate_step() {
 }
 
 #[test]
-fn transient_mosfet_bulk_junction_capacitance_slows_drain_step() {
-    fn run(drain_bulk_capacitance: f64) -> Vec<TransientPoint> {
+fn transient_mosfet_drain_area_scales_bottom_junction_capacitance() {
+    fn run(bottom_junction_capacitance: f64, drain_area: f64) -> Vec<TransientPoint> {
         let mut circuit = Circuit::new();
         circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
             "Vstep",
@@ -449,15 +449,16 @@ fn transient_mosfet_bulk_junction_capacitance_slows_drain_step() {
                 kp: 1.0e-12,
                 w: 1.0,
                 l: 1.0,
-                drain_bulk_capacitance,
+                bottom_junction_capacitance,
+                drain_area,
                 ..MosfetLevel1Params::default()
             },
         )));
         transient_with_method(&circuit, 1.0e-9, 5.0e-9, TransientMethod::Euler).unwrap()
     }
 
-    let uncharged = run(0.0);
-    let charged = run(1.0e-9);
+    let uncharged = run(0.0, 0.0);
+    let charged = run(0.5, 2.0e-9);
     let uncharged_first = uncharged[0].voltage("drain").unwrap();
     let charged_first = charged[0].voltage("drain").unwrap();
 

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Parse Level-1 MOS instance `AD=<area>` and model-card `CJ=<capacitance/area>`
+  into the engine parameter bundle for drain-body junction capacitance.
 - Parse Level-1 MOS instance `NRS=<squares>` into the engine parameter bundle
   so netlist-driven source resistance uses `RSH * NRS`.
 - Parse Level-1 MOS model `RSH` and instance `NRD=<squares>` into the engine

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -760,8 +760,9 @@ parameters, `.model <name> NPN|PNP(...)` BJT cards with `IS`, `BF` /
 `.model <name> NMOS|PMOS(...)` Level-1 MOSFET
 cards with common SPICE aliases (`VT0` / `VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
 `W`, `L`, `RSH`, `IS`, `N_SUB` / `NSUB`, `T_NOM` / `TNOM`, `CGSO`, `CGDO`,
-`CGBO`, `CBS`, and `CBD`), MOS instance `NRD=<squares>` / `NRS=<squares>`, SPICE engineering
-suffixes, capacitor `IC=<voltage>` and inductor `IC=<current>` initial
+`CGBO`, `CBS`, `CBD`, and `CJ`), MOS instance `NRD=<squares>` /
+`NRS=<squares>` / `AD=<area>`, SPICE engineering suffixes, capacitor
+`IC=<voltage>` and inductor `IC=<current>` initial
 conditions, independent-source `AC <magnitude> [phase]` forms,
 PWL/PULSE/SIN/EXP source forms, comments, `.end`, `.subckt` / `X` instance
 expansion, and `.op`, `.tran`, `.dc`, `.ac`, `.tf`, `.sens`, `.mc`, `.noise`,

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1905,6 +1905,9 @@ fn build_mosfet_params(
     if let Some(value) = instance_params.get("NRS") {
         params.source_squares = *value;
     }
+    if let Some(value) = instance_params.get("AD") {
+        params.drain_area = *value;
+    }
     params
 }
 
@@ -1926,6 +1929,7 @@ fn apply_mosfet_param(params: &mut MosfetLevel1Params, name: &str, value: f64) {
         "CGBO" => params.gate_bulk_overlap_capacitance = value,
         "CBS" => params.source_bulk_capacitance = value,
         "CBD" => params.drain_bulk_capacitance = value,
+        "CJ" => params.bottom_junction_capacitance = value,
         _ => {}
     }
 }

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1359,10 +1359,10 @@ Jpull drain gate source pch
 fn parses_mosfet_models_into_operating_point_circuits() {
     let parsed = parse_netlist(
         r#"
-.model nch NMOS(VTO=0.45 KP=250u LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n RSH=250 NSUB=1.5 TNOM=300 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p)
+.model nch NMOS(VTO=0.45 KP=250u LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n RSH=250 NSUB=1.5 TNOM=300 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p CJ=2m)
 Vdd vdd 0 DC 5
 Vgate gate 0 DC 2.5
-M1 vdd gate out 0 nch W=4u L=200n NRD=2 NRS=3
+M1 vdd gate out 0 nch W=4u L=200n NRD=2 NRS=3 AD=3n
 Rload out 0 1k
 .op
 "#,
@@ -1395,6 +1395,8 @@ Rload out 0 1k
     assert_close(mosfet.params.sheet_resistance, 250.0);
     assert_close(mosfet.params.drain_squares, 2.0);
     assert_close(mosfet.params.source_squares, 3.0);
+    assert_close(mosfet.params.drain_area, 3.0e-9);
+    assert_close(mosfet.params.bottom_junction_capacitance, 2.0e-3);
     assert_close(mosfet.params.n_sub, 1.5);
     assert_close(mosfet.params.t_nom, 300.0);
     assert_close(mosfet.params.gate_source_overlap_capacitance, 3.0e-12);
@@ -3413,13 +3415,11 @@ C1 out 0 1p
         shell_dashboard_package.package_capability_id,
         "app-shell-dashboard-package-json"
     );
-    assert!(
-        shell_dashboard_package
-            .package_manifest
-            .artifact_capabilities
-            .iter()
-            .any(|capability| capability == &shell_dashboard_package.package_capability_id)
-    );
+    assert!(shell_dashboard_package
+        .package_manifest
+        .artifact_capabilities
+        .iter()
+        .any(|capability| capability == &shell_dashboard_package.package_capability_id));
     assert_eq!(
         shell_dashboard_package.artifact_capability_count,
         shell_dashboard_package

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add the Level-1 MOS `AD` instance parameter and model-card `CJ` density.
+  Their product augments `CBD` in AC and transient drain-body capacitance.
 - Add the Level-1 MOS `NRS` instance parameter. It defaults to one and scales
   the `RSH` source fallback while preserving explicit positive `RS` precedence,
   intrinsic-node stamping, and `:RS` Johnson noise.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -94,7 +94,9 @@ node, routes the channel and source-side capacitances through it, and contribute
 `RSH` defaults to zero ohms per square. `NRD` and `NRS` default to one drain
 and source square, so the fallbacks are `RSH * NRD` and `RSH * NRS`; explicit
 positive `RD` / `RS` values take precedence.
-The source fallback remains one square until the matching source-geometry slice.
+`AD` and model-card `CJ` default to zero, are finite and non-negative, and add
+`CJ * AD` to the zero-bias drain-body capacitance `CBD` in AC and transient
+analysis.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1782,6 +1782,8 @@ export interface MosfetLevel1Params {
   readonly RSH: number;
   readonly NRD: number;
   readonly NRS: number;
+  readonly AD: number;
+  readonly CJ: number;
   readonly IS: number;
   readonly N_SUB: number;
   readonly T_NOM: number;
@@ -2054,8 +2056,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   PNP: [41, 58, 13, 4],
   NJF: [22, 30, 7, 3],
   PJF: [22, 30, 7, 3],
-  NMOS: [26, 33, 6, 3],
-  PMOS: [26, 33, 6, 3],
+  NMOS: [27, 34, 6, 3],
+  PMOS: [27, 34, 6, 3],
 };
 
 export interface Vccs {
@@ -8044,6 +8046,8 @@ export function defaultMosfetLevel1Params(): MosfetLevel1Params {
     RSH: 0.0,
     NRD: 1.0,
     NRS: 1.0,
+    AD: 0.0,
+    CJ: 0.0,
     IS: 1.0e-15,
     N_SUB: 1.4,
     T_NOM: 300.15,
@@ -8246,6 +8250,7 @@ const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   CJS: "CBS",
   CBD: "CBD",
   CJD: "CBD",
+  CJ: "CJ",
   PB: "PB",
   MJ: "MJ",
   FC: "FC",
@@ -8819,6 +8824,7 @@ export function mosfetFromModelCard(
     ...(p.CGBO !== undefined ? { CGBO: p.CGBO } : {}),
     ...(p.CBS !== undefined ? { CBS: p.CBS } : {}),
     ...(p.CBD !== undefined ? { CBD: p.CBD } : {}),
+    ...(p.CJ !== undefined ? { CJ: p.CJ } : {}),
     ...(p.PB !== undefined ? { PB: p.PB } : {}),
     ...(p.MJ !== undefined ? { MJ: p.MJ } : {}),
     ...(p.FC !== undefined ? { FC: p.FC } : {}),
@@ -20329,7 +20335,7 @@ function evaluateNmosLevel1(
     params.CBS, vbs, params.PB, params.MJ, params.FC,
   );
   const cbdBulk = mosfetBulkJunctionCapacitance(
-    params.CBD, vbs - vds, params.PB, params.MJ, params.FC,
+    params.CBD + params.CJ * params.AD, vbs - vds, params.PB, params.MJ, params.FC,
   );
   const capacitances = {
     cgs: cgsOverlap + channelCapacitance,
@@ -20887,7 +20893,8 @@ function mosfetChargeStateSpecs(element: Mosfet): MosfetChargeStateSpec[] {
   const gateDrainCapacitance = element.params.CGDO * element.params.W;
   const gateBodyCapacitance = element.params.CGBO * element.params.L;
   const sourceBodyCapacitance = element.params.CBS;
-  const drainBodyCapacitance = element.params.CBD;
+  const drainBodyCapacitance =
+    element.params.CBD + element.params.CJ * element.params.AD;
   if (gateSourceCapacitance > 0.0) {
     specs.push({
       name: mosfetGateSourceChargeStateName(element),
@@ -21137,6 +21144,12 @@ function validateMosfet(element: Mosfet): void {
   }
   if (params.NRS < 0.0) {
     throw invalidElement(element.name, "MOSFET NRS must be non-negative");
+  }
+  if (params.AD < 0.0) {
+    throw invalidElement(element.name, "MOSFET AD must be non-negative");
+  }
+  if (params.CJ < 0.0) {
+    throw invalidElement(element.name, "MOSFET CJ must be non-negative");
   }
   if (params.TOX <= 0.0) {
     throw invalidElement(element.name, "MOSFET TOX must be positive");

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -574,6 +574,29 @@ describe("acSweep", () => {
     expect(withCapacitance).toBeLessThan(withoutCapacitance / 100.0);
   });
 
+  it("scales MOSFET bottom junction capacitance by drain area", () => {
+    function drainAmplitude(bottomJunctionCapacitance: number, drainArea: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "in", "0", 0.0, 1.0));
+      circuit.add(resistor("Rin", "in", "drain", 1_000.0));
+      circuit.add(mosfet("M1", "drain", "0", "0", "0", "NMOS", {
+        KP: 1.0e-12,
+        W: 1.0,
+        L: 1.0,
+        TOX: 1.0e9,
+        CJ: bottomJunctionCapacitance,
+        AD: drainArea,
+      }));
+      return complexAbs(acSweep(circuit, 100_000.0, 100_000.0, 1)[0].voltage("drain")!);
+    }
+
+    const withoutAreaCapacitance = drainAmplitude(0.5, 0.0);
+    const withAreaCapacitance = drainAmplitude(0.5, 2.0e-6);
+
+    expect(withoutAreaCapacitance).toBeGreaterThan(0.9);
+    expect(withAreaCapacitance).toBeLessThan(withoutAreaCapacitance / 100.0);
+  });
+
   it("uses MOSFET oxide thickness to scale intrinsic gate capacitance", () => {
     function gateAmplitude(TOX: number): number {
       const circuit = new Circuit();

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -121,7 +121,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(193);
+    expect(coverage).toHaveLength(195);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -141,7 +141,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tAF\tAF\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(193);
+    expect(records).toHaveLength(195);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -167,8 +167,8 @@ describe("dcOp", () => {
     });
     expect(summary[5]).toStrictEqual({
       kind: "NMOS",
-      canonicalParameterCount: 26,
-      acceptedNameCount: 33,
+      canonicalParameterCount: 27,
+      acceptedNameCount: 34,
       aliasedParameterCount: 6,
       maxAliasCount: 3,
       aliasedParameters: ["VT0", "LAMBDA", "N_SUB", "T_NOM", "CBS", "CBD"],
@@ -181,7 +181,7 @@ describe("dcOp", () => {
     );
     expect(table.split("\n")[1]).toBe("D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     expect(table.split("\n").at(-1)).toBe(
-      "PMOS\t26\t33\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
+      "PMOS\t27\t34\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
     );
     const records = modelCardSupportedParameterCoverageSummaryRecords();
     expect(records).toHaveLength(7);
@@ -206,15 +206,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 193,
-      expectedCanonicalParameterCount: 193,
-      acceptedNameCount: 263,
+      canonicalParameterCount: 195,
+      expectedCanonicalParameterCount: 195,
+      acceptedNameCount: 265,
       aliasedParameterCount: 57,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t193\t193\t263\t57\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t195\t195\t265\t57\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -237,15 +237,15 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(192);
-    expect(report.acceptedNameCount).toBe(260);
+    expect(report.canonicalParameterCount).toBe(194);
+    expect(report.acceptedNameCount).toBe(262);
     expect(report.aliasedParameterCount).toBe(56);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 26 canonical supported parameters, found 25",
+      message: "expected NMOS to expose 27 canonical supported parameters, found 26",
     });
     expect(report.issues.at(-1)).toStrictEqual({
       kind: "NMOS",
@@ -253,16 +253,16 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t192\t193\t260\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 26 canonical supported parameters, found 25\nNMOS\taccepted_name_count\texpected NMOS to expose 33 accepted model-card names, found 30\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t194\t195\t262\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 27 canonical supported parameters, found 26\nNMOS\taccepted_name_count\texpected NMOS to expose 34 accepted model-card names, found 31\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 26 canonical supported parameters, found 25",
+      message: "expected NMOS to expose 27 canonical supported parameters, found 26",
     });
     expect(formatModelCardSupportedParameterCoverageGateIssueCsv(report)).toMatch(
-      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 26 canonical supported parameters, found 25"\n/,
+      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 27 canonical supported parameters, found 26"\n/,
     );
     expect(JSON.parse(formatModelCardSupportedParameterCoverageGateIssueJson(report))).toStrictEqual(
       records,
@@ -422,6 +422,7 @@ describe("dcOp", () => {
       RD: 125.0,
       RS: 75.0,
       RSH: 50.0,
+      CJ: 2.0e-3,
       TOX: 25.0e-9,
       KF: 2.0e-24,
       AF: 1.4,
@@ -440,6 +441,7 @@ describe("dcOp", () => {
       RD: 125.0,
       RS: 75.0,
       RSH: 50.0,
+      CJ: 2.0e-3,
       TOX: 25.0e-9,
       KF: 2.0e-24,
       AF: 1.4,
@@ -458,6 +460,7 @@ describe("dcOp", () => {
     expectClose(mosModel.params.RSH, 50.0);
     expectClose(mosModel.params.NRD, 1.0);
     expectClose(mosModel.params.NRS, 1.0);
+    expectClose(mosModel.params.CJ, 2.0e-3);
     expectClose(mosModel.params.TOX, 25.0e-9);
     expectClose(mosModel.params.KF, 2.0e-24);
     expectClose(mosModel.params.AF, 1.4);
@@ -1261,6 +1264,8 @@ describe("dcOp", () => {
           RSH: 50.0,
           NRD: 2.0,
           NRS: 3.0,
+          AD: 4.0e-12,
+          CJ: 2.0e-3,
           TOX: 25.0e-9,
         }),
       ]),
@@ -1278,6 +1283,8 @@ describe("dcOp", () => {
     expectClose(expanded!.params.RSH, 50.0);
     expectClose(expanded!.params.NRD, 2.0);
     expectClose(expanded!.params.NRS, 3.0);
+    expectClose(expanded!.params.AD, 4.0e-12);
+    expectClose(expanded!.params.CJ, 2.0e-3);
     expectClose(expanded!.params.TOX, 25.0e-9);
   });
 
@@ -2555,6 +2562,34 @@ describe("dcOp", () => {
         Number.isFinite(sourceSquares)
           ? "MOSFET NRS must be non-negative"
           : "MOSFET NRS must be finite",
+      );
+    }
+  });
+
+  it("rejects invalid MOSFET drain areas", () => {
+    for (const drainArea of [Number.NaN, -1.0]) {
+      const circuit = new Circuit();
+      circuit.add(mosfet("Mbad", "drain", "gate", "0", "0", "NMOS", {
+        AD: drainArea,
+      }));
+      expect(() => dcOp(circuit)).toThrowError(
+        Number.isFinite(drainArea)
+          ? "MOSFET AD must be non-negative"
+          : "MOSFET AD must be finite",
+      );
+    }
+  });
+
+  it("rejects invalid MOSFET bottom junction capacitance densities", () => {
+    for (const bottomJunctionCapacitance of [Number.NaN, -1.0]) {
+      const circuit = new Circuit();
+      circuit.add(mosfet("Mbad", "drain", "gate", "0", "0", "NMOS", {
+        CJ: bottomJunctionCapacitance,
+      }));
+      expect(() => dcOp(circuit)).toThrowError(
+        Number.isFinite(bottomJunctionCapacitance)
+          ? "MOSFET CJ must be non-negative"
+          : "MOSFET CJ must be finite",
       );
     }
   });

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -373,8 +373,8 @@ describe("transient", () => {
     expect(chargedFirst!).toBeLessThan(unchargedFirst!);
   });
 
-  it("uses MOSFET bulk junction capacitance during transient drain steps", () => {
-    function run(drainBulkCapacitance: number): TransientPoint[] {
+  it("scales MOSFET bottom junction capacitance by drain area", () => {
+    function run(bottomJunctionCapacitance: number, drainArea: number): TransientPoint[] {
       const circuit = new Circuit();
       circuit.add(voltageSourceWithWaveform(
         "Vstep",
@@ -392,13 +392,14 @@ describe("transient", () => {
         KP: 1.0e-12,
         W: 1.0,
         L: 1.0,
-        CBD: drainBulkCapacitance,
+        CJ: bottomJunctionCapacitance,
+        AD: drainArea,
       }));
       return transient(circuit, 1.0e-9, 5.0e-9, "euler");
     }
 
-    const unchargedFirst = run(0.0)[0].voltage("drain");
-    const chargedFirst = run(1.0e-9)[0].voltage("drain");
+    const unchargedFirst = run(0.0, 0.0)[0].voltage("drain");
+    const chargedFirst = run(0.5, 2.0e-9)[0].voltage("drain");
     expect(unchargedFirst).not.toBeUndefined();
     expect(chargedFirst).not.toBeUndefined();
     expect(unchargedFirst!).toBeGreaterThan(0.5);

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,16 +33,17 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS source diffusion squares.
+1. Cross-language Level-1 MOS drain diffusion area and bottom capacitance.
    - Status: current PR completion candidate.
-   - Add the Berkeley Level-1 MOS `NRS` instance parameter in Rust, Python, and
-     TypeScript, defaulting to one source diffusion square.
-   - When explicit `RS` remains zero, use `RSH * NRS` for the source resistance;
-     positive explicit `RS` continues to take precedence.
-   - Reuse the existing intrinsic source topology in DC, TF, AC, transient, and
-     noise analyses, preserve `NRS` through hierarchy and cloning, enforce
-     finite non-negative validation, and keep the model-card coverage gate at
-     193 canonical rows because `NRS` is an instance parameter.
+   - Add the Berkeley Level-1 MOS `AD` instance parameter and model-card `CJ`
+     bottom-junction capacitance density in Rust, Python, and TypeScript,
+     defaulting both to zero.
+   - Use `CBD + CJ * AD` as the zero-bias drain-body capacitance in AC and
+     transient analysis while preserving existing `PB`, `MJ`, and `FC`
+     depletion shaping.
+   - Preserve `AD` / `CJ` through hierarchy and cloning, enforce finite
+     non-negative validation, parse both in the Rust netlist facade, and raise
+     the model-card coverage gate to 195 canonical rows for `CJ`.
 
 ## Completed Slices
 
@@ -3471,6 +3472,16 @@ the Rust, Python, and TypeScript surfaces together.
      resistance across DC, TF, AC, transient, and noise analyses; hierarchy and
      cloning preserve `NRD`, finite non-negative validation is shared, and the
      model-card coverage gate remains at 193 canonical rows because `NRD` is
+     an instance parameter.
+
+273. Cross-language Level-1 MOS source diffusion squares.
+   - Status: completed in PR 9034.
+   - Rust, Python, and TypeScript Level-1 MOS instances now accept `NRS`,
+     defaulting to one source diffusion square.
+   - When explicit `RS` remains zero, `RSH * NRS` supplies the source
+     resistance across DC, TF, AC, transient, and noise analyses; hierarchy and
+     cloning preserve `NRS`, finite non-negative validation is shared, and the
+     model-card coverage gate remains at 193 canonical rows because `NRS` is
      an instance parameter.
 
 ## Backlog


### PR DESCRIPTION
## Summary
- add Berkeley Level-1 MOS `AD` drain diffusion area and model-card `CJ` bottom-junction capacitance density across Rust, Python, and TypeScript
- apply `CBD + CJ * AD` in AC and transient drain-body capacitance while preserving existing depletion shaping
- parse `AD`/`CJ` in Rust netlists, preserve them through hierarchy, validate inputs, and update the model-card coverage gate and SPICE plan

## Verification
- `cargo test -p mosfet-models -p spice-engine -p spice-netlist-parser`
- Python MOSFET/SPICE suites: 687 passed
- Ruff package check (with pre-existing `SIM108` and `F841` exceptions ignored)
- TypeScript SPICE: 391 tests passed
- `npm run build`