### PR TITLE
feat(adj-formula-stdlib): power-conversions — NIST SP 811 B.9 erg/s→watt power table (RS-5, b22)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -1005,6 +1005,53 @@ fn shipped_magnetic_flux_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b22) Shipped table — reference/power-conversions.adj resolves via import (a NEW
+//       dimension: power → watt, the EXACT SP 811 B.9 boldface factor
+//       erg per second = 1.0 E-07 = 0.0000001, the erg DEFINED as exactly 10⁻⁷ J so an erg
+//       per second is exactly 10⁻⁷ W), and a unit of a DIFFERENT quantity (`erg`, an ENERGY
+//       unit → joule, not the watt) — no row — abstains rather than mis-converting across
+//       dimensions. The sharp case: the erg (energy) and the erg per second (power) share the
+//       numeric factor 1.0 E-07, but they name DIFFERENT SI units (joule vs watt), so the
+//       abstain proves dimension safety, not mere absence of a value: power is energy per unit
+//       time; one watt is one joule per second.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_power_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_power");
+    let src = stdlib().join("reference/power-conversions.adj");
+    std::fs::copy(&src, dir.join("power-conversions.adj")).expect("copy shipped power-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"power-conversions.adj\"\n\
+         ? power_to_watt(erg_per_second, $v)\n\
+         ? power_to_watt(erg, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 exact factor resolves, character-for-character from the table
+    // (boldface = exact; the erg is defined as exactly 10^-7 J, so erg/s is exactly 10^-7 W).
+    assert!(
+        out.contains("\"v\":\"0.0000001\""),
+        "erg per second = 0.0000001 W: {out}"
+    );
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `erg` is an ENERGY unit (it converts to the joule, a DIFFERENT quantity), so this power
+    // table has no row for it — the engine abstains rather than mis-converting an energy unit
+    // as if it were a power unit (and rather than silently reusing the coincidentally-equal
+    // 1.0 E-07 factor for the wrong SI unit).
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a wrong-dimension unit abstains, never a cross-dimension fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/power-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/power-conversions.adj
@@ -1,0 +1,61 @@
+% ============================================================================
+% power-conversions — power-unit → watt factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of energy-conversions.adj and the other NIST-cited conversion
+% tables: a native tabular relation ingested VERBATIM from a published NIST conversion
+% table. The row states the factor converting the traditional (CGS) unit of POWER — the
+% RATE at which work is done or energy is transferred — to the SI coherent derived unit,
+% the watt (W):
+%
+%     ? power_to_watt(erg_per_second, $v)   % 0.0000001
+%
+% This is a NEW dimension alongside the length/mass/area/volume/time/speed/energy/
+% pressure/force/acceleration/dynamic-viscosity/kinematic-viscosity/magnetic-flux-density/
+% magnetic-flux/illuminance/luminance/radioactivity/absorbed-dose/dose-equivalent/exposure
+% tables. Do NOT confuse it with ENERGY: those are DIFFERENT quantities. POWER (the
+% erg per second → the watt) is energy PER UNIT TIME; ENERGY (the erg → the joule, see
+% energy-conversions.adj) is the work itself. One watt is one joule per second; the erg per
+% second and the erg are their respective traditional units and convert to DIFFERENT SI
+% units. The traditional unit here is the erg per second (erg/s); the SI unit is the watt.
+% Put a power given in erg/s into SI first, then reason (write-once-use-many). Why a `table`
+% and not a hand-written `relate` clause: this is exactly the shape reference data comes in —
+% a published table, not prose. The citable artifact IS the NIST conversion-factors table at
+% the `locator` below; the factor here is a CELL of NIST Special Publication 811,
+% Appendix B.9 ("Factors for units listed alphabetically"), defended by one provenance
+% envelope. Each `row` lowers to a ground relation `power_to_watt(unit, w)`, so the exact
+% lookup above is the ordinary SLD binding query — the engine returns the factor WITH this
+% table's citation as its proof, on the CPU, with zero model calls.
+%
+% HONESTY NOTE (like the magnetic-flux / radioactivity / absorbed-dose tables, only the EXACT
+% defined factor gets a row): NIST SP 811 B.9 prints the "erg per second" power factor in
+% BOLDFACE, its convention for factors that are EXACT by definition, transcribed here as the
+% plain decimal number of watts it names:
+%
+%     erg per second (erg/s)   1.0 E-07  →  0.0000001
+%
+% This is exact because the erg is DEFINED as exactly 10^-7 joule, so an erg per second is
+% exactly 10^-7 joule per second = 10^-7 watt. It terminates; nothing here is a rounded
+% measurement. Note the erg (energy) and the erg per second (power) happen to share the
+% numeric factor 1.0 E-07, but they convert to DIFFERENT SI units — the joule and the watt
+% respectively — which is exactly why the dimension guard below matters. This table is
+% SPECIFIC to power: a unit of a DIFFERENT quantity — e.g. the "erg", which NIST SP 811 B.9
+% lists separately as an ENERGY unit converting to the joule, NOT the watt (see
+% energy-conversions.adj) — therefore gets no row here, and a `? power_to_watt(erg, $v)`
+% ABSTAINS rather than mis-converting an energy unit as if it were a power unit (and rather
+% than silently reusing the coincidentally-equal 1.0 E-07 factor for the wrong SI unit). The
+% only claim this table makes is "this is the exact factor NIST SP 811 B.9 prints for the
+% erg per second's conversion to the watt" — which is exactly what a byte-check against the
+% cited table verifies. `trust authoritative` — a primary, re-fetchable standards reference.
+% (See ADJ-TABLES.md; and feedback_nothing_human_authored — the factor is a verbatim cell of
+% the cited table, nothing asserted from memory.)
+% ============================================================================
+
+table power_to_watt {
+    columns unit, watt
+
+    row (erg_per_second, 0.0000001)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/power-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/power-conversions.query.adj
@@ -1,0 +1,26 @@
+% ============================================================================
+% power-conversions.query.adj — worked lookups over the NIST power → watt table.
+% ============================================================================
+% The shape a consumer produces to convert a power given in a traditional CGS unit into
+% SI: it `import`s the grounded table and asks the engine to bind the factor. No arithmetic
+% and no factor is stated by the consumer — the engine returns the cell WITH the table's
+% NIST citation as its proof, on the CPU.
+%
+%   ? power_to_watt(erg_per_second, $v)   % 0.0000001   (erg/s = 1.0 E-07 W, exact)
+%
+% And the dimension guard: a unit of a DIFFERENT quantity has no row, so the lookup ABSTAINS
+% rather than mis-converting across dimensions. The "erg" is an ENERGY unit (it converts to
+% the joule, see energy-conversions.adj), NOT a power unit — even though the erg and the
+% erg per second share the numeric factor 1.0 E-07, they name different SI units, so reusing
+% the factor here would be a dimension error:
+%
+%   ? power_to_watt(erg, $v)              % abstains (erg is energy → joule, not power → watt)
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli power-conversions.query.adj
+% ============================================================================
+
+import "power-conversions.adj"
+
+? power_to_watt(erg_per_second, $v)   % expect 0.0000001  (exact NIST SP 811 B.9 factor)
+? power_to_watt(erg, $v)              % expect abstain    (energy unit, wrong dimension)


### PR DESCRIPTION
Ships `reference/power-conversions.adj` — a **new RS-5 conversion-table dimension (power)**, ingesting one cell of NIST Special Publication 811, Appendix B.9 ("Factors for units listed alphabetically") verbatim:

> erg per second (erg/s)   **1.0 E-07**   →   `0.0000001` W

The factor is **exact** (NIST prints it boldface): the erg is defined as exactly 10⁻⁷ J, so an erg per second is exactly 10⁻⁷ W. The row lowers to a ground relation `power_to_watt(unit, w)`, so the lookup `? power_to_watt(erg_per_second, $v)` is the ordinary SLD binding query — the engine returns the factor **with the table's NIST citation as its proof**, on the CPU, zero model calls.

### Dimension-safety (the sharp case)
`erg` (without "per second") is an **energy** unit — NIST B.9 lists it separately, converting to the **joule**. The erg and the erg per second happen to share the numeric factor `1.0 E-07`, but they name **different SI units** (joule vs watt). So `? power_to_watt(erg, $v)` **abstains** rather than mis-converting across dimensions — proving the guard enforces *dimension safety*, not mere value absence. (Power is energy per unit time; one watt is one joule per second.)

### What ships
- `code/specs/data/adj-formula-stdlib/reference/power-conversions.adj` — the `table power_to_watt` + NIST provenance envelope
- `code/specs/data/adj-formula-stdlib/reference/power-conversions.query.adj` — worked lookup + abstain
- `code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs` — appends the **b22** block

### Verification
- rs5 suite **27 passed** (was 26); `cargo clippy -p adj-lang-cli --tests -- -D warnings` clean.
- NUL-scan clean on both new source files.
- Render-probed the shipped query against the built CLI: `erg_per_second → "0.0000001"` carrying the NIST locator, and `erg → "abstained":true`.
- `/security-review`: PASSED — no vulnerabilities found.

Data + test only → **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)