### PR TITLE
feat(gc-native): T5 PR-4 — native gc_register_ref_array_kind builtin (AOT00-T5 COMPLETE)

### DIFF
--- a/code/packages/rust/aarch64-backend/CHANGELOG.md
+++ b/code/packages/rust/aarch64-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — `aarch64-backend`
 
+## 0.33.0 - 2026-07-29 — `gc_register_ref_array_kind` builtin (frontend array GC, AOT00-T5 §7)
+
+- **`gc_register_ref_array_kind` `BuiltinSig` row** (`(fixed, fixed_count, tail_from) -> kind_id`)
+  — a `call_builtin` lowers to a `BL` to `__twig_gc_register_ref_array_kind` via the generic
+  `__twig_<name>` dispatch (three args in x0/x1/x2), the C-ABI seam a language frontend's **array**
+  type calls to declare its layout so the collector traces — and under compaction relocates — the
+  array + its elements precisely instead of pinning them. Adding the row is the whole change (no
+  per-name lowering). Test `gc_register_ref_array_kind_emits_external_twig_call`.
+
 ## 0.32.0 - 2026-07-27 — `gc_collect_incremental_*` builtin trio (frontend incremental GC, AOT00-T4 §6)
 
 - Three new `V1_BUILTINS` entries — `gc_collect_incremental_start` (0 args, void),

--- a/code/packages/rust/aarch64-backend/Cargo.toml
+++ b/code/packages/rust/aarch64-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aarch64-backend"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 description = "ARM64 (AArch64) backend for jit-core / aot-core — lowers CIR to native machine code via aarch64-encoder."
 

--- a/code/packages/rust/aarch64-backend/src/lib.rs
+++ b/code/packages/rust/aarch64-backend/src/lib.rs
@@ -269,6 +269,12 @@ const V1_BUILTINS: &[BuiltinSig] = &[
     BuiltinSig { name: "gc_collect_incremental_finish", n_args: 0, returns: true  },
     BuiltinSig { name: "gc_live_bytes",         n_args: 0, returns: true  },
     BuiltinSig { name: "gc_stackmap_count",     n_args: 0, returns: true  },
+    // AOT00-T5 — declare a variable-length reference-array layout so the collector traces (and
+    // under compaction relocates) the array + its elements precisely. `(fixed, fixed_count,
+    // tail_from) -> kind_id`: the seam a language frontend's array type calls; auto-emits
+    // `__twig_gc_register_ref_array_kind` via the generic `__twig_<name>` dispatch. Pass
+    // `fixed = 0, fixed_count = 0, tail_from = 0` for a pure reference array (every word a ref).
+    BuiltinSig { name: "gc_register_ref_array_kind", n_args: 3, returns: true },
 ];
 
 fn lookup_builtin(name: &str) -> Option<BuiltinSig> {
@@ -1245,7 +1251,8 @@ fn emit_instr(
                 "call_builtin '{name}': returns void but dest is Some",
             )));
         }
-        // AAPCS64 supplies 8 GPR arg slots — all V1 helpers fit in ≤ 2.
+        // AAPCS64 supplies 8 GPR arg slots — every builtin's arity fits (max is 3, for
+        // `gc_register_ref_array_kind`), so `ARG_REGS[i]` is always in range.
         const ARG_REGS: [Reg; 8] = [
             Reg::X0, Reg::X1, Reg::X2, Reg::X3,
             Reg::X4, Reg::X5, Reg::X6, Reg::X7,
@@ -2381,6 +2388,29 @@ mod tests {
         ] {
             assert!(symbols.contains(&want), "missing {want}: {symbols:?}");
         }
+    }
+
+    /// `call_builtin "gc_register_ref_array_kind" (fixed, fixed_count, tail_from) -> kind`
+    /// lowers to a `BL` to `__twig_gc_register_ref_array_kind` (the C-ABI seam a language
+    /// frontend's array type calls, spec AOT00-T5) via the generic `__twig_<name>` dispatch —
+    /// three args marshalled into x0/x1/x2. `(0, 0, 0)` declares a pure reference array.
+    #[test]
+    fn gc_register_ref_array_kind_emits_external_twig_call() {
+        let cir = vec![
+            const_u64("fixed", 0), // null fixed-offsets pointer
+            const_u64("fcount", 0), // no fixed ref fields
+            const_u64("tail", 0), // tail region from offset 0 — every word is a reference
+            call_builtin(Some("kind"), "gc_register_ref_array_kind", &["fixed", "fcount", "tail"]),
+            ret_u64("kind"),
+        ];
+        let (bytes, ext) = compile_with_relocs(&ctx("gc_refarray", &[], "u64"), &cir)
+            .unwrap_or_else(|e| panic!("gc_register_ref_array_kind must lower: {e}"));
+        assert!(!bytes.is_empty() && bytes.len() % 4 == 0);
+        let symbols: Vec<&str> = ext.iter().map(|r| r.symbol.as_str()).collect();
+        assert!(
+            symbols.contains(&"__twig_gc_register_ref_array_kind"),
+            "missing ref-array-kind registration call: {symbols:?}",
+        );
     }
 
     #[test]

