### PR TITLE
feat(sir-c): inheritance + super (C OOP mirror slice 4)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.16.0 — OOP mirror slice 4: inheritance + `super`
+
+Class inheritance and `super` — the fourth slice of the C OOP mirror. No new
+`Feature` (a superclass is a `ClassDef` field; `super` is a builtin).
+
+- `class Dog < Animal` (a `ClassDef` with a `superclass`) emits
+  `_sir_register_super("Dog", "Animal")`, recording the `sub → super` edge in a
+  mutable user-ancestry table.
+- **One ancestry, two consumers.** `_sir_class_super` now consults that user
+  table **first**, falling back to the baked-in exception hierarchy — so the same
+  `super_of` relation drives BOTH `rescue`-by-class matching (a user class that
+  subclasses `StandardError` is caught) AND OOP method resolution.
+- **Inherited dispatch.** `_sir_call_method` resolves a method by walking the
+  ancestry (`_sir_resolve_method`: look up on the class, else climb `super`),
+  so a subclass that doesn't define a method inherits the parent's closure.
+- `super` (`__super__(method, definingClass, …args)`) → `_sir_call_super`, which
+  resolves `method` from the **superclass of the defining class** (so it doesn't
+  re-enter the override) and applies it to the **current** receiver — `super`
+  does not rebind `self`, so `@x` and nested calls still see the original object.
+  No ancestor defines it ⇒ a (rescuable) `NoMethodError`.
+- **DoS guard.** Every ancestry walk (`_sir_class_is_a`, `_sir_resolve_method`)
+  is bounded by `SIR_ANCESTRY_MAX` steps, so a hand-built cyclic hierarchy
+  (`A<B`, `B<A` — which the Ruby frontend never emits) resolves to a clean "not
+  found" instead of looping.
+
+**Anti-RCE by construction.** Class / method / defining-class names emit as
+**quoted C string literals** used only as table keys and `strcmp` targets —
+never as C source — so no name can inject code. Class methods, `@@class` vars,
+and modules remain the next slices (still rejected cleanly).
+
 ## 0.15.0 — OOP mirror slice 3: instance variables (`@x`) + `self`
 
 Instance state — the third slice of the C OOP mirror. Accepts

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -119,13 +119,23 @@ un-registered (built-in) method is rejected cleanly (the Collections batch).  An
 value` map (an unset `@v` reads nil), and a bare `self` → `_sir_self()`.  The
 receiver is carried across the hoisted method body in `_sir_current_self` (saved
 and restored by `_sir_call_method`; an enclosing `begin`/`rescue` restores it on
-the unwind path).  The `@`-name is a quoted C string literal (no injection).
+the unwind path).  The `@`-name is a quoted C string literal (no injection).  And
+**slice 4** — inheritance + `super`: `class Dog < Animal` emits
+`_sir_register_super("Dog", "Animal")` into a mutable user-ancestry table that
+`_sir_class_super` consults **before** the baked-in exception hierarchy (so ONE
+`super_of` drives both `rescue`-matching and method resolution); `_sir_call_method`
+resolves a method up the ancestry (`_sir_resolve_method`), so a subclass inherits
+its parent's methods; and `super` → `_sir_call_super`, resolving the method from
+the superclass of the defining class and applying it to the current `self`.  Every
+ancestry walk is bounded (`SIR_ANCESTRY_MAX`), so a cyclic hand-built hierarchy
+cannot hang.  Class / method / super-class names are all quoted C string literals
+(no injection).
 
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
-`Intrinsics`, `NDArrays`, the rest of OOP (`@@class vars`, inheritance dispatch,
-class methods, modules — later mirror slices, so `__new__` with constructor
-args, a `class << self` singleton, `super`, and the `@@` scope are all refused
-for now), and every other not-yet-wired feature until its batch lands.  `Bignum` stays rejected
+`Intrinsics`, `NDArrays`, the rest of OOP (`@@class vars`, class methods,
+modules — later mirror slices, so `__new__` with constructor args, a
+`class << self` singleton, and the `@@` scope are all refused for now), and
+every other not-yet-wired feature until its batch lands.  `Bignum` stays rejected
 until a bignum runtime ships — a module needing arbitrary precision is refused,
 never silently truncated.
 

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -723,14 +723,26 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             );
             let _ = writeln!(out, "{pad}}}");
         }
-        // OOP slice 1: an empty base class declaration.  A class is just a NAME
-        // in the C runtime (an instance carries its class string; there is no
-        // class object), so the declaration emits only a comment.  `superclass`
-        // is irrelevant without method dispatch (a later slice); a non-empty body
-        // observes the unaccepted `ClassVars` feature and is rejected by the
-        // capability check before emit.
-        Stmt::ClassDef { .. } => {
-            let _ = writeln!(out, "{pad}/* class declaration (no class object) */");
+        // OOP slice 1/4: a class is just a NAME in the C runtime (an instance
+        // carries its class string; there is no class object).  A base class
+        // (no superclass) emits only a comment.  OOP slice 4: a subclass
+        // (`class Dog < Animal`) registers its `sub -> super` edge so method
+        // resolution and `rescue`-matching walk the user hierarchy — both names
+        // are QUOTED C string literals (no injection).  A non-empty body is still
+        // rejected by the scan (class-level code / `@@x` is a later slice).
+        Stmt::ClassDef {
+            name, superclass, ..
+        } => {
+            if let Some(sup) = superclass {
+                let _ = writeln!(
+                    out,
+                    "{pad}_sir_register_super({}, {});",
+                    quote_c_string(name),
+                    quote_c_string(sup)
+                );
+            } else {
+                let _ = writeln!(out, "{pad}/* class declaration (no class object) */");
+            }
         }
         other => unreachable!("C backend reached unsupported statement: {other:?}"),
     }
@@ -1395,6 +1407,32 @@ fn emit_builtin_simple(out: &mut String, name: &str, args: &[Expr], indent: usiz
         }
         return;
     }
+    // OOP slice 4: `super` — `args = [StrLit(method), StrLit(definingClass),
+    // call-args…]`.  Resolve `method` from the SUPERCLASS of the defining class
+    // and apply to the current self.  Method / defining-class are QUOTED C string
+    // literals (no injection); the walk is an ancestry table lookup (anti-RCE).
+    if name == "__super__" {
+        if let (Some(Expr::StrLit { value: m, .. }), Some(Expr::StrLit { value: dc, .. })) =
+            (args.first(), args.get(1))
+        {
+            let call_args = &args[2..];
+            let _ = write!(
+                out,
+                "_sir_call_super({}, {}, {}",
+                quote_c_string(m),
+                quote_c_string(dc),
+                call_args.len()
+            );
+            for a in call_args {
+                out.push_str(", ");
+                emit_expr(out, a, indent);
+            }
+            out.push(')');
+        } else {
+            let _ = write!(out, "_sir_unknown_builtin({})", quote_c_string(name));
+        }
+        return;
+    }
     // OOP slice 3: a bare `self` → the current receiver (`_sir_self()`).
     if name == "__self__" {
         out.push_str("_sir_self()");
@@ -1511,11 +1549,18 @@ fn is_supported_builtin(name: &str) -> bool {
         // methods: `__def_method__` (register a `(class,method)` closure) and
         // `__method__` (dispatch it).  (`__super__`/`__self__`/`__class_method__`/
         // … stay unsupported — later slices.)
-        // Slice 3 adds `__self__` (a bare `self`).  (`__super__`/`__class_method__`
-        // /… stay unsupported — later slices.)
+        // Slice 3 adds `__self__` (a bare `self`); slice 4 adds `__super__`
+        // (`super`).  (`__class_method__`/`__def_class_method__`/… stay
+        // unsupported — later slices.)
         || matches!(
             name,
-            "and" | "or" | "raise" | "__new__" | "__def_method__" | "__method__" | "__self__"
+            "and" | "or"
+                | "raise"
+                | "__new__"
+                | "__def_method__"
+                | "__method__"
+                | "__self__"
+                | "__super__"
         )
 }
 
@@ -1758,15 +1803,13 @@ fn scan_stmt_for_builtin(s: &Stmt) -> Option<(String, Span)> {
         Stmt::SingletonClassDef { span, .. } => {
             Some(("class << self (singleton class)".to_string(), span.clone()))
         }
-        // OOP slice 1: a `Stmt::ClassDef` emits only a comment (the empty base
-        // class is a bare name), so REJECT the two shapes that comment would
-        // silently drop — a superclass (inheritance dispatch is a later slice)
-        // and a non-empty body (class-level code / `@@x` initializers) — rather
-        // than mis-emit.  The empty base class passes through.
-        Stmt::ClassDef {
-            superclass, body, span, ..
-        } if superclass.is_some() || !body.is_empty() => Some((
-            "a class with a superclass or a non-empty body (later OOP slices)".to_string(),
+        // OOP slice 4: a `Stmt::ClassDef` emits a `_sir_register_super` (subclass)
+        // or a comment (base class) — neither carries the body, so REJECT a
+        // non-empty body (class-level code / `@@x` initializers, a later slice)
+        // that the emit would silently drop.  A superclass is now SUPPORTED
+        // (registered), so it no longer triggers rejection.
+        Stmt::ClassDef { body, span, .. } if !body.is_empty() => Some((
+            "a class with a non-empty body (class-level code is a later OOP slice)".to_string(),
             span.clone(),
         )),
         _ => None,
@@ -1810,11 +1853,22 @@ fn scan_expr_for_builtin(e: &Expr) -> Option<(String, Span)> {
             {
                 return Some(("a malformed __method__ dispatch".to_string(), span.clone()));
             }
-            // `__def_method__`/`__method__` carry a `StrLit` class/method name that
-            // must stay a raw C literal.  The compound (control-flow-argument) path
-            // cannot recover it, so reject a call that is not `is_simple` —
-            // deferred, not mis-emitted.
-            if matches!(name.as_str(), "__def_method__" | "__method__") && !is_simple(e) {
+            // OOP slice 4: `__super__` must be `[StrLit(method), StrLit(class), …]`
+            // — the emitter reads both names as raw C literals.
+            if name == "__super__"
+                && !matches!(
+                    (args.first(), args.get(1)),
+                    (Some(Expr::StrLit { .. }), Some(Expr::StrLit { .. }))
+                )
+            {
+                return Some(("a malformed __super__ call".to_string(), span.clone()));
+            }
+            // `__def_method__`/`__method__`/`__super__` carry `StrLit` class/method
+            // names that must stay raw C literals.  The compound (control-flow-
+            // argument) path cannot recover them, so reject a call that is not
+            // `is_simple` — deferred, not mis-emitted.
+            if matches!(name.as_str(), "__def_method__" | "__method__" | "__super__") && !is_simple(e)
+            {
                 return Some((
                     format!("a `{name}` call with a control-flow argument"),
                     span.clone(),

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -900,12 +900,48 @@ SirValue _sir_error(const char *sir_class, SirValue msg) {
     return v;
 }
 
-/* The built-in exception-class ancestry (`sub → super`), baked in from the
- * shared exception hierarchy so a `rescue StandardError` matches a raised
- * `RuntimeError`.  A NULL super terminates the chain (`Exception` is the root).
- * An unlisted class is treated as having no super (matches only itself / a bare
- * rescue) — a user exception class needs the OOP `Classes` batch. */
+/* OOP slice 4: user-declared inheritance (`class Dog < Animal`), registered in
+ * program order by the emitted `_sir_register_super`.  A class has ONE super, so
+ * this is a `sub -> super` table (update-or-append on the interned sub name).
+ * `_sir_class_super` consults it FIRST, so the SAME `super_of` relation drives
+ * BOTH `rescue`-by-class matching AND OOP method resolution (a user class that
+ * subclasses a built-in exception is picked up by rescue too). */
+#define SIR_USER_SUPER_MAX 4096
+static struct { const char *sub; const char *sup; } _sir_user_super_tab[SIR_USER_SUPER_MAX];
+static int _sir_user_super_n = 0;
+
+void _sir_register_super(const char *sub, const char *sup) {
+    const char *b = _sir_intern(sub), *p = _sir_intern(sup);
+    int i;
+    for (i = 0; i < _sir_user_super_n; i++) {
+        if (_sir_user_super_tab[i].sub == b) { _sir_user_super_tab[i].sup = p; return; }
+    }
+    if (_sir_user_super_n < SIR_USER_SUPER_MAX) {
+        _sir_user_super_tab[_sir_user_super_n].sub = b;
+        _sir_user_super_tab[_sir_user_super_n].sup = p;
+        _sir_user_super_n++;
+    }
+}
+
+/* An ancestry walk is bounded by this many steps: a well-formed hierarchy is far
+ * shorter, but a HAND-BUILT module could register a cycle (`A<B`, `B<A`) the Ruby
+ * frontend never emits (Ruby rejects cyclic inheritance) — the cap turns that
+ * into a clean "not found" instead of an infinite loop (DoS). */
+#define SIR_ANCESTRY_MAX 4096
+
+/* The class ancestry (`sub → super`): a user-declared super wins; otherwise the
+ * built-in exception hierarchy (baked in so a `rescue StandardError` matches a
+ * raised `RuntimeError`).  A NULL super terminates the chain (`Exception` /
+ * `Object` is the root).  An unlisted class has no super (matches only itself /
+ * a bare rescue). */
 static const char *_sir_class_super(const char *cls) {
+    {
+        const char *c = _sir_intern(cls);
+        int i;
+        for (i = 0; i < _sir_user_super_n; i++) {
+            if (_sir_user_super_tab[i].sub == c) return _sir_user_super_tab[i].sup;
+        }
+    }
     static const struct { const char *sub; const char *sup; } A[] = {
         { "RuntimeError", "StandardError" },
         { "ArgumentError", "StandardError" },
@@ -931,7 +967,8 @@ static const char *_sir_class_super(const char *cls) {
  * through the ancestry chain. */
 int _sir_class_is_a(const char *actual, const char *target) {
     const char *cur = actual;
-    while (cur) {
+    int steps = 0;
+    while (cur && steps++ < SIR_ANCESTRY_MAX) {
         if (strcmp(cur, target) == 0) return 1;
         cur = _sir_class_super(cur);
     }
@@ -1085,7 +1122,8 @@ SirValue _sir_def_method(const char *cls, const char *method, SirValue fn) {
     return fn;
 }
 
-/* Look up `(cls, method)` -> closure, or a `SIR_NIL` sentinel on a miss. */
+/* Look up `(cls, method)` -> closure on THIS class only (no ancestry), or a
+ * `SIR_NIL` sentinel on a miss. */
 static SirValue _sir_lookup_method(const char *cls, const char *method) {
     const char *c = _sir_intern(cls), *m = _sir_intern(method);
     int i;
@@ -1093,6 +1131,22 @@ static SirValue _sir_lookup_method(const char *cls, const char *method) {
         if (_sir_method_tab[i].cls == c && _sir_method_tab[i].method == m) {
             return _sir_method_tab[i].fn;
         }
+    }
+    return _sir_nil();
+}
+
+/* OOP slice 4: resolve `method` starting at `cls` and walking UP the ancestry
+ * (`_sir_class_super`) until a defining class is found — so an inherited method
+ * dispatches to the closure the superclass registered.  Returns the closure or
+ * `SIR_NIL`.  Bounded by `SIR_ANCESTRY_MAX` steps (a cyclic hand-built hierarchy
+ * cannot hang). */
+static SirValue _sir_resolve_method(const char *cls, const char *method) {
+    const char *cur = cls;
+    int steps = 0;
+    while (cur && steps++ < SIR_ANCESTRY_MAX) {
+        SirValue fn = _sir_lookup_method(cur, method);
+        if (fn.tag == SIR_CLOSURE) return fn;
+        cur = _sir_class_super(cur);
     }
     return _sir_nil();
 }
@@ -1107,7 +1161,8 @@ SirValue _sir_call_method(SirValue recv, const char *method, int argc, ...) {
         return _sir_raise(_sir_error(
             "NoMethodError", _sir_str(_sir_cat("undefined method for a non-object receiver: ", method))));
     }
-    fn = _sir_lookup_method(recv.as.inst->sir_class, method);
+    /* Slice 4: resolve up the ancestry so an inherited method dispatches. */
+    fn = _sir_resolve_method(recv.as.inst->sir_class, method);
     if (fn.tag != SIR_CLOSURE) {
         return _sir_raise(
             _sir_error("NoMethodError", _sir_str(_sir_cat("undefined method ", method))));
@@ -1125,6 +1180,29 @@ SirValue _sir_call_method(SirValue recv, const char *method, int argc, ...) {
         r = fn.as.clo->fn(fn.as.clo->caps, args, argc);
         _sir_current_self = saved_self;
     }
+    if (args) free(args);
+    return r;
+}
+
+/* OOP slice 4: `super` from within `defining_class`'s method `method`.  Resolve
+ * `method` starting at the SUPERCLASS of `defining_class` (so it does not
+ * re-enter the same override) and apply it to the CURRENT `self` — `super` runs
+ * in the same receiver (it does NOT rebind `self`), so `@x` and a nested method
+ * call still see the original object.  No ancestor defines `method` => a
+ * (rescuable) `NoMethodError`. */
+SirValue _sir_call_super(const char *method, const char *defining_class, int argc, ...) {
+    va_list ap;
+    SirValue *args, fn, r;
+    const char *sup = _sir_class_super(defining_class);
+    fn = sup ? _sir_resolve_method(sup, method) : _sir_nil();
+    if (fn.tag != SIR_CLOSURE) {
+        return _sir_raise(_sir_error(
+            "NoMethodError", _sir_str(_sir_cat("super: no superclass method ", method))));
+    }
+    va_start(ap, argc);
+    args = _sir_va_collect(argc, ap);
+    va_end(ap);
+    r = fn.as.clo->fn(fn.as.clo->caps, args, argc);
     if (args) free(args);
     return r;
 }

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_classes.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_classes.rs
@@ -205,15 +205,9 @@ fn deferred_oop_shapes_are_rejected_cleanly() {
         ),
         "an unregistered (built-in) __method__ dispatch must be rejected"
     );
-    // A superclass (inheritance dispatch is a later slice) — the empty-class
-    // comment emit would otherwise silently drop the link.
-    assert!(
-        rejects(
-            vec![Stmt::ClassDef { name: "Dog".into(), superclass: Some("Animal".into()), body: vec![], span: s() }],
-            &[Feature::Classes]
-        ),
-        "a superclass must be rejected"
-    );
+    // (A superclass is now SUPPORTED — OOP slice 4 registers `class Dog < Animal`
+    // as a `_sir_register_super` edge — so it is no longer a rejected shape; see
+    // `compile_and_run_inheritance.rs` for its execution proof.)
     // A non-empty class body (its content would be silently dropped by the
     // comment emit) — here a `Const`-assign body stmt (an accepted feature, so it
     // passes the manifest gate and must be caught by the scan, not dropped).

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_inheritance.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_inheritance.rs
@@ -1,0 +1,126 @@
+//! Execution proof for OOP mirror slice 4 (inheritance + `super`) on the C
+//! backend — lower REAL Ruby source, emit C, compile with a real cc, run, assert
+//! stdout.  Skips gracefully when no `cc` is present.
+//!
+//! `class Dog < Animal` lowers to a `ClassDef` with a `superclass`, which emits a
+//! `_sir_register_super("Dog", "Animal")` edge; instance dispatch then resolves a
+//! method up the ancestry (`_sir_resolve_method`).  `super` lowers to
+//! `__super__(method, definingClass, …args)` → `_sir_call_super`, which resolves
+//! `method` from the SUPERCLASS of the defining class and applies it to the
+//! current receiver.
+
+use std::process::Command;
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    ["cc", "clang", "gcc"]
+        .iter()
+        .find(|c| {
+            Command::new(c)
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        })
+        .map(|s| s.to_string())
+}
+
+/// Lower `src` (Ruby) → C, compile + run, return stdout (or None if no cc).
+fn run_ruby(src: &str) -> Option<String> {
+    let cc = find_cc()?;
+    let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
+    let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
+    let dir = std::env::temp_dir();
+    let stem = format!("sirc_inh_{}_{}", std::process::id(), src.len());
+    let cpath = dir.join(format!("{stem}.c"));
+    let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::write(&cpath, &art.source).expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        art.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "program exited non-zero");
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn subclass_inherits_a_method() {
+    // `Dog < Animal` defines no `legs`, so dispatch resolves it up the ancestry.
+    match run_ruby(
+        "class Animal\n  def legs\n    4\n  end\nend\n\
+         class Dog < Animal\nend\n\
+         puts Dog.new.legs\n",
+    ) {
+        Some(out) => assert_eq!(out, "4\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn super_calls_the_overridden_parent_method() {
+    // `Derived#val` overrides `Base#val` and reaches it via `super`.
+    match run_ruby(
+        "class Base\n  def val\n    10\n  end\nend\n\
+         class Derived < Base\n  def val\n    super + 5\n  end\nend\n\
+         puts Derived.new.val\n",
+    ) {
+        Some(out) => assert_eq!(out, "15\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn super_forwards_an_argument() {
+    // `super(x)` forwards its argument to the parent method.
+    match run_ruby(
+        "class Adder\n  def add(x)\n    x + 1\n  end\nend\n\
+         class Doubler < Adder\n  def add(x)\n    super(x) + x\n  end\nend\n\
+         puts Doubler.new.add(10)\n",
+    ) {
+        // Doubler#add(10): super(10) -> Adder#add(10) = 11; + x(10) = 21.
+        Some(out) => assert_eq!(out, "21\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn super_climbs_a_three_level_chain() {
+    // Each level's `super` climbs exactly one rung: C -> B -> A.
+    match run_ruby(
+        "class A\n  def v\n    1\n  end\nend\n\
+         class B < A\n  def v\n    super + 10\n  end\nend\n\
+         class C < B\n  def v\n    super + 100\n  end\nend\n\
+         puts C.new.v\n",
+    ) {
+        // C#v: super -> B#v (super -> A#v = 1, +10 = 11), +100 = 111.
+        Some(out) => assert_eq!(out, "111\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn ivars_persist_through_an_inherited_method() {
+    // An inherited method runs with `self` bound to the subclass instance, so its
+    // `@x` reads/writes the instance's own ivars (super does not rebind self).
+    match run_ruby(
+        "class Counter\n  def bump\n    @n = 5\n  end\n  def peek\n    @n\n  end\nend\n\
+         class FancyCounter < Counter\nend\n\
+         c = FancyCounter.new\nc.bump\nputs c.peek\n",
+    ) {
+        Some(out) => assert_eq!(out, "5\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}

--- a/code/packages/rust/semantic-ir-to-c/tests/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/emit.rs
@@ -194,6 +194,38 @@ fn explicit_self_renders_as_sir_self() {
 }
 
 #[test]
+fn subclass_registers_its_superclass_edge() {
+    // OOP slice 4: `class Dog < Animal` emits a `_sir_register_super` edge (both
+    // names QUOTED C string literals — no injection), and the runtime carries the
+    // ancestry-walking resolver + `super` dispatcher.
+    let m = lower_ruby("class Animal\n  def legs\n    4\n  end\nend\nclass Dog < Animal\nend\nputs Dog.new.legs");
+    let src = compile(&m).unwrap().source;
+    assert!(
+        src.contains("_sir_register_super(\"Dog\", \"Animal\")"),
+        "a subclass registers its `sub -> super` edge\n{src}"
+    );
+    assert!(
+        src.contains("_sir_resolve_method"),
+        "the runtime resolves methods up the ancestry\n{src}"
+    );
+}
+
+#[test]
+fn super_lowers_to_call_super() {
+    // OOP slice 4: `super` (`__super__`) renders as `_sir_call_super(method,
+    // definingClass, argc, …)` — both names quoted; dispatch is an ancestry walk.
+    let m = lower_ruby(
+        "class Base\n  def val\n    10\n  end\nend\n\
+         class Derived < Base\n  def val\n    super + 5\n  end\nend\nputs Derived.new.val",
+    );
+    let src = compile(&m).unwrap().source;
+    assert!(
+        src.contains("_sir_call_super(\"val\", \"Derived\""),
+        "`super` resolves from the defining class's superclass\n{src}"
+    );
+}
+
+#[test]
 fn sanitize_ident_maps_into_c() {
     assert_eq!(sanitize_ident("foo"), "foo");
     assert_eq!(sanitize_ident("foo_bar1"), "foo_bar1");

--- a/code/specs/SIR24-semantic-ir-to-c.md
+++ b/code/specs/SIR24-semantic-ir-to-c.md
@@ -372,9 +372,13 @@ lockstep:
    receiver's lazily-allocated `@name → value` map; the receiver is carried in
    `_sir_current_self`, saved/restored by `_sir_call_method` and re-bound at each
    `TryCatch` handler since `longjmp` unwinds past the restore) landed in 0.15.0;
-   then inheritance + `super` (a user-ancestry table
-   consulted before the baked-in exception ancestry, so both share one
-   `super_of`), class methods, `ClassVars`, and `Modules` (mixins / MRO).
+   inheritance + `super` (`class Dog < Animal` → `_sir_register_super` into a
+   mutable user-ancestry table `_sir_class_super` consults BEFORE the baked-in
+   exception ancestry, so ONE `super_of` drives both `rescue`-matching and method
+   resolution; `_sir_call_method` resolves up the chain, `super` → `_sir_call_super`
+   from the superclass of the defining class; every walk bounded by
+   `SIR_ANCESTRY_MAX` against a cyclic hand-built hierarchy) landed in 0.16.0;
+   then class methods, `ClassVars`, and `Modules` (mixins / MRO).
 7. **Optional / later** — `Bignum`; SIR21 sized-integer native lowering
    (`int64_t`/`uint32_t` from `IntSpec`); `Range` / regex / backtick shims.
 


### PR DESCRIPTION
## What

Fourth slice of the **C backend OOP mirror** — class inheritance and `super`. No new `Feature` (a superclass is a `ClassDef` field; `super` is a builtin). Mirrors the Ruby backend's landed slice 4.

- `class Dog < Animal` (a `ClassDef` with a `superclass`) emits `_sir_register_super("Dog", "Animal")` into a mutable user-ancestry table.
- **One ancestry, two consumers:** `_sir_class_super` now consults that user table **first**, falling back to the baked-in exception hierarchy — so the same `super_of` relation drives BOTH `rescue`-by-class matching AND OOP method resolution.
- **Inherited dispatch:** `_sir_call_method` resolves a method by walking the ancestry (`_sir_resolve_method`), so a subclass inherits its parent's methods.
- `super` (`__super__(method, definingClass, …args)`) → `_sir_call_super`, resolving `method` from the **superclass of the defining class** (so it doesn't re-enter the override) and applying it to the **current** receiver — `super` does not rebind `self`, so `@x` and nested calls still see the original object. No ancestor defines it ⇒ a rescuable `NoMethodError`.
- **DoS guard:** every ancestry walk (`_sir_class_is_a`, `_sir_resolve_method`) is bounded by `SIR_ANCESTRY_MAX`, so a hand-built cyclic hierarchy (`A<B`, `B<A` — which the Ruby frontend never emits) resolves to a clean "not found" instead of looping.

## Anti-RCE by construction

Class / method / superclass names emit as **quoted C string literals** used only as table keys and `strcmp` targets — never as C source.

## Tests / quality

- **Emit-shape** (`tests/emit.rs`): `subclass_registers_its_superclass_edge`, `super_lowers_to_call_super`. 14/14 pass.
- **cc-exec e2e** (`tests/compile_and_run_inheritance.rs`): inherited method, super→parent, super forwards an arg, 3-level super chain, ivars persist through an inherited method. 5/5 pass.
- **Regression:** exceptions e2e (8) green — the ancestry step-cap is shared with `rescue` matching. Removed the now-stale "a superclass must be rejected" assertion.
- clippy clean; security review passed (Rust+C: no injection, memory-safe, ancestry walks bounded, no reachable `unreachable!`).

Bumps `semantic-ir-to-c` 0.15.0 → 0.16.0; updates CHANGELOG, README, SIR24 spec. Class methods, `@@class` vars, and modules remain later slices (still rejected cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)