### PR TITLE
feat(adj-formula-stdlib): Friedewald LDL — StatPearls LDL-C = TC − HDL − TG/5 estimate library

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_ldl_cholesterol_friedewald_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_ldl_cholesterol_friedewald_e2e.rs
@@ -1,0 +1,176 @@
+//! End-to-end tests for the `clinical/ldl-cholesterol-friedewald.adj` library — the Friedewald
+//! estimate of LDL cholesterol (LDL-C = total cholesterol − HDL − triglycerides/5) and its three
+//! exact rearrangements — driven through the built CLI binary against the SHIPPED stdlib. This
+//! is the first clinical inverter whose definition carries an EMBEDDED NUMERIC CONSTANT (the
+//! divide-by-5, and its inverse ×5 when solved for the triglycerides): the "/5" is part of the
+//! cited equation, evaluated exactly over rationals. The same invariant as every other formula
+//! library: a consumer states NO arithmetic; it imports the grounded library, binds the measured
+//! panel values with `observe`, and the engine applies the cited relation on the CPU, computing
+//! the EXACT value and rendering the relation's citation and trust tier in the `derived` section.
+//! The four formulas INVERT around the worked case TC = 200, HDL = 50, TG = 150:
+//! 200 − 50 − 150/5 = 120; 120 + 50 + 150/5 = 200; 200 − 120 − 150/5 = 50; 5·(200 − 50 − 120) = 150.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped ldl-cholesterol-friedewald library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_friedewald_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/ldl-cholesterol-friedewald.adj")
+        .canonicalize()
+        .expect("shipped ldl-cholesterol-friedewald.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_friedewald_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_friedewald_lib()).unwrap();
+    std::fs::write(dir.join("ldl-cholesterol-friedewald.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// ldl_cholesterol — the Friedewald equation: total − HDL − triglycerides/5.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_friedewald_library_and_estimates_ldl_with_citation() {
+    let dir = scratch("ldl");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"ldl-cholesterol-friedewald.adj\"\n\
+         observe total_cholesterol(200)\n\
+         observe hdl_cholesterol(50)\n\
+         observe triglycerides(150)\n\
+         ? ldl_cholesterol(total_cholesterol, hdl_cholesterol, triglycerides)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied equation's result: 200 − 50 − 150/5 = 120.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"ldl_cholesterol\"") && s.contains("\"value\":120"),
+        "ldl_cholesterol(200, 50, 150) = 120: {s}"
+    );
+    // … AND the StatPearls/NCBI Bookshelf citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied equation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// total_cholesterol — the same equation solved for TC: LDL + HDL + triglycerides/5.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_total_cholesterol_from_ldl_hdl_tg_with_citation() {
+    let dir = scratch("tc");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"ldl-cholesterol-friedewald.adj\"\n\
+         observe ldl_cholesterol(120)\n\
+         observe hdl_cholesterol(50)\n\
+         observe triglycerides(150)\n\
+         ? total_cholesterol(ldl_cholesterol, hdl_cholesterol, triglycerides)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 120 + 50 + 150/5 = 200, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"total_cholesterol\"") && s.contains("\"value\":200"),
+        "total_cholesterol(120, 50, 150) = 200: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "total_cholesterol carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// hdl_cholesterol — the same equation solved for HDL: total − LDL − triglycerides/5.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_hdl_cholesterol_from_total_ldl_tg_with_citation() {
+    let dir = scratch("hdl");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"ldl-cholesterol-friedewald.adj\"\n\
+         observe total_cholesterol(200)\n\
+         observe ldl_cholesterol(120)\n\
+         observe triglycerides(150)\n\
+         ? hdl_cholesterol(total_cholesterol, ldl_cholesterol, triglycerides)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 200 − 120 − 150/5 = 50, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"hdl_cholesterol\"") && s.contains("\"value\":50"),
+        "hdl_cholesterol(200, 120, 150) = 50: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "hdl_cholesterol carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// triglycerides — the same equation solved for TG: 5·(total − HDL − LDL). Here the /5 becomes a
+// ×5, the fourth reading of the one equation.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_triglycerides_from_total_hdl_ldl_with_citation() {
+    let dir = scratch("tg");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"ldl-cholesterol-friedewald.adj\"\n\
+         observe total_cholesterol(200)\n\
+         observe hdl_cholesterol(50)\n\
+         observe ldl_cholesterol(120)\n\
+         ? triglycerides(total_cholesterol, hdl_cholesterol, ldl_cholesterol)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 5·(200 − 50 − 120) = 5·30 = 150, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"triglycerides\"") && s.contains("\"value\":150"),
+        "triglycerides(200, 50, 120) = 150: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "triglycerides carries its StatPearls citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/ldl-cholesterol-friedewald.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/ldl-cholesterol-friedewald.adj
@@ -1,0 +1,118 @@
+% ============================================================================
+% ldl-cholesterol-friedewald.adj — the Friedewald estimate of LDL cholesterol
+% (LDL-C = total cholesterol − HDL cholesterol − triglycerides/5) in the ADJ standard library.
+% ============================================================================
+% The Friedewald-LDL entry of the *clinical* track, a lipidology sibling of
+% `non-hdl-cholesterol.adj`. Where `non-hdl-cholesterol.adj` grounds the plain difference
+% non-HDL-C = TC − HDL-C, this grounds the classic FRIEDEWALD estimate of the LDL cholesterol
+% from a fasting lipid panel: LDL CHOLESTEROL IS THE TOTAL CHOLESTEROL, LESS THE HDL
+% CHOLESTEROL, LESS ONE FIFTH OF THE TRIGLYCERIDES — the "/5" standing in for the cholesterol
+% carried by VLDL, whose triglyceride-to-cholesterol ratio is taken as 5:1 in a normal fasting
+% person. It is the first clinical inverter whose definition carries an EMBEDDED NUMERIC
+% CONSTANT (the divide-by-5): the "/5" is part of the cited equation, not a free parameter, so
+% it appears verbatim in every reading of the relation. It ships as an importable,
+% byte-provenanced, PARAMETERIZED `formula`, together with its three exact rearrangements (the
+% total, the HDL, and the triglycerides each recovered from the other three). As with every
+% compute library, a consumer states NO arithmetic: it `import`s this file, binds the measured
+% panel values from its own byte-provenance decomposition, and asks the engine to APPLY the
+% cited equation on the CPU. Zero math is performed by the model; the engine computes each value
+% EXACTLY (the ADJ engine reasons over exact rationals, so the /5 and *5 are exact, not
+% floating-point), carrying the equation's citation.
+%
+%     import "ldl-cholesterol-friedewald.adj"
+%     observe total_cholesterol(200)    % "…total cholesterol 200 mg/dL…"  (span cited by the model)
+%     observe hdl_cholesterol(50)       % "…HDL-C 50 mg/dL…"               (span cited by the model)
+%     observe triglycerides(150)        % "…triglycerides 150 mg/dL…"      (span cited by the model)
+%     ? ldl_cholesterol(total_cholesterol, hdl_cholesterol, triglycerides)
+%                                          % engine → 120, carrying LDL-C = TC − HDL − TG/5
+%
+% All four formulas are EXACT over their parameters, so every value the engine returns is exact.
+% The four COMPOSE and invert cleanly around the worked case total cholesterol = 200 mg/dL,
+% HDL-C = 50 mg/dL, triglycerides = 150 mg/dL (LDL-C = 200 − 50 − 150/5 = 200 − 50 − 30 =
+% 120 mg/dL): the `ldl_cholesterol` a consumer computes from the panel is exactly the
+% `ldl_cholesterol` the `total_cholesterol` formula adds the HDL and the VLDL cholesterol back
+% to (recovering 200), exactly the value the `hdl_cholesterol` formula subtracts from the total
+% along with the VLDL cholesterol (recovering 50), and exactly the value the `triglycerides`
+% formula multiplies the leftover cholesterol back out by 5 to recover (150).
+%
+%   ldl_cholesterol(total_cholesterol, hdl_cholesterol, triglycerides)
+%       = total_cholesterol - hdl_cholesterol - triglycerides / 5       % LDL-C = TC − HDL − TG/5   (definition)
+%   total_cholesterol(ldl_cholesterol, hdl_cholesterol, triglycerides)
+%       = ldl_cholesterol + hdl_cholesterol + triglycerides / 5         % TC = LDL + HDL + TG/5     (solved for TC)
+%   hdl_cholesterol(total_cholesterol, ldl_cholesterol, triglycerides)
+%       = total_cholesterol - ldl_cholesterol - triglycerides / 5       % HDL = TC − LDL − TG/5     (solved for HDL)
+%   triglycerides(total_cholesterol, hdl_cholesterol, ldl_cholesterol)
+%       = (total_cholesterol - hdl_cholesterol - ldl_cholesterol) * 5   % TG = 5·(TC − HDL − LDL)   (solved for TG)
+%
+% NOTE ON UNITS: the three cholesterols and the triglycerides must all be in the SAME unit
+% (milligrams per decilitre, as in the worked case), and the LDL cholesterol comes out in that
+% same unit; the /5 factor is the one that makes the estimate mg/dL-specific — the Friedewald
+% equation as written here uses the mg/dL convention. NOTE ON VALIDITY: the estimate assumes a
+% FASTING sample and is unreliable at high triglycerides (by convention it is not used when the
+% triglyceride level exceeds 400 mg/dL); this library grounds only the arithmetic of the
+% equation, not the eligibility to use it. For a fasting-independent alternative that needs no
+% triglycerides, see the plain non-HDL cholesterol in `non-hdl-cholesterol.adj`.
+%
+% All four formulas are defended by the SAME equation — "LDL-cholesterol = total cholesterol –
+% HDL-C – triglycerides (VLDL)/5" — because that one equation (the LDL is the total minus the
+% HDL minus a fifth of the triglycerides) sanctions the relation read every way. The quote is
+% transcribed verbatim from the StatPearls "Biochemistry, Low Density Lipoprotein" article on
+% the NCBI Bookshelf, so each `formula` carries the provenance envelope every shipped grounded
+% clause carries; the linter rejects an unsourced one. (See feedback_nothing_human_authored —
+% the equation is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable lipid-panel quantity the equation ranges over, and
+% each result is a derived quantity. `ldl_cholesterol`, `total_cholesterol`, `hdl_cholesterol`
+% and `triglycerides` each appear BOTH as a derived result and as an input (of the other
+% formulas), so each is a single dictionary term used in both roles. The `surface` lists are the
+% everyday names a decomposer maps onto the canonical term; the trailing comment records the
+% intended unit.
+% ----------------------------------------------------------------------------
+dictionary ldl_cholesterol_friedewald_vocab {
+    define total_cholesterol : finding  surface "total cholesterol", "TC"                     % milligrams per decilitre (mg/dL)
+    define hdl_cholesterol    : finding  surface "HDL cholesterol", "HDL-C", "HDL"            % milligrams per decilitre (mg/dL)
+    define triglycerides      : finding  surface "triglycerides", "TG"                        % milligrams per decilitre (mg/dL)
+    define ldl_cholesterol    : finding  surface "LDL cholesterol", "LDL-C", "LDL"            % milligrams per decilitre (mg/dL)
+}
+
+% ----------------------------------------------------------------------------
+% The Friedewald equation, all four ways. Each is a named, importable, reusable formula over its
+% formal parameters, bound at apply time, and each carries the equation from StatPearls on the
+% NCBI Bookshelf (a quote is required on a shipped formula). The embedded /5 (and its inverse
+% *5) is part of the cited equation; the engine evaluates it exactly over rationals, so every
+% value the engine returns is exact.
+% ----------------------------------------------------------------------------
+formulabook ldl_cholesterol_friedewald_laws {
+    use ldl_cholesterol_friedewald_vocab
+
+    % LDL cholesterol — the total, less the HDL, less a fifth of the triglycerides,
+    % i.e. LDL-C = TC − HDL − TG/5.
+    formula ldl_cholesterol(total_cholesterol, hdl_cholesterol, triglycerides) = total_cholesterol - hdl_cholesterol - triglycerides / 5
+        source "LDL-cholesterol = total cholesterol – HDL-C – triglycerides (VLDL)/5"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK500010/"
+        trust authoritative
+
+    % Total cholesterol — the same equation solved for the total (TC = LDL + HDL + TG/5).
+    % Defended by the SAME equation, read the other way.
+    formula total_cholesterol(ldl_cholesterol, hdl_cholesterol, triglycerides) = ldl_cholesterol + hdl_cholesterol + triglycerides / 5
+        source "LDL-cholesterol = total cholesterol – HDL-C – triglycerides (VLDL)/5"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK500010/"
+        trust authoritative
+
+    % HDL cholesterol — the same equation solved for the HDL (HDL = TC − LDL − TG/5).
+    % Again the SAME equation, read the third way.
+    formula hdl_cholesterol(total_cholesterol, ldl_cholesterol, triglycerides) = total_cholesterol - ldl_cholesterol - triglycerides / 5
+        source "LDL-cholesterol = total cholesterol – HDL-C – triglycerides (VLDL)/5"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK500010/"
+        trust authoritative
+
+    % Triglycerides — the same equation solved for the triglycerides (TG = 5·(TC − HDL − LDL)).
+    % The /5 becomes a ×5 when the equation is inverted for the triglycerides; the SAME equation,
+    % read the fourth way.
+    formula triglycerides(total_cholesterol, hdl_cholesterol, ldl_cholesterol) = (total_cholesterol - hdl_cholesterol - ldl_cholesterol) * 5
+        source "LDL-cholesterol = total cholesterol – HDL-C – triglycerides (VLDL)/5"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK500010/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/ldl-cholesterol-friedewald.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/ldl-cholesterol-friedewald.query.adj
@@ -1,0 +1,41 @@
+% ============================================================================
+% ldl-cholesterol-friedewald.query.adj — worked lookups over the Friedewald LDL equation.
+% ============================================================================
+% The shape a consumer produces to estimate LDL cholesterol from a fasting lipid panel: it
+% `import`s the grounded library, `observe`s the total cholesterol, HDL and triglycerides it
+% decomposed from its own source bytes, and asks the engine to APPLY the cited equation. No
+% arithmetic is stated by the consumer (and no constant — the /5 lives in the cited equation,
+% not the query); the engine computes the exact value WITH the StatPearls citation as its proof,
+% on the CPU, with zero model calls.
+%
+% Worked case (total cholesterol = 200 mg/dL, HDL-C = 50 mg/dL, triglycerides = 150 mg/dL):
+%
+%   ? ldl_cholesterol(total_cholesterol, hdl_cholesterol, triglycerides)   % 120  (200 − 50 − 150/5, LDL-C = TC − HDL − TG/5)
+%
+% and the same one equation, inverted the three other ways:
+%
+%   ? total_cholesterol(ldl_cholesterol, hdl_cholesterol, triglycerides)   % 200  (120 + 50 + 150/5, TC = LDL + HDL + TG/5)
+%   ? hdl_cholesterol(total_cholesterol, ldl_cholesterol, triglycerides)   % 50   (200 − 120 − 150/5, HDL = TC − LDL − TG/5)
+%   ? triglycerides(total_cholesterol, hdl_cholesterol, ldl_cholesterol)   % 150  (5·(200 − 50 − 120), TG = 5·(TC − HDL − LDL))
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli ldl-cholesterol-friedewald.query.adj
+% ============================================================================
+
+import "ldl-cholesterol-friedewald.adj"
+
+% Forward: the Friedewald LDL estimate from the fasting panel.
+observe total_cholesterol(200)
+observe hdl_cholesterol(50)
+observe triglycerides(150)
+? ldl_cholesterol(total_cholesterol, hdl_cholesterol, triglycerides)   % expect 120
+
+% Inverse 1: the total cholesterol the other three imply.
+observe ldl_cholesterol(120)
+? total_cholesterol(ldl_cholesterol, hdl_cholesterol, triglycerides)   % expect 200
+
+% Inverse 2: the HDL the other three imply.
+? hdl_cholesterol(total_cholesterol, ldl_cholesterol, triglycerides)   % expect 50
+
+% Inverse 3: the triglycerides the other three imply (the /5 becomes a ×5).
+? triglycerides(total_cholesterol, hdl_cholesterol, ldl_cholesterol)   % expect 150


### PR DESCRIPTION
## What

Grounds the classic **Friedewald estimate** of LDL cholesterol as a byte-provenanced, importable formula library on the *clinical/lipidology* track: `LDL-C = total cholesterol − HDL cholesterol − triglycerides/5`, plus its three exact rearrangements (`TC = LDL + HDL + TG/5`, `HDL = TC − LDL − TG/5`, `TG = 5·(TC − HDL − LDL)`).

**First clinical inverter with an embedded numeric constant.** The `/5` (and its inverse `×5` when the equation is solved for the triglycerides) is part of the *cited equation*, not a free parameter — and the ADJ engine evaluates it **exactly over rationals**, not floating point. A consumer states no arithmetic and no constant; it `observe`s the fasting panel and the engine applies the cited equation on the CPU.

## Provenance

All four formulas carry the **same verbatim equation** from StatPearls *Biochemistry, Low Density Lipoprotein* ([NBK500010](https://www.ncbi.nlm.nih.gov/books/NBK500010/)):

> LDL-cholesterol = total cholesterol – HDL-C – triglycerides (VLDL)/5

Byte-verified against the source page before shipping.

## Worked case

`TC = 200`, `HDL = 50`, `TG = 150` (mg/dL) → `LDL = 200 − 50 − 150/5 = 120`; the four formulas invert cleanly (120 + 50 + 30 = 200; 200 − 120 − 30 = 50; 5·(200 − 50 − 120) = 150).

## Relationship

Sibling of [`clinical/non-hdl-cholesterol.adj`](https://www.ncbi.nlm.nih.gov/books/NBK585106/) — the fasting-independent alternative that needs no triglycerides.

## Tests

Dedicated e2e file `formula_ldl_cholesterol_friedewald_e2e.rs` (4 tests, all green) drives the shipped library through the built CLI against the stdlib. `cargo clippy --tests -D warnings` clean. Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)