### PR TITLE
Add MOS sidewall grading coefficient

### DIFF
--- a/code/packages/python/mosfet-models/CHANGELOG.md
+++ b/code/packages/python/mosfet-models/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [0.1.0] — Unreleased
 
 ### Added
+- `Level1Params.MJSW` adds Berkeley sidewall-junction depletion grading,
+  defaulting to `0.33` independently from bottom-junction `MJ`.
 - `Level1Params.PS` adds zero-default Berkeley source diffusion perimeter,
   contributing `CJSW * PS` to the zero-bias source-body capacitance.
 - `Level1Params.PD` and `Level1Params.CJSW` add zero-default Berkeley drain

--- a/code/packages/python/mosfet-models/README.md
+++ b/code/packages/python/mosfet-models/README.md
@@ -24,14 +24,16 @@ print(r.Id, r.gm, r.gds, r.region)
 
 - `Level1Params`: Level-1 DC, geometry, capacitance, and noise parameters with
   sane defaults for 130 nm-style NMOS, including zero-default `LD` lateral
-  diffusion through `L_eff = L - 2*LD`, `PB` / `MJ` / `FC` bulk-junction
-  depletion shaping, Berkeley-default `TOX` gate oxide thickness for intrinsic
+  diffusion through `L_eff = L - 2*LD`, `PB` / `MJ` / `MJSW` / `FC`
+  bulk-junction depletion shaping, Berkeley-default `TOX` gate oxide thickness
+  for intrinsic
   Meyer capacitance through `Cox = epsilon_ox / TOX`, zero-default `RD` / `RS`
   external drain/source resistance, zero-default `RSH` sheet resistance,
   one-default `NRD` / `NRS` drain/source diffusion square counts, zero-default
   drain/source diffusion areas `AD` / `AS`, perimeters `PD` / `PS`, and
   bottom/sidewall junction capacitance densities `CJ` / `CJSW` contributing
   `CJ * AD + CJSW * PD` to `CBD` and `CJ * AS + CJSW * PS` to `CBS`, and
+  independent bottom/sidewall depletion grading through `MJ` / `MJSW`, plus
   `KF` / `AF` flicker noise.
 - `evaluate_level1(params, V_GS, V_DS, V_BS, T)`: returns `MosResult` with Id, gm, gds, gmb, Cgs/Cgd/Cgb/Cbs/Cbd, region.
 - Region detection: cutoff (subthreshold-aware), triode, saturation.

--- a/code/packages/python/mosfet-models/src/mosfet_models/level1.py
+++ b/code/packages/python/mosfet-models/src/mosfet_models/level1.py
@@ -50,6 +50,7 @@ class Level1Params:
     CBD: float = 0.0  # drain-bulk zero-bias junction capacitance (F)
     PB: float = 0.8  # bulk junction potential (V)
     MJ: float = 0.5  # bulk junction grading coefficient
+    MJSW: float = 0.33  # sidewall junction grading coefficient
     FC: float = 0.5  # forward-bias depletion transition coefficient
     KF: float = 0.0  # flicker-noise coefficient
     AF: float = 1.0  # flicker-noise drain-current exponent
