### PR TITLE
feat(adj-formula-stdlib): non-HDL cholesterol — StatPearls non-HDL-C = total − HDL definition library

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_non_hdl_cholesterol_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_non_hdl_cholesterol_e2e.rs
@@ -1,0 +1,140 @@
+//! End-to-end tests for the `clinical/non-hdl-cholesterol.adj` library — the definition of
+//! non-HDL cholesterol (non-HDL-C = total cholesterol − HDL cholesterol) and its two exact
+//! rearrangements (total = non-HDL + HDL; HDL = total − non-HDL) — driven through the built CLI
+//! binary against the SHIPPED stdlib. The same invariant as every other formula library: a
+//! consumer states NO arithmetic; it imports the grounded library, binds the measured
+//! cholesterols with `observe`, and the engine applies the cited relation on the CPU, computing
+//! the EXACT value and rendering the relation's citation and trust tier in the `derived` section
+//! (the auditable answer). The three formulas INVERT around the worked case total = 190 mg/dL,
+//! HDL = 40 mg/dL: 190 − 40 = 150, 150 + 40 = 190, and 190 − 150 = 40.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped non-hdl-cholesterol library, resolved from this crate's manifest
+/// dir so the test is location-independent.
+fn shipped_non_hdl_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/non-hdl-cholesterol.adj")
+        .canonicalize()
+        .expect("shipped non-hdl-cholesterol.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_nonhdl_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_non_hdl_lib()).unwrap();
+    std::fs::write(dir.join("non-hdl-cholesterol.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// non_hdl_cholesterol — the definition: total cholesterol minus HDL cholesterol.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_non_hdl_library_and_computes_it_with_citation() {
+    let dir = scratch("total");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"non-hdl-cholesterol.adj\"\n\
+         observe total_cholesterol(190)\n\
+         observe hdl_cholesterol(40)\n\
+         ? non_hdl_cholesterol(total_cholesterol, hdl_cholesterol)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 190 − 40 = 150.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"non_hdl_cholesterol\"") && s.contains("\"value\":150"),
+        "non_hdl_cholesterol(190, 40) = 150: {s}"
+    );
+    // … AND the StatPearls/NCBI Bookshelf citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// total_cholesterol — the same relation solved for TC: non-HDL + HDL, which INVERTS the
+// difference.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_total_cholesterol_from_non_hdl_and_hdl_with_citation() {
+    let dir = scratch("tc");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"non-hdl-cholesterol.adj\"\n\
+         observe non_hdl_cholesterol(150)\n\
+         observe hdl_cholesterol(40)\n\
+         ? total_cholesterol(non_hdl_cholesterol, hdl_cholesterol)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 150 + 40 = 190, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"total_cholesterol\"") && s.contains("\"value\":190"),
+        "total_cholesterol(150, 40) = 190: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "total_cholesterol carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// hdl_cholesterol — the same relation solved for HDL: total − non-HDL, the third reading of the
+// one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_hdl_cholesterol_from_total_and_non_hdl_with_citation() {
+    let dir = scratch("hdl");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"non-hdl-cholesterol.adj\"\n\
+         observe total_cholesterol(190)\n\
+         observe non_hdl_cholesterol(150)\n\
+         ? hdl_cholesterol(total_cholesterol, non_hdl_cholesterol)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 190 − 150 = 40, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"hdl_cholesterol\"") && s.contains("\"value\":40"),
+        "hdl_cholesterol(190, 150) = 40: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "hdl_cholesterol carries its StatPearls citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/non-hdl-cholesterol.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/non-hdl-cholesterol.adj
@@ -1,0 +1,105 @@
+% ============================================================================
+% non-hdl-cholesterol.adj — the definition of non-HDL cholesterol
+% (non-HDL-C = total cholesterol − HDL cholesterol) in the ADJ standard library.
+% ============================================================================
+% The non-HDL-cholesterol entry of the *clinical* track, a lipidology sibling of the
+% hemodynamics libraries (`mean-arterial-pressure.adj`, `pulse-pressure.adj`,
+% `cerebral-perfusion-pressure.adj`) and the respiratory `alveolar-arterial-gradient.adj`.
+% Where `cerebral-perfusion-pressure.adj` grounds a pressure difference and `pulse-pressure.adj`
+% a blood-pressure difference, this grounds NON-HDL CHOLESTEROL as the difference of two
+% cholesterol measurements: NON-HDL CHOLESTEROL IS THE TOTAL CHOLESTEROL MINUS THE HDL
+% CHOLESTEROL — the cholesterol carried by every ATHEROGENIC lipoprotein particle (LDL, VLDL,
+% IDL and lipoprotein(a)) taken together, obtained from a routine lipid panel by simple
+% subtraction. It is a single number a clinician reads straight off two panel values — no
+% fasting sample and no estimating equation required (unlike the Friedewald LDL estimate in
+% `ldl-cholesterol-friedewald.adj`, which needs the triglycerides and a fasting draw). It ships
+% as an importable, byte-provenanced, PARAMETERIZED `formula`, together with its two exact
+% rearrangements (the total cholesterol a non-HDL value implies for a given HDL, and the HDL the
+% other two imply). As with every compute library, a consumer states NO arithmetic: it
+% `import`s this file, binds the measured cholesterols from its own byte-provenance
+% decomposition, and asks the engine to APPLY the cited definition on the CPU. Zero math is
+% performed by the model; the engine computes each value EXACTLY, carrying the definition's
+% citation.
+%
+%     import "non-hdl-cholesterol.adj"
+%     observe total_cholesterol(190)    % "…total cholesterol 190 mg/dL…"  (span cited by the model)
+%     observe hdl_cholesterol(40)       % "…HDL-C 40 mg/dL…"               (span cited by the model)
+%     ? non_hdl_cholesterol(total_cholesterol, hdl_cholesterol)
+%                                          % engine → 150, carrying non-HDL-C = TC − HDL-C
+%
+% All three formulas are EXACT over their parameters (a difference and two of its inverse
+% readings), so every value the engine returns is exact. The three COMPOSE and invert cleanly
+% around the worked case total cholesterol = 190 mg/dL, HDL-C = 40 mg/dL (non-HDL-C = 190 − 40 =
+% 150 mg/dL): the `non_hdl_cholesterol` a consumer computes from the two cholesterols is exactly
+% the `non_hdl_cholesterol` the `total_cholesterol` formula adds the HDL back to, to recover the
+% 190 mg/dL total, and exactly the `non_hdl_cholesterol` the `hdl_cholesterol` formula subtracts
+% from the total to recover the 40 mg/dL HDL.
+%
+%   non_hdl_cholesterol(total_cholesterol, hdl_cholesterol)
+%       = total_cholesterol - hdl_cholesterol   % non-HDL-C = TC − HDL-C   (definition)
+%   total_cholesterol(non_hdl_cholesterol, hdl_cholesterol)
+%       = non_hdl_cholesterol + hdl_cholesterol % TC = non-HDL-C + HDL-C   (same def, solved for TC)
+%   hdl_cholesterol(total_cholesterol, non_hdl_cholesterol)
+%       = total_cholesterol - non_hdl_cholesterol % HDL-C = TC − non-HDL-C (same def, solved for HDL-C)
+%
+% NOTE ON UNITS: the two cholesterols must be in the SAME unit (both milligrams per decilitre,
+% as in the worked case, or both millimoles per litre), and the non-HDL cholesterol comes out in
+% that same unit; this library computes the exact value over whatever consistent unit it is
+% given.
+%
+% All three formulas are defended by the SAME definitional sentence — "Non-HDL-C is calculated
+% by subtracting HDL cholesterol from total cholesterol and includes all atherogenic particles,
+% including LDL-C, VLDL-C and IDL-C, and lipoprotein(a)." — because that one definition (non-HDL
+% cholesterol IS the total minus the HDL) sanctions the relation read every way (the non-HDL-C
+% from the two cholesterols, the total from the non-HDL-C and HDL, or the HDL from the total and
+% non-HDL-C). The quote is transcribed verbatim from the StatPearls "Pediatric Dyslipidemia"
+% article on the NCBI Bookshelf, so each `formula` carries the provenance envelope every shipped
+% grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the definitional sentence is a verbatim span of the cited
+% page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable cholesterol the definition ranges over, and each
+% result is a derived quantity. `non_hdl_cholesterol`, `total_cholesterol` and `hdl_cholesterol`
+% each appear BOTH as a derived result and as an input (of the other formulas), so each is a
+% single dictionary term used in both roles. The `surface` lists are the everyday names a
+% decomposer maps onto the canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary non_hdl_cholesterol_vocab {
+    define total_cholesterol   : finding  surface "total cholesterol", "TC"                    % milligrams per decilitre (mg/dL)
+    define hdl_cholesterol      : finding  surface "HDL cholesterol", "HDL-C", "HDL"           % milligrams per decilitre (mg/dL)
+    define non_hdl_cholesterol : finding  surface "non-HDL cholesterol", "non-HDL-C"           % milligrams per decilitre (mg/dL)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the definitional sentence from StatPearls on
+% the NCBI Bookshelf (a quote is required on a shipped formula). Each is an exact
+% difference/sum of measured quantities, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook non_hdl_cholesterol_laws {
+    use non_hdl_cholesterol_vocab
+
+    % Non-HDL cholesterol — the total cholesterol less the HDL cholesterol,
+    % i.e. non-HDL-C = TC − HDL-C.
+    formula non_hdl_cholesterol(total_cholesterol, hdl_cholesterol) = total_cholesterol - hdl_cholesterol
+        source "Non-HDL-C is calculated by subtracting HDL cholesterol from total cholesterol and includes all atherogenic particles, including LDL-C, VLDL-C and IDL-C, and lipoprotein(a)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK585106/"
+        trust authoritative
+
+    % Total cholesterol — the same definition solved for the total cholesterol a non-HDL value
+    % implies for an HDL (TC = non-HDL-C + HDL-C). Defended by the SAME definitional sentence,
+    % read the other way.
+    formula total_cholesterol(non_hdl_cholesterol, hdl_cholesterol) = non_hdl_cholesterol + hdl_cholesterol
+        source "Non-HDL-C is calculated by subtracting HDL cholesterol from total cholesterol and includes all atherogenic particles, including LDL-C, VLDL-C and IDL-C, and lipoprotein(a)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK585106/"
+        trust authoritative
+
+    % HDL cholesterol — the same definition solved for the HDL the other two imply
+    % (HDL-C = TC − non-HDL-C). Again the SAME definitional sentence, read the third way.
+    formula hdl_cholesterol(total_cholesterol, non_hdl_cholesterol) = total_cholesterol - non_hdl_cholesterol
+        source "Non-HDL-C is calculated by subtracting HDL cholesterol from total cholesterol and includes all atherogenic particles, including LDL-C, VLDL-C and IDL-C, and lipoprotein(a)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK585106/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/non-hdl-cholesterol.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/non-hdl-cholesterol.query.adj
@@ -1,0 +1,35 @@
+% ============================================================================
+% non-hdl-cholesterol.query.adj — worked lookups over the non-HDL cholesterol definition.
+% ============================================================================
+% The shape a consumer produces to read non-HDL cholesterol off a lipid panel: it `import`s the
+% grounded library, `observe`s the two panel cholesterols it decomposed from its own source
+% bytes, and asks the engine to APPLY the cited definition. No arithmetic is stated by the
+% consumer; the engine computes the exact value WITH the definition's StatPearls citation as its
+% proof, on the CPU, with zero model calls.
+%
+% Worked case (total cholesterol = 190 mg/dL, HDL-C = 40 mg/dL):
+%
+%   ? non_hdl_cholesterol(total_cholesterol, hdl_cholesterol)   % 150  (190 − 40, non-HDL-C = TC − HDL-C)
+%
+% and the same one definition, inverted both other ways:
+%
+%   ? total_cholesterol(non_hdl_cholesterol, hdl_cholesterol)   % 190  (150 + 40, TC = non-HDL-C + HDL-C)
+%   ? hdl_cholesterol(total_cholesterol, non_hdl_cholesterol)   % 40   (190 − 150, HDL-C = TC − non-HDL-C)
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli non-hdl-cholesterol.query.adj
+% ============================================================================
+
+import "non-hdl-cholesterol.adj"
+
+% Forward: non-HDL cholesterol from the two panel cholesterols.
+observe total_cholesterol(190)
+observe hdl_cholesterol(40)
+? non_hdl_cholesterol(total_cholesterol, hdl_cholesterol)   % expect 150
+
+% Inverse 1: the total cholesterol a non-HDL value implies for an HDL.
+observe non_hdl_cholesterol(150)
+? total_cholesterol(non_hdl_cholesterol, hdl_cholesterol)   % expect 190
+
+% Inverse 2: the HDL the total and non-HDL imply.
+? hdl_cholesterol(total_cholesterol, non_hdl_cholesterol)   % expect 40


### PR DESCRIPTION
## What

Grounds **non-HDL cholesterol** as a byte-provenanced, importable formula library on the *clinical/lipidology* track: `non-HDL-C = total cholesterol − HDL cholesterol`, plus its two exact rearrangements (`TC = non-HDL + HDL`, `HDL = TC − non-HDL`). A consumer states **no arithmetic** — it `observe`s the two lipid-panel cholesterols and the engine applies the cited relation on the CPU, computing the exact value and rendering the citation + trust tier (the auditable answer).

## Provenance

All three formulas carry the **same verbatim definitional sentence** from StatPearls *Pediatric Dyslipidemia* ([NBK585106](https://www.ncbi.nlm.nih.gov/books/NBK585106/)):

> Non-HDL-C is calculated by subtracting HDL cholesterol from total cholesterol and includes all atherogenic particles, including LDL-C, VLDL-C and IDL-C, and lipoprotein(a).

Byte-verified against the source page before shipping (`feedback_nothing_human_authored` — the sentence is a verbatim span of the cited page, nothing asserted from memory).

## Worked case

`total_cholesterol = 190 mg/dL`, `HDL-C = 40 mg/dL` → `non-HDL-C = 150 mg/dL`; the three formulas invert cleanly (150 + 40 = 190; 190 − 150 = 40).

## Tests

Dedicated e2e file `formula_non_hdl_cholesterol_e2e.rs` (3 tests, all green) drives the shipped library through the built CLI against the stdlib. `cargo clippy --tests -D warnings` clean. Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)