### PR TITLE
Add MOS source sidewall capacitance

### DIFF
--- a/code/packages/python/mosfet-models/CHANGELOG.md
+++ b/code/packages/python/mosfet-models/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [0.1.0] — Unreleased
 
 ### Added
+- `Level1Params.PS` adds zero-default Berkeley source diffusion perimeter,
+  contributing `CJSW * PS` to the zero-bias source-body capacitance.
 - `Level1Params.PD` and `Level1Params.CJSW` add zero-default Berkeley drain
   diffusion perimeter and sidewall capacitance density, contributing
   `CJSW * PD` to the zero-bias drain-body capacitance.

--- a/code/packages/python/mosfet-models/README.md
+++ b/code/packages/python/mosfet-models/README.md
@@ -29,9 +29,9 @@ print(r.Id, r.gm, r.gds, r.region)
   Meyer capacitance through `Cox = epsilon_ox / TOX`, zero-default `RD` / `RS`
   external drain/source resistance, zero-default `RSH` sheet resistance,
   one-default `NRD` / `NRS` drain/source diffusion square counts, zero-default
-  drain/source diffusion areas `AD` / `AS`, drain perimeter `PD`, and
+  drain/source diffusion areas `AD` / `AS`, perimeters `PD` / `PS`, and
   bottom/sidewall junction capacitance densities `CJ` / `CJSW` contributing
-  `CJ * AD + CJSW * PD` to `CBD` and `CJ * AS` to `CBS`, and
+  `CJ * AD + CJSW * PD` to `CBD` and `CJ * AS + CJSW * PS` to `CBS`, and
   `KF` / `AF` flicker noise.
 - `evaluate_level1(params, V_GS, V_DS, V_BS, T)`: returns `MosResult` with Id, gm, gds, gmb, Cgs/Cgd/Cgb/Cbs/Cbd, region.
 - Region detection: cutoff (subthreshold-aware), triode, saturation.

--- a/code/packages/python/mosfet-models/src/mosfet_models/level1.py
+++ b/code/packages/python/mosfet-models/src/mosfet_models/level1.py
@@ -37,6 +37,7 @@ class Level1Params:
     AD: float = 0.0  # drain diffusion area (m^2)
     AS: float = 0.0  # source diffusion area (m^2)
     PD: float = 0.0  # drain diffusion perimeter (m)
+    PS: float = 0.0  # source diffusion perimeter (m)
     CJ: float = 0.0  # bottom junction capacitance per area (F/m^2)
     CJSW: float = 0.0  # sidewall junction capacitance per perimeter (F/m)
     IS: float = 1e-15  # saturation current (A)
