### PR TITLE
feat(adj-formula-stdlib): glasgow-coma-scale — StatPearls GCS = E + V + M clinical formulabook (neuro/trauma track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_glasgow_coma_scale_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_glasgow_coma_scale_e2e.rs
@@ -1,0 +1,175 @@
+//! End-to-end tests for the `clinical/glasgow-coma-scale.adj` library — the definition of the
+//! total Glasgow Coma Scale score (GCS = eye + verbal + motor) and its three exact
+//! rearrangements (each element score = the total minus the other two) — driven through the
+//! built CLI binary against the SHIPPED stdlib. This is the first n-ary (three-input) clinical
+//! inverter: the same invariant as every other formula library, extended one dimension. A
+//! consumer states NO arithmetic; it imports the grounded library, binds the measured element
+//! scores with `observe`, and the engine applies the cited relation on the CPU, computing the
+//! EXACT value and rendering the relation's citation and trust tier in the `derived` section
+//! (the auditable answer). The four formulas INVERT around the worked case E = 4, V = 5,
+//! M = 6: 4 + 5 + 6 = 15, and 15 minus any two element scores recovers the third.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped glasgow-coma-scale library, resolved from this crate's manifest
+/// dir so the test is location-independent.
+fn shipped_gcs_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/glasgow-coma-scale.adj")
+        .canonicalize()
+        .expect("shipped glasgow-coma-scale.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_gcs_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_gcs_lib()).unwrap();
+    std::fs::write(dir.join("glasgow-coma-scale.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// glasgow_coma_scale — the definition: the sum of the three element scores.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_gcs_library_and_computes_total_with_citation() {
+    let dir = scratch("total");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"glasgow-coma-scale.adj\"\n\
+         observe eye_response(4)\n\
+         observe verbal_response(5)\n\
+         observe motor_response(6)\n\
+         ? glasgow_coma_scale(eye_response, verbal_response, motor_response)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 4 + 5 + 6 = 15.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"glasgow_coma_scale\"") && s.contains("\"value\":15"),
+        "glasgow_coma_scale(4, 5, 6) = 15: {s}"
+    );
+    // … AND the StatPearls/NCBI Bookshelf citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// eye_response — the same relation solved for E: GCS − V − M, which INVERTS the total.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_eye_response_from_total_and_others_with_citation() {
+    let dir = scratch("eye");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"glasgow-coma-scale.adj\"\n\
+         observe glasgow_coma_scale(15)\n\
+         observe verbal_response(5)\n\
+         observe motor_response(6)\n\
+         ? eye_response(glasgow_coma_scale, verbal_response, motor_response)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 15 - 5 - 6 = 4, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"eye_response\"") && s.contains("\"value\":4"),
+        "eye_response(15, 5, 6) = 4: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "eye_response carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// verbal_response — the same relation solved for V: GCS − E − M.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_verbal_response_from_total_and_others_with_citation() {
+    let dir = scratch("verbal");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"glasgow-coma-scale.adj\"\n\
+         observe glasgow_coma_scale(15)\n\
+         observe eye_response(4)\n\
+         observe motor_response(6)\n\
+         ? verbal_response(glasgow_coma_scale, eye_response, motor_response)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 15 - 4 - 6 = 5, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"verbal_response\"") && s.contains("\"value\":5"),
+        "verbal_response(15, 4, 6) = 5: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "verbal_response carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// motor_response — the same relation solved for M: GCS − E − V, the fourth reading of the one
+// definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_motor_response_from_total_and_others_with_citation() {
+    let dir = scratch("motor");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"glasgow-coma-scale.adj\"\n\
+         observe glasgow_coma_scale(15)\n\
+         observe eye_response(4)\n\
+         observe verbal_response(5)\n\
+         ? motor_response(glasgow_coma_scale, eye_response, verbal_response)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 15 - 4 - 5 = 6, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"motor_response\"") && s.contains("\"value\":6"),
+        "motor_response(15, 4, 5) = 6: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "motor_response carries its StatPearls citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/glasgow-coma-scale.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/glasgow-coma-scale.adj
@@ -1,0 +1,111 @@
+% ============================================================================
+% glasgow-coma-scale.adj — the definition of the total Glasgow Coma Scale score
+% (Glasgow Coma Scale = eye response + verbal response + motor response) in the ADJ
+% standard library.
+% ============================================================================
+% The glasgow-coma-scale entry of the *clinical* track, a neurology/trauma-assessment
+% library. Where the two-quantity clinical libraries ground a sum, difference, or ratio of
+% TWO measurements, this grounds a three-component SUM: THE TOTAL GLASGOW COMA SCALE SCORE
+% IS THE SUM OF ITS THREE ELEMENT SCORES — the eye-opening response (E), the verbal
+% response (V), and the motor response (M). It ships as an importable, byte-provenanced,
+% PARAMETERIZED `formula`, together with its three exact rearrangements (each element score
+% the total leaves once the other two are removed). It is the first n-ary (three-input)
+% inverter in the clinical track: the same substrate that inverts a two-input relation three
+% ways inverts a three-input sum four ways. As with every compute library, a consumer states
+% NO arithmetic: it `import`s this file, binds the measured element scores from its own
+% byte-provenance decomposition, and asks the engine to APPLY the cited definition on the
+% CPU. Zero math is performed by the model; the engine computes each value EXACTLY, carrying
+% the definition's citation.
+%
+%     import "glasgow-coma-scale.adj"
+%     observe eye_response(4)          % "…eyes open to speech, E4…"   (span cited by the model)
+%     observe verbal_response(5)       % "…oriented, V5…"              (span cited by the model)
+%     observe motor_response(6)        % "…obeys commands, M6…"        (span cited by the model)
+%     ? glasgow_coma_scale(eye_response, verbal_response, motor_response)
+%                                        % engine → 15, carrying GCS = E + V + M
+%
+% All four formulas are EXACT over their parameters (a three-term sum and its three inverse
+% readings), so every value the engine returns is exact. The four COMPOSE and invert cleanly
+% around the worked case E = 4, V = 5, M = 6 (GCS = 4 + 5 + 6 = 15): the `glasgow_coma_scale`
+% a consumer computes from the three element scores is exactly the total the `eye_response`
+% formula subtracts the verbal and motor scores from to recover the 4, that the
+% `verbal_response` formula subtracts the eye and motor scores from to recover the 5, and
+% that the `motor_response` formula subtracts the eye and verbal scores from to recover the 6.
+%
+%   glasgow_coma_scale(eye_response, verbal_response, motor_response)
+%       = eye_response + verbal_response + motor_response      % GCS = E + V + M   (definition)
+%   eye_response(glasgow_coma_scale, verbal_response, motor_response)
+%       = glasgow_coma_scale - verbal_response - motor_response % E = GCS − V − M   (solved for E)
+%   verbal_response(glasgow_coma_scale, eye_response, motor_response)
+%       = glasgow_coma_scale - eye_response - motor_response    % V = GCS − E − M   (solved for V)
+%   motor_response(glasgow_coma_scale, eye_response, verbal_response)
+%       = glasgow_coma_scale - eye_response - verbal_response   % M = GCS − E − V   (solved for M)
+%
+% NOTE ON RANGE: each element score is an integer within its own clinical range (eye 1–4,
+% verbal 1–5, motor 1–6), so the total ranges 3–15. This library performs no range checking;
+% it computes the exact sum (or the exact complementary difference) over whatever integer
+% element scores it is given. A consumer that needs the per-element ranges enforces them
+% upstream.
+%
+% All four formulas are defended by the SAME defining span — "The score is the sum of the
+% individual elements' scores" — because that one definition (the total GCS IS the sum of its
+% element scores) sanctions the relation read every way (the total from the three elements, or
+% any one element from the total and the other two). The three elements are the eye, verbal,
+% and motor responses named on the same page. The span is transcribed verbatim from the
+% StatPearls "Glasgow Coma Scale" article on the NCBI Bookshelf, so each `formula` carries the
+% provenance envelope every shipped grounded clause carries; the linter rejects an unsourced
+% one. (See feedback_nothing_human_authored — the defining span is a verbatim quote of the
+% cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each element score is an observable finding the definition ranges over, and the
+% total is the derived score. `glasgow_coma_scale`, `eye_response`, `verbal_response` and
+% `motor_response` each appear BOTH as a derived result and as an input (of the other
+% formulas), so each is a single dictionary term used in both roles. The `surface` lists are
+% the everyday names a decomposer maps onto the canonical term.
+% ----------------------------------------------------------------------------
+dictionary glasgow_coma_scale_vocab {
+    define eye_response        : finding  surface "eye response", "eye-opening response", "E"   % integer 1–4
+    define verbal_response     : finding  surface "verbal response", "V"                        % integer 1–5
+    define motor_response      : finding  surface "motor response", "M"                         % integer 1–6
+    define glasgow_coma_scale  : finding  surface "Glasgow Coma Scale", "GCS", "GCS score"      % integer 3–15
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all four ways. Each is a named, importable, reusable formula over its
+% formal parameters, bound at apply time, and each carries the defining span from StatPearls
+% on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an exact
+% sum/difference of measured element scores, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook glasgow_coma_scale_laws {
+    use glasgow_coma_scale_vocab
+
+    % Total GCS — the sum of the three element scores, i.e. GCS = E + V + M.
+    formula glasgow_coma_scale(eye_response, verbal_response, motor_response) = eye_response + verbal_response + motor_response
+        source "The score is the sum of the individual elements' scores"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK513298/"
+        trust authoritative
+
+    % Eye response — the same definition solved for the eye score a total leaves once the
+    % verbal and motor scores are removed (E = GCS − V − M). Defended by the SAME defining span.
+    formula eye_response(glasgow_coma_scale, verbal_response, motor_response) = glasgow_coma_scale - verbal_response - motor_response
+        source "The score is the sum of the individual elements' scores"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK513298/"
+        trust authoritative
+
+    % Verbal response — the same definition solved for the verbal score a total leaves once the
+    % eye and motor scores are removed (V = GCS − E − M). Again the SAME defining span.
+    formula verbal_response(glasgow_coma_scale, eye_response, motor_response) = glasgow_coma_scale - eye_response - motor_response
+        source "The score is the sum of the individual elements' scores"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK513298/"
+        trust authoritative
+
+    % Motor response — the same definition solved for the motor score a total leaves once the
+    % eye and verbal scores are removed (M = GCS − E − V). The fourth reading of the one
+    % definition.
+    formula motor_response(glasgow_coma_scale, eye_response, verbal_response) = glasgow_coma_scale - eye_response - verbal_response
+        source "The score is the sum of the individual elements' scores"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK513298/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/glasgow-coma-scale.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/glasgow-coma-scale.query.adj
@@ -1,0 +1,35 @@
+% ============================================================================
+% glasgow-coma-scale.query.adj — worked examples over the clinical Glasgow-Coma-Scale library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a GCS question: it states NO
+% arithmetic and NO relation — it only `import`s the grounded library, `observe`s the element
+% scores it decomposed from the prompt (each a byte-provenanced span, elided here), and asks
+% the engine to APPLY the cited definition. The native adj-lang engine binds the parameters,
+% computes each value EXACTLY on the CPU, and returns it with the definition's
+% source/locator/trust.
+%
+% The four questions INVERT: an eye score of 4 plus a verbal score of 5 plus a motor score of
+% 6 gives a total of 4 + 5 + 6 = 15; and that 15 total minus any two of the element scores is
+% exactly what the third element's formula recovers the missing score from.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli glasgow-coma-scale.query.adj
+% ============================================================================
+
+import "glasgow-coma-scale.adj"
+
+% E 4, V 5, M 6: total GCS = 4 + 5 + 6.
+observe eye_response(4)
+observe verbal_response(5)
+observe motor_response(6)
+? glasgow_coma_scale(eye_response, verbal_response, motor_response)   % expect 15  (GCS = E + V + M)
+
+% That 15 total with the same V 5 and M 6: E = 15 − 5 − 6.
+observe glasgow_coma_scale(15)
+? eye_response(glasgow_coma_scale, verbal_response, motor_response)   % expect 4   (same def, solved for E = GCS − V − M)
+
+% That 15 total with the same E 4 and M 6: V = 15 − 4 − 6.
+? verbal_response(glasgow_coma_scale, eye_response, motor_response)   % expect 5   (same def, solved for V = GCS − E − M)
+
+% That 15 total with the same E 4 and V 5: M = 15 − 4 − 5.
+? motor_response(glasgow_coma_scale, eye_response, verbal_response)   % expect 6   (same def, solved for M = GCS − E − V)


### PR DESCRIPTION
## What

Adds the total **Glasgow Coma Scale** score as an importable, byte-provenanced clinical `formulabook` — the **first n-ary (three-input) inverter** in the clinical track:

- `glasgow_coma_scale(E, V, M) = E + V + M` — **GCS = E + V + M** (the definition)
- `eye_response(GCS, V, M) = GCS − V − M` — E = GCS − V − M
- `verbal_response(GCS, E, M) = GCS − E − M` — V = GCS − E − M
- `motor_response(GCS, E, V) = GCS − E − V` — M = GCS − E − V

The same substrate that inverts a two-input relation three ways inverts a three-input sum four ways.

## Grounding

All four formulas are defended by the **same verbatim defining span** — *"The score is the sum of the individual elements' scores"* — transcribed exactly from the StatPearls *"Glasgow Coma Scale"* article on the NCBI Bookshelf ([NBK513298](https://www.ncbi.nlm.nih.gov/books/NBK513298/)), byte-verified via WebFetch. The three elements (eye, verbal, motor) are the parameters named on the same page and mapped via the dictionary's `surface` aliases.

As with every compute library, a consumer states **no arithmetic**: it imports the file, `observe`s the measured element scores, and the engine applies the cited definition on the CPU — computing each value **exactly** (BigRational) and carrying `source`/`locator`/`trust authoritative` into the `derived` section.

## Worked case

E = 4, V = 5, M = 6 → GCS = 4 + 5 + 6 = **15**; and 15 − 5 − 6 = 4, 15 − 4 − 6 = 5, 15 − 4 − 5 = 6 recover each element.

## Files

- `clinical/glasgow-coma-scale.adj` — dictionary + formulabook (4 formulas)
- `clinical/glasgow-coma-scale.query.adj` — worked-example consumer
- `adj-lang-cli/tests/formula_glasgow_coma_scale_e2e.rs` — 4 e2e tests driving the built CLI against the shipped stdlib

## Verification

- `cargo test -p adj-lang-cli --test formula_glasgow_coma_scale_e2e` → **4 passed**
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean
- shipped `.query.adj` run through the built CLI renders GCS=15 / E=4 / V=5 / M=6 with the NBK513298 citation + `trust: authoritative`
- NUL-scan clean; `/security-review` → passed

**Data + test only; no engine change, so no version bump.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)