### PR TITLE
fix(spice): preserve remaining MOS model fields in netlists

### DIFF
--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Preserve the remaining supported Level-1 MOS model-card fields `LD`, `TOX`,
+  `RD`, `RS`, `KF`, and `AF`, plus `VTH`, `LAM`, `CJS`, and `CJD` aliases,
+  when lowering Berkeley netlists into engine parameters.
 - Preserve Level-1 MOS model-card `PB`, `MJ`, and `FC` values when lowering
   Berkeley netlists into the engine parameter bundle.
 - Accept Level-1 MOS model-card `MJSW=<grading>` through the normalized engine

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -758,9 +758,10 @@ This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`, `F`, and
 parameters, `.model <name> NPN|PNP(...)` BJT cards with `IS`, `BF` /
 `BETA_F`, `VT`, `CJE`, `CJC`, `TF`, and `TR` parameters,
 `.model <name> NMOS|PMOS(...)` Level-1 MOSFET
-cards with common SPICE aliases (`VT0` / `VTO`, `KP`, `LAMBDA`, `GAMMA`, `PHI`,
-`W`, `L`, `RSH`, `IS`, `N_SUB` / `NSUB`, `T_NOM` / `TNOM`, `CGSO`, `CGDO`,
-`CGBO`, `CBS`, `CBD`, `CJ`, `CJSW`, `PB`, `MJ`, `MJSW`, and `FC`), MOS instance `NRD=<squares>` /
+cards with common SPICE aliases (`VT0` / `VTO` / `VTH`, `KP`, `LAMBDA` /
+`LAM`, `GAMMA`, `PHI`, `W`, `L`, `LD`, `TOX`, `RD`, `RS`, `RSH`, `IS`,
+`N_SUB` / `NSUB`, `T_NOM` / `TNOM`, `CGSO`, `CGDO`, `CGBO`, `CBS` / `CJS`,
+`CBD` / `CJD`, `CJ`, `CJSW`, `PB`, `MJ`, `MJSW`, `FC`, `KF`, and `AF`), MOS instance `NRD=<squares>` /
 `NRS=<squares>` / `AD=<area>` / `AS=<area>` / `PD=<perimeter>` /
 `PS=<perimeter>`, SPICE
 engineering suffixes, capacitor

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1922,13 +1922,17 @@ fn build_mosfet_params(
 
 fn apply_mosfet_param(params: &mut MosfetLevel1Params, name: &str, value: f64) {
     match name {
-        "VT0" | "VTO" => params.vt0 = value,
+        "VT0" | "VTO" | "VTH" => params.vt0 = value,
         "KP" => params.kp = value,
-        "LAMBDA" => params.lambda = value,
+        "LAMBDA" | "LAM" => params.lambda = value,
         "GAMMA" => params.gamma = value,
         "PHI" => params.phi = value,
         "W" => params.w = value,
         "L" => params.l = value,
+        "LD" => params.lateral_diffusion_length = value,
+        "TOX" => params.oxide_thickness = value,
+        "RD" => params.drain_resistance = value,
+        "RS" => params.source_resistance = value,
         "RSH" => params.sheet_resistance = value,
         "IS" => params.saturation_current = value,
         "N_SUB" | "NSUB" | "N" => params.n_sub = value,
@@ -1936,14 +1940,16 @@ fn apply_mosfet_param(params: &mut MosfetLevel1Params, name: &str, value: f64) {
         "CGSO" => params.gate_source_overlap_capacitance = value,
         "CGDO" => params.gate_drain_overlap_capacitance = value,
         "CGBO" => params.gate_bulk_overlap_capacitance = value,
-        "CBS" => params.source_bulk_capacitance = value,
-        "CBD" => params.drain_bulk_capacitance = value,
+        "CBS" | "CJS" => params.source_bulk_capacitance = value,
+        "CBD" | "CJD" => params.drain_bulk_capacitance = value,
         "CJ" => params.bottom_junction_capacitance = value,
         "CJSW" => params.sidewall_junction_capacitance = value,
         "PB" => params.bulk_junction_potential = value,
         "MJ" => params.bulk_junction_grading_coefficient = value,
         "MJSW" => params.sidewall_junction_grading_coefficient = value,
         "FC" => params.forward_bias_depletion_coefficient = value,
+        "KF" => params.flicker_noise_coefficient = value,
+        "AF" => params.flicker_noise_exponent = value,
         _ => {}
     }
 }

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1359,7 +1359,7 @@ Jpull drain gate source pch
 fn parses_mosfet_models_into_operating_point_circuits() {
     let parsed = parse_netlist(
         r#"
-.model nch NMOS(VTO=0.45 KP=250u LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n RSH=250 NSUB=1.5 TNOM=300 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p CJ=2m CJSW=5u PB=0.9 MJ=0.45 MJSW=0.25 FC=0.4)
+.model nch NMOS(VTO=0.45 KP=250u LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n LD=10n TOX=20n RD=10 RS=20 RSH=250 NSUB=1.5 TNOM=300 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p CJ=2m CJSW=5u PB=0.9 MJ=0.45 MJSW=0.25 FC=0.4 KF=1p AF=1.2)
 Vdd vdd 0 DC 5
 Vgate gate 0 DC 2.5
 M1 vdd gate out 0 nch W=4u L=200n NRD=2 NRS=3 AD=3n AS=4n PD=6u PS=7u
@@ -1392,6 +1392,10 @@ Rload out 0 1k
     assert_close(mosfet.params.phi, 0.8);
     assert_close(mosfet.params.w, 4.0e-6);
     assert_close(mosfet.params.l, 200.0e-9);
+    assert_close(mosfet.params.lateral_diffusion_length, 10.0e-9);
+    assert_close(mosfet.params.oxide_thickness, 20.0e-9);
+    assert_close(mosfet.params.drain_resistance, 10.0);
+    assert_close(mosfet.params.source_resistance, 20.0);
     assert_close(mosfet.params.sheet_resistance, 250.0);
     assert_close(mosfet.params.drain_squares, 2.0);
     assert_close(mosfet.params.source_squares, 3.0);
@@ -1405,6 +1409,8 @@ Rload out 0 1k
     assert_close(mosfet.params.bulk_junction_grading_coefficient, 0.45);
     assert_close(mosfet.params.sidewall_junction_grading_coefficient, 0.25);
     assert_close(mosfet.params.forward_bias_depletion_coefficient, 0.4);
+    assert_close(mosfet.params.flicker_noise_coefficient, 1.0e-12);
+    assert_close(mosfet.params.flicker_noise_exponent, 1.2);
     assert_close(mosfet.params.n_sub, 1.5);
     assert_close(mosfet.params.t_nom, 300.0);
     assert_close(mosfet.params.gate_source_overlap_capacitance, 3.0e-12);
@@ -1423,7 +1429,7 @@ Rload out 0 1k
 fn parses_pmos_mosfet_model_cards() {
     let parsed = parse_netlist(
         r#"
-.model pch PMOS(VT0=-0.5 KP=90u W=3u L=180n)
+.model pch PMOS(VTH=-0.5 KP=90u LAM=0.03 W=3u L=180n CJS=2p CJD=3p)
 Mpull out gate vdd vdd pch
 "#,
     )
@@ -1435,7 +1441,10 @@ Mpull out gate vdd vdd pch
     assert_eq!(mosfet.mosfet_type, MosfetType::Pmos);
     assert_close(mosfet.params.vt0, -0.5);
     assert_close(mosfet.params.kp, 90.0e-6);
+    assert_close(mosfet.params.lambda, 0.03);
     assert_close(mosfet.params.w, 3.0e-6);
+    assert_close(mosfet.params.source_bulk_capacitance, 2.0e-12);
+    assert_close(mosfet.params.drain_bulk_capacitance, 3.0e-12);
 }
 
 #[test]

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,13 +33,13 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Berkeley netlist lowering for Level-1 MOS junction shaping.
+1. Berkeley netlist lowering for remaining Level-1 MOS model fields.
    - Status: current PR completion candidate.
-   - Preserve model-card `PB`, `MJ`, and `FC` when the Rust Berkeley netlist
-     facade lowers Level-1 MOS devices into the engine parameter bundle.
-   - Prove source-deck values reach the existing cross-language AC and transient
-     depletion-capacitance behavior instead of silently falling back to
-     defaults.
+   - Preserve canonical `LD`, `TOX`, `RD`, `RS`, `KF`, and `AF` values plus
+     the supported `VTH`, `LAM`, `CJS`, and `CJD` aliases when the Rust
+     Berkeley facade lowers Level-1 MOS devices.
+   - Prove canonical and alias forms reach their existing engine fields instead
+     of silently falling back to defaults.
 
 ## Completed Slices
 
@@ -3526,6 +3526,13 @@ the Rust, Python, and TypeScript surfaces together.
      `MJ`-controlled bottom-junction terms in AC and transient analysis.
    - Hierarchy, cloning, validation, model-card coverage, and the Rust netlist
      facade preserve the parameter.
+
+279. Berkeley netlist lowering for Level-1 MOS junction shaping.
+   - Status: completed in PR 9088.
+   - The Rust Berkeley netlist facade now preserves model-card `PB`, `MJ`, and
+     `FC` in the Level-1 engine parameter bundle.
+   - Source-deck integration coverage proves all three values reach the existing
+     cross-language depletion-capacitance behavior.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- preserve Level-1 MOS `LD`, `TOX`, `RD`, `RS`, `KF`, and `AF` model-card values in Rust Berkeley netlist lowering
- accept the supported `VTH`, `LAM`, `CJS`, and `CJD` aliases
- extend source-deck integration coverage and reconcile the SPICE completion plan after PR #9088

## Verification
- `cargo test -p spice-netlist-parser --test spice_netlist_parser_test` (95 passed)
- `cargo fmt --check -p spice-netlist-parser`
- `cargo clippy -p spice-netlist-parser --all-targets -- -D warnings`
- `git diff --check`