@@ -148,6 +149,8 @@ def evaluate_level1(
         raise ValueError("MOSFET AS must be finite and non-negative")
     if not isfinite(p.PD) or p.PD < 0.0:
         raise ValueError("MOSFET PD must be finite and non-negative")
+    if not isfinite(p.PS) or p.PS < 0.0:
+        raise ValueError("MOSFET PS must be finite and non-negative")
     if not isfinite(p.CJ) or p.CJ < 0.0:
         raise ValueError("MOSFET CJ must be finite and non-negative")
     if not isfinite(p.CJSW) or p.CJSW < 0.0:
@@ -174,7 +177,7 @@ def evaluate_level1(
     Cgd_intrinsic = 0.0
     Cgb_intrinsic = 0.0
     Cbs_bulk = bulk_junction_capacitance(
-        p.CBS + p.CJ * p.AS,
+        p.CBS + p.CJ * p.AS + p.CJSW * p.PS,
         V_BS,
         p.PB,
         p.MJ,

--- a/code/packages/python/mosfet-models/tests/test_models.py
+++ b/code/packages/python/mosfet-models/tests/test_models.py
@@ -234,12 +234,22 @@ def test_source_area_scales_bottom_junction_capacitance():
     assert result.Cbs == pytest.approx(7.0e-12)
 
 
+def test_source_perimeter_scales_sidewall_junction_capacitance():
+    result = evaluate_level1(
+        Level1Params(CBS=1.0e-12, PS=3.0e-6, CJSW=2.0e-6, MJ=0.0),
+        V_GS=1.8,
+        V_DS=0.0,
+    )
+    assert result.Cbs == pytest.approx(7.0e-12)
+
+
 @pytest.mark.parametrize(
     ("params", "message"),
     [
         (Level1Params(AD=-1.0), "MOSFET AD must be finite and non-negative"),
         (Level1Params(AS=-1.0), "MOSFET AS must be finite and non-negative"),
         (Level1Params(PD=-1.0), "MOSFET PD must be finite and non-negative"),
+        (Level1Params(PS=-1.0), "MOSFET PS must be finite and non-negative"),
         (Level1Params(CJ=-1.0), "MOSFET CJ must be finite and non-negative"),
         (Level1Params(CJSW=-1.0), "MOSFET CJSW must be finite and non-negative"),
     ],

--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add the Level-1 MOS `PS` instance parameter. With model-card `CJSW`, its
+  product augments `CBS` in AC and transient source-body capacitance.
 - Add the Level-1 MOS `PD` instance parameter and model-card `CJSW` density.
   Their product augments `CBD` in AC and transient drain-body capacitance.
 - Add the Level-1 MOS `AS` instance parameter. With model-card `CJ`, its

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -102,9 +102,9 @@ node, routes the channel and source-side capacitances through it, and contribute
 `RSH` defaults to zero ohms per square. `NRD` and `NRS` default to one drain
 and source square, so the fallbacks are `RSH * NRD` and `RSH * NRS`; explicit
 positive `RD` / `RS` values take precedence.
-`AD`, `AS`, `PD`, and model-card `CJ` / `CJSW` default to zero and are finite
-and non-negative. They add `CJ * AD + CJSW * PD` to drain-body `CBD` and
-`CJ * AS` to source-body `CBS` in AC and transient analysis.
+`AD`, `AS`, `PD`, `PS`, and model-card `CJ` / `CJSW` default to zero and are
+finite and non-negative. They add `CJ * AD + CJSW * PD` to drain-body `CBD`
+and `CJ * AS + CJSW * PS` to source-body `CBS` in AC and transient analysis.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -9112,8 +9112,10 @@ def _mosfet_charge_state_specs(el: Mosfet) -> list[tuple[str, str, str, float]]:
     cgs = getattr(params, "CGSO", 0.0) * width
     cgd = getattr(params, "CGDO", 0.0) * width
     cgb = getattr(params, "CGBO", 0.0) * length
-    cbs = getattr(params, "CBS", 0.0) + (
-        getattr(params, "CJ", 0.0) * getattr(params, "AS", 0.0)
+    cbs = (
+        getattr(params, "CBS", 0.0)
+        + getattr(params, "CJ", 0.0) * getattr(params, "AS", 0.0)
+        + getattr(params, "CJSW", 0.0) * getattr(params, "PS", 0.0)
     )
     cbd = (
         getattr(params, "CBD", 0.0)

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1912,6 +1912,50 @@ def test_transient_mosfet_source_area_scales_bottom_junction_capacitance() -> No
     assert charged_first < uncharged_first
 
 
+def test_transient_mosfet_source_perimeter_scales_sidewall_capacitance() -> None:
+    def run(cjsw: float, source_perimeter: float) -> TransientResult:
+        circuit = Circuit()
+        circuit.add(VoltageSource(
+            "Vstep",
+            "in",
+            "0",
+            0.0,
+            waveform=PwlWaveform(((0.0, 0.0), (1.0e-9, 1.0), (5.0e-9, 1.0))),
+        ))
+        circuit.add(Resistor("Rin", "in", "source", 1_000.0))
+        circuit.add(Mosfet(
+            "M1",
+            "0",
+            "0",
+            "source",
+            "0",
+            MOSFET(
+                MosfetType.NMOS,
+                Level1Model(
+                    Level1Params(
+                        KP=1.0e-12,
+                        W=1.0,
+                        L=1.0,
+                        CJSW=cjsw,
+                        PS=source_perimeter,
+                    )
+                ),
+            ),
+        ))
+        return transient(circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler")
+
+    uncharged = run(0.0, 0.0)
+    charged = run(0.5, 2.0e-9)
+
+    assert uncharged.converged
+    assert charged.converged
+    uncharged_first = uncharged.points[1].node_voltages["source"]
+    charged_first = charged.points[1].node_voltages["source"]
+    assert uncharged_first > 0.5
+    assert charged_first < 0.01
+    assert charged_first < uncharged_first
+
+
 def test_transient_mosfet_bulk_junction_depletion_shaping_reduces_reverse_bias_capacitance() -> None:
     def run(grading_coefficient: float) -> TransientResult:
         circuit = Circuit()
@@ -2231,6 +2275,28 @@ def test_mosfet_rejects_invalid_source_area(source_area: float) -> None:
     with pytest.raises(
         ValueError,
         match="MOSFET AS must be finite and non-negative",
+    ):
+        dc_op(circuit)
+
+
+@pytest.mark.parametrize("source_perimeter", [float("nan"), -1.0])
+def test_mosfet_rejects_invalid_source_perimeter(source_perimeter: float) -> None:
+    circuit = Circuit()
+    circuit.add(Mosfet(
+        "Mbad",
+        "drain",
+        "gate",
+        "0",
+        "0",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(Level1Params(PS=source_perimeter)),
+        ),
+    ))
+
+    with pytest.raises(
+        ValueError,
+        match="MOSFET PS must be finite and non-negative",
     ):
         dc_op(circuit)
 
@@ -3207,6 +3273,7 @@ def test_subcircuit_expansion_preserves_mos_geometry():
                             NRS=3.0,
                             AD=4.0e-12,
                             AS=5.0e-12,
+                            PS=6.0e-6,
                             CJ=2.0e-3,
                             TOX=25.0e-9,
                         )
@@ -3231,6 +3298,7 @@ def test_subcircuit_expansion_preserves_mos_geometry():
     assert pytest.approx(3.0) == expanded.model.model.params.NRS
     assert pytest.approx(4.0e-12) == expanded.model.model.params.AD
     assert pytest.approx(5.0e-12) == expanded.model.model.params.AS
+    assert pytest.approx(6.0e-6) == expanded.model.model.params.PS
     assert pytest.approx(2.0e-3) == expanded.model.model.params.CJ
     assert pytest.approx(25.0e-9) == expanded.model.model.params.TOX
 
@@ -6009,6 +6077,41 @@ def test_ac_mosfet_source_area_scales_bottom_junction_capacitance():
 
     assert without_area_capacitance > 0.9
     assert with_area_capacitance < without_area_capacitance / 100.0
+
+
+def test_ac_mosfet_source_perimeter_scales_sidewall_capacitance():
+    def source_amplitude(cjsw: float, source_perimeter: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vac", "in", "0", 0.0, ac=AcSource(1.0)))
+        circuit.add(Resistor("Rin", "in", "source", 1000.0))
+        circuit.add(Mosfet(
+            "M1",
+            "0",
+            "0",
+            "source",
+            "0",
+            MOSFET(
+                MosfetType.NMOS,
+                Level1Model(
+                    Level1Params(
+                        KP=1.0e-12,
+                        W=1.0,
+                        L=1.0,
+                        TOX=1.0e9,
+                        CJSW=cjsw,
+                        PS=source_perimeter,
+                    )
+                ),
+            ),
+        ))
+        result = ac_sweep(circuit, f_start=100000.0, f_stop=100000.0, n_points=1)
+        return abs(result.points[0].node_voltages["source"])
+
+    without_sidewall_capacitance = source_amplitude(0.5, 0.0)
+    with_sidewall_capacitance = source_amplitude(0.5, 2.0e-6)
+
+    assert without_sidewall_capacitance > 0.9
+    assert with_sidewall_capacitance < without_sidewall_capacitance / 100.0
 
 
 def test_ac_mosfet_oxide_thickness_scales_intrinsic_gate_capacitance():

--- a/code/packages/rust/mosfet-models/CHANGELOG.md
+++ b/code/packages/rust/mosfet-models/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `Level1Params::ps` adds zero-default Berkeley source diffusion perimeter,
+  contributing `CJSW * PS` to the zero-bias source-body capacitance.
 - `Level1Params::pd` and `Level1Params::cjsw` add zero-default Berkeley drain
   diffusion perimeter and sidewall capacitance density, contributing
   `CJSW * PD` to the zero-bias drain-body capacitance.

--- a/code/packages/rust/mosfet-models/README.md
+++ b/code/packages/rust/mosfet-models/README.md
@@ -8,8 +8,9 @@ This crate implements the classical square-law MOSFET model used in introductory
 
 - **`Level1Params`** — Level-1 geometry, DC, capacitance, temperature, and
   noise parameters, including zero-default `LD` lateral diffusion,
-  Berkeley-default `TOX` gate oxide thickness, drain diffusion area/perimeter
-  `AD` / `PD`, bottom/sidewall junction capacitance densities `CJ` / `CJSW`,
+  Berkeley-default `TOX` gate oxide thickness, drain/source diffusion
+  areas/perimeters `AD` / `AS` / `PD` / `PS`, bottom/sidewall junction
+  capacitance densities `CJ` / `CJSW`,
   `KF` flicker noise, and a
   unit-default `AF` exponent.
 - **`evaluate_level1`** — core I-V evaluation returning `MosResult` with `Id`, `gm`, `gds`, `gmb`, gate/body capacitances, and the operating `Region`.
@@ -33,9 +34,9 @@ and must leave a positive effective channel length. `TOX` defaults to
 external drain, source, and sheet-resistance parameters for engine topology and
 default to zero ohms. `NRD` and `NRS` are finite, non-negative drain/source
 diffusion square counts and default to one.
-`AD`, `AS`, `PD`, `CJ`, and `CJSW` are finite, non-negative and default to
-zero. They add `CJ * AD + CJSW * PD` to drain-body `CBD` and `CJ * AS` to
-source-body `CBS`.
+`AD`, `AS`, `PD`, `PS`, `CJ`, and `CJSW` are finite, non-negative and default
+to zero. They add `CJ * AD + CJSW * PD` to drain-body `CBD` and
+`CJ * AS + CJSW * PS` to source-body `CBS`.
 
 ## Usage
 

--- a/code/packages/rust/mosfet-models/src/lib.rs
+++ b/code/packages/rust/mosfet-models/src/lib.rs
@@ -48,6 +48,7 @@ const OXIDE_PERMITTIVITY: f64 = 3.453_133e-11;
 /// | AD        | Drain diffusion area (m²)             | 0        |
 /// | AS        | Source diffusion area (m²)            | 0        |
 /// | PD        | Drain diffusion perimeter (m)          | 0        |
+/// | PS        | Source diffusion perimeter (m)         | 0        |
 /// | CJ        | Bottom junction capacitance (F/m²)    | 0        |
 /// | CJSW      | Sidewall junction capacitance (F/m)    | 0        |
 /// | IS        | Drain–body saturation current (A)  | 1 fA     |
@@ -91,6 +92,8 @@ pub struct Level1Params {
     pub as_: f64,
     /// Drain diffusion perimeter [m].
     pub pd: f64,
+    /// Source diffusion perimeter [m].
+    pub ps: f64,
     /// Bottom junction capacitance per unit area [F/m²].
     pub cj: f64,
     /// Sidewall junction capacitance per unit perimeter [F/m].
@@ -145,6 +148,7 @@ impl Default for Level1Params {
             ad: 0.0,
             as_: 0.0,
             pd: 0.0,
+            ps: 0.0,
             cj: 0.0,
             cjsw: 0.0,
             is: 1e-15,
@@ -317,6 +321,10 @@ pub fn evaluate_level1(
         "MOSFET PD must be finite and non-negative"
     );
     assert!(
+        p.ps.is_finite() && p.ps >= 0.0,
+        "MOSFET PS must be finite and non-negative"
+    );
+    assert!(
         p.cj.is_finite() && p.cj >= 0.0,
         "MOSFET CJ must be finite and non-negative"
     );
@@ -345,7 +353,8 @@ pub fn evaluate_level1(
 
     // Meyer gate-to-channel capacitance, partitioned by operating region below.
     let channel_capacitance = p.w * effective_length * (OXIDE_PERMITTIVITY / p.tox);
-    let cbs_bulk = bulk_junction_capacitance(p.cbs + p.cj * p.as_, v_bs, p.pb, p.mj, p.fc);
+    let cbs_bulk =
+        bulk_junction_capacitance(p.cbs + p.cj * p.as_ + p.cjsw * p.ps, v_bs, p.pb, p.mj, p.fc);
     let cbd_bulk = bulk_junction_capacitance(
         p.cbd + p.cj * p.ad + p.cjsw * p.pd,
         v_bs - v_ds,

--- a/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
+++ b/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
@@ -298,6 +298,24 @@ fn test_source_area_scales_bottom_junction_capacitance() {
 }
 
 #[test]
+fn test_source_perimeter_scales_sidewall_junction_capacitance() {
+    let result = evaluate_level1(
+        &Level1Params {
+            cbs: 1.0e-12,
+            ps: 3.0e-6,
+            cjsw: 2.0e-6,
+            mj: 0.0,
+            ..Level1Params::default()
+        },
+        1.8,
+        0.0,
+        0.0,
+        300.15,
+    );
+    assert!((result.cbs - 7.0e-12).abs() < 1.0e-24);
+}
+
+#[test]
 #[should_panic(expected = "MOSFET AD must be finite and non-negative")]
 fn test_drain_area_rejects_negative_value() {
     let _ = evaluate_level1(
@@ -333,6 +351,21 @@ fn test_drain_perimeter_rejects_negative_value() {
     let _ = evaluate_level1(
         &Level1Params {
             pd: -1.0,
+            ..Level1Params::default()
+        },
+        1.8,
+        1.8,
+        0.0,
+        300.15,
+    );
+}
+
+#[test]
+#[should_panic(expected = "MOSFET PS must be finite and non-negative")]
+fn test_source_perimeter_rejects_negative_value() {
+    let _ = evaluate_level1(
+        &Level1Params {
+            ps: -1.0,
             ..Level1Params::default()
         },
         1.8,

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add the Level-1 MOS `PS` instance parameter. With model-card `CJSW`, its
+  product augments `CBS` in AC and transient source-body capacitance.
 - Add the Level-1 MOS `PD` instance parameter and model-card `CJSW` density.
   Their product augments `CBD` in AC and transient drain-body capacitance.
 - Add the Level-1 MOS `AS` instance parameter. With model-card `CJ`, its

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -143,9 +143,9 @@ node, routes the channel and source-side capacitances through it, and contribute
 `RSH` defaults to zero ohms per square. `NRD` and `NRS` default to one drain
 and source square, so the fallbacks are `RSH * NRD` and `RSH * NRS`; explicit
 positive `RD` / `RS` values take precedence.
-`AD`, `AS`, `PD`, and model-card `CJ` / `CJSW` default to zero and are finite
-and non-negative. They add `CJ * AD + CJSW * PD` to drain-body `CBD` and
-`CJ * AS` to source-body `CBS` in AC and transient analysis.
+`AD`, `AS`, `PD`, `PS`, and model-card `CJ` / `CJSW` default to zero and are
+finite and non-negative. They add `CJ * AD + CJSW * PD` to drain-body `CBD`
+and `CJ * AS + CJSW * PS` to source-body `CBS` in AC and transient analysis.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3617,6 +3617,7 @@ pub struct MosfetLevel1Params {
     pub drain_area: f64,
     pub source_area: f64,
     pub drain_perimeter: f64,
+    pub source_perimeter: f64,
     pub bottom_junction_capacitance: f64,
     pub sidewall_junction_capacitance: f64,
     pub saturation_current: f64,
@@ -3654,6 +3655,7 @@ impl Default for MosfetLevel1Params {
             drain_area: 0.0,
             source_area: 0.0,
             drain_perimeter: 0.0,
+            source_perimeter: 0.0,
             bottom_junction_capacitance: 0.0,
             sidewall_junction_capacitance: 0.0,
             saturation_current: 1.0e-15,
@@ -24317,7 +24319,9 @@ fn evaluate_nmos_level1(
     let channel_capacitance =
         params.w * effective_length * (OXIDE_PERMITTIVITY / params.oxide_thickness);
     let cbs_bulk = mosfet_bulk_junction_capacitance(
-        params.source_bulk_capacitance + params.bottom_junction_capacitance * params.source_area,
+        params.source_bulk_capacitance
+            + params.bottom_junction_capacitance * params.source_area
+            + params.sidewall_junction_capacitance * params.source_perimeter,
         vbs,
         params.bulk_junction_potential,
         params.bulk_junction_grading_coefficient,
@@ -25057,8 +25061,9 @@ fn mosfet_charge_state_specs(mosfet: &Mosfet) -> Vec<MosfetChargeStateSpec> {
     let gate_source_capacitance = params.gate_source_overlap_capacitance * params.w;
     let gate_drain_capacitance = params.gate_drain_overlap_capacitance * params.w;
     let gate_body_capacitance = params.gate_bulk_overlap_capacitance * params.l;
-    let source_body_capacitance =
-        params.source_bulk_capacitance + params.bottom_junction_capacitance * params.source_area;
+    let source_body_capacitance = params.source_bulk_capacitance
+        + params.bottom_junction_capacitance * params.source_area
+        + params.sidewall_junction_capacitance * params.source_perimeter;
     let drain_body_capacitance = params.drain_bulk_capacitance
         + params.bottom_junction_capacitance * params.drain_area
         + params.sidewall_junction_capacitance * params.drain_perimeter;
@@ -25695,6 +25700,7 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         ("AD", params.drain_area),
         ("AS", params.source_area),
         ("PD", params.drain_perimeter),
+        ("PS", params.source_perimeter),
         ("CJ", params.bottom_junction_capacitance),
         ("CJSW", params.sidewall_junction_capacitance),
         ("TOX", params.oxide_thickness),
@@ -25785,6 +25791,12 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: mosfet.name.clone(),
             reason: "MOSFET PD must be non-negative".to_string(),
+        });
+    }
+    if params.source_perimeter < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET PS must be non-negative".to_string(),
         });
     }
     if params.bottom_junction_capacitance < 0.0 {

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -1479,6 +1479,47 @@ fn ac_mosfet_source_area_scales_bottom_junction_capacitance() {
 }
 
 #[test]
+fn ac_mosfet_source_perimeter_scales_sidewall_junction_capacitance() {
+    fn source_amplitude(sidewall_capacitance: f64, source_perimeter: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "in", "0", 0.0, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "source", 1_000.0,
+        )));
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "M1",
+            "0",
+            "0",
+            "source",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                kp: 1.0e-12,
+                w: 1.0,
+                l: 1.0,
+                oxide_thickness: 1.0e9,
+                source_perimeter,
+                sidewall_junction_capacitance: sidewall_capacitance,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+
+        ac_sweep(&circuit, 100_000.0, 100_000.0, 1).unwrap()[0]
+            .voltage("source")
+            .unwrap()
+            .abs()
+    }
+
+    let without_sidewall_capacitance = source_amplitude(0.5, 0.0);
+    let with_sidewall_capacitance = source_amplitude(0.5, 2.0e-6);
+
+    assert!(without_sidewall_capacitance > 0.9);
+    assert!(with_sidewall_capacitance < without_sidewall_capacitance / 100.0);
+}
+
+#[test]
 fn ac_mosfet_oxide_thickness_scales_intrinsic_gate_capacitance() {
     let gate_amplitude = |oxide_thickness| {
         let mut circuit = Circuit::new();

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1804,6 +1804,7 @@ fn subcircuit_expansion_preserves_mos_geometry() {
             source_squares: 3.0,
             drain_area: 4.0e-12,
             source_area: 5.0e-12,
+            source_perimeter: 6.0e-6,
             bottom_junction_capacitance: 2.0e-3,
             oxide_thickness: 25.0e-9,
             ..MosfetLevel1Params::default()
@@ -1852,6 +1853,7 @@ fn subcircuit_expansion_preserves_mos_geometry() {
     assert_close(expanded.params.source_squares, 3.0);
     assert_close(expanded.params.drain_area, 4.0e-12);
     assert_close(expanded.params.source_area, 5.0e-12);
+    assert_close(expanded.params.source_perimeter, 6.0e-6);
     assert_close(expanded.params.bottom_junction_capacitance, 2.0e-3);
     assert_close(expanded.params.oxide_thickness, 25.0e-9);
 }
@@ -4120,6 +4122,38 @@ fn dc_mosfet_rejects_invalid_source_area() {
                     "MOSFET AS must be non-negative".to_string()
                 } else {
                     "MOSFET AS must be finite".to_string()
+                },
+            }
+        );
+    }
+}
+
+#[test]
+fn dc_mosfet_rejects_invalid_source_perimeter() {
+    for source_perimeter in [f64::NAN, -1.0] {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "Mbad",
+            "drain",
+            "gate",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                source_perimeter,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+
+        let err = dc_op(&circuit).unwrap_err();
+        assert_eq!(
+            err,
+            SpiceError::InvalidElement {
+                name: "Mbad".to_string(),
+                reason: if source_perimeter.is_finite() {
+                    "MOSFET PS must be non-negative".to_string()
+                } else {
+                    "MOSFET PS must be finite".to_string()
                 },
             }
         );

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -562,6 +562,53 @@ fn transient_mosfet_source_area_scales_bottom_junction_capacitance() {
 }
 
 #[test]
+fn transient_mosfet_source_perimeter_scales_sidewall_junction_capacitance() {
+    fn run(sidewall_capacitance: f64, source_perimeter: f64) -> Vec<TransientPoint> {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
+            "Vstep",
+            "in",
+            "0",
+            0.0,
+            Waveform::Pwl(PwlWaveform::new(vec![
+                (0.0, 0.0),
+                (1.0e-9, 1.0),
+                (5.0e-9, 1.0),
+            ])),
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "source", 1_000.0,
+        )));
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "M1",
+            "0",
+            "0",
+            "source",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                kp: 1.0e-12,
+                w: 1.0,
+                l: 1.0,
+                source_perimeter,
+                sidewall_junction_capacitance: sidewall_capacitance,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+        transient_with_method(&circuit, 1.0e-9, 5.0e-9, TransientMethod::Euler).unwrap()
+    }
+
+    let uncharged = run(0.0, 0.0);
+    let charged = run(0.5, 2.0e-9);
+    let uncharged_first = uncharged[0].voltage("source").unwrap();
+    let charged_first = charged[0].voltage("source").unwrap();
+
+    assert!(uncharged_first > 0.5);
+    assert!(charged_first < 0.01);
+    assert!(charged_first < uncharged_first);
+}
+
+#[test]
 fn transient_mosfet_bulk_junction_depletion_shaping_reduces_reverse_bias_capacitance() {
     fn run(grading_coefficient: f64) -> Vec<TransientPoint> {
         let mut circuit = Circuit::new();

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Parse Level-1 MOS instance `PS=<perimeter>` into the engine parameter bundle
+  for source-body sidewall capacitance.
 - Parse Level-1 MOS instance `PD=<perimeter>` and model-card
   `CJSW=<capacitance/length>` into the engine parameter bundle for drain-body
   sidewall capacitance.

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -761,7 +761,8 @@ parameters, `.model <name> NPN|PNP(...)` BJT cards with `IS`, `BF` /
 cards with common SPICE aliases (`VT0` / `VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
 `W`, `L`, `RSH`, `IS`, `N_SUB` / `NSUB`, `T_NOM` / `TNOM`, `CGSO`, `CGDO`,
 `CGBO`, `CBS`, `CBD`, `CJ`, and `CJSW`), MOS instance `NRD=<squares>` /
-`NRS=<squares>` / `AD=<area>` / `AS=<area>` / `PD=<perimeter>`, SPICE
+`NRS=<squares>` / `AD=<area>` / `AS=<area>` / `PD=<perimeter>` /
+`PS=<perimeter>`, SPICE
 engineering suffixes, capacitor
 `IC=<voltage>` and inductor `IC=<current>` initial
 conditions, independent-source `AC <magnitude> [phase]` forms,

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1914,6 +1914,9 @@ fn build_mosfet_params(
     if let Some(value) = instance_params.get("PD") {
         params.drain_perimeter = *value;
     }
+    if let Some(value) = instance_params.get("PS") {
+        params.source_perimeter = *value;
+    }
     params
 }
 

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1362,7 +1362,7 @@ fn parses_mosfet_models_into_operating_point_circuits() {
 .model nch NMOS(VTO=0.45 KP=250u LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n RSH=250 NSUB=1.5 TNOM=300 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p CJ=2m CJSW=5u)
 Vdd vdd 0 DC 5
 Vgate gate 0 DC 2.5
-M1 vdd gate out 0 nch W=4u L=200n NRD=2 NRS=3 AD=3n AS=4n PD=6u
+M1 vdd gate out 0 nch W=4u L=200n NRD=2 NRS=3 AD=3n AS=4n PD=6u PS=7u
 Rload out 0 1k
 .op
 "#,
@@ -1398,6 +1398,7 @@ Rload out 0 1k
     assert_close(mosfet.params.drain_area, 3.0e-9);
     assert_close(mosfet.params.source_area, 4.0e-9);
     assert_close(mosfet.params.drain_perimeter, 6.0e-6);
+    assert_close(mosfet.params.source_perimeter, 7.0e-6);
     assert_close(mosfet.params.bottom_junction_capacitance, 2.0e-3);
     assert_close(mosfet.params.sidewall_junction_capacitance, 5.0e-6);
     assert_close(mosfet.params.n_sub, 1.5);

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add the Level-1 MOS `PS` instance parameter. With model-card `CJSW`, its
+  product augments `CBS` in AC and transient source-body capacitance.
 - Add the Level-1 MOS `PD` instance parameter and model-card `CJSW` density.
   Their product augments `CBD` in AC and transient drain-body capacitance.
 - Add the Level-1 MOS `AS` instance parameter. With model-card `CJ`, its

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -94,9 +94,9 @@ node, routes the channel and source-side capacitances through it, and contribute
 `RSH` defaults to zero ohms per square. `NRD` and `NRS` default to one drain
 and source square, so the fallbacks are `RSH * NRD` and `RSH * NRS`; explicit
 positive `RD` / `RS` values take precedence.
-`AD`, `AS`, `PD`, and model-card `CJ` / `CJSW` default to zero and are finite
-and non-negative. They add `CJ * AD + CJSW * PD` to drain-body `CBD` and
-`CJ * AS` to source-body `CBS` in AC and transient analysis.
+`AD`, `AS`, `PD`, `PS`, and model-card `CJ` / `CJSW` default to zero and are
+finite and non-negative. They add `CJ * AD + CJSW * PD` to drain-body `CBD`
+and `CJ * AS + CJSW * PS` to source-body `CBS` in AC and transient analysis.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
 for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1785,6 +1785,7 @@ export interface MosfetLevel1Params {
   readonly AD: number;
   readonly AS: number;
   readonly PD: number;
+  readonly PS: number;
   readonly CJ: number;
   readonly CJSW: number;
   readonly IS: number;
@@ -8052,6 +8053,7 @@ export function defaultMosfetLevel1Params(): MosfetLevel1Params {
     AD: 0.0,
     AS: 0.0,
     PD: 0.0,
+    PS: 0.0,
     CJ: 0.0,
     CJSW: 0.0,
     IS: 1.0e-15,
@@ -20340,7 +20342,8 @@ function evaluateNmosLevel1(
   const channelCapacitance =
     params.W * effectiveLength * (OXIDE_PERMITTIVITY / params.TOX);
   const cbsBulk = mosfetBulkJunctionCapacitance(
-    params.CBS + params.CJ * params.AS, vbs, params.PB, params.MJ, params.FC,
+    params.CBS + params.CJ * params.AS + params.CJSW * params.PS,
+    vbs, params.PB, params.MJ, params.FC,
   );
   const cbdBulk = mosfetBulkJunctionCapacitance(
     params.CBD + params.CJ * params.AD + params.CJSW * params.PD,
@@ -20902,7 +20905,9 @@ function mosfetChargeStateSpecs(element: Mosfet): MosfetChargeStateSpec[] {
   const gateDrainCapacitance = element.params.CGDO * element.params.W;
   const gateBodyCapacitance = element.params.CGBO * element.params.L;
   const sourceBodyCapacitance =
-    element.params.CBS + element.params.CJ * element.params.AS;
+    element.params.CBS
+    + element.params.CJ * element.params.AS
+    + element.params.CJSW * element.params.PS;
   const drainBodyCapacitance =
     element.params.CBD
     + element.params.CJ * element.params.AD
@@ -21168,6 +21173,9 @@ function validateMosfet(element: Mosfet): void {
   }
   if (params.PD < 0.0) {
     throw invalidElement(element.name, "MOSFET PD must be non-negative");
+  }
+  if (params.PS < 0.0) {
+    throw invalidElement(element.name, "MOSFET PS must be non-negative");
   }
   if (params.CJSW < 0.0) {
     throw invalidElement(element.name, "MOSFET CJSW must be non-negative");

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -643,6 +643,29 @@ describe("acSweep", () => {
     expect(withAreaCapacitance).toBeLessThan(withoutAreaCapacitance / 100.0);
   });
 
+  it("scales MOSFET sidewall junction capacitance by source perimeter", () => {
+    function sourceAmplitude(sidewallCapacitance: number, sourcePerimeter: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "in", "0", 0.0, 1.0));
+      circuit.add(resistor("Rin", "in", "source", 1_000.0));
+      circuit.add(mosfet("M1", "0", "0", "source", "0", "NMOS", {
+        KP: 1.0e-12,
+        W: 1.0,
+        L: 1.0,
+        TOX: 1.0e9,
+        CJSW: sidewallCapacitance,
+        PS: sourcePerimeter,
+      }));
+      return complexAbs(acSweep(circuit, 100_000.0, 100_000.0, 1)[0].voltage("source")!);
+    }
+
+    const withoutSidewallCapacitance = sourceAmplitude(0.5, 0.0);
+    const withSidewallCapacitance = sourceAmplitude(0.5, 2.0e-6);
+
+    expect(withoutSidewallCapacitance).toBeGreaterThan(0.9);
+    expect(withSidewallCapacitance).toBeLessThan(withoutSidewallCapacitance / 100.0);
+  });
+
   it("uses MOSFET oxide thickness to scale intrinsic gate capacitance", () => {
     function gateAmplitude(TOX: number): number {
       const circuit = new Circuit();

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -2610,6 +2610,20 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects invalid MOSFET source perimeters", () => {
+    for (const sourcePerimeter of [Number.NaN, -1.0]) {
+      const circuit = new Circuit();
+      circuit.add(mosfet("Mbad", "drain", "gate", "0", "0", "NMOS", {
+        PS: sourcePerimeter,
+      }));
+      expect(() => dcOp(circuit)).toThrowError(
+        Number.isFinite(sourcePerimeter)
+          ? "MOSFET PS must be non-negative"
+          : "MOSFET PS must be finite",
+      );
+    }
+  });
+
   it("rejects invalid MOSFET bottom junction capacitance densities", () => {
     for (const bottomJunctionCapacitance of [Number.NaN, -1.0]) {
       const circuit = new Circuit();

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -475,6 +475,40 @@ describe("transient", () => {
     expect(chargedFirst!).toBeLessThan(unchargedFirst!);
   });
 
+  it("scales MOSFET sidewall junction capacitance by source perimeter", () => {
+    function run(sidewallCapacitance: number, sourcePerimeter: number): TransientPoint[] {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithWaveform(
+        "Vstep",
+        "in",
+        "0",
+        0.0,
+        new PwlWaveform([
+          [0.0, 0.0],
+          [1.0e-9, 1.0],
+          [5.0e-9, 1.0],
+        ]),
+      ));
+      circuit.add(resistor("Rin", "in", "source", 1_000.0));
+      circuit.add(mosfet("M1", "0", "0", "source", "0", "NMOS", {
+        KP: 1.0e-12,
+        W: 1.0,
+        L: 1.0,
+        CJSW: sidewallCapacitance,
+        PS: sourcePerimeter,
+      }));
+      return transient(circuit, 1.0e-9, 5.0e-9, "euler");
+    }
+
+    const unchargedFirst = run(0.0, 0.0)[0].voltage("source");
+    const chargedFirst = run(0.5, 2.0e-9)[0].voltage("source");
+    expect(unchargedFirst).not.toBeUndefined();
+    expect(chargedFirst).not.toBeUndefined();
+    expect(unchargedFirst!).toBeGreaterThan(0.5);
+    expect(chargedFirst!).toBeLessThan(0.01);
+    expect(chargedFirst!).toBeLessThan(unchargedFirst!);
+  });
+
   it("shapes MOSFET bulk junction transient capacitance under reverse bias", () => {
     function run(gradingCoefficient: number): TransientPoint[] {
       const circuit = new Circuit();

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,14 +33,14 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS drain diffusion perimeter.
+1. Cross-language Level-1 MOS source diffusion perimeter.
    - Status: current PR completion candidate.
-   - Add the Berkeley Level-1 MOS `PD` instance parameter and model-card
-     `CJSW` in Rust, Python, and TypeScript, defaulting both to zero.
-   - Use `CBD + CJ * AD + CJSW * PD` as the zero-bias drain-body capacitance
+   - Add the Berkeley Level-1 MOS `PS` instance parameter in Rust, Python, and
+     TypeScript, defaulting to zero.
+   - Use `CBS + CJ * AS + CJSW * PS` as the zero-bias source-body capacitance
      in AC and transient analysis while preserving existing depletion shaping.
-   - Preserve `PD` / `CJSW` through hierarchy and cloning, enforce finite
-     non-negative validation, and parse both in the Rust netlist facade.
+   - Preserve `PS` through hierarchy and cloning, enforce finite non-negative
+     validation, and parse it in the Rust netlist facade.
 
 ## Completed Slices
 
@@ -3500,6 +3500,15 @@ the Rust, Python, and TypeScript surfaces together.
      transient analysis while preserving `PB`, `MJ`, and `FC` shaping.
    - Hierarchy and cloning preserve `AS`, finite non-negative validation is
      shared, and the Rust netlist facade parses it.
+
+276. Cross-language Level-1 MOS drain diffusion perimeter.
+   - Status: completed in PR 9052.
+   - Rust, Python, and TypeScript Level-1 MOS instances now accept `PD`, and
+     model cards accept `CJSW`, both defaulting to zero.
+   - `CBD + CJ * AD + CJSW * PD` supplies zero-bias drain-body capacitance in
+     AC and transient analysis while preserving depletion shaping.
+   - Hierarchy and cloning preserve `PD` / `CJSW`, finite non-negative
+     validation is shared, and the Rust netlist facade parses both.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley Level-1 MOS `PS` source diffusion perimeter support across Rust, Python, and TypeScript
- include `CJSW * PS` in source-body AC and transient capacitance while preserving depletion shaping
- parse, validate, document, and test source perimeter through model, engine, hierarchy, and netlist surfaces

## Verification
- `cargo test -p mosfet-models`
- `cargo test -p spice-engine --test ac_tests`
- `cargo test -p spice-engine --test dc_tests`
- `cargo test -p spice-engine --test transient_tests`
- `cargo test -p spice-netlist-parser --test spice_netlist_parser_test`
- `cargo clippy -p mosfet-models -p spice-engine -p spice-netlist-parser --all-targets -- -D warnings`
- Python MOSFET model and SPICE engine suites: 704 passed
- TypeScript SPICE engine: 401 passed; `npm run build`