--- a/code/packages/rust/gc-core-capi/CHANGELOG.md
+++ b/code/packages/rust/gc-core-capi/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this crate are documented here.
 
+## 0.20.0 - 2026-07-29 — twig-compat alias `__twig_gc_register_ref_array_kind` — PR-4 (AOT00-T5)
+
+- **`__twig_gc_register_ref_array_kind(fixed, fixed_count, tail_from)`** (new `twig_compat` alias
+  → `__gc_register_ref_array_kind`, 0.19.0) — the `__twig_gc_*` linker name the native code
+  generators emit for the `gc_register_ref_array_kind` builtin, so a language frontend's **array**
+  type can declare its layout (fixed ref fields + a variable reference tail) and have the
+  collector trace — and under compaction **relocate** — the array and its elements precisely
+  instead of pinning them. A plain forwarding alias (registers a kind; no allocation or stack
+  scan), mirroring `__twig_gc_alloc`.
+- **Test** `twig_register_ref_array_kind_alias_forwards`: an array allocated under the alias's
+  returned kind has its tail traced — an element in a tail slot is retained via the array and
+  reclaimed once the slot is cleared.
+- Completes the AOT00-T5 arc's native seam (PR-4 of 4): the backends' new
+  `gc_register_ref_array_kind` `BuiltinSig` row auto-emits this symbol.
+
 ## 0.19.0 - 2026-07-28 — C ABI `__gc_register_ref_array_kind` — PR-3 (AOT00-T5)
 
 - **`__gc_register_ref_array_kind(fixed, fixed_count, tail_from) -> kind_id`** (new `#[no_mangle]`

--- a/code/packages/rust/gc-core-capi/Cargo.toml
+++ b/code/packages/rust/gc-core-capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gc-core-capi"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "C ABI for gc-core's flat-native heap — the gc_runtime_<target> archive linked into native-AOT output (LANG16 / AOT00 T1)."
 license = "MIT"

--- a/code/packages/rust/gc-core-capi/src/twig_compat.rs
+++ b/code/packages/rust/gc-core-capi/src/twig_compat.rs
@@ -31,13 +31,33 @@ use crate::stack_scan::{
     __gc_collect_incremental_start, __gc_collect_incremental_step, __gc_collect_precise,
     __gc_safepoint,
 };
-use crate::{__gc_alloc, __gc_collection_count, __gc_live_bytes};
+use crate::{__gc_alloc, __gc_collection_count, __gc_live_bytes, __gc_register_ref_array_kind};
 
 /// `__twig_gc_alloc(n)` → [`__gc_alloc`]. Called by the emitted code and by
 /// `dynval_runtime.c` for every heap allocation.
 #[no_mangle]
 pub extern "C" fn __twig_gc_alloc(n: i64) -> i64 {
     __gc_alloc(n)
+}
+
+/// `__twig_gc_register_ref_array_kind(fixed, fixed_count, tail_from)` →
+/// [`__gc_register_ref_array_kind`]. The `__twig_gc_*` linker name a native code generator
+/// emits for the `gc_register_ref_array_kind` builtin — the seam a language frontend's **array**
+/// type calls to declare its layout (fixed ref fields + a variable reference tail), so the
+/// collector traces and, under compaction, **relocates** the array and its elements precisely
+/// instead of pinning them. Registers a kind; performs no allocation or stack scan.
+///
+/// # Safety
+///
+/// Same contract as [`__gc_register_ref_array_kind`]: `fixed` must point to `fixed_count`
+/// readable `int64` words (or be null with `fixed_count <= 0`).
+#[no_mangle]
+pub unsafe extern "C" fn __twig_gc_register_ref_array_kind(
+    fixed: *const i64,
+    fixed_count: i64,
+    tail_from: i64,
+) -> i64 {
+    __gc_register_ref_array_kind(fixed, fixed_count, tail_from)
 }
 
 /// `__twig_gc_collect()` → [`__gc_collect`] (return value discarded to match the
@@ -195,6 +215,40 @@ mod tests {
         assert_eq!(__twig_gc_collection_count(), 1);
         assert_eq!(unsafe { *(p as *const i64) }, 0x7161);
         core::hint::black_box(p);
+
+        __gc_reset();
+    }
+
+    /// `__twig_gc_register_ref_array_kind` forwards to the ref-array kind registration: an array
+    /// allocated under the returned kind has its reference **tail** traced, so an element stored
+    /// in a tail slot is retained via the array and reclaimed once that slot is cleared.
+    #[test]
+    fn twig_register_ref_array_kind_alias_forwards() {
+        let _guard = crate::TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        __gc_reset();
+
+        // Register a pure reference array (no fixed fields, tail from offset 0) via the twig alias.
+        let kind = unsafe { __twig_gc_register_ref_array_kind(core::ptr::null(), 0, 0) };
+        assert!(kind >= 1, "kind ids are 1-based");
+
+        let elem = __twig_gc_alloc(16);
+        let arr = crate::__gc_alloc_kind(16, kind as u16); // a 2-slot array of the registered kind
+        assert!(elem != 0 && arr != 0);
+        unsafe {
+            *(arr as *mut i64) = elem; // arr[0] = elem (a reference in the tail)
+            *((arr as usize + 8) as *mut i64) = 0; // arr[1] = null
+        }
+
+        // Root only the array: `elem` survives via the tail → 32 live bytes.
+        let roots = [arr];
+        let freed = unsafe { crate::__gc_collect_roots(roots.as_ptr(), 1) };
+        assert_eq!(freed, 0, "the element is retained via the array's reference tail");
+        assert_eq!(__twig_gc_live_bytes(), 32);
+
+        // Clear the tail slot → the element is reclaimed, proving the tail was traced.
+        unsafe { *(arr as *mut i64) = 0 };
+        let freed2 = unsafe { crate::__gc_collect_roots(roots.as_ptr(), 1) };
+        assert_eq!(freed2, 1, "clearing the tail slot reclaims the element");
 
         __gc_reset();
     }

--- a/code/packages/rust/x86_64-backend/CHANGELOG.md
+++ b/code/packages/rust/x86_64-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — `x86_64-backend`
 
+## 0.35.0 - 2026-07-29 — `gc_register_ref_array_kind` builtin (frontend array GC, AOT00-T5 §7)
+
+- **`gc_register_ref_array_kind` `BuiltinSig` row** (`(fixed, fixed_count, tail_from) -> kind_id`)
+  — a `call_builtin` lowers to a `call` to `__twig_gc_register_ref_array_kind` via the generic
+  `__twig_<name>` dispatch (three args in rdi/rsi/rdx), the C-ABI seam a language frontend's
+  **array** type calls to declare its layout so the collector traces — and under compaction
+  relocates — the array + its elements precisely instead of pinning them. Test
+  `gc_register_ref_array_kind_emits_external_twig_call` (SysV).
+
 ## 0.34.0 - 2026-07-27 — `gc_collect_incremental_*` builtin trio (frontend incremental GC, AOT00-T4 §6)
 
 - Three new `V1_BUILTINS` entries — `gc_collect_incremental_start` (0 args, void),

--- a/code/packages/rust/x86_64-backend/Cargo.toml
+++ b/code/packages/rust/x86_64-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x86_64-backend"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 description = "x86-64 (AMD64) backend for jit-core / aot-core — lowers CIR to native machine code via x86_64-encoder, with both System V (Linux) and Microsoft x64 (Windows) ABIs."
 

--- a/code/packages/rust/x86_64-backend/src/lib.rs
+++ b/code/packages/rust/x86_64-backend/src/lib.rs
@@ -415,6 +415,12 @@ const V1_BUILTINS: &[BuiltinSig] = &[
     BuiltinSig { name: "gc_collect_incremental_finish", n_args: 0, returns: true  },
     BuiltinSig { name: "gc_live_bytes",         n_args: 0, returns: true  },
     BuiltinSig { name: "gc_stackmap_count",     n_args: 0, returns: true  },
+    // AOT00-T5 — declare a variable-length reference-array layout so the collector traces (and
+    // under compaction relocates) the array + its elements precisely. `(fixed, fixed_count,
+    // tail_from) -> kind_id`: the seam a language frontend's array type calls; auto-emits
+    // `__twig_gc_register_ref_array_kind` via the generic `__twig_<name>` dispatch. Pass
+    // `fixed = 0, fixed_count = 0, tail_from = 0` for a pure reference array (every word a ref).
+    BuiltinSig { name: "gc_register_ref_array_kind", n_args: 3, returns: true },
 ];
 
 fn lookup_builtin(name: &str) -> Option<BuiltinSig> {
@@ -2248,6 +2254,30 @@ mod tests {
         ] {
             assert!(symbols.contains(&want), "missing {want}: {symbols:?}");
         }
+    }
+
+    /// `call_builtin "gc_register_ref_array_kind" (fixed, fixed_count, tail_from) -> kind`
+    /// lowers to a `call` to `__twig_gc_register_ref_array_kind` (the C-ABI seam a language
+    /// frontend's array type calls, spec AOT00-T5) via the generic `__twig_<name>` dispatch —
+    /// three args in rdi/rsi/rdx. `(0, 0, 0)` declares a pure reference array.
+    #[test]
+    fn gc_register_ref_array_kind_emits_external_twig_call() {
+        let ir = vec![
+            instr("const_u64", Some("fixed"), vec![Op::Int(0)]), // null fixed-offsets pointer
+            instr("const_u64", Some("fcount"), vec![Op::Int(0)]), // no fixed ref fields
+            instr("const_u64", Some("tail"), vec![Op::Int(0)]), // tail from offset 0 (all refs)
+            call_builtin(Some("kind"), "gc_register_ref_array_kind", &["fixed", "fcount", "tail"]),
+            instr("ret_u64", None, vec![Op::Var("kind".into())]),
+        ];
+        let (bytes, relocs) =
+            compile_function_with_relocs(&fn_ctx("gc_refarray", &[], "u64"), &ir, X86_64Abi::SysV)
+                .expect("gc_register_ref_array_kind must lower");
+        assert!(!bytes.is_empty());
+        let symbols: Vec<&str> = relocs.iter().map(|r| r.symbol.as_str()).collect();
+        assert!(
+            symbols.contains(&"__twig_gc_register_ref_array_kind"),
+            "missing ref-array-kind registration call: {symbols:?}",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## T5 PR-4: the native seam — AOT00-T5 complete

The final PR of the variable-length-reference-array arc. A language frontend's array type can now, **from compiled native code**, declare a ref-array layout so the collector traces — and under compaction **relocates** — the array and its elements precisely instead of pinning them.

### Change
- **gc-core-capi 0.20.0**: `__twig_gc_register_ref_array_kind(fixed, fixed_count, tail_from)` twig-compat alias → `__gc_register_ref_array_kind` (#9075). A plain forwarding wrapper (registers a kind; no allocation, no stack scan — so no `#[inline(never)]`, unlike the collect aliases). Test proves an array of the returned kind has its tail traced (element retained via a tail slot, reclaimed when cleared).
- **aarch64-backend 0.33.0 + x86_64-backend 0.35.0**: a `gc_register_ref_array_kind` `BuiltinSig` row (3 args, returns). A `call_builtin` auto-emits a `BL`/`call` to `__twig_gc_register_ref_array_kind` via the generic `__twig_<name>` dispatch (args in x0/x1/x2 · rdi/rsi/rdx) — adding the row is the whole change. Emission unit tests on both backends assert the external symbol.

### Scope note (why no bespoke exec differential)
Relocation of **kind-registered** objects is already proven end-to-end on hardware by the cons-cell compaction differential (#8936), and specifically for the ref-array *tail* by gc-core 0.23.0's in-Rust compaction test (an array + its elements relocate, tail slots fixed up). This PR delivers the native **registration seam** — the entry point a real frontend array type emits — rather than re-proving relocation through a new bespoke compiled program.

### Verification
- **72** aarch64 + **72** x86_64 + **35** capi tests pass, clippy clean, twig-aot builds.
- **Security review PASSED** — the alias adds no stack-scan concern; the `BuiltinSig` row's 3-arg marshalling (pointer-as-i64 in one GPR) is ABI-correct and can't overrun `ARG_REGS`; the only pointer deref is the already-reviewed, guarded `from_raw_parts` in `__gc_register_ref_array_kind`, carrying the identical trusted-frontend contract as `__gc_register_kind`.

**AOT00-T5 COMPLETE** (spec §7: PR-1 refactor #9061 · PR-2 arrays #9068 · PR-3 C ABI #9075 · PR-4 native seam). Variable-length reference arrays — JS/Ruby/Python's dominant heap object — are now precise and movable across gc-core, the C ABI, and the native code generators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)