@@ -155,6 +156,8 @@ def evaluate_level1(
         raise ValueError("MOSFET CJ must be finite and non-negative")
     if not isfinite(p.CJSW) or p.CJSW < 0.0:
         raise ValueError("MOSFET CJSW must be finite and non-negative")
+    if not isfinite(p.MJSW) or p.MJSW < 0.0:
+        raise ValueError("MOSFET MJSW must be finite and non-negative")
     beta = p.KP * (p.W / effective_length)
 
     # Threshold with body effect. The formula is well-defined whenever
@@ -177,18 +180,20 @@ def evaluate_level1(
     Cgd_intrinsic = 0.0
     Cgb_intrinsic = 0.0
     Cbs_bulk = bulk_junction_capacitance(
-        p.CBS + p.CJ * p.AS + p.CJSW * p.PS,
+        p.CBS + p.CJ * p.AS,
         V_BS,
         p.PB,
         p.MJ,
         p.FC,
-    )
+    ) + bulk_junction_capacitance(p.CJSW * p.PS, V_BS, p.PB, p.MJSW, p.FC)
     Cbd_bulk = bulk_junction_capacitance(
-        p.CBD + p.CJ * p.AD + p.CJSW * p.PD,
+        p.CBD + p.CJ * p.AD,
         V_BS - V_DS,
         p.PB,
         p.MJ,
         p.FC,
+    ) + bulk_junction_capacitance(
+        p.CJSW * p.PD, V_BS - V_DS, p.PB, p.MJSW, p.FC
     )
 
     if V_OV <= 0:

--- a/code/packages/python/mosfet-models/tests/test_models.py
+++ b/code/packages/python/mosfet-models/tests/test_models.py
@@ -243,6 +243,15 @@ def test_source_perimeter_scales_sidewall_junction_capacitance():
     assert result.Cbs == pytest.approx(7.0e-12)
 
 
+def test_sidewall_grading_coefficient_shapes_reverse_bias_capacitance():
+    result = evaluate_level1(
+        Level1Params(PD=1.0e-6, CJSW=4.0e-6, MJ=0.0, MJSW=0.5, PB=1.0),
+        V_GS=0.0,
+        V_DS=1.0,
+    )
+    assert result.Cbd == pytest.approx(4.0e-12 / (2.0 ** 0.5))
+
+
 @pytest.mark.parametrize(
     ("params", "message"),
     [
@@ -252,6 +261,7 @@ def test_source_perimeter_scales_sidewall_junction_capacitance():
         (Level1Params(PS=-1.0), "MOSFET PS must be finite and non-negative"),
         (Level1Params(CJ=-1.0), "MOSFET CJ must be finite and non-negative"),
         (Level1Params(CJSW=-1.0), "MOSFET CJSW must be finite and non-negative"),
+        (Level1Params(MJSW=-1.0), "MOSFET MJSW must be finite and non-negative"),
     ],
 )
 def test_drain_geometry_rejects_negative_values(params, message):

--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add Level-1 MOS model-card `MJSW`, defaulting to `0.33`, to shape `CJSW`
+  sidewall depletion independently from `MJ` bottom-junction capacitance.
 - Add the Level-1 MOS `PS` instance parameter. With model-card `CJSW`, its
   product augments `CBS` in AC and transient source-body capacitance.
 - Add the Level-1 MOS `PD` instance parameter and model-card `CJSW` density.

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -105,8 +105,10 @@ positive `RD` / `RS` values take precedence.
 `AD`, `AS`, `PD`, `PS`, and model-card `CJ` / `CJSW` default to zero and are
 finite and non-negative. They add `CJ * AD + CJSW * PD` to drain-body `CBD`
 and `CJ * AS + CJSW * PS` to source-body `CBS` in AC and transient analysis.
+`MJ` shapes bottom-junction depletion while `MJSW` defaults to `0.33` and
+independently shapes the sidewall terms.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
-for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
+for `CBS` / `CBD` depletion capacitance shaped by `PB`, `MJ`, and `MJSW`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.
 `dc_temperature_sweep()` and `dc_temperature_sweep_corners()` run
 `.temp`-style DC operating-point snapshots across explicit analysis

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -9183,11 +9183,17 @@ def _mosfet_charge_dynamic_capacitance(
         return zero_bias_capacitance
     junction_potential = getattr(params, "PB", 0.8)
     grading_coefficient = getattr(params, "MJ", 0.5)
+    sidewall_grading_coefficient = getattr(params, "MJSW", 0.33)
     forward_bias_coefficient = getattr(params, "FC", 0.5)
     if not math.isfinite(junction_potential) or junction_potential <= 0.0:
         raise ValueError(f"{el.name}: MOSFET PB must be finite and positive")
     if not math.isfinite(grading_coefficient) or grading_coefficient < 0.0:
         raise ValueError(f"{el.name}: MOSFET MJ must be finite and non-negative")
+    if (
+        not math.isfinite(sidewall_grading_coefficient)
+        or sidewall_grading_coefficient < 0.0
+    ):
+        raise ValueError(f"{el.name}: MOSFET MJSW must be finite and non-negative")
     if (
         not math.isfinite(forward_bias_coefficient)
         or forward_bias_coefficient < 0.0
@@ -9196,11 +9202,31 @@ def _mosfet_charge_dynamic_capacitance(
         raise ValueError(f"{el.name}: MOSFET FC must be finite and in [0, 1)")
     mosfet_type = getattr(el.model, "type", None)
     junction_voltage = state_voltage if mosfet_type == MosfetType.PMOS else -state_voltage
+    if state_name == _mosfet_source_body_charge_state_name(el):
+        bottom_capacitance = getattr(params, "CBS", 0.0) + (
+            getattr(params, "CJ", 0.0) * getattr(params, "AS", 0.0)
+        )
+        sidewall_capacitance = getattr(params, "CJSW", 0.0) * getattr(
+            params, "PS", 0.0
+        )
+    else:
+        bottom_capacitance = getattr(params, "CBD", 0.0) + (
+            getattr(params, "CJ", 0.0) * getattr(params, "AD", 0.0)
+        )
+        sidewall_capacitance = getattr(params, "CJSW", 0.0) * getattr(
+            params, "PD", 0.0
+        )
     return bulk_junction_capacitance(
-        zero_bias_capacitance,
+        bottom_capacitance,
         junction_voltage,
         junction_potential,
         grading_coefficient,
+        forward_bias_coefficient,
+    ) + bulk_junction_capacitance(
+        sidewall_capacitance,
+        junction_voltage,
+        junction_potential,
+        sidewall_grading_coefficient,
         forward_bias_coefficient,
     )
 

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -311,8 +311,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "PNP": (41, 58, 13, 4),
     "NJF": (22, 30, 7, 3),
     "PJF": (22, 30, 7, 3),
-    "NMOS": (28, 35, 6, 3),
-    "PMOS": (28, 35, 6, 3),
+    "NMOS": (29, 36, 6, 3),
+    "PMOS": (29, 36, 6, 3),
 }
 
 
@@ -484,6 +484,7 @@ _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
     "CJSW": "CJSW",
     "PB": "PB",
     "MJ": "MJ",
+    "MJSW": "MJSW",
     "FC": "FC",
     "KF": "KF",
     "AF": "AF",
@@ -1091,6 +1092,7 @@ def mosfet_from_model_card(
         CJSW=p.get("CJSW", defaults.CJSW),
         PB=p.get("PB", defaults.PB),
         MJ=p.get("MJ", defaults.MJ),
+        MJSW=p.get("MJSW", defaults.MJSW),
         FC=p.get("FC", defaults.FC),
         KF=p.get("KF", defaults.KF),
         AF=p.get("AF", defaults.AF),

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -408,7 +408,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 197
+    assert len(coverage) == 199
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -423,7 +423,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tAF\tAF\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 197
+    assert len(records) == 199
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -446,8 +446,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert summary[0].max_alias_count == 3
     assert summary[0].aliased_parameters == ("IS", "VT", "CJO", "VJ", "M")
     assert summary[5].kind == "NMOS"
-    assert summary[5].canonical_parameter_count == 28
-    assert summary[5].accepted_name_count == 35
+    assert summary[5].canonical_parameter_count == 29
+    assert summary[5].accepted_name_count == 36
     assert summary[5].aliased_parameter_count == 6
     assert summary[5].max_alias_count == 3
     assert summary[5].aliased_parameters == (
@@ -469,7 +469,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert table.splitlines()[1] == "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M"
     assert (
         table.splitlines()[-1]
-        == "PMOS\t28\t35\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        == "PMOS\t29\t36\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
     )
     records = model_card_supported_parameter_coverage_summary_records()
     assert len(records) == 7
@@ -497,9 +497,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 197
-    assert report.expected_canonical_parameter_count == 197
-    assert report.accepted_name_count == 267
+    assert report.canonical_parameter_count == 199
+    assert report.expected_canonical_parameter_count == 199
+    assert report.accepted_name_count == 269
     assert report.aliased_parameter_count == 57
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -507,7 +507,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t197\t197\t267\t57\t4\t0"
+        "true\t7\t7\t199\t199\t269\t57\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -535,15 +535,15 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 196
-    assert report.accepted_name_count == 264
+    assert report.canonical_parameter_count == 198
+    assert report.accepted_name_count == 266
     assert report.aliased_parameter_count == 56
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
     assert report.issues[0].field == "canonical_parameter_count"
     assert report.issues[0].message == (
-        "expected NMOS to expose 28 canonical supported parameters, found 27"
+        "expected NMOS to expose 29 canonical supported parameters, found 28"
     )
     assert report.issues[-1].field == "max_alias_count"
     assert report.issues[-1].message == "expected NMOS max alias count 3, found 2"
@@ -551,12 +551,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t196\t197\t264\t56\t4\t4\n"
+        "false\t7\t7\t198\t199\t266\t56\t4\t4\n"
         "kind\tfield\tmessage\n"
-        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 28 canonical "
-        "supported parameters, found 27\n"
-        "NMOS\taccepted_name_count\texpected NMOS to expose 35 accepted model-card "
-        "names, found 32\n"
+        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 29 canonical "
+        "supported parameters, found 28\n"
+        "NMOS\taccepted_name_count\texpected NMOS to expose 36 accepted model-card "
+        "names, found 33\n"
         "NMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing "
         "parameters, found 5\n"
         "NMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
@@ -565,12 +565,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
     assert records[0] == {
         "kind": "NMOS",
         "field": "canonical_parameter_count",
-        "message": "expected NMOS to expose 28 canonical supported parameters, found 27",
+        "message": "expected NMOS to expose 29 canonical supported parameters, found 28",
     }
     assert format_model_card_supported_parameter_coverage_gate_issue_csv(report).startswith(
         "kind,field,message\n"
-        'NMOS,canonical_parameter_count,"expected NMOS to expose 28 canonical '
-        'supported parameters, found 27"\n'
+        'NMOS,canonical_parameter_count,"expected NMOS to expose 29 canonical '
+        'supported parameters, found 28"\n'
     )
     assert (
         json.loads(format_model_card_supported_parameter_coverage_gate_issue_json(report))
@@ -746,6 +746,7 @@ def test_model_card_aliases_build_device_instances() -> None:
             "CJD": 3.0e-13,
             "PB": 0.9,
             "MJ": 0.45,
+            "MJSW": 0.25,
             "FC": 0.4,
             "LD": 50.0e-9,
             "RD": 125.0,
@@ -766,6 +767,7 @@ def test_model_card_aliases_build_device_instances() -> None:
         "CBD": 3.0e-13,
         "PB": 0.9,
         "MJ": 0.45,
+        "MJSW": 0.25,
         "FC": 0.4,
         "LD": 50.0e-9,
         "RD": 125.0,
@@ -785,6 +787,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(3.0e-13) == mos_model.model.model.params.CBD
     assert pytest.approx(0.9) == mos_model.model.model.params.PB
     assert pytest.approx(0.45) == mos_model.model.model.params.MJ
+    assert pytest.approx(0.25) == mos_model.model.model.params.MJSW
     assert pytest.approx(0.4) == mos_model.model.model.params.FC
     assert pytest.approx(50.0e-9) == mos_model.model.model.params.LD
     assert pytest.approx(125.0) == mos_model.model.model.params.RD
@@ -1999,6 +2002,48 @@ def test_transient_mosfet_bulk_junction_depletion_shaping_reduces_reverse_bias_c
     assert shaped_first < 1.7
 
 
+def test_transient_mosfet_sidewall_grading_coefficient_shapes_reverse_bias_capacitance() -> None:
+    def run(grading_coefficient: float) -> TransientResult:
+        circuit = Circuit()
+        circuit.add(VoltageSource(
+            "Vstep",
+            "in",
+            "0",
+            1.0,
+            waveform=PwlWaveform(((0.0, 1.0), (1.0e-9, 2.0), (5.0e-9, 2.0))),
+        ))
+        circuit.add(Resistor("Rin", "in", "drain", 1_000.0))
+        circuit.add(Mosfet(
+            "M1",
+            "drain",
+            "0",
+            "0",
+            "0",
+            MOSFET(
+                MosfetType.NMOS,
+                Level1Model(Level1Params(
+                    KP=1.0e-12,
+                    W=1.0,
+                    L=1.0,
+                    PD=1.0,
+                    CJSW=1.0e-12,
+                    PB=1.0,
+                    MJSW=grading_coefficient,
+                )),
+            ),
+        ))
+        return transient(circuit, t_stop=5.0e-9, t_step=1.0e-9, method="euler")
+
+    fixed = run(0.0)
+    shaped = run(0.5)
+    assert fixed.converged
+    assert shaped.converged
+    assert (
+        shaped.points[1].node_voltages["drain"]
+        > fixed.points[1].node_voltages["drain"] + 0.04
+    )
+
+
 def test_transient_mosfet_forward_bias_depletion_coefficient_shapes_bulk_charge() -> None:
     def first_drain_voltage(fc: float) -> float:
         circuit = Circuit()
@@ -2053,6 +2098,25 @@ def test_mosfet_rejects_invalid_forward_bias_depletion_coefficient(fc: float) ->
     ))
 
     with pytest.raises(ValueError, match=r"MOSFET FC must be finite and in \[0, 1\)"):
+        dc_op(circuit)
+
+
+@pytest.mark.parametrize("mjsw", [float("nan"), -1.0])
+def test_mosfet_rejects_invalid_sidewall_grading_coefficient(mjsw: float) -> None:
+    circuit = Circuit()
+    circuit.add(Mosfet(
+        "Mbad",
+        "drain",
+        "gate",
+        "0",
+        "0",
+        MOSFET(MosfetType.NMOS, Level1Model(Level1Params(MJSW=mjsw))),
+    ))
+
+    with pytest.raises(
+        ValueError,
+        match="MOSFET MJSW must be finite and non-negative",
+    ):
         dc_op(circuit)
 
 
@@ -3274,6 +3338,7 @@ def test_subcircuit_expansion_preserves_mos_geometry():
                             AD=4.0e-12,
                             AS=5.0e-12,
                             PS=6.0e-6,
+                            MJSW=0.25,
                             CJ=2.0e-3,
                             TOX=25.0e-9,
                         )
@@ -3299,6 +3364,7 @@ def test_subcircuit_expansion_preserves_mos_geometry():
     assert pytest.approx(4.0e-12) == expanded.model.model.params.AD
     assert pytest.approx(5.0e-12) == expanded.model.model.params.AS
     assert pytest.approx(6.0e-6) == expanded.model.model.params.PS
+    assert pytest.approx(0.25) == expanded.model.model.params.MJSW
     assert pytest.approx(2.0e-3) == expanded.model.model.params.CJ
     assert pytest.approx(25.0e-9) == expanded.model.model.params.TOX
 
@@ -6112,6 +6178,38 @@ def test_ac_mosfet_source_perimeter_scales_sidewall_capacitance():
 
     assert without_sidewall_capacitance > 0.9
     assert with_sidewall_capacitance < without_sidewall_capacitance / 100.0
+
+
+def test_ac_mosfet_sidewall_grading_coefficient_shapes_reverse_bias_capacitance():
+    def source_amplitude(grading_coefficient: float) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vac", "in", "0", 1.0, ac=AcSource(1.0)))
+        circuit.add(Resistor("Rin", "in", "source", 1000.0))
+        circuit.add(Mosfet(
+            "M1",
+            "0",
+            "0",
+            "source",
+            "0",
+            MOSFET(
+                MosfetType.NMOS,
+                Level1Model(Level1Params(
+                    KP=1.0e-12,
+                    W=1.0,
+                    L=1.0,
+                    TOX=1.0e9,
+                    CJSW=0.5,
+                    PS=2.0e-6,
+                    MJSW=grading_coefficient,
+                )),
+            ),
+        ))
+        result = ac_sweep(circuit, f_start=100000.0, f_stop=100000.0, n_points=1)
+        return abs(result.points[0].node_voltages["source"])
+
+    fixed = source_amplitude(0.0)
+    shaped = source_amplitude(0.5)
+    assert shaped > fixed * 1.3
 
 
 def test_ac_mosfet_oxide_thickness_scales_intrinsic_gate_capacitance():
@@ -12411,7 +12509,7 @@ def test_distortion_text_output_table_is_stable() -> None:
                         harmonic=2,
                         frequency=2000.0,
                         magnitude=0.025,
-                        phase_degrees=-1.5707963267948966,
+                        phase_degrees=-1.5707963269948966,
                     ),
                 ],
                 total_harmonic_distortion=0.025,
@@ -12446,7 +12544,7 @@ def test_corner_distortion_text_output_table_is_stable() -> None:
                                     2,
                                     2000.0,
                                     0.025,
-                                    -1.5707963267948966,
+                                    -1.5707963269948966,
                                 ),
                             ],
                             total_harmonic_distortion=0.025,

