### PR TITLE
feat(adj-formula-stdlib): total-lung-capacity-volumes — StatPearls TLC = RV + ERV + IRV + TV (first 4-input inverter)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_total_lung_capacity_volumes_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_total_lung_capacity_volumes_e2e.rs
@@ -1,0 +1,213 @@
+//! End-to-end tests for the `clinical/total-lung-capacity-volumes.adj` library — the
+//! definition of the total lung capacity as the sum of its FOUR primary volumes
+//! (TLC = RV + ERV + IRV + TV) and its four exact rearrangements (each volume = the total
+//! minus the other three) — driven through the built CLI binary against the SHIPPED stdlib.
+//! This is the first four-input (five-formula) n-ary inverter in the clinical track: the same
+//! invariant as every other formula library, extended one dimension past the three-input GCS
+//! sum. A consumer states NO arithmetic; it imports the grounded library, binds the measured
+//! volumes with `observe`, and the engine applies the cited relation on the CPU, computing the
+//! EXACT value and rendering the relation's citation and trust tier in the `derived` section
+//! (the auditable answer). The five formulas INVERT around the worked case
+//! RV = 2, ERV = 3, IRV = 4, TV = 5: 2 + 3 + 4 + 5 = 14, and 14 minus any three volumes
+//! recovers the fourth.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped total-lung-capacity-volumes library, resolved from this
+/// crate's manifest dir so the test is location-independent.
+fn shipped_tlc_volumes_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/total-lung-capacity-volumes.adj")
+        .canonicalize()
+        .expect("shipped total-lung-capacity-volumes.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_tlcvol_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_tlc_volumes_lib()).unwrap();
+    std::fs::write(dir.join("total-lung-capacity-volumes.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// total_lung_capacity — the definition: the sum of the four primary volumes.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_tlc_volumes_library_and_computes_total_with_citation() {
+    let dir = scratch("total");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"total-lung-capacity-volumes.adj\"\n\
+         observe residual_volume(2)\n\
+         observe expiratory_reserve_volume(3)\n\
+         observe inspiratory_reserve_volume(4)\n\
+         observe tidal_volume(5)\n\
+         ? total_lung_capacity(residual_volume, expiratory_reserve_volume, inspiratory_reserve_volume, tidal_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 2 + 3 + 4 + 5 = 14.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"total_lung_capacity\"") && s.contains("\"value\":14"),
+        "total_lung_capacity(2, 3, 4, 5) = 14: {s}"
+    );
+    // … AND the StatPearls/NCBI Bookshelf citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// residual_volume — the same relation solved for RV: TLC − ERV − IRV − TV.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_residual_volume_from_total_and_others_with_citation() {
+    let dir = scratch("rv");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"total-lung-capacity-volumes.adj\"\n\
+         observe total_lung_capacity(14)\n\
+         observe expiratory_reserve_volume(3)\n\
+         observe inspiratory_reserve_volume(4)\n\
+         observe tidal_volume(5)\n\
+         ? residual_volume(total_lung_capacity, expiratory_reserve_volume, inspiratory_reserve_volume, tidal_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 14 - 3 - 4 - 5 = 2, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"residual_volume\"") && s.contains("\"value\":2"),
+        "residual_volume(14, 3, 4, 5) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "residual_volume carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// expiratory_reserve_volume — solved for ERV: TLC − RV − IRV − TV.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_expiratory_reserve_volume_from_total_and_others_with_citation() {
+    let dir = scratch("erv");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"total-lung-capacity-volumes.adj\"\n\
+         observe total_lung_capacity(14)\n\
+         observe residual_volume(2)\n\
+         observe inspiratory_reserve_volume(4)\n\
+         observe tidal_volume(5)\n\
+         ? expiratory_reserve_volume(total_lung_capacity, residual_volume, inspiratory_reserve_volume, tidal_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 14 - 2 - 4 - 5 = 3, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"expiratory_reserve_volume\"") && s.contains("\"value\":3"),
+        "expiratory_reserve_volume(14, 2, 4, 5) = 3: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "expiratory_reserve_volume carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// inspiratory_reserve_volume — solved for IRV: TLC − RV − ERV − TV.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_inspiratory_reserve_volume_from_total_and_others_with_citation() {
+    let dir = scratch("irv");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"total-lung-capacity-volumes.adj\"\n\
+         observe total_lung_capacity(14)\n\
+         observe residual_volume(2)\n\
+         observe expiratory_reserve_volume(3)\n\
+         observe tidal_volume(5)\n\
+         ? inspiratory_reserve_volume(total_lung_capacity, residual_volume, expiratory_reserve_volume, tidal_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 14 - 2 - 3 - 5 = 4, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"inspiratory_reserve_volume\"") && s.contains("\"value\":4"),
+        "inspiratory_reserve_volume(14, 2, 3, 5) = 4: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "inspiratory_reserve_volume carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// tidal_volume — solved for TV: TLC − RV − ERV − IRV, the fifth reading of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_tidal_volume_from_total_and_others_with_citation() {
+    let dir = scratch("tv");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"total-lung-capacity-volumes.adj\"\n\
+         observe total_lung_capacity(14)\n\
+         observe residual_volume(2)\n\
+         observe expiratory_reserve_volume(3)\n\
+         observe inspiratory_reserve_volume(4)\n\
+         ? tidal_volume(total_lung_capacity, residual_volume, expiratory_reserve_volume, inspiratory_reserve_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 14 - 2 - 3 - 4 = 5, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"tidal_volume\"") && s.contains("\"value\":5"),
+        "tidal_volume(14, 2, 3, 4) = 5: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "tidal_volume carries its StatPearls citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/total-lung-capacity-volumes.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/total-lung-capacity-volumes.adj
@@ -1,0 +1,131 @@
+% ============================================================================
+% total-lung-capacity-volumes.adj — the definition of the total lung capacity as the
+% sum of its FOUR primary volumes (total lung capacity = residual volume + expiratory
+% reserve volume + inspiratory reserve volume + tidal volume) in the ADJ standard library.
+% ============================================================================
+% The total-lung-capacity-volumes entry of the *clinical* track, a pulmonary-physiology
+% library. Where total-lung-capacity.adj decomposes the total into two CAPACITIES
+% (TLC = VC + RV) and inspiratory-capacity.adj decomposes it another way (TLC = FRC + IC),
+% this grounds the FULL four-VOLUME decomposition: THE TOTAL LUNG CAPACITY IS THE SUM OF THE
+% FOUR PRIMARY LUNG VOLUMES — the residual volume (RV), the expiratory reserve volume (ERV),
+% the inspiratory reserve volume (IRV), and the tidal volume (TV). It ships as an importable,
+% byte-provenanced, PARAMETERIZED `formula`, together with its four exact rearrangements
+% (each primary volume the total leaves once the other three are removed). It is the first
+% four-input (five-formula) n-ary inverter in the clinical track: the same substrate that
+% inverts a two-input relation three ways and a three-input sum four ways inverts a
+% four-input sum five ways. As with every compute library, a consumer states NO arithmetic:
+% it `import`s this file, binds the measured volumes from its own byte-provenance
+% decomposition, and asks the engine to APPLY the cited definition on the CPU. Zero math is
+% performed by the model; the engine computes each value EXACTLY, carrying the definition's
+% citation.
+%
+%     import "total-lung-capacity-volumes.adj"
+%     observe residual_volume(2)             % "…RV 2 L…"    (span cited by the model)
+%     observe expiratory_reserve_volume(3)   % "…ERV 3 L…"   (span cited by the model)
+%     observe inspiratory_reserve_volume(4)  % "…IRV 4 L…"   (span cited by the model)
+%     observe tidal_volume(5)                % "…Vt 5 L…"    (span cited by the model)
+%     ? total_lung_capacity(residual_volume, expiratory_reserve_volume,
+%                           inspiratory_reserve_volume, tidal_volume)
+%                                              % engine → 14, carrying TLC = RV + ERV + IRV + TV
+%
+% All five formulas are EXACT over their parameters (a four-term sum and its four inverse
+% readings), so every value the engine returns is exact. The five COMPOSE and invert cleanly
+% around the worked case RV = 2, ERV = 3, IRV = 4, TV = 5 (TLC = 2 + 3 + 4 + 5 = 14): the
+% `total_lung_capacity` a consumer computes from the four volumes is exactly the total each
+% single-volume formula subtracts the other three from to recover the missing volume.
+%
+%   total_lung_capacity(residual_volume, expiratory_reserve_volume,
+%                       inspiratory_reserve_volume, tidal_volume)
+%       = residual_volume + expiratory_reserve_volume
+%         + inspiratory_reserve_volume + tidal_volume        % TLC = RV + ERV + IRV + TV (definition)
+%   residual_volume(total_lung_capacity, expiratory_reserve_volume,
+%                   inspiratory_reserve_volume, tidal_volume)
+%       = total_lung_capacity - expiratory_reserve_volume
+%         - inspiratory_reserve_volume - tidal_volume        % RV = TLC − ERV − IRV − TV (solved for RV)
+%   expiratory_reserve_volume(total_lung_capacity, residual_volume,
+%                             inspiratory_reserve_volume, tidal_volume)
+%       = total_lung_capacity - residual_volume
+%         - inspiratory_reserve_volume - tidal_volume        % ERV = TLC − RV − IRV − TV (solved for ERV)
+%   inspiratory_reserve_volume(total_lung_capacity, residual_volume,
+%                              expiratory_reserve_volume, tidal_volume)
+%       = total_lung_capacity - residual_volume
+%         - expiratory_reserve_volume - tidal_volume         % IRV = TLC − RV − ERV − TV (solved for IRV)
+%   tidal_volume(total_lung_capacity, residual_volume,
+%                expiratory_reserve_volume, inspiratory_reserve_volume)
+%       = total_lung_capacity - residual_volume
+%         - expiratory_reserve_volume - inspiratory_reserve_volume % TV = TLC − RV − ERV − IRV (solved for TV)
+%
+% NOTE ON UNITS: RV, ERV, IRV, TV, and TLC are all lung gas volumes and must be observed in
+% the SAME unit (e.g. litres, or millilitres) for the sum to be meaningful; this library
+% performs no unit conversion. It computes the exact sum (or the exact complementary
+% difference) over whatever same-unit volumes it is given. A consumer that mixes units
+% converts them upstream.
+%
+% All five formulas are defended by the SAME defining span — "TLC = RV + ERV + IRV + TV" —
+% because that one definition (the total lung capacity IS the sum of the four primary lung
+% volumes) sanctions the relation read every way (the total from the four volumes, or any one
+% volume from the total and the other three). The span is transcribed verbatim from the
+% StatPearls "Physiology, Lung Capacity" article on the NCBI Bookshelf, so each `formula`
+% carries the provenance envelope every shipped grounded clause carries; the linter rejects an
+% unsourced one. (See feedback_nothing_human_authored — the defining span is a verbatim quote
+% of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each primary volume is an observable finding the definition ranges over, and
+% the capacity is the derived total. `total_lung_capacity`, `residual_volume`,
+% `expiratory_reserve_volume`, `inspiratory_reserve_volume` and `tidal_volume` each appear
+% BOTH as a derived result and as an input (of the other formulas), so each is a single
+% dictionary term used in both roles. The `surface` lists are the everyday names a decomposer
+% maps onto the canonical term.
+% ----------------------------------------------------------------------------
+dictionary total_lung_capacity_volumes_vocab {
+    define residual_volume             : finding  surface "residual volume", "RV"
+    define expiratory_reserve_volume   : finding  surface "expiratory reserve volume", "ERV"
+    define inspiratory_reserve_volume  : finding  surface "inspiratory reserve volume", "IRV"
+    define tidal_volume                : finding  surface "tidal volume", "TV", "Vt"
+    define total_lung_capacity         : finding  surface "total lung capacity", "TLC"
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all five ways. Each is a named, importable, reusable formula over its
+% formal parameters, bound at apply time, and each carries the defining span from StatPearls
+% on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an exact
+% sum/difference of measured volumes, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook total_lung_capacity_volumes_laws {
+    use total_lung_capacity_volumes_vocab
+
+    % Total lung capacity — the sum of the four primary volumes, i.e. TLC = RV + ERV + IRV + TV.
+    formula total_lung_capacity(residual_volume, expiratory_reserve_volume, inspiratory_reserve_volume, tidal_volume) = residual_volume + expiratory_reserve_volume + inspiratory_reserve_volume + tidal_volume
+        source "TLC = RV + ERV + IRV + TV"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541029/"
+        trust authoritative
+
+    % Residual volume — the same definition solved for the residual gas a total leaves once the
+    % expiratory reserve, inspiratory reserve, and tidal volumes are removed
+    % (RV = TLC − ERV − IRV − TV). Defended by the SAME defining span.
+    formula residual_volume(total_lung_capacity, expiratory_reserve_volume, inspiratory_reserve_volume, tidal_volume) = total_lung_capacity - expiratory_reserve_volume - inspiratory_reserve_volume - tidal_volume
+        source "TLC = RV + ERV + IRV + TV"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541029/"
+        trust authoritative
+
+    % Expiratory reserve volume — solved for ERV (ERV = TLC − RV − IRV − TV). Same defining span.
+    formula expiratory_reserve_volume(total_lung_capacity, residual_volume, inspiratory_reserve_volume, tidal_volume) = total_lung_capacity - residual_volume - inspiratory_reserve_volume - tidal_volume
+        source "TLC = RV + ERV + IRV + TV"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541029/"
+        trust authoritative
+
+    % Inspiratory reserve volume — solved for IRV (IRV = TLC − RV − ERV − TV). Same defining span.
+    formula inspiratory_reserve_volume(total_lung_capacity, residual_volume, expiratory_reserve_volume, tidal_volume) = total_lung_capacity - residual_volume - expiratory_reserve_volume - tidal_volume
+        source "TLC = RV + ERV + IRV + TV"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541029/"
+        trust authoritative
+
+    % Tidal volume — solved for TV (TV = TLC − RV − ERV − IRV). The fifth reading of the one
+    % definition.
+    formula tidal_volume(total_lung_capacity, residual_volume, expiratory_reserve_volume, inspiratory_reserve_volume) = total_lung_capacity - residual_volume - expiratory_reserve_volume - inspiratory_reserve_volume
+        source "TLC = RV + ERV + IRV + TV"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541029/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/total-lung-capacity-volumes.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/total-lung-capacity-volumes.query.adj
@@ -1,0 +1,41 @@
+% ============================================================================
+% total-lung-capacity-volumes.query.adj — worked examples over the clinical
+% Total-Lung-Capacity-from-four-volumes library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a TLC question from the four
+% primary lung volumes: it states NO arithmetic and NO relation — it only `import`s the
+% grounded library, `observe`s the volumes it decomposed from the prompt (each a
+% byte-provenanced span, elided here), and asks the engine to APPLY the cited definition. The
+% native adj-lang engine binds the parameters, computes each value EXACTLY on the CPU, and
+% returns it with the definition's source/locator/trust.
+%
+% The five questions INVERT: a residual volume of 2 plus an expiratory reserve volume of 3
+% plus an inspiratory reserve volume of 4 plus a tidal volume of 5 gives a total lung capacity
+% of 2 + 3 + 4 + 5 = 14; and that 14 total minus any three of the volumes is exactly what the
+% fourth volume's formula recovers the missing volume from.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli total-lung-capacity-volumes.query.adj
+% ============================================================================
+
+import "total-lung-capacity-volumes.adj"
+
+% RV 2, ERV 3, IRV 4, TV 5: total TLC = 2 + 3 + 4 + 5.
+observe residual_volume(2)
+observe expiratory_reserve_volume(3)
+observe inspiratory_reserve_volume(4)
+observe tidal_volume(5)
+? total_lung_capacity(residual_volume, expiratory_reserve_volume, inspiratory_reserve_volume, tidal_volume)   % expect 14  (TLC = RV + ERV + IRV + TV)
+
+% That 14 total with the same ERV 3, IRV 4, TV 5: RV = 14 − 3 − 4 − 5.
+observe total_lung_capacity(14)
+? residual_volume(total_lung_capacity, expiratory_reserve_volume, inspiratory_reserve_volume, tidal_volume)   % expect 2   (same def, solved for RV = TLC − ERV − IRV − TV)
+
+% That 14 total with the same RV 2, IRV 4, TV 5: ERV = 14 − 2 − 4 − 5.
+? expiratory_reserve_volume(total_lung_capacity, residual_volume, inspiratory_reserve_volume, tidal_volume)   % expect 3   (same def, solved for ERV = TLC − RV − IRV − TV)
+
+% That 14 total with the same RV 2, ERV 3, TV 5: IRV = 14 − 2 − 3 − 5.
+? inspiratory_reserve_volume(total_lung_capacity, residual_volume, expiratory_reserve_volume, tidal_volume)   % expect 4   (same def, solved for IRV = TLC − RV − ERV − TV)
+
+% That 14 total with the same RV 2, ERV 3, IRV 4: TV = 14 − 2 − 3 − 4.
+? tidal_volume(total_lung_capacity, residual_volume, expiratory_reserve_volume, inspiratory_reserve_volume)   % expect 5   (same def, solved for TV = TLC − RV − ERV − IRV)


### PR DESCRIPTION
Ships `clinical/total-lung-capacity-volumes.adj` — a byte-provenanced clinical `formulabook` grounding the **full four-primary-volume decomposition** of the total lung capacity, **TLC = RV + ERV + IRV + TV**, with its four exact rearrangements (each primary volume = the total minus the other three).

All five formulas carry the **same verbatim defining span**, transcribed from the StatPearls *"Physiology, Lung Capacity"* article (NCBI Bookshelf [NBK541029](https://www.ncbi.nlm.nih.gov/books/NBK541029/)):

> TLC = RV + ERV + IRV + TV

This is the **first four-input (five-formula) n-ary inverter** in the clinical track — one dimension past the three-input GCS sum. It is a distinct, separately-cited decomposition from the two TLC relations already on `main` (`total-lung-capacity.adj`: TLC = VC + RV; `inspiratory-capacity.adj`: TLC = FRC + IC) — the same total, viewed through its four primary volumes.

A consumer states **no arithmetic**: it imports the library, `observe`s the measured volumes (each byte-provenanced), and asks the engine to APPLY the cited definition on the CPU. The engine binds the parameters, computes each value EXACTLY, and returns it with the definition's `source`/`locator`/`trust`. The five formulas invert cleanly around the worked case **RV = 2, ERV = 3, IRV = 4, TV = 5 → TLC = 14**: 14 minus any three volumes recovers the fourth.

### What ships
- `code/specs/data/adj-formula-stdlib/clinical/total-lung-capacity-volumes.adj` — dictionary + 5-formula formulabook
- `code/specs/data/adj-formula-stdlib/clinical/total-lung-capacity-volumes.query.adj` — worked examples
- `code/packages/rust/adj-lang-cli/tests/formula_total_lung_capacity_volumes_e2e.rs` — dedicated e2e (5 tests, all green)

### Verification
- All 5 e2e tests pass; `cargo clippy -p adj-lang-cli --tests -- -D warnings` clean.
- NUL-scan clean on all new source files.
- Render-probed the shipped query against the built CLI: TLC=14 / RV=2 / ERV=3 / IRV=4 / TV=5 render as plain integers, matching the asserted values (worked-case numbers chosen to avoid prefix collisions).
- `/security-review`: PASSED — no vulnerabilities found.

Data + test only → **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)