### PR TITLE
Preserve MOS junction shaping in netlists

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Preserve Level-1 MOS model-card `PB`, `MJ`, and `FC` values when lowering
+  Berkeley netlists into the engine parameter bundle.
 - Accept Level-1 MOS model-card `MJSW=<grading>` through the normalized engine
   model-card contract for independent sidewall depletion shaping.
 - Parse Level-1 MOS instance `PS=<perimeter>` into the engine parameter bundle

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -760,7 +760,7 @@ parameters, `.model <name> NPN|PNP(...)` BJT cards with `IS`, `BF` /
 `.model <name> NMOS|PMOS(...)` Level-1 MOSFET
 cards with common SPICE aliases (`VT0` / `VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
 `W`, `L`, `RSH`, `IS`, `N_SUB` / `NSUB`, `T_NOM` / `TNOM`, `CGSO`, `CGDO`,
-`CGBO`, `CBS`, `CBD`, `CJ`, `CJSW`, and `MJSW`), MOS instance `NRD=<squares>` /
+`CGBO`, `CBS`, `CBD`, `CJ`, `CJSW`, `PB`, `MJ`, `MJSW`, and `FC`), MOS instance `NRD=<squares>` /
 `NRS=<squares>` / `AD=<area>` / `AS=<area>` / `PD=<perimeter>` /
 `PS=<perimeter>`, SPICE
 engineering suffixes, capacitor

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1940,7 +1940,10 @@ fn apply_mosfet_param(params: &mut MosfetLevel1Params, name: &str, value: f64) {
         "CBD" => params.drain_bulk_capacitance = value,
         "CJ" => params.bottom_junction_capacitance = value,
         "CJSW" => params.sidewall_junction_capacitance = value,
+        "PB" => params.bulk_junction_potential = value,
+        "MJ" => params.bulk_junction_grading_coefficient = value,
         "MJSW" => params.sidewall_junction_grading_coefficient = value,
+        "FC" => params.forward_bias_depletion_coefficient = value,
         _ => {}
     }
 }

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1359,7 +1359,7 @@ Jpull drain gate source pch
 fn parses_mosfet_models_into_operating_point_circuits() {
     let parsed = parse_netlist(
         r#"
-.model nch NMOS(VTO=0.45 KP=250u LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n RSH=250 NSUB=1.5 TNOM=300 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p CJ=2m CJSW=5u MJSW=0.25)
+.model nch NMOS(VTO=0.45 KP=250u LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n RSH=250 NSUB=1.5 TNOM=300 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p CJ=2m CJSW=5u PB=0.9 MJ=0.45 MJSW=0.25 FC=0.4)
 Vdd vdd 0 DC 5
 Vgate gate 0 DC 2.5
 M1 vdd gate out 0 nch W=4u L=200n NRD=2 NRS=3 AD=3n AS=4n PD=6u PS=7u
@@ -1401,7 +1401,10 @@ Rload out 0 1k
     assert_close(mosfet.params.source_perimeter, 7.0e-6);
     assert_close(mosfet.params.bottom_junction_capacitance, 2.0e-3);
     assert_close(mosfet.params.sidewall_junction_capacitance, 5.0e-6);
+    assert_close(mosfet.params.bulk_junction_potential, 0.9);
+    assert_close(mosfet.params.bulk_junction_grading_coefficient, 0.45);
     assert_close(mosfet.params.sidewall_junction_grading_coefficient, 0.25);
+    assert_close(mosfet.params.forward_bias_depletion_coefficient, 0.4);
     assert_close(mosfet.params.n_sub, 1.5);
     assert_close(mosfet.params.t_nom, 300.0);
     assert_close(mosfet.params.gate_source_overlap_capacitance, 3.0e-12);

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,15 +33,13 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS sidewall grading coefficient.
+1. Berkeley netlist lowering for Level-1 MOS junction shaping.
    - Status: current PR completion candidate.
-   - Add Berkeley Level-1 MOS model-card `MJSW` in Rust, Python, and TypeScript,
-     defaulting to `0.33`.
-   - Shape `CJSW * PD` and `CJSW * PS` independently from the `MJ`-controlled
-     bottom-junction terms in AC and transient analysis.
-   - Preserve `MJSW` through hierarchy and cloning, enforce finite non-negative
-     validation, parse it through the Rust netlist facade, and extend the
-     supported-parameter release gate.
+   - Preserve model-card `PB`, `MJ`, and `FC` when the Rust Berkeley netlist
+     facade lowers Level-1 MOS devices into the engine parameter bundle.
+   - Prove source-deck values reach the existing cross-language AC and transient
+     depletion-capacitance behavior instead of silently falling back to
+     defaults.
 
 ## Completed Slices
 
@@ -3519,6 +3517,15 @@ the Rust, Python, and TypeScript surfaces together.
      AC and transient analysis while preserving depletion shaping.
    - Hierarchy and cloning preserve `PS`, finite non-negative validation is
      shared, and the Rust netlist facade parses it.
+
+278. Cross-language Level-1 MOS sidewall grading coefficient.
+   - Status: completed in PR 9080.
+   - Berkeley Level-1 MOS model cards now accept `MJSW` in Rust, Python, and
+     TypeScript, defaulting to `0.33`.
+   - `CJSW * PD` and `CJSW * PS` are shaped independently from the
+     `MJ`-controlled bottom-junction terms in AC and transient analysis.
+   - Hierarchy, cloning, validation, model-card coverage, and the Rust netlist
+     facade preserve the parameter.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- preserve Level-1 MOS `PB`, `MJ`, and `FC` model-card values when the Rust Berkeley netlist facade lowers devices into the SPICE engine
- extend the source-deck integration fixture to prove all junction-shaping values reach the engine parameter bundle
- reconcile the SPICE implementation ledger after merged PR #9080 and document the expanded parser surface

## Verification
- `cargo test -p spice-netlist-parser --test spice_netlist_parser_test` (95 passed)
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`
- scoped `rustfmt --check`
- `git diff --check`