--- a/code/packages/rust/mosfet-models/CHANGELOG.md
+++ b/code/packages/rust/mosfet-models/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `Level1Params::mjsw` adds Berkeley sidewall-junction depletion grading,
+  defaulting to `0.33` independently from bottom-junction `MJ`.
 - `Level1Params::ps` adds zero-default Berkeley source diffusion perimeter,
   contributing `CJSW * PS` to the zero-bias source-body capacitance.
 - `Level1Params::pd` and `Level1Params::cjsw` add zero-default Berkeley drain

--- a/code/packages/rust/mosfet-models/README.md
+++ b/code/packages/rust/mosfet-models/README.md
@@ -1,6 +1,6 @@
 # mosfet-models
 
-SPICE Level-1 (Shockley) MOSFET I-V model with full small-signal parameter extraction, body effect, subthreshold conduction, and PMOS sign conventions. Bulk-junction capacitance supports Berkeley `PB`, `MJ`, and `FC` depletion shaping.
+SPICE Level-1 (Shockley) MOSFET I-V model with full small-signal parameter extraction, body effect, subthreshold conduction, and PMOS sign conventions. Bulk-junction capacitance supports Berkeley `PB`, `MJ`, `MJSW`, and `FC` depletion shaping.
 
 ## What it does
 
@@ -36,7 +36,8 @@ default to zero ohms. `NRD` and `NRS` are finite, non-negative drain/source
 diffusion square counts and default to one.
 `AD`, `AS`, `PD`, `PS`, `CJ`, and `CJSW` are finite, non-negative and default
 to zero. They add `CJ * AD + CJSW * PD` to drain-body `CBD` and
-`CJ * AS + CJSW * PS` to source-body `CBS`.
+`CJ * AS + CJSW * PS` to source-body `CBS`. `MJ` shapes bottom-junction
+depletion while `MJSW` defaults to `0.33` and shapes the sidewall terms.
 
 ## Usage
 

