### PR TITLE
feat(sir-c): instance variables (@x) + self (C OOP mirror slice 3)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.15.0 — OOP mirror slice 3: instance variables (`@x`) + `self`
+
+Instance state — the third slice of the C OOP mirror. Accepts
+`Feature::InstanceVars`, so a method body can now read and write the receiver's
+instance variables and refer to the receiver directly.
+
+- `@v = x` (a `Scope::Instance` `Assign`) → `_sir_ivar_set("@v", x)`, and `@v`
+  (a `Scope::Instance` `VarRef`) → `_sir_ivar_get("@v")`. Each instance carries a
+  lazily-allocated `@name → value` map (`struct SirInstance` gains an `ivars`
+  slot, `NULL` until the first write); an unset `@v` reads **nil**, matching Ruby.
+- A bare `self` (`__self__`) → `_sir_self()`, the current receiver — so a method
+  can return `self` for chaining (`w.me.size`).
+- **How a hoisted method body finds its receiver.** A method lowers to a
+  top-level function with no lexical `self`, so dispatch carries the receiver in a
+  process-global `_sir_current_self`: `_sir_call_method` saves the caller's
+  `self`, binds it to the receiver for the call, and restores it after (nested
+  calls stack correctly through these C-local saves). `@x`/`self` read that
+  global; the top-level `main` object gets its own ivar bag (`_sir_toplevel_ivars`).
+- **Exceptions interaction.** A method that `raise`s inside a `begin` `longjmp`s
+  past `_sir_call_method`'s own restore, so an enclosing `TryCatch` snapshots
+  `_sir_current_self` at the `begin` and restores it on the rescue/ensure/escape
+  paths — so `@x` in a rescue body reads the *catcher's* ivars, not the raiser's.
+
+**Anti-RCE by construction.** The `@`-name (including the leading `@`) emits as a
+**quoted C string literal** and is used only as an interned map key — never as C
+source — so no `@`-name can inject code, exactly as with class/method/rescue
+names. `@@class` variables (`Feature::ClassVars`), inheritance/`super`, class
+methods, and modules remain the next slices (still rejected cleanly).
+
 ## 0.14.0 — OOP mirror slice 2: instance methods
 
 Instance-method definition and dispatch — the second slice of the C OOP mirror.

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -113,14 +113,19 @@ closure` into an explicit table (`_sir_def_method`), and `__method__` dispatches
 via `_sir_call_method` (resolve `(recv's class, method)`, apply the closure; miss
 → `NoMethodError`).  Dispatch is an explicit data lookup — **never reflection** on
 a source string — so it is anti-RCE by construction; a dispatch to an
