### PR TITLE
content(latin): numbers 1–10 — the Roman root of every Romance number

### DIFF
--- a/code/learning/human-languages/latin/lessons/LA-C02-numbers-1-5.md
+++ b/code/learning/human-languages/latin/lessons/LA-C02-numbers-1-5.md
@@ -1,0 +1,82 @@
+---
+id: LA-C02-numbers-1-5
+chapter: 2
+type: word
+headword: ūnus duo trēs quattuor quīnque
+gloss: one to five — the Roman originals that became every Romance number
+concept_tag: LA-NUM-1-5
+prerequisites: [LA-C01-salve]
+sounds: [macron-long-vowel, qu-as-kw, v-as-w]
+roots: [unus, duo, tres, quattuor, quinque]
+etymology_hook: "the ancestors the Spanish and French tracks point back to — quattuor is the source of both quatre and cuatro"
+est_minutes: 5
+reviews_of: [LA-C01-salve]
+---
+
+# ūnus, duo, trēs, quattuor, quīnque — one to five
+
+## Warm-up
+
+[PAUSE 2s] You've seen these numbers before — worn down. Here they are new,
+before a thousand years of erosion set to work.
+
+## The five
+
+| | numeral | Latin | said |
+|---|---|---|---|
+| 1 | **I** | **ūnus** | *OO-nus* |
+| 2 | **II** | **duo** | *DOO-oh* |
+| 3 | **III** | **trēs** | *trayss* |
+| 4 | **IV** | **quattuor** | *KWAT-twor* |
+| 5 | **V** | **quīnque** | *KWEEN-kwe* |
+
+The Roman numerals **I II III IV V** are the tally you already half-know from
+clock faces — one, two, three strokes, then **IV** (one *before* five) and **V**
+(five itself). (The **qu** in *quattuor*/*quīnque* is said **kw**, and every
+Latin **v** is a **w** — so *quīnque* is *KWEEN-kwe*.)
+
+## The root of a whole family
+
+Latin is the well the Romance tracks keep drawing from. Line these up against
+their descendants and you see the erosion happen:
+
+| Latin | → French | → Spanish |
+|---|---|---|
+| *ūnus* | un | uno |
+| *duo* | deux | dos |
+| *trēs* | trois | tres |
+| **quattuor** | **quatre** | **cuatro** |
+| *quīnque* | cinq | cinco |
+
+(A purist's note: French *deux* and Spanish *dos* actually descend from the
+**accusative** *duōs*, not the *duo* shown — as Romance words generally do.)
+
+*Quattuor → quatre → cuatro* is the same wearing-down the Hindi track shows for
+*catvāri → chār* — two branches of one ancient word (**PIE \*kʷetwóres**), one
+softening in Europe, one in India. And they seed English too: *ūnus* in *unit*
+and *union*, *duo* in *duo* and *dual*, *trēs* in *trio* and *triple*, *quīnque*
+in *quintet*.
+
+## A grammar seed: the first three bend
+
+Here's something Latin does that its children mostly dropped: **one, two and
+three change their endings** to match what they count — *ūnus/ūna/ūnum*,
+*duo/duae*, *trēs/tria* — while **four and up stay fixed**. You don't need the
+full tables yet; just notice that *ūnus* is really *ūn-* with a changeable tail,
+and file away that Latin makes even its numbers agree.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ūnus, duo, trēs, quattuor, quīnque" — remember v = w, qu = kw]
+- [YOU SAY: the erosion — "quattuor → quatre → cuatro"]
+- [YOU SAY: the tally — I, II, III, IV, V]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Count to five in Latin. (*Ūnus, duo, trēs, quattuor, quīnque*.) Which
+Latin word is the source of both French *quatre* and Spanish *cuatro*?
+(**quattuor**.) How is the **qu** in *quīnque* pronounced? (**kw** — *KWEEN-kwe*.)
+Which of the first five numbers **change their endings** to match what they
+count? (**One, two, three** — four and up stay fixed.) Next: six to ten, and the
+numbers hiding in the calendar.

--- a/code/learning/human-languages/latin/lessons/LA-C02-numbers-6-10.md
+++ b/code/learning/human-languages/latin/lessons/LA-C02-numbers-6-10.md
@@ -1,0 +1,76 @@
+---
+id: LA-C02-numbers-6-10
+chapter: 2
+type: word
+headword: sex septem octō novem decem
+gloss: six to ten — and the four that got frozen into the calendar
+concept_tag: LA-NUM-6-10
+prerequisites: [LA-C02-numbers-1-5]
+sounds: [macron-long-vowel, x-as-ks, c-as-k]
+roots: [sex, septem, octo, novem, decem]
+etymology_hook: "September–December still count 7–10 — Rome's year began in March, so the month names ended up two places short"
+est_minutes: 5
+reviews_of: [LA-C02-numbers-1-5, LA-C01-salve]
+---
+
+# sex, septem, octō, novem, decem — six to ten
+
+## Warm-up
+
+[PAUSE 2s] Four of these five are hiding in your calendar right now — with the
+wrong numbers on them. Here's why.
+
+## The five
+
+| | numeral | Latin | said |
+|---|---|---|---|
+| 6 | **VI** | **sex** | *sex* |
+| 7 | **VII** | **septem** | *SEP-tem* |
+| 8 | **VIII** | **octō** | *OK-toh* |
+| 9 | **IX** | **novem** | *NO-wem* |
+| 10 | **X** | **decem** | *DEK-em* |
+
+The numerals climb by adding to five — **VI VII VIII** (five-and-one, -two,
+-three) — then **IX** (one *before* ten) and **X**. (Remember *v* = *w*, so
+*novem* is *NO-wem*; and *c* is always hard *k*, so *decem* is *DEK-em*.)
+
+## The numbers frozen in the calendar
+
+Say the last four out loud and read the months beside them:
+
+| Latin | month | but it's month # |
+|---|---|---|
+| *septem* (7) | **September** | 9 |
+| *octō* (8) | **October** | 10 |
+| *novem* (9) | **November** | 11 |
+| *decem* (10) | **December** | 12 |
+
+*September* literally means "the seventh." It sits in ninth place because the
+old Roman year **began in March** — so month one was March, and the seventh
+month was our September. When January and February were later pushed to the
+front, the names never moved. Every year you write four Latin numbers, each two
+places off, because Rome renumbered the calendar and forgot to rename the months.
+
+## They seed English too
+
+- *sex* → **sextet**, **sextant** (and *sex-* "six" in *sexagesimal*, base-60)
+- *octō* → **octave**, **October** — while its Greek twin *oktṓ* gives
+  **octagon** and **octopus** (eight arms)
+- *decem* → **decimal**, and — via *duodecim* "twelve" — **dozen** (its Greek
+  cousin *dekás* "group of ten" adds **decade**)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "sex, septem, octō, novem, decem" — v = w, c = k]
+- [YOU SAY: the calendar — "septem → September, the seventh month… now ninth"]
+- [YOU SAY: the tally — VI, VII, VIII, IX, X]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Count six to ten in Latin. (*Sex, septem, octō, novem, decem*.) Why
+does **September** ("the seventh") fall in the ninth month? (Rome's year began in
+**March**; two months were later added at the front and the names never changed.)
+How is *novem* said, and why? (*NO-wem* — Latin **v** is a **w**.) What everyday
+base-ten word comes straight from *decem*? (**decimal**.) You can now
+count to ten in the language every Romance number came from.


### PR DESCRIPTION
## What
**Completes the numbers concept across the chain.** Tamil ([#9051](https://github.com/adhithyan15/coding-adventures/pull/9051)) and the Dravidian trio ([#9062](https://github.com/adhithyan15/coding-adventures/pull/9062)) merged; **French already had 1–10** (`FR-C06`) — so the one chain language still missing numbers was **Latin** (which had only chapter 1). Two atom-first lessons: `LA-C02-numbers-1-5` / `-6-10`.

Latin is the well the Romance tracks draw from, so these tie the family together **at the source**.

## The hooks (grounded)
- **Erosion made explicit**: *quattuor → quatre → cuatro* — the twin of the Hindi track's *catvāri → chār*, both from **PIE \*kʷetwóres**.
- **Calendar fossils**: *September–December* still mean 7–10 because Rome's year began in **March**.
- **Grammar seed**: the first three (*ūnus/ūna/ūnum, duo/duae, trēs/tria*) decline; four and up are fixed.
- Roman numerals **I–X** and restored-pronunciation cues (**v=w, qu=kw, c=k**) inline.

## Review & checks
- **Classics / historical-linguistics subagent review**: all forms, macrons, numerals, the PIE cognate, the grammar claim, and the calendar account confirmed correct. It caught **three etymology slips** — *octopus/octagon* and *decade* are Greek (not Latin) under a "Latin seeds English" header, and *deux/dos* descend from the accusative *duōs* — **all corrected**.
- Latin-script → **zero validation warnings, zero errors**; **human-language-data 38 + app 268 green**.

## Program status
**Numbers concept: complete across the chain** (Tamil ✅ · Kannada/Telugu/Malayalam ✅ · French pre-existing ✅ · Latin, this PR). Next: the loop walks to the **next universal concept gap** in Spanish's spine, breadth-first. (Latin, at only ch.1–2, will need a broad forward build-out over many future slices.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)