### PR TITLE
feat(adj-formula-stdlib): total-lung-capacity — StatPearls TLC = VC + RV 3-way inverter (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_total_lung_capacity_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_total_lung_capacity_e2e.rs
@@ -1,0 +1,141 @@
+//! End-to-end tests for the `clinical/total-lung-capacity.adj` library — the definition of the
+//! total lung capacity (total lung capacity = vital capacity + residual volume) and its two
+//! exact rearrangements (vital capacity = TLC − RV, residual volume = TLC − VC) — driven
+//! through the built CLI binary against the SHIPPED stdlib. Each proves the same invariant as
+//! the other formula libraries: a consumer states NO arithmetic; it imports the grounded
+//! library, binds the measured quantities with `observe`, and the engine applies the cited
+//! relation on the CPU, computing the EXACT value and rendering the relation's citation and
+//! trust tier in the `derived` section (the auditable answer). The three formulas INVERT around
+//! the worked case VC = 4 L, RV = 2 L: 4 + 2 = 6, and both 6 − 2 = 4 and 6 − 4 = 2 recover the
+//! inputs.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped total-lung-capacity library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_tlc_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/total-lung-capacity.adj")
+        .canonicalize()
+        .expect("shipped total-lung-capacity.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_tlc_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_tlc_lib()).unwrap();
+    std::fs::write(dir.join("total-lung-capacity.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// total_lung_capacity — the definition: the vital capacity plus the residual volume.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_tlc_library_and_computes_total_lung_capacity_with_citation() {
+    let dir = scratch("tlc");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"total-lung-capacity.adj\"\n\
+         observe vital_capacity(4)\n\
+         observe residual_volume(2)\n\
+         ? total_lung_capacity(vital_capacity, residual_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 4 + 2 = 6.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"total_lung_capacity\"") && s.contains("\"value\":6"),
+        "total_lung_capacity(4, 2) = 6: {s}"
+    );
+    // … AND the StatPearls/NCBI Bookshelf citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// vital_capacity — the same relation solved for VC: TLC − RV, which INVERTS the total lung
+// capacity just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_vital_capacity_from_tlc_and_rv_with_citation() {
+    let dir = scratch("vc");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"total-lung-capacity.adj\"\n\
+         observe total_lung_capacity(6)\n\
+         observe residual_volume(2)\n\
+         ? vital_capacity(total_lung_capacity, residual_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 6 - 2 = 4, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"vital_capacity\"") && s.contains("\"value\":4"),
+        "vital_capacity(6, 2) = 4: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "vital_capacity carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// residual_volume — the same relation solved for RV: TLC − VC, the third exact reading of the
+// one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_residual_volume_from_tlc_and_vc_with_citation() {
+    let dir = scratch("rv");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"total-lung-capacity.adj\"\n\
+         observe total_lung_capacity(6)\n\
+         observe vital_capacity(4)\n\
+         ? residual_volume(total_lung_capacity, vital_capacity)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 6 - 4 = 2, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"residual_volume\"") && s.contains("\"value\":2"),
+        "residual_volume(6, 4) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "residual_volume carries its StatPearls citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/total-lung-capacity.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/total-lung-capacity.adj
@@ -1,0 +1,99 @@
+% ============================================================================
+% total-lung-capacity.adj — the definition of the total lung capacity
+% (total lung capacity = vital capacity + residual volume) in the ADJ standard library.
+% ============================================================================
+% The total-lung-capacity entry of the *clinical* track, a respiratory-physiology library.
+% Where the hemodynamics libraries ground pressure differences and ratios, this grounds a
+% respiratory SUM: THE TOTAL LUNG CAPACITY IS THE VITAL CAPACITY PLUS THE RESIDUAL VOLUME —
+% the greatest volume the lungs hold at the end of a maximal inspiration (TLC) is the volume a
+% person can move between a maximal inspiration and a maximal expiration (the vital capacity,
+% VC) plus the volume that CANNOT be exhaled and always remains behind (the residual volume,
+% RV). It ships as an importable, byte-provenanced, PARAMETERIZED `formula`, together with its
+% two exact rearrangements (the vital capacity a total capacity leaves once the residual volume
+% is taken out, and the residual volume a total capacity leaves once the vital capacity is taken
+% out). As with every compute library, a consumer states NO arithmetic: it `import`s this file,
+% binds the measured quantities from its own byte-provenance decomposition, and asks the engine
+% to APPLY the cited definition on the CPU. Zero math is performed by the model; the engine
+% computes each value EXACTLY, carrying the definition's citation.
+%
+%     import "total-lung-capacity.adj"
+%     observe vital_capacity(4)          % "…vital capacity 4 L…"     (span cited by the model)
+%     observe residual_volume(2)         % "…residual volume 2 L…"    (span cited by the model)
+%     ? total_lung_capacity(vital_capacity, residual_volume)
+%                                         % engine → 6, carrying TLC = VC + RV
+%
+% All three formulas are EXACT over their parameters (a sum and two of its inverse readings),
+% so every value the engine returns is exact. The three COMPOSE and invert cleanly around the
+% worked case VC = 4 L, RV = 2 L (TLC = 4 + 2 = 6 L): the `total_lung_capacity` a consumer
+% computes from the two volumes is exactly the `total_lung_capacity` the `vital_capacity`
+% formula subtracts the residual volume from, to recover the 4 L vital capacity, and exactly
+% the `total_lung_capacity` the `residual_volume` formula subtracts the vital capacity from to
+% recover the 2 L residual volume.
+%
+%   total_lung_capacity(vital_capacity, residual_volume)
+%       = vital_capacity + residual_volume        % TLC = VC + RV   (definition)
+%   vital_capacity(total_lung_capacity, residual_volume)
+%       = total_lung_capacity - residual_volume   % VC = TLC − RV   (same def, solved for VC)
+%   residual_volume(total_lung_capacity, vital_capacity)
+%       = total_lung_capacity - vital_capacity    % RV = TLC − VC   (same def, solved for RV)
+%
+% NOTE ON UNITS: the three volumes must be in the SAME unit (all litres, as in the worked case),
+% and the total lung capacity comes out in that same unit (here 6 L). This library computes the
+% exact value over whatever consistent volume unit it is given.
+%
+% All three formulas are defended by the SAME defining span — "the sum of vital capacity and the
+% residual volume: TLC = VC + RV" — because that one definition (the total lung capacity IS the
+% vital capacity plus the residual volume) sanctions the relation read every way (the total from
+% the two volumes, the vital capacity from the total and the residual volume, or the residual
+% volume from the total and the vital capacity). The span is transcribed verbatim from the
+% StatPearls "Physiology, Lung Capacity" article on the NCBI Bookshelf, so each `formula`
+% carries the provenance envelope every shipped grounded clause carries; the linter rejects an
+% unsourced one. (See feedback_nothing_human_authored — the defining span is a verbatim quote
+% of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable respiratory volume the definition ranges over,
+% and each result is a derived volume. `total_lung_capacity`, `vital_capacity` and
+% `residual_volume` each appear BOTH as a derived result and as an input (of the other
+% formulas), so each is a single dictionary term used in both roles. The `surface` lists are
+% the everyday names a decomposer maps onto the canonical term; the trailing comment records
+% the intended unit.
+% ----------------------------------------------------------------------------
+dictionary total_lung_capacity_vocab {
+    define vital_capacity        : finding  surface "vital capacity", "VC"           % litres (L)
+    define residual_volume       : finding  surface "residual volume", "RV"          % litres (L)
+    define total_lung_capacity   : finding  surface "total lung capacity", "TLC"     % litres (L)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable formula over its
+% formal parameters, bound at apply time, and each carries the defining span from StatPearls on
+% the NCBI Bookshelf (a quote is required on a shipped formula). Each is an exact sum/difference
+% of measured quantities, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook total_lung_capacity_laws {
+    use total_lung_capacity_vocab
+
+    % Total lung capacity — the vital capacity plus the residual volume, i.e. TLC = VC + RV.
+    formula total_lung_capacity(vital_capacity, residual_volume) = vital_capacity + residual_volume
+        source "the sum of vital capacity and the residual volume: TLC = VC + RV"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541029/"
+        trust authoritative
+
+    % Vital capacity — the same definition solved for the vital capacity a total capacity leaves
+    % once the residual volume is removed (VC = TLC − RV). Defended by the SAME defining span,
+    % read the other way.
+    formula vital_capacity(total_lung_capacity, residual_volume) = total_lung_capacity - residual_volume
+        source "the sum of vital capacity and the residual volume: TLC = VC + RV"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541029/"
+        trust authoritative
+
+    % Residual volume — the same definition solved for the residual volume a total capacity
+    % leaves once the vital capacity is removed (RV = TLC − VC). Again the SAME defining span,
+    % read the third way.
+    formula residual_volume(total_lung_capacity, vital_capacity) = total_lung_capacity - vital_capacity
+        source "the sum of vital capacity and the residual volume: TLC = VC + RV"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541029/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/total-lung-capacity.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/total-lung-capacity.query.adj
@@ -1,0 +1,33 @@
+% ============================================================================
+% total-lung-capacity.query.adj — worked examples over the clinical total-lung-capacity library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a total-lung-capacity question:
+% it states NO arithmetic and NO relation — it only `import`s the grounded library, `observe`s
+% the quantities it decomposed from the prompt (each a byte-provenanced span, elided here), and
+% asks the engine to APPLY the cited definition. The native adj-lang engine binds the
+% parameters, computes each value EXACTLY on the CPU, and returns it with the definition's
+% source/locator/trust.
+%
+% The three questions INVERT: a vital capacity of 4 L plus a residual volume of 2 L gives a
+% total lung capacity of 4 + 2 = 6 L; that 6 L total lung capacity minus the same 2 L residual
+% volume is exactly what the vital-capacity formula recovers the 4 L from, and that 6 L total
+% lung capacity minus the same 4 L vital capacity is exactly what the residual-volume formula
+% recovers the 2 L from.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli total-lung-capacity.query.adj
+% ============================================================================
+
+import "total-lung-capacity.adj"
+
+% VC 4 L, RV 2 L: total lung capacity = 4 + 2.
+observe vital_capacity(4)
+observe residual_volume(2)
+? total_lung_capacity(vital_capacity, residual_volume)         % expect 6  (TLC = VC + RV)
+
+% That 6 L total lung capacity with the same 2 L residual volume: VC = 6 − 2.
+observe total_lung_capacity(6)
+? vital_capacity(total_lung_capacity, residual_volume)         % expect 4  (same def, solved for VC = TLC − RV)
+
+% That 6 L total lung capacity with the same 4 L vital capacity: RV = 6 − 4.
+? residual_volume(total_lung_capacity, vital_capacity)         % expect 2  (same def, solved for RV = TLC − VC)


### PR DESCRIPTION
## What

A clinical `formulabook` grounding the **total lung capacity** as a SUM — the **first sum-shaped inverter** in the clinical track — with its two exact algebraic rearrangements:

| formula | reads |
|---|---|
| `total_lung_capacity(vital_capacity, residual_volume)` | VC + RV (definition) |
| `vital_capacity(total_lung_capacity, residual_volume)` | TLC − RV (solved for VC) |
| `residual_volume(total_lung_capacity, vital_capacity)` | TLC − VC (solved for RV) |

All three carry the **same defining span**, transcribed verbatim from the StatPearls "Physiology, Lung Capacity" article on the NCBI Bookshelf:

> "the sum of vital capacity and the residual volume: TLC = VC + RV"

(locator `https://www.ncbi.nlm.nih.gov/books/NBK541029/`, **byte-verified via WebFetch**). A consumer states **no arithmetic**: it imports the library, `observe`s the measured volumes, and the engine applies the cited relation on the CPU, EXACT, carrying the citation and trust tier in the auditable `derived` section.

## Worked case (the three invert)

VC = 4 L, RV = 2 L → **TLC = 4 + 2 = 6 L**; and both **6 − 2 = 4** and **6 − 4 = 2** recover the inputs. (The total lung capacity is the volume a person can move maximally — the vital capacity — plus the volume that always remains behind and cannot be exhaled — the residual volume.)

## Contents

- `clinical/total-lung-capacity.adj` — the grounded library + literate rationale
- `clinical/total-lung-capacity.query.adj` — a worked, inverting example
- `formula_total_lung_capacity_e2e.rs` — a **dedicated** e2e test file (3 tests; its own anchor, no shared table)

## Verification

- `cargo test -p adj-lang-cli --test formula_total_lung_capacity_e2e` — **3 passed**
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — **clean**
- Shipped `.query.adj` run through the CLI renders `total_lung_capacity=6`, `vital_capacity=4`, `residual_volume=2`, each carrying the NCBI citation and `authoritative` trust.
- Source **byte-verified** against StatPearls NBK541029 via WebFetch.

Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)