### PR TITLE
feat(adj-formula-stdlib): fick-principle — StatPearls CO = VO2/(CaO2−CvO2) cardiac-output library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_fick_principle_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_fick_principle_e2e.rs
@@ -1,0 +1,147 @@
+//! End-to-end tests for the `clinical/fick-principle.adj` library — the Fick principle
+//! for cardiac output (CO = VO2 / (CaO2 - CvO2)) and its two exact rearrangements
+//! (VO2 = CO * (CaO2 - CvO2), CvO2 = CaO2 - VO2 / CO) — driven through the built CLI
+//! binary against the SHIPPED stdlib. Each proves the same invariant as the other formula
+//! libraries: a consumer states NO arithmetic; it imports the grounded library, binds the
+//! measured quantities with `observe`, and the engine applies the cited relation on the
+//! CPU, computing the EXACT value and rendering the relation's citation and trust tier in
+//! the `derived` section (the auditable answer). The three formulas INVERT around the
+//! worked case VO2 = 250 mL/min, CaO2 = 200 mL O2/L, CvO2 = 150 mL O2/L: 250 / (200 - 150)
+//! = 5, and both 5 * (200 - 150) = 250 and 200 - 250 / 5 = 150 recover the inputs.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped fick-principle library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_fick_principle_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/fick-principle.adj")
+        .canonicalize()
+        .expect("shipped fick-principle.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_fick_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_fick_principle_lib()).unwrap();
+    std::fs::write(dir.join("fick-principle.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// cardiac_output — the Fick relation: the oxygen consumption over the arteriovenous
+// oxygen-content difference.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_fick_library_and_computes_cardiac_output_with_citation() {
+    let dir = scratch("co");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fick-principle.adj\"\n\
+         observe oxygen_consumption(250)\n\
+         observe arterial_oxygen_content(200)\n\
+         observe venous_oxygen_content(150)\n\
+         ? cardiac_output(oxygen_consumption, arterial_oxygen_content, venous_oxygen_content)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result:
+    // 250 / (200 - 150) = 5.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"cardiac_output\"") && s.contains("\"value\":5"),
+        "cardiac_output(250, 200, 150) = 5: {s}"
+    );
+    // … AND the StatPearls/NCBI Bookshelf citation and trust tier, so the answer is
+    // auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// oxygen_consumption — the same relation solved for VO2: CO * (CaO2 - CvO2), which INVERTS
+// the cardiac output just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_oxygen_consumption_from_cardiac_output_and_the_contents_with_citation() {
+    let dir = scratch("vo2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fick-principle.adj\"\n\
+         observe cardiac_output(5)\n\
+         observe arterial_oxygen_content(200)\n\
+         observe venous_oxygen_content(150)\n\
+         ? oxygen_consumption(cardiac_output, arterial_oxygen_content, venous_oxygen_content)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 5 * (200 - 150) = 250, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"oxygen_consumption\"") && s.contains("\"value\":250"),
+        "oxygen_consumption(5, 200, 150) = 250: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "oxygen_consumption carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// venous_oxygen_content — the same relation solved for CvO2: CaO2 - VO2 / CO, the third
+// exact reading of the one relation.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_venous_oxygen_content_from_the_other_three_with_citation() {
+    let dir = scratch("cvo2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"fick-principle.adj\"\n\
+         observe arterial_oxygen_content(200)\n\
+         observe oxygen_consumption(250)\n\
+         observe cardiac_output(5)\n\
+         ? venous_oxygen_content(arterial_oxygen_content, oxygen_consumption, cardiac_output)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 200 - 250 / 5 = 200 - 50 = 150, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"venous_oxygen_content\"") && s.contains("\"value\":150"),
+        "venous_oxygen_content(200, 250, 5) = 150: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "venous_oxygen_content carries its StatPearls citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/fick-principle.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/fick-principle.adj
@@ -1,0 +1,110 @@
+% ============================================================================
+% fick-principle.adj — the Fick principle for cardiac output
+% (CO = VO2 / (CaO2 − CvO2)) in the ADJ standard library.
+% ============================================================================
+% The Fick-principle entry of the *clinical* track, a hemodynamics sibling of
+% `cardiac-output.adj`, `mean-arterial-pressure.adj` and `pulse-pressure.adj`. It is a
+% SECOND, independent determination of cardiac output: where `cardiac-output.adj` grounds
+% the definitional CO = stroke volume × heart rate, this grounds the Fick principle —
+% CARDIAC OUTPUT IS THE OXYGEN CONSUMPTION DIVIDED BY THE ARTERIOVENOUS OXYGEN-CONTENT
+% DIFFERENCE — as an importable, byte-provenanced, PARAMETERIZED `formula`, together with
+% its two exact rearrangements (the oxygen consumption a cardiac output implies for an
+% a–v difference, and the venous content implied by the other three). As with every
+% compute library, a consumer states NO arithmetic: it `import`s this file, binds the
+% measured quantities from its own byte-provenance decomposition, and asks the engine to
+% APPLY the cited relation on the CPU. Zero math is performed by the model; the engine
+% computes each value EXACTLY, carrying the relation's citation.
+%
+%     import "fick-principle.adj"
+%     observe oxygen_consumption(250)          % "…VO2 250 mL/min…"          (span cited by the model)
+%     observe arterial_oxygen_content(200)     % "…CaO2 200 mL O2/L blood…"  (span cited by the model)
+%     observe venous_oxygen_content(150)       % "…CvO2 150 mL O2/L blood…"  (span cited by the model)
+%     ? cardiac_output(oxygen_consumption, arterial_oxygen_content, venous_oxygen_content)
+%                                                % engine → 5, carrying CO = VO2 / (CaO2 − CvO2)
+%
+% All three formulas are EXACT over their parameters (a quotient over a difference, a
+% product of a difference, and a difference of a quotient); there is no separately
+% grounded physiological constant, so every value the engine returns is exact. The three
+% COMPOSE and invert cleanly around the worked case VO2 = 250 mL/min, CaO2 = 200 mL O2/L,
+% CvO2 = 150 mL O2/L (CO = 250 / (200 − 150) = 250 / 50 = 5 L/min): the `cardiac_output` a
+% consumer computes from the consumption and the two contents is exactly the
+% `cardiac_output` the `oxygen_consumption` formula multiplies the a–v difference back by
+% to recover the 250 mL/min consumption, and exactly the `cardiac_output` the
+% `venous_oxygen_content` formula divides the consumption by to recover the 150 mL O2/L
+% venous content.
+%
+%   cardiac_output(oxygen_consumption, arterial_oxygen_content, venous_oxygen_content)
+%       = oxygen_consumption / (arterial_oxygen_content - venous_oxygen_content)   % CO = VO2 / (CaO2 − CvO2)   (Fick principle)
+%   oxygen_consumption(cardiac_output, arterial_oxygen_content, venous_oxygen_content)
+%       = cardiac_output * (arterial_oxygen_content - venous_oxygen_content)        % VO2 = CO × (CaO2 − CvO2)   (same relation, solved for VO2)
+%   venous_oxygen_content(arterial_oxygen_content, oxygen_consumption, cardiac_output)
+%       = arterial_oxygen_content - oxygen_consumption / cardiac_output             % CvO2 = CaO2 − VO2 / CO     (same relation, solved for CvO2)
+%
+% NOTE ON UNITS: the two oxygen contents must be in the SAME unit of oxygen per unit
+% volume of blood; the consumption is oxygen per unit time. With contents in millilitres
+% of O2 per LITRE of blood and consumption in millilitres of O2 per minute, the cardiac
+% output comes out directly in litres per minute (as in the worked case). Clinical
+% content is often quoted per DECILITRE (mL O2/dL); a consumer that observes contents in
+% mL/dL must convert them to the same basis as the consumption first — this library
+% computes the exact value over whatever consistent units it is given, it does not itself
+% carry the dL↔L factor.
+%
+% All three formulas are defended by the SAME relation statement — "Cardiac output =
+% Tissue oxygen consumption/(Arterial oxygen content - Venous oxygen content)" — because
+% that one relation (cardiac output IS the consumption over the arteriovenous difference)
+% sanctions it read every way (CO from the three, VO2 from CO and the difference, or CvO2
+% from the other three). The quote is transcribed verbatim from the StatPearls
+% "Physiology, Cardiac Output" article on the NCBI Bookshelf, so each `formula` carries
+% the provenance envelope every shipped grounded clause carries; the linter rejects an
+% unsourced one. (See feedback_nothing_human_authored — the relation is a verbatim span of
+% the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable hemodynamic/respiratory quantity the Fick
+% relation ranges over, and each result is a derived quantity. `cardiac_output`,
+% `oxygen_consumption` and `venous_oxygen_content` each appear BOTH as a derived result
+% and as an input (of the other formulas), so each is a single dictionary term used in
+% both roles. The `surface` lists are the everyday names a decomposer maps onto the
+% canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary fick_vocab {
+    define oxygen_consumption      : finding  surface "oxygen consumption", "VO2", "tissue oxygen consumption"   % millilitres of O2 per minute (mL/min)
+    define arterial_oxygen_content : finding  surface "arterial oxygen content", "CaO2"                          % millilitres of O2 per litre of blood (mL/L)
+    define venous_oxygen_content   : finding  surface "venous oxygen content", "CvO2", "mixed venous oxygen content"  % millilitres of O2 per litre of blood (mL/L)
+    define cardiac_output          : finding  surface "cardiac output", "CO"                                     % litres per minute (L/min)
+}
+
+% ----------------------------------------------------------------------------
+% The Fick relation, all three ways. Each is a named, importable, reusable `let` over its
+% formal parameters, bound at apply time, and each carries the relation statement from
+% StatPearls on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an
+% exact quotient/product over a difference of measured quantities, so the engine returns
+% each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook fick_laws {
+    use fick_vocab
+
+    % Cardiac output — the oxygen consumption over the arteriovenous oxygen-content
+    % difference, i.e. CO = VO2 / (CaO2 − CvO2).
+    formula cardiac_output(oxygen_consumption, arterial_oxygen_content, venous_oxygen_content) = oxygen_consumption / (arterial_oxygen_content - venous_oxygen_content)
+        source "Cardiac output = Tissue oxygen consumption/(Arterial oxygen content - Venous oxygen content)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470455/"
+        trust authoritative
+
+    % Oxygen consumption — the same relation solved for the consumption a cardiac output
+    % implies for an a–v difference (VO2 = CO × (CaO2 − CvO2)). Defended by the SAME
+    % relation statement, read the other way.
+    formula oxygen_consumption(cardiac_output, arterial_oxygen_content, venous_oxygen_content) = cardiac_output * (arterial_oxygen_content - venous_oxygen_content)
+        source "Cardiac output = Tissue oxygen consumption/(Arterial oxygen content - Venous oxygen content)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470455/"
+        trust authoritative
+
+    % Venous oxygen content — the same relation solved for the venous content the other
+    % three imply (CvO2 = CaO2 − VO2 / CO). Again the SAME relation statement, read the
+    % third way.
+    formula venous_oxygen_content(arterial_oxygen_content, oxygen_consumption, cardiac_output) = arterial_oxygen_content - oxygen_consumption / cardiac_output
+        source "Cardiac output = Tissue oxygen consumption/(Arterial oxygen content - Venous oxygen content)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470455/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/fick-principle.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/fick-principle.query.adj
@@ -1,0 +1,37 @@
+% ============================================================================
+% fick-principle.query.adj — worked examples over the clinical Fick-principle library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a Fick cardiac-output
+% question: it states NO arithmetic and NO relation — it only `import`s the grounded
+% library, `observe`s the quantities it decomposed from the prompt (each a
+% byte-provenanced span, elided here), and asks the engine to APPLY the cited relation.
+% The native adj-lang engine binds the parameters, computes each value EXACTLY on the CPU,
+% and returns it with the relation's source/locator/trust.
+%
+% The three questions INVERT: an oxygen consumption of 250 mL/min across an arteriovenous
+% content difference of 200 − 150 = 50 mL O2/L gives a cardiac output of 250 / 50 = 5
+% L/min; that 5 L/min cardiac output across the same 50 mL O2/L difference is exactly what
+% the oxygen-consumption formula multiplies back to recover the 250 mL/min consumption,
+% and that 5 L/min cardiac output with the same 200 mL O2/L arterial content and 250
+% mL/min consumption is exactly what the venous-content formula recovers the 150 mL O2/L
+% venous content from.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli fick-principle.query.adj
+% ============================================================================
+
+import "fick-principle.adj"
+
+% VO2 250 mL/min, CaO2 200 mL O2/L, CvO2 150 mL O2/L: cardiac output = 250 / (200 − 150).
+observe oxygen_consumption(250)
+observe arterial_oxygen_content(200)
+observe venous_oxygen_content(150)
+? cardiac_output(oxygen_consumption, arterial_oxygen_content, venous_oxygen_content)     % expect 5    (Fick: CO = VO2 / (CaO2 − CvO2))
+
+% That 5 L/min cardiac output across the same 200/150 contents: VO2 = 5 × (200 − 150).
+observe cardiac_output(5)
+? oxygen_consumption(cardiac_output, arterial_oxygen_content, venous_oxygen_content)       % expect 250  (same relation, solved for VO2 = CO × (CaO2 − CvO2))
+
+% That 5 L/min cardiac output with the same 200 mL O2/L arterial and 250 mL/min VO2:
+% CvO2 = 200 − 250 / 5.
+? venous_oxygen_content(arterial_oxygen_content, oxygen_consumption, cardiac_output)       % expect 150  (same relation, solved for CvO2 = CaO2 − VO2 / CO)


### PR DESCRIPTION
## What

Adds the **Fick principle** for cardiac output to the clinical formula-library track — a **second, independent** determination of cardiac output alongside the definitional CO = stroke volume × heart rate in `cardiac-output.adj`. A byte-provenanced, importable `formulabook` grounds **CO = VO₂ / (CaO₂ − CvO₂)** and its two exact algebraic rearrangements.

A consumer states **NO arithmetic**: it `import`s the library, `observe`s the measured quantities it decomposed from the prompt, and the engine **applies the cited relation on the CPU, EXACT** (BigRational), carrying `source`/`locator`/`trust` into the auditable `derived` section.

## The three grounded formulas (one relation, read three ways)

| formula | reading |
|---|---|
| `cardiac_output(oxygen_consumption, arterial_oxygen_content, venous_oxygen_content) = oxygen_consumption / (arterial_oxygen_content - venous_oxygen_content)` | CO = VO₂ / (CaO₂ − CvO₂) — Fick principle |
| `oxygen_consumption(cardiac_output, arterial_oxygen_content, venous_oxygen_content) = cardiac_output * (arterial_oxygen_content - venous_oxygen_content)` | VO₂ = CO × (CaO₂ − CvO₂) |
| `venous_oxygen_content(arterial_oxygen_content, oxygen_consumption, cardiac_output) = arterial_oxygen_content - oxygen_consumption / cardiac_output` | CvO₂ = CaO₂ − VO₂ / CO |

They compose and invert cleanly around the worked case **VO₂ 250 mL/min, CaO₂ 200 mL O₂/L, CvO₂ 150 mL O₂/L → CO = 250 / 50 = 5 L/min** (clinically correct and exact).

## Provenance

All three formulas carry the SAME verbatim relation, transcribed from the StatPearls *"Physiology, Cardiac Output"* article on the NCBI Bookshelf:

> "Cardiac output = Tissue oxygen consumption/(Arterial oxygen content - Venous oxygen content)"

`locator https://www.ncbi.nlm.nih.gov/books/NBK470455/` · `trust authoritative`. Nothing asserted from memory — the relation is a verbatim span of the cited page. (Units note in the header: contents must share a per-volume basis with the consumption; the library computes exact over whatever consistent units it is given, it does not carry the dL↔L factor.)

## Files (data + one dedicated e2e test only; no version bump)

- `clinical/fick-principle.adj` — dictionary + formulabook (3 grounded formulas)
- `clinical/fick-principle.query.adj` — worked, inverting query triple over the library
- `adj-lang-cli/tests/formula_fick_principle_e2e.rs` — 3 e2e tests through the built CLI against the shipped stdlib: exact value (5 / 250 / 150) + `trust authoritative` + `ncbi.nlm.nih.gov` locator in the derived section

## Verification

- Shipped query renders 5 / 250 / 150 exact (all `trust authoritative`, all NCBI locator)
- `cargo test -p adj-lang-cli --test formula_fick_principle_e2e` → **3/3 pass**
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean
- New source files NUL-scan 0
- `/security-review` → PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)