### PR TITLE
content(tamil): numbers 1–10 (first Spanish-parity concept)

### DIFF
--- a/code/learning/human-languages/tamil/lessons/TA-C07-numbers-1-5.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C07-numbers-1-5.md
@@ -1,0 +1,88 @@
+---
+id: TA-C07-numbers-1-5
+chapter: 7
+type: word
+headword: ஒன்று இரண்டு மூன்று நான்கு ஐந்து
+gloss: one to five — Tamil's own Dravidian numbers, not borrowed
+concept_tag: TA-NUMBERS-1-5
+prerequisites: [TA-C01-vanakkam]
+sounds: [tamil-inherent-a, pulli-virama, alveolar-rra, retroflex-nn]
+roots: [proto-dravidian-numbers]
+etymology_hook: "Tamil's numbers are native Dravidian, not borrowed — and 2–5 stay visibly cousin across Tamil, Kannada, Telugu, Malayalam"
+est_minutes: 5
+reviews_of: [TA-C01-vanakkam]
+---
+
+# ஒன்று, இரண்டு, மூன்று, நான்கு, ஐந்து — one to five
+
+## Warm-up
+
+[PAUSE 2s] Five words — and the same point *vaṇakkam* made, told again in
+numbers: Tamil counts with **its own** words, not borrowed ones.
+
+## The five
+
+| | numeral | word | said |
+|---|---|---|---|
+| 1 | **௧** | **ஒன்று** | *oṉṟu* |
+| 2 | **௨** | **இரண்டு** | *iraṇṭu* |
+| 3 | **௩** | **மூன்று** | *mūṉṟu* |
+| 4 | **௪** | **நான்கு** | *nāṉku* |
+| 5 | **௫** | **ஐந்து** | *aintu* |
+
+Two writing systems sit side by side here: the **word** (spelled out in
+letters) and the **numeral** (a single symbol — ௧ ௨ ௩ ௪ ௫, Tamil's own
+digits, as distinct from 1 2 3 4 5 as they are from Roman I II III). You'll
+meet the digits again whenever a price or a page number is written in Tamil.
+
+If you're doing the writing track, you can already read pieces of these: **ந**
+and **ன** (the *n*-family), **ற** the hard *r* inside *mūṉṟu*, and the **puḷḷi**
+dot that stacks *ன்ற* into the single cluster you hear in **ஒன்று** and
+**மூன்று**.
+
+## Where they come from — the family stays together
+
+Hindi's numbers are **Sanskrit worn smooth** (*eka → ek*). Tamil's are not
+borrowed at all: they are **native Dravidian**, the same instinct that kept
+*vaṇakkam* where the north reached for *namaste*. And because they're the
+family's own, they stay visibly **cousin** across the four Dravidian languages:
+
+| | Tamil | Kannada | Telugu | Malayalam |
+|---|---|---|---|---|
+| 2 | *iraṇṭu* | *eraḍu* | *reṇḍu* | *raṇṭu* |
+| 3 | *mūṉṟu* | *mūru* | *mūḍu* | *mūnnu* |
+| 4 | *nāṉku* | *nālku* | *nālugu* | *nālu* |
+| 5 | *aintu* | *aidu* | *aidu* | *añcu* |
+
+Read down any column and you can see one word wearing four regional coats —
+*iraṇṭu / eraḍu / reṇḍu / raṇṭu* is unmistakably **one** number, four ways.
+That shared skeleton is the whole reason learning one Dravidian language gives
+you a running start on the next.
+
+**One** is the odd one out. Tamil *oṉṟu*, Kannada *ondu* and Malayalam *onnu*
+are cousins (from an old *oṉ-*), but **Telugu** breaks ranks with *okaṭi* — a
+different formation entirely. A useful thing to know early: the family agrees
+on 2–5 far more tidily than on 1.
+
+## A sound to notice
+
+**ஏ**... not yet — that's next lesson. For now, the one to feel is the cluster
+**ன்ற** in *oṉṟu* and *mūṉṟu*: an alveolar *n* running straight into the hard
+*ṟ*, said almost as a single knock — *on-ru*, *muun-ru*. It's a very Tamil
+sound, and the puḷḷi dot on **ன்** is what tells you the two letters fuse.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "oṉṟu, iraṇṭu, mūṉṟu, nāṉku, aintu"]
+- [YOU SAY: the cousins — "iraṇṭu … eraḍu … reṇḍu … raṇṭu": one number, four coats]
+- [YOU SAY: read the digits aloud — ௧ ௨ ௩ ௪ ௫]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Count to five in Tamil. (*Oṉṟu, iraṇṭu, mūṉṟu, nāṉku, aintu*.) Are
+Tamil's numbers borrowed from Sanskrit, like Hindi's? (**No** — they're native
+Dravidian.) Which number does **Telugu** form differently from its cousins?
+(**One** — *okaṭi*, where Tamil/Kannada/Malayalam share *oṉṟu / ondu / onnu*.)
+What does the puḷḷi on **ன்** do inside *oṉṟu*? (Fuses *ன்* + *ற* into one
+cluster.) Next: six to ten.

