### PR TITLE
content(dravidian): numbers 1–10 for Kannada, Telugu, Malayalam

### DIFF
--- a/code/learning/human-languages/kannada/lessons/KA-C07-numbers-1-5.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C07-numbers-1-5.md
@@ -1,0 +1,73 @@
+---
+id: KA-C07-numbers-1-5
+chapter: 7
+type: word
+headword: ಒಂದು ಎರಡು ಮೂರು ನಾಲ್ಕು ಐದು
+gloss: one to five — the same Dravidian numbers as Tamil, with a Kannada accent
+concept_tag: KA-NUMBERS-1-5
+prerequisites: [KA-C01-namaskara]
+sounds: [kannada-inherent-a, anusvara, retroflex-series]
+roots: [proto-dravidian-numbers]
+etymology_hook: "Kannada shares Tamil's native Dravidian numbers — 2–5 the same word in a Kannada coat (iraṇṭu ↔ eraḍu)"
+est_minutes: 5
+reviews_of: [KA-C01-namaskara]
+---
+
+# ಒಂದು, ಎರಡು, ಮೂರು, ನಾಲ್ಕು, ಐದು — one to five
+
+## Warm-up
+
+[PAUSE 2s] If you walked here through Tamil, you already know these numbers —
+Kannada just says them with its own accent.
+
+## The five
+
+| | numeral | word | said |
+|---|---|---|---|
+| 1 | **೧** | **ಒಂದು** | *ondu* |
+| 2 | **೨** | **ಎರಡು** | *eraḍu* |
+| 3 | **೩** | **ಮೂರು** | *mūru* |
+| 4 | **೪** | **ನಾಲ್ಕು** | *nālku* |
+| 5 | **೫** | **ಐದು** | *aidu* |
+
+The single symbols **೧ ೨ ೩ ೪ ೫** are Kannada's own digits — you'll meet them on
+bus numbers and prices, distinct from the words above.
+
+## The family stays together
+
+These are **native Dravidian** numbers, not Sanskrit borrowings — the same
+word-stock Tamil kept. Line them up against Tamil and they are plainly the same
+word wearing a Kannada coat:
+
+| | Tamil | Kannada |
+|---|---|---|
+| 2 | *iraṇṭu* | **eraḍu** |
+| 3 | *mūṉṟu* | **mūru** |
+| 4 | *nāṉku* | **nālku** |
+| 5 | *aintu* | **aidu** |
+
+**One** is the family's odd number: Tamil *oṉṟu* and Kannada *ondu* are cousins
+(from an old *oṉ-*), but Telugu will break rank with *okaṭi* when you get there.
+So learn *ondu* now, but expect Telugu's "one" to surprise you.
+
+## A Kannada habit to notice
+
+The **anusvara** — the small circle **ಂ** in *ಒಂದು* (*on-du*) — is a nasal
+that takes its colour from the letter after it: an *n* before *d* in *ondu*, an
+*m* before *b* later in *ombattu* (nine). One mark, whatever nasal the next
+consonant needs. You'll see it constantly.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ondu, eraḍu, mūru, nālku, aidu"]
+- [YOU SAY: the Tamil→Kannada shift — "iraṇṭu → eraḍu", same number, new coat]
+- [YOU SAY: read the digits — ೧ ೨ ೩ ೪ ೫]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Count to five in Kannada. (*Ondu, eraḍu, mūru, nālku, aidu*.) Are
+these borrowed from Sanskrit? (**No** — native Dravidian, shared with Tamil.)
+Which number will Telugu form differently? (**One** — *okaṭi*, vs Kannada
+*ondu*.) What does the **ಂ** anusvara do in *ondu*? (Stands for the nasal the
+next consonant needs — here *n* before *d*.) Next: six to ten.