--- a/code/packages/rust/mosfet-models/src/lib.rs
+++ b/code/packages/rust/mosfet-models/src/lib.rs
@@ -118,6 +118,8 @@ pub struct Level1Params {
     pub pb: f64,
     /// Bulk-junction grading coefficient.
     pub mj: f64,
+    /// Sidewall-junction grading coefficient.
+    pub mjsw: f64,
     /// Forward-bias depletion-capacitance transition coefficient.
     pub fc: f64,
     /// Flicker-noise coefficient.
@@ -161,6 +163,7 @@ impl Default for Level1Params {
             cbd: 0.0,
             pb: 0.8,
             mj: 0.5,
+            mjsw: 0.33,
             fc: 0.5,
             kf: 0.0,
             af: 1.0,
@@ -332,6 +335,10 @@ pub fn evaluate_level1(
         p.cjsw.is_finite() && p.cjsw >= 0.0,
         "MOSFET CJSW must be finite and non-negative"
     );
+    assert!(
+        p.mjsw.is_finite() && p.mjsw >= 0.0,
+        "MOSFET MJSW must be finite and non-negative"
+    );
     let beta = p.kp * (p.w / effective_length);
 
     // Threshold with body effect.
@@ -353,15 +360,10 @@ pub fn evaluate_level1(
 
     // Meyer gate-to-channel capacitance, partitioned by operating region below.
     let channel_capacitance = p.w * effective_length * (OXIDE_PERMITTIVITY / p.tox);
-    let cbs_bulk =
-        bulk_junction_capacitance(p.cbs + p.cj * p.as_ + p.cjsw * p.ps, v_bs, p.pb, p.mj, p.fc);
-    let cbd_bulk = bulk_junction_capacitance(
-        p.cbd + p.cj * p.ad + p.cjsw * p.pd,
-        v_bs - v_ds,
-        p.pb,
-        p.mj,
-        p.fc,
-    );
+    let cbs_bulk = bulk_junction_capacitance(p.cbs + p.cj * p.as_, v_bs, p.pb, p.mj, p.fc)
+        + bulk_junction_capacitance(p.cjsw * p.ps, v_bs, p.pb, p.mjsw, p.fc);
+    let cbd_bulk = bulk_junction_capacitance(p.cbd + p.cj * p.ad, v_bs - v_ds, p.pb, p.mj, p.fc)
+        + bulk_junction_capacitance(p.cjsw * p.pd, v_bs - v_ds, p.pb, p.mjsw, p.fc);
 
     // -----------------------------------------------------------------------
     // Cutoff / subthreshold

--- a/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
+++ b/code/packages/rust/mosfet-models/tests/test_mosfet_models.rs
@@ -316,6 +316,25 @@ fn test_source_perimeter_scales_sidewall_junction_capacitance() {
 }
 
 #[test]
+fn test_sidewall_grading_coefficient_shapes_reverse_bias_capacitance() {
+    let result = evaluate_level1(
+        &Level1Params {
+            pd: 1.0e-6,
+            cjsw: 4.0e-6,
+            mj: 0.0,
+            mjsw: 0.5,
+            pb: 1.0,
+            ..Level1Params::default()
+        },
+        0.0,
+        1.0,
+        0.0,
+        300.15,
+    );
+    assert!((result.cbd - 4.0e-12 / 2.0_f64.sqrt()).abs() < 1.0e-24);
+}
+
+#[test]
 #[should_panic(expected = "MOSFET AD must be finite and non-negative")]
 fn test_drain_area_rejects_negative_value() {
     let _ = evaluate_level1(
@@ -366,6 +385,21 @@ fn test_source_perimeter_rejects_negative_value() {
     let _ = evaluate_level1(
         &Level1Params {
             ps: -1.0,
+            ..Level1Params::default()
+        },
+        1.8,
+        1.8,
+        0.0,
+        300.15,
+    );
+}
+
+#[test]
+#[should_panic(expected = "MOSFET MJSW must be finite and non-negative")]
+fn test_sidewall_grading_coefficient_rejects_negative_value() {
+    let _ = evaluate_level1(
+        &Level1Params {
+            mjsw: -1.0,
             ..Level1Params::default()
         },
         1.8,

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add Level-1 MOS model-card `MJSW`, defaulting to `0.33`, to shape `CJSW`
+  sidewall depletion independently from `MJ` bottom-junction capacitance.
 - Add the Level-1 MOS `PS` instance parameter. With model-card `CJSW`, its
   product augments `CBS` in AC and transient source-body capacitance.
 - Add the Level-1 MOS `PD` instance parameter and model-card `CJSW` density.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -146,8 +146,10 @@ positive `RD` / `RS` values take precedence.
 `AD`, `AS`, `PD`, `PS`, and model-card `CJ` / `CJSW` default to zero and are
 finite and non-negative. They add `CJ * AD + CJSW * PD` to drain-body `CBD`
 and `CJ * AS + CJSW * PS` to source-body `CBS` in AC and transient analysis.
+`MJ` shapes bottom-junction depletion while `MJSW` defaults to `0.33` and
+independently shapes the sidewall terms.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
-for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
+for `CBS` / `CBD` depletion capacitance shaped by `PB`, `MJ`, and `MJSW`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.
 
 `normalize_model_card`, `diode_from_model_card`, `bjt_from_model_card`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3630,6 +3630,7 @@ pub struct MosfetLevel1Params {
     pub drain_bulk_capacitance: f64,
     pub bulk_junction_potential: f64,
     pub bulk_junction_grading_coefficient: f64,
+    pub sidewall_junction_grading_coefficient: f64,
     pub forward_bias_depletion_coefficient: f64,
     pub flicker_noise_coefficient: f64,
     pub flicker_noise_exponent: f64,
@@ -3668,6 +3669,7 @@ impl Default for MosfetLevel1Params {
             drain_bulk_capacitance: 0.0,
             bulk_junction_potential: 0.8,
             bulk_junction_grading_coefficient: 0.5,
+            sidewall_junction_grading_coefficient: 0.33,
             forward_bias_depletion_coefficient: 0.5,
             flicker_noise_coefficient: 0.0,
             flicker_noise_exponent: 1.0,
@@ -4014,8 +4016,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     (ModelCardKind::Pnp, 41, 58, 13, 4),
     (ModelCardKind::Njf, 22, 30, 7, 3),
     (ModelCardKind::Pjf, 22, 30, 7, 3),
-    (ModelCardKind::Nmos, 28, 35, 6, 3),
-    (ModelCardKind::Pmos, 28, 35, 6, 3),
+    (ModelCardKind::Nmos, 29, 36, 6, 3),
+    (ModelCardKind::Pmos, 29, 36, 6, 3),
 ];
 const DIODE_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IS", "IS"),
@@ -4165,6 +4167,7 @@ const MOS_LEVEL1_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("CJSW", "CJSW"),
     ("PB", "PB"),
     ("MJ", "MJ"),
+    ("MJSW", "MJSW"),
     ("FC", "FC"),
     ("KF", "KF"),
     ("AF", "AF"),
@@ -4977,6 +4980,9 @@ pub fn mosfet_from_model_card(
     }
     if let Some(value) = model.parameters.get("MJ") {
         params.bulk_junction_grading_coefficient = *value;
+    }
+    if let Some(value) = model.parameters.get("MJSW") {
+        params.sidewall_junction_grading_coefficient = *value;
     }
     if let Some(value) = model.parameters.get("FC") {
         params.forward_bias_depletion_coefficient = *value;
@@ -24319,21 +24325,29 @@ fn evaluate_nmos_level1(
     let channel_capacitance =
         params.w * effective_length * (OXIDE_PERMITTIVITY / params.oxide_thickness);
     let cbs_bulk = mosfet_bulk_junction_capacitance(
-        params.source_bulk_capacitance
-            + params.bottom_junction_capacitance * params.source_area
-            + params.sidewall_junction_capacitance * params.source_perimeter,
+        params.source_bulk_capacitance + params.bottom_junction_capacitance * params.source_area,
         vbs,
         params.bulk_junction_potential,
         params.bulk_junction_grading_coefficient,
         params.forward_bias_depletion_coefficient,
+    ) + mosfet_bulk_junction_capacitance(
+        params.sidewall_junction_capacitance * params.source_perimeter,
+        vbs,
+        params.bulk_junction_potential,
+        params.sidewall_junction_grading_coefficient,
+        params.forward_bias_depletion_coefficient,
     );
     let cbd_bulk = mosfet_bulk_junction_capacitance(
-        params.drain_bulk_capacitance
-            + params.bottom_junction_capacitance * params.drain_area
-            + params.sidewall_junction_capacitance * params.drain_perimeter,
+        params.drain_bulk_capacitance + params.bottom_junction_capacitance * params.drain_area,
         vbs - vds,
         params.bulk_junction_potential,
         params.bulk_junction_grading_coefficient,
+        params.forward_bias_depletion_coefficient,
+    ) + mosfet_bulk_junction_capacitance(
+        params.sidewall_junction_capacitance * params.drain_perimeter,
+        vbs - vds,
+        params.bulk_junction_potential,
+        params.sidewall_junction_grading_coefficient,
         params.forward_bias_depletion_coefficient,
     );
     let threshold = if params.phi - vbs >= 0.0 {
@@ -25137,11 +25151,30 @@ fn mosfet_charge_dynamic_capacitance(
         MosfetType::Pmos => state_voltage,
         MosfetType::Nmos => -state_voltage,
     };
+    let (bottom_capacitance, sidewall_capacitance) = match spec.kind {
+        MosfetChargeStateKind::SourceBody => (
+            mosfet.params.source_bulk_capacitance
+                + mosfet.params.bottom_junction_capacitance * mosfet.params.source_area,
+            mosfet.params.sidewall_junction_capacitance * mosfet.params.source_perimeter,
+        ),
+        MosfetChargeStateKind::DrainBody => (
+            mosfet.params.drain_bulk_capacitance
+                + mosfet.params.bottom_junction_capacitance * mosfet.params.drain_area,
+            mosfet.params.sidewall_junction_capacitance * mosfet.params.drain_perimeter,
+        ),
+        _ => unreachable!(),
+    };
     mosfet_bulk_junction_capacitance(
-        spec.capacitance,
+        bottom_capacitance,
         junction_voltage,
         mosfet.params.bulk_junction_potential,
         mosfet.params.bulk_junction_grading_coefficient,
+        mosfet.params.forward_bias_depletion_coefficient,
+    ) + mosfet_bulk_junction_capacitance(
+        sidewall_capacitance,
+        junction_voltage,
+        mosfet.params.bulk_junction_potential,
+        mosfet.params.sidewall_junction_grading_coefficient,
         mosfet.params.forward_bias_depletion_coefficient,
     )
 }
@@ -25714,6 +25747,7 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         ("CBD", params.drain_bulk_capacitance),
         ("PB", params.bulk_junction_potential),
         ("MJ", params.bulk_junction_grading_coefficient),
+        ("MJSW", params.sidewall_junction_grading_coefficient),
         ("FC", params.forward_bias_depletion_coefficient),
         ("KF", params.flicker_noise_coefficient),
         ("AF", params.flicker_noise_exponent),
@@ -25833,6 +25867,12 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: mosfet.name.clone(),
             reason: "MOSFET PB must be positive and MJ must be non-negative".to_string(),
+        });
+    }
+    if params.sidewall_junction_grading_coefficient < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET MJSW must be non-negative".to_string(),
         });
     }
     if !(0.0..1.0).contains(&params.forward_bias_depletion_coefficient) {

--- a/code/packages/rust/spice-engine/tests/ac_tests.rs
+++ b/code/packages/rust/spice-engine/tests/ac_tests.rs
@@ -1520,6 +1520,46 @@ fn ac_mosfet_source_perimeter_scales_sidewall_junction_capacitance() {
 }
 
 #[test]
+fn ac_mosfet_sidewall_grading_coefficient_shapes_reverse_bias_capacitance() {
+    fn source_amplitude(grading_coefficient: f64) -> f64 {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_ac(
+            "Vac", "in", "0", 1.0, 1.0, 0.0,
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "source", 1_000.0,
+        )));
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "M1",
+            "0",
+            "0",
+            "source",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                kp: 1.0e-12,
+                w: 1.0,
+                l: 1.0,
+                oxide_thickness: 1.0e9,
+                source_perimeter: 2.0e-6,
+                sidewall_junction_capacitance: 0.5,
+                sidewall_junction_grading_coefficient: grading_coefficient,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+
+        ac_sweep(&circuit, 100_000.0, 100_000.0, 1).unwrap()[0]
+            .voltage("source")
+            .unwrap()
+            .abs()
+    }
+
+    let fixed = source_amplitude(0.0);
+    let shaped = source_amplitude(0.5);
+    assert!(shaped > fixed * 1.3);
+}
+
+#[test]
 fn ac_mosfet_oxide_thickness_scales_intrinsic_gate_capacitance() {
     let gate_amplitude = |oxide_thickness| {
         let mut circuit = Circuit::new();

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -95,7 +95,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 197);
+    assert_eq!(coverage.len(), 199);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -114,7 +114,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tAF\tAF\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 197);
+    assert_eq!(records.len(), 199);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -147,8 +147,8 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         vec!["IS", "VT", "CJO", "VJ", "M"]
     );
     assert_eq!(summary[5].kind, ModelCardKind::Nmos);
-    assert_eq!(summary[5].canonical_parameter_count, 28);
-    assert_eq!(summary[5].accepted_name_count, 35);
+    assert_eq!(summary[5].canonical_parameter_count, 29);
+    assert_eq!(summary[5].accepted_name_count, 36);
     assert_eq!(summary[5].aliased_parameter_count, 6);
     assert_eq!(summary[5].max_alias_count, 3);
     assert_eq!(
@@ -166,7 +166,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     assert_eq!(lines[1], "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\t28\t35\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        &"PMOS\t29\t36\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
     );
     let records = model_card_supported_parameter_coverage_summary_records();
     assert_eq!(records.len(), 7);
@@ -184,7 +184,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         "[{\"kind\":\"D\",\"canonical_parameter_count\":\"15\",\"accepted_name_count\":\"21\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
     ));
     assert!(json.ends_with(
-        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"28\",\"accepted_name_count\":\"35\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
+        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"29\",\"accepted_name_count\":\"36\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
     ));
 }
 
