### PR TITLE
feat(adj-formula-stdlib): alveolar-arterial-gradient — StatPearls A–a = PAO2 − PaO2 definition library (clinical/respiratory track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_alveolar_arterial_gradient_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_alveolar_arterial_gradient_e2e.rs
@@ -1,0 +1,141 @@
+//! End-to-end tests for the `clinical/alveolar-arterial-gradient.adj` library — the
+//! definition of the alveolar–arterial oxygen gradient (A–a = alveolar PO2 − arterial PO2)
+//! and its two exact rearrangements (alveolar PO2 = A–a + arterial PO2, arterial PO2 =
+//! alveolar PO2 − A–a) — driven through the built CLI binary against the SHIPPED stdlib. Each
+//! proves the same invariant as the other formula libraries: a consumer states NO arithmetic;
+//! it imports the grounded library, binds the measured partial pressures with `observe`, and
+//! the engine applies the cited relation on the CPU, computing the EXACT value and rendering
+//! the relation's citation and trust tier in the `derived` section (the auditable answer). The
+//! three formulas INVERT around the worked case PAO2 = 100 mmHg, PaO2 = 90 mmHg: 100 − 90 =
+//! 10, and both 10 + 90 = 100 and 100 − 10 = 90 recover the inputs.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped A–a gradient library, resolved from this crate's manifest dir
+/// so the test is location-independent.
+fn shipped_aa_gradient_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/alveolar-arterial-gradient.adj")
+        .canonicalize()
+        .expect("shipped alveolar-arterial-gradient.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_aag_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_aa_gradient_lib()).unwrap();
+    std::fs::write(dir.join("alveolar-arterial-gradient.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// aa_gradient — the definition: the alveolar oxygen partial pressure less the arterial.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_aa_gradient_library_and_computes_gradient_with_citation() {
+    let dir = scratch("aag");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"alveolar-arterial-gradient.adj\"\n\
+         observe alveolar_partial_pressure_o2(100)\n\
+         observe arterial_partial_pressure_o2(90)\n\
+         ? aa_gradient(alveolar_partial_pressure_o2, arterial_partial_pressure_o2)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 100 - 90 = 10.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"aa_gradient\"") && s.contains("\"value\":10"),
+        "aa_gradient(100, 90) = 10: {s}"
+    );
+    // … AND the StatPearls/NCBI Bookshelf citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// alveolar_partial_pressure_o2 — the same relation solved for PAO2: A–a + PaO2, which INVERTS
+// the gradient just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_alveolar_po2_from_gradient_and_arterial_po2_with_citation() {
+    let dir = scratch("pao2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"alveolar-arterial-gradient.adj\"\n\
+         observe aa_gradient(10)\n\
+         observe arterial_partial_pressure_o2(90)\n\
+         ? alveolar_partial_pressure_o2(aa_gradient, arterial_partial_pressure_o2)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 10 + 90 = 100, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"alveolar_partial_pressure_o2\"") && s.contains("\"value\":100"),
+        "alveolar_partial_pressure_o2(10, 90) = 100: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "alveolar_partial_pressure_o2 carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// arterial_partial_pressure_o2 — the same relation solved for PaO2: PAO2 − A–a, the third exact
+// reading of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_arterial_po2_from_alveolar_po2_and_gradient_with_citation() {
+    let dir = scratch("paco2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"alveolar-arterial-gradient.adj\"\n\
+         observe alveolar_partial_pressure_o2(100)\n\
+         observe aa_gradient(10)\n\
+         ? arterial_partial_pressure_o2(alveolar_partial_pressure_o2, aa_gradient)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 100 - 10 = 90, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"arterial_partial_pressure_o2\"") && s.contains("\"value\":90"),
+        "arterial_partial_pressure_o2(100, 10) = 90: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "arterial_partial_pressure_o2 carries its StatPearls citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/alveolar-arterial-gradient.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/alveolar-arterial-gradient.adj
@@ -1,0 +1,108 @@
+% ============================================================================
+% alveolar-arterial-gradient.adj — the definition of the A–a oxygen gradient
+% (A–a gradient = alveolar PO2 − arterial PO2) in the ADJ standard library.
+% ============================================================================
+% The alveolar–arterial oxygen gradient entry of the *clinical* track, a respiratory
+% sibling of the hemodynamics libraries (`stroke-volume.adj`, `cardiac-output.adj`,
+% `pulse-pressure.adj`, `mean-arterial-pressure.adj`) and the pulmonary
+% `minute-ventilation.adj`. Where `pulse-pressure.adj` grounds the arterial pulse pressure
+% as a difference of two blood pressures, this grounds the A–a OXYGEN GRADIENT as a
+% difference of two oxygen partial pressures: THE A–a GRADIENT IS THE ALVEOLAR OXYGEN
+% PARTIAL PRESSURE MINUS THE ARTERIAL OXYGEN PARTIAL PRESSURE — how much higher the oxygen
+% tension is in the alveolar gas than in the arterial blood, the bedside measure of how well
+% oxygen is crossing the alveolar–capillary membrane (a widened gradient points to a
+% diffusion defect, a shunt, or a V/Q mismatch; a normal gradient with hypoxaemia points to
+% hypoventilation or low inspired oxygen). It ships as an importable, byte-provenanced,
+% PARAMETERIZED `formula`, together with its two exact rearrangements (the alveolar PO2 a
+% gradient implies for a given arterial PO2, and the arterial PO2 the other two imply). As
+% with every compute library, a consumer states NO arithmetic: it `import`s this file, binds
+% the measured partial pressures from its own byte-provenance decomposition, and asks the
+% engine to APPLY the cited definition on the CPU. Zero math is performed by the model; the
+% engine computes each value EXACTLY, carrying the definition's citation.
+%
+%     import "alveolar-arterial-gradient.adj"
+%     observe alveolar_partial_pressure_o2(100)   % "…PAO2 100 mmHg…"  (span cited by the model)
+%     observe arterial_partial_pressure_o2(90)    % "…PaO2 90 mmHg…"   (span cited by the model)
+%     ? aa_gradient(alveolar_partial_pressure_o2, arterial_partial_pressure_o2)
+%                                                    % engine → 10, carrying A–a = PAO2 − PaO2
+%
+% All three formulas are EXACT over their parameters (a difference and two of its inverse
+% readings), so every value the engine returns is exact. The three COMPOSE and invert
+% cleanly around the worked case PAO2 = 100 mmHg, PaO2 = 90 mmHg (A–a = 100 − 90 = 10 mmHg, a
+% normal gradient for a young adult breathing room air): the `aa_gradient` a consumer computes
+% from the two partial pressures is exactly the `aa_gradient` the `alveolar_partial_pressure_o2`
+% formula adds the arterial PO2 back to, to recover the 100 mmHg alveolar PO2, and exactly the
+% `aa_gradient` the `arterial_partial_pressure_o2` formula subtracts from the alveolar PO2 to
+% recover the 90 mmHg arterial PO2.
+%
+%   aa_gradient(alveolar_partial_pressure_o2, arterial_partial_pressure_o2)
+%       = alveolar_partial_pressure_o2 - arterial_partial_pressure_o2   % A–a = PAO2 − PaO2   (definition)
+%   alveolar_partial_pressure_o2(aa_gradient, arterial_partial_pressure_o2)
+%       = aa_gradient + arterial_partial_pressure_o2                    % PAO2 = A–a + PaO2   (same def, solved for PAO2)
+%   arterial_partial_pressure_o2(alveolar_partial_pressure_o2, aa_gradient)
+%       = alveolar_partial_pressure_o2 - aa_gradient                    % PaO2 = PAO2 − A–a   (same def, solved for PaO2)
+%
+% NOTE ON UNITS: the two partial pressures must be in the SAME unit (both millimetres of
+% mercury, as in the worked case), and the gradient comes out in that same unit; this library
+% computes the exact value over whatever consistent unit it is given. (The alveolar PO2 is
+% itself usually obtained from the alveolar gas equation; this library takes it as a given
+% input and grounds only the gradient definition that stands on top of it.)
+%
+% All three formulas are defended by the SAME definitional sentence — "The A-a gradient, or
+% the alveolar-arterial gradient, measures the difference between the oxygen concentration in
+% the alveoli and arterial system." — because that one definition (the gradient IS the
+% alveolar minus the arterial oxygen tension) sanctions the relation read every way (the
+% gradient from the two pressures, the alveolar PO2 from the gradient and arterial PO2, or the
+% arterial PO2 from the alveolar PO2 and gradient). The quote is transcribed verbatim from the
+% StatPearls "Physiology, Alveolar to Arterial Oxygen Gradient" article on the NCBI Bookshelf,
+% so each `formula` carries the provenance envelope every shipped grounded clause carries; the
+% linter rejects an unsourced one. (See feedback_nothing_human_authored — the definitional
+% sentence is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable oxygen partial pressure the definition ranges
+% over, and each result is a derived quantity. `aa_gradient`, `alveolar_partial_pressure_o2`
+% and `arterial_partial_pressure_o2` each appear BOTH as a derived result and as an input (of
+% the other formulas), so each is a single dictionary term used in both roles. The `surface`
+% lists are the everyday names a decomposer maps onto the canonical term; the trailing comment
+% records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary aa_gradient_vocab {
+    define alveolar_partial_pressure_o2 : finding  surface "alveolar oxygen partial pressure", "alveolar PO2", "PAO2"   % millimetres of mercury (mmHg)
+    define arterial_partial_pressure_o2 : finding  surface "arterial oxygen partial pressure", "arterial PO2", "PaO2"   % millimetres of mercury (mmHg)
+    define aa_gradient                  : finding  surface "A-a gradient", "alveolar-arterial gradient", "A-a oxygen gradient"   % millimetres of mercury (mmHg)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable formula over its
+% formal parameters, bound at apply time, and each carries the definitional sentence from
+% StatPearls on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an
+% exact difference/sum of measured quantities, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook aa_gradient_laws {
+    use aa_gradient_vocab
+
+    % A–a gradient — the alveolar oxygen partial pressure less the arterial oxygen partial
+    % pressure, i.e. A–a = PAO2 − PaO2.
+    formula aa_gradient(alveolar_partial_pressure_o2, arterial_partial_pressure_o2) = alveolar_partial_pressure_o2 - arterial_partial_pressure_o2
+        source "The A-a gradient, or the alveolar-arterial gradient, measures the difference between the oxygen concentration in the alveoli and arterial system."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK545153/"
+        trust authoritative
+
+    % Alveolar PO2 — the same definition solved for the alveolar oxygen partial pressure a
+    % gradient implies for an arterial PO2 (PAO2 = A–a + PaO2). Defended by the SAME
+    % definitional sentence, read the other way.
+    formula alveolar_partial_pressure_o2(aa_gradient, arterial_partial_pressure_o2) = aa_gradient + arterial_partial_pressure_o2
+        source "The A-a gradient, or the alveolar-arterial gradient, measures the difference between the oxygen concentration in the alveoli and arterial system."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK545153/"
+        trust authoritative
+
+    % Arterial PO2 — the same definition solved for the arterial oxygen partial pressure the
+    % other two imply (PaO2 = PAO2 − A–a). Again the SAME definitional sentence, read the third
+    % way.
+    formula arterial_partial_pressure_o2(alveolar_partial_pressure_o2, aa_gradient) = alveolar_partial_pressure_o2 - aa_gradient
+        source "The A-a gradient, or the alveolar-arterial gradient, measures the difference between the oxygen concentration in the alveoli and arterial system."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK545153/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/alveolar-arterial-gradient.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/alveolar-arterial-gradient.query.adj
@@ -1,0 +1,33 @@
+% ============================================================================
+% alveolar-arterial-gradient.query.adj — worked examples over the clinical A–a gradient library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER an A–a gradient question: it
+% states NO arithmetic and NO relation — it only `import`s the grounded library, `observe`s the
+% quantities it decomposed from the prompt (each a byte-provenanced span, elided here), and
+% asks the engine to APPLY the cited definition. The native adj-lang engine binds the
+% parameters, computes each value EXACTLY on the CPU, and returns it with the definition's
+% source/locator/trust.
+%
+% The three questions INVERT: an alveolar oxygen partial pressure of 100 mmHg less an arterial
+% oxygen partial pressure of 90 mmHg gives an A–a gradient of 100 − 90 = 10 mmHg; that 10 mmHg
+% gradient added back to the same 90 mmHg arterial PO2 is exactly what the alveolar-PO2 formula
+% recovers the 100 mmHg from, and that 10 mmHg gradient subtracted from the same 100 mmHg
+% alveolar PO2 is exactly what the arterial-PO2 formula recovers the 90 mmHg from.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli alveolar-arterial-gradient.query.adj
+% ============================================================================
+
+import "alveolar-arterial-gradient.adj"
+
+% PAO2 100 mmHg, PaO2 90 mmHg: A–a gradient = 100 − 90.
+observe alveolar_partial_pressure_o2(100)
+observe arterial_partial_pressure_o2(90)
+? aa_gradient(alveolar_partial_pressure_o2, arterial_partial_pressure_o2)          % expect 10   (A–a = PAO2 − PaO2)
+
+% That 10 mmHg gradient with the same 90 mmHg arterial PO2: PAO2 = 10 + 90.
+observe aa_gradient(10)
+? alveolar_partial_pressure_o2(aa_gradient, arterial_partial_pressure_o2)          % expect 100  (same def, solved for PAO2 = A–a + PaO2)
+
+% That 10 mmHg gradient with the same 100 mmHg alveolar PO2: PaO2 = 100 − 10.
+? arterial_partial_pressure_o2(alveolar_partial_pressure_o2, aa_gradient)          % expect 90   (same def, solved for PaO2 = PAO2 − A–a)


### PR DESCRIPTION
## What

Ships a new **clinical `formulabook`** grounded reference library — a respiratory sibling of `stroke-volume.adj` / `pulse-pressure.adj` — adding the **alveolar–arterial oxygen gradient**: the A–a gradient is the alveolar oxygen partial pressure minus the arterial oxygen partial pressure (**A–a = PAO2 − PaO2**), the bedside measure of how well oxygen crosses the alveolar–capillary membrane.

An importable, byte-provenanced, parameterized `formula` plus its two exact algebraic rearrangements, all three defended by the **same verbatim StatPearls definitional sentence**:

> "The A-a gradient, or the alveolar-arterial gradient, measures the difference between the oxygen concentration in the alveoli and arterial system."

```
aa_gradient(alveolar_partial_pressure_o2, arterial_partial_pressure_o2)
    = alveolar_partial_pressure_o2 - arterial_partial_pressure_o2   % A–a = PAO2 − PaO2   (definition)
alveolar_partial_pressure_o2(aa_gradient, arterial_partial_pressure_o2)
    = aa_gradient + arterial_partial_pressure_o2                    % PAO2 = A–a + PaO2   (same def, solved for PAO2)
arterial_partial_pressure_o2(alveolar_partial_pressure_o2, aa_gradient)
    = alveolar_partial_pressure_o2 - aa_gradient                    % PaO2 = PAO2 − A–a   (same def, solved for PaO2)
```

Each formula carries `source` (the sentence above) + `locator "https://www.ncbi.nlm.nih.gov/books/NBK545153/"` (StatPearls "Physiology, Alveolar to Arterial Oxygen Gradient", NCBI Bookshelf) + `trust authoritative`. **Byte-verified against the cited page via WebFetch** before shipping.

A consumer states **no arithmetic** — it `import`s the grounded library, `observe`s the measured partial pressures, and the engine applies the cited definition on the CPU, **exact**, carrying the citation.

## Worked case

Room air, young adult: PAO2 100 mmHg, PaO2 90 mmHg → **A–a 10 mmHg**. The three formulas invert cleanly: `10 + 90 = 100`, `100 − 10 = 90`.

## Ships

- `clinical/alveolar-arterial-gradient.adj` — the grounded formulabook + literate provenance narrative.
- `clinical/alveolar-arterial-gradient.query.adj` — worked lookup driving all three inversions.
- A dedicated e2e test `adj-lang-cli/tests/formula_alveolar_arterial_gradient_e2e.rs` (3 tests) asserting 10 / 100 / 90 + `trust authoritative` + `ncbi.nlm.nih.gov`.

## Verification

- `cargo test -p adj-lang-cli --test formula_alveolar_arterial_gradient_e2e` — **3/3 green**.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean.
- CLI run over the shipped `.query.adj` confirms `aa_gradient=10`, `alveolar_partial_pressure_o2=100`, `arterial_partial_pressure_o2=90`, each with the StatPearls citation + trust.
- NUL-scan of all new source files: 0 bytes.
- `/security-review`: **PASSED — no vulnerabilities found**.

Distinct from `cardiac-output.adj` / `minute-ventilation.adj` / `stroke-volume.adj`. **Data + test only — no version bump.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)