### PR TITLE
feat(adj-formula-stdlib): magnetic-flux — NIST SP 811 B.9 maxwell→weber factor (RS-5 table, b21)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -960,6 +960,51 @@ fn shipped_exposure_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b21) Shipped table — reference/magnetic-flux-conversions.adj resolves via import (a
+//       NEW dimension: magnetic flux → weber, the EXACT SP 811 B.9 boldface factor
+//       maxwell = 1.0 E-08 = 0.00000001, the maxwell DEFINED as exactly 10⁻⁸ Wb), and a unit
+//       of a DIFFERENT quantity (`gauss`, a magnetic-flux-DENSITY unit → tesla, not the weber)
+//       — no row — abstains rather than mis-converting across dimensions. Distinct from
+//       magnetic-flux-density (gauss→tesla): flux is the total field through a surface, flux
+//       density is the field per unit area; one weber over one square metre is one tesla.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_magnetic_flux_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_magnetic_flux");
+    let src = stdlib().join("reference/magnetic-flux-conversions.adj");
+    std::fs::copy(&src, dir.join("magnetic-flux-conversions.adj"))
+        .expect("copy shipped magnetic-flux-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"magnetic-flux-conversions.adj\"\n\
+         ? magnetic_flux_to_weber(maxwell, $v)\n\
+         ? magnetic_flux_to_weber(gauss, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 exact factor resolves, character-for-character from the table
+    // (boldface = exact; the maxwell is defined as exactly 10^-8 Wb).
+    assert!(
+        out.contains("\"v\":\"0.00000001\""),
+        "maxwell = 0.00000001 Wb: {out}"
+    );
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `gauss` is a magnetic-flux-DENSITY unit (it converts to the tesla, a DIFFERENT quantity),
+    // so this flux table has no row for it — the engine abstains rather than mis-converting a
+    // flux-density unit as if it were a flux unit.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a wrong-dimension unit abstains, never a cross-dimension fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/magnetic-flux-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/magnetic-flux-conversions.adj
@@ -1,0 +1,59 @@
+% ============================================================================
+% magnetic-flux-conversions — magnetic-flux-unit → weber factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of `magnetic-flux-density-conversions.adj` and the other NIST-cited
+% conversion tables: a native tabular relation ingested VERBATIM from a published NIST
+% conversion table. The row states the factor converting the traditional (CGS-Gaussian /
+% EMU) unit of MAGNETIC FLUX — the total magnetic field threading a surface — to the SI
+% coherent derived unit, the weber (Wb):
+%
+%     ? magnetic_flux_to_weber(maxwell, $v)   % 0.00000001
+%
+% This is a NEW dimension alongside the length/mass/area/volume/time/speed/energy/
+% pressure/force/acceleration/dynamic-viscosity/kinematic-viscosity/magnetic-flux-density/
+% illuminance/luminance/radioactivity/absorbed-dose/dose-equivalent/exposure tables. Do NOT
+% confuse it with magnetic-flux-DENSITY: those are DIFFERENT quantities. MAGNETIC FLUX
+% (the maxwell → the weber) is the total field through a surface; MAGNETIC FLUX DENSITY
+% (the gauss → the tesla, see `magnetic-flux-density-conversions.adj`) is the field per unit
+% area. One weber spread over one square metre is one tesla; the maxwell and the gauss are
+% their respective traditional units and convert to DIFFERENT SI units. The traditional unit
+% here is the maxwell (Mx); the SI unit is the weber. Put a flux given in maxwells into SI
+% first, then reason (write-once-use-many). Why a `table` and not a hand-written `relate`
+% clause: this is exactly the shape reference data comes in — a published table, not prose.
+% The citable artifact IS the NIST conversion-factors table at the `locator` below; the
+% factor here is a CELL of NIST Special Publication 811, Appendix B.9 ("Factors for units
+% listed alphabetically"), defended by one provenance envelope. Each `row` lowers to a ground
+% relation `magnetic_flux_to_weber(unit, wb)`, so the exact lookup above is the ordinary SLD
+% binding query — the engine returns the factor WITH this table's citation as its proof, on
+% the CPU, with zero model calls.
+%
+% HONESTY NOTE (like the magnetic-flux-density / radioactivity / absorbed-dose tables, only
+% the EXACT defined factor gets a row): NIST SP 811 B.9 prints the "maxwell" flux factor in
+% BOLDFACE, its convention for factors that are EXACT by definition, transcribed here as the
+% plain decimal number of webers it names:
+%
+%     maxwell (Mx)   1.0 E-08  →  0.00000001
+%
+% This is exact because the maxwell is DEFINED as exactly 10^-8 weber (one maxwell is exactly
+% one line of the CGS-Gaussian magnetic field, defined as 10^-8 Wb). It terminates; nothing
+% here is a rounded measurement. This table is SPECIFIC to magnetic flux: a unit of a
+% DIFFERENT quantity — e.g. the "gauss", which NIST SP 811 B.9 lists separately as a magnetic-
+% flux-DENSITY unit converting to the tesla, NOT the weber (see
+% `magnetic-flux-density-conversions.adj`) — therefore gets no row here, and a
+% `? magnetic_flux_to_weber(gauss, $v)` ABSTAINS rather than mis-converting a flux-density unit
+% as if it were a flux unit. The only claim this table makes is "this is the exact factor NIST
+% SP 811 B.9 prints for the maxwell's conversion to the weber" — which is exactly what a
+% byte-check against the cited table verifies. `trust authoritative` — a primary, re-fetchable
+% standards reference. (See ADJ-TABLES.md; and feedback_nothing_human_authored — the factor is
+% a verbatim cell of the cited table, nothing asserted from memory.)
+% ============================================================================
+
+table magnetic_flux_to_weber {
+    columns unit, weber
+
+    row (maxwell, 0.00000001)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/magnetic-flux-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/magnetic-flux-conversions.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% magnetic-flux-conversions.query.adj — worked example over the magnetic-flux table.
+% ============================================================================
+% The shape a consumer produces to convert a magnetic flux out of a traditional unit and
+% into SI before reasoning: it states NO arithmetic — it `import`s the grounded table and
+% asks the engine to look the factor up. The native adj-lang engine binds the row and
+% returns the weber value EXACTLY, with the NIST SP 811 B.9 citation as its proof.
+%
+% The first query HITS (the maxwell has a row); the second ABSTAINS honestly — the "gauss"
+% is a magnetic-flux-DENSITY unit (it converts to the tesla, a different quantity), so this
+% flux table has no row for it and the engine refuses to fabricate a cross-dimension factor.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli magnetic-flux-conversions.query.adj
+% ============================================================================
+
+import "magnetic-flux-conversions.adj"
+
+? magnetic_flux_to_weber(maxwell, $v)   % expect 0.00000001  (maxwell = 1.0 E-08 Wb, exact)
+? magnetic_flux_to_weber(gauss, $v)     % expect ABSTAIN     (gauss → tesla, a different quantity)


### PR DESCRIPTION
## What

Adds a **new NIST SP 811 Appendix B.9 conversion dimension** as an importable, byte-provenanced RS-5 `table`: **magnetic flux → weber**. One exact boldface row, transcribed verbatim:

```
maxwell (Mx)   1.0 E-08  →  0.00000001
```

Exact because the maxwell is *defined* as exactly 10⁻⁸ Wb (byte-verified via WebFetch against the cited [NIST B.9 page](https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9)). Each row lowers to a ground relation `magnetic_flux_to_weber(unit, wb)`, so exact lookup `? magnetic_flux_to_weber(maxwell, $v)` is the ordinary SLD binding query — returning the factor **with the table's citation** on the CPU, zero model calls.

## Not to be confused with magnetic-flux-*density*

Distinct from the already-shipped `magnetic-flux-density-conversions.adj` (gauss→tesla). Magnetic **flux** is the total field through a surface; flux **density** is the field per unit area (one weber over one square metre is one tesla). They are **different quantities**, so `? magnetic_flux_to_weber(gauss, $v)` — gauss being a flux-density unit that converts to the tesla, not the weber — **abstains** (`no_grounded_support`) rather than fabricating a cross-dimension factor.

## Files

- `reference/magnetic-flux-conversions.adj` — the cited RS-5 table (one exact row)
- `reference/magnetic-flux-conversions.query.adj` — worked example (hit + honest abstain)
- `adj-lang-cli/tests/rs5_table_e2e.rs` — new **(b21)** block asserting the exact factor resolves with the NIST locator and a wrong-dimension unit abstains

## Verification

- `cargo test -p adj-lang-cli --test rs5_table_e2e` → **26 passed**
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean
- shipped `.query.adj` run through the built CLI renders `maxwell → 0.00000001` Wb with the NIST locator + `trust: authoritative`, and `gauss → abstained: true`
- NUL-scan clean; `/security-review` → passed

**Data + test only; no engine change, so no version bump.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)