### PR TITLE
feat(fold-control-flow): normalize an empty loop body {} to ; (0.37.0)

### DIFF
--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.37.0] - 2026-07-25
+
+### Added - normalize an empty loop body `{}` to `;`
+
+A `for` loop whose body folds to an empty block (`{}`, `{;;}`, `{{}}`) now
+normalizes that body to an empty statement (`;`), matching the reference
+Closure Compiler at SIMPLE:
+
+```text
+  for (; c;) {}   ->  for (; c;) ;
+  while (c) {}    ->  for (; c;) ;   (while first lowers to for, then re-folds)
+```
+
+An empty block declares no bindings, so the `;` form is behaviour-identical.
+Because `while` is already rewritten to `for` (0.31.0) and re-folded here, this
+one change covers both `for` and `while` empty bodies. The existing
+`statement_is_empty` helper (used by the if-empty-then fold) recognises the
+do-nothing body, so nested empties (`{{}}`) collapse too.
+
+Not handled here (follow-up #226): an empty-bodied `do … while` (`do{}while(c)`
+-> `for(; c;) ;`), which additionally needs the do -> while/for rewrite.
+
 ## [0.36.0] - 2026-07-24
 
 ### Added - do-while loop-body comma-fusion

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -1965,21 +1965,39 @@ fn fold_for_statement(s: &ForStatement, st: &mut FoldState) -> Statement {
     // `for (…) { if (x) a(); b(); }` → `for (…) x && a(), b();`.
     let body = match &body {
         Statement::Tagged(TaggedStatement::BlockStatement(_)) => {
-            match stmts_as_sequence_expr(&body) {
-                Some(expr) => {
-                    let body_cv = statement_cv(&body);
-                    st.record_fold(
-                        &s.cv,
-                        "loop-body-fuse",
-                        "for (…) { s1; s2; … }",
-                        "for (…) s1, s2, …",
-                    );
-                    Statement::expression_statement(ExpressionStatement {
-                        cv: body_cv,
-                        expression: expr,
-                    })
+            if statement_is_empty(&body) {
+                // Empty loop body: `for (…) {}` (or `{;;}`, `{{}}`) normalizes to
+                // `for (…) ;` — the reference compiler drops the braces of a
+                // do-nothing body. An empty block declares no bindings, so the
+                // `;` form is behaviour-identical. This also catches a `while`
+                // loop, since `while` is first rewritten to `for` (0.31.0) and
+                // then re-folded here: `while (c) {}` → `for (; c;) {}` → `for
+                // (; c;) ;`.
+                let body_cv = statement_cv(&body);
+                st.record_fold(
+                    &s.cv,
+                    "empty-loop-body",
+                    "for (…) {}",
+                    "for (…) ;",
+                );
+                Statement::empty_statement(EmptyStatement { cv: body_cv })
+            } else {
+                match stmts_as_sequence_expr(&body) {
+                    Some(expr) => {
+                        let body_cv = statement_cv(&body);
+                        st.record_fold(
+                            &s.cv,
+                            "loop-body-fuse",
+                            "for (…) { s1; s2; … }",
+                            "for (…) s1, s2, …",
+                        );
+                        Statement::expression_statement(ExpressionStatement {
+                            cv: body_cv,
+                            expression: expr,
+                        })
+                    }
+                    None => body,
                 }
-                None => body,
             }
         }
         _ => body,
@@ -2787,6 +2805,27 @@ mod tests {
                 }
                 other => panic!("expected a bare expression-statement body; got {other:?}"),
             },
+            other => panic!("expected ForStatement; got {other:?}"),
+        }
+    }
+
+    /// `for (;;) {}` → `for (;;) ;` — an empty block body normalizes to an
+    /// empty statement (dropping the braces). Also covers `while (c) {}`, which
+    /// first lowers to `for` and then re-folds through this same path.
+    #[test]
+    fn for_empty_block_body_normalizes_to_empty_statement() {
+        let body = block(Some("blk.1"), vec![]);
+        let f = for_stmt(None, None, body);
+        let (out, contribs, changed, _) =
+            run_pass(program().with_body(vec![ProgramItem::Statement(f)]));
+        assert!(changed);
+        assert!(contribs.iter().any(|c| c.tag == "empty-loop-body"));
+        match first_stmt(&out) {
+            Statement::Tagged(TaggedStatement::ForStatement(f)) => assert!(
+                matches!(f.body.as_ref(), Statement::Tagged(TaggedStatement::EmptyStatement(_))),
+                "empty for body must normalize to `;`; got {:?}",
+                f.body
+            ),
             other => panic!("expected ForStatement; got {other:?}"),
         }
     }

--- a/code/programs/rust/closurec/tests/diff/simple-empty-loop-body/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-empty-loop-body/README.md
@@ -1,0 +1,18 @@
+# simple-empty-loop-body
+
+End-to-end oracle for **empty-loop-body normalization** in
+`closure-pass-fold-control-flow` (fcf 0.37.0).
+
+A `for` loop whose body folds to an empty block (`{}`, `{;;}`, `{{}}`) has that
+body normalized to an empty statement (`;`). Because `while` is first rewritten
+to `for` (0.31.0) and re-folded, the one change covers both `for` and `while`
+empty bodies. A non-empty body is unaffected.
+
+## Expected output
+
+```text
+for(var i=0;i<n;i++);for(;cond;);for(;run();)step();
+```
+
+Byte-identical to the reference Closure Compiler (`v20260712`,
+`SIMPLE_OPTIMIZATIONS`, `ECMASCRIPT_2020`, `NO_TRANSPILE`), verified with `xxd`.

--- a/code/programs/rust/closurec/tests/diff/simple-empty-loop-body/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-empty-loop-body/expected.stdout
@@ -1,0 +1,1 @@
+for(var i=0;i<n;i++);for(;cond;);for(;run();)step();

--- a/code/programs/rust/closurec/tests/diff/simple-empty-loop-body/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-empty-loop-body/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-empty-loop-body/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-empty-loop-body/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-empty-loop-body/input/a.js
@@ -1,0 +1,12 @@
+// SIMPLE-level empty-loop-body normalization (fold-control-flow 0.37.0).
+//
+// A loop whose body folds to an empty block ({}, {;;}, {{}}) has that body
+// normalized to an empty statement (;), dropping the braces -- an empty block
+// declares no bindings, so the ; form is behaviour-identical:
+//   for (var i = 0; i < n; i++) {}  -> for(var i=0;i<n;i++);
+//   while (cond) {}                 -> for(;cond;);   (while lowers to for first)
+// A non-empty body is unaffected (a single statement just unwraps its braces):
+//   for (; run();) { step(); }      -> for(;run();)step();
+for (var i = 0; i < n; i++) {}
+while (cond) {}
+for (; run();) { step(); }

--- a/code/programs/rust/closurec/tests/diff_simple_empty_loop_body.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_empty_loop_body.rs
@@ -1,0 +1,51 @@
+//! Integration test for the `tests/diff/simple-empty-loop-body/` fixture.
+//!
+//! End-to-end oracle for empty-loop-body normalization in
+//! `closure-pass-fold-control-flow`: a `for`/`while` loop whose body folds to an
+//! empty block (`{}`, `{;;}`, `{{}}`) has that body normalized to an empty
+//! statement (`;`), dropping the braces. `while` first lowers to `for` and then
+//! re-folds through the same path. A non-empty body is unaffected.
+//!
+//! At SIMPLE the fixture optimizes to:
+//!
+//! ```text
+//! for(var i=0;i<n;i++);for(;cond;);for(;run();)step();
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-empty-loop-body/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_empty_loop_body_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-empty-loop-body/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}


