### PR TITLE
Add MOS drain sidewall capacitance

### DIFF
--- a/code/packages/python/mosfet-models/CHANGELOG.md
+++ b/code/packages/python/mosfet-models/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [0.1.0] — Unreleased
 
 ### Added
+- `Level1Params.PD` and `Level1Params.CJSW` add zero-default Berkeley drain
+  diffusion perimeter and sidewall capacitance density, contributing
+  `CJSW * PD` to the zero-bias drain-body capacitance.
 - `Level1Params.AS` adds the zero-default Berkeley source diffusion area,
   contributing `CJ * AS` to the zero-bias source-body capacitance.
 - `Level1Params.AD` and `Level1Params.CJ` add zero-default Berkeley drain

--- a/code/packages/python/mosfet-models/README.md
+++ b/code/packages/python/mosfet-models/README.md
@@ -29,8 +29,9 @@ print(r.Id, r.gm, r.gds, r.region)
   Meyer capacitance through `Cox = epsilon_ox / TOX`, zero-default `RD` / `RS`
   external drain/source resistance, zero-default `RSH` sheet resistance,
   one-default `NRD` / `NRS` drain/source diffusion square counts, zero-default
-  drain/source diffusion areas `AD` / `AS` and bottom-junction capacitance
-  density `CJ` contributing `CJ * AD` to `CBD` and `CJ * AS` to `CBS`, and
+  drain/source diffusion areas `AD` / `AS`, drain perimeter `PD`, and
+  bottom/sidewall junction capacitance densities `CJ` / `CJSW` contributing
+  `CJ * AD + CJSW * PD` to `CBD` and `CJ * AS` to `CBS`, and
   `KF` / `AF` flicker noise.
 - `evaluate_level1(params, V_GS, V_DS, V_BS, T)`: returns `MosResult` with Id, gm, gds, gmb, Cgs/Cgd/Cgb/Cbs/Cbd, region.
 - Region detection: cutoff (subthreshold-aware), triode, saturation.

--- a/code/packages/python/mosfet-models/src/mosfet_models/level1.py
+++ b/code/packages/python/mosfet-models/src/mosfet_models/level1.py
@@ -36,7 +36,9 @@ class Level1Params:
     NRS: float = 1.0  # number of source diffusion squares
     AD: float = 0.0  # drain diffusion area (m^2)
     AS: float = 0.0  # source diffusion area (m^2)
+    PD: float = 0.0  # drain diffusion perimeter (m)
     CJ: float = 0.0  # bottom junction capacitance per area (F/m^2)
+    CJSW: float = 0.0  # sidewall junction capacitance per perimeter (F/m)
     IS: float = 1e-15  # saturation current (A)
     N_SUB: float = 1.4  # subthreshold slope factor
     T_NOM: float = 300.15  # nominal temperature (K)
