### PR TITLE
Foster residual table start tags

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -121,6 +121,9 @@ documented in this file.
   accesskey, autofocus, and related focus metadata.
 
 ### Fixed
+- Residual HTML start tags processed through the table insertion mode now use
+  foster parenting after table-context and head-element exceptions, keeping a
+  `marquee` sibling before its open table in the current adoption-agency WPT.
 - Replacement characters from null input are now stripped only at MathML and
   SVG HTML integration points, preserving them in ordinary foreign-content
   text while matching the current WPT fragment and CDATA cases.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -134,8 +134,8 @@ focused regression test in `tests/browser_readiness_test.rs`. The
 executable source of truth for that boundary and should fail if a future field
 is added without coverage evidence.
 
-The checked-in tree-construction smoke corpus contains 2,493 passing DOM cases.
-Current WPT contains 1,934 upstream tree-construction cases, with 148 source
+The checked-in tree-construction smoke corpus contains 2,494 passing DOM cases.
+Current WPT contains 1,934 upstream tree-construction cases, with 147 source
 signatures not yet mirrored locally. The checked audit report makes that debt
 explicit so follow-up conformance slices can ratchet it to zero. A separate
 adapter can project DOM into `document-ast` for existing native document
@@ -152,7 +152,7 @@ tests moved from html5lib-tests to WPT, so a current audit uses both checkouts:
 HTML5LIB_TESTS_ROOT=/path/to/html5lib-tests \
 WPT_ROOT=/path/to/wpt \
   python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py \
-  --expect-tree-missing 148 \
+  --expect-tree-missing 147 \
   --expect-tokenizer-missing 0
 ```
 
@@ -170,8 +170,8 @@ python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
   /path/to/html5lib-tests \
   --wpt-root /path/to/wpt \
   --expect-tree-upstream-cases 1934 \
-  --expect-tree-local-cases 2493 \
-  --expect-tree-missing 148 \
+  --expect-tree-local-cases 2494 \
+  --expect-tree-missing 147 \
   --expect-tokenizer-upstream-cases 6806 \
   --expect-tokenizer-local-raw-cases 7015 \
   --expect-tokenizer-missing 0 \

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -5295,11 +5295,24 @@ impl HtmlParser {
         if namespace.is_none() && name == "form" {
             self.form_element_pointer_set = true;
         }
-        let child_index = self.append_node(element_node(name.clone(), attributes, namespace));
-        if !acknowledges_self_closing && !html_void_element {
+        let node = element_node(name.clone(), attributes, namespace);
+        let inserted_path = if !in_foreign_content
+            && self.current_element_is_table_structure()
+            && self.has_open_element("table")
+            && !starts_table_context(&name)
+            && !is_head_element(&name)
+        {
+            self.insert_node_before_open_table(node)
+        } else {
+            let child_index = self.append_node(node);
             let mut path = self.current_parent_path().to_vec();
             path.push(child_index);
-            self.open_elements.push(path);
+            Some(path)
+        };
+        if !acknowledges_self_closing && !html_void_element {
+            if let Some(path) = inserted_path {
+                self.open_elements.push(path);
+            }
         }
         if namespace.is_none()
             && name == "div"

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -185,7 +185,7 @@ source signature:
 HTML5LIB_TESTS_ROOT=/path/to/html5lib-tests \
 WPT_ROOT=/path/to/wpt \
   python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py \
-  --expect-tree-missing 148 \
+  --expect-tree-missing 147 \
   --expect-tokenizer-missing 0
 ```
 
@@ -201,8 +201,8 @@ python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
   /path/to/html5lib-tests \
   --wpt-root /path/to/wpt \
   --expect-tree-upstream-cases 1934 \
-  --expect-tree-local-cases 2493 \
-  --expect-tree-missing 148 \
+  --expect-tree-local-cases 2494 \
+  --expect-tree-missing 147 \
   --expect-tokenizer-upstream-cases 6806 \
   --expect-tokenizer-local-raw-cases 7015 \
   --expect-tokenizer-missing 0 \