### PR DESCRIPTION
## What

`fold-control-flow` (0.37.0): normalize an empty loop body `{}` to `;`, matching the reference Closure Compiler at SIMPLE.

```text
for (; c;) {}   ->  for(;c;);
while (c) {}    ->  for(;c;);   (while first lowers to for, then re-folds)
```

A `for` loop whose body folds to an empty block (`{}`, `{;;}`, `{{}}`) has that body replaced with an empty statement (`;`). An empty block declares no bindings, so the `;` form is behaviour-identical. Because `while` is already rewritten to `for` (0.31.0) and re-folded through `fold_for_statement`, this one change covers both `for` and `while` empty bodies.

## Scope

The existing `statement_is_empty` helper recognizes the do-nothing body (recursing through nested empties like `{{}}`). Anything carrying an observable effect — a declaration, a `LabeledStatement`, a `"use strict"` directive — is a different statement variant and keeps the block.

Not handled here (follow-up #226): an empty-bodied `do … while` (`do{}while(c)` → `for(;c;);`), which additionally needs the do → while/for rewrite.

## Verification

- 93 fold-control-flow unit tests (1 new) + 13 integration, zero regressions.
- New closurec e2e fixture `simple-empty-loop-body`, byte-identical to the oracle jar (`v20260712`, `SIMPLE`, `ECMASCRIPT_2020`, `NO_TRANSPILE`), verified with `xxd` — empty `for`, empty `while`, and a non-empty `for` (kept).
- Full closurec suite: **162 suites / 959 tests, zero failures, zero drift.**
- `cargo clippy -- -D warnings` clean in both workspaces.
- Inline security review: **PASSED** — semantics-preserving (only truly-empty blocks fold), no new recursion/panic vector, `statement_is_empty` short-circuits on the first non-empty member.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