--- a/code/learning/human-languages/tamil/lessons/TA-C07-numbers-6-10.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C07-numbers-6-10.md
@@ -1,0 +1,84 @@
+---
+id: TA-C07-numbers-6-10
+chapter: 7
+type: word
+headword: ஆறு ஏழு எட்டு ஒன்பது பத்து
+gloss: six to ten — and the number that carries Tamil's own letter
+concept_tag: TA-NUMBERS-6-10
+prerequisites: [TA-C07-numbers-1-5]
+sounds: [tamil-inherent-a, pulli-virama, tamil-zha-llla]
+roots: [proto-dravidian-numbers]
+etymology_hook: "seven ஏழு ēḻu carries ழ — the letter and sound in the name Tamiḻ itself; and nine is oṉ (one) + patu (ten)"
+est_minutes: 5
+reviews_of: [TA-C07-numbers-1-5, TA-C01-vanakkam]
+---
+
+# ஆறு, ஏழு, எட்டு, ஒன்பது, பத்து — six to ten
+
+## Warm-up
+
+[PAUSE 2s] Five more — and one of them is written with the single letter Tamil
+is most proud of.
+
+## The five
+
+| | numeral | word | said |
+|---|---|---|---|
+| 6 | **௬** | **ஆறு** | *āṟu* |
+| 7 | **௭** | **ஏழு** | *ēḻu* |
+| 8 | **௮** | **எட்டு** | *eṭṭu* |
+| 9 | **௯** | **ஒன்பது** | *oṉpatu* |
+| 10 | **௰** | **பத்து** | *pattu* |
+
+## Seven carries the letter that names the language
+
+Look at **ஏழு** (*ēḻu*, seven). Its middle letter is **ழ** — the retroflex
+approximant, the sound English can only clumsily spell *zh*. It is the rarest
+and most characteristic sound in Tamil, and it sits inside the language's **own
+name**: *Tamiḻ* (தமிழ்) ends in this very letter. So *seven* is a free daily
+rehearsal of the sound that says who the language is. Curl the tongue back, don't
+touch, and voice it: *ē-ḻu*.
+
+(You met its cousin *ற* — the hard *ṟ* — back in *ஆறு* / *āṟu*, six. Tamil keeps
+these apart carefully: **ஆறு** *āṟu* and **ஏழு** *ēḻu* end in two different
+sounds English would both call "r/zh".)
+
+## Nine is built from words you already have
+
+**ஒன்பது** (*oṉpatu*, nine) is not a fresh word to memorise — it is two you
+already know, joined:
+
+> **ஒன்** (*oṉ-*, "one," from last lesson) + **பது** (*patu*, "ten")
+> → **ஒன்பது** = "one‑to‑ten" — one short of ten.
+
+And ten itself is **பத்து** (*pattu*). Say *oṉpatu* then *pattu* and you can hear
+nine leaning on ten. That is a common Dravidian habit — nine described as
+one-away-from-ten rather than named outright.
+
+## The family, still together (mostly)
+
+Six, seven and ten stay clear cousins across the Dravidian languages — Tamil
+*āṟu*, Kannada *āru*, Malayalam *āṟu*; Tamil *ēḻu*, Kannada *ēḷu*, Malayalam
+*ēḻu*. Ten is a nice one to watch: Tamil **pattu**, Malayalam **pattu**, but
+Kannada softens the *p‑* to *h‑* → **hattu** — a regular Kannada sound-shift
+you'll see again (Tamil *pāl* "milk" ↔ Kannada *hālu*). Tamil and Malayalam even
+keep **eight** and **nine** nearly identical (*eṭṭu*, *oṉpatu* / *onpatu*); it's
+**Telugu** that wanders off there (*enimidi*, *tommidi*) — so those two are the
+least reliable as family-wide cousins.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "āṟu, ēḻu, eṭṭu, oṉpatu, pattu"]
+- [YOU SAY: seven, feeling the ழ — "ē‑ḻu", the sound in *Tamiḻ*]
+- [YOU SAY: nine taken apart — "oṉ + patu → oṉpatu", one short of ten]
+- [YOU SAY: read the digits — ௬ ௭ ௮ ௯ ௰]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Count six to ten in Tamil. (*Āṟu, ēḻu, eṭṭu, oṉpatu, pattu*.) Which
+number is written with **ழ**, and where else does that letter appear? (**Seven**,
+*ēḻu* — the same letter that ends *Tamiḻ*.) How is **nine** built? (*Oṉ* "one" +
+*patu* "ten" → *oṉpatu*, one short of ten.) What happens to Tamil *pattu* when you
+cross into Kannada? (The *p‑* softens to *h‑*: *hattu*.) Next chapter builds on
+these to ask *how many?* and *how old are you?*


