### PR TITLE
content(romance): yes/no for Spanish and French

### DIFF
--- a/code/learning/human-languages/french/lessons/FR-C18-non.md
+++ b/code/learning/human-languages/french/lessons/FR-C18-non.md
@@ -1,0 +1,64 @@
+---
+id: FR-C18-non
+chapter: 18
+type: word
+headword: non
+gloss: no / not
+concept_tag: RESPONSE-NO
+prerequisites: [FR-C18-oui]
+sounds: [nasal-vowel-on]
+roots: [non]
+etymology_hook: "non is Latin nōn — Spanish dropped the n to make no, French kept it as a nasal vowel: the vowel itself carries the n"
+est_minutes: 3
+reviews_of: [FR-C18-oui, FR-C01-bonjour]
+---
+
+# non — no / not
+
+## Warm-up
+
+[PAUSE 2s] After French's home-grown *oui*, its **no** is the family word,
+shared straight with Spanish — but said the French way, through the nose.
+
+## The word
+
+**non** = **no**. It comes from Latin **nōn**, the same source as Spanish *no*
+and Italian *no*:
+
+| Latin *nōn* | → |
+|---|---|
+| Spanish | no |
+| Italian | no |
+| **French** | **non** |
+
+Spanish dropped the *n* and left a clean *no*. French **kept** the *n* — but
+turned it into a **nasal vowel**: you don't quite touch your tongue to say the
+final *n*, you send the vowel through your nose. That's the sound written **‑on**
+in *non*, *bon*, *bonjour* — you've met it before.
+
+## The seed of French negation
+
+The word that actually carries negation inside a French sentence isn't *non* but
+its **unstressed twin, ne** — both worn down from the same Latin *nōn*. Modern
+French usually reinforces *ne* with a second word, giving the pair *ne … pas*:
+
+> *Je **ne** parle **pas** français* = "I do **not** speak French."
+
+For now, **non** on its own is your answer-word. In *ne … pas*, the **ne** is
+*non*'s cousin from *nōn*; the **pas** was added later — it originally meant "a
+step" (Latin *passus*), as in "not walk a *step*" — and simply stuck. That fuller
+sentence negation is something you'll build later.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "non" — nasal, through the nose, like the *-on* in *bon*]
+- [YOU SAY: the pair with yes — "oui / non"]
+- [YOU SAY: the family — Latin *nōn* → Spanish *no*, French *non*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How do you say no in French? (**non**.) What Latin word is it from,
+and which Spanish word is its twin? (**nōn**; Spanish **no**.) What did French do
+to the *n* that Spanish dropped? (Kept it as a **nasal vowel** — the *-on* sound.)
+What pair does full French negation usually wrap around the verb? (***ne … pas***.)

--- a/code/learning/human-languages/french/lessons/FR-C18-oui.md
+++ b/code/learning/human-languages/french/lessons/FR-C18-oui.md
@@ -1,0 +1,70 @@
+---
+id: FR-C18-oui
+chapter: 18
+type: word
+headword: oui
+gloss: yes
+concept_tag: RESPONSE-YES
+prerequisites: [FR-C01-bonjour]
+sounds: [semivowel-w, vowel-i]
+roots: [hoc-ille]
+etymology_hook: "oui is Latin hoc ille 'this is it' worn through oïl — the whole north of France was named for it: the langue d'oïl"
+est_minutes: 4
+reviews_of: [FR-C01-bonjour]
+---
+
+# oui — yes
+
+## Warm-up
+
+[PAUSE 2s] Where Spanish kept Latin's word for yes, French built a brand-new one
+— and named half a country after it.
+
+## The word
+
+**oui** = **yes**. Just two sounds, *wee*.
+
+Its Romance cousins (Spanish *sí*, Italian *sì*) come from Latin *sīc* "thus."
+**French took a different road entirely.** *oui* comes from Old French **oïl**,
+and *oïl* is a squeezed-down Latin phrase:
+
+> **hoc ille** ("this [is] it") → *o-ïl* → **oui**
+
+You answered "yes" by saying, in effect, "*that's the one*."
+
+## A word that split a country
+
+This mattered so much it became a map. In the Middle Ages France was divided by
+how people said *yes*:
+
+- the **north** said *oïl* → the **langue d'oïl** (which became modern French)
+- the **south** said *oc* → the **langue d'oc** — still visible in the region
+  name **Languedoc**, and in the language **Occitan**
+
+One little answer-word, drawn as a border.
+
+## The other "yes": si
+
+French keeps a **second** yes — **si** — for one special job: contradicting a
+**negative**. When someone says something *isn't* so and you insist it *is*, you
+answer **si**, not *oui*:
+
+> *Tu ne viens pas ?* ("You're not coming?") — ***Si !*** ("Yes I am!")
+
+(That *si* is the Latin *sīc* the Spanish *sí* also comes from — French kept it
+only for this contradicting move.)
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "oui" — *wee*]
+- [YOU SAY: the origin — "hoc ille → oïl → oui": *that's the one*]
+- [YOU SAY: the contradiction — "Tu ne viens pas ? — Si !"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How do you say yes in French? (**oui**.) What Latin phrase is it worn
+down from? (**hoc ille**, "this is it," via *oïl*.) What were the *langue d'oïl*
+and *langue d'oc* named after? (The two medieval words for **yes**.) When do you
+answer **si** instead of *oui*? (To **contradict a negative** — *Tu ne viens
+pas? — Si!*)

--- a/code/learning/human-languages/spanish/lessons/ES-C19-no.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C19-no.md
@@ -1,0 +1,62 @@
+---
+id: ES-C19-no
+chapter: 19
+type: word
+headword: no
+gloss: no / not
+concept_tag: RESPONSE-NO
+prerequisites: [ES-C19-si]
+sounds: [vowel-o]
+roots: [non]
+etymology_hook: "no is Latin nōn barely touched — and does double duty: both 'no' the answer and 'not' the negator (no hablo)"
+est_minutes: 3
+reviews_of: [ES-C19-si, ES-C01-hola]
+---
+
+# no — no / not
+
+## Warm-up
+
+[PAUSE 2s] The easiest word yet — and it quietly does two jobs Spanish never
+splits apart.
+
+## The word
+
+**no** = **no**. Said *noh*, a clean single vowel.
+
+It is Latin **nōn** with almost nothing worn off — just the final consonant
+gone. Compare the family, all from the same *nōn*:
+
+| Latin *nōn* | → |
+|---|---|
+| Spanish | **no** |
+| Italian | **no** |
+| French | **non** |
+
+## One word, two jobs
+
+Here's the thing English splits and Spanish doesn't. English has **"no"** (the
+answer) and **"not"** (inside a sentence) — two different words. Spanish uses
+**no** for **both**:
+
+- as the **answer**: *¿Hablas inglés?* — **No.**
+- as the **negator**, placed right before the verb: ***No** hablo inglés* = "I
+  do **not** speak English."
+
+So learning *no* gives you the whole of Spanish negation for free: to make any
+sentence negative, drop **no** in front of the verb. One little word, two
+everyday jobs.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "no" — *noh*]
+- [YOU SAY: as an answer — "¿Hablas inglés? No."]
+- [YOU SAY: as a negator — "No hablo inglés"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How do you say no in Spanish? (**no**.) What Latin word is it from?
+(**nōn**.) Spanish *no* does the work of which **two** English words? (**"no"**
+the answer and **"not"** the negator — *No hablo* = "I do not speak.") Where does
+*no* go to negate a sentence? (**Right before the verb**.)

--- a/code/learning/human-languages/spanish/lessons/ES-C19-si.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C19-si.md
@@ -1,0 +1,63 @@
+---
+id: ES-C19-si
+chapter: 19
+type: word
+headword: sí
+gloss: yes
+concept_tag: RESPONSE-YES
+prerequisites: [ES-C01-hola]
+sounds: [vowel-i, written-accent]
+roots: [sic]
+etymology_hook: "sí 'yes' is Latin sīc 'thus, so' — the accent is the whole word: sí (yes) vs si (if) are a minimal pair"
+est_minutes: 3
+reviews_of: [ES-C01-hola]
+---
+
+# sí — yes
+
+## Warm-up
+
+[PAUSE 2s] The smallest useful word — and the accent on it is doing real work.
+
+## The word
+
+**sí** = **yes**. One syllable, said *see*.
+
+The written accent is not decoration — it is the **whole difference** between
+two words:
+
+- **sí** (with the accent) = **yes**
+- **si** (no accent) = **if**
+
+They sound almost identical, so Spanish uses the mark to tell them apart on the
+page: *Sí, si quieres* = "Yes, if you want." Miss the accent and you've written
+"if" where you meant "yes."
+
+## Where it comes from
+
+**sí** is Latin **sīc**, "thus, so" — answering a question with "just so,"
+exactly the move Latin also made with **ita** ("thus" = yes, from the Latin
+yes/no lesson). Its Romance cousins kept the same root:
+
+| Latin *sīc* | → |
+|---|---|
+| Spanish | **sí** |
+| Italian | **sì** |
+| Portuguese | **sim** |
+
+French is the odd one out — it went a completely different way for "yes"
+(*oui*), which its own lesson tells. But say *sí, sì, sim* in a row and you hear
+one Latin word answering across three countries.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "sí" — *see*, and picture the accent]
+- [YOU SAY: the pair — "sí" (yes) vs "si" (if)]
+- [YOU SAY: the cousins — "sí, sì, sim" — all from Latin *sīc*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How do you say yes in Spanish? (**sí**.) What is the *only* difference
+between **sí** "yes" and **si** "if"? (The **written accent**.) What Latin word
+is *sí* from, and what did it mean? (**sīc** — "thus, so".)


### PR DESCRIPTION
## What
New concept after numbers, breadth-first. A frontier survey showed **yes/no** was missing from Spanish, French, German, Arabic, Hindi (the four Dravidian tracks already have `RESPONSE-YES`/`RESPONSE-NO`, and Latin already covers it via `LA-C01-ita-non`). This PR does the **Romance pair the pilot family**: Spanish **sí/no** + French **oui/non**, using the canonical `RESPONSE-YES` / `RESPONSE-NO` tags so they interleave cross-language in Concepts mode.

## Atom-first, grounded in the shared Latin roots
- **ES sí** ← Latin *sīc* "thus" (cousins Italian *sì*, Portuguese *sim*); the **sí / si** (yes / if) **accent minimal pair**.
- **ES no** ← *nōn* — one word doing English's two jobs ("no" + preverbal "not", *no hablo*).
- **FR oui** ← Old French *oïl* ← Latin *hoc ille* "this is it" — the **langue d'oïl vs langue d'oc** split (Languedoc/Occitan); plus **si** to contradict a negative (*Tu ne viens pas? — Si!*).
- **FR non** ← *nōn* (Spanish's twin), kept as a **nasal vowel**.

## Review
Romance-linguistics subagent confirmed *sí/sīc*, *oui/oïl/hoc-ille*, the oïl/oc split, Portuguese *sim ← sīc*, and *si*-contradicting-a-negative. It caught **one real error** — I'd mis-derived *ne…pas* from *nōn* (only *ne* is; **pas** is from *passus* "step", and the negation rides on *ne*) — **now fixed**. Latin-script → **zero warnings/errors**; **human-language-data 38 + app 268 green**.

## Note on tags
Existing yes/no tags are inconsistent in the corpus: Dravidian ×4 use separate `RESPONSE-YES`/`RESPONSE-NO`, Latin uses combined `RESPONSE-YESNO`. I matched the **majority (separate)** convention. Normalizing Latin's combined tag could be a small later cleanup.

## Next
German, Arabic, Hindi yes/no (ja/nein, naʿam/lā, hāṃ/nahīṃ — Unicode-composed, reviewed), then the next frontier concept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)