### PR TITLE
Fix MathML integration-point null text

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -121,6 +121,9 @@ documented in this file.
   accesskey, autofocus, and related focus metadata.
 
 ### Fixed
+- Replacement characters from null input are now stripped only at MathML and
+  SVG HTML integration points, preserving them in ordinary foreign-content
+  text while matching the current WPT fragment and CDATA cases.
 - Test fixture generators: `COMMENT_MARKUP` regex accepts both `-->` and
   `--!>` comment end forms, and tag-axis classifier scans pass `re.I` even
   though their inputs are already lowercased.  Both changes silence codeql

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -134,8 +134,8 @@ focused regression test in `tests/browser_readiness_test.rs`. The
 executable source of truth for that boundary and should fail if a future field
 is added without coverage evidence.
 
-The checked-in tree-construction smoke corpus contains 2,485 passing DOM cases.
-Current WPT contains 1,934 upstream tree-construction cases, with 156 source
+The checked-in tree-construction smoke corpus contains 2,493 passing DOM cases.
+Current WPT contains 1,934 upstream tree-construction cases, with 148 source
 signatures not yet mirrored locally. The checked audit report makes that debt
 explicit so follow-up conformance slices can ratchet it to zero. A separate
 adapter can project DOM into `document-ast` for existing native document
@@ -152,7 +152,7 @@ tests moved from html5lib-tests to WPT, so a current audit uses both checkouts:
 HTML5LIB_TESTS_ROOT=/path/to/html5lib-tests \
 WPT_ROOT=/path/to/wpt \
   python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py \
-  --expect-tree-missing 156 \
+  --expect-tree-missing 148 \
   --expect-tokenizer-missing 0
 ```
 
@@ -170,8 +170,8 @@ python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
   /path/to/html5lib-tests \
   --wpt-root /path/to/wpt \
   --expect-tree-upstream-cases 1934 \
-  --expect-tree-local-cases 2485 \
-  --expect-tree-missing 156 \
+  --expect-tree-local-cases 2493 \
+  --expect-tree-missing 148 \
   --expect-tokenizer-upstream-cases 6806 \
   --expect-tokenizer-local-raw-cases 7015 \
   --expect-tokenizer-missing 0 \

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5396,7 +5396,7 @@ impl HtmlParser {
 
         let text = if text.contains('\u{FFFD}')
             && (self.current_node_is_svg_html_integration_point()
-                || self.current_namespace() == Some("math")
+                || self.current_node_is_mathml_integration_point()
                 || (self.replacement_text_is_ignorable_in_current_context(&text)
                     && !self.current_element_is("plaintext")))
         {

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -185,7 +185,7 @@ source signature:
 HTML5LIB_TESTS_ROOT=/path/to/html5lib-tests \
 WPT_ROOT=/path/to/wpt \
   python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py \
-  --expect-tree-missing 156 \
+  --expect-tree-missing 148 \
   --expect-tokenizer-missing 0
 ```
 
@@ -201,8 +201,8 @@ python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
   /path/to/html5lib-tests \
   --wpt-root /path/to/wpt \
   --expect-tree-upstream-cases 1934 \
-  --expect-tree-local-cases 2485 \
-  --expect-tree-missing 156 \
+  --expect-tree-local-cases 2493 \
+  --expect-tree-missing 148 \
   --expect-tokenizer-upstream-cases 6806 \
   --expect-tokenizer-local-raw-cases 7015 \
   --expect-tokenizer-missing 0 \
@@ -216,10 +216,10 @@ Regenerate or check it with:
 ```bash
 python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py \
   /path/to/html5lib-tests --wpt-root /path/to/wpt \
-  --expect-tree-missing 156 --expect-tokenizer-missing 0 --write-report
+  --expect-tree-missing 148 --expect-tokenizer-missing 0 --write-report
 python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py \
   /path/to/html5lib-tests --wpt-root /path/to/wpt \
-  --expect-tree-missing 156 --expect-tokenizer-missing 0 --check-report
+  --expect-tree-missing 148 --expect-tokenizer-missing 0 --check-report
 ```
 
 `whatwg-tree-insertion-audit.json` is a generated index over the high-signal

--- a/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_foreign_audit_fixture.py
+++ b/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_foreign_audit_fixture.py
@@ -173,12 +173,17 @@ def is_foreign_content_case(
 ) -> bool:
     if source.startswith("foreign-fragment.dat:"):
         return True