### PR DESCRIPTION
## What
The first step of **deepening the curriculum toward the Spanish pilot** — breadth-first by concept. Adds **Tamil numbers 1–10** as two atom-first lessons (`TA-C07-numbers-1-5`, `TA-C07-numbers-6-10`).

**Numbers are a real gap almost everywhere** (Tamil / Kannada / Telugu / Malayalam / Latin / French have none; the `‹LANG›-NUMBERS-1-5` / `-6-10` pattern already exists for Hindi, Bengali, Gujarati, Marathi, Punjabi, Sanskrit). I'm piloting the deepening on **Tamil first — the one language you can natively verify** — so the quality bar is calibrated before it scales to languages neither of us reads.

## For your native eyeball (please check the Tamil)
| | numeral | word | said | | numeral | word | said |
|---|---|---|---|---|---|---|---|
| 1 | ௧ | ஒன்று | *oṉṟu* | 6 | ௬ | ஆறு | *āṟu* |
| 2 | ௨ | இரண்டு | *iraṇṭu* | 7 | ௭ | ஏழு | *ēḻu* |
| 3 | ௩ | மூன்று | *mūṉṟu* | 8 | ௮ | எட்டு | *eṭṭu* |
| 4 | ௪ | நான்கு | *nāṉku* | 9 | ௯ | ஒன்பது | *oṉpatu* |
| 5 | ௫ | ஐந்து | *aintu* | 10 | ௰ | பத்து | *pattu* |

## Theme (the memory hooks)
- Tamil's numbers are **native Dravidian**, not Sanskrit-borrowed (echoes `TA-C01-vanakkam`); **2–5 stay visibly cousin** across Tamil/Kannada/Telugu/Malayalam — "one number, four coats."
- **Seven ஏழு *ēḻu* carries ழ** — the very letter that ends the name **Tamiḻ**.
- **Nine ஒன்பது = *oṉ* (one) + *patu* (ten)** — one short of ten.
- Honest divergence notes: **one** (Telugu *okaṭi*) and **8–9** (Telugu *enimidi/tommidi*) are where the family parts ways; the Kannada **p→h** shift (*pattu* ↔ *hattu*).

## Grounding & checks
- Numeral glyphs ௧–௰ **composed from Unicode** (verified); number words carefully authored.
- **Linguistics-reviewed** by a subagent — every claim, incl. the unverifiable Kannada/Telugu/Malayalam cognates and the Kannada *p→h* lenition, confirmed correct.
- **Validates with zero errors** (uncovered-glyph + missing-romanization warnings are expected while `tamil.json` is a stub — consistent with the rest of the corpus); **human-language-data suite 38 green**.

## Next
On merge, the loop replicates numbers 1–10 across the other chain languages (Kannada, Telugu, Malayalam, Latin, French — which I ground + self-review), then walks to the next concept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)