@@ -195,15 +195,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 197);
-    assert_eq!(report.expected_canonical_parameter_count, 197);
-    assert_eq!(report.accepted_name_count, 267);
+    assert_eq!(report.canonical_parameter_count, 199);
+    assert_eq!(report.expected_canonical_parameter_count, 199);
+    assert_eq!(report.accepted_name_count, 269);
     assert_eq!(report.aliased_parameter_count, 57);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t197\t197\t267\t57\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t199\t199\t269\t57\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -230,8 +230,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 196);
-    assert_eq!(report.accepted_name_count, 264);
+    assert_eq!(report.canonical_parameter_count, 198);
+    assert_eq!(report.accepted_name_count, 266);
     assert_eq!(report.aliased_parameter_count, 56);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -239,7 +239,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     assert_eq!(report.issues[0].field, "canonical_parameter_count");
     assert_eq!(
         report.issues[0].message,
-        "expected NMOS to expose 28 canonical supported parameters, found 27"
+        "expected NMOS to expose 29 canonical supported parameters, found 28"
     );
     assert_eq!(report.issues.last().unwrap().field, "max_alias_count");
     assert_eq!(
@@ -248,20 +248,20 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t196\t197\t264\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 28 canonical supported parameters, found 27\nNMOS\taccepted_name_count\texpected NMOS to expose 35 accepted model-card names, found 32\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t198\t199\t266\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 29 canonical supported parameters, found 28\nNMOS\taccepted_name_count\texpected NMOS to expose 36 accepted model-card names, found 33\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
     assert_eq!(records[0]["field"], "canonical_parameter_count");
     assert_eq!(
         records[0]["message"],
-        "expected NMOS to expose 28 canonical supported parameters, found 27"
+        "expected NMOS to expose 29 canonical supported parameters, found 28"
     );
     assert!(format_model_card_supported_parameter_coverage_gate_issue_csv(&report).starts_with(
-        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 28 canonical supported parameters, found 27\"\n"
+        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 29 canonical supported parameters, found 28\"\n"
     ));
     assert!(format_model_card_supported_parameter_coverage_gate_issue_json(&report).starts_with(
-        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 28 canonical supported parameters, found 27\"}"
+        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 29 canonical supported parameters, found 28\"}"
     ));
 }
 
@@ -283,8 +283,8 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(dashboard[0].issue_count, 0);
     assert!(dashboard[0].issue_fields.is_empty());
     assert_eq!(dashboard[5].kind, ModelCardKind::Nmos);
-    assert_eq!(dashboard[5].canonical_parameter_count, 28);
-    assert_eq!(dashboard[5].accepted_name_count, 35);
+    assert_eq!(dashboard[5].canonical_parameter_count, 29);
+    assert_eq!(dashboard[5].accepted_name_count, 36);
     assert_eq!(dashboard[5].issue_count, 0);
 
     let table = format_model_card_supported_parameter_coverage_dashboard_table(&coverage);
@@ -296,7 +296,7 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(lines[1], "D\ttrue\t15\t15\t21\t21\t5\t5\t3\t3\t0\t");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\ttrue\t28\t28\t35\t35\t6\t6\t3\t3\t0\t"
+        &"PMOS\ttrue\t29\t29\t36\t36\t6\t6\t3\t3\t0\t"
     );
     let records = model_card_supported_parameter_coverage_dashboard_records(&coverage);
     assert_eq!(records.len(), 7);
@@ -328,10 +328,10 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         .unwrap();
 
     assert!(!nmos.passed);
-    assert_eq!(nmos.canonical_parameter_count, 27);
-    assert_eq!(nmos.expected_canonical_parameter_count, 28);
-    assert_eq!(nmos.accepted_name_count, 32);
-    assert_eq!(nmos.expected_accepted_name_count, 35);
+    assert_eq!(nmos.canonical_parameter_count, 28);
+    assert_eq!(nmos.expected_canonical_parameter_count, 29);
+    assert_eq!(nmos.accepted_name_count, 33);
+    assert_eq!(nmos.expected_accepted_name_count, 36);
     assert_eq!(nmos.aliased_parameter_count, 5);
     assert_eq!(nmos.expected_aliased_parameter_count, 6);
     assert_eq!(nmos.max_alias_count, 2);
