### PR TITLE
feat(adj-formula-stdlib): luminance-conversions — NIST SP 811 B.9 stilb→cd/m² exact factor (RS-5 table)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -756,6 +756,45 @@ fn shipped_illuminance_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b16) Shipped table — reference/luminance-conversions.adj resolves via import (a
+//       NEW dimension: luminance → candela per square metre, the EXACT SP 811 B.9
+//       boldface CGS factor stilb), and a non-exact customary unit (`footlambert`) — a
+//       rounded factor with no row — abstains.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_luminance_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_lumin");
+    let src = stdlib().join("reference/luminance-conversions.adj");
+    std::fs::copy(&src, dir.join("luminance-conversions.adj"))
+        .expect("copy shipped luminance-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"luminance-conversions.adj\"\n\
+         ? luminance_to_candela_per_square_metre(stilb, $v)\n\
+         ? luminance_to_candela_per_square_metre(footlambert, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 "Luminance" exact factor resolves, character-for-character from
+    // the table (boldface = exact; scientific notation to plain decimal).
+    assert!(out.contains("\"v\":\"10000\""), "stilb = 10000 cd/m^2: {out}");
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `footlambert` is a NIST customary row printed as a ROUNDED (non-boldface) factor —
+    // not an exact row here, so the engine abstains rather than committing to a rounded
+    // value.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a non-exact unit abstains, never a fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/luminance-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/luminance-conversions.adj
@@ -1,0 +1,55 @@
+% ============================================================================
+% luminance-conversions — luminance-unit → candela per square metre factors
+% (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of `illuminance-conversions.adj` and the other NIST-cited
+% conversion tables: a native tabular relation ingested VERBATIM from a published NIST
+% conversion table. The row states the factor converting the CGS luminance unit to the SI
+% coherent unit of luminance, the candela per square metre (cd/m²):
+%
+%     ? luminance_to_candela_per_square_metre(stilb, $v)   % 10000
+%
+% This is a NEW dimension alongside the length/mass/area/volume/time/speed/energy/
+% pressure/force/acceleration/dynamic-viscosity/kinematic-viscosity/magnetic-flux-density/
+% illuminance tables: where illuminance normalises luminous flux per unit AREA (the lux),
+% this one normalises LUMINANCE — luminous intensity per unit projected area, the candela
+% per square metre. (The two are the photometric pair: illuminance is light arriving on a
+% surface; luminance is light leaving one.) Put a luminance given in the CGS stilb into SI
+% first, then reason (write-once-use-many). Why a `table` and not a hand-written `relate`
+% clause: this is exactly the shape reference data comes in — a published table, not prose.
+% The citable artifact IS the NIST conversion-factors table at the `locator` below; the
+% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors for units
+% listed alphabetically"), defended by one provenance envelope. Each `row` lowers to a
+% ground relation `luminance_to_candela_per_square_metre(unit, cd_per_m2)`, so the exact
+% lookup above is the ordinary SLD binding query — the engine returns the factor WITH this
+% table's citation as its proof, on the CPU, with zero model calls.
+%
+% HONESTY NOTE (like illuminance-/force-/viscosity-conversions, only the EXACT defined
+% factor gets a row, not the rounded ones): NIST SP 811 B.9 prints the "stilb" luminance
+% factor in BOLDFACE, its convention for factors that are EXACT by definition, transcribed
+% here as the plain decimal number of candela per square metre it names:
+%
+%     stilb (sb)   1.0 E+04  →  10000
+%
+% This is exact because the stilb is a coherent CGS unit — one stilb is one candela per
+% square centimetre, i.e. exactly 10⁴ candela per square metre. It terminates; nothing
+% here is a rounded measurement. NIST's other luminance rows are customary units whose
+% factors NIST prints in plain (non-boldface) type as ROUNDED values — e.g. the
+% "footlambert" at 3.426 259 E+00 cd/m² — so they are NOT given rows here; a
+% `? luminance_to_candela_per_square_metre(footlambert, $v)` ABSTAINS rather than
+% committing to a rounded factor. The only claim this table makes is "this is the exact
+% factor NIST SP 811 B.9 prints" — which is exactly what a byte-check against the cited
+% table verifies. `trust authoritative` — a primary, re-fetchable standards reference.
+% (See ADJ-TABLES.md; and feedback_nothing_human_authored — the factor is a verbatim cell
+% of the cited table, nothing asserted from memory.)
+% ============================================================================
+
+table luminance_to_candela_per_square_metre {
+    columns unit, candela_per_square_metre
+
+    row (stilb, 10000)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/luminance-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/luminance-conversions.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% luminance-conversions.query.adj — a worked lookup over the luminance table.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a "how many candela per
+% square metre is one stilb?" question: it states no conversion fact — it only `import`s
+% the grounded table and asks binding queries. The native adj-lang engine resolves each
+% `?` against the table's row (lowered to a `luminance_to_candela_per_square_metre`
+% relation) and returns the binding + the table's source/locator/trust. A unit not in the
+% table abstains honestly — the engine never invents a factor (notably NIST's non-exact
+% customary rows, e.g. the footlambert, which is rounded and therefore gets no row).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli luminance-conversions.query.adj
+% ============================================================================
+
+import "luminance-conversions.adj"
+
+? luminance_to_candela_per_square_metre(stilb, $v)        % expect 10000
+? luminance_to_candela_per_square_metre(footlambert, $v)  % expect abstain — non-exact, no row


### PR DESCRIPTION
## What

Adds a **new NIST-cited RS-5 conversion table** to the `reference/` (Facts) track: **luminance**, the photometric sibling of the just-merged illuminance table. One `table` row ingests VERBATIM the NIST SP 811 Appendix B.9 exact (boldface) factor converting the CGS **stilb** to the SI coherent unit of luminance, the **candela per square metre**:

```
stilb (sb)   1.0 E+04  →  10000
```

The stilb is a coherent CGS unit (1 cd/cm² = exactly 10⁴ cd/m²), so the factor is **exact by definition** and terminates.

## How it works (write-once-use-many, zero model calls)

A consumer states no conversion fact — it `import`s the grounded table, and the exact lookup

```
? luminance_to_candela_per_square_metre(stilb, $v)
```

is the ordinary SLD binding query, returning `10000` **with the table's NIST citation** as its proof, on the CPU.

## Honesty / abstention

NIST's other luminance rows are customary units printed as **ROUNDED (non-boldface)** factors (e.g. footlambert 3.426 259 E+00 cd/m²), so they get **no row**: a `? luminance_to_candela_per_square_metre(footlambert, $v)` **ABSTAINS** rather than committing to a rounded value. The only claim the table makes is "this is the exact factor NIST SP 811 B.9 prints" — which a byte-check against the cited table verifies.

`locator` → NIST SP 811 Appendix B.9 · `trust authoritative` (primary, re-fetchable standards reference).

## Files (data + one e2e block only; no version bump)

- `reference/luminance-conversions.adj` — single exact-row `table` + NIST B.9 provenance
- `reference/luminance-conversions.query.adj` — worked lookup (stilb → 10000; footlambert abstains)
- `adj-lang-cli/tests/rs5_table_e2e.rs` — new **(b16)** block asserting `"v":"10000"` + `nist-guide-si-appendix-b9` locator + `"abstained":true` (suite now **21 tests**)

## Verification

- Shipped query renders `"v":"10000"` + `trust authoritative` + NIST b9 locator for stilb; `"abstained":true` for footlambert
- `cargo test -p adj-lang-cli --test rs5_table_e2e` → **21/21 pass**
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean
- New source files NUL-scan 0
- `/security-review` → PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)