### PR TITLE
feat(adj-formula-stdlib): cardiac-index — StatPearls CI = CO ÷ BSA 3-way inverter (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_cardiac_index_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_cardiac_index_e2e.rs
@@ -1,0 +1,141 @@
+//! End-to-end tests for the `clinical/cardiac-index.adj` library — the definition of the
+//! cardiac index (cardiac index = cardiac output ÷ body surface area) and its two exact
+//! rearrangements (cardiac output = cardiac index × body surface area, body surface area =
+//! cardiac output ÷ cardiac index) — driven through the built CLI binary against the SHIPPED
+//! stdlib. Each proves the same invariant as the other formula libraries: a consumer states NO
+//! arithmetic; it imports the grounded library, binds the measured quantities with `observe`,
+//! and the engine applies the cited relation on the CPU, computing the EXACT value and
+//! rendering the relation's citation and trust tier in the `derived` section (the auditable
+//! answer). The three formulas INVERT around the worked case CO = 6 L/min, BSA = 2 m²:
+//! 6 ÷ 2 = 3, and both 3 × 2 = 6 and 6 ÷ 3 = 2 recover the inputs.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped cardiac-index library, resolved from this crate's manifest dir
+/// so the test is location-independent.
+fn shipped_ci_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/cardiac-index.adj")
+        .canonicalize()
+        .expect("shipped cardiac-index.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_ci_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_ci_lib()).unwrap();
+    std::fs::write(dir.join("cardiac-index.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// cardiac_index — the definition: the cardiac output over the body surface area.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_ci_library_and_computes_cardiac_index_with_citation() {
+    let dir = scratch("ci");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"cardiac-index.adj\"\n\
+         observe cardiac_output(6)\n\
+         observe body_surface_area(2)\n\
+         ? cardiac_index(cardiac_output, body_surface_area)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 6 / 2 = 3.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"cardiac_index\"") && s.contains("\"value\":3"),
+        "cardiac_index(6, 2) = 3: {s}"
+    );
+    // … AND the StatPearls/NCBI Bookshelf citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// cardiac_output — the same relation solved for CO: CI × BSA, which INVERTS the cardiac index
+// just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_cardiac_output_from_ci_and_bsa_with_citation() {
+    let dir = scratch("co");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"cardiac-index.adj\"\n\
+         observe cardiac_index(3)\n\
+         observe body_surface_area(2)\n\
+         ? cardiac_output(cardiac_index, body_surface_area)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 3 * 2 = 6, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"cardiac_output\"") && s.contains("\"value\":6"),
+        "cardiac_output(3, 2) = 6: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "cardiac_output carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// body_surface_area — the same relation solved for BSA: CO ÷ CI, the third exact reading of
+// the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_bsa_from_co_and_ci_with_citation() {
+    let dir = scratch("bsa");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"cardiac-index.adj\"\n\
+         observe cardiac_output(6)\n\
+         observe cardiac_index(3)\n\
+         ? body_surface_area(cardiac_output, cardiac_index)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 6 / 3 = 2, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"body_surface_area\"") && s.contains("\"value\":2"),
+        "body_surface_area(6, 3) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "body_surface_area carries its StatPearls citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/cardiac-index.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/cardiac-index.adj
@@ -1,0 +1,100 @@
+% ============================================================================
+% cardiac-index.adj — the definition of the cardiac index
+% (cardiac index = cardiac output ÷ body surface area) in the ADJ standard library.
+% ============================================================================
+% The cardiac-index entry of the *clinical* track, a hemodynamics sibling of
+% `cardiac-output.adj` (which supplies the cardiac output this library indexes) and
+% `filtration-fraction.adj` (another physiological RATIO). Where the cardiac-output library
+% grounds a PRODUCT (cardiac output = heart rate × stroke volume), this grounds the RATIO that
+% NORMALISES that output for body size: THE CARDIAC INDEX IS THE CARDIAC OUTPUT DIVIDED BY THE
+% BODY SURFACE AREA — the same litres-per-minute of blood flow expressed per square metre of
+% the patient, so a small adult and a large adult with the same true cardiac reserve read the
+% same index (a normal cardiac index is about 2.5–4.0 L/min/m²). It ships as an importable,
+% byte-provenanced, PARAMETERIZED `formula`, together with its two exact rearrangements (the
+% cardiac output an index implies for a given body surface area, and the body surface area the
+% other two imply). As with every compute library, a consumer states NO arithmetic: it
+% `import`s this file, binds the measured quantities from its own byte-provenance decomposition,
+% and asks the engine to APPLY the cited definition on the CPU. Zero math is performed by the
+% model; the engine computes each value EXACTLY, carrying the definition's citation.
+%
+%     import "cardiac-index.adj"
+%     observe cardiac_output(6)          % "…cardiac output 6 L/min…"  (span cited by the model)
+%     observe body_surface_area(2)       % "…BSA 2 m²…"                (span cited by the model)
+%     ? cardiac_index(cardiac_output, body_surface_area)
+%                                         % engine → 3, carrying CI = CO ÷ BSA
+%
+% All three formulas are EXACT over their parameters (a quotient and two of its inverse
+% readings), so every value the engine returns is exact. The three COMPOSE and invert cleanly
+% around the worked case CO = 6 L/min, BSA = 2 m² (CI = 6 ÷ 2 = 3 L/min/m², a normal cardiac
+% index): the `cardiac_index` a consumer computes from output and body surface area is exactly
+% the `cardiac_index` the `cardiac_output` formula multiplies the body surface area by, to
+% recover the 6 L/min cardiac output, and exactly the `cardiac_index` the `body_surface_area`
+% formula divides the cardiac output by to recover the 2 m² body surface area.
+%
+%   cardiac_index(cardiac_output, body_surface_area)
+%       = cardiac_output / body_surface_area   % CI = CO ÷ BSA   (definition)
+%   cardiac_output(cardiac_index, body_surface_area)
+%       = cardiac_index * body_surface_area    % CO = CI × BSA   (same def, solved for CO)
+%   body_surface_area(cardiac_output, cardiac_index)
+%       = cardiac_output / cardiac_index       % BSA = CO ÷ CI   (same def, solved for BSA)
+%
+% NOTE ON UNITS: the cardiac output is in litres per minute (L/min) and the body surface area
+% in square metres (m²); the cardiac index comes out in litres per minute per square metre
+% (L/min/m², here 3). This library computes the exact value over whatever consistent units it
+% is given.
+%
+% All three formulas are defended by the SAME defining equation — "Cardiac index = cardiac
+% output/body surface area (BSA) = (heart rate x stroke volume)/BSA" — because that one
+% definition (the cardiac index IS the cardiac output over the body surface area) sanctions the
+% relation read every way (the index from output and area, the output from index and area, or
+% the area from output and index). The equation is transcribed verbatim from the StatPearls
+% "Physiology, Cardiac Index" article on the NCBI Bookshelf, so each `formula` carries the
+% provenance envelope every shipped grounded clause carries; the linter rejects an unsourced
+% one. (See feedback_nothing_human_authored — the defining equation is a verbatim span of the
+% cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable hemodynamic quantity the definition ranges over,
+% and each result is a derived quantity. `cardiac_index`, `cardiac_output` and
+% `body_surface_area` each appear BOTH as a derived result and as an input (of the other
+% formulas), so each is a single dictionary term used in both roles. The `surface` lists are
+% the everyday names a decomposer maps onto the canonical term; the trailing comment records
+% the intended unit.
+% ----------------------------------------------------------------------------
+dictionary cardiac_index_vocab {
+    define cardiac_output     : finding  surface "cardiac output", "CO"          % litres per minute (L/min)
+    define body_surface_area  : finding  surface "body surface area", "BSA"      % square metres (m²)
+    define cardiac_index      : finding  surface "cardiac index", "CI"           % litres per minute per square metre (L/min/m²)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable formula over its
+% formal parameters, bound at apply time, and each carries the defining equation from StatPearls
+% on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an exact
+% quotient/product of measured quantities, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook cardiac_index_laws {
+    use cardiac_index_vocab
+
+    % Cardiac index — the cardiac output over the body surface area, i.e. CI = CO ÷ BSA.
+    formula cardiac_index(cardiac_output, body_surface_area) = cardiac_output / body_surface_area
+        source "Cardiac index = cardiac output/body surface area (BSA) = (heart rate x stroke volume)/BSA"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK539905/"
+        trust authoritative
+
+    % Cardiac output — the same definition solved for the cardiac output an index implies for a
+    % body surface area (CO = CI × BSA). Defended by the SAME defining equation, read the other
+    % way.
+    formula cardiac_output(cardiac_index, body_surface_area) = cardiac_index * body_surface_area
+        source "Cardiac index = cardiac output/body surface area (BSA) = (heart rate x stroke volume)/BSA"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK539905/"
+        trust authoritative
+
+    % Body surface area — the same definition solved for the body surface area the other two
+    % imply (BSA = CO ÷ CI). Again the SAME defining equation, read the third way.
+    formula body_surface_area(cardiac_output, cardiac_index) = cardiac_output / cardiac_index
+        source "Cardiac index = cardiac output/body surface area (BSA) = (heart rate x stroke volume)/BSA"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK539905/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/cardiac-index.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/cardiac-index.query.adj
@@ -1,0 +1,33 @@
+% ============================================================================
+% cardiac-index.query.adj — worked examples over the clinical cardiac-index library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a cardiac-index question: it
+% states NO arithmetic and NO relation — it only `import`s the grounded library, `observe`s the
+% quantities it decomposed from the prompt (each a byte-provenanced span, elided here), and asks
+% the engine to APPLY the cited definition. The native adj-lang engine binds the parameters,
+% computes each value EXACTLY on the CPU, and returns it with the definition's source/locator/
+% trust.
+%
+% The three questions INVERT: a cardiac output of 6 L/min over a body surface area of 2 m² gives
+% a cardiac index of 6 ÷ 2 = 3 L/min/m²; that 3 cardiac index multiplied back by the same 2 m²
+% body surface area is exactly what the cardiac-output formula recovers the 6 L/min from, and
+% that 3 cardiac index divided into the same 6 L/min cardiac output is exactly what the
+% body-surface-area formula recovers the 2 m² from.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli cardiac-index.query.adj
+% ============================================================================
+
+import "cardiac-index.adj"
+
+% CO 6 L/min, BSA 2 m²: cardiac index = 6 ÷ 2.
+observe cardiac_output(6)
+observe body_surface_area(2)
+? cardiac_index(cardiac_output, body_surface_area)              % expect 3  (CI = CO ÷ BSA)
+
+% That 3 cardiac index with the same 2 m² body surface area: CO = 3 × 2.
+observe cardiac_index(3)
+? cardiac_output(cardiac_index, body_surface_area)             % expect 6  (same def, solved for CO = CI × BSA)
+
+% That 3 cardiac index with the same 6 L/min cardiac output: BSA = 6 ÷ 3.
+? body_surface_area(cardiac_output, cardiac_index)             % expect 2  (same def, solved for BSA = CO ÷ CI)


### PR DESCRIPTION
## What

A clinical `formulabook` grounding the **cardiac index** — the cardiac output normalised for body size — as a RATIO, with its two exact algebraic rearrangements:

| formula | reads |
|---|---|
| `cardiac_index(cardiac_output, body_surface_area)` | CO ÷ BSA (definition) |
| `cardiac_output(cardiac_index, body_surface_area)` | CI × BSA (solved for CO) |
| `body_surface_area(cardiac_output, cardiac_index)` | CO ÷ CI (solved for BSA) |

All three carry the **same defining equation**, transcribed verbatim from the StatPearls "Physiology, Cardiac Index" article on the NCBI Bookshelf:

> "Cardiac index = cardiac output/body surface area (BSA) = (heart rate x stroke volume)/BSA"

(locator `https://www.ncbi.nlm.nih.gov/books/NBK539905/`, **byte-verified via WebFetch**). A consumer states **no arithmetic**: it imports the library, `observe`s the measured quantities, and the engine applies the cited relation on the CPU, EXACT, carrying the citation and trust tier in the auditable `derived` section.

## Worked case (the three invert)

CO = 6 L/min, BSA = 2 m² → **CI = 6 ÷ 2 = 3 L/min/m²** (a normal cardiac index); and both **3 × 2 = 6** and **6 ÷ 3 = 2** recover the inputs.

A hemodynamics sibling of `cardiac-output.adj` (which supplies the output this indexes) and `filtration-fraction.adj` (another physiological ratio).

## Contents

- `clinical/cardiac-index.adj` — the grounded library + literate rationale
- `clinical/cardiac-index.query.adj` — a worked, inverting example
- `formula_cardiac_index_e2e.rs` — a **dedicated** e2e test file (3 tests; its own anchor, no shared table)

## Verification

- `cargo test -p adj-lang-cli --test formula_cardiac_index_e2e` — **3 passed**
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — **clean**
- Shipped `.query.adj` run through the CLI renders `cardiac_index=3`, `cardiac_output=6`, `body_surface_area=2`, each carrying the NCBI citation and `authoritative` trust.
- Source **byte-verified** against StatPearls NBK539905 via WebFetch.

Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)