@@ -347,7 +347,7 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         ]
     );
     assert!(format_model_card_supported_parameter_coverage_dashboard_table(&coverage).contains(
-        "NMOS\tfalse\t27\t28\t32\t35\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
+        "NMOS\tfalse\t28\t29\t33\t36\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
     ));
 }
 
@@ -592,6 +592,7 @@ fn model_card_aliases_build_device_instances() {
             ("CJD", 3.0e-13),
             ("PB", 0.9),
             ("MJ", 0.45),
+            ("MJSW", 0.25),
             ("FC", 0.4),
             ("LD", 50.0e-9),
             ("RD", 125.0),
@@ -611,6 +612,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*mos_card.parameters.get("CBD").unwrap(), 3.0e-13);
     assert_close(*mos_card.parameters.get("PB").unwrap(), 0.9);
     assert_close(*mos_card.parameters.get("MJ").unwrap(), 0.45);
+    assert_close(*mos_card.parameters.get("MJSW").unwrap(), 0.25);
     assert_close(*mos_card.parameters.get("FC").unwrap(), 0.4);
     assert_close(*mos_card.parameters.get("LD").unwrap(), 50.0e-9);
     assert_close(*mos_card.parameters.get("RD").unwrap(), 125.0);
@@ -627,6 +629,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(mos_model.params.drain_bulk_capacitance, 3.0e-13);
     assert_close(mos_model.params.bulk_junction_potential, 0.9);
     assert_close(mos_model.params.bulk_junction_grading_coefficient, 0.45);
+    assert_close(mos_model.params.sidewall_junction_grading_coefficient, 0.25);
     assert_close(mos_model.params.forward_bias_depletion_coefficient, 0.4);
     assert_close(mos_model.params.lateral_diffusion_length, 50.0e-9);
     assert_close(mos_model.params.drain_resistance, 125.0);