--- a/code/learning/human-languages/kannada/lessons/KA-C07-numbers-6-10.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C07-numbers-6-10.md
@@ -1,0 +1,74 @@
+---
+id: KA-C07-numbers-6-10
+chapter: 7
+type: word
+headword: ಆರು ಏಳು ಎಂಟು ಒಂಬತ್ತು ಹತ್ತು
+gloss: six to ten — and the sound-change that turns Tamil p- into Kannada h-
+concept_tag: KA-NUMBERS-6-10
+prerequisites: [KA-C07-numbers-1-5]
+sounds: [kannada-inherent-a, anusvara, retroflex-la]
+roots: [proto-dravidian-numbers]
+etymology_hook: "ten shows Kannada's signature p→h shift — Tamil pattu becomes hattu, as pāl (milk) becomes hālu"
+est_minutes: 5
+reviews_of: [KA-C07-numbers-1-5]
+---
+
+# ಆರು, ಏಳು, ಎಂಟು, ಒಂಬತ್ತು, ಹತ್ತು — six to ten
+
+## Warm-up
+
+[PAUSE 2s] Five more — and the last one shows the single sound-change that most
+makes Kannada *sound* like Kannada.
+
+## The five
+
+| | numeral | word | said |
+|---|---|---|---|
+| 6 | **೬** | **ಆರು** | *āru* |
+| 7 | **೭** | **ಏಳು** | *ēḷu* |
+| 8 | **೮** | **ಎಂಟು** | *eṇṭu* |
+| 9 | **೯** | **ಒಂಬತ್ತು** | *ombattu* |
+| 10 | **೧೦** | **ಹತ್ತು** | *hattu* |
+
+(Ten needs two digits — **೧೦**, a one and a zero — just like *10*.)
+
+## Ten reveals the p → h shift
+
+Put ten beside Tamil:
+
+> Tamil **pattu** → Kannada **hattu**.
+
+Kannada systematically softened an old word-initial **p‑** into **h‑**. It isn't
+a one-off: it runs right through the language —
+
+| | Tamil | Kannada |
+|---|---|---|
+| ten | *pattu* | **hattu** |
+| milk | *pāl* | **hālu** |
+| tooth | *pal* | **hallu** |
+
+Once you know the rule, a Kannada *h‑* word often hands you its Tamil cousin for
+free: hide the *h‑*, restore a *p‑*.
+
+## Where the family parts
+
+Six and seven stay close cousins (Tamil *āṟu* / Kannada *āru*; Tamil *ēḻu* /
+Kannada *ēḷu* — note Kannada hardened Tamil's rare **ḻ** into an ordinary
+retroflex **ḷ**). **Eight and nine** wander more: Kannada *eṇṭu* and *ombattu*
+are still relatives of Tamil *eṭṭu* and *oṉpatu*, but **Telugu** leaves the
+family entirely there (*enimidi*, *tommidi*) — so treat 8–9 as the loose cells.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "āru, ēḷu, eṇṭu, ombattu, hattu"]
+- [YOU SAY: the shift — "pattu → hattu", "pāl → hālu": hide the h, find the p]
+- [YOU SAY: read the digits — ೬ ೭ ೮ ೯ ೧೦]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Count six to ten in Kannada. (*Āru, ēḷu, eṇṭu, ombattu, hattu*.) What
+regular shift turns Tamil *pattu* into Kannada *hattu*? (Word-initial **p‑ → h‑**
+— also *pāl → hālu*.) What happened to Tamil's rare **ḻ** in Kannada *ēḷu*?
+(It hardened into an ordinary retroflex **ḷ**.) Which numbers should you trust
+least as family cousins? (**Eight and nine** — Telugu especially wanders.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C07-numbers-1-5.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C07-numbers-1-5.md
@@ -1,0 +1,73 @@
+---
+id: ML-C07-numbers-1-5
+chapter: 7
+type: word
+headword: ഒന്ന് രണ്ട് മൂന്ന് നാല് അഞ്ച്
+gloss: one to five — Tamil's closest sister, its numbers almost unchanged
+concept_tag: ML-NUMBERS-1-5
+prerequisites: [ML-C01-namaskaram]
+sounds: [malayalam-inherent-a, chandrakkala, gemination]
+roots: [proto-dravidian-numbers]
+etymology_hook: "Malayalam split from Tamil ~1000 years ago — its numbers are the family's closest, and even ONE agrees (onnu ↔ oṉṟu)"
+est_minutes: 5
+reviews_of: [ML-C01-namaskaram]
+---
+
+# ഒന്ന്, രണ്ട്, മൂന്ന്, നാല്, അഞ്ച് — one to five
+
+## Warm-up
+
+[PAUSE 2s] Of all the Dravidian cousins, Malayalam is Tamil's closest — they
+were one language a thousand years ago — and its numbers show it.
+
+## The five
+
+| | numeral | word | said |
+|---|---|---|---|
+| 1 | **൧** | **ഒന്ന്** | *onnu* |
+| 2 | **൨** | **രണ്ട്** | *raṇṭu* |
+| 3 | **൩** | **മൂന്ന്** | *mūnnu* |
+| 4 | **൪** | **നാല്** | *nālu* |
+| 5 | **൫** | **അഞ്ച്** | *añcu* |
+
+The symbols **൧ ൨ ൩ ൪ ൫** are Malayalam's own digits.
+
+## Even "one" agrees
+
+Where Telugu breaks the family with *okaṭi*, Malayalam stays loyal: its **one**
+is *onnu*, the direct cousin of Tamil *oṉṟu* (both from the old *oṉ-*). Laid
+beside Tamil, the whole row is barely changed:
+
+| | Tamil | Malayalam |
+|---|---|---|
+| 1 | *oṉṟu* | **onnu** |
+| 2 | *iraṇṭu* | **raṇṭu** |
+| 3 | *mūṉṟu* | **mūnnu** |
+| 4 | *nāṉku* | **nālu** |
+
+The one that moved most is **five**: Tamil *aintu* softened its *nt* to a
+palatal, giving Malayalam **añcu** — the same shift English feels between
+*nature* said stiffly and said naturally.
+
+## A Malayalam habit to notice
+
+Every word here ends in ** chandrakkala** — the little hook **് ** on the last
+letter (*ഒന്ന്*, *നാല്*) — which trims the final vowel down to a half-heard
+*ŭ*. It's why these read *onn'*, *nāl'* rather than a full *onnu*, *nālu*. And
+the doubled letters (*onnu*, *mūnnu*) are real **held** consonants — linger on
+the *nn*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "onnu, raṇṭu, mūnnu, nālu, añcu"]
+- [YOU SAY: the near-identity — "oṉṟu ↔ onnu", "iraṇṭu ↔ raṇṭu"]
+- [YOU SAY: the one that shifted — "aintu → añcu"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Count to five in Malayalam. (*Onnu, raṇṭu, mūnnu, nālu, añcu*.) Does
+Malayalam's **one** follow Tamil or break away like Telugu? (**Follows Tamil** —
+*onnu* ↔ *oṉṟu*.) Which number changed most from Tamil, and how? (**Five** —
+*aintu*'s *nt* palatalised to *añcu*.) What does the **chandrakkala** ് do to a
+word's last sound? (Trims its vowel to a half-heard *ŭ*.) Next: six to ten.

--- a/code/learning/human-languages/malayalam/lessons/ML-C07-numbers-6-10.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C07-numbers-6-10.md
@@ -1,0 +1,71 @@
+---
+id: ML-C07-numbers-6-10
+chapter: 7
+type: word
+headword: ആറ് ഏഴ് എട്ട് ഒമ്പത് പത്ത്
+gloss: six to ten — Malayalam keeps Tamil's rare ḻ where the others lost it
+concept_tag: ML-NUMBERS-6-10
+prerequisites: [ML-C07-numbers-1-5]
+sounds: [malayalam-inherent-a, chandrakkala, zha-llla]
+roots: [proto-dravidian-numbers]
+etymology_hook: "seven ēḻu keeps the rare ḻ that Kannada hardened to ḷ and Telugu to ḍ — Malayalam and Tamil alone preserve it"
+est_minutes: 5
+reviews_of: [ML-C07-numbers-1-5, ML-C01-namaskaram]
+---
+
+# ആറ്, ഏഴ്, എട്ട്, ഒമ്പത്, പത്ത് — six to ten
+
+## Warm-up
+
+[PAUSE 2s] Malayalam holds onto a Tamil sound the other cousins let go — and
+you'll hear it in seven.
+
+## The five
+
+| | numeral | word | said |
+|---|---|---|---|
+| 6 | **൬** | **ആറ്** | *āṟu* |
+| 7 | **൭** | **ഏഴ്** | *ēḻu* |
+| 8 | **൮** | **എട്ട്** | *eṭṭu* |
+| 9 | **൯** | **ഒമ്പത്** | *ompatu* |
+| 10 | **൰** | **പത്ത്** | *pattu* |
+
+## Seven keeps the rare sound
+
+Watch **seven** travel across the three sister scripts:
+
+| | word | its 7-letter |
+|---|---|---|
+| Tamil | *ēḻu* | **ழ** (ḻ) |
+| **Malayalam** | ***ēḻu*** | **ഴ** (ḻ) — kept |
+| Kannada | *ēḷu* | ḷ — hardened |
+| Telugu | *ēḍu* | ḍ — hardened further |
+
+Malayalam, alone with Tamil, **keeps the ḻ** — the rare retroflex sound that
+sits in the name *Tamiḻ* itself. (The name *Malayāḷam*, by contrast, carries the
+**hardened** cousin **ḷ** — ള — the very sound Kannada's *ēḷu* shows; the two
+letters ഴ *ḻ* and ള *ḷ* are worth keeping apart.) Six (*āṟu*), eight (*eṭṭu*)
+and ten (*pattu*) are likewise almost letter-for-letter Tamil: this is the
+closest of all the cousin-columns.
+
+## Nine, written with an m
+
+**Nine** comes, exactly as in Tamil, from the old *oṉ* ("one") + *patu* ("ten")
+— one short of ten. But before the *p*, the *n* shifts to an **m**: so the
+underlying *oṉpatu* is both **written ഒമ്പത്** and **said *ompatu*** (say
+"onpatu" fast and you'll do it yourself). Kannada does the same in *ombattu*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "āṟu, ēḻu, eṭṭu, onpatu, pattu"]
+- [YOU SAY: seven's kept sound — "ēḻu", the ḻ of *Tamiḻ* (not the ḷ of *Malayāḷam*)]
+- [YOU SAY: nine taken apart — "oṉ + patu → ompatu", one short of ten]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Count six to ten in Malayalam. (*Āṟu, ēḻu, eṭṭu, onpatu, pattu*.)
+Which sister languages keep Tamil's rare **ḻ** in *seven*, and which hardened it?
+(**Malayalam keeps it**; Kannada → *ḷ*, Telugu → *ḍ*.) How is *ompatu* built, and
+why the **m**? (*oṉ* "one" + *patu* "ten"; the *n* becomes *m* before *p*.) Which of these numbers is furthest from Tamil? (None much — this is
+the closest cousin-set.)

--- a/code/learning/human-languages/telugu/lessons/TE-C07-numbers-1-5.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C07-numbers-1-5.md
@@ -1,0 +1,73 @@
+---
+id: TE-C07-numbers-1-5
+chapter: 7
+type: word
+headword: ఒకటి రెండు మూడు నాలుగు ఐదు
+gloss: one to five — the Dravidian family numbers, with Telugu's maverick "one"
+concept_tag: TE-NUMBERS-1-5
+prerequisites: [TE-C01-namaskaram]
+sounds: [telugu-inherent-a, retroflex-series, telugu-u-ending]
+roots: [proto-dravidian-numbers]
+etymology_hook: "Telugu shares the family's 2–5 (iraṇṭu ↔ reṇḍu) but strikes out alone on ONE — okaṭi, not oṉṟu/ondu/onnu"
+est_minutes: 5
+reviews_of: [TE-C01-namaskaram]
+---
+
+# ఒకటి, రెండు, మూడు, నాలుగు, ఐదు — one to five
+
+## Warm-up
+
+[PAUSE 2s] Four of these five are old Dravidian friends. The very first one is
+Telugu going its own way.
+
+## The five
+
+| | numeral | word | said |
+|---|---|---|---|
+| 1 | **౧** | **ఒకటి** | *okaṭi* |
+| 2 | **౨** | **రెండు** | *reṇḍu* |
+| 3 | **౩** | **మూడు** | *mūḍu* |
+| 4 | **౪** | **నాలుగు** | *nālugu* |
+| 5 | **౫** | **ఐదు** | *aidu* |
+
+The symbols **౧ ౨ ౩ ౪ ౫** are Telugu's own digits.
+
+## The odd one, then the family
+
+**One** is where Telugu leaves the family. Its cousins agree — Tamil *oṉṟu*,
+Kannada *ondu*, Malayalam *onnu*, all from an old *oṉ-* — but Telugu says
+**okaṭi**, a different formation altogether. It's the number to memorise fresh
+rather than reason across from Tamil.
+
+From two onward, the family closes ranks again:
+
+| | Tamil | Telugu |
+|---|---|---|
+| 2 | *iraṇṭu* | **reṇḍu** |
+| 3 | *mūṉṟu* | **mūḍu** |
+| 4 | *nāṉku* | **nālugu** |
+| 5 | *aintu* | **aidu** |
+
+*Reṇḍu* has simply dropped the opening vowel of *iraṇṭu*; *mūḍu* is *mūṉṟu* with
+its cluster smoothed to a single **ḍ**. Same numbers, a Telugu polish.
+
+## A Telugu shape to notice
+
+Nearly every Telugu word here ends in **‑u** (*reṇḍu, mūḍu, nālugu*) — the
+language's strong preference for open, vowel-final syllables. Even where Tamil
+ends hard, Telugu tends to round the word off with a vowel.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "okaṭi, reṇḍu, mūḍu, nālugu, aidu"]
+- [YOU SAY: the maverick — "okaṭi", NOT the oṉṟu/ondu/onnu of its cousins]
+- [YOU SAY: the family — "iraṇṭu → reṇḍu", the opening vowel dropped]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Count to five in Telugu. (*Okaṭi, reṇḍu, mūḍu, nālugu, aidu*.) Which
+number does Telugu form unlike the rest of the family, and what do the others
+say? (**One** — Telugu *okaṭi* vs *oṉṟu / ondu / onnu*.) How does *reṇḍu* relate
+to Tamil *iraṇṭu*? (The opening vowel was dropped.) What vowel do most Telugu
+words here end in? (**‑u**.) Next: six to ten.

--- a/code/learning/human-languages/telugu/lessons/TE-C07-numbers-6-10.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C07-numbers-6-10.md
@@ -1,0 +1,72 @@
+---
+id: TE-C07-numbers-6-10
+chapter: 7
+type: word
+headword: ఆరు ఏడు ఎనిమిది తొమ్మిది పది
+gloss: six to ten — where Telugu wanders furthest from its Dravidian cousins
+concept_tag: TE-NUMBERS-6-10
+prerequisites: [TE-C07-numbers-1-5]
+sounds: [telugu-inherent-a, retroflex-da, telugu-u-ending]
+roots: [proto-dravidian-numbers]
+etymology_hook: "eight and nine — enimidi, tommidi — you can't derive from Tamil's eṭṭu/oṉpatu; seven ēḍu shows Telugu's ḻ→ḍ"
+est_minutes: 5
+reviews_of: [TE-C07-numbers-1-5]
+---
+
+# ఆరు, ఏడు, ఎనిమిది, తొమ్మిది, పది — six to ten
+
+## Warm-up
+
+[PAUSE 2s] The top of the count is where Telugu is least like its cousins — two
+of these you simply learn on their own.
+
+## The five
+
+| | numeral | word | said |
+|---|---|---|---|
+| 6 | **౬** | **ఆరు** | *āru* |
+| 7 | **౭** | **ఏడు** | *ēḍu* |
+| 8 | **౮** | **ఎనిమిది** | *enimidi* |
+| 9 | **౯** | **తొమ్మిది** | *tommidi* |
+| 10 | **౧౦** | **పది** | *padi* |
+
+## Seven, and a lost sound
+
+Six is an easy cousin (Tamil *āṟu* → Telugu *āru*). **Seven** is more
+interesting: Tamil *ēḻu* carries the rare **ḻ** (the *zh* of *Tamiḻ*); Kannada
+hardened it to **ḷ** (*ēḷu*); **Telugu went further still** and turned it into a
+plain **ḍ** — *ēḍu*. One inherited sound, three fates across the three scripts.
+
+## Eight and nine strike out alone
+
+Here Telugu strays furthest from its cousins —
+
+| | Tamil | Malayalam | Telugu |
+|---|---|---|---|
+| 8 | *eṭṭu* | *eṭṭu* | **enimidi** |
+| 9 | *oṉpatu* | *onpatu* | **tommidi** |
+
+You can't reach *enimidi* and *tommidi* from Tamil by regular sound-change the
+way you can *reṇḍu* from *iraṇṭu*: *tommidi* is a different word entirely, and
+*enimidi* — though it shares the ancient *eṇ-* root behind *eṭṭu* — has drifted
+too far to derive. So unlike 2–7, learn these two **fresh**.
+
+**Ten** comes partly back into the fold — Telugu *padi* is a worn-down relative
+of the *pat‑* in Tamil *pattu* (and the *‑patu* hiding inside *tommidi* and
+Tamil *oṉpatu*, "one-to-ten").
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "āru, ēḍu, enimidi, tommidi, padi"]
+- [YOU SAY: seven's three fates — "Tamil ēḻu, Kannada ēḷu, Telugu ēḍu"]
+- [YOU SAY: the two you learn fresh — "enimidi, tommidi"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Count six to ten in Telugu. (*Āru, ēḍu, enimidi, tommidi, padi*.)
+What became of Tamil's **ḻ** (in *ēḻu*) by the time it reached Telugu *ēḍu*? (It
+hardened all the way to **ḍ**.) Which two numbers can't you
+derive from Tamil by regular correspondence? (**Eight and nine** — learn
+*enimidi, tommidi* fresh.) How does *padi*
+relate to Tamil *pattu*? (A worn-down relative of the same *pat‑* "ten".)


### PR DESCRIPTION
## What
Second content-parity slice (breadth-first): after Tamil ([PR #9051](https://github.com/adhithyan15/coding-adventures/pull/9051)), this replicates **numbers 1–10 across the rest of the Dravidian chain** — six atom-first lessons (`KA/TE/ML-C07-numbers-1-5` / `-6-10`).

They're anchored on the **Tamil the learner already met** — "the same Dravidian numbers with a Kannada / Telugu / Malayalam accent" — so the family resemblance itself is the memory hook. That also lets you (the one native reviewer) sanity-check via Tamil.

## Per-language teaching points (grounded, not filler)
- **Kannada** — the regular **p→h shift** (*pattu→hattu*, *pāl→hālu*, *pal→hallu*); Tamil's rare **ḻ** hardened to **ḷ** (*ēḷu*).
- **Telugu** — the **family maverick**: *one* is **okaṭi** (not *oṉṟu/ondu/onnu*); *eight/nine* (*enimidi, tommidi*) can't be derived from Tamil by regular correspondence; **ḻ→ḍ** (*ēḍu*).
- **Malayalam** — **Tamil's closest sister**: *onnu / raṇṭu / mūnnu* near-identical; **keeps the ḻ** (*ēḻu*) the others hardened; *aintu→añcu* palatalization.

## Grounding & review
- Every numeral glyph and number word **composed/verified from Unicode code points** — nothing hand-typed.
- **Rigorously linguistics-reviewed** by a subagent (since neither you nor I read these three natively). It caught a **real factual error** — *Malayāḷam* carries **ḷ**, not **ḻ** (fixed) — corrected Malayalam nine's transliteration to match its glyph (**ompatu**), and softened the Telugu-eight claim (*enimidi* shares the *eṇ-* root). All applied.
- **Zero validation errors**; uncovered-glyph + missing-romanization warnings are expected while the Kannada/Telugu/Malayalam script files are still stubs. **human-language-data 38 + app 268 green.**

## Next
On merge: numbers for **Latin & French** (Romance-groundable), then walk to the next universal concept gap in Spanish's spine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)