### PR TITLE
content(please): Latin quaesō + French s'il vous plaît

### DIFF
--- a/code/learning/human-languages/french/lessons/FR-C19-sil-vous-plait.md
+++ b/code/learning/human-languages/french/lessons/FR-C19-sil-vous-plait.md
@@ -1,0 +1,63 @@
+---
+id: FR-C19-sil-vous-plait
+chapter: 19
+type: phrase
+headword: s'il vous plaît
+gloss: please (literally "if it pleases you")
+concept_tag: COURTESY-PLEASE
+prerequisites: [FR-C01-bonjour]
+sounds: [liaison, nasal-vowel, silent-final-t]
+roots: [placere]
+etymology_hook: "s'il vous plaît is literally 'if it pleases you' — plaît ← Latin placēre, root of English please, pleasure, placid"
+est_minutes: 4
+reviews_of: [FR-C01-bonjour]
+---
+
+# s'il vous plaît — please
+
+## Warm-up
+
+[PAUSE 2s] French doesn't order you to do things — it asks, very politely, *if
+it would please you.*
+
+## The phrase
+
+**s'il vous plaît** = **please** — but taken apart it's a tiny sentence:
+
+> **s'** (*si*, "if") + **il** ("it") + **vous** ("you") + **plaît** ("pleases")
+> → "**if it pleases you.**"
+
+You're not demanding; you're checking whether the favour would please them. It's
+the polite indirectness Spanish also uses in *por favor* ("for a favour") — same
+courtesy, built a different way.
+
+The verb **plaît** is from Latin **placēre**, "to please" — which English
+borrowed wholesale: **please**, **pleasure**, **pleasant**, and (via "calm,
+pleasing") even **placid**.
+
+## Formal and familiar
+
+French chooses the word for "you" by who you're talking to — and *please* comes
+in both:
+
+- **s'il vous plaît** — *vous*, the **formal / plural** you (a stranger, an
+  elder, a room). Often written **SVP**.
+- **s'il te plaît** — *te*, the **familiar** you (a friend, a child).
+
+Two sounds to respect: the final **‑t** of *plaît* is **silent** (*pleh*), and
+*plaît* itself carries the *ai* = *eh* you've met.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "s'il vous plaît" — final t silent, *see voo pleh*]
+- [YOU SAY: taken apart — "if it pleases you"]
+- [YOU SAY: familiar — "s'il te plaît" to a friend]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How do you say please in French? (**s'il vous plaît**.) What does it
+literally mean? ("**If it pleases you.**") Which Latin verb is *plaît* from, and
+what English words come from it? (**placēre** — *please, pleasure, placid*.) When
+do you say **s'il te plaît** instead? (To someone you address as **tu** — a
+friend or child.)

--- a/code/learning/human-languages/latin/lessons/LA-C03-quaeso.md
+++ b/code/learning/human-languages/latin/lessons/LA-C03-quaeso.md
@@ -1,0 +1,58 @@
+---
+id: LA-C03-quaeso
+chapter: 3
+type: word
+headword: quaesō
+gloss: please (literally "I ask, I beg")
+concept_tag: COURTESY-PLEASE
+prerequisites: [LA-C01-salve]
+sounds: [qu-as-kw, macron-long-vowel, ae-diphthong]
+roots: [quaerere]
+etymology_hook: "Latin had no word for 'please' — you said quaesō 'I ask', from quaerere 'to seek' (source of query, quest, require)"
+est_minutes: 4
+reviews_of: [LA-C01-salve]
+---
+
+# quaesō — please (I ask)
+
+## Warm-up
+
+[PAUSE 2s] Latin has no word that simply means "please." Instead you say what
+you're actually doing: **asking.**
+
+## The word
+
+**quaesō** — said *KWAI-so* (qu = **kw**, ae = **eye**) — literally means **"I
+ask"** or **"I beg."** Romans dropped it into a sentence exactly where English
+drops *please*:
+
+> *Dā mihi aquam, **quaesō*** — "Give me water, **please**" (lit. "…I ask").
+
+It's a worn-down cousin of the verb **quaerere**, "to seek, to ask" — the same
+root English took for **query**, **quest**, **question**, **require** and
+**inquire**. So *quaesō* is, at heart, "I'm seeking [this] of you."
+
+## Latin's other ways to say please
+
+Because there's no single word, Latin had a small kit of polite moves — worth
+meeting so the absence doesn't feel like a gap:
+
+- **sīs** — a squeezed **sī vīs**, "**if you wish**" (to one person); plural
+  **sultis** (*sī vultis*). This is the *same* "if you wish" strategy French
+  will use in *s'il te plaît*.
+- **amābō tē** — literally "**I will love you**" — a warm, coaxing "please,"
+  the way English might say "be a dear."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "quaesō" — *KWAI-so*, "I ask"]
+- [YOU SAY: in place — "Dā mihi aquam, quaesō"]
+- [YOU SAY: the "if you wish" version — "sīs" (from *sī vīs*)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What did Romans literally say instead of "please"? (**quaesō** — "I
+ask/beg.") What verb is it from, and which English words share that root?
+(**quaerere** "to seek" — *query, quest, require*.) What does **sīs** stand for?
+(***sī vīs***, "if you wish" — the same idea French uses in *s'il te plaît*.)


### PR DESCRIPTION
## What
New concept — **please** (`COURTESY-PLEASE`). Frontier survey: only Spanish had it (*por favor*); 9 chain languages lacked it. This is the **Romance group — Latin + French**.

*(German is already covered — `GE-C03-bitte` teaches *bitte*, whose gloss explicitly includes "please"; it's tagged `COURTESY-YOUREWELCOME` for *bitte*'s dual role, so a second *bitte* lesson would be redundant.)*

## Idiom-honest (please varies wildly)
- **Latin quaesō** — the honest point that Classical Latin had **no word for "please"**: you said *quaesō* "I ask/beg" (← *quaerere* "to seek" → *query/quest/require*), or *sīs* (< *sī vīs* "if you wish"), or *amābō tē* ("I'll love you").
- **French s'il vous plaît** — literally **"if it pleases you"** (*plaît* ← *placēre* → *please/pleasure/placid*); the *vous*/*te* formal-familiar split; **SVP**; silent final *-t*.

Both express *please* by **polite indirection** — the same move as Spanish *por favor* — and Latin's *sīs* "if you wish" is the very strategy French reuses in *s'il te plaît*.

## Review & checks
Latin + Romance linguistics subagent: **SHIP IT** — every claim (the *quaesō*/*quaerere* root, the *sī vīs*/*sī vultis* contractions, the *placēre* derivations, the Latin example sentence) confirmed correct, no fixes. Latin-script → **zero warnings/errors**; **38 + 268 green**.

## Next
Please for **Arabic + Hindi** (*min faḍlik* / *kṛpayā* — Unicode-composed, reviewed), then the **Dravidian** group, then `COURTESY-SORRY` (which no language has yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)