### PR TITLE
feat(adj-formula-stdlib): stroke-volume — StatPearls SV = EDV − ESV definition library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_stroke_volume_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_stroke_volume_e2e.rs
@@ -1,0 +1,142 @@
+//! End-to-end tests for the `clinical/stroke-volume.adj` library — the definition of
+//! stroke volume (SV = end-diastolic volume − end-systolic volume) and its two exact
+//! rearrangements (EDV = SV + ESV, ESV = EDV − SV) — driven through the built CLI binary
+//! against the SHIPPED stdlib. Each proves the same invariant as the other formula
+//! libraries: a consumer states NO arithmetic; it imports the grounded library, binds the
+//! measured quantities with `observe`, and the engine applies the cited relation on the
+//! CPU, computing the EXACT value and rendering the relation's citation and trust tier in
+//! the `derived` section (the auditable answer). The three formulas INVERT around the
+//! worked case EDV = 120 mL, ESV = 50 mL: 120 − 50 = 70, and both 70 + 50 = 120 and
+//! 120 − 70 = 50 recover the inputs.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped stroke-volume library, resolved from this crate's manifest
+/// dir so the test is location-independent.
+fn shipped_stroke_volume_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/stroke-volume.adj")
+        .canonicalize()
+        .expect("shipped stroke-volume.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_sv_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_stroke_volume_lib()).unwrap();
+    std::fs::write(dir.join("stroke-volume.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// stroke_volume — the definition: the end-diastolic volume less the end-systolic volume.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_stroke_volume_library_and_computes_stroke_volume_with_citation() {
+    let dir = scratch("sv");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"stroke-volume.adj\"\n\
+         observe end_diastolic_volume(120)\n\
+         observe end_systolic_volume(50)\n\
+         ? stroke_volume(end_diastolic_volume, end_systolic_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 120 - 50 = 70.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"stroke_volume\"") && s.contains("\"value\":70"),
+        "stroke_volume(120, 50) = 70: {s}"
+    );
+    // … AND the StatPearls/NCBI Bookshelf citation and trust tier, so the answer is
+    // auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// end_diastolic_volume — the same relation solved for EDV: SV + ESV, which INVERTS the
+// stroke volume just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_end_diastolic_volume_from_stroke_volume_and_end_systolic_with_citation() {
+    let dir = scratch("edv");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"stroke-volume.adj\"\n\
+         observe stroke_volume(70)\n\
+         observe end_systolic_volume(50)\n\
+         ? end_diastolic_volume(stroke_volume, end_systolic_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 70 + 50 = 120, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"end_diastolic_volume\"") && s.contains("\"value\":120"),
+        "end_diastolic_volume(70, 50) = 120: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "end_diastolic_volume carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// end_systolic_volume — the same relation solved for ESV: EDV − SV, the third exact reading
+// of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_end_systolic_volume_from_end_diastolic_and_stroke_volume_with_citation() {
+    let dir = scratch("esv");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"stroke-volume.adj\"\n\
+         observe end_diastolic_volume(120)\n\
+         observe stroke_volume(70)\n\
+         ? end_systolic_volume(end_diastolic_volume, stroke_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 120 - 70 = 50, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"end_systolic_volume\"") && s.contains("\"value\":50"),
+        "end_systolic_volume(120, 70) = 50: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "end_systolic_volume carries its StatPearls citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/stroke-volume.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/stroke-volume.adj
@@ -1,0 +1,101 @@
+% ============================================================================
+% stroke-volume.adj — the definition of stroke volume
+% (SV = end-diastolic volume − end-systolic volume) in the ADJ standard library.
+% ============================================================================
+% The stroke-volume entry of the *clinical* track, a hemodynamics sibling of
+% `cardiac-output.adj`, `mean-arterial-pressure.adj`, `pulse-pressure.adj` and
+% `fick-principle.adj`. Where `cardiac-output.adj` grounds cardiac output as the product
+% CO = stroke volume × heart rate, this grounds the PRIOR, independent definition of the
+% stroke volume itself: STROKE VOLUME IS THE END-DIASTOLIC VOLUME MINUS THE END-SYSTOLIC
+% VOLUME — the amount of blood a ventricle ejects in one beat, the volume it held when full
+% (end of diastole) less the volume it retains after contracting (end of systole). It ships
+% as an importable, byte-provenanced, PARAMETERIZED `formula`, together with its two exact
+% rearrangements (the end-diastolic volume a stroke volume implies for a given end-systolic
+% volume, and the end-systolic volume the other two imply). As with every compute library,
+% a consumer states NO arithmetic: it `import`s this file, binds the measured quantities
+% from its own byte-provenance decomposition, and asks the engine to APPLY the cited
+% definition on the CPU. Zero math is performed by the model; the engine computes each value
+% EXACTLY, carrying the definition's citation.
+%
+%     import "stroke-volume.adj"
+%     observe end_diastolic_volume(120)     % "…EDV 120 mL…"  (span cited by the model)
+%     observe end_systolic_volume(50)       % "…ESV 50 mL…"   (span cited by the model)
+%     ? stroke_volume(end_diastolic_volume, end_systolic_volume)
+%                                              % engine → 70, carrying SV = EDV − ESV
+%
+% All three formulas are EXACT over their parameters (a difference and two of its inverse
+% readings), so every value the engine returns is exact. The three COMPOSE and invert
+% cleanly around the worked case EDV = 120 mL, ESV = 50 mL (SV = 120 − 50 = 70 mL, a normal
+% resting stroke volume): the `stroke_volume` a consumer computes from the two volumes is
+% exactly the `stroke_volume` the `end_diastolic_volume` formula adds the end-systolic
+% volume back to, to recover the 120 mL end-diastolic volume, and exactly the `stroke_volume`
+% the `end_systolic_volume` formula subtracts from the end-diastolic volume to recover the
+% 50 mL end-systolic volume.
+%
+%   stroke_volume(end_diastolic_volume, end_systolic_volume)
+%       = end_diastolic_volume - end_systolic_volume     % SV = EDV − ESV   (definition)
+%   end_diastolic_volume(stroke_volume, end_systolic_volume)
+%       = stroke_volume + end_systolic_volume            % EDV = SV + ESV   (same def, solved for EDV)
+%   end_systolic_volume(end_diastolic_volume, stroke_volume)
+%       = end_diastolic_volume - stroke_volume           % ESV = EDV − SV   (same def, solved for ESV)
+%
+% NOTE ON UNITS: the two volumes must be in the SAME unit (both millilitres, as in the
+% worked case), and the stroke volume comes out in that same unit; this library computes the
+% exact value over whatever consistent unit it is given.
+%
+% All three formulas are defended by the SAME definitional sentence — "The difference
+% between end-diastolic volume and end-systolic volume defines stroke volume." — because
+% that one definition (stroke volume IS the end-diastolic minus the end-systolic volume)
+% sanctions the relation read every way (SV from the two volumes, EDV from SV and ESV, or
+% ESV from EDV and SV). The quote is transcribed verbatim from the StatPearls "Physiology,
+% Stroke Volume" article on the NCBI Bookshelf, so each `formula` carries the provenance
+% envelope every shipped grounded clause carries; the linter rejects an unsourced one.
+% (See feedback_nothing_human_authored — the definitional sentence is a verbatim span of the
+% cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable ventricular volume the definition ranges over,
+% and each result is a derived quantity. `stroke_volume`, `end_diastolic_volume` and
+% `end_systolic_volume` each appear BOTH as a derived result and as an input (of the other
+% formulas), so each is a single dictionary term used in both roles. The `surface` lists are
+% the everyday names a decomposer maps onto the canonical term; the trailing comment records
+% the intended unit.
+% ----------------------------------------------------------------------------
+dictionary stroke_volume_vocab {
+    define end_diastolic_volume : finding  surface "end-diastolic volume", "EDV"   % millilitres (mL)
+    define end_systolic_volume  : finding  surface "end-systolic volume", "ESV"    % millilitres (mL)
+    define stroke_volume        : finding  surface "stroke volume", "SV"           % millilitres per beat (mL)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable `let` over its
+% formal parameters, bound at apply time, and each carries the definitional sentence from
+% StatPearls on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an
+% exact difference/sum of measured quantities, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook stroke_volume_laws {
+    use stroke_volume_vocab
+
+    % Stroke volume — the end-diastolic volume less the end-systolic volume, i.e.
+    % SV = EDV − ESV.
+    formula stroke_volume(end_diastolic_volume, end_systolic_volume) = end_diastolic_volume - end_systolic_volume
+        source "The difference between end-diastolic volume and end-systolic volume defines stroke volume."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK547686/"
+        trust authoritative
+
+    % End-diastolic volume — the same definition solved for the end-diastolic volume a
+    % stroke volume implies for an end-systolic volume (EDV = SV + ESV). Defended by the
+    % SAME definitional sentence, read the other way.
+    formula end_diastolic_volume(stroke_volume, end_systolic_volume) = stroke_volume + end_systolic_volume
+        source "The difference between end-diastolic volume and end-systolic volume defines stroke volume."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK547686/"
+        trust authoritative
+
+    % End-systolic volume — the same definition solved for the end-systolic volume the other
+    % two imply (ESV = EDV − SV). Again the SAME definitional sentence, read the third way.
+    formula end_systolic_volume(end_diastolic_volume, stroke_volume) = end_diastolic_volume - stroke_volume
+        source "The difference between end-diastolic volume and end-systolic volume defines stroke volume."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK547686/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/stroke-volume.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/stroke-volume.query.adj
@@ -1,0 +1,34 @@
+% ============================================================================
+% stroke-volume.query.adj — worked examples over the clinical stroke-volume library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a stroke-volume question:
+% it states NO arithmetic and NO relation — it only `import`s the grounded library,
+% `observe`s the quantities it decomposed from the prompt (each a byte-provenanced span,
+% elided here), and asks the engine to APPLY the cited definition. The native adj-lang
+% engine binds the parameters, computes each value EXACTLY on the CPU, and returns it with
+% the definition's source/locator/trust.
+%
+% The three questions INVERT: an end-diastolic volume of 120 mL less an end-systolic volume
+% of 50 mL gives a stroke volume of 120 − 50 = 70 mL; that 70 mL stroke volume added back to
+% the same 50 mL end-systolic volume is exactly what the end-diastolic-volume formula
+% recovers the 120 mL from, and that 70 mL stroke volume subtracted from the same 120 mL
+% end-diastolic volume is exactly what the end-systolic-volume formula recovers the 50 mL
+% from.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli stroke-volume.query.adj
+% ============================================================================
+
+import "stroke-volume.adj"
+
+% EDV 120 mL, ESV 50 mL: stroke volume = 120 − 50.
+observe end_diastolic_volume(120)
+observe end_systolic_volume(50)
+? stroke_volume(end_diastolic_volume, end_systolic_volume)          % expect 70   (SV = EDV − ESV)
+
+% That 70 mL stroke volume with the same 50 mL end-systolic volume: EDV = 70 + 50.
+observe stroke_volume(70)
+? end_diastolic_volume(stroke_volume, end_systolic_volume)          % expect 120  (same def, solved for EDV = SV + ESV)
+
+% That 70 mL stroke volume with the same 120 mL end-diastolic volume: ESV = 120 − 70.
+? end_systolic_volume(end_diastolic_volume, stroke_volume)          % expect 50   (same def, solved for ESV = EDV − SV)


### PR DESCRIPTION
## What

Adds a new **clinical formula library** to the ADJ formula stdlib (Libraries front, FL): **stroke volume as the end-diastolic volume minus the end-systolic volume**.

A `dictionary` + `formulabook` grounding the definition **three ways**, each carrying the SAME verbatim StatPearls sentence:

- `stroke_volume(EDV, ESV) = EDV − ESV` — the definition (SV = EDV − ESV)
- `end_diastolic_volume(SV, ESV) = SV + ESV` — solved for EDV
- `end_systolic_volume(EDV, SV) = EDV − SV` — solved for ESV

**Verbatim source** (byte-verified via WebFetch): *"The difference between end-diastolic volume and end-systolic volume defines stroke volume."* — StatPearls "Physiology, Stroke Volume", `locator "https://www.ncbi.nlm.nih.gov/books/NBK547686/"`, `trust authoritative`.

As with every compute library, a consumer states **NO arithmetic**: it imports the library, `observe`s the measured volumes, and the engine applies the cited relation **EXACTLY on the CPU**, carrying the citation into the auditable `derived` section. The three formulas invert cleanly around the worked case **EDV 120 mL, ESV 50 mL → SV 70 mL** (and 70+50=120, 120−70=50 recover the inputs).

**Distinct from `cardiac-output.adj`** (which grounds CO = SV × HR): this grounds the prior definition of the stroke volume *itself* — a new pure-subtraction shape among the clinical libraries.

## Files
- `clinical/stroke-volume.adj` — the grounded library (+ literate header).
- `clinical/stroke-volume.query.adj` — worked inversion example.
- `adj-lang-cli/tests/formula_stroke_volume_e2e.rs` — **dedicated** e2e file (own anchor, no rs5 conflict): 3 tests asserting 70/120/50 + `trust authoritative` + `ncbi.nlm.nih.gov`.

## Verification
- `cargo test -p adj-lang-cli --test formula_stroke_volume_e2e` → **3 passed**.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean (exit 0).
- Ran the shipped `.query.adj` through the built CLI: `stroke_volume=70`, `end_diastolic_volume=120`, `end_systolic_volume=50`, each with the StatPearls citation + `trust authoritative`.
- Source byte-verified against NCBI Bookshelf NBK547686 via WebFetch.

Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)