### PR TITLE
feat(adj-formula-stdlib): inspiratory-capacity — StatPearls TLC = FRC + IC lung-volume partition (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_inspiratory_capacity_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_inspiratory_capacity_e2e.rs
@@ -1,0 +1,143 @@
+//! End-to-end tests for the `clinical/inspiratory-capacity.adj` library — the FRC/IC
+//! partition of the total lung capacity (total lung capacity = functional residual
+//! capacity + inspiratory capacity) and its two exact rearrangements (inspiratory
+//! capacity = TLC − FRC, functional residual capacity = TLC − IC) — driven through the
+//! built CLI binary against the SHIPPED stdlib. Each proves the same invariant as the
+//! other formula libraries: a consumer states NO arithmetic; it imports the grounded
+//! library, binds the measured quantities with `observe`, and the engine applies the
+//! cited relation on the CPU, computing the EXACT value and rendering the relation's
+//! citation and trust tier in the `derived` section (the auditable answer). The three
+//! formulas INVERT around the worked case FRC = 2 L, IC = 4 L: 2 + 4 = 6, and both
+//! 6 − 2 = 4 and 6 − 4 = 2 recover the inputs.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped inspiratory-capacity library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_ic_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/inspiratory-capacity.adj")
+        .canonicalize()
+        .expect("shipped inspiratory-capacity.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_ic_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_ic_lib()).unwrap();
+    std::fs::write(dir.join("inspiratory-capacity.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// total_lung_capacity — the definition: the functional residual capacity plus the
+// inspiratory capacity.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_ic_library_and_computes_total_lung_capacity_with_citation() {
+    let dir = scratch("tlc");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"inspiratory-capacity.adj\"\n\
+         observe functional_residual_capacity(2)\n\
+         observe inspiratory_capacity(4)\n\
+         ? total_lung_capacity(functional_residual_capacity, inspiratory_capacity)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 2 + 4 = 6.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"total_lung_capacity\"") && s.contains("\"value\":6"),
+        "total_lung_capacity(2, 4) = 6: {s}"
+    );
+    // … AND the StatPearls/NCBI Bookshelf citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// inspiratory_capacity — the same relation solved for IC: TLC − FRC, which INVERTS the
+// total lung capacity just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_inspiratory_capacity_from_tlc_and_frc_with_citation() {
+    let dir = scratch("ic");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"inspiratory-capacity.adj\"\n\
+         observe total_lung_capacity(6)\n\
+         observe functional_residual_capacity(2)\n\
+         ? inspiratory_capacity(total_lung_capacity, functional_residual_capacity)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 6 - 2 = 4, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"inspiratory_capacity\"") && s.contains("\"value\":4"),
+        "inspiratory_capacity(6, 2) = 4: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "inspiratory_capacity carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// functional_residual_capacity — the same relation solved for FRC: TLC − IC, the third
+// exact reading of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_functional_residual_capacity_from_tlc_and_ic_with_citation() {
+    let dir = scratch("frc");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"inspiratory-capacity.adj\"\n\
+         observe total_lung_capacity(6)\n\
+         observe inspiratory_capacity(4)\n\
+         ? functional_residual_capacity(total_lung_capacity, inspiratory_capacity)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 6 - 4 = 2, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"functional_residual_capacity\"") && s.contains("\"value\":2"),
+        "functional_residual_capacity(6, 4) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "functional_residual_capacity carries its StatPearls citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/inspiratory-capacity.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/inspiratory-capacity.adj
@@ -1,0 +1,113 @@
+% ============================================================================
+% inspiratory-capacity.adj — the FRC/IC partition of the total lung capacity
+% (total lung capacity = functional residual capacity + inspiratory capacity)
+% in the ADJ standard library.
+% ============================================================================
+% The inspiratory-capacity entry of the *clinical* track, a respiratory-physiology
+% library. Where total-lung-capacity.adj grounds the VC/RV partition (TLC = VC + RV),
+% this grounds the OTHER standard partition of the same total: THE TOTAL LUNG CAPACITY
+% IS THE FUNCTIONAL RESIDUAL CAPACITY PLUS THE INSPIRATORY CAPACITY — the greatest
+% volume the lungs hold at the end of a maximal inspiration (TLC) is the volume left
+% in the lungs at the end of a NORMAL (quiet) expiration (the functional residual
+% capacity, FRC) plus the volume that can still be inspired from that quiet-expiration
+% resting point on a maximal inspiration (the inspiratory capacity, IC). It ships as an
+% importable, byte-provenanced, PARAMETERIZED `formula`, together with its two exact
+% rearrangements (the inspiratory capacity a total capacity leaves once the functional
+% residual capacity is taken out, and the functional residual capacity a total capacity
+% leaves once the inspiratory capacity is taken out). As with every compute library, a
+% consumer states NO arithmetic: it `import`s this file, binds the measured quantities
+% from its own byte-provenance decomposition, and asks the engine to APPLY the cited
+% definition on the CPU. Zero math is performed by the model; the engine computes each
+% value EXACTLY, carrying the definition's citation.
+%
+%     import "inspiratory-capacity.adj"
+%     observe functional_residual_capacity(2)   % "…FRC 2 L…"   (span cited by the model)
+%     observe inspiratory_capacity(4)            % "…IC 4 L…"    (span cited by the model)
+%     ? total_lung_capacity(functional_residual_capacity, inspiratory_capacity)
+%                                                 % engine → 6, carrying TLC = FRC + IC
+%
+% All three formulas are EXACT over their parameters (a sum and two of its inverse
+% readings), so every value the engine returns is exact. The three COMPOSE and invert
+% cleanly around the worked case FRC = 2 L, IC = 4 L (TLC = 2 + 4 = 6 L): the
+% `total_lung_capacity` a consumer computes from the two volumes is exactly the
+% `total_lung_capacity` the `inspiratory_capacity` formula subtracts the functional
+% residual capacity from, to recover the 4 L inspiratory capacity, and exactly the
+% `total_lung_capacity` the `functional_residual_capacity` formula subtracts the
+% inspiratory capacity from to recover the 2 L functional residual capacity.
+%
+%   total_lung_capacity(functional_residual_capacity, inspiratory_capacity)
+%       = functional_residual_capacity + inspiratory_capacity   % TLC = FRC + IC   (definition)
+%   inspiratory_capacity(total_lung_capacity, functional_residual_capacity)
+%       = total_lung_capacity - functional_residual_capacity     % IC = TLC − FRC   (same def, solved for IC)
+%   functional_residual_capacity(total_lung_capacity, inspiratory_capacity)
+%       = total_lung_capacity - inspiratory_capacity             % FRC = TLC − IC   (same def, solved for FRC)
+%
+% NOTE ON UNITS: the three volumes must be in the SAME unit (all litres, as in the worked
+% case), and the derived volume comes out in that same unit (here 6 L). This library
+% computes the exact value over whatever consistent volume unit it is given.
+%
+% NOTE ON PARTITIONS: this is a DIFFERENT partition of the same total from
+% total-lung-capacity.adj. That library splits the total into what a person can move
+% (VC) and what always remains (RV): TLC = VC + RV. This library splits the SAME total
+% at the quiet-breathing resting point into what sits below it (FRC) and what can still
+% be drawn in above it (IC): TLC = FRC + IC. Both are exact; a consumer imports whichever
+% partition its measured quantities populate.
+%
+% All three formulas are defended by the SAME defining span — "TLC = FRC + IC" — because
+% that one printed equation (the total lung capacity IS the functional residual capacity
+% plus the inspiratory capacity) sanctions the relation read every way (the total from the
+% two volumes, the inspiratory capacity from the total and the functional residual
+% capacity, or the functional residual capacity from the total and the inspiratory
+% capacity). The span is transcribed verbatim from the StatPearls "Physiology, Lung
+% Capacity" article on the NCBI Bookshelf, so each `formula` carries the provenance
+% envelope every shipped grounded clause carries; the linter rejects an unsourced one.
+% (See feedback_nothing_human_authored — the defining span is a verbatim quote of the
+% cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable respiratory volume/capacity the definition
+% ranges over, and each result is a derived volume/capacity. `total_lung_capacity`,
+% `functional_residual_capacity` and `inspiratory_capacity` each appear BOTH as a derived
+% result and as an input (of the other formulas), so each is a single dictionary term used
+% in both roles. The `surface` lists are the everyday names a decomposer maps onto the
+% canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary inspiratory_capacity_vocab {
+    define functional_residual_capacity : finding  surface "functional residual capacity", "FRC"  % litres (L)
+    define inspiratory_capacity          : finding  surface "inspiratory capacity", "IC"            % litres (L)
+    define total_lung_capacity           : finding  surface "total lung capacity", "TLC"            % litres (L)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable formula over its
+% formal parameters, bound at apply time, and each carries the defining span from StatPearls
+% on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an exact
+% sum/difference of measured quantities, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook inspiratory_capacity_laws {
+    use inspiratory_capacity_vocab
+
+    % Total lung capacity — the functional residual capacity plus the inspiratory capacity,
+    % i.e. TLC = FRC + IC.
+    formula total_lung_capacity(functional_residual_capacity, inspiratory_capacity) = functional_residual_capacity + inspiratory_capacity
+        source "TLC = FRC + IC"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541029/"
+        trust authoritative
+
+    % Inspiratory capacity — the same definition solved for the inspiratory capacity a total
+    % capacity leaves once the functional residual capacity is removed (IC = TLC − FRC).
+    % Defended by the SAME defining span, read the other way.
+    formula inspiratory_capacity(total_lung_capacity, functional_residual_capacity) = total_lung_capacity - functional_residual_capacity
+        source "TLC = FRC + IC"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541029/"
+        trust authoritative
+
+    % Functional residual capacity — the same definition solved for the functional residual
+    % capacity a total capacity leaves once the inspiratory capacity is removed
+    % (FRC = TLC − IC). Again the SAME defining span, read the third way.
+    formula functional_residual_capacity(total_lung_capacity, inspiratory_capacity) = total_lung_capacity - inspiratory_capacity
+        source "TLC = FRC + IC"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541029/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/inspiratory-capacity.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/inspiratory-capacity.query.adj
@@ -1,0 +1,34 @@
+% ============================================================================
+% inspiratory-capacity.query.adj — worked examples over the clinical inspiratory-capacity library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER an inspiratory-capacity
+% question: it states NO arithmetic and NO relation — it only `import`s the grounded
+% library, `observe`s the quantities it decomposed from the prompt (each a byte-provenanced
+% span, elided here), and asks the engine to APPLY the cited definition. The native adj-lang
+% engine binds the parameters, computes each value EXACTLY on the CPU, and returns it with
+% the definition's source/locator/trust.
+%
+% The three questions INVERT: a functional residual capacity of 2 L plus an inspiratory
+% capacity of 4 L gives a total lung capacity of 2 + 4 = 6 L; that 6 L total lung capacity
+% minus the same 2 L functional residual capacity is exactly what the inspiratory-capacity
+% formula recovers the 4 L from, and that 6 L total lung capacity minus the same 4 L
+% inspiratory capacity is exactly what the functional-residual-capacity formula recovers
+% the 2 L from.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli inspiratory-capacity.query.adj
+% ============================================================================
+
+import "inspiratory-capacity.adj"
+
+% FRC 2 L, IC 4 L: total lung capacity = 2 + 4.
+observe functional_residual_capacity(2)
+observe inspiratory_capacity(4)
+? total_lung_capacity(functional_residual_capacity, inspiratory_capacity)   % expect 6  (TLC = FRC + IC)
+
+% That 6 L total lung capacity with the same 2 L functional residual capacity: IC = 6 − 2.
+observe total_lung_capacity(6)
+? inspiratory_capacity(total_lung_capacity, functional_residual_capacity)   % expect 4  (same def, solved for IC = TLC − FRC)
+
+% That 6 L total lung capacity with the same 4 L inspiratory capacity: FRC = 6 − 4.
+? functional_residual_capacity(total_lung_capacity, inspiratory_capacity)   % expect 2  (same def, solved for FRC = TLC − IC)


### PR DESCRIPTION
## What

Adds the **FRC/IC partition** of the total lung capacity as an importable, byte-provenanced clinical `formulabook`:

- `total_lung_capacity(FRC, IC) = FRC + IC` — **TLC = FRC + IC** (the definition)
- `inspiratory_capacity(TLC, FRC) = TLC − FRC` — IC = TLC − FRC (solved for IC)
- `functional_residual_capacity(TLC, IC) = TLC − IC` — FRC = TLC − IC (solved for FRC)

Sibling to the just-merged **total-lung-capacity** library (the VC/RV partition, `TLC = VC + RV`): both are exact decompositions of the *same* total, split at different reference points. A consumer imports whichever partition its measured quantities populate.

## Grounding

All three formulas are defended by the **same verbatim defining span** — `"TLC = FRC + IC"` — transcribed exactly as printed from the StatPearls *"Physiology, Lung Capacity"* article on the NCBI Bookshelf ([NBK541029](https://www.ncbi.nlm.nih.gov/books/NBK541029/)), byte-verified via WebFetch before shipping. Nothing is asserted from memory.

As with every compute library, a consumer states **no arithmetic**: it `import`s the file, `observe`s the measured volumes from its own byte-provenance decomposition, and the engine applies the cited definition on the CPU — computing each value **exactly** (BigRational) and carrying `source`/`locator`/`trust authoritative` into the `derived` section.

## Worked case

FRC = 2 L, IC = 4 L → TLC = 2 + 4 = **6 L**; and 6 − 2 = 4, 6 − 4 = 2 recover the inputs (integers chosen so no asserted value is a prefix of another).

## Files

- `clinical/inspiratory-capacity.adj` — dictionary + formulabook (3 formulas)
- `clinical/inspiratory-capacity.query.adj` — worked-example consumer
- `adj-lang-cli/tests/formula_inspiratory_capacity_e2e.rs` — 3 e2e tests driving the built CLI against the shipped stdlib (all green)

## Verification

- `cargo test -p adj-lang-cli --test formula_inspiratory_capacity_e2e` → **3 passed**
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean
- shipped `.query.adj` run through the built CLI renders TLC=6/IC=4/FRC=2 with the NBK541029 citation + `trust: authoritative`
- NUL-scan clean; `/security-review` → passed

**Data + test only; no engine change, so no version bump.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)