### PR TITLE
feat(adj-formula-stdlib): absorbed-dose-conversions — NIST SP 811 B.9 rad→gray factor (RS-5 table, radiology track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -836,6 +836,45 @@ fn shipped_radioactivity_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b18) Shipped table — reference/absorbed-dose-conversions.adj resolves via import (a
+//       NEW dimension: absorbed dose → gray, the EXACT SP 811 B.9 boldface factor
+//       rad = 1.0 E-02 = 0.01, the rad DEFINED as exactly 10⁻² gray), and a traditional
+//       absorbed-dose unit NIST does not tabulate (`rep`) — no row — abstains.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_absorbed_dose_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_absdose");
+    let src = stdlib().join("reference/absorbed-dose-conversions.adj");
+    std::fs::copy(&src, dir.join("absorbed-dose-conversions.adj"))
+        .expect("copy shipped absorbed-dose-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"absorbed-dose-conversions.adj\"\n\
+         ? absorbed_dose_to_gray(rad, $v)\n\
+         ? absorbed_dose_to_gray(rep, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 "Radiology" exact factor resolves, character-for-character from
+    // the table (boldface = exact; the rad is defined as exactly 10⁻² gray = 0.01).
+    assert!(out.contains("\"v\":\"0.01\""), "rad = 0.01 Gy: {out}");
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `rep` (roentgen equivalent physical) is a historical absorbed-dose unit that NIST SP
+    // 811 B.9 does NOT tabulate — no row here, so the engine abstains rather than committing
+    // to a fabricated factor.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "an untabulated unit abstains, never a fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/absorbed-dose-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/absorbed-dose-conversions.adj
@@ -1,0 +1,56 @@
+% ============================================================================
+% absorbed-dose-conversions — absorbed-dose-unit → gray factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of `radioactivity-conversions.adj` and the other NIST-cited conversion
+% tables: a native tabular relation ingested VERBATIM from a published NIST conversion
+% table. The row states the factor converting the CGS/traditional unit of ABSORBED DOSE
+% (energy imparted by ionizing radiation per unit mass of matter) to the SI coherent unit,
+% the gray (Gy = one joule per kilogram):
+%
+%     ? absorbed_dose_to_gray(rad, $v)   % 0.01
+%
+% This is a NEW dimension alongside the length/mass/area/volume/time/speed/energy/
+% pressure/force/acceleration/dynamic-viscosity/kinematic-viscosity/magnetic-flux-density/
+% illuminance/luminance/radioactivity tables: where radioactivity normalises the ACTIVITY
+% of a source (decays per second, the becquerel), this normalises the ABSORBED DOSE it
+% delivers to matter — the joules of ionizing energy deposited per kilogram, the gray. The
+% traditional unit is the rad (100 erg per gram); the SI unit is the gray, one joule per
+% kilogram. Put a dose given in rad into SI first, then reason (write-once-use-many). Why a
+% `table` and not a hand-written `relate` clause: this is exactly the shape reference data
+% comes in — a published table, not prose. The citable artifact IS the NIST conversion-
+% factors table at the `locator` below; the factor here is a CELL of NIST Special
+% Publication 811, Appendix B.9 ("Factors for units listed alphabetically"), defended by
+% one provenance envelope. Each `row` lowers to a ground relation
+% `absorbed_dose_to_gray(unit, gy)`, so the exact lookup above is the ordinary SLD binding
+% query — the engine returns the factor WITH this table's citation as its proof, on the
+% CPU, with zero model calls.
+%
+% HONESTY NOTE (like radioactivity-/luminance-conversions, only the EXACT defined factor
+% gets a row): NIST SP 811 B.9 prints the "rad" absorbed-dose factor in BOLDFACE, its
+% convention for factors that are EXACT by definition, transcribed here as the plain
+% decimal number of grays it names:
+%
+%     rad (absorbed dose) (rad)   1.0 E-02  →  0.01
+%
+% This is exact because the rad is DEFINED as exactly 10⁻² gray (one rad is 100 erg per
+% gram, i.e. 0.01 joule per kilogram, by definition — the same defining relation NIST prints
+% in boldface). It terminates; nothing here is a rounded measurement. A traditional
+% absorbed-dose unit that NIST SP 811 B.9 does NOT tabulate — e.g. the "rep" (roentgen
+% equivalent physical) — therefore gets no row here, and a
+% `? absorbed_dose_to_gray(rep, $v)` ABSTAINS rather than inventing a factor. The only claim
+% this table makes is "this is the exact factor NIST SP 811 B.9 prints for the rad" — which
+% is exactly what a byte-check against the cited table verifies. `trust authoritative` — a
+% primary, re-fetchable standards reference. (See ADJ-TABLES.md; and
+% feedback_nothing_human_authored — the factor is a verbatim cell of the cited table,
+% nothing asserted from memory.)
+% ============================================================================
+
+table absorbed_dose_to_gray {
+    columns unit, gray
+
+    row (rad, 0.01)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/absorbed-dose-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/absorbed-dose-conversions.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% absorbed-dose-conversions.query.adj — worked lookup over the absorbed-dose table.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to convert an absorbed dose given in
+% the traditional CGS unit (the rad) into the SI coherent unit (the gray, one joule per
+% kilogram): it states NO arithmetic — it `import`s the grounded table and asks the exact
+% lookup. The engine answers by ordinary SLD binding against the table's rows, returning the
+% factor WITH the table's NIST citation as its proof, on the CPU, with zero model calls.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli absorbed-dose-conversions.query.adj
+% ============================================================================
+
+import "absorbed-dose-conversions.adj"
+
+% The exact defined factor: one rad IS exactly 10⁻² gray (0.01 Gy).
+? absorbed_dose_to_gray(rad, $gy)          % expect 0.01  (NIST SP 811 B.9, EXACT by definition)
+
+% A traditional absorbed-dose unit NIST SP 811 B.9 does NOT tabulate (the historical "rep",
+% roentgen equivalent physical): no row, so the engine ABSTAINS rather than inventing a
+% factor.
+? absorbed_dose_to_gray(rep, $gy)          % expect abstention (no such row)


### PR DESCRIPTION
## What

Ships a new **RS-5 `table`** grounded reference library — a radiology sibling of `radioactivity-conversions.adj` and the other NIST-cited conversion tables — adding a **new dimension, absorbed dose**, that normalises the traditional CGS unit (the **rad**) to the SI coherent unit, the **gray** (Gy = one joule per kilogram):

```
table absorbed_dose_to_gray {
    columns unit, gray
    row (rad, 0.01)
    source "Factors for units listed alphabetically"
    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
    trust authoritative
}
```

- **`? absorbed_dose_to_gray(rad, $v)` → `0.01`**, carrying the NIST citation and `trust authoritative`.
- The single row is the **exact boldface factor** NIST Special Publication 811, Appendix B.9 ("Factors for units listed alphabetically", Radiology section) prints for the rad: **1.0 E-02**, carried verbatim as the plain decimal `0.01`. It is **exact by definition** — the rad is *defined* as exactly 10⁻² gray (100 erg per gram = 0.01 J/kg), the same defining relation NIST prints in boldface.
- The row lowers to a ground relation, so the lookup is **ordinary SLD binding** — the engine returns the factor **with the table's citation as its proof**, on the CPU, zero model calls.

## Honesty / abstention

Like the other radiology tables, only the **exact defined factor** gets a row. A traditional absorbed-dose unit NIST SP 811 B.9 does **not** tabulate — the historical **`rep`** (roentgen equivalent physical) — gets no row, so `? absorbed_dose_to_gray(rep, $v)` **abstains** (`no_grounded_support`) rather than inventing a factor. Byte-verified against the cited NIST page (WebFetch) before shipping.

## Ships

- `reference/absorbed-dose-conversions.adj` — the grounded table + literate provenance narrative.
- `reference/absorbed-dose-conversions.query.adj` — worked lookup (rad → 0.01 with citation; rep abstains).
- A numbered **(b18)** block in `adj-lang-cli/tests/rs5_table_e2e.rs` asserting `v=0.01`, the `nist-guide-si-appendix-b9` locator, and the `rep` abstention.

## Verification

- `cargo test -p adj-lang-cli --test rs5_table_e2e` — new test green; rs5 suite now **23 tests**.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean.
- CLI run over the shipped `.query.adj` confirms `"gy":"0.01"` + NIST citation for `rad`, and `"abstained":true` (`no_grounded_support`) for `rep`.
- NUL-scan of all new source files: 0 bytes.
- `/security-review`: **PASSED — no vulnerabilities found**.

**Data + test only — no version bump.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)