@@ -144,8 +146,12 @@ def evaluate_level1(
         raise ValueError("MOSFET AD must be finite and non-negative")
     if not isfinite(p.AS) or p.AS < 0.0:
         raise ValueError("MOSFET AS must be finite and non-negative")
+    if not isfinite(p.PD) or p.PD < 0.0:
+        raise ValueError("MOSFET PD must be finite and non-negative")
     if not isfinite(p.CJ) or p.CJ < 0.0:
         raise ValueError("MOSFET CJ must be finite and non-negative")
+    if not isfinite(p.CJSW) or p.CJSW < 0.0:
+        raise ValueError("MOSFET CJSW must be finite and non-negative")
     beta = p.KP * (p.W / effective_length)
 
     # Threshold with body effect. The formula is well-defined whenever
@@ -175,7 +181,7 @@ def evaluate_level1(
         p.FC,
     )
     Cbd_bulk = bulk_junction_capacitance(
-        p.CBD + p.CJ * p.AD,
+        p.CBD + p.CJ * p.AD + p.CJSW * p.PD,
         V_BS - V_DS,
         p.PB,
         p.MJ,

--- a/code/packages/python/mosfet-models/tests/test_models.py
+++ b/code/packages/python/mosfet-models/tests/test_models.py
@@ -216,6 +216,15 @@ def test_drain_area_scales_bottom_junction_capacitance():
     assert result.Cbd == pytest.approx(7.0e-12)
 
 
+def test_drain_perimeter_scales_sidewall_junction_capacitance():
+    result = evaluate_level1(
+        Level1Params(CBD=1.0e-12, PD=3.0e-6, CJSW=2.0e-6, MJ=0.0),
+        V_GS=1.8,
+        V_DS=0.0,
+    )
+    assert result.Cbd == pytest.approx(7.0e-12)
+
+
 def test_source_area_scales_bottom_junction_capacitance():
     result = evaluate_level1(
         Level1Params(CBS=1.0e-12, CJ=2.0e-3, AS=3.0e-9, MJ=0.0),
@@ -230,7 +239,9 @@ def test_source_area_scales_bottom_junction_capacitance():
     [
         (Level1Params(AD=-1.0), "MOSFET AD must be finite and non-negative"),
         (Level1Params(AS=-1.0), "MOSFET AS must be finite and non-negative"),
+        (Level1Params(PD=-1.0), "MOSFET PD must be finite and non-negative"),
         (Level1Params(CJ=-1.0), "MOSFET CJ must be finite and non-negative"),
+        (Level1Params(CJSW=-1.0), "MOSFET CJSW must be finite and non-negative"),
     ],
 )
 def test_drain_geometry_rejects_negative_values(params, message):

--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add the Level-1 MOS `PD` instance parameter and model-card `CJSW` density.
+  Their product augments `CBD` in AC and transient drain-body capacitance.
 - Add the Level-1 MOS `AS` instance parameter. With model-card `CJ`, its
   product augments `CBS` in AC and transient source-body capacitance.
 - Add the Level-1 MOS `AD` instance parameter and model-card `CJ` density.

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -102,9 +102,9 @@ node, routes the channel and source-side capacitances through it, and contribute
 `RSH` defaults to zero ohms per square. `NRD` and `NRS` default to one drain
 and source square, so the fallbacks are `RSH * NRD` and `RSH * NRS`; explicit
 positive `RD` / `RS` values take precedence.
-`AD`, `AS`, and model-card `CJ` default to zero and are finite and non-negative.
-They add `CJ * AD` to drain-body `CBD` and `CJ * AS` to source-body `CBS` in
-AC and transient analysis.
+`AD`, `AS`, `PD`, and model-card `CJ` / `CJSW` default to zero and are finite
+and non-negative. They add `CJ * AD + CJSW * PD` to drain-body `CBD` and
+`CJ * AS` to source-body `CBS` in AC and transient analysis.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -9115,8 +9115,10 @@ def _mosfet_charge_state_specs(el: Mosfet) -> list[tuple[str, str, str, float]]:
     cbs = getattr(params, "CBS", 0.0) + (
         getattr(params, "CJ", 0.0) * getattr(params, "AS", 0.0)
     )
-    cbd = getattr(params, "CBD", 0.0) + (
-        getattr(params, "CJ", 0.0) * getattr(params, "AD", 0.0)
+    cbd = (
+        getattr(params, "CBD", 0.0)
+        + getattr(params, "CJ", 0.0) * getattr(params, "AD", 0.0)
+        + getattr(params, "CJSW", 0.0) * getattr(params, "PD", 0.0)
     )
     if cgs > 0.0:
         specs.append(

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -311,8 +311,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "PNP": (41, 58, 13, 4),
     "NJF": (22, 30, 7, 3),
     "PJF": (22, 30, 7, 3),
-    "NMOS": (27, 34, 6, 3),
-    "PMOS": (27, 34, 6, 3),
+    "NMOS": (28, 35, 6, 3),
+    "PMOS": (28, 35, 6, 3),
 }
 
 
@@ -481,6 +481,7 @@ _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
     "CBD": "CBD",
     "CJD": "CBD",
     "CJ": "CJ",
+    "CJSW": "CJSW",
     "PB": "PB",
     "MJ": "MJ",
     "FC": "FC",
@@ -1087,6 +1088,7 @@ def mosfet_from_model_card(
         CBS=p.get("CBS", defaults.CBS),
         CBD=p.get("CBD", defaults.CBD),
         CJ=p.get("CJ", defaults.CJ),
+        CJSW=p.get("CJSW", defaults.CJSW),
         PB=p.get("PB", defaults.PB),
         MJ=p.get("MJ", defaults.MJ),
         FC=p.get("FC", defaults.FC),

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -408,7 +408,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 195
+    assert len(coverage) == 197
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -423,7 +423,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tAF\tAF\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 195
+    assert len(records) == 197
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -446,8 +446,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert summary[0].max_alias_count == 3
     assert summary[0].aliased_parameters == ("IS", "VT", "CJO", "VJ", "M")
     assert summary[5].kind == "NMOS"
-    assert summary[5].canonical_parameter_count == 27
-    assert summary[5].accepted_name_count == 34
+    assert summary[5].canonical_parameter_count == 28
+    assert summary[5].accepted_name_count == 35
     assert summary[5].aliased_parameter_count == 6
     assert summary[5].max_alias_count == 3
     assert summary[5].aliased_parameters == (
@@ -469,7 +469,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert table.splitlines()[1] == "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M"
     assert (
         table.splitlines()[-1]
-        == "PMOS\t27\t34\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        == "PMOS\t28\t35\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
     )
     records = model_card_supported_parameter_coverage_summary_records()
     assert len(records) == 7
@@ -497,9 +497,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 195
-    assert report.expected_canonical_parameter_count == 195
-    assert report.accepted_name_count == 265
+    assert report.canonical_parameter_count == 197
+    assert report.expected_canonical_parameter_count == 197
+    assert report.accepted_name_count == 267
     assert report.aliased_parameter_count == 57
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -507,7 +507,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t195\t195\t265\t57\t4\t0"
+        "true\t7\t7\t197\t197\t267\t57\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -535,15 +535,15 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 194
-    assert report.accepted_name_count == 262
+    assert report.canonical_parameter_count == 196
+    assert report.accepted_name_count == 264
     assert report.aliased_parameter_count == 56
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
     assert report.issues[0].field == "canonical_parameter_count"
     assert report.issues[0].message == (
-        "expected NMOS to expose 27 canonical supported parameters, found 26"
+        "expected NMOS to expose 28 canonical supported parameters, found 27"
     )
     assert report.issues[-1].field == "max_alias_count"
     assert report.issues[-1].message == "expected NMOS max alias count 3, found 2"
@@ -551,12 +551,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t194\t195\t262\t56\t4\t4\n"
+        "false\t7\t7\t196\t197\t264\t56\t4\t4\n"
         "kind\tfield\tmessage\n"
-        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 27 canonical "
-        "supported parameters, found 26\n"
-        "NMOS\taccepted_name_count\texpected NMOS to expose 34 accepted model-card "
-        "names, found 31\n"
+        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 28 canonical "
+        "supported parameters, found 27\n"
+        "NMOS\taccepted_name_count\texpected NMOS to expose 35 accepted model-card "
+        "names, found 32\n"
         "NMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing "
         "parameters, found 5\n"
         "NMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
@@ -565,12 +565,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
     assert records[0] == {
         "kind": "NMOS",
         "field": "canonical_parameter_count",
-        "message": "expected NMOS to expose 27 canonical supported parameters, found 26",
+        "message": "expected NMOS to expose 28 canonical supported parameters, found 27",
     }
     assert format_model_card_supported_parameter_coverage_gate_issue_csv(report).startswith(
         "kind,field,message\n"
-        'NMOS,canonical_parameter_count,"expected NMOS to expose 27 canonical '
-        'supported parameters, found 26"\n'
+        'NMOS,canonical_parameter_count,"expected NMOS to expose 28 canonical '
+        'supported parameters, found 27"\n'
     )
     assert (
         json.loads(format_model_card_supported_parameter_coverage_gate_issue_json(report))
@@ -1816,6 +1816,42 @@ def test_transient_mosfet_drain_area_scales_bottom_junction_capacitance() -> Non
             MOSFET(
                 MosfetType.NMOS,
                 Level1Model(Level1Params(KP=1.0e-12, W=1.0, L=1.0, CJ=cj, AD=ad)),
+            ),
+        ))
+        return transient(circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler")
+
+    uncharged = run(0.0, 0.0)
+    charged = run(0.5, 2.0e-9)
+
+    assert uncharged.converged
+    assert charged.converged
+    uncharged_first = uncharged.points[1].node_voltages["drain"]
+    charged_first = charged.points[1].node_voltages["drain"]
+    assert uncharged_first > 0.5
+    assert charged_first < 0.01
+    assert charged_first < uncharged_first
+
+
+def test_transient_mosfet_drain_perimeter_scales_sidewall_capacitance() -> None:
+    def run(cjsw: float, pd: float) -> TransientResult:
+        circuit = Circuit()
+        circuit.add(VoltageSource(
+            "Vstep",
+            "in",
+            "0",
+            0.0,
+            waveform=PwlWaveform(((0.0, 0.0), (1.0e-9, 1.0), (5.0e-9, 1.0))),
+        ))
+        circuit.add(Resistor("Rin", "in", "drain", 1_000.0))
+        circuit.add(Mosfet(
+            "M1",
+            "drain",
+            "0",
+            "0",
+            "0",
+            MOSFET(
+                MosfetType.NMOS,
+                Level1Model(Level1Params(KP=1.0e-12, W=1.0, L=1.0, CJSW=cjsw, PD=pd)),
             ),
         ))
         return transient(circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler")
@@ -5903,6 +5939,41 @@ def test_ac_mosfet_drain_area_scales_bottom_junction_capacitance():
 
     assert without_area_capacitance > 0.9
     assert with_area_capacitance < without_area_capacitance / 100.0
+
+
+def test_ac_mosfet_drain_perimeter_scales_sidewall_capacitance():
+    def drain_amplitude(cjsw: float, pd: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vac", "in", "0", 0.0, ac=AcSource(1.0)))
+        circuit.add(Resistor("Rin", "in", "drain", 1000.0))
+        circuit.add(Mosfet(
+            "M1",
+            "drain",
+            "0",
+            "0",
+            "0",
+            MOSFET(
+                MosfetType.NMOS,
+                Level1Model(
+                    Level1Params(
+                        KP=1.0e-12,
+                        W=1.0,
+                        L=1.0,
+                        TOX=1.0e9,
+                        CJSW=cjsw,
+                        PD=pd,
+                    )
+                ),
+            ),
+        ))
+        result = ac_sweep(circuit, f_start=100000.0, f_stop=100000.0, n_points=1)
+        return abs(result.points[0].node_voltages["drain"])
+
+    without_sidewall_capacitance = drain_amplitude(0.5, 0.0)
+    with_sidewall_capacitance = drain_amplitude(0.5, 2.0e-6)
+
+    assert without_sidewall_capacitance > 0.9
+    assert with_sidewall_capacitance < without_sidewall_capacitance / 100.0
 
 
 def test_ac_mosfet_source_area_scales_bottom_junction_capacitance():

--- a/code/packages/rust/mosfet-models/CHANGELOG.md
+++ b/code/packages/rust/mosfet-models/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- `Level1Params::pd` and `Level1Params::cjsw` add zero-default Berkeley drain
+  diffusion perimeter and sidewall capacitance density, contributing
+  `CJSW * PD` to the zero-bias drain-body capacitance.
 - `Level1Params::as_` adds the zero-default Berkeley source diffusion area,
   contributing `CJ * AS` to the zero-bias source-body capacitance.
 - `Level1Params::ad` and `Level1Params::cj` add zero-default Berkeley drain

--- a/code/packages/rust/mosfet-models/README.md
+++ b/code/packages/rust/mosfet-models/README.md
@@ -8,8 +8,9 @@ This crate implements the classical square-law MOSFET model used in introductory
 
 - **`Level1Params`** — Level-1 geometry, DC, capacitance, temperature, and
   noise parameters, including zero-default `LD` lateral diffusion,
-  Berkeley-default `TOX` gate oxide thickness, drain diffusion area `AD`,
-  bottom-junction capacitance density `CJ`, `KF` flicker noise, and a
+  Berkeley-default `TOX` gate oxide thickness, drain diffusion area/perimeter
+  `AD` / `PD`, bottom/sidewall junction capacitance densities `CJ` / `CJSW`,
+  `KF` flicker noise, and a
   unit-default `AF` exponent.
 - **`evaluate_level1`** — core I-V evaluation returning `MosResult` with `Id`, `gm`, `gds`, `gmb`, gate/body capacitances, and the operating `Region`.
 - **`Region`** — `Cutoff`, `Subthreshold`, `Triode`, `Saturation`.
@@ -32,8 +33,9 @@ and must leave a positive effective channel length. `TOX` defaults to
 external drain, source, and sheet-resistance parameters for engine topology and
 default to zero ohms. `NRD` and `NRS` are finite, non-negative drain/source
 diffusion square counts and default to one.
-`AD`, `AS`, and `CJ` are finite, non-negative and default to zero. They add
-`CJ * AD` to drain-body `CBD` and `CJ * AS` to source-body `CBS`.
+`AD`, `AS`, `PD`, `CJ`, and `CJSW` are finite, non-negative and default to
+zero. They add `CJ * AD + CJSW * PD` to drain-body `CBD` and `CJ * AS` to
+source-body `CBS`.
 
 ## Usage
 

--- a/code/packages/rust/mosfet-models/src/lib.rs
+++ b/code/packages/rust/mosfet-models/src/lib.rs
@@ -47,7 +47,9 @@ const OXIDE_PERMITTIVITY: f64 = 3.453_133e-11;
 /// | NRS       | Number of source squares             | 1        |
 /// | AD        | Drain diffusion area (m²)             | 0        |
 /// | AS        | Source diffusion area (m²)            | 0        |
+/// | PD        | Drain diffusion perimeter (m)          | 0        |
 /// | CJ        | Bottom junction capacitance (F/m²)    | 0        |
+/// | CJSW      | Sidewall junction capacitance (F/m)    | 0        |
 /// | IS        | Drain–body saturation current (A)  | 1 fA     |
 /// | N_SUB     | Subthreshold slope factor          | 1.4      |
 /// | T_NOM     | Nominal temperature (K)            | 300.15   |
@@ -87,8 +89,12 @@ pub struct Level1Params {
     pub ad: f64,
     /// Source diffusion area [m²].
     pub as_: f64,
+    /// Drain diffusion perimeter [m].
+    pub pd: f64,
     /// Bottom junction capacitance per unit area [F/m²].
     pub cj: f64,
+    /// Sidewall junction capacitance per unit perimeter [F/m].
+    pub cjsw: f64,
     /// Drain–body saturation current [A] (used for subthreshold floor).
     pub is: f64,
     /// Subthreshold slope factor n.  Subthreshold current ∝ exp(V_OV / (n V_T)).
@@ -138,7 +144,9 @@ impl Default for Level1Params {
             nrs: 1.0,
             ad: 0.0,
             as_: 0.0,
+            pd: 0.0,
             cj: 0.0,
+            cjsw: 0.0,
             is: 1e-15,
             n_sub: 1.4,
             t_nom: 300.15,
@@ -305,8 +313,16 @@ pub fn evaluate_level1(
         "MOSFET AS must be finite and non-negative"
     );
     assert!(
+        p.pd.is_finite() && p.pd >= 0.0,
+        "MOSFET PD must be finite and non-negative"
+    );
+    assert!(
         p.cj.is_finite() && p.cj >= 0.0,
         "MOSFET CJ must be finite and non-negative"
+    );
+    assert!(
+        p.cjsw.is_finite() && p.cjsw >= 0.0,
+        "MOSFET CJSW must be finite and non-negative"
     );
     let beta = p.kp * (p.w / effective_length);
 
@@ -330,7 +346,13 @@ pub fn evaluate_level1(
     // Meyer gate-to-channel capacitance, partitioned by operating region below.
     let channel_capacitance = p.w * effective_length * (OXIDE_PERMITTIVITY / p.tox);
     let cbs_bulk = bulk_junction_capacitance(p.cbs + p.cj * p.as_, v_bs, p.pb, p.mj, p.fc);
-    let cbd_bulk = bulk_junction_capacitance(p.cbd + p.cj * p.ad, v_bs - v_ds, p.pb, p.mj, p.fc);
+    let cbd_bulk = bulk_junction_capacitance(
+        p.cbd + p.cj * p.ad + p.cjsw * p.pd,
+        v_bs - v_ds,
+        p.pb,
+        p.mj,
+        p.fc,
+    );
 
     // -----------------------------------------------------------------------
     // Cutoff / subthreshold

--- a/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
+++ b/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
@@ -262,6 +262,24 @@ fn test_drain_area_scales_bottom_junction_capacitance() {
 }
 
 #[test]
+fn test_drain_perimeter_scales_sidewall_junction_capacitance() {
+    let result = evaluate_level1(
+        &Level1Params {
+            cbd: 1.0e-12,
+            pd: 3.0e-6,
+            cjsw: 2.0e-6,
+            mj: 0.0,
+            ..Level1Params::default()
+        },
+        1.8,
+        0.0,
+        0.0,
+        300.15,
+    );
+    assert!((result.cbd - 7.0e-12).abs() < 1.0e-24);
+}
+
+#[test]
 fn test_source_area_scales_bottom_junction_capacitance() {
     let result = evaluate_level1(
         &Level1Params {
@@ -300,6 +318,36 @@ fn test_source_area_rejects_negative_value() {
     let _ = evaluate_level1(
         &Level1Params {
             as_: -1.0,
+            ..Level1Params::default()
+        },
+        1.8,
+        1.8,
+        0.0,
+        300.15,
+    );
+}
+
+#[test]
+#[should_panic(expected = "MOSFET PD must be finite and non-negative")]
+fn test_drain_perimeter_rejects_negative_value() {
+    let _ = evaluate_level1(
+        &Level1Params {
+            pd: -1.0,
+            ..Level1Params::default()
+        },
+        1.8,
+        1.8,
+        0.0,
+        300.15,
+    );
+}
+
+#[test]
+#[should_panic(expected = "MOSFET CJSW must be finite and non-negative")]
+fn test_sidewall_junction_capacitance_rejects_negative_value() {
+    let _ = evaluate_level1(
+        &Level1Params {
+            cjsw: -1.0,
             ..Level1Params::default()
         },
         1.8,

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add the Level-1 MOS `PD` instance parameter and model-card `CJSW` density.
+  Their product augments `CBD` in AC and transient drain-body capacitance.
 - Add the Level-1 MOS `AS` instance parameter. With model-card `CJ`, its
   product augments `CBS` in AC and transient source-body capacitance.
 - Add the Level-1 MOS `AD` instance parameter and model-card `CJ` density.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -143,9 +143,9 @@ node, routes the channel and source-side capacitances through it, and contribute
 `RSH` defaults to zero ohms per square. `NRD` and `NRS` default to one drain
 and source square, so the fallbacks are `RSH * NRD` and `RSH * NRS`; explicit
 positive `RD` / `RS` values take precedence.
-`AD`, `AS`, and model-card `CJ` default to zero and are finite and non-negative.
-They add `CJ * AD` to drain-body `CBD` and `CJ * AS` to source-body `CBS` in
-AC and transient analysis.
+`AD`, `AS`, `PD`, and model-card `CJ` / `CJSW` default to zero and are finite
+and non-negative. They add `CJ * AD + CJSW * PD` to drain-body `CBD` and
+`CJ * AS` to source-body `CBS` in AC and transient analysis.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3616,7 +3616,9 @@ pub struct MosfetLevel1Params {
     pub source_squares: f64,
     pub drain_area: f64,
     pub source_area: f64,
+    pub drain_perimeter: f64,
     pub bottom_junction_capacitance: f64,
+    pub sidewall_junction_capacitance: f64,
     pub saturation_current: f64,
     pub n_sub: f64,
     pub t_nom: f64,
@@ -3651,7 +3653,9 @@ impl Default for MosfetLevel1Params {
             source_squares: 1.0,
             drain_area: 0.0,
             source_area: 0.0,
+            drain_perimeter: 0.0,
             bottom_junction_capacitance: 0.0,
+            sidewall_junction_capacitance: 0.0,
             saturation_current: 1.0e-15,
             n_sub: 1.4,
             t_nom: 300.15,
@@ -4008,8 +4012,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     (ModelCardKind::Pnp, 41, 58, 13, 4),
     (ModelCardKind::Njf, 22, 30, 7, 3),
     (ModelCardKind::Pjf, 22, 30, 7, 3),
-    (ModelCardKind::Nmos, 27, 34, 6, 3),
-    (ModelCardKind::Pmos, 27, 34, 6, 3),
+    (ModelCardKind::Nmos, 28, 35, 6, 3),
+    (ModelCardKind::Pmos, 28, 35, 6, 3),
 ];
 const DIODE_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IS", "IS"),
@@ -4156,6 +4160,7 @@ const MOS_LEVEL1_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("CBD", "CBD"),
     ("CJD", "CBD"),
     ("CJ", "CJ"),
+    ("CJSW", "CJSW"),
     ("PB", "PB"),
     ("MJ", "MJ"),
     ("FC", "FC"),
@@ -4961,6 +4966,9 @@ pub fn mosfet_from_model_card(
     }
     if let Some(value) = model.parameters.get("CJ") {
         params.bottom_junction_capacitance = *value;
+    }
+    if let Some(value) = model.parameters.get("CJSW") {
+        params.sidewall_junction_capacitance = *value;
     }
     if let Some(value) = model.parameters.get("PB") {
         params.bulk_junction_potential = *value;
@@ -24316,7 +24324,9 @@ fn evaluate_nmos_level1(
         params.forward_bias_depletion_coefficient,
     );
     let cbd_bulk = mosfet_bulk_junction_capacitance(
-        params.drain_bulk_capacitance + params.bottom_junction_capacitance * params.drain_area,
+        params.drain_bulk_capacitance
+            + params.bottom_junction_capacitance * params.drain_area
+            + params.sidewall_junction_capacitance * params.drain_perimeter,
         vbs - vds,
         params.bulk_junction_potential,
         params.bulk_junction_grading_coefficient,
@@ -25049,8 +25059,9 @@ fn mosfet_charge_state_specs(mosfet: &Mosfet) -> Vec<MosfetChargeStateSpec> {
     let gate_body_capacitance = params.gate_bulk_overlap_capacitance * params.l;
     let source_body_capacitance =
         params.source_bulk_capacitance + params.bottom_junction_capacitance * params.source_area;
-    let drain_body_capacitance =
-        params.drain_bulk_capacitance + params.bottom_junction_capacitance * params.drain_area;
+    let drain_body_capacitance = params.drain_bulk_capacitance
+        + params.bottom_junction_capacitance * params.drain_area
+        + params.sidewall_junction_capacitance * params.drain_perimeter;
     if gate_source_capacitance > 0.0 {
         specs.push(MosfetChargeStateSpec {
             name: mosfet_gate_source_charge_state_name(mosfet),
@@ -25683,7 +25694,9 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         ("NRS", params.source_squares),
         ("AD", params.drain_area),
         ("AS", params.source_area),
+        ("PD", params.drain_perimeter),
         ("CJ", params.bottom_junction_capacitance),
+        ("CJSW", params.sidewall_junction_capacitance),
         ("TOX", params.oxide_thickness),
         ("IS", params.saturation_current),
         ("N_SUB", params.n_sub),
@@ -25768,10 +25781,22 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
             reason: "MOSFET AS must be non-negative".to_string(),
         });
     }
+    if params.drain_perimeter < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET PD must be non-negative".to_string(),
+        });
+    }
     if params.bottom_junction_capacitance < 0.0 {
         return Err(SpiceError::InvalidElement {
             name: mosfet.name.clone(),
             reason: "MOSFET CJ must be non-negative".to_string(),
+        });
+    }
+    if params.sidewall_junction_capacitance < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET CJSW must be non-negative".to_string(),
         });
     }
     if params.oxide_thickness <= 0.0 {

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -1397,6 +1397,47 @@ fn ac_mosfet_drain_area_scales_bottom_junction_capacitance() {
 }
 
 #[test]
+fn ac_mosfet_drain_perimeter_scales_sidewall_junction_capacitance() {
+    fn drain_amplitude(sidewall_capacitance: f64, drain_perimeter: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "in", "0", 0.0, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "drain", 1_000.0,
+        )));
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "M1",
+            "drain",
+            "0",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                kp: 1.0e-12,
+                w: 1.0,
+                l: 1.0,
+                oxide_thickness: 1.0e9,
+                drain_perimeter,
+                sidewall_junction_capacitance: sidewall_capacitance,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+
+        ac_sweep(&circuit, 100_000.0, 100_000.0, 1).unwrap()[0]
+            .voltage("drain")
+            .unwrap()
+            .abs()
+    }
+
+    let without_sidewall_capacitance = drain_amplitude(0.5, 0.0);
+    let with_sidewall_capacitance = drain_amplitude(0.5, 2.0e-6);
+
+    assert!(without_sidewall_capacitance > 0.9);
+    assert!(with_sidewall_capacitance < without_sidewall_capacitance / 100.0);
+}
+
+#[test]
 fn ac_mosfet_source_area_scales_bottom_junction_capacitance() {
     fn source_amplitude(bottom_junction_capacitance: f64, source_area: f64) -> f64 {
         let mut circuit = Circuit::new();

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -95,7 +95,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 195);
+    assert_eq!(coverage.len(), 197);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -114,7 +114,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tAF\tAF\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 195);
+    assert_eq!(records.len(), 197);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -147,8 +147,8 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         vec!["IS", "VT", "CJO", "VJ", "M"]
     );
     assert_eq!(summary[5].kind, ModelCardKind::Nmos);
-    assert_eq!(summary[5].canonical_parameter_count, 27);
-    assert_eq!(summary[5].accepted_name_count, 34);
+    assert_eq!(summary[5].canonical_parameter_count, 28);
+    assert_eq!(summary[5].accepted_name_count, 35);
     assert_eq!(summary[5].aliased_parameter_count, 6);
     assert_eq!(summary[5].max_alias_count, 3);
     assert_eq!(
@@ -166,7 +166,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     assert_eq!(lines[1], "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\t27\t34\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        &"PMOS\t28\t35\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
     );
     let records = model_card_supported_parameter_coverage_summary_records();
     assert_eq!(records.len(), 7);
@@ -184,7 +184,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         "[{\"kind\":\"D\",\"canonical_parameter_count\":\"15\",\"accepted_name_count\":\"21\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
     ));
     assert!(json.ends_with(
-        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"27\",\"accepted_name_count\":\"34\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
+        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"28\",\"accepted_name_count\":\"35\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
     ));
 }
 
@@ -195,15 +195,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 195);
-    assert_eq!(report.expected_canonical_parameter_count, 195);
-    assert_eq!(report.accepted_name_count, 265);
+    assert_eq!(report.canonical_parameter_count, 197);
+    assert_eq!(report.expected_canonical_parameter_count, 197);
+    assert_eq!(report.accepted_name_count, 267);
     assert_eq!(report.aliased_parameter_count, 57);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t195\t195\t265\t57\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t197\t197\t267\t57\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -230,8 +230,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 194);
-    assert_eq!(report.accepted_name_count, 262);
+    assert_eq!(report.canonical_parameter_count, 196);
+    assert_eq!(report.accepted_name_count, 264);
     assert_eq!(report.aliased_parameter_count, 56);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -239,7 +239,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     assert_eq!(report.issues[0].field, "canonical_parameter_count");
     assert_eq!(
         report.issues[0].message,
-        "expected NMOS to expose 27 canonical supported parameters, found 26"
+        "expected NMOS to expose 28 canonical supported parameters, found 27"
     );
     assert_eq!(report.issues.last().unwrap().field, "max_alias_count");
     assert_eq!(
@@ -248,20 +248,20 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t194\t195\t262\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 27 canonical supported parameters, found 26\nNMOS\taccepted_name_count\texpected NMOS to expose 34 accepted model-card names, found 31\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t196\t197\t264\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 28 canonical supported parameters, found 27\nNMOS\taccepted_name_count\texpected NMOS to expose 35 accepted model-card names, found 32\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
     assert_eq!(records[0]["field"], "canonical_parameter_count");
     assert_eq!(
         records[0]["message"],
-        "expected NMOS to expose 27 canonical supported parameters, found 26"
+        "expected NMOS to expose 28 canonical supported parameters, found 27"
     );
     assert!(format_model_card_supported_parameter_coverage_gate_issue_csv(&report).starts_with(
-        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 27 canonical supported parameters, found 26\"\n"
+        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 28 canonical supported parameters, found 27\"\n"
     ));
     assert!(format_model_card_supported_parameter_coverage_gate_issue_json(&report).starts_with(
-        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 27 canonical supported parameters, found 26\"}"
+        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 28 canonical supported parameters, found 27\"}"
     ));
 }
 
@@ -283,8 +283,8 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(dashboard[0].issue_count, 0);
     assert!(dashboard[0].issue_fields.is_empty());
     assert_eq!(dashboard[5].kind, ModelCardKind::Nmos);
-    assert_eq!(dashboard[5].canonical_parameter_count, 27);
-    assert_eq!(dashboard[5].accepted_name_count, 34);
+    assert_eq!(dashboard[5].canonical_parameter_count, 28);
+    assert_eq!(dashboard[5].accepted_name_count, 35);
     assert_eq!(dashboard[5].issue_count, 0);
 
     let table = format_model_card_supported_parameter_coverage_dashboard_table(&coverage);
@@ -296,7 +296,7 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(lines[1], "D\ttrue\t15\t15\t21\t21\t5\t5\t3\t3\t0\t");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\ttrue\t27\t27\t34\t34\t6\t6\t3\t3\t0\t"
+        &"PMOS\ttrue\t28\t28\t35\t35\t6\t6\t3\t3\t0\t"
     );
     let records = model_card_supported_parameter_coverage_dashboard_records(&coverage);
     assert_eq!(records.len(), 7);
@@ -328,10 +328,10 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         .unwrap();
 
     assert!(!nmos.passed);
-    assert_eq!(nmos.canonical_parameter_count, 26);
-    assert_eq!(nmos.expected_canonical_parameter_count, 27);
-    assert_eq!(nmos.accepted_name_count, 31);
-    assert_eq!(nmos.expected_accepted_name_count, 34);
+    assert_eq!(nmos.canonical_parameter_count, 27);
+    assert_eq!(nmos.expected_canonical_parameter_count, 28);
+    assert_eq!(nmos.accepted_name_count, 32);
+    assert_eq!(nmos.expected_accepted_name_count, 35);
     assert_eq!(nmos.aliased_parameter_count, 5);
     assert_eq!(nmos.expected_aliased_parameter_count, 6);
     assert_eq!(nmos.max_alias_count, 2);
@@ -347,7 +347,7 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         ]
     );
     assert!(format_model_card_supported_parameter_coverage_dashboard_table(&coverage).contains(
-        "NMOS\tfalse\t26\t27\t31\t34\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
+        "NMOS\tfalse\t27\t28\t32\t35\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
     ));
 }
 

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -468,6 +468,53 @@ fn transient_mosfet_drain_area_scales_bottom_junction_capacitance() {
 }
 
 #[test]
+fn transient_mosfet_drain_perimeter_scales_sidewall_junction_capacitance() {
+    fn run(sidewall_capacitance: f64, drain_perimeter: f64) -> Vec<TransientPoint> {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
+            "Vstep",
+            "in",
+            "0",
+            0.0,
+            Waveform::Pwl(PwlWaveform::new(vec![
+                (0.0, 0.0),
+                (1.0e-9, 1.0),
+                (5.0e-9, 1.0),
+            ])),
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "drain", 1_000.0,
+        )));
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "M1",
+            "drain",
+            "0",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                kp: 1.0e-12,
+                w: 1.0,
+                l: 1.0,
+                drain_perimeter,
+                sidewall_junction_capacitance: sidewall_capacitance,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+        transient_with_method(&circuit, 1.0e-9, 5.0e-9, TransientMethod::Euler).unwrap()
+    }
+
+    let uncharged = run(0.0, 0.0);
+    let charged = run(0.5, 2.0e-9);
+    let uncharged_first = uncharged[0].voltage("drain").unwrap();
+    let charged_first = charged[0].voltage("drain").unwrap();
+
+    assert!(uncharged_first > 0.5);
+    assert!(charged_first < 0.01);
+    assert!(charged_first < uncharged_first);
+}
+
+#[test]
 fn transient_mosfet_source_area_scales_bottom_junction_capacitance() {
     fn run(bottom_junction_capacitance: f64, source_area: f64) -> Vec<TransientPoint> {
         let mut circuit = Circuit::new();

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Parse Level-1 MOS instance `PD=<perimeter>` and model-card
+  `CJSW=<capacitance/length>` into the engine parameter bundle for drain-body
+  sidewall capacitance.
 - Parse Level-1 MOS instance `AS=<area>` into the engine parameter bundle for
   source-body junction capacitance.
 - Parse Level-1 MOS instance `AD=<area>` and model-card `CJ=<capacitance/area>`

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -760,8 +760,9 @@ parameters, `.model <name> NPN|PNP(...)` BJT cards with `IS`, `BF` /
 `.model <name> NMOS|PMOS(...)` Level-1 MOSFET
 cards with common SPICE aliases (`VT0` / `VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
 `W`, `L`, `RSH`, `IS`, `N_SUB` / `NSUB`, `T_NOM` / `TNOM`, `CGSO`, `CGDO`,
-`CGBO`, `CBS`, `CBD`, and `CJ`), MOS instance `NRD=<squares>` /
-`NRS=<squares>` / `AD=<area>` / `AS=<area>`, SPICE engineering suffixes, capacitor
+`CGBO`, `CBS`, `CBD`, `CJ`, and `CJSW`), MOS instance `NRD=<squares>` /
+`NRS=<squares>` / `AD=<area>` / `AS=<area>` / `PD=<perimeter>`, SPICE
+engineering suffixes, capacitor
 `IC=<voltage>` and inductor `IC=<current>` initial
 conditions, independent-source `AC <magnitude> [phase]` forms,
 PWL/PULSE/SIN/EXP source forms, comments, `.end`, `.subckt` / `X` instance

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1911,6 +1911,9 @@ fn build_mosfet_params(
     if let Some(value) = instance_params.get("AS") {
         params.source_area = *value;
     }
+    if let Some(value) = instance_params.get("PD") {
+        params.drain_perimeter = *value;
+    }
     params
 }
 
@@ -1933,6 +1936,7 @@ fn apply_mosfet_param(params: &mut MosfetLevel1Params, name: &str, value: f64) {
         "CBS" => params.source_bulk_capacitance = value,
         "CBD" => params.drain_bulk_capacitance = value,
         "CJ" => params.bottom_junction_capacitance = value,
+        "CJSW" => params.sidewall_junction_capacitance = value,
         _ => {}
     }
 }

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1359,10 +1359,10 @@ Jpull drain gate source pch
 fn parses_mosfet_models_into_operating_point_circuits() {
     let parsed = parse_netlist(
         r#"
-.model nch NMOS(VTO=0.45 KP=250u LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n RSH=250 NSUB=1.5 TNOM=300 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p CJ=2m)
+.model nch NMOS(VTO=0.45 KP=250u LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n RSH=250 NSUB=1.5 TNOM=300 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p CJ=2m CJSW=5u)
 Vdd vdd 0 DC 5
 Vgate gate 0 DC 2.5
-M1 vdd gate out 0 nch W=4u L=200n NRD=2 NRS=3 AD=3n AS=4n
+M1 vdd gate out 0 nch W=4u L=200n NRD=2 NRS=3 AD=3n AS=4n PD=6u
 Rload out 0 1k
 .op
 "#,
@@ -1397,7 +1397,9 @@ Rload out 0 1k
     assert_close(mosfet.params.source_squares, 3.0);
     assert_close(mosfet.params.drain_area, 3.0e-9);
     assert_close(mosfet.params.source_area, 4.0e-9);
+    assert_close(mosfet.params.drain_perimeter, 6.0e-6);
     assert_close(mosfet.params.bottom_junction_capacitance, 2.0e-3);
+    assert_close(mosfet.params.sidewall_junction_capacitance, 5.0e-6);
     assert_close(mosfet.params.n_sub, 1.5);
     assert_close(mosfet.params.t_nom, 300.0);
     assert_close(mosfet.params.gate_source_overlap_capacitance, 3.0e-12);

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add the Level-1 MOS `PD` instance parameter and model-card `CJSW` density.
+  Their product augments `CBD` in AC and transient drain-body capacitance.
 - Add the Level-1 MOS `AS` instance parameter. With model-card `CJ`, its
   product augments `CBS` in AC and transient source-body capacitance.
 - Add the Level-1 MOS `AD` instance parameter and model-card `CJ` density.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -94,9 +94,9 @@ node, routes the channel and source-side capacitances through it, and contribute
 `RSH` defaults to zero ohms per square. `NRD` and `NRS` default to one drain
 and source square, so the fallbacks are `RSH * NRD` and `RSH * NRS`; explicit
 positive `RD` / `RS` values take precedence.
-`AD`, `AS`, and model-card `CJ` default to zero and are finite and non-negative.
-They add `CJ * AD` to drain-body `CBD` and `CJ * AS` to source-body `CBS` in
-AC and transient analysis.
+`AD`, `AS`, `PD`, and model-card `CJ` / `CJSW` default to zero and are finite
+and non-negative. They add `CJ * AD + CJSW * PD` to drain-body `CBD` and
+`CJ * AS` to source-body `CBS` in AC and transient analysis.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1784,7 +1784,9 @@ export interface MosfetLevel1Params {
   readonly NRS: number;
   readonly AD: number;
   readonly AS: number;
+  readonly PD: number;
   readonly CJ: number;
+  readonly CJSW: number;
   readonly IS: number;
   readonly N_SUB: number;
   readonly T_NOM: number;
@@ -2057,8 +2059,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   PNP: [41, 58, 13, 4],
   NJF: [22, 30, 7, 3],
   PJF: [22, 30, 7, 3],
-  NMOS: [27, 34, 6, 3],
-  PMOS: [27, 34, 6, 3],
+  NMOS: [28, 35, 6, 3],
+  PMOS: [28, 35, 6, 3],
 };
 
 export interface Vccs {
@@ -8049,7 +8051,9 @@ export function defaultMosfetLevel1Params(): MosfetLevel1Params {
     NRS: 1.0,
     AD: 0.0,
     AS: 0.0,
+    PD: 0.0,
     CJ: 0.0,
+    CJSW: 0.0,
     IS: 1.0e-15,
     N_SUB: 1.4,
     T_NOM: 300.15,
@@ -8253,6 +8257,7 @@ const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   CBD: "CBD",
   CJD: "CBD",
   CJ: "CJ",
+  CJSW: "CJSW",
   PB: "PB",
   MJ: "MJ",
   FC: "FC",
@@ -8827,6 +8832,7 @@ export function mosfetFromModelCard(
     ...(p.CBS !== undefined ? { CBS: p.CBS } : {}),
     ...(p.CBD !== undefined ? { CBD: p.CBD } : {}),
     ...(p.CJ !== undefined ? { CJ: p.CJ } : {}),
+    ...(p.CJSW !== undefined ? { CJSW: p.CJSW } : {}),
     ...(p.PB !== undefined ? { PB: p.PB } : {}),
     ...(p.MJ !== undefined ? { MJ: p.MJ } : {}),
     ...(p.FC !== undefined ? { FC: p.FC } : {}),
@@ -20337,7 +20343,8 @@ function evaluateNmosLevel1(
     params.CBS + params.CJ * params.AS, vbs, params.PB, params.MJ, params.FC,
   );
   const cbdBulk = mosfetBulkJunctionCapacitance(
-    params.CBD + params.CJ * params.AD, vbs - vds, params.PB, params.MJ, params.FC,
+    params.CBD + params.CJ * params.AD + params.CJSW * params.PD,
+    vbs - vds, params.PB, params.MJ, params.FC,
   );
   const capacitances = {
     cgs: cgsOverlap + channelCapacitance,
@@ -20897,7 +20904,9 @@ function mosfetChargeStateSpecs(element: Mosfet): MosfetChargeStateSpec[] {
   const sourceBodyCapacitance =
     element.params.CBS + element.params.CJ * element.params.AS;
   const drainBodyCapacitance =
-    element.params.CBD + element.params.CJ * element.params.AD;
+    element.params.CBD
+    + element.params.CJ * element.params.AD
+    + element.params.CJSW * element.params.PD;
   if (gateSourceCapacitance > 0.0) {
     specs.push({
       name: mosfetGateSourceChargeStateName(element),
@@ -21156,6 +21165,12 @@ function validateMosfet(element: Mosfet): void {
   }
   if (params.CJ < 0.0) {
     throw invalidElement(element.name, "MOSFET CJ must be non-negative");
+  }
+  if (params.PD < 0.0) {
+    throw invalidElement(element.name, "MOSFET PD must be non-negative");
+  }
+  if (params.CJSW < 0.0) {
+    throw invalidElement(element.name, "MOSFET CJSW must be non-negative");
   }
   if (params.TOX <= 0.0) {
     throw invalidElement(element.name, "MOSFET TOX must be positive");

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -597,6 +597,29 @@ describe("acSweep", () => {
     expect(withAreaCapacitance).toBeLessThan(withoutAreaCapacitance / 100.0);
   });
 
+  it("scales MOSFET sidewall junction capacitance by drain perimeter", () => {
+    function drainAmplitude(sidewallCapacitance: number, drainPerimeter: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "in", "0", 0.0, 1.0));
+      circuit.add(resistor("Rin", "in", "drain", 1_000.0));
+      circuit.add(mosfet("M1", "drain", "0", "0", "0", "NMOS", {
+        KP: 1.0e-12,
+        W: 1.0,
+        L: 1.0,
+        TOX: 1.0e9,
+        CJSW: sidewallCapacitance,
+        PD: drainPerimeter,
+      }));
+      return complexAbs(acSweep(circuit, 100_000.0, 100_000.0, 1)[0].voltage("drain")!);
+    }
+
+    const withoutSidewallCapacitance = drainAmplitude(0.5, 0.0);
+    const withSidewallCapacitance = drainAmplitude(0.5, 2.0e-6);
+
+    expect(withoutSidewallCapacitance).toBeGreaterThan(0.9);
+    expect(withSidewallCapacitance).toBeLessThan(withoutSidewallCapacitance / 100.0);
+  });
+
   it("scales MOSFET bottom junction capacitance by source area", () => {
     function sourceAmplitude(bottomJunctionCapacitance: number, sourceArea: number): number {
       const circuit = new Circuit();

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -121,7 +121,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(195);
+    expect(coverage).toHaveLength(197);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -141,7 +141,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tAF\tAF\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(195);
+    expect(records).toHaveLength(197);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -167,8 +167,8 @@ describe("dcOp", () => {
     });
     expect(summary[5]).toStrictEqual({
       kind: "NMOS",
-      canonicalParameterCount: 27,
-      acceptedNameCount: 34,
+      canonicalParameterCount: 28,
+      acceptedNameCount: 35,
       aliasedParameterCount: 6,
       maxAliasCount: 3,
       aliasedParameters: ["VT0", "LAMBDA", "N_SUB", "T_NOM", "CBS", "CBD"],
@@ -181,7 +181,7 @@ describe("dcOp", () => {
     );
     expect(table.split("\n")[1]).toBe("D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     expect(table.split("\n").at(-1)).toBe(
-      "PMOS\t27\t34\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
+      "PMOS\t28\t35\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
     );
     const records = modelCardSupportedParameterCoverageSummaryRecords();
     expect(records).toHaveLength(7);
@@ -206,15 +206,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 195,
-      expectedCanonicalParameterCount: 195,
-      acceptedNameCount: 265,
+      canonicalParameterCount: 197,
+      expectedCanonicalParameterCount: 197,
+      acceptedNameCount: 267,
       aliasedParameterCount: 57,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t195\t195\t265\t57\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t197\t197\t267\t57\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -237,15 +237,15 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(194);
-    expect(report.acceptedNameCount).toBe(262);
+    expect(report.canonicalParameterCount).toBe(196);
+    expect(report.acceptedNameCount).toBe(264);
     expect(report.aliasedParameterCount).toBe(56);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 27 canonical supported parameters, found 26",
+      message: "expected NMOS to expose 28 canonical supported parameters, found 27",
     });
     expect(report.issues.at(-1)).toStrictEqual({
       kind: "NMOS",
@@ -253,16 +253,16 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t194\t195\t262\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 27 canonical supported parameters, found 26\nNMOS\taccepted_name_count\texpected NMOS to expose 34 accepted model-card names, found 31\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t196\t197\t264\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 28 canonical supported parameters, found 27\nNMOS\taccepted_name_count\texpected NMOS to expose 35 accepted model-card names, found 32\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 27 canonical supported parameters, found 26",
+      message: "expected NMOS to expose 28 canonical supported parameters, found 27",
     });
     expect(formatModelCardSupportedParameterCoverageGateIssueCsv(report)).toMatch(
-      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 27 canonical supported parameters, found 26"\n/,
+      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 28 canonical supported parameters, found 27"\n/,
     );
     expect(JSON.parse(formatModelCardSupportedParameterCoverageGateIssueJson(report))).toStrictEqual(
       records,
@@ -2596,6 +2596,20 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects invalid MOSFET drain perimeters", () => {
+    for (const drainPerimeter of [Number.NaN, -1.0]) {
+      const circuit = new Circuit();
+      circuit.add(mosfet("Mbad", "drain", "gate", "0", "0", "NMOS", {
+        PD: drainPerimeter,
+      }));
+      expect(() => dcOp(circuit)).toThrowError(
+        Number.isFinite(drainPerimeter)
+          ? "MOSFET PD must be non-negative"
+          : "MOSFET PD must be finite",
+      );
+    }
+  });
+
   it("rejects invalid MOSFET bottom junction capacitance densities", () => {
     for (const bottomJunctionCapacitance of [Number.NaN, -1.0]) {
       const circuit = new Circuit();
@@ -2606,6 +2620,20 @@ describe("dcOp", () => {
         Number.isFinite(bottomJunctionCapacitance)
           ? "MOSFET CJ must be non-negative"
           : "MOSFET CJ must be finite",
+      );
+    }
+  });
+
+  it("rejects invalid MOSFET sidewall junction capacitance densities", () => {
+    for (const sidewallCapacitance of [Number.NaN, -1.0]) {
+      const circuit = new Circuit();
+      circuit.add(mosfet("Mbad", "drain", "gate", "0", "0", "NMOS", {
+        CJSW: sidewallCapacitance,
+      }));
+      expect(() => dcOp(circuit)).toThrowError(
+        Number.isFinite(sidewallCapacitance)
+          ? "MOSFET CJSW must be non-negative"
+          : "MOSFET CJSW must be finite",
       );
     }
   });

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -407,6 +407,40 @@ describe("transient", () => {
     expect(chargedFirst!).toBeLessThan(unchargedFirst!);
   });
 
+  it("scales MOSFET sidewall junction capacitance by drain perimeter", () => {
+    function run(sidewallCapacitance: number, drainPerimeter: number): TransientPoint[] {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithWaveform(
+        "Vstep",
+        "in",
+        "0",
+        0.0,
+        new PwlWaveform([
+          [0.0, 0.0],
+          [1.0e-9, 1.0],
+          [5.0e-9, 1.0],
+        ]),
+      ));
+      circuit.add(resistor("Rin", "in", "drain", 1_000.0));
+      circuit.add(mosfet("M1", "drain", "0", "0", "0", "NMOS", {
+        KP: 1.0e-12,
+        W: 1.0,
+        L: 1.0,
+        CJSW: sidewallCapacitance,
+        PD: drainPerimeter,
+      }));
+      return transient(circuit, 1.0e-9, 5.0e-9, "euler");
+    }
+
+    const unchargedFirst = run(0.0, 0.0)[0].voltage("drain");
+    const chargedFirst = run(0.5, 2.0e-9)[0].voltage("drain");
+    expect(unchargedFirst).not.toBeUndefined();
+    expect(chargedFirst).not.toBeUndefined();
+    expect(unchargedFirst!).toBeGreaterThan(0.5);
+    expect(chargedFirst!).toBeLessThan(0.01);
+    expect(chargedFirst!).toBeLessThan(unchargedFirst!);
+  });
+
   it("scales MOSFET bottom junction capacitance by source area", () => {
     function run(bottomJunctionCapacitance: number, sourceArea: number): TransientPoint[] {
       const circuit = new Circuit();

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,14 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS source diffusion area.
+1. Cross-language Level-1 MOS drain diffusion perimeter.
    - Status: current PR completion candidate.
-   - Add the Berkeley Level-1 MOS `AS` instance parameter in Rust, Python, and
-     TypeScript, defaulting to zero.
-   - Use `CBS + CJ * AS` as the zero-bias source-body capacitance in AC and
-     transient analysis while preserving existing `PB`, `MJ`, and `FC`
-     depletion shaping.
-   - Preserve `AS` through hierarchy and cloning, enforce finite non-negative
-     validation, and parse it in the Rust netlist facade.
+   - Add the Berkeley Level-1 MOS `PD` instance parameter and model-card
+     `CJSW` in Rust, Python, and TypeScript, defaulting both to zero.
+   - Use `CBD + CJ * AD + CJSW * PD` as the zero-bias drain-body capacitance
+     in AC and transient analysis while preserving existing depletion shaping.
+   - Preserve `PD` / `CJSW` through hierarchy and cloning, enforce finite
+     non-negative validation, and parse both in the Rust netlist facade.
 
 ## Completed Slices
 
@@ -3492,6 +3491,15 @@ the Rust, Python, and TypeScript surfaces together.
    - Hierarchy and cloning preserve `AD` / `CJ`, finite non-negative
      validation is shared, the Rust netlist facade parses both, and the
      model-card coverage gate now covers 195 canonical rows.
+
+275. Cross-language Level-1 MOS source diffusion area.
+   - Status: completed in PR 9043.
+   - Rust, Python, and TypeScript Level-1 MOS instances now accept `AS`,
+     defaulting to zero.
+   - `CBS + CJ * AS` supplies zero-bias source-body capacitance in AC and
+     transient analysis while preserving `PB`, `MJ`, and `FC` shaping.
+   - Hierarchy and cloning preserve `AS`, finite non-negative validation is
+     shared, and the Rust netlist facade parses it.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley Level-1 MOS `PD` drain diffusion perimeter and model-card `CJSW` across Rust, Python, and TypeScript
- include `CJSW * PD` in drain-body capacitance for model evaluation, AC, and transient analysis
- parse the new parameters, validate them, update coverage gates, documentation, and the SPICE completion plan

## Verification
- `cargo test -p mosfet-models --test test_mosfet_models`
- `cargo test -p spice-engine --test ac_tests`
- `cargo test -p spice-engine --test dc_tests`
- `cargo test -p spice-engine --test transient_tests`
- `cargo test -p spice-netlist-parser`
- Python MOSFET-models + SPICE-engine: 698 passed
- TypeScript SPICE-engine: 398 passed; `npm run build`
- Ruff and scoped Rust formatting checks