-un-registered (built-in) method is rejected cleanly (the Collections batch).
+un-registered (built-in) method is rejected cleanly (the Collections batch).  And
+**slice 3** — `InstanceVars`: `@v = x` / `@v` (`Scope::Instance`) →
+`_sir_ivar_set` / `_sir_ivar_get` on the receiver's lazily-allocated `@name →
+value` map (an unset `@v` reads nil), and a bare `self` → `_sir_self()`.  The
+receiver is carried across the hoisted method body in `_sir_current_self` (saved
+and restored by `_sir_call_method`; an enclosing `begin`/`rescue` restores it on
+the unwind path).  The `@`-name is a quoted C string literal (no injection).
 
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
-`Intrinsics`, `NDArrays`, the rest of OOP (instance methods, `@ivars`,
-`@@class vars`, inheritance dispatch, class methods, modules — later mirror
-slices, so `__new__` with constructor args, `__def_method__`/`__method__`, a
-`class << self` singleton, and `@`/`@@` scopes are all refused for now), and
-every other not-yet-wired feature until its batch lands.  `Bignum` stays rejected
+`Intrinsics`, `NDArrays`, the rest of OOP (`@@class vars`, inheritance dispatch,
+class methods, modules — later mirror slices, so `__new__` with constructor
+args, a `class << self` singleton, `super`, and the `@@` scope are all refused
+for now), and every other not-yet-wired feature until its batch lands.  `Bignum` stays rejected
 until a bignum runtime ships — a module needing arbitrary precision is refused,
 never silently truncated.
 

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -420,6 +420,24 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
                         quote_c_string(name)
                     );
                 }
+            } else if matches!(scope, Scope::Instance) {
+                // OOP slice 3: `@v = …` writes the current receiver's ivar map.
+                // The `@`-name is a QUOTED C string literal (no injection).  A
+                // compound value is hoisted into a temp first.
+                if is_simple(value) {
+                    let _ = write!(out, "{pad}(void)_sir_ivar_set({}, ", quote_c_string(name));
+                    emit_expr(out, value, indent);
+                    out.push_str(");\n");
+                } else {
+                    let tmp = format!("_sir_t{}", fresh_id());
+                    let _ = writeln!(out, "{pad}SirValue {tmp};");
+                    emit_assign(out, &tmp, value, indent);
+                    let _ = writeln!(
+                        out,
+                        "{pad}(void)_sir_ivar_set({}, {tmp});",
+                        quote_c_string(name)
+                    );
+                }
             } else {
                 let n = sanitize_ident(name);
                 emit_assign(out, &n, value, indent);
@@ -613,6 +631,11 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             let p2 = indent_str(i2);
             let p3 = indent_str(i3);
             let _ = writeln!(out, "{pad}{{");
+            // OOP slice 3: snapshot the current `self` — a method that `raise`s
+            // inside the guarded body `longjmp`s past `_sir_call_method`'s own
+            // restore, so the rescue/ensure paths below re-bind `self` to what it
+            // was when this `begin` started (else `@x` would read the raiser's).
+            let _ = writeln!(out, "{p1}SirValue _sir_selfsave{id} = _sir_current_self;");
             let _ = writeln!(out, "{p1}int _sir_eh{id} = _sir_push_handler();");
             let _ = writeln!(out, "{p1}volatile int _sir_esc{id} = 0;");
             let _ = writeln!(
@@ -633,6 +656,9 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             let _ = writeln!(out, "{p2}}}");
             let _ = writeln!(out, "{p2}_sir_pop_handler();");
             let _ = writeln!(out, "{p2}if (_sir_c{id}) {{");
+            // Restore `self` before a rescue body runs (the body raised & was
+            // caught, so `_sir_current_self` may be the raiser's).
+            let _ = writeln!(out, "{p3}_sir_current_self = _sir_selfsave{id};");
             let _ = writeln!(out, "{p3}SirValue _sir_ex{id} = _sir_current_error;");
             for (k, rc) in rescues.iter().enumerate() {
                 let kw = if k == 0 { "if" } else { "} else if" };
@@ -681,6 +707,10 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             // and propagate the WRONG exception.  (Meaningful only when
             // `_sir_esc` is set; harmlessly nil on the normal path.)
             let _ = writeln!(out, "{p1}SirValue _sir_pend{id} = _sir_current_error;");
+            // Restore `self` on the escape path too (reached whether the body
+            // completed normally or an exception unwound to here) before `ensure`
+            // runs and before control leaves the `begin`.
+            let _ = writeln!(out, "{p1}_sir_current_self = _sir_selfsave{id};");
             let _ = writeln!(out, "{p1}_sir_pop_handler();");
             if let Some(ens) = ensure_body {
                 for st in ens {
@@ -1292,8 +1322,14 @@ fn emit_var_ref(out: &mut String, name: &str, scope: Scope) {
         Scope::Const => {
             let _ = write!(out, "_sir_const_get({})", quote_c_string(name));
         }
-        // `Instance` / `ClassVar` belong to features the backend does not yet
-        // accept, so the capability check rejects such modules before emit.
+        // OOP slice 3: a `Scope::Instance` reference (`@v`) reads the current
+        // receiver's instance-variable map (nil when unset).  The name (incl. the
+        // `@`) is a QUOTED C string literal (no injection).
+        Scope::Instance => {
+            let _ = write!(out, "_sir_ivar_get({})", quote_c_string(name));
+        }
+        // `ClassVar` belongs to `Feature::ClassVars` (a later slice), not yet
+        // accepted, so the capability check rejects such modules before emit.
         other => unreachable!("C backend reached unsupported var scope: {other:?}"),
     }
 }
@@ -1359,6 +1395,11 @@ fn emit_builtin_simple(out: &mut String, name: &str, args: &[Expr], indent: usiz
         }
         return;
     }
+    // OOP slice 3: a bare `self` → the current receiver (`_sir_self()`).
+    if name == "__self__" {
+        out.push_str("_sir_self()");
+        return;
+    }
     // Variadic-shaped builtins take (count, args...).
     if let Some(helper) = variadic_helper(name) {
         let _ = write!(out, "{}({}", helper, args.len());
@@ -1405,6 +1446,11 @@ fn emit_builtin_with_names(out: &mut String, name: &str, names: &[String]) {
     // unreachable — emit a clear marker rather than a wrong construction.
     if matches!(name, "__new__" | "__def_method__" | "__method__") {
         let _ = write!(out, "_sir_unknown_builtin({})", quote_c_string(name));
+        return;
+    }
+    // `__self__` takes no arguments, so it is always simple; render it here too.
+    if name == "__self__" {
+        out.push_str("_sir_self()");
         return;
     }
     if let Some(helper) = variadic_helper(name) {
@@ -1465,7 +1511,12 @@ fn is_supported_builtin(name: &str) -> bool {
         // methods: `__def_method__` (register a `(class,method)` closure) and
         // `__method__` (dispatch it).  (`__super__`/`__self__`/`__class_method__`/
         // … stay unsupported — later slices.)
-        || matches!(name, "and" | "or" | "raise" | "__new__" | "__def_method__" | "__method__")
+        // Slice 3 adds `__self__` (a bare `self`).  (`__super__`/`__class_method__`
+        // /… stay unsupported — later slices.)
+        || matches!(
+            name,
+            "and" | "or" | "raise" | "__new__" | "__def_method__" | "__method__" | "__self__"
+        )
 }
 
 // The structural gate below (`first_unsupported_builtin`) reports the first

--- a/code/packages/rust/semantic-ir-to-c/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/lib.rs
@@ -166,6 +166,14 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // unaccepted features — `@ivars`/`@@cvars`/inheritance-dispatch/modules.
     Feature::Classes,
     Feature::Constants,
+    // ── OOP mirror, slice 3: instance variables (`@x`) + `self` ──────────
+    // `Feature::InstanceVars` — `@v = x` / `@v` (`Scope::Instance`).  A method
+    // body runs in a hoisted function, so `@v` routes through
+    // `_sir_ivar_get`/`_sir_ivar_set` on `_sir_current_self` (the receiver the
+    // dispatch bound), and `__self__` renders `_sir_self()`.  The `@`-name is a
+    // quoted C string literal (no injection).  `@@class` variables are the
+    // separate `Feature::ClassVars`, still rejected.
+    Feature::InstanceVars,
 ];
 
 impl Backend for CBackend {

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -92,10 +92,10 @@ struct SirPair { SirValue car; SirValue cdr; };
  * `SIR_STR`, or nil for a bare `raise Class` — then the class name is shown). */
 struct SirError { const char *sir_class; SirValue msg; };
 
-/* A SIR OOP instance.  `sir_class` is the interned class name (`"Foo"`); it is
- * how method dispatch (later slices) keys the method table and how the ancestry
- * walk finds the superclass.  Instance variables (`@x`) join in a later slice. */
-struct SirInstance { const char *sir_class; };
+/* A SIR OOP instance.  `sir_class` is the interned class name (`"Foo"`) — how
+ * method dispatch keys the method table.  `ivars` is a lazily-allocated
+ * `@name -> value` map (NULL until the first `@x = …`; an unset `@x` reads nil). */
+struct SirInstance { const char *sir_class; SirMap *ivars; };
 
 /* A SIR16 sequence (`[1, 2, 3]`) — a heap-boxed dynamic array. `items` points
  * at `len` `SirValue`s (arena-allocated, never freed like every other heap
@@ -177,6 +177,7 @@ SirValue _sir_sym(const char *s) { SirValue v; v.tag = SIR_SYM; v.as.s = _sir_in
 SirValue _sir_new_instance(const char *cls) {
     SirInstance *o = (SirInstance *)_sir_alloc(sizeof(SirInstance));
     o->sir_class = _sir_intern(cls);
+    o->ivars = NULL;  /* lazily allocated on the first `@x = …` */
     { SirValue v; v.tag = SIR_INSTANCE; v.as.inst = o; return v; }
 }
 
@@ -1013,6 +1014,45 @@ SirValue _sir_const_get(const char *name) {
     return _sir_raise(_sir_error("NameError", _sir_str(_sir_cat("uninitialized constant ", name))));
 }
 
+/* ---- OOP: current self + instance variables (@x) ------------ */
+
+/* The receiver of the method currently executing.  A method body runs in a
+ * hoisted top-level function (no lexical `self`), so `_sir_call_method` sets this
+ * before applying the closure and restores it after; `@x` and `self` read it.
+ * Nil at top level (Ruby's `main`). */
+static SirValue _sir_current_self = { SIR_NIL, { 0 } };
+
+/* Instance variables (`@x`) when `self` is NOT an instance (top-level `main`).
+ * Lazily allocated, matching Ruby's `main`-object ivars. */
+static SirMap *_sir_toplevel_ivars = NULL;
+
+SirValue _sir_self(void) { return _sir_current_self; }
+
+/* The `@name -> value` map owner for the current `self`: the instance's own
+ * `ivars` slot (an instance), else the top-level bag. */
+static SirMap **_sir_ivar_owner(void) {
+    if (_sir_current_self.tag == SIR_INSTANCE) return &_sir_current_self.as.inst->ivars;
+    return &_sir_toplevel_ivars;
+}
+
+/* `@x` read — nil when unset (Ruby's semantics), never an error. */
+SirValue _sir_ivar_get(const char *name) {
+    SirMap *m = *_sir_ivar_owner();
+    SirValue mv;
+    if (!m) return _sir_nil();
+    mv.tag = SIR_MAP; mv.as.map = m;
+    return _sir_map_get(mv, _sir_sym(name));
+}
+
+/* `@x = v` write — lazily allocates the owner's ivar map.  The `@`-name is an
+ * interned symbol key (so lookup is a pointer compare). */
+SirValue _sir_ivar_set(const char *name, SirValue v) {
+    SirMap **owner = _sir_ivar_owner();
+    if (!*owner) *owner = _sir_map_new(4);
+    _sir_map_put(*owner, _sir_sym(name), v);
+    return v;
+}
+
 /* ---- OOP: instance-method table & dispatch ------------------ */
 
 /* An EXPLICIT (class, method) -> closure table, populated by emitted
@@ -1075,7 +1115,16 @@ SirValue _sir_call_method(SirValue recv, const char *method, int argc, ...) {
     va_start(ap, argc);
     args = _sir_va_collect(argc, ap);
     va_end(ap);
-    r = fn.as.clo->fn(fn.as.clo->caps, args, argc);
+    /* Bind `self` to the receiver for the method body (so `@x`/`self` see it),
+     * restoring the caller's `self` afterwards.  Nested calls stack correctly via
+     * these C-local saves.  If the body `raise`s, `longjmp` skips this restore —
+     * an enclosing `TryCatch` restores `_sir_current_self` on the unwind path. */
+    {
+        SirValue saved_self = _sir_current_self;
+        _sir_current_self = recv;
+        r = fn.as.clo->fn(fn.as.clo->caps, args, argc);
+        _sir_current_self = saved_self;
+    }
     if (args) free(args);
     return r;
 }

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_ivars.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_ivars.rs
@@ -1,0 +1,105 @@
+//! Execution proof for OOP mirror slice 3 (instance variables + `self`) on the C
+//! backend — lower REAL Ruby source, emit C, compile with a real cc, run, assert
+//! stdout.  Skips gracefully when no `cc` is present.
+//!
+//! An `@x` read/write lowers to a `Scope::Instance` `VarRef`/`Assign`, which the
+//! emitter routes through `_sir_ivar_get`/`_sir_ivar_set` on `_sir_current_self`
+//! — the receiver the dispatch bound.  The `@`-name is a QUOTED C string literal
+//! (no injection).  A bare `self` lowers to `__self__` → `_sir_self()`.
+
+use std::process::Command;
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    ["cc", "clang", "gcc"]
+        .iter()
+        .find(|c| {
+            Command::new(c)
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        })
+        .map(|s| s.to_string())
+}
+
+/// Lower `src` (Ruby) → C, compile + run, return stdout (or None if no cc).
+fn run_ruby(src: &str) -> Option<String> {
+    let cc = find_cc()?;
+    let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
+    let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
+    let dir = std::env::temp_dir();
+    let stem = format!("sirc_ivar_{}_{}", std::process::id(), src.len());
+    let cpath = dir.join(format!("{stem}.c"));
+    let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::write(&cpath, &art.source).expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        art.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "program exited non-zero");
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn ivar_set_then_get() {
+    // `@v` written by one method, read by another, on a stored instance.
+    match run_ruby(
+        "class Box\n  def set(v)\n    @v = v\n  end\n  def get\n    @v\n  end\nend\n\
+         b = Box.new\nb.set(7)\nputs b.get\n",
+    ) {
+        Some(out) => assert_eq!(out, "7\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn two_ivars_summed() {
+    // Two distinct `@`-names on one instance, combined in a third method.
+    match run_ruby(
+        "class Pair\n  def init\n    @a = 1\n    @b = 2\n  end\n  def sum\n    @a + @b\n  end\nend\n\
+         p = Pair.new\np.init\nputs p.sum\n",
+    ) {
+        Some(out) => assert_eq!(out, "3\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn ivar_read_modify_write_persists() {
+    // `@n = @n + 1` reads and writes the same ivar; state persists across calls.
+    match run_ruby(
+        "class Counter\n  def start\n    @n = 0\n  end\n  def inc\n    @n = @n + 1\n  end\n  \
+         def val\n    @n\n  end\nend\n\
+         c = Counter.new\nc.start\nc.inc\nc.inc\nc.inc\nputs c.val\n",
+    ) {
+        Some(out) => assert_eq!(out, "3\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn self_returns_receiver_for_chaining() {
+    // A bare `self` (`__self__` → `_sir_self()`) returns the receiver, so a method
+    // returning `self` can be chained into another dispatch.
+    match run_ruby(
+        "class Widget\n  def me\n    self\n  end\n  def size\n    9\n  end\nend\n\
+         w = Widget.new\nputs w.me.size\n",
+    ) {
+        Some(out) => assert_eq!(out, "9\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}

--- a/code/packages/rust/semantic-ir-to-c/tests/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/emit.rs
@@ -158,6 +158,42 @@ fn builtin_method_dispatch_is_rejected() {
 }
 
 #[test]
+fn instance_vars_route_through_ivar_helpers() {
+    // OOP slice 3: `@v = v` is a `Scope::Instance` Assign → `_sir_ivar_set`, and
+    // `@v` a `Scope::Instance` VarRef → `_sir_ivar_get`.  The `@`-name is a QUOTED
+    // C string literal (no name injection), and the runtime carries the helpers.
+    let m = lower_ruby("class Box\n  def set(v)\n    @v = v\n  end\n  def get\n    @v\n  end\nend");
+    let src = compile(&m).unwrap().source;
+    assert!(
+        src.contains("_sir_ivar_set(\"@v\","),
+        "an `@v =` write calls the setter with the quoted `@`-name\n{src}"
+    );
+    assert!(
+        src.contains("_sir_ivar_get(\"@v\")"),
+        "an `@v` read calls the getter with the quoted `@`-name\n{src}"
+    );
+    // The runtime defines the helpers + the current-self machinery they read.
+    assert!(src.contains("_sir_ivar_get"), "runtime declares the getter");
+    assert!(src.contains("_sir_ivar_set"), "runtime declares the setter");
+    assert!(
+        src.contains("_sir_current_self"),
+        "dispatch binds the receiver into `_sir_current_self`\n{src}"
+    );
+}
+
+#[test]
+fn explicit_self_renders_as_sir_self() {
+    // A bare `self` (`__self__`) renders as the `_sir_self()` accessor, so a method
+    // can return the receiver for chaining.
+    let m = lower_ruby("class Widget\n  def me\n    self\n  end\nend");
+    let src = compile(&m).unwrap().source;
+    assert!(
+        src.contains("_sir_self()"),
+        "`self` lowers to the `_sir_self()` accessor\n{src}"
+    );
+}
+
+#[test]
 fn sanitize_ident_maps_into_c() {
     assert_eq!(sanitize_ident("foo"), "foo");
     assert_eq!(sanitize_ident("foo_bar1"), "foo_bar1");

--- a/code/specs/SIR24-semantic-ir-to-c.md
+++ b/code/specs/SIR24-semantic-ir-to-c.md
@@ -362,8 +362,19 @@ lockstep:
 4. **Collections** — the `__method__` dispatch catalog
    (String / Array / Hash / Numeric / Symbol / Object, block and non-block).
 5. **Exceptions** — `setjmp`/`longjmp` + typed runtime errors.
-6. **OOP** — `Classes` / `Constants` / `InstanceVars` / `ClassVars`, then
-   `Modules` (mixins / MRO).
+6. **OOP** (mirroring the Ruby backend's landed 7-slice arc) — slice 1
+   (`Classes` + `Constants`: the `SIR_INSTANCE` runtime, an empty class, `Foo.new`
+   → `_sir_new_instance`, and a `_sir_const_set`/`_sir_const_get` table) landed in
+   0.13.0; instance **methods** (an explicit `(class,method)`→closure table —
+   `_sir_def_method`/`_sir_call_method` — a data lookup, never reflection, per
+   §Security #2, so anti-RCE by construction) landed in 0.14.0;
+   `InstanceVars` + `self` (`@v` → `_sir_ivar_get`/`_sir_ivar_set` on the
+   receiver's lazily-allocated `@name → value` map; the receiver is carried in
+   `_sir_current_self`, saved/restored by `_sir_call_method` and re-bound at each
+   `TryCatch` handler since `longjmp` unwinds past the restore) landed in 0.15.0;
+   then inheritance + `super` (a user-ancestry table
+   consulted before the baked-in exception ancestry, so both share one
+   `super_of`), class methods, `ClassVars`, and `Modules` (mixins / MRO).
 7. **Optional / later** — `Bignum`; SIR21 sized-integer native lowering
    (`int64_t`/`uint32_t` from `IntSpec`); `Range` / regex / backtick shims.
 


### PR DESCRIPTION
## What

Third slice of the **C backend OOP mirror** — accepts `Feature::InstanceVars`, so a compiled method body can read/write the receiver's instance variables and refer to the receiver directly. Mirrors the Ruby backend's landed slice 3 (`semantic-ir-to-ruby` 0.12.0).

- `@v = x` (a `Scope::Instance` `Assign`) → `_sir_ivar_set("@v", x)`, and `@v` (a `Scope::Instance` `VarRef`) → `_sir_ivar_get("@v")`. Each `SirInstance` carries a lazily-allocated `@name → value` map (`ivars` slot, `NULL` until the first write); an unset `@v` reads **nil**, matching Ruby.
- A bare `self` (`__self__`) → `_sir_self()`, the current receiver — so a method can return `self` for chaining (`w.me.size`).
- **Receiver plumbing:** a method lowers to a hoisted top-level function with no lexical `self`, so dispatch carries the receiver in a process-global `_sir_current_self`. `_sir_call_method` saves the caller's `self`, binds the receiver for the call, and restores after (nested calls stack via C-local saves); the top-level `main` object gets its own ivar bag.
- **Exceptions interaction:** a `raise` inside a `begin` `longjmp`s past `_sir_call_method`'s restore, so the emitted `TryCatch` snapshots `_sir_current_self` at the `begin` and restores it on the rescue/ensure/escape paths — so `@x` in a rescue body reads the *catcher's* ivars, not the raiser's.

## Anti-RCE by construction

The `@`-name (including the leading `@`) emits as a **quoted C string literal** and is used only as an interned map key — never as C source — so no `@`-name can inject code, exactly as with class/method/rescue names.

## Tests / quality

- **Emit-shape** (`tests/emit.rs`): `instance_vars_route_through_ivar_helpers`, `explicit_self_renders_as_sir_self`. 12/12 pass.
- **cc-exec e2e** (`tests/compile_and_run_ivars.rs`): set/get, two ivars summed, read-modify-write persistence, `self`-chaining. 4/4 pass.
- **Regression:** exceptions e2e (8, TryCatch path), methods e2e (3), classes rejection test — all green.
- clippy clean; security review passed (Rust+C: no injection, no memory-safety/DoS/totality issues).

Bumps `semantic-ir-to-c` 0.14.0 → 0.15.0; updates CHANGELOG, README, and the SIR24 spec. `@@class` vars, inheritance/`super`, class methods, and modules remain later slices (still rejected cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)