### PR TITLE
fix(sql-vm): round() returns positive zero, matching SQLite

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.68 — `round()` returns positive zero
+
+`round(-0.4)` and `round(-0.0)` now return `0.0`, not `-0.0`, matching SQLite —
+a zero `round()` result is always positive zero. Non-zero results keep their sign
+(`round(-0.5)` = `-1.0`), rounding to N places behaves the same, and a bare
+`-0.0` literal is unaffected. Found by probing real SQLite. Verified against
+bundled real SQLite. Spans sql-vm 0.4.38.
+
 ## 0.5.67 — `TOTAL()` aggregate
 
 `SELECT total(v) FROM t` is now supported — SQLite's NULL-free companion to

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.67"
+version = "0.5.68"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -2309,6 +2309,20 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT total(v), sum(v) FROM t",
     },
+    // `round()` reports a zero result as POSITIVE zero, matching SQLite:
+    // `round(-0.4)` and `round(-0.0)` are `0.0`, not `-0.0` (Rust's `f64::round`
+    // returns `-0.0` for a value rounding to zero from below). A non-zero result
+    // keeps its sign (`round(-0.5)` = `-1.0`), and rounding to N places behaves
+    // the same (`round(-0.004, 2)` = `0.0`). `Real(0.0)` vs `Real(-0.0)` is caught
+    // by the oracle's value comparison — the two are not bit-equal.
+    // (Aliased so the column names match trivially — an un-aliased `round(-0.4)`
+    // is named `?` here because the negative-literal argument has no rendered
+    // label; that naming gap is orthogonal. What we assert is the VALUE.)
+    Case {
+        id: "round_negative_zero_is_positive",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT round(-0.4) AS a, round(-0.0) AS b, round(-0.5) AS c, round(-0.004, 2) AS d FROM t",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.38] - Unreleased
+
+### Fixed
+
+- **`round()` reports a zero result as positive zero.** Rust's `f64::round`
+  returns `-0.0` for a value that rounds to zero from below (`round(-0.4)`,
+  `round(-0.0)`), but SQLite's `round()` always yields `0.0`. Normalized in the
+  `ROUND` builtin (`-0.0 → +0.0`); non-zero results keep their sign, and a bare
+  `-0.0` literal elsewhere is unaffected (round()-specific).
+
 ## [0.4.37] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.37"
+version = "0.4.38"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -1630,6 +1630,13 @@ fn call_builtin(name: &str, args: Vec<SqlValue>) -> Result<SqlValue, VmError> {
             // Round half away from zero (SQLite semantics), to `digits` decimal places.
             let factor = 10_f64.powi(digits);
             let rounded = (x * factor).round() / factor;
+            // Normalize negative zero to positive zero: Rust's `f64::round` yields
+            // `-0.0` for a value that rounds to zero from below (`round(-0.4)` →
+            // `-0.0`), but SQLite's `round()` always reports a zero result as
+            // `0.0`. `-0.0 == 0.0` is true, so this maps `-0.0` → `+0.0` and leaves
+            // every non-zero result untouched. (A bare `-0.0` literal elsewhere in
+            // the engine still keeps its sign — this is round()-specific.)
+            let rounded = if rounded == 0.0 { 0.0 } else { rounded };
             Ok(SqlValue::Float(rounded))
         }
 


### PR DESCRIPTION
## What

`round()` now reports a zero result as **positive zero**, matching SQLite:

```sql
SELECT round(-0.4);   -- 0.0   (was -0.0)
SELECT round(-0.0);   -- 0.0   (was -0.0)
SELECT round(-0.5);   -- -1.0  (unchanged — non-zero keeps its sign)
```

Rust's `f64::round` yields `-0.0` for any value that rounds to zero from below, but SQLite's `round()` always returns `0.0`.

## How

One-line normalization in the `ROUND` builtin: `let rounded = if rounded == 0.0 { 0.0 } else { rounded };` — `-0.0 == 0.0` is true, so it maps `-0.0 → +0.0` and leaves every non-zero result untouched. Rounding to N places behaves the same (`round(-0.004, 2)` = `0.0`). The normalization is **round()-specific** — a bare `-0.0` literal elsewhere still keeps its sign (mini already matches SQLite there).

Found by probing real SQLite for edge-case divergences.

## Verification
- Differential oracle green vs **bundled real SQLite** (`round_negative_zero_is_positive` — `Real(0.0)` vs `Real(-0.0)` is a value-comparison difference, since the two are not bit-equal).
- Full `sql-vm` / `mini-sqlite` / `storage-sqlite` suites pass; clippy clean.
- Security posture: the change is a single pure-numeric normalization with no untrusted-input, allocation, or memory-safety surface — inline assessment, no security-relevant surface (a subagent review would be disproportionate for a one-line `if x == 0.0` in safe Rust).

Versions: `sql-vm` 0.4.38, `mini-sqlite` 0.5.68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
