### PR TITLE
feat(adj-formula-stdlib): exposure-conversions — NIST SP 811 B.9 roentgen→coulomb-per-kilogram exact table (RS-5)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -915,6 +915,51 @@ fn shipped_dose_equivalent_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b20) Shipped table — reference/exposure-conversions.adj resolves via import (a
+//       NEW dimension: exposure → coulomb per kilogram, the EXACT SP 811 B.9 boldface factor
+//       roentgen = 2.58 E-04 = 0.000258, the roentgen DEFINED as exactly 2.58×10⁻⁴ C/kg), and
+//       a unit of a DIFFERENT quantity (`rad`, an absorbed-dose unit → gray, not C/kg) — no
+//       row — abstains rather than mis-converting across dimensions. Completes the radiological
+//       quartet: radioactivity (curie→becquerel), absorbed dose (rad→gray), dose equivalent
+//       (rem→sievert), exposure (roentgen→coulomb per kilogram).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_exposure_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_exposure");
+    let src = stdlib().join("reference/exposure-conversions.adj");
+    std::fs::copy(&src, dir.join("exposure-conversions.adj"))
+        .expect("copy shipped exposure-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"exposure-conversions.adj\"\n\
+         ? exposure_to_coulomb_per_kilogram(roentgen, $v)\n\
+         ? exposure_to_coulomb_per_kilogram(rad, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 "Radiology" exact factor resolves, character-for-character from
+    // the table (boldface = exact; the roentgen is defined as exactly 2.58×10⁻⁴ C/kg).
+    assert!(
+        out.contains("\"v\":\"0.000258\""),
+        "roentgen = 0.000258 C/kg: {out}"
+    );
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `rad` is an ABSORBED-DOSE unit (it converts to the gray, a DIFFERENT quantity), so this
+    // exposure table has no row for it — the engine abstains rather than mis-converting an
+    // absorbed-dose unit as if it were an exposure unit.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a wrong-dimension unit abstains, never a cross-dimension fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/exposure-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/exposure-conversions.adj
@@ -1,0 +1,62 @@
+% ============================================================================
+% exposure-conversions — exposure-unit → coulomb-per-kilogram factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of `absorbed-dose-conversions.adj`, `dose-equivalent-conversions.adj`,
+% `radioactivity-conversions.adj` and the other NIST-cited conversion tables: a native tabular
+% relation ingested VERBATIM from a published NIST conversion table. The row states the factor
+% converting the traditional unit of EXPOSURE (the ionization a beam of x- or gamma radiation
+% produces in air — the electric charge liberated per unit mass of air) to the SI coherent
+% derived unit, the coulomb per kilogram (C/kg):
+%
+%     ? exposure_to_coulomb_per_kilogram(roentgen, $v)   % 0.000258
+%
+% This is a NEW dimension alongside the length/mass/area/volume/time/speed/energy/
+% pressure/force/acceleration/dynamic-viscosity/kinematic-viscosity/magnetic-flux-density/
+% illuminance/luminance/radioactivity/absorbed-dose/dose-equivalent tables. It completes the
+% radiological trio: RADIOACTIVITY (the curie → the becquerel) counts disintegrations in the
+% source per second; ABSORBED DOSE (the rad → the gray) measures the energy the radiation
+% deposits per kilogram of the irradiated body; DOSE EQUIVALENT (the rem → the sievert)
+% weights that energy for biological damage; and EXPOSURE (the roentgen → the coulomb per
+% kilogram) measures something else again — the ionizing ability of the beam itself, as the
+% charge it liberates per kilogram of AIR, before any body is even present. The traditional
+% unit is the roentgen (R); the SI unit is the coulomb per kilogram. Put an exposure given in
+% roentgen into SI first, then reason (write-once-use-many). Why a `table` and not a
+% hand-written `relate` clause: this is exactly the shape reference data comes in — a
+% published table, not prose. The citable artifact IS the NIST conversion-factors table at the
+% `locator` below; the factor here is a CELL of NIST Special Publication 811, Appendix B.9
+% ("Factors for units listed alphabetically"), defended by one provenance envelope. Each `row`
+% lowers to a ground relation `exposure_to_coulomb_per_kilogram(unit, ckg)`, so the exact
+% lookup above is the ordinary SLD binding query — the engine returns the factor WITH this
+% table's citation as its proof, on the CPU, with zero model calls.
+%
+% HONESTY NOTE (like absorbed-dose-/dose-equivalent-/radioactivity-conversions, only the EXACT
+% defined factor gets a row): NIST SP 811 B.9 prints the "roentgen" exposure factor in
+% BOLDFACE, its convention for factors that are EXACT by definition, transcribed here as the
+% plain decimal number of coulombs per kilogram it names:
+%
+%     roentgen (R)   2.58 E-04  →  0.000258
+%
+% This is exact because the roentgen is DEFINED as exactly 2.58 x 10^-4 coulomb per kilogram
+% (one roentgen liberates exactly 2.58 x 10^-4 C of charge per kilogram of air, by definition —
+% the same defining relation NIST prints in boldface). It terminates; nothing here is a rounded
+% measurement. This table is SPECIFIC to exposure: a unit of a DIFFERENT radiological quantity
+% — e.g. the "rad", which NIST SP 811 B.9 lists separately as an ABSORBED-DOSE unit converting
+% to the gray, NOT the coulomb per kilogram (see `absorbed-dose-conversions.adj`) — therefore
+% gets no row here, and a `? exposure_to_coulomb_per_kilogram(rad, $v)` ABSTAINS rather than
+% mis-converting an absorbed-dose unit as if it were an exposure unit. The only claim this table
+% makes is "this is the exact factor NIST SP 811 B.9 prints for the roentgen's conversion to the
+% coulomb per kilogram" — which is exactly what a byte-check against the cited table verifies.
+% `trust authoritative` — a primary, re-fetchable standards reference. (See ADJ-TABLES.md; and
+% feedback_nothing_human_authored — the factor is a verbatim cell of the cited table, nothing
+% asserted from memory.)
+% ============================================================================
+
+table exposure_to_coulomb_per_kilogram {
+    columns unit, coulomb_per_kilogram
+
+    row (roentgen, 0.000258)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/exposure-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/exposure-conversions.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% exposure-conversions.query.adj — worked lookup over the exposure table.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to convert an exposure given in the
+% traditional unit (the roentgen) into the SI coherent unit (the coulomb per kilogram): it
+% states NO arithmetic — it `import`s the grounded table and asks the exact lookup. The engine
+% answers by ordinary SLD binding against the table's rows, returning the factor WITH the
+% table's NIST citation as its proof, on the CPU, with zero model calls.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli exposure-conversions.query.adj
+% ============================================================================
+
+import "exposure-conversions.adj"
+
+% The exact defined factor: one roentgen IS exactly 2.58 x 10^-4 coulomb per kilogram.
+? exposure_to_coulomb_per_kilogram(roentgen, $ckg)   % expect 0.000258  (NIST SP 811 B.9, EXACT by definition)
+
+% The "rad" is an ABSORBED-DOSE unit (it converts to the gray, not the coulomb per kilogram —
+% see absorbed-dose-conversions.adj), a DIFFERENT radiological quantity, so this exposure
+% table has no row for it and the engine ABSTAINS rather than mis-converting it.
+? exposure_to_coulomb_per_kilogram(rad, $ckg)        % expect abstention (rad is absorbed dose, not exposure)


### PR DESCRIPTION
## What

A new grounded RS-5 `table` for the **exposure** dimension, ingested verbatim from **NIST Special Publication 811, Appendix B.9** ("Factors for units listed alphabetically"):

```
? exposure_to_coulomb_per_kilogram(roentgen, $v)   % 0.000258
```

The one row is the SP 811 B.9 **boldface** (exact-by-definition) factor **roentgen (R) = 2.58 E-04 = 0.000258 coulomb per kilogram** — the roentgen is *defined* as exactly 2.58×10⁻⁴ C/kg. Byte-verified against the cited page before shipping. The row lowers to a ground relation, so exact lookup is ordinary SLD binding, and the engine returns the factor **carrying the table's NIST citation as its proof**, on the CPU, with zero model calls.

This **completes the radiological quartet** of NIST-cited conversion tables:

| quantity | traditional → SI | factor |
|---|---|---|
| radioactivity | curie → becquerel | (shipped) |
| absorbed dose | rad → gray | 0.01 (shipped) |
| dose equivalent | rem → sievert | 0.01 (shipped) |
| **exposure** | **roentgen → coulomb/kg** | **0.000258 (this PR)** |

## Dimension-specific abstention

`rad` is an **absorbed-dose** unit (it converts to the gray, a *different* quantity), so this exposure table has no row for it and:

```
? exposure_to_coulomb_per_kilogram(rad, $v)   → abstains (no_grounded_support)
```

rather than mis-converting an absorbed-dose unit as if it were an exposure unit.

## Contents

- `reference/exposure-conversions.adj` — the grounded table + literate provenance rationale
- `reference/exposure-conversions.query.adj` — a worked lookup (roentgen resolves, rad abstains)
- `rs5_table_e2e.rs` — a **(b20)** e2e block asserting the exact value `"0.000258"`, the NIST locator, and the wrong-dimension abstention

## Verification

- `cargo test -p adj-lang-cli --test rs5_table_e2e shipped_exposure` — **passed**
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — **clean**
- Shipped `.query.adj` run through the CLI renders `roentgen → 0.000258` with the NIST B.9 citation as its proof step, and `rad` abstains with `no_grounded_support`.
- Source **byte-verified** against NIST SP 811 B.9 (roentgen 2.58 E-04, boldface = exact).

Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)