### PR TITLE
Add MOS source diffusion area capacitance

### DIFF
--- a/code/packages/python/mosfet-models/CHANGELOG.md
+++ b/code/packages/python/mosfet-models/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [0.1.0] — Unreleased
 
 ### Added
+- `Level1Params.AS` adds the zero-default Berkeley source diffusion area,
+  contributing `CJ * AS` to the zero-bias source-body capacitance.
 - `Level1Params.AD` and `Level1Params.CJ` add zero-default Berkeley drain
   diffusion area and bottom-junction capacitance density, contributing
   `CJ * AD` to the zero-bias drain-body capacitance.

--- a/code/packages/python/mosfet-models/README.md
+++ b/code/packages/python/mosfet-models/README.md
@@ -29,8 +29,9 @@ print(r.Id, r.gm, r.gds, r.region)
   Meyer capacitance through `Cox = epsilon_ox / TOX`, zero-default `RD` / `RS`
   external drain/source resistance, zero-default `RSH` sheet resistance,
   one-default `NRD` / `NRS` drain/source diffusion square counts, zero-default
-  drain diffusion area `AD` and bottom-junction capacitance density `CJ`
-  contributing `CJ * AD` to `CBD`, and `KF` / `AF` flicker noise.
+  drain/source diffusion areas `AD` / `AS` and bottom-junction capacitance
+  density `CJ` contributing `CJ * AD` to `CBD` and `CJ * AS` to `CBS`, and
+  `KF` / `AF` flicker noise.
 - `evaluate_level1(params, V_GS, V_DS, V_BS, T)`: returns `MosResult` with Id, gm, gds, gmb, Cgs/Cgd/Cgb/Cbs/Cbd, region.
 - Region detection: cutoff (subthreshold-aware), triode, saturation.
 - Body effect via gamma * (sqrt(PHI-V_BS) - sqrt(PHI)) shift.

--- a/code/packages/python/mosfet-models/src/mosfet_models/level1.py
+++ b/code/packages/python/mosfet-models/src/mosfet_models/level1.py
@@ -35,6 +35,7 @@ class Level1Params:
     NRD: float = 1.0  # number of drain diffusion squares
     NRS: float = 1.0  # number of source diffusion squares
     AD: float = 0.0  # drain diffusion area (m^2)
+    AS: float = 0.0  # source diffusion area (m^2)
     CJ: float = 0.0  # bottom junction capacitance per area (F/m^2)
     IS: float = 1e-15  # saturation current (A)
     N_SUB: float = 1.4  # subthreshold slope factor
