### PR TITLE
feat(adj-formula-stdlib): ejection-fraction — StatPearls EF = SV/EDV clinical formulabook (cardiac track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_ejection_fraction_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_ejection_fraction_e2e.rs
@@ -1,0 +1,142 @@
+//! End-to-end tests for the `clinical/ejection-fraction.adj` library — the definition of the
+//! (left-ventricular) ejection fraction (ejection fraction = stroke volume / end-diastolic
+//! volume) and its two exact rearrangements (stroke volume = EF × EDV, end-diastolic
+//! volume = SV / EF) — driven through the built CLI binary against the SHIPPED stdlib. Each
+//! proves the same invariant as the other formula libraries: a consumer states NO arithmetic;
+//! it imports the grounded library, binds the measured quantities with `observe`, and the
+//! engine applies the cited relation on the CPU, computing the EXACT value and rendering the
+//! relation's citation and trust tier in the `derived` section (the auditable answer). The
+//! three formulas INVERT around the worked case SV = 3 mL, EDV = 6 mL: 3 / 6 = 0.5, and both
+//! 0.5 × 6 = 3 and 3 / 0.5 = 6 recover the inputs.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped ejection-fraction library, resolved from this crate's manifest
+/// dir so the test is location-independent.
+fn shipped_ef_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/ejection-fraction.adj")
+        .canonicalize()
+        .expect("shipped ejection-fraction.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_ef_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_ef_lib()).unwrap();
+    std::fs::write(dir.join("ejection-fraction.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// ejection_fraction — the definition: the stroke volume as a fraction of the end-diastolic
+// volume.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_ef_library_and_computes_ejection_fraction_with_citation() {
+    let dir = scratch("ef");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"ejection-fraction.adj\"\n\
+         observe stroke_volume(3)\n\
+         observe end_diastolic_volume(6)\n\
+         ? ejection_fraction(stroke_volume, end_diastolic_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 3 / 6 = 0.5.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"ejection_fraction\"") && s.contains("\"value\":0.5"),
+        "ejection_fraction(3, 6) = 0.5: {s}"
+    );
+    // … AND the StatPearls/NCBI Bookshelf citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// stroke_volume — the same relation solved for SV: EF × EDV, which INVERTS the ejection
+// fraction just produced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_stroke_volume_from_ef_and_edv_with_citation() {
+    let dir = scratch("sv");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"ejection-fraction.adj\"\n\
+         observe ejection_fraction(0.5)\n\
+         observe end_diastolic_volume(6)\n\
+         ? stroke_volume(ejection_fraction, end_diastolic_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 0.5 * 6 = 3, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"stroke_volume\"") && s.contains("\"value\":3"),
+        "stroke_volume(0.5, 6) = 3: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "stroke_volume carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// end_diastolic_volume — the same relation solved for EDV: SV / EF, the third exact reading
+// of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_end_diastolic_volume_from_sv_and_ef_with_citation() {
+    let dir = scratch("edv");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"ejection-fraction.adj\"\n\
+         observe stroke_volume(3)\n\
+         observe ejection_fraction(0.5)\n\
+         ? end_diastolic_volume(stroke_volume, ejection_fraction)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 3 / 0.5 = 6, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"end_diastolic_volume\"") && s.contains("\"value\":6"),
+        "end_diastolic_volume(3, 0.5) = 6: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "end_diastolic_volume carries its StatPearls citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/ejection-fraction.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/ejection-fraction.adj
@@ -1,0 +1,109 @@
+% ============================================================================
+% ejection-fraction.adj — the definition of the (left-ventricular) ejection fraction
+% (ejection fraction = stroke volume / end-diastolic volume) in the ADJ standard library.
+% ============================================================================
+% The ejection-fraction entry of the *clinical* track, a cardiac-physiology library. Where
+% the lung-volume libraries ground respiratory SUMS and the hemodynamics libraries ground
+% pressure differences, this grounds a cardiac RATIO: THE EJECTION FRACTION IS THE STROKE
+% VOLUME DIVIDED BY THE END-DIASTOLIC VOLUME — the fraction of the blood present in the
+% ventricle at the end of filling (the end-diastolic volume, EDV) that is actually ejected
+% on the next beat (the stroke volume, SV, the volume the ventricle expels in one
+% contraction). It ships as an importable, byte-provenanced, PARAMETERIZED `formula`,
+% together with its two exact rearrangements (the stroke volume an ejection fraction implies
+% for a given filling volume, and the end-diastolic volume implied by a stroke volume at a
+% given ejection fraction). As with every compute library, a consumer states NO arithmetic:
+% it `import`s this file, binds the measured quantities from its own byte-provenance
+% decomposition, and asks the engine to APPLY the cited definition on the CPU. Zero math is
+% performed by the model; the engine computes each value EXACTLY, carrying the definition's
+% citation.
+%
+%     import "ejection-fraction.adj"
+%     observe stroke_volume(3)              % "…stroke volume 3…"         (span cited by the model)
+%     observe end_diastolic_volume(6)       % "…end-diastolic volume 6…"  (span cited by the model)
+%     ? ejection_fraction(stroke_volume, end_diastolic_volume)
+%                                            % engine → 0.5, carrying EF = SV / EDV
+%
+% NOTE ON THE PERCENTAGE: the ejection fraction is a pure fraction of a volume by a volume
+% (dimensionless); clinically it is usually REPORTED as that fraction times 100, i.e. a
+% percentage (an EF of 0.5 is reported as "50%"). This library computes the underlying
+% dimensionless FRACTION exactly (0.5 here); a consumer that wants the percentage multiplies
+% by 100 downstream. Grounding the bare fraction keeps the relation an exact ratio with no
+% embedded scale constant, so it inverts cleanly.
+%
+% All three formulas are EXACT over their parameters (a ratio and its two algebraic
+% rearrangements), so every value the engine returns is exact. The three COMPOSE and invert
+% cleanly around the worked case SV = 3, EDV = 6 (EF = 3 / 6 = 0.5): the `ejection_fraction`
+% a consumer computes from the two volumes is exactly the `ejection_fraction` the
+% `stroke_volume` formula multiplies the end-diastolic volume by, to recover the 3 stroke
+% volume, and exactly the `ejection_fraction` the `end_diastolic_volume` formula divides the
+% stroke volume by to recover the 6 end-diastolic volume.
+%
+%   ejection_fraction(stroke_volume, end_diastolic_volume)
+%       = stroke_volume / end_diastolic_volume      % EF = SV / EDV   (definition)
+%   stroke_volume(ejection_fraction, end_diastolic_volume)
+%       = ejection_fraction * end_diastolic_volume   % SV = EF × EDV   (same def, solved for SV)
+%   end_diastolic_volume(stroke_volume, ejection_fraction)
+%       = stroke_volume / ejection_fraction          % EDV = SV / EF   (same def, solved for EDV)
+%
+% NOTE ON UNITS: the two volumes must be in the SAME unit (both millilitres, say); the
+% ejection fraction that comes out is DIMENSIONLESS (a volume divided by a volume). The two
+% rearrangements return a volume in whatever unit the volume input carried.
+%
+% All three formulas are defended by the SAME defining span — "LVEF is the fraction of blood
+% ejected from the left ventricle during systole (stroke volume [SV]) relative to the volume
+% of blood present at the end of diastole (end-diastolic volume [EDV])" — because that one
+% definition (the ejection fraction IS the stroke volume as a fraction of the end-diastolic
+% volume) sanctions the relation read every way (the fraction from the two volumes, the
+% stroke volume from the fraction and the filling volume, or the filling volume from the
+% stroke volume and the fraction). The span is transcribed verbatim from the StatPearls
+% "Left Ventricular Ejection Fraction" article on the NCBI Bookshelf, so each `formula`
+% carries the provenance envelope every shipped grounded clause carries; the linter rejects
+% an unsourced one. (See feedback_nothing_human_authored — the defining span is a verbatim
+% quote of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `stroke_volume` and `end_diastolic_volume` are observable cardiac volumes the
+% definition ranges over; `ejection_fraction` is the derived dimensionless ratio. Each term
+% appears BOTH as a derived result and as an input (of the other formulas), so each is a
+% single dictionary term used in both roles. The `surface` lists are the everyday names a
+% decomposer maps onto the canonical term.
+% ----------------------------------------------------------------------------
+dictionary ejection_fraction_vocab {
+    define stroke_volume        : finding  surface "stroke volume", "SV"                    % millilitres (mL)
+    define end_diastolic_volume : finding  surface "end-diastolic volume", "EDV"            % millilitres (mL)
+    define ejection_fraction    : finding  surface "ejection fraction", "EF", "LVEF"        % dimensionless fraction
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable formula over its
+% formal parameters, bound at apply time, and each carries the defining span from StatPearls
+% on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an exact
+% ratio/product of measured quantities, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook ejection_fraction_laws {
+    use ejection_fraction_vocab
+
+    % Ejection fraction — the stroke volume as a fraction of the end-diastolic volume,
+    % i.e. EF = SV / EDV.
+    formula ejection_fraction(stroke_volume, end_diastolic_volume) = stroke_volume / end_diastolic_volume
+        source "LVEF is the fraction of blood ejected from the left ventricle during systole (stroke volume [SV]) relative to the volume of blood present at the end of diastole (end-diastolic volume [EDV])"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459131/"
+        trust authoritative
+
+    % Stroke volume — the same definition solved for the stroke volume an ejection fraction
+    % implies at a given end-diastolic volume (SV = EF × EDV). Defended by the SAME defining
+    % span, read the other way.
+    formula stroke_volume(ejection_fraction, end_diastolic_volume) = ejection_fraction * end_diastolic_volume
+        source "LVEF is the fraction of blood ejected from the left ventricle during systole (stroke volume [SV]) relative to the volume of blood present at the end of diastole (end-diastolic volume [EDV])"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459131/"
+        trust authoritative
+
+    % End-diastolic volume — the same definition solved for the filling volume a stroke volume
+    % implies at a given ejection fraction (EDV = SV / EF). Again the SAME defining span, read
+    % the third way.
+    formula end_diastolic_volume(stroke_volume, ejection_fraction) = stroke_volume / ejection_fraction
+        source "LVEF is the fraction of blood ejected from the left ventricle during systole (stroke volume [SV]) relative to the volume of blood present at the end of diastole (end-diastolic volume [EDV])"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK459131/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/ejection-fraction.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/ejection-fraction.query.adj
@@ -1,0 +1,33 @@
+% ============================================================================
+% ejection-fraction.query.adj — worked examples over the clinical ejection-fraction library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER an ejection-fraction
+% question: it states NO arithmetic and NO relation — it only `import`s the grounded library,
+% `observe`s the quantities it decomposed from the prompt (each a byte-provenanced span,
+% elided here), and asks the engine to APPLY the cited definition. The native adj-lang engine
+% binds the parameters, computes each value EXACTLY on the CPU, and returns it with the
+% definition's source/locator/trust.
+%
+% The three questions INVERT: a stroke volume of 3 mL out of an end-diastolic volume of 6 mL
+% gives an ejection fraction of 3 / 6 = 0.5; that 0.5 ejection fraction times the same 6 mL
+% end-diastolic volume is exactly what the stroke-volume formula recovers the 3 mL from, and
+% that 3 mL stroke volume divided by the same 0.5 ejection fraction is exactly what the
+% end-diastolic-volume formula recovers the 6 mL from.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli ejection-fraction.query.adj
+% ============================================================================
+
+import "ejection-fraction.adj"
+
+% SV 3 mL, EDV 6 mL: ejection fraction = 3 / 6.
+observe stroke_volume(3)
+observe end_diastolic_volume(6)
+? ejection_fraction(stroke_volume, end_diastolic_volume)   % expect 0.5  (EF = SV / EDV)
+
+% That 0.5 ejection fraction with the same 6 mL end-diastolic volume: SV = 0.5 × 6.
+observe ejection_fraction(0.5)
+? stroke_volume(ejection_fraction, end_diastolic_volume)   % expect 3  (same def, solved for SV = EF × EDV)
+
+% That 3 mL stroke volume with the same 0.5 ejection fraction: EDV = 3 / 0.5.
+? end_diastolic_volume(stroke_volume, ejection_fraction)   % expect 6  (same def, solved for EDV = SV / EF)


### PR DESCRIPTION
## What

Adds the **(left-ventricular) ejection fraction** as an importable, byte-provenanced clinical `formulabook` — the first cardiac **ratio** inverter in the clinical track:

- `ejection_fraction(SV, EDV) = SV / EDV` — **EF = SV / EDV** (the definition)
- `stroke_volume(EF, EDV) = EF × EDV` — SV = EF × EDV (solved for SV)
- `end_diastolic_volume(SV, EF) = SV / EF` — EDV = SV / EF (solved for EDV)

## Grounding

All three formulas are defended by the **same verbatim defining span** — *"LVEF is the fraction of blood ejected from the left ventricle during systole (stroke volume [SV]) relative to the volume of blood present at the end of diastole (end-diastolic volume [EDV])"* — transcribed exactly from the StatPearls *"Left Ventricular Ejection Fraction"* article on the NCBI Bookshelf ([NBK459131](https://www.ncbi.nlm.nih.gov/books/NBK459131/)), byte-verified via WebFetch.

The library grounds the **bare dimensionless fraction** (0.5), not the ×100 percentage presentation, so the relation carries no embedded scale constant and inverts cleanly. As with every compute library, a consumer states **no arithmetic**: it imports the file, `observe`s the measured volumes, and the engine applies the cited definition on the CPU — computing each value **exactly** (BigRational) and carrying `source`/`locator`/`trust authoritative` into the `derived` section.

## Worked case

SV = 3 mL, EDV = 6 mL → EF = 3 / 6 = **0.5**; and 0.5 × 6 = 3, 3 / 0.5 = 6 recover the inputs.

## Files

- `clinical/ejection-fraction.adj` — dictionary + formulabook (3 formulas)
- `clinical/ejection-fraction.query.adj` — worked-example consumer
- `adj-lang-cli/tests/formula_ejection_fraction_e2e.rs` — 3 e2e tests driving the built CLI against the shipped stdlib

## Verification

- `cargo test -p adj-lang-cli --test formula_ejection_fraction_e2e` → **3 passed**
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean
- shipped `.query.adj` run through the built CLI renders EF=0.5 / SV=3 / EDV=6 with the NBK459131 citation + `trust: authoritative`
- NUL-scan clean; `/security-review` → passed

**Data + test only; no engine change, so no version bump.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)