### PR TITLE
feat(adj-formula-stdlib): filtration-fraction — StatPearls FF = GFR ÷ RPF definition library (clinical/renal-physiology track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_filtration_fraction_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_filtration_fraction_e2e.rs
@@ -1,0 +1,142 @@
+//! End-to-end tests for the `clinical/filtration-fraction.adj` library — the definition of
+//! the renal filtration fraction (FF = glomerular filtration rate ÷ renal plasma flow) and
+//! its two exact rearrangements (GFR = FF × RPF, RPF = GFR ÷ FF) — driven through the built
+//! CLI binary against the SHIPPED stdlib. Each proves the same invariant as the other formula
+//! libraries: a consumer states NO arithmetic; it imports the grounded library, binds the
+//! measured quantities with `observe`, and the engine applies the cited relation on the CPU,
+//! computing the EXACT value and rendering the relation's citation and trust tier in the
+//! `derived` section (the auditable answer). The three formulas INVERT around the worked case
+//! GFR = 120 mL/min, RPF = 600 mL/min: 120 ÷ 600 = 0.2, and both 0.2 × 600 = 120 and
+//! 120 ÷ 0.2 = 600 recover the inputs.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped filtration-fraction library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_ff_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/filtration-fraction.adj")
+        .canonicalize()
+        .expect("shipped filtration-fraction.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_ff_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_ff_lib()).unwrap();
+    std::fs::write(dir.join("filtration-fraction.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// filtration_fraction — the definition: the glomerular filtration rate over the renal plasma
+// flow.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_ff_library_and_computes_filtration_fraction_with_citation() {
+    let dir = scratch("ff");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"filtration-fraction.adj\"\n\
+         observe glomerular_filtration_rate(120)\n\
+         observe renal_plasma_flow(600)\n\
+         ? filtration_fraction(glomerular_filtration_rate, renal_plasma_flow)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 120 / 600 = 0.2.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"filtration_fraction\"") && s.contains("\"value\":0.2"),
+        "filtration_fraction(120, 600) = 0.2: {s}"
+    );
+    // … AND the StatPearls/NCBI Bookshelf citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// glomerular_filtration_rate — the same relation solved for GFR: FF × RPF, which INVERTS the
+// filtration fraction just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_gfr_from_ff_and_rpf_with_citation() {
+    let dir = scratch("gfr");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"filtration-fraction.adj\"\n\
+         observe filtration_fraction(0.2)\n\
+         observe renal_plasma_flow(600)\n\
+         ? glomerular_filtration_rate(filtration_fraction, renal_plasma_flow)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 0.2 * 600 = 120, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"glomerular_filtration_rate\"") && s.contains("\"value\":120"),
+        "glomerular_filtration_rate(0.2, 600) = 120: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "glomerular_filtration_rate carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// renal_plasma_flow — the same relation solved for RPF: GFR ÷ FF, the third exact reading of
+// the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_rpf_from_gfr_and_ff_with_citation() {
+    let dir = scratch("rpf");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"filtration-fraction.adj\"\n\
+         observe glomerular_filtration_rate(120)\n\
+         observe filtration_fraction(0.2)\n\
+         ? renal_plasma_flow(glomerular_filtration_rate, filtration_fraction)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 120 / 0.2 = 600, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"renal_plasma_flow\"") && s.contains("\"value\":600"),
+        "renal_plasma_flow(120, 0.2) = 600: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "renal_plasma_flow carries its StatPearls citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/filtration-fraction.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/filtration-fraction.adj
@@ -1,0 +1,103 @@
+% ============================================================================
+% filtration-fraction.adj — the definition of the renal filtration fraction
+% (FF = glomerular filtration rate ÷ renal plasma flow) in the ADJ standard library.
+% ============================================================================
+% The filtration-fraction entry of the *clinical* track, a renal-physiology sibling of
+% `cockcroft_gault.adj` (which estimates the glomerular filtration rate this library consumes).
+% Where the hemodynamics libraries ground pressure differences and the cardiac-output library
+% grounds a product, this grounds a renal RATIO: THE FILTRATION FRACTION IS THE GLOMERULAR
+% FILTRATION RATE DIVIDED BY THE RENAL PLASMA FLOW — the portion of the plasma entering the
+% kidney (the renal plasma flow) that is filtered across the glomerulus into Bowman's space
+% (the glomerular filtration rate), normally about one fifth (0.2, i.e. 20%). It ships as an
+% importable, byte-provenanced, PARAMETERIZED `formula`, together with its two exact
+% rearrangements (the glomerular filtration rate a filtration fraction implies for a given
+% renal plasma flow, and the renal plasma flow the other two imply). As with every compute
+% library, a consumer states NO arithmetic: it `import`s this file, binds the measured
+% quantities from its own byte-provenance decomposition, and asks the engine to APPLY the
+% cited definition on the CPU. Zero math is performed by the model; the engine computes each
+% value EXACTLY, carrying the definition's citation.
+%
+%     import "filtration-fraction.adj"
+%     observe glomerular_filtration_rate(120)   % "…GFR 120 mL/min…"  (span cited by the model)
+%     observe renal_plasma_flow(600)            % "…RPF 600 mL/min…"  (span cited by the model)
+%     ? filtration_fraction(glomerular_filtration_rate, renal_plasma_flow)
+%                                                 % engine → 0.2, carrying FF = GFR ÷ RPF
+%
+% All three formulas are EXACT over their parameters (a quotient and two of its inverse
+% readings), so every value the engine returns is exact. The three COMPOSE and invert cleanly
+% around the worked case GFR = 120 mL/min, RPF = 600 mL/min (FF = 120 ÷ 600 = 0.2, a normal
+% filtration fraction): the `filtration_fraction` a consumer computes from the two flows is
+% exactly the `filtration_fraction` the `glomerular_filtration_rate` formula multiplies the
+% renal plasma flow by, to recover the 120 mL/min glomerular filtration rate, and exactly the
+% `filtration_fraction` the `renal_plasma_flow` formula divides the glomerular filtration rate
+% by to recover the 600 mL/min renal plasma flow.
+%
+%   filtration_fraction(glomerular_filtration_rate, renal_plasma_flow)
+%       = glomerular_filtration_rate / renal_plasma_flow   % FF = GFR ÷ RPF   (definition)
+%   glomerular_filtration_rate(filtration_fraction, renal_plasma_flow)
+%       = filtration_fraction * renal_plasma_flow          % GFR = FF × RPF   (same def, solved for GFR)
+%   renal_plasma_flow(glomerular_filtration_rate, filtration_fraction)
+%       = glomerular_filtration_rate / filtration_fraction % RPF = GFR ÷ FF   (same def, solved for RPF)
+%
+% NOTE ON UNITS: the two flows must be in the SAME unit (both millilitres per minute, as in
+% the worked case), and the filtration fraction comes out DIMENSIONLESS (a pure ratio, here
+% 0.2 = 20%); this library computes the exact value over whatever consistent flow unit it is
+% given.
+%
+% All three formulas are defended by the SAME definitional sentence — "This is the portion of
+% plasma entering the kidney (RPF) that ends up as filtrate (GFR). FF = GFR / RPF and is
+% approximately 20% for a healthy individual." — because that one definition (the filtration
+% fraction IS the glomerular filtration rate over the renal plasma flow) sanctions the relation
+% read every way (the FF from the two flows, the GFR from FF and RPF, or the RPF from GFR and
+% FF). The quote is transcribed verbatim from the StatPearls "Physiology, Glomerular Filtration
+% Rate" article on the NCBI Bookshelf, so each `formula` carries the provenance envelope every
+% shipped grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the definitional sentence is a verbatim span of the cited
+% page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable renal quantity the definition ranges over, and
+% each result is a derived quantity. `filtration_fraction`, `glomerular_filtration_rate` and
+% `renal_plasma_flow` each appear BOTH as a derived result and as an input (of the other
+% formulas), so each is a single dictionary term used in both roles. The `surface` lists are
+% the everyday names a decomposer maps onto the canonical term; the trailing comment records
+% the intended unit.
+% ----------------------------------------------------------------------------
+dictionary filtration_fraction_vocab {
+    define glomerular_filtration_rate : finding  surface "glomerular filtration rate", "GFR"   % millilitres per minute (mL/min)
+    define renal_plasma_flow          : finding  surface "renal plasma flow", "RPF"            % millilitres per minute (mL/min)
+    define filtration_fraction        : finding  surface "filtration fraction", "FF"           % dimensionless ratio (fraction)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable formula over its
+% formal parameters, bound at apply time, and each carries the definitional sentence from
+% StatPearls on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an exact
+% quotient/product of measured quantities, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook filtration_fraction_laws {
+    use filtration_fraction_vocab
+
+    % Filtration fraction — the glomerular filtration rate over the renal plasma flow, i.e.
+    % FF = GFR ÷ RPF.
+    formula filtration_fraction(glomerular_filtration_rate, renal_plasma_flow) = glomerular_filtration_rate / renal_plasma_flow
+        source "This is the portion of plasma entering the kidney (RPF) that ends up as filtrate (GFR). FF = GFR / RPF and is approximately 20% for a healthy individual."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK500032/"
+        trust authoritative
+
+    % Glomerular filtration rate — the same definition solved for the glomerular filtration
+    % rate a filtration fraction implies for a renal plasma flow (GFR = FF × RPF). Defended by
+    % the SAME definitional sentence, read the other way.
+    formula glomerular_filtration_rate(filtration_fraction, renal_plasma_flow) = filtration_fraction * renal_plasma_flow
+        source "This is the portion of plasma entering the kidney (RPF) that ends up as filtrate (GFR). FF = GFR / RPF and is approximately 20% for a healthy individual."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK500032/"
+        trust authoritative
+
+    % Renal plasma flow — the same definition solved for the renal plasma flow the other two
+    % imply (RPF = GFR ÷ FF). Again the SAME definitional sentence, read the third way.
+    formula renal_plasma_flow(glomerular_filtration_rate, filtration_fraction) = glomerular_filtration_rate / filtration_fraction
+        source "This is the portion of plasma entering the kidney (RPF) that ends up as filtrate (GFR). FF = GFR / RPF and is approximately 20% for a healthy individual."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK500032/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/filtration-fraction.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/filtration-fraction.query.adj
@@ -1,0 +1,34 @@
+% ============================================================================
+% filtration-fraction.query.adj — worked examples over the clinical filtration-fraction library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a filtration-fraction question:
+% it states NO arithmetic and NO relation — it only `import`s the grounded library, `observe`s
+% the quantities it decomposed from the prompt (each a byte-provenanced span, elided here), and
+% asks the engine to APPLY the cited definition. The native adj-lang engine binds the
+% parameters, computes each value EXACTLY on the CPU, and returns it with the definition's
+% source/locator/trust.
+%
+% The three questions INVERT: a glomerular filtration rate of 120 mL/min over a renal plasma
+% flow of 600 mL/min gives a filtration fraction of 120 ÷ 600 = 0.2; that 0.2 filtration
+% fraction multiplied back by the same 600 mL/min renal plasma flow is exactly what the
+% GFR formula recovers the 120 mL/min from, and that 0.2 filtration fraction divided into the
+% same 120 mL/min glomerular filtration rate is exactly what the RPF formula recovers the
+% 600 mL/min from.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli filtration-fraction.query.adj
+% ============================================================================
+
+import "filtration-fraction.adj"
+
+% GFR 120 mL/min, RPF 600 mL/min: filtration fraction = 120 ÷ 600.
+observe glomerular_filtration_rate(120)
+observe renal_plasma_flow(600)
+? filtration_fraction(glomerular_filtration_rate, renal_plasma_flow)          % expect 0.2  (FF = GFR ÷ RPF)
+
+% That 0.2 filtration fraction with the same 600 mL/min renal plasma flow: GFR = 0.2 × 600.
+observe filtration_fraction(0.2)
+? glomerular_filtration_rate(filtration_fraction, renal_plasma_flow)          % expect 120  (same def, solved for GFR = FF × RPF)
+
+% That 0.2 filtration fraction with the same 120 mL/min glomerular filtration rate: RPF = 120 ÷ 0.2.
+? renal_plasma_flow(glomerular_filtration_rate, filtration_fraction)          % expect 600  (same def, solved for RPF = GFR ÷ FF)


### PR DESCRIPTION
## What

Ships a new **clinical `formulabook`** grounded reference library — a renal-physiology companion to `cockcroft_gault.adj` (which estimates the GFR this library consumes) — adding the renal **filtration fraction**: FF is the glomerular filtration rate divided by the renal plasma flow (**FF = GFR ÷ RPF**), the portion of the plasma entering the kidney that is filtered across the glomerulus (normally ~0.2 = 20%).

An importable, byte-provenanced, parameterized `formula` plus its two exact algebraic rearrangements, all three defended by the **same verbatim StatPearls span**:

> "This is the portion of plasma entering the kidney (RPF) that ends up as filtrate (GFR). FF = GFR / RPF and is approximately 20% for a healthy individual."

```
filtration_fraction(glomerular_filtration_rate, renal_plasma_flow)
    = glomerular_filtration_rate / renal_plasma_flow   % FF = GFR ÷ RPF   (definition)
glomerular_filtration_rate(filtration_fraction, renal_plasma_flow)
    = filtration_fraction * renal_plasma_flow          % GFR = FF × RPF   (same def, solved for GFR)
renal_plasma_flow(glomerular_filtration_rate, filtration_fraction)
    = glomerular_filtration_rate / filtration_fraction % RPF = GFR ÷ FF   (same def, solved for RPF)
```

Each formula carries `source` (the span above) + `locator "https://www.ncbi.nlm.nih.gov/books/NBK500032/"` (StatPearls "Physiology, Glomerular Filtration Rate", NCBI Bookshelf) + `trust authoritative`. **Byte-verified against the cited page via WebFetch** before shipping.

This is the **first ratio-type (÷/×) clinical inverter** in the stdlib, alongside the difference-type (stroke-volume, A–a gradient, CPP) and product-type (cardiac-output) ones. A consumer states **no arithmetic** — it imports the grounded library, `observe`s the measured quantities, and the engine applies the cited definition on the CPU, **exact**, carrying the citation.

## Worked case

GFR 120 mL/min, RPF 600 mL/min → **FF 0.2** (dimensionless). The three formulas invert cleanly: `0.2 × 600 = 120`, `120 ÷ 0.2 = 600`.

## Ships

- `clinical/filtration-fraction.adj` — the grounded formulabook + literate provenance narrative.
- `clinical/filtration-fraction.query.adj` — worked lookup driving all three inversions.
- A dedicated e2e test `adj-lang-cli/tests/formula_filtration_fraction_e2e.rs` (3 tests) asserting 0.2 / 120 / 600 + `trust authoritative` + `ncbi.nlm.nih.gov`.

## Verification

- `cargo test -p adj-lang-cli --test formula_filtration_fraction_e2e` — **3/3 green**.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean.
- CLI run over the shipped `.query.adj` confirms `filtration_fraction=0.2`, `glomerular_filtration_rate=120`, `renal_plasma_flow=600`, each with the StatPearls citation + trust.
- NUL-scan of all new source files: 0 bytes.
- `/security-review`: **PASSED — no vulnerabilities found**.

**Data + test only — no version bump.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)