### PR TITLE
feat(fold-control-flow): lower an empty-bodied do-while to while/for (0.38.0)

### DIFF
--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.38.0] - 2026-07-28
+
+### Added - empty-bodied `do … while` becomes the equivalent `while`/`for`
+
+An empty-bodied `do … while` now lowers to the equivalent loop, matching the
+reference Closure Compiler at SIMPLE:
+
+```text
+  do {} while(c);   ->  for(; c;) ;
+  do {} while(0);   ->  removed      (dead loop; dce drops the residual `;`)
+```
+
+`do {} while(test)` runs the (empty) body once and then evaluates `test`;
+because the body is a no-op, its test-evaluation sequence is IDENTICAL to
+`while(test){}` (the leading empty run changes nothing observable). We rewrite
+the empty case to a `while`, which the existing machinery lowers to `for` and —
+via the empty loop-body normalization (0.37.0) — collapses to `for(; test;) ;`;
+a statically-falsy test makes it a dead loop that collapses to `;` (removed
+downstream by dce). A NON-empty `do` body keeps the `do` form (a `do` body runs
+before its test, so it cannot generally become a `while`) and still gets the
+loop-body comma-fusion (0.36.0).
+
+This completes the empty-body follow-up noted in 0.37.0. (The other do-while
+gaps -- trailing `continue` removal, trailing `return` -> `break` -- remain
+tracked separately.)
+
 ## [0.37.0] - 2026-07-25
 
 ### Added - normalize an empty loop body `{}` to `;`

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.37.0"
+version = "0.38.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -415,6 +415,37 @@ fn fold_tagged_statement(stmt: &TaggedStatement, st: &mut FoldState) -> Statemen
         // `do { if (x) a(); b(); } while(c);` → `do x && a(), b(); while(c);`.
         TaggedStatement::DoWhileStatement(s) => {
             let body = fold_statement(&s.body, st);
+
+            // Empty-bodied `do … while` ≡ `while`. `do {} while(test)` runs the
+            // (empty) body once and then evaluates `test`; because the body is a
+            // no-op, its test-evaluation sequence is IDENTICAL to `while(test){}`
+            // (the leading empty run changes nothing observable). We rewrite to
+            // the equivalent `while`, which lowers to `for` and — via the empty
+            // loop-body normalization — collapses the braces:
+            //
+            //   do {} while(c);   →  while(c){}  →  for(; c;) {}  →  for(; c;) ;
+            //   do {} while(0);   →  while(0){}  →  dead loop     →  ;  (dce drops)
+            //
+            // A NON-empty body keeps the `do` form (a `do` body runs before its
+            // test, so it can't generally become a `while`); those fall through
+            // to the loop-body comma-fusion below.
+            if statement_is_empty(&body) {
+                st.record_fold(
+                    &s.cv,
+                    "empty-do-while-to-while",
+                    "do {} while(<test>)",
+                    "while(<test>) {}",
+                );
+                return fold_while_statement(
+                    &WhileStatement {
+                        cv: s.cv.clone(),
+                        test: s.test.clone(),
+                        body: Box::new(body),
+                    },
+                    st,
+                );
+            }
+
             let body = match &body {
                 Statement::Tagged(TaggedStatement::BlockStatement(_)) => {
                     match stmts_as_sequence_expr(&body) {
@@ -2753,6 +2784,34 @@ mod tests {
                 other => panic!("expected a fused expression-statement body; got {other:?}"),
             },
             other => panic!("expected DoWhileStatement; got {other:?}"),
+        }
+    }
+
+    /// `do {} while(c);` → an empty-bodied do-while lowers to the equivalent
+    /// `while`, which the pass rewrites to `for(; c;)` (with the empty body
+    /// normalized to `;`). The result is a `ForStatement`, not a `DoWhile`.
+    #[test]
+    fn empty_do_while_lowers_to_for() {
+        let dw = Statement::Tagged(TaggedStatement::DoWhileStatement(DoWhileStatement {
+            cv: Some("dw.1".to_string()),
+            body: Box::new(block(Some("blk.1"), vec![])),
+            test: ident("c"),
+        }));
+        let (out, contribs, changed, _) =
+            run_pass(program().with_body(vec![ProgramItem::Statement(dw)]));
+        assert!(changed);
+        assert!(contribs.iter().any(|c| c.tag == "empty-do-while-to-while"));
+        // One pass lowers `do{}while(c)` to `for(;c;){}`; the empty-block -> `;`
+        // normalization runs on the next sweep (covered by
+        // `for_empty_block_body_normalizes_to_empty_statement`). Either way the
+        // body is empty, and it is now a `for`, not a `do`.
+        match first_stmt(&out) {
+            Statement::Tagged(TaggedStatement::ForStatement(f)) => assert!(
+                statement_is_empty(f.body.as_ref()),
+                "empty do-while must lower to a for with an empty body; got {:?}",
+                f.body
+            ),
+            other => panic!("expected ForStatement; got {other:?}"),
         }
     }
 

--- a/code/programs/rust/closurec/tests/diff/simple-empty-do-while/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-empty-do-while/README.md
@@ -1,0 +1,18 @@
+# simple-empty-do-while
+
+End-to-end oracle for **empty-bodied do-while lowering** in
+`closure-pass-fold-control-flow` (fcf 0.38.0).
+
+`do {} while(test)` is equivalent to `while(test){}` (the leading empty body is
+a no-op), so the empty case lowers to the equivalent loop, which is rewritten to
+`for` with the empty body normalized to `;`. A statically-falsy test makes it a
+dead loop (removed). A non-empty do-while keeps the `do` form.
+
+## Expected output
+
+```text
+for(;cond;);for(;run(););do work();while(again);
+```
+
+Byte-identical to the reference Closure Compiler (`v20260712`,
+`SIMPLE_OPTIMIZATIONS`, `ECMASCRIPT_2020`, `NO_TRANSPILE`), verified with `xxd`.

--- a/code/programs/rust/closurec/tests/diff/simple-empty-do-while/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-empty-do-while/expected.stdout
@@ -1,0 +1,1 @@
+for(;cond;);for(;run(););do work();while(again);

--- a/code/programs/rust/closurec/tests/diff/simple-empty-do-while/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-empty-do-while/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-empty-do-while/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-empty-do-while/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-empty-do-while/input/a.js
@@ -1,0 +1,15 @@
+// SIMPLE-level empty-bodied do-while lowering (fold-control-flow 0.38.0).
+//
+// `do {} while(test)` runs its (empty) body once and then evaluates `test`.
+// Because the body is a no-op, the test-evaluation sequence is IDENTICAL to
+// `while(test){}`, so the empty case lowers to the equivalent loop, which the
+// existing machinery rewrites to `for` (and normalizes the empty body to `;`):
+//   do {} while (cond);   -> for(;cond;);
+//   do {} while (run());  -> for(;run(););   (impure test preserved)
+//
+// A NON-empty do-while keeps the `do` form (its body runs before the test, so
+// it can't generally become a `while`); a single-statement body just unwraps:
+//   do { work(); } while (again);  -> do work();while(again);
+do {} while (cond);
+do {} while (run());
+do { work(); } while (again);

--- a/code/programs/rust/closurec/tests/diff_simple_empty_do_while.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_empty_do_while.rs
@@ -1,0 +1,47 @@
+//! Integration test for the `tests/diff/simple-empty-do-while/` fixture.
+//!
+//! End-to-end oracle for empty-bodied do-while lowering in
+//! `closure-pass-fold-control-flow`: `do {} while(test)` is equivalent to
+//! `while(test){}` (the leading empty body is a no-op), so it lowers to the
+//! equivalent loop, rewritten to `for` with the empty body normalized to `;`.
+//! A statically-falsy test makes it a dead loop (removed); a non-empty do-while
+//! keeps the `do` form.
+//!
+//! At SIMPLE the fixture optimizes to:
+//!
+//! ```text
+//! for(;cond;);for(;run(););do work();while(again);
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-empty-do-while/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_empty_do_while_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY).args(&flags).output().expect("run closurec");
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-empty-do-while/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}


