### PR TITLE
feat(adj-formula-stdlib): dose-equivalent-conversions — NIST SP 811 B.9 rem→sievert factor (RS-5 table, radiology track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -875,6 +875,46 @@ fn shipped_absorbed_dose_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b19) Shipped table — reference/dose-equivalent-conversions.adj resolves via import (a
+//       NEW dimension: dose equivalent → sievert, the EXACT SP 811 B.9 boldface factor
+//       rem = 1.0 E-02 = 0.01, the rem DEFINED as exactly 10⁻² sievert), and a unit of a
+//       DIFFERENT quantity (`rad`, an absorbed-dose unit → gray, not sievert) — no row —
+//       abstains rather than mis-converting across dimensions.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_dose_equivalent_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_doseeq");
+    let src = stdlib().join("reference/dose-equivalent-conversions.adj");
+    std::fs::copy(&src, dir.join("dose-equivalent-conversions.adj"))
+        .expect("copy shipped dose-equivalent-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"dose-equivalent-conversions.adj\"\n\
+         ? dose_equivalent_to_sievert(rem, $v)\n\
+         ? dose_equivalent_to_sievert(rad, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 "Radiology" exact factor resolves, character-for-character from
+    // the table (boldface = exact; the rem is defined as exactly 10⁻² sievert = 0.01).
+    assert!(out.contains("\"v\":\"0.01\""), "rem = 0.01 Sv: {out}");
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `rad` is an ABSORBED-DOSE unit (it converts to the gray, a DIFFERENT quantity), so this
+    // dose-equivalent table has no row for it — the engine abstains rather than mis-converting
+    // an absorbed-dose unit as if it were a dose-equivalent unit.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a wrong-dimension unit abstains, never a cross-dimension fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/dose-equivalent-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/dose-equivalent-conversions.adj
@@ -1,0 +1,61 @@
+% ============================================================================
+% dose-equivalent-conversions — dose-equivalent-unit → sievert factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of `absorbed-dose-conversions.adj`, `radioactivity-conversions.adj` and
+% the other NIST-cited conversion tables: a native tabular relation ingested VERBATIM from a
+% published NIST conversion table. The row states the factor converting the traditional unit
+% of DOSE EQUIVALENT (the biological-effect-weighted absorbed dose — the absorbed dose scaled
+% by a radiation-weighting factor so that equal numbers mean equal stochastic risk) to the SI
+% coherent unit, the sievert (Sv = one joule per kilogram, weighted):
+%
+%     ? dose_equivalent_to_sievert(rem, $v)   % 0.01
+%
+% This is a NEW dimension alongside the length/mass/area/volume/time/speed/energy/
+% pressure/force/acceleration/dynamic-viscosity/kinematic-viscosity/magnetic-flux-density/
+% illuminance/luminance/radioactivity/absorbed-dose tables. It is the companion to
+% `absorbed-dose-conversions.adj`: absorbed dose (the rad → the gray) measures the raw energy
+% ionizing radiation deposits per kilogram; DOSE EQUIVALENT (the rem → the sievert) measures
+% that same energy weighted for how biologically damaging the particular radiation is, so two
+% doses with the same sievert value carry the same stochastic risk even when their gray values
+% differ. The traditional unit is the rem (roentgen equivalent man); the SI unit is the
+% sievert. Put a dose given in rem into SI first, then reason (write-once-use-many). Why a
+% `table` and not a hand-written `relate` clause: this is exactly the shape reference data
+% comes in — a published table, not prose. The citable artifact IS the NIST conversion-
+% factors table at the `locator` below; the factor here is a CELL of NIST Special
+% Publication 811, Appendix B.9 ("Factors for units listed alphabetically"), defended by
+% one provenance envelope. Each `row` lowers to a ground relation
+% `dose_equivalent_to_sievert(unit, sv)`, so the exact lookup above is the ordinary SLD
+% binding query — the engine returns the factor WITH this table's citation as its proof, on
+% the CPU, with zero model calls.
+%
+% HONESTY NOTE (like absorbed-dose-/radioactivity-conversions, only the EXACT defined factor
+% gets a row): NIST SP 811 B.9 prints the "rem" dose-equivalent factor in BOLDFACE, its
+% convention for factors that are EXACT by definition, transcribed here as the plain decimal
+% number of sieverts it names:
+%
+%     rem (rem)   1.0 E-02  →  0.01
+%
+% This is exact because the rem is DEFINED as exactly 10⁻² sievert (one rem is 0.01 J/kg of
+% weighted dose, by definition — the same defining relation NIST prints in boldface). It
+% terminates; nothing here is a rounded measurement. This table is SPECIFIC to dose
+% equivalent: a unit of a DIFFERENT radiological quantity — e.g. the "rad", which NIST SP 811
+% B.9 lists separately as an ABSORBED-DOSE unit converting to the gray, NOT the sievert (see
+% `absorbed-dose-conversions.adj`) — therefore gets no row here, and a
+% `? dose_equivalent_to_sievert(rad, $v)` ABSTAINS rather than mis-converting an absorbed-dose
+% unit as if it were a dose-equivalent unit. The only claim this table makes is "this is the
+% exact factor NIST SP 811 B.9 prints for the rem's conversion to the sievert" — which is
+% exactly what a byte-check against the cited table verifies. `trust authoritative` — a
+% primary, re-fetchable standards reference. (See ADJ-TABLES.md; and
+% feedback_nothing_human_authored — the factor is a verbatim cell of the cited table,
+% nothing asserted from memory.)
+% ============================================================================
+
+table dose_equivalent_to_sievert {
+    columns unit, sievert
+
+    row (rem, 0.01)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/dose-equivalent-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/dose-equivalent-conversions.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% dose-equivalent-conversions.query.adj — worked lookup over the dose-equivalent table.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to convert a dose equivalent given in
+% the traditional unit (the rem) into the SI coherent unit (the sievert): it states NO
+% arithmetic — it `import`s the grounded table and asks the exact lookup. The engine answers
+% by ordinary SLD binding against the table's rows, returning the factor WITH the table's NIST
+% citation as its proof, on the CPU, with zero model calls.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli dose-equivalent-conversions.query.adj
+% ============================================================================
+
+import "dose-equivalent-conversions.adj"
+
+% The exact defined factor: one rem IS exactly 10⁻² sievert (0.01 Sv).
+? dose_equivalent_to_sievert(rem, $sv)          % expect 0.01  (NIST SP 811 B.9, EXACT by definition)
+
+% The "rad" is an ABSORBED-DOSE unit (it converts to the gray, not the sievert — see
+% absorbed-dose-conversions.adj), a DIFFERENT radiological quantity, so this dose-equivalent
+% table has no row for it and the engine ABSTAINS rather than mis-converting it.
+? dose_equivalent_to_sievert(rad, $sv)          % expect abstention (rad is absorbed dose, not dose equivalent)


### PR DESCRIPTION
## What

Ships a new **RS-5 `table`** grounded reference library — a radiology sibling of `absorbed-dose-conversions.adj` and `radioactivity-conversions.adj` — adding a **new dimension, dose equivalent** (the biological-effect-weighted absorbed dose), that normalises the traditional unit (the **rem**) to the SI coherent unit, the **sievert**:

```
table dose_equivalent_to_sievert {
    columns unit, sievert
    row (rem, 0.01)
    source "Factors for units listed alphabetically"
    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
    trust authoritative
}
```

- **`? dose_equivalent_to_sievert(rem, $v)` → `0.01`**, carrying the NIST citation and `trust authoritative`.
- The single row is the **exact boldface factor** NIST Special Publication 811, Appendix B.9 (Radiology section) prints for the rem: **1.0 E-02**, carried verbatim as `0.01`. Exact by definition — the rem is *defined* as exactly 10⁻² sievert.
- The row lowers to a ground relation, so the lookup is **ordinary SLD binding** — the engine returns the factor **with the table's citation as its proof**, on the CPU, zero model calls.

## Companion to absorbed-dose + dimension-specific abstention

This is the pair to `absorbed-dose-conversions.adj`: absorbed dose (rad→gray) measures the raw energy ionizing radiation deposits per kilogram; **dose equivalent** (rem→sievert) measures that same energy weighted for biological damage, so equal sievert values mean equal stochastic risk.

The table is **dimension-specific**: a unit of a *different* quantity — the **`rad`**, which NIST SP 811 B.9 lists separately as an **absorbed-dose** unit converting to the gray (see `absorbed-dose-conversions.adj`), **not** the sievert — gets no row here. So `? dose_equivalent_to_sievert(rad, $v)` **abstains** (`no_grounded_support`) rather than mis-converting an absorbed-dose unit as if it were a dose-equivalent unit. Byte-verified against the cited NIST page (WebFetch) before shipping.

## Ships

- `reference/dose-equivalent-conversions.adj` — the grounded table + literate provenance narrative.
- `reference/dose-equivalent-conversions.query.adj` — worked lookup (rem → 0.01 with citation; rad abstains).
- A numbered **(b19)** block in `adj-lang-cli/tests/rs5_table_e2e.rs` asserting `v=0.01`, the `nist-guide-si-appendix-b9` locator, and the cross-dimension `rad` abstention.

## Verification

- `cargo test -p adj-lang-cli --test rs5_table_e2e` — new test green; rs5 suite now **24 tests**.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean.
- CLI run over the shipped `.query.adj` confirms `"sv":"0.01"` + NIST citation for `rem`, and `"abstained":true` (`no_grounded_support`) for `rad`.
- NUL-scan of all new source files: 0 bytes.
- `/security-review`: **PASSED — no vulnerabilities found**.

**Data + test only — no version bump.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)