@@ -1805,6 +1808,7 @@ fn subcircuit_expansion_preserves_mos_geometry() {
             drain_area: 4.0e-12,
             source_area: 5.0e-12,
             source_perimeter: 6.0e-6,
+            sidewall_junction_grading_coefficient: 0.25,
             bottom_junction_capacitance: 2.0e-3,
             oxide_thickness: 25.0e-9,
             ..MosfetLevel1Params::default()
@@ -1854,6 +1858,7 @@ fn subcircuit_expansion_preserves_mos_geometry() {
     assert_close(expanded.params.drain_area, 4.0e-12);
     assert_close(expanded.params.source_area, 5.0e-12);
     assert_close(expanded.params.source_perimeter, 6.0e-6);
+    assert_close(expanded.params.sidewall_junction_grading_coefficient, 0.25);
     assert_close(expanded.params.bottom_junction_capacitance, 2.0e-3);
     assert_close(expanded.params.oxide_thickness, 25.0e-9);
 }
@@ -4186,6 +4191,38 @@ fn dc_mosfet_rejects_invalid_bottom_junction_capacitance() {
                     "MOSFET CJ must be non-negative".to_string()
                 } else {
                     "MOSFET CJ must be finite".to_string()
+                },
+            }
+        );
+    }
+}
+
+#[test]
+fn dc_mosfet_rejects_invalid_sidewall_grading_coefficient() {
+    for sidewall_junction_grading_coefficient in [f64::NAN, -1.0] {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "Mbad",
+            "drain",
+            "gate",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                sidewall_junction_grading_coefficient,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+
+        let err = dc_op(&circuit).unwrap_err();
+        assert_eq!(
+            err,
+            SpiceError::InvalidElement {
+                name: "Mbad".to_string(),
+                reason: if sidewall_junction_grading_coefficient.is_finite() {
+                    "MOSFET MJSW must be non-negative".to_string()
+                } else {
+                    "MOSFET MJSW must be finite".to_string()
                 },
             }
         );

--- a/code/packages/rust/spice-engine/tests/transient_tests.rs
+++ b/code/packages/rust/spice-engine/tests/transient_tests.rs
@@ -660,6 +660,52 @@ fn transient_mosfet_bulk_junction_depletion_shaping_reduces_reverse_bias_capacit
 }
 
 #[test]
+fn transient_mosfet_sidewall_grading_coefficient_shapes_reverse_bias_capacitance() {
+    fn run(grading_coefficient: f64) -> Vec<TransientPoint> {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::with_waveform(
+            "Vstep",
+            "in",
+            "0",
+            1.0,
+            Waveform::Pwl(PwlWaveform::new(vec![
+                (0.0, 1.0),
+                (1.0e-9, 2.0),
+                (5.0e-9, 2.0),
+            ])),
+        )));
+        circuit.add(Element::Resistor(Resistor::new(
+            "Rin", "in", "drain", 1_000.0,
+        )));
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "M1",
+            "drain",
+            "0",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                kp: 1.0e-12,
+                w: 1.0,
+                l: 1.0,
+                drain_perimeter: 1.0,
+                sidewall_junction_capacitance: 1.0e-12,
+                bulk_junction_potential: 1.0,
+                sidewall_junction_grading_coefficient: grading_coefficient,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+        transient_with_method(&circuit, 1.0e-9, 5.0e-9, TransientMethod::Euler).unwrap()
+    }
+
+    let fixed = run(0.0);
+    let shaped = run(0.5);
+    let fixed_first = fixed[0].voltage("drain").unwrap();
+    let shaped_first = shaped[0].voltage("drain").unwrap();
+    assert!(shaped_first > fixed_first + 0.04);
+}
+
+#[test]
 fn transient_mosfet_forward_bias_depletion_coefficient_shapes_bulk_charge() {
     fn first_drain_voltage(coefficient: f64) -> f64 {
         let mut circuit = Circuit::new();

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Accept Level-1 MOS model-card `MJSW=<grading>` through the normalized engine
+  model-card contract for independent sidewall depletion shaping.
 - Parse Level-1 MOS instance `PS=<perimeter>` into the engine parameter bundle
   for source-body sidewall capacitance.
 - Parse Level-1 MOS instance `PD=<perimeter>` and model-card

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -760,7 +760,7 @@ parameters, `.model <name> NPN|PNP(...)` BJT cards with `IS`, `BF` /
 `.model <name> NMOS|PMOS(...)` Level-1 MOSFET
 cards with common SPICE aliases (`VT0` / `VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
 `W`, `L`, `RSH`, `IS`, `N_SUB` / `NSUB`, `T_NOM` / `TNOM`, `CGSO`, `CGDO`,
-`CGBO`, `CBS`, `CBD`, `CJ`, and `CJSW`), MOS instance `NRD=<squares>` /
+`CGBO`, `CBS`, `CBD`, `CJ`, `CJSW`, and `MJSW`), MOS instance `NRD=<squares>` /
 `NRS=<squares>` / `AD=<area>` / `AS=<area>` / `PD=<perimeter>` /
 `PS=<perimeter>`, SPICE
 engineering suffixes, capacitor

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1940,6 +1940,7 @@ fn apply_mosfet_param(params: &mut MosfetLevel1Params, name: &str, value: f64) {
         "CBD" => params.drain_bulk_capacitance = value,
         "CJ" => params.bottom_junction_capacitance = value,
         "CJSW" => params.sidewall_junction_capacitance = value,
+        "MJSW" => params.sidewall_junction_grading_coefficient = value,
         _ => {}
     }
 }

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1359,7 +1359,7 @@ Jpull drain gate source pch
 fn parses_mosfet_models_into_operating_point_circuits() {
     let parsed = parse_netlist(
         r#"
-.model nch NMOS(VTO=0.45 KP=250u LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n RSH=250 NSUB=1.5 TNOM=300 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p CJ=2m CJSW=5u)
+.model nch NMOS(VTO=0.45 KP=250u LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n RSH=250 NSUB=1.5 TNOM=300 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p CJ=2m CJSW=5u MJSW=0.25)
 Vdd vdd 0 DC 5
 Vgate gate 0 DC 2.5
 M1 vdd gate out 0 nch W=4u L=200n NRD=2 NRS=3 AD=3n AS=4n PD=6u PS=7u
@@ -1401,6 +1401,7 @@ Rload out 0 1k
     assert_close(mosfet.params.source_perimeter, 7.0e-6);
     assert_close(mosfet.params.bottom_junction_capacitance, 2.0e-3);
     assert_close(mosfet.params.sidewall_junction_capacitance, 5.0e-6);
+    assert_close(mosfet.params.sidewall_junction_grading_coefficient, 0.25);
     assert_close(mosfet.params.n_sub, 1.5);
     assert_close(mosfet.params.t_nom, 300.0);
     assert_close(mosfet.params.gate_source_overlap_capacitance, 3.0e-12);

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add Level-1 MOS model-card `MJSW`, defaulting to `0.33`, to shape `CJSW`
+  sidewall depletion independently from `MJ` bottom-junction capacitance.
 - Add the Level-1 MOS `PS` instance parameter. With model-card `CJSW`, its
   product augments `CBS` in AC and transient source-body capacitance.
 - Add the Level-1 MOS `PD` instance parameter and model-card `CJSW` density.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -97,8 +97,10 @@ positive `RD` / `RS` values take precedence.
 `AD`, `AS`, `PD`, `PS`, and model-card `CJ` / `CJSW` default to zero and are
 finite and non-negative. They add `CJ * AD + CJSW * PD` to drain-body `CBD`
 and `CJ * AS + CJSW * PS` to source-body `CBS` in AC and transient analysis.
+`MJ` shapes bottom-junction depletion while `MJSW` defaults to `0.33` and
+independently shapes the sidewall terms.
 `FC` (default `0.5`) selects the continuous Berkeley forward-bias continuation
-for `CBS` / `CBD` depletion capacitance shaped by `PB` and `MJ`.
+for `CBS` / `CBD` depletion capacitance shaped by `PB`, `MJ`, and `MJSW`.
 All temperature coefficients honor model-card `TNOM` / `T_NOM`.
 `dcTemperatureSweep` and `dcTemperatureSweepCorners` run `.temp`-style DC
 operating-point snapshots across explicit analysis temperatures, with stable

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1798,6 +1798,7 @@ export interface MosfetLevel1Params {
   readonly CBD: number;
   readonly PB: number;
   readonly MJ: number;
+  readonly MJSW: number;
   readonly FC: number;
   readonly KF: number;
   readonly AF: number;
@@ -2060,8 +2061,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   PNP: [41, 58, 13, 4],
   NJF: [22, 30, 7, 3],
   PJF: [22, 30, 7, 3],
-  NMOS: [28, 35, 6, 3],
-  PMOS: [28, 35, 6, 3],
+  NMOS: [29, 36, 6, 3],
+  PMOS: [29, 36, 6, 3],
 };
 
 export interface Vccs {
@@ -8066,6 +8067,7 @@ export function defaultMosfetLevel1Params(): MosfetLevel1Params {
     CBD: 0.0,
     PB: 0.8,
     MJ: 0.5,
+    MJSW: 0.33,
     FC: 0.5,
     KF: 0.0,
     AF: 1.0,
@@ -8262,6 +8264,7 @@ const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   CJSW: "CJSW",
   PB: "PB",
   MJ: "MJ",
+  MJSW: "MJSW",
   FC: "FC",
   KF: "KF",
   AF: "AF",
@@ -8837,6 +8840,7 @@ export function mosfetFromModelCard(
     ...(p.CJSW !== undefined ? { CJSW: p.CJSW } : {}),
     ...(p.PB !== undefined ? { PB: p.PB } : {}),
     ...(p.MJ !== undefined ? { MJ: p.MJ } : {}),
+    ...(p.MJSW !== undefined ? { MJSW: p.MJSW } : {}),
     ...(p.FC !== undefined ? { FC: p.FC } : {}),
     ...(p.KF !== undefined ? { KF: p.KF } : {}),
     ...(p.AF !== undefined ? { AF: p.AF } : {}),
@@ -20342,12 +20346,18 @@ function evaluateNmosLevel1(
   const channelCapacitance =
     params.W * effectiveLength * (OXIDE_PERMITTIVITY / params.TOX);
   const cbsBulk = mosfetBulkJunctionCapacitance(
-    params.CBS + params.CJ * params.AS + params.CJSW * params.PS,
+    params.CBS + params.CJ * params.AS,
     vbs, params.PB, params.MJ, params.FC,
+  ) + mosfetBulkJunctionCapacitance(
+    params.CJSW * params.PS,
+    vbs, params.PB, params.MJSW, params.FC,
   );
   const cbdBulk = mosfetBulkJunctionCapacitance(
-    params.CBD + params.CJ * params.AD + params.CJSW * params.PD,
+    params.CBD + params.CJ * params.AD,
     vbs - vds, params.PB, params.MJ, params.FC,
+  ) + mosfetBulkJunctionCapacitance(
+    params.CJSW * params.PD,
+    vbs - vds, params.PB, params.MJSW, params.FC,
   );
   const capacitances = {
     cgs: cgsOverlap + channelCapacitance,
@@ -20976,11 +20986,23 @@ function mosfetChargeDynamicCapacitance(
     return spec.capacitance;
   }
   const junctionVoltage = element.type === "PMOS" ? stateVoltage : -stateVoltage;
+  const bottomCapacitance = spec.kind === "source-body"
+    ? element.params.CBS + element.params.CJ * element.params.AS
+    : element.params.CBD + element.params.CJ * element.params.AD;
+  const sidewallCapacitance = spec.kind === "source-body"
+    ? element.params.CJSW * element.params.PS
+    : element.params.CJSW * element.params.PD;
   return mosfetBulkJunctionCapacitance(
-    spec.capacitance,
+    bottomCapacitance,
     junctionVoltage,
     element.params.PB,
     element.params.MJ,
+    element.params.FC,
+  ) + mosfetBulkJunctionCapacitance(
+    sidewallCapacitance,
+    junctionVoltage,
+    element.params.PB,
+    element.params.MJSW,
     element.params.FC,
   );
 }
@@ -21191,6 +21213,9 @@ function validateMosfet(element: Mosfet): void {
   }
   if (params.PB <= 0.0 || params.MJ < 0.0) {
     throw invalidElement(element.name, "MOSFET PB must be positive and MJ must be non-negative");
+  }
+  if (params.MJSW < 0.0) {
+    throw invalidElement(element.name, "MOSFET MJSW must be non-negative");
   }
   if (params.FC < 0.0 || params.FC >= 1.0) {
     throw invalidElement(element.name, "MOSFET FC must be in [0, 1)");

--- a/code/packages/typescript/spice-engine/tests/ac.test.ts
+++ b/code/packages/typescript/spice-engine/tests/ac.test.ts
@@ -666,6 +666,28 @@ describe("acSweep", () => {
     expect(withSidewallCapacitance).toBeLessThan(withoutSidewallCapacitance / 100.0);
   });
 
+  it("uses MOSFET MJSW to shape reverse-biased sidewall capacitance", () => {
+    function sourceAmplitude(gradingCoefficient: number): number {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithAc("Vac", "in", "0", 1.0, 1.0));
+      circuit.add(resistor("Rin", "in", "source", 1_000.0));
+      circuit.add(mosfet("M1", "0", "0", "source", "0", "NMOS", {
+        KP: 1.0e-12,
+        W: 1.0,
+        L: 1.0,
+        TOX: 1.0e9,
+        CJSW: 0.5,
+        PS: 2.0e-6,
+        MJSW: gradingCoefficient,
+      }));
+      return complexAbs(acSweep(circuit, 100_000.0, 100_000.0, 1)[0].voltage("source")!);
+    }
+
+    const fixed = sourceAmplitude(0.0);
+    const shaped = sourceAmplitude(0.5);
+    expect(shaped).toBeGreaterThan(fixed * 1.3);
+  });
+
   it("uses MOSFET oxide thickness to scale intrinsic gate capacitance", () => {
     function gateAmplitude(TOX: number): number {
       const circuit = new Circuit();

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -121,7 +121,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(197);
+    expect(coverage).toHaveLength(199);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -141,7 +141,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tAF\tAF\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(197);
+    expect(records).toHaveLength(199);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -167,8 +167,8 @@ describe("dcOp", () => {
     });
     expect(summary[5]).toStrictEqual({
       kind: "NMOS",
-      canonicalParameterCount: 28,
-      acceptedNameCount: 35,
+      canonicalParameterCount: 29,
+      acceptedNameCount: 36,
       aliasedParameterCount: 6,
       maxAliasCount: 3,
       aliasedParameters: ["VT0", "LAMBDA", "N_SUB", "T_NOM", "CBS", "CBD"],
@@ -181,7 +181,7 @@ describe("dcOp", () => {
     );
     expect(table.split("\n")[1]).toBe("D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     expect(table.split("\n").at(-1)).toBe(
-      "PMOS\t28\t35\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
+      "PMOS\t29\t36\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
     );
     const records = modelCardSupportedParameterCoverageSummaryRecords();
     expect(records).toHaveLength(7);
@@ -206,15 +206,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 197,
-      expectedCanonicalParameterCount: 197,
-      acceptedNameCount: 267,
+      canonicalParameterCount: 199,
+      expectedCanonicalParameterCount: 199,
+      acceptedNameCount: 269,
       aliasedParameterCount: 57,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t197\t197\t267\t57\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t199\t199\t269\t57\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -237,15 +237,15 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(196);
-    expect(report.acceptedNameCount).toBe(264);
+    expect(report.canonicalParameterCount).toBe(198);
+    expect(report.acceptedNameCount).toBe(266);
     expect(report.aliasedParameterCount).toBe(56);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 28 canonical supported parameters, found 27",
+      message: "expected NMOS to expose 29 canonical supported parameters, found 28",
     });
     expect(report.issues.at(-1)).toStrictEqual({
       kind: "NMOS",
@@ -253,16 +253,16 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t196\t197\t264\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 28 canonical supported parameters, found 27\nNMOS\taccepted_name_count\texpected NMOS to expose 35 accepted model-card names, found 32\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t198\t199\t266\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 29 canonical supported parameters, found 28\nNMOS\taccepted_name_count\texpected NMOS to expose 36 accepted model-card names, found 33\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 28 canonical supported parameters, found 27",
+      message: "expected NMOS to expose 29 canonical supported parameters, found 28",
     });
     expect(formatModelCardSupportedParameterCoverageGateIssueCsv(report)).toMatch(
-      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 28 canonical supported parameters, found 27"\n/,
+      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 29 canonical supported parameters, found 28"\n/,
     );
     expect(JSON.parse(formatModelCardSupportedParameterCoverageGateIssueJson(report))).toStrictEqual(
       records,
@@ -417,6 +417,7 @@ describe("dcOp", () => {
       CJD: 3.0e-13,
       PB: 0.9,
       MJ: 0.45,
+      MJSW: 0.25,
       FC: 0.4,
       LD: 50.0e-9,
       RD: 125.0,
@@ -436,6 +437,7 @@ describe("dcOp", () => {
       CBD: 3.0e-13,
       PB: 0.9,
       MJ: 0.45,
+      MJSW: 0.25,
       FC: 0.4,
       LD: 50.0e-9,
       RD: 125.0,
@@ -453,6 +455,7 @@ describe("dcOp", () => {
     expectClose(mosModel.params.CBD, 3.0e-13);
     expectClose(mosModel.params.PB, 0.9);
     expectClose(mosModel.params.MJ, 0.45);
+    expectClose(mosModel.params.MJSW, 0.25);
     expectClose(mosModel.params.FC, 0.4);
     expectClose(mosModel.params.LD, 50.0e-9);
     expectClose(mosModel.params.RD, 125.0);
@@ -2648,6 +2651,20 @@ describe("dcOp", () => {
         Number.isFinite(sidewallCapacitance)
           ? "MOSFET CJSW must be non-negative"
           : "MOSFET CJSW must be finite",
+      );
+    }
+  });
+
+  it("rejects invalid MOSFET sidewall grading coefficients", () => {
+    for (const gradingCoefficient of [Number.NaN, -1.0]) {
+      const circuit = new Circuit();
+      circuit.add(mosfet("Mbad", "drain", "gate", "0", "0", "NMOS", {
+        MJSW: gradingCoefficient,
+      }));
+      expect(() => dcOp(circuit)).toThrowError(
+        Number.isFinite(gradingCoefficient)
+          ? "MOSFET MJSW must be non-negative"
+          : "MOSFET MJSW must be finite",
       );
     }
   });

--- a/code/packages/typescript/spice-engine/tests/transient.test.ts
+++ b/code/packages/typescript/spice-engine/tests/transient.test.ts
@@ -574,6 +574,38 @@ describe("transient", () => {
     expect(firstDrainVoltage(0.2)).toBeLessThan(firstDrainVoltage(0.8));
   });
 
+  it("uses MOSFET MJSW to shape reverse-biased sidewall charge", () => {
+    function run(gradingCoefficient: number): TransientPoint[] {
+      const circuit = new Circuit();
+      circuit.add(voltageSourceWithWaveform(
+        "Vstep",
+        "in",
+        "0",
+        1.0,
+        new PwlWaveform([
+          [0.0, 1.0],
+          [1.0e-9, 2.0],
+          [5.0e-9, 2.0],
+        ]),
+      ));
+      circuit.add(resistor("Rin", "in", "drain", 1_000.0));
+      circuit.add(mosfet("M1", "drain", "0", "0", "0", "NMOS", {
+        KP: 1.0e-12,
+        W: 1.0,
+        L: 1.0,
+        PD: 1.0,
+        CJSW: 1.0e-12,
+        PB: 1.0,
+        MJSW: gradingCoefficient,
+      }));
+      return transient(circuit, 1.0e-9, 5.0e-9, "euler");
+    }
+
+    const fixed = run(0.0)[0].voltage("drain")!;
+    const shaped = run(0.5)[0].voltage("drain")!;
+    expect(shaped).toBeGreaterThan(fixed + 0.04);
+  });
+
   it("uses diode transit time to hold forward charge on turnoff", () => {
     function run(transitTime: number): TransientPoint[] {
       const circuit = new Circuit();

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,14 +33,15 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS source diffusion perimeter.
+1. Cross-language Level-1 MOS sidewall grading coefficient.
    - Status: current PR completion candidate.
-   - Add the Berkeley Level-1 MOS `PS` instance parameter in Rust, Python, and
-     TypeScript, defaulting to zero.
-   - Use `CBS + CJ * AS + CJSW * PS` as the zero-bias source-body capacitance
-     in AC and transient analysis while preserving existing depletion shaping.
-   - Preserve `PS` through hierarchy and cloning, enforce finite non-negative
-     validation, and parse it in the Rust netlist facade.
+   - Add Berkeley Level-1 MOS model-card `MJSW` in Rust, Python, and TypeScript,
+     defaulting to `0.33`.
+   - Shape `CJSW * PD` and `CJSW * PS` independently from the `MJ`-controlled
+     bottom-junction terms in AC and transient analysis.
+   - Preserve `MJSW` through hierarchy and cloning, enforce finite non-negative
+     validation, parse it through the Rust netlist facade, and extend the
+     supported-parameter release gate.
 
 ## Completed Slices
 
@@ -3509,6 +3510,15 @@ the Rust, Python, and TypeScript surfaces together.
      AC and transient analysis while preserving depletion shaping.
    - Hierarchy and cloning preserve `PD` / `CJSW`, finite non-negative
      validation is shared, and the Rust netlist facade parses both.
+
+277. Cross-language Level-1 MOS source diffusion perimeter.
+   - Status: completed in PR 9064.
+   - Rust, Python, and TypeScript Level-1 MOS instances now accept `PS`,
+     defaulting to zero.
+   - `CBS + CJ * AS + CJSW * PS` supplies zero-bias source-body capacitance in
+     AC and transient analysis while preserving depletion shaping.
+   - Hierarchy and cloning preserve `PS`, finite non-negative validation is
+     shared, and the Rust netlist facade parses it.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Berkeley Level-1 MOS `MJSW` support across Rust, Python, and TypeScript with the SPICE default of `0.33`
- shape source/drain sidewall depletion capacitance independently from `MJ`-controlled bottom-junction capacitance in AC and transient analysis
- preserve and validate `MJSW` through model cards, hierarchy, cloning, and the Rust netlist facade; update package docs and the SPICE implementation ledger

## Verification
- Rust MOSFET models: 39 tests
- Rust SPICE AC: 59 tests
- Rust SPICE DC: 156 tests
- Rust SPICE transient: 113 tests
- Rust netlist parser: 95 tests
- Rust clippy for all touched packages with warnings denied
- scoped rustfmt check
- Python MOSFET models + SPICE engine: 710 tests
- TypeScript SPICE engine: 404 tests
- TypeScript build / `tsc`
- `git diff --check`