@@ -216,10 +216,10 @@ Regenerate or check it with:
 ```bash
 python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py \
   /path/to/html5lib-tests --wpt-root /path/to/wpt \
-  --expect-tree-missing 148 --expect-tokenizer-missing 0 --write-report
+  --expect-tree-missing 147 --expect-tokenizer-missing 0 --write-report
 python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py \
   /path/to/html5lib-tests --wpt-root /path/to/wpt \
-  --expect-tree-missing 148 --expect-tokenizer-missing 0 --check-report
+  --expect-tree-missing 147 --expect-tokenizer-missing 0 --check-report
 ```
 
 `whatwg-tree-insertion-audit.json` is a generated index over the high-signal

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
@@ -9,10 +9,9 @@
     "upstream_source": "html5lib-tests/tokenizer"
   },
   "tree_construction": {
-    "local_cases": 2493,
-    "missing": 148,
+    "local_cases": 2494,
+    "missing": 147,
     "missing_sources": [
-      "adoption02.dat:3",
       "html5test-com.dat:12",
       "html5test-com.dat:14",
       "html5test-com.dat:15",

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -40503,3 +40503,21 @@ math ms
 math annotation-xml
 #document
 | "�x"
+
+#source adoption02.dat:3
+#data
+<nobr><table><marquee></table><nobr>
+#errors
+(1,6): expected-doctype-but-got-start-tag
+(1,22): unexpected-start-tag-implies-table-voodoo
+(1,30): end-tag-too-early-named
+(1,36): unexpected-start-tag-implies-end-tag
+(1,36): expected-closing-tag-but-got-eof
+#document
+| <html>
+|   <head>
+|   <body>
+|     <nobr>
+|       <marquee>
+|       <table>
+|     <nobr>

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-form-interactive-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-form-interactive-audit.json
@@ -1,5 +1,5 @@
 {
-  "case_count": 410,
+  "case_count": 411,
   "cases": [
     {
       "axis": "interactive-formatting",
@@ -2460,13 +2460,19 @@
       "id": "tests-innerhtml-1-dat-76",
       "reason": "fragment parsing in form and interactive element contexts",
       "source": "tests_innerHTML_1.dat:76"
+    },
+    {
+      "axis": "interactive-formatting",
+      "id": "adoption02-dat-3",
+      "reason": "anchor and nobr adoption-agency or repeated-interactive recovery",
+      "source": "adoption02.dat:3"
     }
   ],
   "counts_by_axis": {
     "button-boundary": 96,
     "form-control": 33,
     "fragment-context": 7,
-    "interactive-formatting": 123,
+    "interactive-formatting": 124,
     "select-option": 123,
     "stray-interactive-end-tags": 4,
     "textarea-rawtext": 24

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-formatting-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-formatting-audit.json
@@ -1,5 +1,5 @@
 {
-  "case_count": 638,
+  "case_count": 639,
   "cases": [
     {
       "axis": "interactive-formatting-boundary",
@@ -3828,13 +3828,19 @@
       "id": "webkit02-dat-49",
       "reason": "standalone active formatting element reconstruction and stack cleanup",
       "source": "webkit02.dat:49"
+    },
+    {
+      "axis": "interactive-formatting-boundary",
+      "id": "adoption02-dat-3",
+      "reason": "anchor and nobr formatting boundaries through adoption-agency recovery",
+      "source": "adoption02.dat:3"
     }
   ],
   "counts_by_axis": {
     "adoption-agency-formatting": 114,
     "formatting-reconstruction": 30,
     "heading-boundary": 26,
-    "interactive-formatting-boundary": 150,
+    "interactive-formatting-boundary": 151,
     "list-definition-boundary": 57,
     "paragraph-boundary": 218,
     "ruby-implied-end-tags": 43

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-fragment-context-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-fragment-context-audit.json
@@ -1,5 +1,5 @@
 {
-  "case_count": 192,
+  "case_count": 196,
   "cases": [
     {
       "axis": "fragment-basic-context",
@@ -1344,12 +1344,40 @@
       "id": "tests-innerhtml-1-dat-76",
       "reason": "fragment parser context in select, option, and optgroup insertion modes",
       "source": "tests_innerHTML_1.dat:76"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg path",
+      "id": "plain-text-unsafe-dat-38",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "plain-text-unsafe.dat:38"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "svg title",
+      "id": "plain-text-unsafe-dat-39",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "plain-text-unsafe.dat:39"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math ms",
+      "id": "plain-text-unsafe-dat-40",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "plain-text-unsafe.dat:40"
+    },
+    {
+      "axis": "fragment-foreign-context",
+      "context": "math annotation-xml",
+      "id": "plain-text-unsafe-dat-41",
+      "reason": "fragment parser context in SVG and MathML integration modes",
+      "source": "plain-text-unsafe.dat:41"
     }
   ],
   "counts_by_axis": {
     "fragment-basic-context": 3,
     "fragment-block-context": 5,
-    "fragment-foreign-context": 66,
+    "fragment-foreign-context": 70,
     "fragment-select-context": 5,
     "fragment-shell-context": 15,
     "fragment-table-context": 91,

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-table-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-table-audit.json
@@ -1,5 +1,5 @@
 {
-  "case_count": 455,
+  "case_count": 456,
   "cases": [
     {
       "axis": "foster-parenting",
@@ -2730,12 +2730,18 @@
       "id": "webkit02-dat-35",
       "reason": "select handling while table insertion modes are active",
       "source": "webkit02.dat:35"
+    },
+    {
+      "axis": "foster-parenting",
+      "id": "adoption02-dat-3",
+      "reason": "non-table content, formatting, and form recovery around tables",
+      "source": "adoption02.dat:3"
     }
   ],
   "counts_by_axis": {
     "caption-colgroup": 69,
     "cell-boundary": 103,
-    "foster-parenting": 58,
+    "foster-parenting": 59,
     "row-group-boundary": 54,
     "select-in-table": 51,
     "table-fragment-context": 91,

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-tree-insertion-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-tree-insertion-audit.json
@@ -1,5 +1,5 @@
 {
-  "case_count": 299,
+  "case_count": 300,
   "cases": [
     {
       "axis": "adoption-agency",
@@ -1794,10 +1794,16 @@
       "id": "tests-innerhtml-1-dat-76",
       "reason": "innerHTML fragment shell recovery across HTML contexts",
       "source": "tests_innerHTML_1.dat:76"
+    },
+    {
+      "axis": "adoption-agency",
+      "id": "adoption02-dat-3",
+      "reason": "misnested formatting elements and adoption-agency recovery",
+      "source": "adoption02.dat:3"
     }
   ],
   "counts_by_axis": {
-    "adoption-agency": 20,
+    "adoption-agency": 21,
     "foreign-fragment": 66,
     "html-fragment": 81,
     "table-insertion": 19,

--- a/code/packages/rust/html-parser/tests/html5lib_coverage_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/html5lib_coverage_audit_test.rs
@@ -74,8 +74,8 @@ fn html5lib_coverage_audit_fixture_matches_checked_local_corpora() {
     );
     assert_eq!(audit.tree_construction.upstream_cases, 1934);
     assert_eq!(audit.tree_construction.local_cases, tree_cases.len());
-    assert_eq!(audit.tree_construction.local_cases, 2493);
-    assert_eq!(audit.tree_construction.missing, 148);
+    assert_eq!(audit.tree_construction.local_cases, 2494);
+    assert_eq!(audit.tree_construction.missing, 147);
     assert_eq!(
         audit.tree_construction.missing_sources.len(),
         audit.tree_construction.missing
@@ -102,7 +102,7 @@ fn html5lib_coverage_audit_fixture_matches_checked_local_corpora() {
     );
     assert_eq!(
         missing_source_count(&audit.tree_construction, "adoption02.dat:"),
-        1
+        0
     );
 
     assert_eq!(audit.tokenizer.upstream_source, "html5lib-tests/tokenizer");


### PR DESCRIPTION
## What changed

- Foster-parent residual HTML start tags before the open table when the parser is in a table-structure context, while preserving table-context, head-element, foreign-content, void-element, and self-closing behavior.
- Import the current adoption-agency WPT case that keeps a `marquee` sibling before its open table.
- Regenerate the focused WHATWG audit indexes and update the checked conformance debt from 148 to 147 missing WPT source signatures.

## Why

The generic start-tag insertion path always appended elements to the current table-structure node. Tokens that reached that residual path therefore skipped HTML's foster-parenting rule, producing the wrong DOM for the remaining `marquee`/table adoption-agency case.

## Impact

This advances current tree-construction conformance by one upstream WPT signature without changing the already-complete tokenizer coverage. The checked local tree corpus grows from 2,493 to 2,494 passing cases.

## Validation

- `cargo test -p coding-adventures-html-parser` (full exact-source suite, including the 2,494-case tree corpus and all focused WHATWG audits)
- Post-rebase parser unit suite: 173 passed
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_coverage.py --check`
- Fresh sparse upstream audit: WPT tree 1,934 / local 2,494 / missing 147; html5lib tokenizer 6,806 / missing 0; normalized tokenizer 7,242 / skipped 0