@@ -141,6 +142,8 @@ def evaluate_level1(
         raise ValueError("MOSFET NRS must be finite and non-negative")
     if not isfinite(p.AD) or p.AD < 0.0:
         raise ValueError("MOSFET AD must be finite and non-negative")
+    if not isfinite(p.AS) or p.AS < 0.0:
+        raise ValueError("MOSFET AS must be finite and non-negative")
     if not isfinite(p.CJ) or p.CJ < 0.0:
         raise ValueError("MOSFET CJ must be finite and non-negative")
     beta = p.KP * (p.W / effective_length)
@@ -164,7 +167,13 @@ def evaluate_level1(
     )
     Cgd_intrinsic = 0.0
     Cgb_intrinsic = 0.0
-    Cbs_bulk = bulk_junction_capacitance(p.CBS, V_BS, p.PB, p.MJ, p.FC)
+    Cbs_bulk = bulk_junction_capacitance(
+        p.CBS + p.CJ * p.AS,
+        V_BS,
+        p.PB,
+        p.MJ,
+        p.FC,
+    )
     Cbd_bulk = bulk_junction_capacitance(
         p.CBD + p.CJ * p.AD,
         V_BS - V_DS,

--- a/code/packages/python/mosfet-models/tests/test_models.py
+++ b/code/packages/python/mosfet-models/tests/test_models.py
@@ -216,10 +216,20 @@ def test_drain_area_scales_bottom_junction_capacitance():
     assert result.Cbd == pytest.approx(7.0e-12)
 
 
+def test_source_area_scales_bottom_junction_capacitance():
+    result = evaluate_level1(
+        Level1Params(CBS=1.0e-12, CJ=2.0e-3, AS=3.0e-9, MJ=0.0),
+        V_GS=1.8,
+        V_DS=0.0,
+    )
+    assert result.Cbs == pytest.approx(7.0e-12)
+
+
 @pytest.mark.parametrize(
     ("params", "message"),
     [
         (Level1Params(AD=-1.0), "MOSFET AD must be finite and non-negative"),
+        (Level1Params(AS=-1.0), "MOSFET AS must be finite and non-negative"),
         (Level1Params(CJ=-1.0), "MOSFET CJ must be finite and non-negative"),
     ],
 )

--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add the Level-1 MOS `AS` instance parameter. With model-card `CJ`, its
+  product augments `CBS` in AC and transient source-body capacitance.
 - Add the Level-1 MOS `AD` instance parameter and model-card `CJ` density.
   Their product augments `CBD` in AC and transient drain-body capacitance.
 - Add the Level-1 MOS `NRS` instance parameter. It defaults to one and scales

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -102,9 +102,9 @@ node, routes the channel and source-side capacitances through it, and contribute
 `RSH` defaults to zero ohms per square. `NRD` and `NRS` default to one drain
 and source square, so the fallbacks are `RSH * NRD` and `RSH * NRS`; explicit
 positive `RD` / `RS` values take precedence.
-`AD` and model-card `CJ` default to zero, are finite and non-negative, and add
-`CJ * AD` to the zero-bias drain-body capacitance `CBD` in AC and transient
-analysis.
+`AD`, `AS`, and model-card `CJ` default to zero and are finite and non-negative.
+They add `CJ * AD` to drain-body `CBD` and `CJ * AS` to source-body `CBS` in
+AC and transient analysis.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -9112,7 +9112,9 @@ def _mosfet_charge_state_specs(el: Mosfet) -> list[tuple[str, str, str, float]]:
     cgs = getattr(params, "CGSO", 0.0) * width
     cgd = getattr(params, "CGDO", 0.0) * width
     cgb = getattr(params, "CGBO", 0.0) * length
-    cbs = getattr(params, "CBS", 0.0)
+    cbs = getattr(params, "CBS", 0.0) + (
+        getattr(params, "CJ", 0.0) * getattr(params, "AS", 0.0)
+    )
     cbd = getattr(params, "CBD", 0.0) + (
         getattr(params, "CJ", 0.0) * getattr(params, "AD", 0.0)
     )

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1832,6 +1832,50 @@ def test_transient_mosfet_drain_area_scales_bottom_junction_capacitance() -> Non
     assert charged_first < uncharged_first
 
 
+def test_transient_mosfet_source_area_scales_bottom_junction_capacitance() -> None:
+    def run(cj: float, source_area: float) -> TransientResult:
+        circuit = Circuit()
+        circuit.add(VoltageSource(
+            "Vstep",
+            "in",
+            "0",
+            0.0,
+            waveform=PwlWaveform(((0.0, 0.0), (1.0e-9, 1.0), (5.0e-9, 1.0))),
+        ))
+        circuit.add(Resistor("Rin", "in", "source", 1_000.0))
+        circuit.add(Mosfet(
+            "M1",
+            "0",
+            "0",
+            "source",
+            "0",
+            MOSFET(
+                MosfetType.NMOS,
+                Level1Model(
+                    Level1Params(
+                        KP=1.0e-12,
+                        W=1.0,
+                        L=1.0,
+                        CJ=cj,
+                        AS=source_area,
+                    )
+                ),
+            ),
+        ))
+        return transient(circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler")
+
+    uncharged = run(0.0, 0.0)
+    charged = run(0.5, 2.0e-9)
+
+    assert uncharged.converged
+    assert charged.converged
+    uncharged_first = uncharged.points[1].node_voltages["source"]
+    charged_first = charged.points[1].node_voltages["source"]
+    assert uncharged_first > 0.5
+    assert charged_first < 0.01
+    assert charged_first < uncharged_first
+
+
 def test_transient_mosfet_bulk_junction_depletion_shaping_reduces_reverse_bias_capacitance() -> None:
     def run(grading_coefficient: float) -> TransientResult:
         circuit = Circuit()
@@ -2129,6 +2173,28 @@ def test_mosfet_rejects_invalid_drain_area(drain_area: float) -> None:
     with pytest.raises(
         ValueError,
         match="MOSFET AD must be finite and non-negative",
+    ):
+        dc_op(circuit)
+
+
+@pytest.mark.parametrize("source_area", [float("nan"), -1.0])
+def test_mosfet_rejects_invalid_source_area(source_area: float) -> None:
+    circuit = Circuit()
+    circuit.add(Mosfet(
+        "Mbad",
+        "drain",
+        "gate",
+        "0",
+        "0",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(Level1Params(AS=source_area)),
+        ),
+    ))
+
+    with pytest.raises(
+        ValueError,
+        match="MOSFET AS must be finite and non-negative",
     ):
         dc_op(circuit)
 
@@ -3104,6 +3170,7 @@ def test_subcircuit_expansion_preserves_mos_geometry():
                             NRD=2.0,
                             NRS=3.0,
                             AD=4.0e-12,
+                            AS=5.0e-12,
                             CJ=2.0e-3,
                             TOX=25.0e-9,
                         )
@@ -3127,6 +3194,7 @@ def test_subcircuit_expansion_preserves_mos_geometry():
     assert pytest.approx(2.0) == expanded.model.model.params.NRD
     assert pytest.approx(3.0) == expanded.model.model.params.NRS
     assert pytest.approx(4.0e-12) == expanded.model.model.params.AD
+    assert pytest.approx(5.0e-12) == expanded.model.model.params.AS
     assert pytest.approx(2.0e-3) == expanded.model.model.params.CJ
     assert pytest.approx(25.0e-9) == expanded.model.model.params.TOX
 
@@ -5832,6 +5900,41 @@ def test_ac_mosfet_drain_area_scales_bottom_junction_capacitance():
 
     without_area_capacitance = drain_amplitude(0.5, 0.0)
     with_area_capacitance = drain_amplitude(0.5, 2.0e-6)
+
+    assert without_area_capacitance > 0.9
+    assert with_area_capacitance < without_area_capacitance / 100.0
+
+
+def test_ac_mosfet_source_area_scales_bottom_junction_capacitance():
+    def source_amplitude(cj: float, source_area: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vac", "in", "0", 0.0, ac=AcSource(1.0)))
+        circuit.add(Resistor("Rin", "in", "source", 1000.0))
+        circuit.add(Mosfet(
+            "M1",
+            "0",
+            "0",
+            "source",
+            "0",
+            MOSFET(
+                MosfetType.NMOS,
+                Level1Model(
+                    Level1Params(
+                        KP=1.0e-12,
+                        W=1.0,
+                        L=1.0,
+                        TOX=1.0e9,
+                        CJ=cj,
+                        AS=source_area,
+                    )
+                ),
+            ),
+        ))
+        result = ac_sweep(circuit, f_start=100000.0, f_stop=100000.0, n_points=1)
+        return abs(result.points[0].node_voltages["source"])
+
+    without_area_capacitance = source_amplitude(0.5, 0.0)
+    with_area_capacitance = source_amplitude(0.5, 2.0e-6)
 
     assert without_area_capacitance > 0.9
     assert with_area_capacitance < without_area_capacitance / 100.0

--- a/code/packages/rust/mosfet-models/CHANGELOG.md
+++ b/code/packages/rust/mosfet-models/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `Level1Params::as_` adds the zero-default Berkeley source diffusion area,
+  contributing `CJ * AS` to the zero-bias source-body capacitance.
 - `Level1Params::ad` and `Level1Params::cj` add zero-default Berkeley drain
   diffusion area and bottom-junction capacitance density, contributing
   `CJ * AD` to the zero-bias drain-body capacitance.

--- a/code/packages/rust/mosfet-models/README.md
+++ b/code/packages/rust/mosfet-models/README.md
@@ -32,8 +32,8 @@ and must leave a positive effective channel length. `TOX` defaults to
 external drain, source, and sheet-resistance parameters for engine topology and
 default to zero ohms. `NRD` and `NRS` are finite, non-negative drain/source
 diffusion square counts and default to one.
-`AD` and `CJ` are finite, non-negative and default to zero; together they add
-`CJ * AD` to the zero-bias drain-body capacitance `CBD`.
+`AD`, `AS`, and `CJ` are finite, non-negative and default to zero. They add
+`CJ * AD` to drain-body `CBD` and `CJ * AS` to source-body `CBS`.
 
 ## Usage
 

--- a/code/packages/rust/mosfet-models/src/lib.rs
+++ b/code/packages/rust/mosfet-models/src/lib.rs
@@ -46,6 +46,7 @@ const OXIDE_PERMITTIVITY: f64 = 3.453_133e-11;
 /// | NRD       | Number of drain squares              | 1        |
 /// | NRS       | Number of source squares             | 1        |
 /// | AD        | Drain diffusion area (m²)             | 0        |
+/// | AS        | Source diffusion area (m²)            | 0        |
 /// | CJ        | Bottom junction capacitance (F/m²)    | 0        |
 /// | IS        | Drain–body saturation current (A)  | 1 fA     |
 /// | N_SUB     | Subthreshold slope factor          | 1.4      |
@@ -84,6 +85,8 @@ pub struct Level1Params {
     pub nrs: f64,
     /// Drain diffusion area [m²].
     pub ad: f64,
+    /// Source diffusion area [m²].
+    pub as_: f64,
     /// Bottom junction capacitance per unit area [F/m²].
     pub cj: f64,
     /// Drain–body saturation current [A] (used for subthreshold floor).
@@ -134,6 +137,7 @@ impl Default for Level1Params {
             nrd: 1.0,
             nrs: 1.0,
             ad: 0.0,
+            as_: 0.0,
             cj: 0.0,
             is: 1e-15,
             n_sub: 1.4,
@@ -297,6 +301,10 @@ pub fn evaluate_level1(
         "MOSFET AD must be finite and non-negative"
     );
     assert!(
+        p.as_.is_finite() && p.as_ >= 0.0,
+        "MOSFET AS must be finite and non-negative"
+    );
+    assert!(
         p.cj.is_finite() && p.cj >= 0.0,
         "MOSFET CJ must be finite and non-negative"
     );
@@ -321,7 +329,7 @@ pub fn evaluate_level1(
 
     // Meyer gate-to-channel capacitance, partitioned by operating region below.
     let channel_capacitance = p.w * effective_length * (OXIDE_PERMITTIVITY / p.tox);
-    let cbs_bulk = bulk_junction_capacitance(p.cbs, v_bs, p.pb, p.mj, p.fc);
+    let cbs_bulk = bulk_junction_capacitance(p.cbs + p.cj * p.as_, v_bs, p.pb, p.mj, p.fc);
     let cbd_bulk = bulk_junction_capacitance(p.cbd + p.cj * p.ad, v_bs - v_ds, p.pb, p.mj, p.fc);
 
     // -----------------------------------------------------------------------

--- a/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
+++ b/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
@@ -262,11 +262,44 @@ fn test_drain_area_scales_bottom_junction_capacitance() {
 }
 
 #[test]
+fn test_source_area_scales_bottom_junction_capacitance() {
+    let result = evaluate_level1(
+        &Level1Params {
+            cbs: 1.0e-12,
+            cj: 2.0e-3,
+            as_: 3.0e-9,
+            mj: 0.0,
+            ..Level1Params::default()
+        },
+        1.8,
+        0.0,
+        0.0,
+        300.15,
+    );
+    assert!((result.cbs - 7.0e-12).abs() < 1.0e-24);
+}
+
+#[test]
 #[should_panic(expected = "MOSFET AD must be finite and non-negative")]
 fn test_drain_area_rejects_negative_value() {
     let _ = evaluate_level1(
         &Level1Params {
             ad: -1.0,
+            ..Level1Params::default()
+        },
+        1.8,
+        1.8,
+        0.0,
+        300.15,
+    );
+}
+
+#[test]
+#[should_panic(expected = "MOSFET AS must be finite and non-negative")]
+fn test_source_area_rejects_negative_value() {
+    let _ = evaluate_level1(
+        &Level1Params {
+            as_: -1.0,
             ..Level1Params::default()
         },
         1.8,

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add the Level-1 MOS `AS` instance parameter. With model-card `CJ`, its
+  product augments `CBS` in AC and transient source-body capacitance.
 - Add the Level-1 MOS `AD` instance parameter and model-card `CJ` density.
   Their product augments `CBD` in AC and transient drain-body capacitance.
 - Add the Level-1 MOS `NRS` instance parameter. It defaults to one and scales

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -143,9 +143,9 @@ node, routes the channel and source-side capacitances through it, and contribute
 `RSH` defaults to zero ohms per square. `NRD` and `NRS` default to one drain
 and source square, so the fallbacks are `RSH * NRD` and `RSH * NRS`; explicit
 positive `RD` / `RS` values take precedence.
-`AD` and model-card `CJ` default to zero, are finite and non-negative, and add
-`CJ * AD` to the zero-bias drain-body capacitance `CBD` in AC and transient
-analysis.
+`AD`, `AS`, and model-card `CJ` default to zero and are finite and non-negative.
+They add `CJ * AD` to drain-body `CBD` and `CJ * AS` to source-body `CBS` in
+AC and transient analysis.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3615,6 +3615,7 @@ pub struct MosfetLevel1Params {
     pub drain_squares: f64,
     pub source_squares: f64,
     pub drain_area: f64,
+    pub source_area: f64,
     pub bottom_junction_capacitance: f64,
     pub saturation_current: f64,
     pub n_sub: f64,
@@ -3649,6 +3650,7 @@ impl Default for MosfetLevel1Params {
             drain_squares: 1.0,
             source_squares: 1.0,
             drain_area: 0.0,
+            source_area: 0.0,
             bottom_junction_capacitance: 0.0,
             saturation_current: 1.0e-15,
             n_sub: 1.4,
@@ -24307,7 +24309,7 @@ fn evaluate_nmos_level1(
     let channel_capacitance =
         params.w * effective_length * (OXIDE_PERMITTIVITY / params.oxide_thickness);
     let cbs_bulk = mosfet_bulk_junction_capacitance(
-        params.source_bulk_capacitance,
+        params.source_bulk_capacitance + params.bottom_junction_capacitance * params.source_area,
         vbs,
         params.bulk_junction_potential,
         params.bulk_junction_grading_coefficient,
@@ -25045,7 +25047,8 @@ fn mosfet_charge_state_specs(mosfet: &Mosfet) -> Vec<MosfetChargeStateSpec> {
     let gate_source_capacitance = params.gate_source_overlap_capacitance * params.w;
     let gate_drain_capacitance = params.gate_drain_overlap_capacitance * params.w;
     let gate_body_capacitance = params.gate_bulk_overlap_capacitance * params.l;
-    let source_body_capacitance = params.source_bulk_capacitance;
+    let source_body_capacitance =
+        params.source_bulk_capacitance + params.bottom_junction_capacitance * params.source_area;
     let drain_body_capacitance =
         params.drain_bulk_capacitance + params.bottom_junction_capacitance * params.drain_area;
     if gate_source_capacitance > 0.0 {
@@ -25679,6 +25682,7 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         ("NRD", params.drain_squares),
         ("NRS", params.source_squares),
         ("AD", params.drain_area),
+        ("AS", params.source_area),
         ("CJ", params.bottom_junction_capacitance),
         ("TOX", params.oxide_thickness),
         ("IS", params.saturation_current),
@@ -25756,6 +25760,12 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: mosfet.name.clone(),
             reason: "MOSFET AD must be non-negative".to_string(),
+        });
+    }
+    if params.source_area < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET AS must be non-negative".to_string(),
         });
     }
     if params.bottom_junction_capacitance < 0.0 {

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -1397,6 +1397,47 @@ fn ac_mosfet_drain_area_scales_bottom_junction_capacitance() {
 }
 
 #[test]
+fn ac_mosfet_source_area_scales_bottom_junction_capacitance() {
+    fn source_amplitude(bottom_junction_capacitance: f64, source_area: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "in", "0", 0.0, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "source", 1_000.0,
+        )));
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "M1",
+            "0",
+            "0",
+            "source",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                kp: 1.0e-12,
+                w: 1.0,
+                l: 1.0,
+                oxide_thickness: 1.0e9,
+                source_area,
+                bottom_junction_capacitance,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+
+        ac_sweep(&circuit, 100_000.0, 100_000.0, 1).unwrap()[0]
+            .voltage("source")
+            .unwrap()
+            .abs()
+    }
+
+    let without_area_capacitance = source_amplitude(0.5, 0.0);
+    let with_area_capacitance = source_amplitude(0.5, 2.0e-6);
+
+    assert!(without_area_capacitance > 0.9);
+    assert!(with_area_capacitance < without_area_capacitance / 100.0);
+}
+
+#[test]
 fn ac_mosfet_oxide_thickness_scales_intrinsic_gate_capacitance() {
     let gate_amplitude = |oxide_thickness| {
         let mut circuit = Circuit::new();

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1803,6 +1803,7 @@ fn subcircuit_expansion_preserves_mos_geometry() {
             drain_squares: 2.0,
             source_squares: 3.0,
             drain_area: 4.0e-12,
+            source_area: 5.0e-12,
             bottom_junction_capacitance: 2.0e-3,
             oxide_thickness: 25.0e-9,
             ..MosfetLevel1Params::default()
@@ -1850,6 +1851,7 @@ fn subcircuit_expansion_preserves_mos_geometry() {
     assert_close(expanded.params.drain_squares, 2.0);
     assert_close(expanded.params.source_squares, 3.0);
     assert_close(expanded.params.drain_area, 4.0e-12);
+    assert_close(expanded.params.source_area, 5.0e-12);
     assert_close(expanded.params.bottom_junction_capacitance, 2.0e-3);
     assert_close(expanded.params.oxide_thickness, 25.0e-9);
 }
@@ -4086,6 +4088,38 @@ fn dc_mosfet_rejects_invalid_drain_area() {
                     "MOSFET AD must be non-negative".to_string()
                 } else {
                     "MOSFET AD must be finite".to_string()
+                },
+            }
+        );
+    }
+}
+
+#[test]
+fn dc_mosfet_rejects_invalid_source_area() {
+    for source_area in [f64::NAN, -1.0] {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "Mbad",
+            "drain",
+            "gate",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                source_area,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+
+        let err = dc_op(&circuit).unwrap_err();
+        assert_eq!(
+            err,
+            SpiceError::InvalidElement {
+                name: "Mbad".to_string(),
+                reason: if source_area.is_finite() {
+                    "MOSFET AS must be non-negative".to_string()
+                } else {
+                    "MOSFET AS must be finite".to_string()
                 },
             }
         );

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -468,6 +468,53 @@ fn transient_mosfet_drain_area_scales_bottom_junction_capacitance() {
 }
 
 #[test]
+fn transient_mosfet_source_area_scales_bottom_junction_capacitance() {
+    fn run(bottom_junction_capacitance: f64, source_area: f64) -> Vec<TransientPoint> {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
+            "Vstep",
+            "in",
+            "0",
+            0.0,
+            Waveform::Pwl(PwlWaveform::new(vec![
+                (0.0, 0.0),
+                (1.0e-9, 1.0),
+                (5.0e-9, 1.0),
+            ])),
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "source", 1_000.0,
+        )));
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "M1",
+            "0",
+            "0",
+            "source",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                kp: 1.0e-12,
+                w: 1.0,
+                l: 1.0,
+                bottom_junction_capacitance,
+                source_area,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+        transient_with_method(&circuit, 1.0e-9, 5.0e-9, TransientMethod::Euler).unwrap()
+    }
+
+    let uncharged = run(0.0, 0.0);
+    let charged = run(0.5, 2.0e-9);
+    let uncharged_first = uncharged[0].voltage("source").unwrap();
+    let charged_first = charged[0].voltage("source").unwrap();
+
+    assert!(uncharged_first > 0.5);
+    assert!(charged_first < 0.01);
+    assert!(charged_first < uncharged_first);
+}
+
+#[test]
 fn transient_mosfet_bulk_junction_depletion_shaping_reduces_reverse_bias_capacitance() {
     fn run(grading_coefficient: f64) -> Vec<TransientPoint> {
         let mut circuit = Circuit::new();

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Parse Level-1 MOS instance `AS=<area>` into the engine parameter bundle for
+  source-body junction capacitance.
 - Parse Level-1 MOS instance `AD=<area>` and model-card `CJ=<capacitance/area>`
   into the engine parameter bundle for drain-body junction capacitance.
 - Parse Level-1 MOS instance `NRS=<squares>` into the engine parameter bundle

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -761,7 +761,7 @@ parameters, `.model <name> NPN|PNP(...)` BJT cards with `IS`, `BF` /
 cards with common SPICE aliases (`VT0` / `VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
 `W`, `L`, `RSH`, `IS`, `N_SUB` / `NSUB`, `T_NOM` / `TNOM`, `CGSO`, `CGDO`,
 `CGBO`, `CBS`, `CBD`, and `CJ`), MOS instance `NRD=<squares>` /
-`NRS=<squares>` / `AD=<area>`, SPICE engineering suffixes, capacitor
+`NRS=<squares>` / `AD=<area>` / `AS=<area>`, SPICE engineering suffixes, capacitor
 `IC=<voltage>` and inductor `IC=<current>` initial
 conditions, independent-source `AC <magnitude> [phase]` forms,
 PWL/PULSE/SIN/EXP source forms, comments, `.end`, `.subckt` / `X` instance

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1908,6 +1908,9 @@ fn build_mosfet_params(
     if let Some(value) = instance_params.get("AD") {
         params.drain_area = *value;
     }
+    if let Some(value) = instance_params.get("AS") {
+        params.source_area = *value;
+    }
     params
 }
 

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1362,7 +1362,7 @@ fn parses_mosfet_models_into_operating_point_circuits() {
 .model nch NMOS(VTO=0.45 KP=250u LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n RSH=250 NSUB=1.5 TNOM=300 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p CJ=2m)
 Vdd vdd 0 DC 5
 Vgate gate 0 DC 2.5
-M1 vdd gate out 0 nch W=4u L=200n NRD=2 NRS=3 AD=3n
+M1 vdd gate out 0 nch W=4u L=200n NRD=2 NRS=3 AD=3n AS=4n
 Rload out 0 1k
 .op
 "#,
@@ -1396,6 +1396,7 @@ Rload out 0 1k
     assert_close(mosfet.params.drain_squares, 2.0);
     assert_close(mosfet.params.source_squares, 3.0);
     assert_close(mosfet.params.drain_area, 3.0e-9);
+    assert_close(mosfet.params.source_area, 4.0e-9);
     assert_close(mosfet.params.bottom_junction_capacitance, 2.0e-3);
     assert_close(mosfet.params.n_sub, 1.5);
     assert_close(mosfet.params.t_nom, 300.0);

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add the Level-1 MOS `AS` instance parameter. With model-card `CJ`, its
+  product augments `CBS` in AC and transient source-body capacitance.
 - Add the Level-1 MOS `AD` instance parameter and model-card `CJ` density.
   Their product augments `CBD` in AC and transient drain-body capacitance.
 - Add the Level-1 MOS `NRS` instance parameter. It defaults to one and scales

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -94,9 +94,9 @@ node, routes the channel and source-side capacitances through it, and contribute
 `RSH` defaults to zero ohms per square. `NRD` and `NRS` default to one drain
 and source square, so the fallbacks are `RSH * NRD` and `RSH * NRS`; explicit
 positive `RD` / `RS` values take precedence.
-`AD` and model-card `CJ` default to zero, are finite and non-negative, and add
-`CJ * AD` to the zero-bias drain-body capacitance `CBD` in AC and transient
-analysis.
+`AD`, `AS`, and model-card `CJ` default to zero and are finite and non-negative.
+They add `CJ * AD` to drain-body `CBD` and `CJ * AS` to source-body `CBS` in
+AC and transient analysis.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1783,6 +1783,7 @@ export interface MosfetLevel1Params {
   readonly NRD: number;
   readonly NRS: number;
   readonly AD: number;
+  readonly AS: number;
   readonly CJ: number;
   readonly IS: number;
   readonly N_SUB: number;
@@ -8047,6 +8048,7 @@ export function defaultMosfetLevel1Params(): MosfetLevel1Params {
     NRD: 1.0,
     NRS: 1.0,
     AD: 0.0,
+    AS: 0.0,
     CJ: 0.0,
     IS: 1.0e-15,
     N_SUB: 1.4,
@@ -20332,7 +20334,7 @@ function evaluateNmosLevel1(
   const channelCapacitance =
     params.W * effectiveLength * (OXIDE_PERMITTIVITY / params.TOX);
   const cbsBulk = mosfetBulkJunctionCapacitance(
-    params.CBS, vbs, params.PB, params.MJ, params.FC,
+    params.CBS + params.CJ * params.AS, vbs, params.PB, params.MJ, params.FC,
   );
   const cbdBulk = mosfetBulkJunctionCapacitance(
     params.CBD + params.CJ * params.AD, vbs - vds, params.PB, params.MJ, params.FC,
@@ -20892,7 +20894,8 @@ function mosfetChargeStateSpecs(element: Mosfet): MosfetChargeStateSpec[] {
   const gateSourceCapacitance = element.params.CGSO * element.params.W;
   const gateDrainCapacitance = element.params.CGDO * element.params.W;
   const gateBodyCapacitance = element.params.CGBO * element.params.L;
-  const sourceBodyCapacitance = element.params.CBS;
+  const sourceBodyCapacitance =
+    element.params.CBS + element.params.CJ * element.params.AS;
   const drainBodyCapacitance =
     element.params.CBD + element.params.CJ * element.params.AD;
   if (gateSourceCapacitance > 0.0) {
@@ -21147,6 +21150,9 @@ function validateMosfet(element: Mosfet): void {
   }
   if (params.AD < 0.0) {
     throw invalidElement(element.name, "MOSFET AD must be non-negative");
+  }
+  if (params.AS < 0.0) {
+    throw invalidElement(element.name, "MOSFET AS must be non-negative");
   }
   if (params.CJ < 0.0) {
     throw invalidElement(element.name, "MOSFET CJ must be non-negative");

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -597,6 +597,29 @@ describe("acSweep", () => {
     expect(withAreaCapacitance).toBeLessThan(withoutAreaCapacitance / 100.0);
   });
 
+  it("scales MOSFET bottom junction capacitance by source area", () => {
+    function sourceAmplitude(bottomJunctionCapacitance: number, sourceArea: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "in", "0", 0.0, 1.0));
+      circuit.add(resistor("Rin", "in", "source", 1_000.0));
+      circuit.add(mosfet("M1", "0", "0", "source", "0", "NMOS", {
+        KP: 1.0e-12,
+        W: 1.0,
+        L: 1.0,
+        TOX: 1.0e9,
+        CJ: bottomJunctionCapacitance,
+        AS: sourceArea,
+      }));
+      return complexAbs(acSweep(circuit, 100_000.0, 100_000.0, 1)[0].voltage("source")!);
+    }
+
+    const withoutAreaCapacitance = sourceAmplitude(0.5, 0.0);
+    const withAreaCapacitance = sourceAmplitude(0.5, 2.0e-6);
+
+    expect(withoutAreaCapacitance).toBeGreaterThan(0.9);
+    expect(withAreaCapacitance).toBeLessThan(withoutAreaCapacitance / 100.0);
+  });
+
   it("uses MOSFET oxide thickness to scale intrinsic gate capacitance", () => {
     function gateAmplitude(TOX: number): number {
       const circuit = new Circuit();

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -1265,6 +1265,7 @@ describe("dcOp", () => {
           NRD: 2.0,
           NRS: 3.0,
           AD: 4.0e-12,
+          AS: 5.0e-12,
           CJ: 2.0e-3,
           TOX: 25.0e-9,
         }),
@@ -1284,6 +1285,7 @@ describe("dcOp", () => {
     expectClose(expanded!.params.NRD, 2.0);
     expectClose(expanded!.params.NRS, 3.0);
     expectClose(expanded!.params.AD, 4.0e-12);
+    expectClose(expanded!.params.AS, 5.0e-12);
     expectClose(expanded!.params.CJ, 2.0e-3);
     expectClose(expanded!.params.TOX, 25.0e-9);
   });
@@ -2576,6 +2578,20 @@ describe("dcOp", () => {
         Number.isFinite(drainArea)
           ? "MOSFET AD must be non-negative"
           : "MOSFET AD must be finite",
+      );
+    }
+  });
+
+  it("rejects invalid MOSFET source areas", () => {
+    for (const sourceArea of [Number.NaN, -1.0]) {
+      const circuit = new Circuit();
+      circuit.add(mosfet("Mbad", "drain", "gate", "0", "0", "NMOS", {
+        AS: sourceArea,
+      }));
+      expect(() => dcOp(circuit)).toThrowError(
+        Number.isFinite(sourceArea)
+          ? "MOSFET AS must be non-negative"
+          : "MOSFET AS must be finite",
       );
     }
   });

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -407,6 +407,40 @@ describe("transient", () => {
     expect(chargedFirst!).toBeLessThan(unchargedFirst!);
   });
 
+  it("scales MOSFET bottom junction capacitance by source area", () => {
+    function run(bottomJunctionCapacitance: number, sourceArea: number): TransientPoint[] {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithWaveform(
+        "Vstep",
+        "in",
+        "0",
+        0.0,
+        new PwlWaveform([
+          [0.0, 0.0],
+          [1.0e-9, 1.0],
+          [5.0e-9, 1.0],
+        ]),
+      ));
+      circuit.add(resistor("Rin", "in", "source", 1_000.0));
+      circuit.add(mosfet("M1", "0", "0", "source", "0", "NMOS", {
+        KP: 1.0e-12,
+        W: 1.0,
+        L: 1.0,
+        CJ: bottomJunctionCapacitance,
+        AS: sourceArea,
+      }));
+      return transient(circuit, 1.0e-9, 5.0e-9, "euler");
+    }
+
+    const unchargedFirst = run(0.0, 0.0)[0].voltage("source");
+    const chargedFirst = run(0.5, 2.0e-9)[0].voltage("source");
+    expect(unchargedFirst).not.toBeUndefined();
+    expect(chargedFirst).not.toBeUndefined();
+    expect(unchargedFirst!).toBeGreaterThan(0.5);
+    expect(chargedFirst!).toBeLessThan(0.01);
+    expect(chargedFirst!).toBeLessThan(unchargedFirst!);
+  });
+
   it("shapes MOSFET bulk junction transient capacitance under reverse bias", () => {
     function run(gradingCoefficient: number): TransientPoint[] {
       const circuit = new Circuit();

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,17 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS drain diffusion area and bottom capacitance.
+1. Cross-language Level-1 MOS source diffusion area.
    - Status: current PR completion candidate.
-   - Add the Berkeley Level-1 MOS `AD` instance parameter and model-card `CJ`
-     bottom-junction capacitance density in Rust, Python, and TypeScript,
-     defaulting both to zero.
-   - Use `CBD + CJ * AD` as the zero-bias drain-body capacitance in AC and
+   - Add the Berkeley Level-1 MOS `AS` instance parameter in Rust, Python, and
+     TypeScript, defaulting to zero.
+   - Use `CBS + CJ * AS` as the zero-bias source-body capacitance in AC and
      transient analysis while preserving existing `PB`, `MJ`, and `FC`
      depletion shaping.
-   - Preserve `AD` / `CJ` through hierarchy and cloning, enforce finite
-     non-negative validation, parse both in the Rust netlist facade, and raise
-     the model-card coverage gate to 195 canonical rows for `CJ`.
+   - Preserve `AS` through hierarchy and cloning, enforce finite non-negative
+     validation, and parse it in the Rust netlist facade.
 
 ## Completed Slices
 
@@ -3483,6 +3481,17 @@ the Rust, Python, and TypeScript surfaces together.
      cloning preserve `NRS`, finite non-negative validation is shared, and the
      model-card coverage gate remains at 193 canonical rows because `NRS` is
      an instance parameter.
+
+274. Cross-language Level-1 MOS drain diffusion area and bottom capacitance.
+   - Status: completed in PR 9038.
+   - Rust, Python, and TypeScript Level-1 MOS instances now accept `AD`, and
+     model cards accept `CJ`, both defaulting to zero.
+   - `CBD + CJ * AD` supplies the zero-bias drain-body capacitance in AC and
+     transient analysis while preserving `PB`, `MJ`, and `FC` depletion
+     shaping.
+   - Hierarchy and cloning preserve `AD` / `CJ`, finite non-negative
+     validation is shared, the Rust netlist facade parses both, and the
+     model-card coverage gate now covers 195 canonical rows.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add the Berkeley Level-1 MOS `AS` source diffusion area in Rust, Python, and TypeScript
- apply `CBS + CJ * AS` consistently in operating-point capacitance and transient charge stamping
- preserve and validate `AS`, parse it in the Rust netlist facade, and reconcile the SPICE implementation plan after #9038

## Verification
- `cargo test -p mosfet-models -p spice-engine -p spice-netlist-parser`
- Python MOSFET models and SPICE suites: 693 passed
- Ruff on touched Python packages
- TypeScript SPICE: 394 passed
- `npm run build`