### PR DESCRIPTION
## What

`fold-control-flow` (0.38.0): lower an empty-bodied `do … while` to the equivalent `while`/`for`, matching the reference Closure Compiler at SIMPLE.

```text
do {} while(cond);   ->  for(;cond;);
do {} while(run());  ->  for(;run(););   (impure test preserved)
do {} while(0);      ->  removed         (dead loop; dce drops the residual ;)
```

`do {} while(test)` runs the (empty) body once and then evaluates `test`; because the body is a no-op, its test-evaluation sequence is **identical** to `while(test){}` (the leading empty run changes nothing observable). We rewrite the empty case by delegating to the existing while fold, which lowers to `for` and — via the empty loop-body normalization ([#9045](https://github.com/adhithyan15/coding-adventures/pull/9045), 0.37.0) — collapses to `for(;test;);`. A statically-falsy test makes it a dead loop that collapses to `;` (removed downstream by dce).

No **new** non-termination is introduced: a truthy `do{}while(true)` maps to `for(;;)`, the same infinite loop already in the source.

## Scope

A **non-empty** `do` body keeps the `do` form (a `do` body runs before its test, so it cannot generally become a `while`) and still gets the loop-body comma-fusion (0.36.0). `statement_is_empty` returns false for any declaration, label, or non-empty nested statement, and the body is **moved** (not dropped) into the while, so no binding is ever discarded.

This closes the empty-body follow-up from 0.37.0. The remaining do-while gaps (trailing `continue` removal, trailing `return`→`break`) stay tracked as #226.

## Verification

- 94 fold-control-flow unit tests (1 new) + 13 integration, zero regressions.
- New closurec e2e fixture `simple-empty-do-while`, byte-identical to the oracle jar (`v20260712`, `SIMPLE`, `ECMASCRIPT_2020`, `NO_TRANSPILE`), verified with `xxd`. Sub-cases `do{}while(true)`→`for(;;)`, `do{}while(0)`→removed, `do;while(c)`→`for(;c;)` also oracle-checked.
- Full closurec suite: **164 suites / 961 tests, zero failures, zero drift.**
- `cargo clippy -- -D warnings` clean in both workspaces.
- Inline security review: **PASSED** — semantics-preserving (incl. truthy/falsy tests), no new non-termination, no panic/recursion vector; empty bodies carry no bindings and are preserved, not dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
