### PR TITLE
feat(adj-formula-stdlib): functional-residual-capacity — StatPearls FRC = RV + ERV clinical formulabook

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_functional_residual_capacity_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_functional_residual_capacity_e2e.rs
@@ -1,0 +1,138 @@
+//! End-to-end tests for the `clinical/functional-residual-capacity.adj` library — the
+//! definition of the functional residual capacity (FRC = residual volume + expiratory
+//! reserve volume) and its two exact rearrangements (each component = the total minus the
+//! other) — driven through the built CLI binary against the SHIPPED stdlib. A consumer
+//! states NO arithmetic; it imports the grounded library, binds the measured sub-volumes
+//! with `observe`, and the engine applies the cited relation on the CPU, computing the
+//! EXACT value and rendering the relation's citation and trust tier in the `derived`
+//! section (the auditable answer). The three formulas INVERT around the worked case
+//! RV = 2, ERV = 4: 2 + 4 = 6, and 6 minus either sub-volume recovers the other.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped functional-residual-capacity library, resolved from this
+/// crate's manifest dir so the test is location-independent.
+fn shipped_frc_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/functional-residual-capacity.adj")
+        .canonicalize()
+        .expect("shipped functional-residual-capacity.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_frc_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_frc_lib()).unwrap();
+    std::fs::write(dir.join("functional-residual-capacity.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// functional_residual_capacity — the definition: the sum of the two sub-volumes.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_frc_library_and_computes_total_with_citation() {
+    let dir = scratch("total");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"functional-residual-capacity.adj\"\n\
+         observe residual_volume(2)\n\
+         observe expiratory_reserve_volume(4)\n\
+         ? functional_residual_capacity(residual_volume, expiratory_reserve_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 2 + 4 = 6.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"functional_residual_capacity\"") && s.contains("\"value\":6"),
+        "functional_residual_capacity(2, 4) = 6: {s}"
+    );
+    // … AND the StatPearls/NCBI Bookshelf citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// residual_volume — the same relation solved for RV: FRC − ERV, which INVERTS the total.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_residual_volume_from_total_and_erv_with_citation() {
+    let dir = scratch("rv");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"functional-residual-capacity.adj\"\n\
+         observe functional_residual_capacity(6)\n\
+         observe expiratory_reserve_volume(4)\n\
+         ? residual_volume(functional_residual_capacity, expiratory_reserve_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 6 - 4 = 2, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"residual_volume\"") && s.contains("\"value\":2"),
+        "residual_volume(6, 4) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "residual_volume carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// expiratory_reserve_volume — the same relation solved for ERV: FRC − RV.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_expiratory_reserve_volume_from_total_and_rv_with_citation() {
+    let dir = scratch("erv");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"functional-residual-capacity.adj\"\n\
+         observe functional_residual_capacity(6)\n\
+         observe residual_volume(2)\n\
+         ? expiratory_reserve_volume(functional_residual_capacity, residual_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 6 - 2 = 4, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"expiratory_reserve_volume\"") && s.contains("\"value\":4"),
+        "expiratory_reserve_volume(6, 2) = 4: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "expiratory_reserve_volume carries its StatPearls citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/functional-residual-capacity.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/functional-residual-capacity.adj
@@ -1,0 +1,106 @@
+% ============================================================================
+% functional-residual-capacity.adj — the definition of the functional residual
+% capacity (functional residual capacity = residual volume + expiratory reserve
+% volume) in the ADJ standard library.
+% ============================================================================
+% The functional-residual-capacity entry of the *clinical* track, a
+% pulmonary-physiology library. Where total-lung-capacity.adj grounds the whole-lung
+% sum (TLC = VC + RV) and inspiratory-capacity.adj grounds the top-of-tidal sum
+% (TLC = FRC + IC), this grounds the RESTING end-expiratory sum: THE FUNCTIONAL
+% RESIDUAL CAPACITY — the gas left in the lungs after a normal quiet exhalation —
+% IS THE SUM OF THE RESIDUAL VOLUME (RV, the gas that cannot be exhaled) AND THE
+% EXPIRATORY RESERVE VOLUME (ERV, the gas a maximal effort can still push out past
+% the resting point). It ships as an importable, byte-provenanced, PARAMETERIZED
+% `formula`, together with its two exact rearrangements (each component the total
+% leaves once the other is removed). As with every compute library, a consumer
+% states NO arithmetic: it `import`s this file, binds the measured sub-volumes from
+% its own byte-provenance decomposition, and asks the engine to APPLY the cited
+% definition on the CPU. Zero math is performed by the model; the engine computes
+% each value EXACTLY, carrying the definition's citation.
+%
+%     import "functional-residual-capacity.adj"
+%     observe residual_volume(2)            % "…RV 2 L…"    (span cited by the model)
+%     observe expiratory_reserve_volume(4)  % "…ERV 4 L…"   (span cited by the model)
+%     ? functional_residual_capacity(residual_volume, expiratory_reserve_volume)
+%                                             % engine → 6, carrying FRC = RV + ERV
+%
+% All three formulas are EXACT over their parameters (a two-term sum and its two
+% inverse readings), so every value the engine returns is exact. The three COMPOSE
+% and invert cleanly around the worked case RV = 2, ERV = 4 (FRC = 2 + 4 = 6): the
+% `functional_residual_capacity` a consumer computes from the two sub-volumes is
+% exactly the total the `residual_volume` formula subtracts the expiratory reserve
+% volume from to recover the 2, and that the `expiratory_reserve_volume` formula
+% subtracts the residual volume from to recover the 4.
+%
+%   functional_residual_capacity(residual_volume, expiratory_reserve_volume)
+%       = residual_volume + expiratory_reserve_volume   % FRC = RV + ERV   (definition)
+%   residual_volume(functional_residual_capacity, expiratory_reserve_volume)
+%       = functional_residual_capacity - expiratory_reserve_volume % RV = FRC − ERV (solved for RV)
+%   expiratory_reserve_volume(functional_residual_capacity, residual_volume)
+%       = functional_residual_capacity - residual_volume  % ERV = FRC − RV  (solved for ERV)
+%
+% NOTE ON UNITS: RV, ERV, and FRC are all lung gas volumes and must be observed in
+% the SAME unit (e.g. litres, or millilitres) for the sum to be meaningful; this
+% library performs no unit conversion. It computes the exact sum (or the exact
+% complementary difference) over whatever same-unit volumes it is given. A consumer
+% that mixes units converts them upstream.
+%
+% All three formulas are defended by the SAME defining span — "the FRC can be
+% represented by the equation FRC = RV + ERV" — because that one definition (the
+% functional residual capacity IS the sum of the residual volume and the expiratory
+% reserve volume) sanctions the relation read every way (the total from the two
+% sub-volumes, or either sub-volume from the total and the other). The span is
+% transcribed verbatim from the StatPearls "Physiology, Functional Residual
+% Capacity" article on the NCBI Bookshelf, so each `formula` carries the provenance
+% envelope every shipped grounded clause carries; the linter rejects an unsourced
+% one. (See feedback_nothing_human_authored — the defining span is a verbatim quote
+% of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each sub-volume is an observable finding the definition ranges over,
+% and the capacity is the derived total. `functional_residual_capacity`,
+% `residual_volume` and `expiratory_reserve_volume` each appear BOTH as a derived
+% result and as an input (of the other formulas), so each is a single dictionary
+% term used in both roles. The `surface` lists are the everyday names a decomposer
+% maps onto the canonical term.
+% ----------------------------------------------------------------------------
+dictionary functional_residual_capacity_vocab {
+    define residual_volume               : finding  surface "residual volume", "RV"
+    define expiratory_reserve_volume     : finding  surface "expiratory reserve volume", "ERV"
+    define functional_residual_capacity  : finding  surface "functional residual capacity", "FRC"
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable formula
+% over its formal parameters, bound at apply time, and each carries the defining
+% span from StatPearls on the NCBI Bookshelf (a quote is required on a shipped
+% formula). Each is an exact sum/difference of measured sub-volumes, so the engine
+% returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook functional_residual_capacity_laws {
+    use functional_residual_capacity_vocab
+
+    % FRC — the sum of the residual volume and the expiratory reserve volume,
+    % i.e. FRC = RV + ERV.
+    formula functional_residual_capacity(residual_volume, expiratory_reserve_volume) = residual_volume + expiratory_reserve_volume
+        source "the FRC can be represented by the equation FRC = RV + ERV"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK500007/"
+        trust authoritative
+
+    % Residual volume — the same definition solved for the residual gas an FRC
+    % leaves once the expiratory reserve volume is removed (RV = FRC − ERV).
+    % Defended by the SAME defining span.
+    formula residual_volume(functional_residual_capacity, expiratory_reserve_volume) = functional_residual_capacity - expiratory_reserve_volume
+        source "the FRC can be represented by the equation FRC = RV + ERV"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK500007/"
+        trust authoritative
+
+    % Expiratory reserve volume — the same definition solved for the reserve an FRC
+    % leaves once the residual volume is removed (ERV = FRC − RV). The third reading
+    % of the one definition.
+    formula expiratory_reserve_volume(functional_residual_capacity, residual_volume) = functional_residual_capacity - residual_volume
+        source "the FRC can be represented by the equation FRC = RV + ERV"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK500007/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/functional-residual-capacity.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/functional-residual-capacity.query.adj
@@ -1,0 +1,33 @@
+% ============================================================================
+% functional-residual-capacity.query.adj — worked examples over the clinical
+% Functional-Residual-Capacity library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER an FRC question: it
+% states NO arithmetic and NO relation — it only `import`s the grounded library,
+% `observe`s the sub-volumes it decomposed from the prompt (each a byte-provenanced
+% span, elided here), and asks the engine to APPLY the cited definition. The native
+% adj-lang engine binds the parameters, computes each value EXACTLY on the CPU, and
+% returns it with the definition's source/locator/trust.
+%
+% The three questions INVERT: a residual volume of 2 plus an expiratory reserve
+% volume of 4 gives a functional residual capacity of 2 + 4 = 6; and that 6 total
+% minus either sub-volume is exactly what the other sub-volume's formula recovers
+% the missing volume from.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli functional-residual-capacity.query.adj
+% ============================================================================
+
+import "functional-residual-capacity.adj"
+
+% RV 2, ERV 4: total FRC = 2 + 4.
+observe residual_volume(2)
+observe expiratory_reserve_volume(4)
+? functional_residual_capacity(residual_volume, expiratory_reserve_volume)   % expect 6  (FRC = RV + ERV)
+
+% That 6 total with the same ERV 4: RV = 6 − 4.
+observe functional_residual_capacity(6)
+? residual_volume(functional_residual_capacity, expiratory_reserve_volume)   % expect 2  (same def, solved for RV = FRC − ERV)
+
+% That 6 total with the same RV 2: ERV = 6 − 2.
+? expiratory_reserve_volume(functional_residual_capacity, residual_volume)   % expect 4  (same def, solved for ERV = FRC − RV)


### PR DESCRIPTION
Ships `clinical/functional-residual-capacity.adj` — a byte-provenanced clinical `formulabook` grounding the resting end-expiratory pulmonary sum **FRC = RV + ERV**, with its two exact rearrangements (`RV = FRC − ERV`, `ERV = FRC − RV`).

All three formulas carry the **same verbatim defining span**, transcribed from the StatPearls *"Physiology, Functional Residual Capacity"* article (NCBI Bookshelf [NBK500007](https://www.ncbi.nlm.nih.gov/books/NBK500007/)):

> the FRC can be represented by the equation FRC = RV + ERV

A consumer states **no arithmetic**: it imports the library, `observe`s the measured sub-volumes it decomposed from its prompt (each byte-provenanced), and asks the engine to APPLY the cited definition on the CPU. The engine binds the parameters, computes each value EXACTLY, and returns it with the definition's `source`/`locator`/`trust` in the `derived` section — the auditable answer. Zero math is performed by the model.

The three formulas invert cleanly around the worked case **RV = 2, ERV = 4 → FRC = 6**: 6 minus either sub-volume recovers the other.

### What ships
- `code/specs/data/adj-formula-stdlib/clinical/functional-residual-capacity.adj` — dictionary + 3-formula formulabook
- `code/specs/data/adj-formula-stdlib/clinical/functional-residual-capacity.query.adj` — worked examples
- `code/packages/rust/adj-lang-cli/tests/formula_functional_residual_capacity_e2e.rs` — dedicated e2e (3 tests, all green)

### Verification
- All 3 e2e tests pass; `cargo clippy -p adj-lang-cli --tests -- -D warnings` clean.
- NUL-scan clean on all new source files.
- Render-probed the shipped query against the built CLI: FRC=6 / RV=2 / ERV=4 render as plain integers, matching the asserted values.
- `/security-review`: PASSED — no vulnerabilities found.

Data + test only → **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)