-    if (
-        fragment_context is not None
-        and fragment_context.lower() in FOREIGN_FRAGMENT_CONTEXTS
-    ):
+    if is_foreign_fragment_context(fragment_context):
         return True
     return CORE_FOREIGN_MARKUP.search(data) is not None
+
+
+def is_foreign_fragment_context(fragment_context: str | None) -> bool:
+    if fragment_context is None:
+        return False
+    normalized = fragment_context.lower()
+    namespace = normalized.split(maxsplit=1)[0]
+    return normalized in FOREIGN_FRAGMENT_CONTEXTS or namespace in {"math", "svg"}
 
 
 def build_fixture(cases: list[SmokeCase]) -> dict[str, object]:
@@ -226,7 +231,7 @@ def axis_for_case(case: SmokeCase) -> str:
 
     if case.source.startswith("foreign-fragment.dat:"):
         return "foreign-fragment"
-    if fragment_context in FOREIGN_FRAGMENT_CONTEXTS:
+    if is_foreign_fragment_context(case.fragment_context):
         return "foreign-fragment"
     if HTML_INTEGRATION_MARKUP.search(case.data):
         return "html-integration-point"

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
@@ -9,8 +9,8 @@
     "upstream_source": "html5lib-tests/tokenizer"
   },
   "tree_construction": {
-    "local_cases": 2485,
-    "missing": 156,
+    "local_cases": 2493,
+    "missing": 148,
     "missing_sources": [
       "adoption02.dat:3",
       "html5test-com.dat:12",
@@ -20,14 +20,6 @@
       "html5test-com.dat:17",
       "html5test-com.dat:18",
       "html5test-com.dat:19",
-      "plain-text-unsafe.dat:34",
-      "plain-text-unsafe.dat:35",
-      "plain-text-unsafe.dat:36",
-      "plain-text-unsafe.dat:37",
-      "plain-text-unsafe.dat:38",
-      "plain-text-unsafe.dat:39",
-      "plain-text-unsafe.dat:40",
-      "plain-text-unsafe.dat:41",
       "processing-instructions.dat:1",
       "processing-instructions.dat:2",
       "processing-instructions.dat:3",

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -40383,3 +40383,123 @@ template
 select
 #document
 | <option>
+
+#source plain-text-unsafe.dat:34
+#data
+<math> filler text
+#errors
+(1,6): expected-doctype-but-got-start-tag
+(1,7): invalid-codepoint
+(1,7): invalid-codepoint-in-foreign-content
+(1,14): invalid-codepoint
+(1,14): invalid-codepoint-in-foreign-content
+(1,18): expected-closing-tag-but-got-eof
+#new-errors
+(1:7) unexpected-null-character
+(1:14) unexpected-null-character
+#document
+| <html>
+|   <head>
+|   <body>
+|     <math math>
+|       "�filler�text"
+
+#source plain-text-unsafe.dat:35
+#data
+<math><![CDATA[ filler text ]]>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+(1,31): invalid-codepoint
+(1,31): invalid-codepoint
+(1,31): invalid-codepoint
+(1,31): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <math math>
+|       "�filler�text�"
+
+#source plain-text-unsafe.dat:36
+#data
+<math><annotation-xml> x
+#errors
+(1,6): expected-doctype-but-got-start-tag
+(1,23): invalid-codepoint
+(1,23): invalid-codepoint-in-foreign-content
+(1,24): expected-closing-tag-but-got-eof
+#new-errors
+(1:23) unexpected-null-character
+#document
+| <html>
+|   <head>
+|   <body>
+|     <math math>
+|       <math annotation-xml>
+|         "�x"
+
+#source plain-text-unsafe.dat:37
+#data
+<math><annotation-xml encoding="text/html"> x
+#errors
+(1,6): expected-doctype-but-got-start-tag
+(1,44): invalid-codepoint
+(1,44): invalid-codepoint-in-body
+(1,45): expected-closing-tag-but-got-eof
+#new-errors
+(1:44) unexpected-null-character
+#document
+| <html>
+|   <head>
+|   <body>
+|     <math math>
+|       <math annotation-xml>
+|         encoding="text/html"
+|         "x"
+
+#source plain-text-unsafe.dat:38
+#data
+ filler text
+#errors
+#new-errors
+(1:1) unexpected-null-character
+(1:8) unexpected-null-character
+#document-fragment
+svg path
+#document
+| "�filler�text"
+
+#source plain-text-unsafe.dat:39
+#data
+ filler text
+#errors
+#new-errors
+(1:1) unexpected-null-character
+(1:8) unexpected-null-character
+#document-fragment
+svg title
+#document
+| "fillertext"
+
+#source plain-text-unsafe.dat:40
+#data
+ filler text
+#errors
+#new-errors
+(1:1) unexpected-null-character
+(1:8) unexpected-null-character
+#document-fragment
+math ms
+#document
+| "fillertext"
+
+#source plain-text-unsafe.dat:41
+#data
+ x
+#errors
+#new-errors
+(1:1) unexpected-null-character
+#document-fragment
+math annotation-xml
+#document
+| "�x"

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-foreign-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-foreign-audit.json
@@ -1,5 +1,5 @@
 {
-  "case_count": 427,
+  "case_count": 435,
   "cases": [
     {
       "axis": "table-foreign-boundary",
@@ -2562,12 +2562,60 @@
       "id": "webkit02-dat-25",
       "reason": "MathML insertion-mode boundaries and text-integration recovery",
       "source": "webkit02.dat:25"
+    },
+    {
+      "axis": "mathml-boundary",
+      "id": "plain-text-unsafe-dat-34",
+      "reason": "MathML insertion-mode boundaries and text-integration recovery",
+      "source": "plain-text-unsafe.dat:34"
+    },
+    {
+      "axis": "mathml-boundary",
+      "id": "plain-text-unsafe-dat-35",
+      "reason": "MathML insertion-mode boundaries and text-integration recovery",
+      "source": "plain-text-unsafe.dat:35"
+    },
+    {
+      "axis": "html-integration-point",
+      "id": "plain-text-unsafe-dat-36",
+      "reason": "foreignObject, desc/title, and annotation-xml HTML integration points",
+      "source": "plain-text-unsafe.dat:36"
+    },
+    {
+      "axis": "html-integration-point",
+      "id": "plain-text-unsafe-dat-37",
+      "reason": "foreignObject, desc/title, and annotation-xml HTML integration points",
+      "source": "plain-text-unsafe.dat:37"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "plain-text-unsafe-dat-38",
+      "reason": "SVG and MathML fragment parsing with foreign-content context seeding",
+      "source": "plain-text-unsafe.dat:38"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "plain-text-unsafe-dat-39",
+      "reason": "SVG and MathML fragment parsing with foreign-content context seeding",
+      "source": "plain-text-unsafe.dat:39"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "plain-text-unsafe-dat-40",
+      "reason": "SVG and MathML fragment parsing with foreign-content context seeding",
+      "source": "plain-text-unsafe.dat:40"
+    },
+    {
+      "axis": "foreign-fragment",
+      "id": "plain-text-unsafe-dat-41",
+      "reason": "SVG and MathML fragment parsing with foreign-content context seeding",
+      "source": "plain-text-unsafe.dat:41"
     }
   ],
   "counts_by_axis": {
-    "foreign-fragment": 66,
-    "html-integration-point": 96,
-    "mathml-boundary": 78,
+    "foreign-fragment": 70,
+    "html-integration-point": 98,
+    "mathml-boundary": 80,
     "svg-boundary": 130,
     "table-foreign-boundary": 57
   },

--- a/code/packages/rust/html-parser/tests/html5lib_coverage_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/html5lib_coverage_audit_test.rs
@@ -74,8 +74,8 @@ fn html5lib_coverage_audit_fixture_matches_checked_local_corpora() {
     );
     assert_eq!(audit.tree_construction.upstream_cases, 1934);
     assert_eq!(audit.tree_construction.local_cases, tree_cases.len());
-    assert_eq!(audit.tree_construction.local_cases, 2485);
-    assert_eq!(audit.tree_construction.missing, 156);
+    assert_eq!(audit.tree_construction.local_cases, 2493);
+    assert_eq!(audit.tree_construction.missing, 148);
     assert_eq!(
         audit.tree_construction.missing_sources.len(),
         audit.tree_construction.missing
@@ -90,7 +90,7 @@ fn html5lib_coverage_audit_fixture_matches_checked_local_corpora() {
     );
     assert_eq!(
         missing_source_count(&audit.tree_construction, "plain-text-unsafe.dat:"),
-        8
+        0
     );
     assert_eq!(
         missing_source_count(&audit.tree_construction, "html5test-com.dat:"),

--- a/code/packages/rust/html-parser/tests/mathml_text_conformance_test.rs
+++ b/code/packages/rust/html-parser/tests/mathml_text_conformance_test.rs
@@ -1,0 +1,111 @@
+#[allow(dead_code)]
+mod common;
+
+use coding_adventures_html_lexer::HtmlScriptingMode;
+use common::{actual_dom_dump_for_tree_case, TreeConstructionCase};
+
+#[test]
+fn wpt_mathml_and_svg_null_text_cases_match_dom_dump() {
+    let cases = [
+        tree_case(
+            "plain-text-unsafe.dat:34",
+            "<math>\0filler\0text",
+            None,
+            &[
+                "| <html>",
+                "|   <head>",
+                "|   <body>",
+                "|     <math math>",
+                "|       \"�filler�text\"",
+            ],
+        ),
+        tree_case(
+            "plain-text-unsafe.dat:35",
+            "<math><![CDATA[\0filler\0text\0]]>",
+            None,
+            &[
+                "| <html>",
+                "|   <head>",
+                "|   <body>",
+                "|     <math math>",
+                "|       \"�filler�text�\"",
+            ],
+        ),
+        tree_case(
+            "plain-text-unsafe.dat:36",
+            "<math><annotation-xml>\0x",
+            None,
+            &[
+                "| <html>",
+                "|   <head>",
+                "|   <body>",
+                "|     <math math>",
+                "|       <math annotation-xml>",
+                "|         \"�x\"",
+            ],
+        ),
+        tree_case(
+            "plain-text-unsafe.dat:37",
+            "<math><annotation-xml encoding=\"text/html\">\0x",
+            None,
+            &[
+                "| <html>",
+                "|   <head>",
+                "|   <body>",
+                "|     <math math>",
+                "|       <math annotation-xml>",
+                "|         encoding=\"text/html\"",
+                "|         \"x\"",
+            ],
+        ),
+        tree_case(
+            "plain-text-unsafe.dat:38",
+            "\0filler\0text",
+            Some("svg path"),
+            &["| \"�filler�text\""],
+        ),
+        tree_case(
+            "plain-text-unsafe.dat:39",
+            "\0filler\0text",
+            Some("svg title"),
+            &["| \"fillertext\""],
+        ),
+        tree_case(
+            "plain-text-unsafe.dat:40",
+            "\0filler\0text",
+            Some("math ms"),
+            &["| \"fillertext\""],
+        ),
+        tree_case(
+            "plain-text-unsafe.dat:41",
+            "\0x",
+            Some("math annotation-xml"),
+            &["| \"�x\""],
+        ),
+    ];
+
+    for case in cases {
+        let actual = actual_dom_dump_for_tree_case(&case)
+            .expect("parser should accept any WPT HTML or HTML fragment input");
+        assert_eq!(
+            actual, case.document,
+            "WPT tree-construction case {} failed for input {:?}",
+            case.source, case.data
+        );
+    }
+}
+
+fn tree_case(
+    source: &str,
+    data: &str,
+    fragment_context: Option<&str>,
+    document: &[&str],
+) -> TreeConstructionCase {
+    TreeConstructionCase {
+        source: source.to_string(),
+        data: data.to_string(),
+        scripting: HtmlScriptingMode::Enabled,
+        fragment_context: fragment_context.map(str::to_string),
+        document: document.iter().map(|line| (*line).to_string()).collect(),
+    }
+}


### PR DESCRIPTION
## What changed

- distinguish MathML HTML integration points from the entire MathML namespace when normalizing replacement characters
- add a focused executable test for eight current WPT MathML/SVG null-text cases
- import those cases into the canonical tree-construction corpus and foreign-content audit
- ratchet the live WPT tree-construction debt from 156 to 148 missing source signatures

## Why

The parser treated every MathML element as an HTML integration point while deciding whether U+FFFD replacement text should be removed. That dropped null-derived text in ordinary MathML foreign content, even though only actual MathML integration points should take the integration-point path.

## Impact

MathML foreign-content text and fragment parsing now match current WPT behavior for the covered null-text boundaries. The checked corpus grows from 2,485 to 2,493 passing tree-construction cases.

## Validation

- `cargo test -p coding-adventures-html-parser`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `generate_whatwg_foreign_audit_fixture.py --check`
- `check_whatwg_audit_coverage.py --check` (2,493 indexed, 0 missing/stale)
- live WPT/html5lib coverage audit (1,934 upstream tree cases, 148 missing; 6,806 tokenizer cases, 0 missing; 7,242 normalized, 0 skipped)