### PR TITLE
feat(adj-formula-stdlib): cerebral-perfusion-pressure — StatPearls CPP = MAP − ICP definition library (clinical/neuro-critical-care track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_cerebral_perfusion_pressure_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_cerebral_perfusion_pressure_e2e.rs
@@ -1,0 +1,142 @@
+//! End-to-end tests for the `clinical/cerebral-perfusion-pressure.adj` library — the
+//! definition of cerebral perfusion pressure (CPP = mean arterial pressure − intracranial
+//! pressure) and its two exact rearrangements (MAP = CPP + ICP, ICP = MAP − CPP) — driven
+//! through the built CLI binary against the SHIPPED stdlib. Each proves the same invariant as
+//! the other formula libraries: a consumer states NO arithmetic; it imports the grounded
+//! library, binds the measured pressures with `observe`, and the engine applies the cited
+//! relation on the CPU, computing the EXACT value and rendering the relation's citation and
+//! trust tier in the `derived` section (the auditable answer). The three formulas INVERT
+//! around the worked case MAP = 90 mmHg, ICP = 10 mmHg: 90 − 10 = 80, and both 80 + 10 = 90
+//! and 90 − 80 = 10 recover the inputs.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped CPP library, resolved from this crate's manifest dir so the
+/// test is location-independent.
+fn shipped_cpp_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/cerebral-perfusion-pressure.adj")
+        .canonicalize()
+        .expect("shipped cerebral-perfusion-pressure.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_cpp_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_cpp_lib()).unwrap();
+    std::fs::write(dir.join("cerebral-perfusion-pressure.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// cerebral_perfusion_pressure — the definition: the mean arterial pressure less the
+// intracranial pressure.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_cpp_library_and_computes_cpp_with_citation() {
+    let dir = scratch("cpp");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"cerebral-perfusion-pressure.adj\"\n\
+         observe mean_arterial_pressure(90)\n\
+         observe intracranial_pressure(10)\n\
+         ? cerebral_perfusion_pressure(mean_arterial_pressure, intracranial_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 90 - 10 = 80.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"cerebral_perfusion_pressure\"") && s.contains("\"value\":80"),
+        "cerebral_perfusion_pressure(90, 10) = 80: {s}"
+    );
+    // … AND the StatPearls/NCBI Bookshelf citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// mean_arterial_pressure — the same relation solved for MAP: CPP + ICP, which INVERTS the CPP
+// just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_map_from_cpp_and_icp_with_citation() {
+    let dir = scratch("map");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"cerebral-perfusion-pressure.adj\"\n\
+         observe cerebral_perfusion_pressure(80)\n\
+         observe intracranial_pressure(10)\n\
+         ? mean_arterial_pressure(cerebral_perfusion_pressure, intracranial_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 80 + 10 = 90, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"mean_arterial_pressure\"") && s.contains("\"value\":90"),
+        "mean_arterial_pressure(80, 10) = 90: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "mean_arterial_pressure carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// intracranial_pressure — the same relation solved for ICP: MAP − CPP, the third exact
+// reading of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_icp_from_map_and_cpp_with_citation() {
+    let dir = scratch("icp");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"cerebral-perfusion-pressure.adj\"\n\
+         observe mean_arterial_pressure(90)\n\
+         observe cerebral_perfusion_pressure(80)\n\
+         ? intracranial_pressure(mean_arterial_pressure, cerebral_perfusion_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 90 - 80 = 10, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"intracranial_pressure\"") && s.contains("\"value\":10"),
+        "intracranial_pressure(90, 80) = 10: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "intracranial_pressure carries its StatPearls citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/cerebral-perfusion-pressure.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/cerebral-perfusion-pressure.adj
@@ -1,0 +1,109 @@
+% ============================================================================
+% cerebral-perfusion-pressure.adj — the definition of cerebral perfusion pressure
+% (CPP = mean arterial pressure − intracranial pressure) in the ADJ standard library.
+% ============================================================================
+% The cerebral perfusion pressure entry of the *clinical* track, a neuro/critical-care
+% sibling of the hemodynamics libraries (`mean-arterial-pressure.adj`, `pulse-pressure.adj`,
+% `stroke-volume.adj`) and the respiratory `alveolar-arterial-gradient.adj`. Where
+% `alveolar-arterial-gradient.adj` grounds an oxygen-tension difference and `pulse-pressure.adj`
+% a blood-pressure difference, this grounds the CEREBRAL PERFUSION PRESSURE as the difference
+% of two pressures: CEREBRAL PERFUSION PRESSURE IS THE MEAN ARTERIAL PRESSURE MINUS THE
+% INTRACRANIAL PRESSURE — the net pressure gradient that drives blood (and thus oxygen) into
+% the brain, the bedside quantity a neurocritical-care team defends after head injury (a CPP
+% too low starves the brain of perfusion; too high risks oedema and haemorrhage). It ships as
+% an importable, byte-provenanced, PARAMETERIZED `formula`, together with its two exact
+% rearrangements (the mean arterial pressure a CPP implies for a given intracranial pressure,
+% and the intracranial pressure the other two imply). As with every compute library, a
+% consumer states NO arithmetic: it `import`s this file, binds the measured pressures from its
+% own byte-provenance decomposition, and asks the engine to APPLY the cited definition on the
+% CPU. Zero math is performed by the model; the engine computes each value EXACTLY, carrying
+% the definition's citation.
+%
+%     import "cerebral-perfusion-pressure.adj"
+%     observe mean_arterial_pressure(90)      % "…MAP 90 mmHg…"  (span cited by the model)
+%     observe intracranial_pressure(10)       % "…ICP 10 mmHg…"  (span cited by the model)
+%     ? cerebral_perfusion_pressure(mean_arterial_pressure, intracranial_pressure)
+%                                                % engine → 80, carrying CPP = MAP − ICP
+%
+% All three formulas are EXACT over their parameters (a difference and two of its inverse
+% readings), so every value the engine returns is exact. The three COMPOSE and invert
+% cleanly around the worked case MAP = 90 mmHg, ICP = 10 mmHg (CPP = 90 − 10 = 80 mmHg, a
+% normal cerebral perfusion pressure): the `cerebral_perfusion_pressure` a consumer computes
+% from the two pressures is exactly the `cerebral_perfusion_pressure` the
+% `mean_arterial_pressure` formula adds the intracranial pressure back to, to recover the
+% 90 mmHg mean arterial pressure, and exactly the `cerebral_perfusion_pressure` the
+% `intracranial_pressure` formula subtracts from the mean arterial pressure to recover the
+% 10 mmHg intracranial pressure.
+%
+%   cerebral_perfusion_pressure(mean_arterial_pressure, intracranial_pressure)
+%       = mean_arterial_pressure - intracranial_pressure   % CPP = MAP − ICP   (definition)
+%   mean_arterial_pressure(cerebral_perfusion_pressure, intracranial_pressure)
+%       = cerebral_perfusion_pressure + intracranial_pressure   % MAP = CPP + ICP   (same def, solved for MAP)
+%   intracranial_pressure(mean_arterial_pressure, cerebral_perfusion_pressure)
+%       = mean_arterial_pressure - cerebral_perfusion_pressure   % ICP = MAP − CPP   (same def, solved for ICP)
+%
+% NOTE ON UNITS: the two pressures must be in the SAME unit (both millimetres of mercury, as
+% in the worked case), and the cerebral perfusion pressure comes out in that same unit; this
+% library computes the exact value over whatever consistent unit it is given. (The mean
+% arterial pressure is itself usually derived from systolic and diastolic pressures — see
+% `mean-arterial-pressure.adj`; this library takes it as a given input and grounds only the
+% perfusion-pressure definition that stands on top of it.)
+%
+% All three formulas are defended by the SAME definitional sentence — "CPP is the net pressure
+% gradient that drives oxygen delivery to cerebral tissue. It is the difference between the
+% mean arterial pressure (MAP) and the intracranial pressure (ICP)." — because that one
+% definition (the cerebral perfusion pressure IS the mean arterial minus the intracranial
+% pressure) sanctions the relation read every way (the CPP from the two pressures, the MAP
+% from the CPP and ICP, or the ICP from the MAP and CPP). The quote is transcribed verbatim
+% from the StatPearls "Cerebral Perfusion Pressure" article on the NCBI Bookshelf, so each
+% `formula` carries the provenance envelope every shipped grounded clause carries; the linter
+% rejects an unsourced one. (See feedback_nothing_human_authored — the definitional sentence
+% is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable pressure the definition ranges over, and each
+% result is a derived quantity. `cerebral_perfusion_pressure`, `mean_arterial_pressure` and
+% `intracranial_pressure` each appear BOTH as a derived result and as an input (of the other
+% formulas), so each is a single dictionary term used in both roles. The `surface` lists are
+% the everyday names a decomposer maps onto the canonical term; the trailing comment records
+% the intended unit.
+% ----------------------------------------------------------------------------
+dictionary cerebral_perfusion_pressure_vocab {
+    define mean_arterial_pressure      : finding  surface "mean arterial pressure", "MAP"                 % millimetres of mercury (mmHg)
+    define intracranial_pressure       : finding  surface "intracranial pressure", "ICP"                 % millimetres of mercury (mmHg)
+    define cerebral_perfusion_pressure : finding  surface "cerebral perfusion pressure", "CPP"           % millimetres of mercury (mmHg)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable formula over its
+% formal parameters, bound at apply time, and each carries the definitional sentence from
+% StatPearls on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an
+% exact difference/sum of measured quantities, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook cerebral_perfusion_pressure_laws {
+    use cerebral_perfusion_pressure_vocab
+
+    % Cerebral perfusion pressure — the mean arterial pressure less the intracranial pressure,
+    % i.e. CPP = MAP − ICP.
+    formula cerebral_perfusion_pressure(mean_arterial_pressure, intracranial_pressure) = mean_arterial_pressure - intracranial_pressure
+        source "CPP is the net pressure gradient that drives oxygen delivery to cerebral tissue. It is the difference between the mean arterial pressure (MAP) and the intracranial pressure (ICP)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537271/"
+        trust authoritative
+
+    % Mean arterial pressure — the same definition solved for the mean arterial pressure a
+    % cerebral perfusion pressure implies for an intracranial pressure (MAP = CPP + ICP).
+    % Defended by the SAME definitional sentence, read the other way.
+    formula mean_arterial_pressure(cerebral_perfusion_pressure, intracranial_pressure) = cerebral_perfusion_pressure + intracranial_pressure
+        source "CPP is the net pressure gradient that drives oxygen delivery to cerebral tissue. It is the difference between the mean arterial pressure (MAP) and the intracranial pressure (ICP)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537271/"
+        trust authoritative
+
+    % Intracranial pressure — the same definition solved for the intracranial pressure the
+    % other two imply (ICP = MAP − CPP). Again the SAME definitional sentence, read the third
+    % way.
+    formula intracranial_pressure(mean_arterial_pressure, cerebral_perfusion_pressure) = mean_arterial_pressure - cerebral_perfusion_pressure
+        source "CPP is the net pressure gradient that drives oxygen delivery to cerebral tissue. It is the difference between the mean arterial pressure (MAP) and the intracranial pressure (ICP)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537271/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/cerebral-perfusion-pressure.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/cerebral-perfusion-pressure.query.adj
@@ -1,0 +1,33 @@
+% ============================================================================
+% cerebral-perfusion-pressure.query.adj — worked examples over the clinical CPP library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a cerebral-perfusion-pressure
+% question: it states NO arithmetic and NO relation — it only `import`s the grounded library,
+% `observe`s the quantities it decomposed from the prompt (each a byte-provenanced span,
+% elided here), and asks the engine to APPLY the cited definition. The native adj-lang engine
+% binds the parameters, computes each value EXACTLY on the CPU, and returns it with the
+% definition's source/locator/trust.
+%
+% The three questions INVERT: a mean arterial pressure of 90 mmHg less an intracranial
+% pressure of 10 mmHg gives a cerebral perfusion pressure of 90 − 10 = 80 mmHg; that 80 mmHg
+% CPP added back to the same 10 mmHg intracranial pressure is exactly what the MAP formula
+% recovers the 90 mmHg from, and that 80 mmHg CPP subtracted from the same 90 mmHg mean
+% arterial pressure is exactly what the ICP formula recovers the 10 mmHg from.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli cerebral-perfusion-pressure.query.adj
+% ============================================================================
+
+import "cerebral-perfusion-pressure.adj"
+
+% MAP 90 mmHg, ICP 10 mmHg: cerebral perfusion pressure = 90 − 10.
+observe mean_arterial_pressure(90)
+observe intracranial_pressure(10)
+? cerebral_perfusion_pressure(mean_arterial_pressure, intracranial_pressure)   % expect 80   (CPP = MAP − ICP)
+
+% That 80 mmHg CPP with the same 10 mmHg intracranial pressure: MAP = 80 + 10.
+observe cerebral_perfusion_pressure(80)
+? mean_arterial_pressure(cerebral_perfusion_pressure, intracranial_pressure)   % expect 90   (same def, solved for MAP = CPP + ICP)
+
+% That 80 mmHg CPP with the same 90 mmHg mean arterial pressure: ICP = 90 − 80.
+? intracranial_pressure(mean_arterial_pressure, cerebral_perfusion_pressure)   % expect 10   (same def, solved for ICP = MAP − CPP)


### PR DESCRIPTION
## What

Ships a new **clinical `formulabook`** grounded reference library — a neuro/critical-care sibling of `stroke-volume.adj` / `alveolar-arterial-gradient.adj` — adding the **cerebral perfusion pressure**: CPP is the mean arterial pressure minus the intracranial pressure (**CPP = MAP − ICP**), the net pressure gradient that drives blood (and oxygen) into the brain — the quantity a neurocritical-care team defends after head injury.

An importable, byte-provenanced, parameterized `formula` plus its two exact algebraic rearrangements, all three defended by the **same verbatim StatPearls definitional sentence**:

> "CPP is the net pressure gradient that drives oxygen delivery to cerebral tissue. It is the difference between the mean arterial pressure (MAP) and the intracranial pressure (ICP)."

```
cerebral_perfusion_pressure(mean_arterial_pressure, intracranial_pressure)
    = mean_arterial_pressure - intracranial_pressure   % CPP = MAP − ICP   (definition)
mean_arterial_pressure(cerebral_perfusion_pressure, intracranial_pressure)
    = cerebral_perfusion_pressure + intracranial_pressure   % MAP = CPP + ICP   (same def, solved for MAP)
intracranial_pressure(mean_arterial_pressure, cerebral_perfusion_pressure)
    = mean_arterial_pressure - cerebral_perfusion_pressure   % ICP = MAP − CPP   (same def, solved for ICP)
```

Each formula carries `source` (the sentence above) + `locator "https://www.ncbi.nlm.nih.gov/books/NBK537271/"` (StatPearls "Cerebral Perfusion Pressure", NCBI Bookshelf) + `trust authoritative`. **Byte-verified against the cited page via WebFetch** before shipping.

A consumer states **no arithmetic** — it `import`s the grounded library, `observe`s the measured pressures, and the engine applies the cited definition on the CPU, **exact**, carrying the citation. Composes with `mean-arterial-pressure.adj` (which derives the MAP this library consumes).

## Worked case

MAP 90 mmHg, ICP 10 mmHg → **CPP 80 mmHg** (a normal cerebral perfusion pressure). The three formulas invert cleanly: `80 + 10 = 90`, `90 − 80 = 10`.

## Ships

- `clinical/cerebral-perfusion-pressure.adj` — the grounded formulabook + literate provenance narrative.
- `clinical/cerebral-perfusion-pressure.query.adj` — worked lookup driving all three inversions.
- A dedicated e2e test `adj-lang-cli/tests/formula_cerebral_perfusion_pressure_e2e.rs` (3 tests) asserting 80 / 90 / 10 + `trust authoritative` + `ncbi.nlm.nih.gov`.

## Verification

- `cargo test -p adj-lang-cli --test formula_cerebral_perfusion_pressure_e2e` — **3/3 green**.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean.
- CLI run over the shipped `.query.adj` confirms `cerebral_perfusion_pressure=80`, `mean_arterial_pressure=90`, `intracranial_pressure=10`, each with the StatPearls citation + trust.
- NUL-scan of all new source files: 0 bytes.
- `/security-review`: **PASSED — no vulnerabilities found**.

Distinct from `mean-arterial-pressure.adj` / `pulse-pressure.adj` / `stroke-volume.adj`. **Data + test only — no version bump.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)