### PR TITLE
content(de/ar/hi): yes/no for German, Arabic, Hindi — completes the concept

### DIFF
--- a/code/learning/human-languages/arabic/lessons/AR-C05-la.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C05-la.md
@@ -1,0 +1,64 @@
+---
+id: AR-C05-la
+chapter: 5
+type: word
+headword: لا
+gloss: no (lā)
+concept_tag: RESPONSE-NO
+prerequisites: [AR-C05-naam]
+sounds: [lam-alif-ligature, arabic-rtl]
+roots: [la-negation]
+etymology_hook: "لا lā is the great Arabic 'no' — the same word that opens the shahada, lā ilāha illā llāh, 'there is no god but God'"
+est_minutes: 4
+reviews_of: [AR-C05-naam, AR-C01-salam]
+---
+
+# لا (lā) — no
+
+## Warm-up
+
+[PAUSE 2s] Two letters, one long vowel — and one of the most recognisable words
+in the language.
+
+## The word
+
+**لا** = **no**, said **lā** (a long *aah*). It's just two letters — **ل** (l) +
+**ا** (the long *ā*, *alif*) — but they're written joined into one sweeping
+shape, **لا**, a *lam‑alif* that Arabic always writes as a single unit. It's one
+of the first letter-joins learners recognise on sight.
+
+## More than an answer
+
+**lā** isn't only the reply "no." It is Arabic's great word of **negation**, and
+it opens the most-spoken sentence in the language — the first half of the
+*shahada*:
+
+> **لا إله إلا الله** — *lā ilāha illā llāh* — "**There is no** god but God."
+
+That opening **lā** is your word. The same *lā* also negates present-tense
+verbs — **لا أعرف** *lā aʿrif*, "I do **not** know" — so, like Spanish *no*, one
+little word is both the answer "no" and the sentence's "not."
+
+## Yes and no, together
+
+You now have the pair:
+
+| | Arabic | said |
+|---|---|---|
+| yes | **نعم** | *naʿam* |
+| no | **لا** | *lā* |
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "lā" — a long, open *aah*]
+- [YOU SAY: the join — ل + ا written as one, لا]
+- [YOU SAY: the pair — "naʿam / lā"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How do you say no in Arabic? (**lā**, لا.) What two letters make it,
+and how are they written? (**ل** + **ا**, joined as a single *lam‑alif* لا.)
+Which famous sentence does *lā* open? (The *shahada* — *lā ilāha illā llāh*.)
+Besides "no," what job does *lā* do? (It **negates verbs** — *lā aʿrif*, "I don't
+know.")

--- a/code/learning/human-languages/arabic/lessons/AR-C05-naam.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C05-naam.md
@@ -1,0 +1,57 @@
+---
+id: AR-C05-naam
+chapter: 5
+type: word
+headword: نعم
+gloss: yes (naʿam)
+concept_tag: RESPONSE-YES
+prerequisites: [AR-C01-salam]
+sounds: [ayn-pharyngeal, arabic-rtl]
+roots: [naam]
+etymology_hook: "نعم naʿam 'yes' carries the ع ʿayn — a throat sound with no English match, the most Arabic thing in the word"
+est_minutes: 4
+reviews_of: [AR-C01-salam]
+---
+
+# نعم (naʿam) — yes
+
+## Warm-up
+
+[PAUSE 2s] A short word to mean yes — with one sound English simply doesn't have.
+
+## The word
+
+**نعم** = **yes**, said **naʿam**. Arabic reads **right to left**, so its three
+letters run:
+
+> ن  (n) · ع  (ʿ) · م  (m)  →  **na‑ʿa‑m**
+
+The middle letter **ع** is the famous **ʿayn** — a *pharyngeal* sound made deep
+in the throat, a tight squeeze with no English equivalent. Don't worry about
+mastering it today; just know that the little apostrophe-like mark in *naʿam*
+(the **ʿ**) is standing in for a real, throaty consonant, not a pause.
+
+## Saying yes, and other ways
+
+*naʿam* is the clear, standard **yes** — polite and safe anywhere. Two neighbours
+you'll also hear:
+
+- **أجل** (*ajal*) — a more formal, emphatic "yes, indeed."
+- In everyday speech, many dialects say **أيوة** (*aywa*) for a casual "yeah."
+
+And a useful twist: said as a question, **naʿam?** also means **"pardon? / you
+were saying?"** — the same stretch English gives "yes?"
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "naʿam" — feel the ع squeeze in the middle of the throat]
+- [YOU SAY: right to left — ن · ع · م]
+- [YOU SAY: as a question — "naʿam?" = "pardon?"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How do you say yes in Arabic? (**naʿam**, نعم.) Which way does the
+script run? (**Right to left**.) What is the **ع** in the middle — a pause or a
+sound? (A **sound** — the throaty *ʿayn*, with no English match.) What does
+*naʿam?* mean when you say it as a question? (**"Pardon?"**)

--- a/code/learning/human-languages/german/lessons/GE-C18-ja.md
+++ b/code/learning/human-languages/german/lessons/GE-C18-ja.md
@@ -1,0 +1,64 @@
+---
+id: GE-C18-ja
+chapter: 18
+type: word
+headword: ja
+gloss: yes
+concept_tag: RESPONSE-YES
+prerequisites: [GE-C01-hallo]
+sounds: [vowel-a-long, j-as-y]
+roots: [ja-germanic]
+etymology_hook: "German ja is the old Germanic yes — the same word English keeps in the archaic yea (and, perhaps, the sailor's aye)"
+est_minutes: 3
+reviews_of: [GE-C01-hallo]
+---
+
+# ja — yes
+
+## Warm-up
+
+[PAUSE 2s] The easiest German word to say, and one English almost shares.
+
+## The word
+
+**ja** = **yes**. Said *yah* — remember German **j** is pronounced like English
+**y**, never the English "j."
+
+It's an ancient **Germanic** word, and English kept the very same root in the
+one word that still clearly shows it:
+
+- **yea** — the old, formal "yes" (*the yeas and the nays* in a vote) — this is
+  *ja*'s direct cousin, same Proto-Germanic root.
+- **aye** — the sailor's and parliament's "yes" (*Aye, aye, captain*) — *sounds*
+  like a cousin, but its origin is actually **uncertain**; it may come from a
+  different word entirely, so don't bank on it.
+
+So German *ja* and English *yea* are the same little word, split between two
+cousin languages. (English's everyday *yes* is a compound of that same *yea* with
+an old "be it so.")
+
+## A German habit to file away
+
+German also has a **third** answer-word, **doch**, for one special job:
+contradicting a **negative** — exactly like French *si*. If someone says
+something *isn't* so and you insist it *is*, you say **doch**, not *ja*:
+
+> *Du kommst nicht?* ("You're not coming?") — ***Doch!*** ("Yes I am!")
+
+You'll drill *doch* on its own later; for now, keep *ja* for a plain yes and know
+*doch* is waiting for the contradictions.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "ja" — *yah*, the j like English y]
+- [YOU SAY: the English cousin — "yea… ja" (and maybe *aye*)]
+- [YOU SAY: the contradiction preview — "Du kommst nicht? — Doch!"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How do you say yes in German? (**ja**, *yah*.) How is the **j**
+pronounced? (Like English **y**.) Which English word is *ja*'s firm direct
+cousin? (**yea** — *aye* only looks like one; its origin is uncertain.) What
+German word answers *yes* specifically to
+contradict a **negative**? (**doch**.)

--- a/code/learning/human-languages/german/lessons/GE-C18-nein.md
+++ b/code/learning/human-languages/german/lessons/GE-C18-nein.md
@@ -1,0 +1,61 @@
+---
+id: GE-C18-nein
+chapter: 18
+type: word
+headword: nein
+gloss: no
+concept_tag: RESPONSE-NO
+prerequisites: [GE-C18-ja]
+sounds: [diphthong-ei, n-consonant]
+roots: [ni-ein, pie-ne]
+etymology_hook: "nein is literally ni + ein, 'not one' — the same 'not-one' English froze into none, from the PIE *ne of no"
+est_minutes: 4
+reviews_of: [GE-C18-ja, GE-C01-hallo]
+---
+
+# nein — no
+
+## Warm-up
+
+[PAUSE 2s] German's "no" is a tiny sentence with a number hidden inside it.
+
+## The word
+
+**nein** = **no**. Said to rhyme with English *nine* (the **ei** in German is
+always *eye*).
+
+Take it apart and it's two words fused: **ni + ein** — literally **"not one."**
+English did the *exact same trick*: **ne + one → none**. So German *nein* and
+English *none* are the same idea — "not a single one" — hardened into a bare
+"no."
+
+## One "no" runs across the whole chain
+
+That **n‑** at the front is not a coincidence. A single ancient sound — linguists
+write it **PIE \*ne** — is the negator behind an astonishing sweep of languages
+you're learning:
+
+| from PIE *\*ne* | |
+|---|---|
+| Latin | *nōn* → Spanish **no**, French **non** |
+| German | **nein** (*ni*-ein) |
+| Hindi | **nahīṃ** (from *na*) |
+| English | **no, not, none** |
+
+Learn *nein* and you've really met the same "n‑of‑no" that will greet you again
+in Hindi, and that you already met in Spanish and French. One negative, half the
+world.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nein" — rhymes with *nine*]
+- [YOU SAY: taken apart — "ni + ein = not one", like English *none*]
+- [YOU SAY: the family — "nōn… non… nein… nahīṃ" — all the PIE *ne*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How do you say no in German? (**nein**, rhymes with *nine*.) What two
+words is it fused from, and what do they mean? (***ni + ein*** — "not one.") Which
+English word is built the same way? (**none** = *ne + one*.) What ancient sound
+links German *nein*, Latin *nōn* and Hindi *nahīṃ*? (**PIE \*ne**, the negator.)

--- a/code/learning/human-languages/hindi/lessons/HI-C07-haan.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C07-haan.md
@@ -1,0 +1,55 @@
+---
+id: HI-C07-haan
+chapter: 7
+type: word
+headword: हाँ
+gloss: yes (hāṃ)
+concept_tag: RESPONSE-YES
+prerequisites: [HI-C01-namaste]
+sounds: [chandrabindu-nasal, vowel-aa]
+roots: [haan]
+etymology_hook: "हाँ hāṃ 'yes' is a nasalised aa — the chandrabindu ँ (moon-dot) sends the vowel through the nose; jī hāṃ is polite"
+est_minutes: 4
+reviews_of: [HI-C01-namaste]
+---
+
+# हाँ (hāṃ) — yes
+
+## Warm-up
+
+[PAUSE 2s] A single open vowel, said through the nose — that's Hindi's yes.
+
+## The word
+
+**हाँ** = **yes**, said **hāṃ**. It's the letter **ह** (h) with the **ा** sign
+for long *ā*, and — the key mark — the **ँ** on top: the **chandrabindu**, the
+"moon-dot." It does one thing: it **nasalises** the vowel. So *hāṃ* isn't "hah"
+but a humming *hããⁿ*, the sound sent up through the nose, the way French does in
+*bon*.
+
+(Don't confuse the moon-dot **ँ** with the plain dot **ं** *anusvara* you'll see
+in the next word — both nasalise, but the moon-dot rides a vowel that has nothing
+above it, like *ा*.)
+
+## Saying it politely
+
+A bare *hāṃ* is a normal, friendly yes. To an elder, a stranger, or anyone you'd
+show respect, Hindi adds the honorific **जी** (*jī*):
+
+> **जी हाँ** — *jī hāṃ* — "yes" (polite)
+
+*jī* on its own is already a respectful "yes." You met *‑jī* on names; here it
+warms up a plain yes into a courteous one.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "hāṃ" — let the *ā* hum through your nose]
+- [YOU SAY: polite — "jī hāṃ"]
+- [YOU SAY: spot the mark — the moon-dot **ँ** is what nasalises it]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How do you say yes in Hindi? (**hāṃ**, हाँ.) What does the
+**chandrabindu** ँ do to the vowel? (**Nasalises** it — sends it through the
+nose.) How do you make *hāṃ* polite? (Add **जी** — *jī hāṃ*.) Next: **नहीं**, no.

--- a/code/learning/human-languages/hindi/lessons/HI-C07-nahin.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C07-nahin.md
@@ -1,0 +1,68 @@
+---
+id: HI-C07-nahin
+chapter: 7
+type: word
+headword: नहीं
+gloss: no / not (nahīṃ)
+concept_tag: RESPONSE-NO
+prerequisites: [HI-C07-haan]
+sounds: [anusvara-nasal, vowel-ii]
+roots: [na-sanskrit, pie-ne]
+etymology_hook: "नहीं nahīṃ holds Sanskrit na — the same PIE *ne that negates Latin nōn, German nein and English no"
+est_minutes: 4
+reviews_of: [HI-C07-haan, HI-C01-namaste]
+---
+
+# नहीं (nahīṃ) — no / not
+
+## Warm-up
+
+[PAUSE 2s] Hindi's "no" carries a sound so old it also sits inside German and
+Latin.
+
+## The word
+
+**नहीं** = **no**, said **nahīṃ** — **न** (na) + **ह** (h) + **ी** (long *ī*) +
+the **ं** *anusvara* that nasalises the end. The heart of it is that first
+syllable **na**, which is Hindi's ancient negator, straight from **Sanskrit
+na**.
+
+## The oldest "no" you'll meet
+
+That **na** is not just Sanskrit's — it is the same negative root that runs
+across nearly every language in this course, all descended from one ancient
+sound, **PIE \*ne**:
+
+| from *\*ne* | |
+|---|---|
+| Sanskrit *na* | → Hindi **nahīṃ** |
+| Latin *nōn* | → Spanish **no**, French **non** |
+| Germanic | → German **nein**, English **no / not** |
+
+You met this exact idea in the German *nein* lesson ("not one"); here it is again
+at the other end of the family, in Hindi. The word for *no* is one of the most
+stubbornly unchanged things human languages have.
+
+## One word, two jobs
+
+Like Spanish *no*, **nahīṃ** is both the **answer** and the **sentence-negator**:
+
+- **answer**: *आप आ रहे हैं?* — **नहीं.** ("Are you coming?" — "No.")
+- **negator**: *मैं **नहीं** जानता* — "I do **not** know."
+
+So this single word gives you both "no" and how to make a sentence negative.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "nahīṃ" — nasal at the end, from the *anusvara*]
+- [YOU SAY: the ancient root — "na… nōn… nein… no": one PIE *ne]
+- [YOU SAY: as a negator — "maĩ nahīṃ jāntā", "I don't know"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How do you say no in Hindi? (**nahīṃ**, नहीं.) What Sanskrit word is
+its core, and what ancient sound is that from? (**na**, from **PIE \*ne**.) Which
+other course words share that root? (Latin *nōn*, German *nein*, English *no/not*
+— and Spanish/French *no/non*.) Besides "no," what else does *nahīṃ* do? (It
+**negates a sentence** — *maĩ nahīṃ jāntā*, "I don't know.")


### PR DESCRIPTION
## What
**Completes yes/no across the entire chain.** Latin, Spanish, French, and the four Dravidian tracks already had it; this adds the last three — **German ja/nein, Arabic naʿam/lā, Hindi hāṃ/nahīṃ** — six atom-first lessons with the canonical `RESPONSE-YES`/`RESPONSE-NO` tags.

## The unifying thread: PIE \*ne
The concept is tied together by one grounded etymology — the **\*ne negator that runs through the whole course**:

| from PIE \*ne | |
|---|---|
| Latin *nōn* | → Spanish **no**, French **non** |
| German | **nein** (*ni*+*ein*, "not one", cf. English *none*) |
| Hindi | **nahīṃ** (← Sanskrit *na*) |

The German and Hindi "no" lessons each show this table, so the learner meets the same ancient *n*-of-no at both ends of the chain.

## Per-language grounding
- **German** — j=y; **doch** (yes to contradict a negative, like French *si*).
- **Arabic** — the **ʿayn** throat-sound; **lā** opens the *shahada* (RTL, right-to-left).
- **Hindi** — the **chandrabindu vs anusvara** nasal distinction (exactly why हाँ and नहीं differ); *jī hāṃ* politeness.
- Arabic/Hindi glyphs **composed + verified from Unicode**.

## Review
Historical-linguistics subagent confirmed **every Arabic and Hindi glyph, romanization, and gloss at the codepoint level** (the shahada, the chandrabindu/anusvara rule, *आप आ रहे हैं?*, etc.). It caught **one German overclaim** — English *aye* is **not** a settled cognate of *ja/yea* (disputed origin) — now hedged. Zero errors; **38 + 268 green**.

## Program status
**yes/no: complete across the chain.** Next: the loop surveys the frontier and picks the next universal concept gap (courtesy *please/sorry*, farewells, days, colors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)