### PR TITLE
feat(spice): model MOS bulk-junction leakage

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Apply Level-1 MOS model-card `IS` to the source-body and drain-body junctions
+  in DC, transient, transfer-function, and AC analysis, and emit distinct
+  `IBS` / `IBD` shot-noise sources.
 - Add Level-1 MOS model-card `MJSW`, defaulting to `0.33`, to shape `CJSW`
   sidewall depletion independently from `MJ` bottom-junction capacitance.
 - Add the Level-1 MOS `PS` instance parameter. With model-card `CJSW`, its

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -89,6 +89,9 @@ noise model. `NLEV >= 3` selects the Berkeley linear-region equation, with
 `GDSNOI` (default `1`) scaling its channel-noise conductance.
 Level-1 MOS model cards accept `KF` (default `0`) and `AF` (default `1`) and add
 `KF * abs(Id)^AF / frequency` flicker noise alongside channel thermal noise.
+Their `IS` value also drives source-body and drain-body junction leakage in
+DC, transient, transfer-function, and AC analysis, with separate `IBS` and
+`IBD` shot-noise contributions.
 `LD` defaults to zero and applies `L_eff = L - 2*LD` to channel current and
 length-scaled intrinsic/`CGBO` capacitance.
 `TOX` defaults to `1e-7 m`, must be finite and positive, and derives intrinsic

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -9277,6 +9277,24 @@ def _stamp_mosfet(
         b[node_to_idx[intrinsic_drain]] -= Ieq
     if not _is_ground(intrinsic_source):
         b[node_to_idx[intrinsic_source]] += Ieq
+    _stamp_mosfet_bulk_junction(
+        G,
+        b,
+        node_to_idx,
+        el,
+        intrinsic_source,
+        Vs,
+        Vb,
+    )
+    _stamp_mosfet_bulk_junction(
+        G,
+        b,
+        node_to_idx,
+        el,
+        intrinsic_drain,
+        Vd,
+        Vb,
+    )
     drain_resistance = _mosfet_drain_resistance(el)
     if drain_resistance > 0.0:
         _stamp_g(
@@ -9295,6 +9313,63 @@ def _stamp_mosfet(
             intrinsic_source,
             1.0 / source_resistance,
         )
+
+
+def _mosfet_bulk_junction_current_conductance(
+    el: Mosfet,
+    terminal_voltage: float,
+    body_voltage: float,
+) -> tuple[float, float]:
+    params = el.model.model.params  # type: ignore[attr-defined]
+    junction_voltage = (
+        body_voltage - terminal_voltage
+        if el.model.type == MosfetType.NMOS  # type: ignore[attr-defined]
+        else terminal_voltage - body_voltage
+    )
+    thermal_voltage = _BOLTZMANN * params.T_NOM / _ELECTRON_CHARGE
+    normalized_voltage = junction_voltage / thermal_voltage
+    limited_exp = math.exp(max(-40.0, min(40.0, normalized_voltage)))
+    if normalized_voltage > 40.0:
+        current_factor = limited_exp * (1.0 + normalized_voltage - 40.0)
+        conductance_factor = limited_exp
+    else:
+        current_factor = limited_exp
+        conductance_factor = limited_exp
+    return (
+        params.IS * (current_factor - 1.0),
+        params.IS / thermal_voltage * conductance_factor,
+    )
+
+
+def _stamp_mosfet_bulk_junction(
+    G: list[list[float]],
+    b: list[float],
+    node_to_idx: dict[str, int],
+    el: Mosfet,
+    terminal: str,
+    terminal_voltage: float,
+    body_voltage: float,
+) -> None:
+    current, conductance = _mosfet_bulk_junction_current_conductance(
+        el,
+        terminal_voltage,
+        body_voltage,
+    )
+    is_nmos = el.model.type == MosfetType.NMOS  # type: ignore[attr-defined]
+    junction_voltage = (
+        body_voltage - terminal_voltage
+        if is_nmos
+        else terminal_voltage - body_voltage
+    )
+    positive, negative = (
+        (el.body, terminal) if is_nmos else (terminal, el.body)
+    )
+    equivalent_current = current - conductance * junction_voltage
+    _stamp_g(G, node_to_idx, positive, negative, conductance)
+    if not _is_ground(positive):
+        b[node_to_idx[positive]] -= equivalent_current
+    if not _is_ground(negative):
+        b[node_to_idx[negative]] += equivalent_current
 
 
 def _eval_jfet(el: JFET, vgs: float, vds: float) -> tuple[float, float, float]:
@@ -13180,12 +13255,30 @@ def _stamp_ac(
         r = el.model.dc(Vg - Vs, Vd - Vs, Vb - Vs)  # type: ignore[attr-defined]
         gm_m: float = r.gm
         gds_m: float = r.gds
+        _, source_bulk_conductance = _mosfet_bulk_junction_current_conductance(
+            el, Vs, Vb
+        )
+        _, drain_bulk_conductance = _mosfet_bulk_junction_current_conductance(
+            el, Vd, Vb
+        )
         _stamp_g_c(G, node_to_idx, intrinsic_drain, intrinsic_source, gds_m + 0j)
         _stamp_g_c(G, node_to_idx, el.gate, intrinsic_source, 1j * omega * r.Cgs)
         _stamp_g_c(G, node_to_idx, el.gate, intrinsic_drain, 1j * omega * r.Cgd)
         _stamp_g_c(G, node_to_idx, el.gate, el.body, 1j * omega * r.Cgb)
-        _stamp_g_c(G, node_to_idx, el.body, intrinsic_source, 1j * omega * r.Cbs)
-        _stamp_g_c(G, node_to_idx, el.body, intrinsic_drain, 1j * omega * r.Cbd)
+        _stamp_g_c(
+            G,
+            node_to_idx,
+            el.body,
+            intrinsic_source,
+            source_bulk_conductance + 1j * omega * r.Cbs,
+        )
+        _stamp_g_c(
+            G,
+            node_to_idx,
+            el.body,
+            intrinsic_drain,
+            drain_bulk_conductance + 1j * omega * r.Cbd,
+        )
         if not _is_ground(intrinsic_drain):
             d = node_to_idx[intrinsic_drain]
             if not _is_ground(el.gate):
@@ -13935,7 +14028,27 @@ def _build_ss_matrix(
             r = el.model.dc(Vg - Vs, Vd - Vs, Vb - Vs)  # type: ignore[attr-defined]
             gm_m: float = r.gm
             gds_m: float = r.gds
+            _, source_bulk_conductance = _mosfet_bulk_junction_current_conductance(
+                el, Vs, Vb
+            )
+            _, drain_bulk_conductance = _mosfet_bulk_junction_current_conductance(
+                el, Vd, Vb
+            )
             _stamp_g(G, node_to_idx, intrinsic_drain, intrinsic_source, gds_m)
+            _stamp_g(
+                G,
+                node_to_idx,
+                el.body,
+                intrinsic_source,
+                source_bulk_conductance,
+            )
+            _stamp_g(
+                G,
+                node_to_idx,
+                el.body,
+                intrinsic_drain,
+                drain_bulk_conductance,
+            )
             if not _is_ground(intrinsic_drain):
                 d = node_to_idx[intrinsic_drain]
                 if not _is_ground(el.gate):
@@ -15844,6 +15957,34 @@ def _collect_noise_sources(
                         1.0,
                     )
                 )
+            source_bulk_current, _ = _mosfet_bulk_junction_current_conductance(
+                el, Vs, Vb
+            )
+            drain_bulk_current, _ = _mosfet_bulk_junction_current_conductance(
+                el, Vd, Vb
+            )
+            n_b = None if _is_ground(el.body) else node_to_idx[el.body]
+            is_nmos = el.model.type == MosfetType.NMOS  # type: ignore[attr-defined]
+            sources.append(
+                (
+                    f"{el.name}:IBS",
+                    "shot",
+                    n_b if is_nmos else n_s,
+                    n_s if is_nmos else n_b,
+                    q2 * abs(source_bulk_current),
+                    0.0,
+                )
+            )
+            sources.append(
+                (
+                    f"{el.name}:IBD",
+                    "shot",
+                    n_b if is_nmos else n_d,
+                    n_d if is_nmos else n_b,
+                    q2 * abs(drain_bulk_current),
+                    0.0,
+                )
+            )
             drain_resistance = _mosfet_drain_resistance(el)
             if drain_resistance > 0.0:
                 sources.append(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -935,6 +935,38 @@ def test_dc_mosfet_drain_resistance_drops_intrinsic_drain_voltage() -> None:
     assert result.node_voltages["__spice_M1_drain"] < 5.0
 
 
+def test_dc_mosfet_bulk_junction_saturation_current_sets_reverse_leakage() -> None:
+    def bias_current(
+        mosfet_type: MosfetType,
+        bias_voltage: float,
+        saturation_current: float,
+    ) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vbias", "body", "0", bias_voltage))
+        circuit.add(
+            Mosfet(
+                "M1",
+                "0",
+                "0",
+                "0",
+                "body",
+                MOSFET(
+                    mosfet_type,
+                    Level1Model(Level1Params(IS=saturation_current)),
+                ),
+            )
+        )
+        return abs(dc_op(circuit).branch_currents["I(Vbias)"])
+
+    for mosfet_type, bias_voltage in (
+        (MosfetType.NMOS, -0.3),
+        (MosfetType.PMOS, 0.3),
+    ):
+        unloaded = bias_current(mosfet_type, bias_voltage, 1.0e-30)
+        loaded = bias_current(mosfet_type, bias_voltage, 1.0e-12)
+        assert loaded > unloaded
+
+
 def test_dc_mosfet_source_resistance_raises_intrinsic_source_voltage() -> None:
     circuit = Circuit()
     circuit.add(VoltageSource("Vdrain", "drain", "0", 5.0))
@@ -9074,6 +9106,35 @@ def test_noise_mosfet_channel_thermal_noise() -> None:
         expected_source_psd * 1000.0 ** 2,
         rel_tol=1e-6,
     )
+
+
+def test_noise_mosfet_bulk_junctions_emit_distinct_shot_noise_sources() -> None:
+    circuit = Circuit()
+    circuit.add(VoltageSource("Vbody", "body", "0", -0.3))
+    circuit.add(
+        Mosfet(
+            "M1",
+            "0",
+            "0",
+            "0",
+            "body",
+            MOSFET(
+                MosfetType.NMOS,
+                Level1Model(Level1Params(IS=1.0e-12)),
+            ),
+        )
+    )
+
+    entries = noise_ac(
+        circuit, "body", "Vbody", freqs=[1_000.0], temperature=300.0
+    ).points[0].entries
+    for name in ("M1:IBS", "M1:IBD"):
+        entry = next(
+            entry
+            for entry in entries
+            if entry.element_name == name and entry.noise_type == "shot"
+        )
+        assert entry.source_psd > 0.0
 
 
 def test_noise_mosfet_flicker_noise_scales_inversely_with_frequency() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Apply Level-1 MOS model-card `IS` to the source-body and drain-body junctions
+  in DC, transient, transfer-function, and AC analysis, and emit distinct
+  `IBS` / `IBD` shot-noise sources.
 - Add Level-1 MOS model-card `MJSW`, defaulting to `0.33`, to shape `CJSW`
   sidewall depletion independently from `MJ` bottom-junction capacitance.
 - Add the Level-1 MOS `PS` instance parameter. With model-card `CJSW`, its

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -130,6 +130,9 @@ noise model. `NLEV >= 3` selects the Berkeley linear-region equation, with
 `GDSNOI` (default `1`) scaling its channel-noise conductance.
 Level-1 MOS model cards accept `KF` (default `0`) and `AF` (default `1`) and add
 `KF * abs(Id)^AF / frequency` flicker noise alongside channel thermal noise.
+Their `IS` value also drives source-body and drain-body junction leakage in
+DC, transient, transfer-function, and AC analysis, with separate `IBS` and
+`IBD` shot-noise contributions.
 `LD` defaults to zero and applies `L_eff = L - 2*LD` to channel current and
 length-scaled intrinsic/`CGBO` capacitance.
 `TOX` defaults to `1e-7 m`, must be finite and positive, and derives intrinsic

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -22881,6 +22881,34 @@ fn collect_noise_sources(
                         frequency_exponent: 1.0,
                     });
                 }
+                let (source_bulk_current, _) =
+                    mosfet_bulk_junction_current_conductance(mosfet, source_voltage, body_voltage);
+                let (drain_bulk_current, _) =
+                    mosfet_bulk_junction_current_conductance(mosfet, drain_voltage, body_voltage);
+                let (source_bulk_positive, source_bulk_negative) = match mosfet.mosfet_type {
+                    MosfetType::Nmos => (body, source),
+                    MosfetType::Pmos => (source, body),
+                };
+                let (drain_bulk_positive, drain_bulk_negative) = match mosfet.mosfet_type {
+                    MosfetType::Nmos => (body, drain),
+                    MosfetType::Pmos => (drain, body),
+                };
+                sources.push(NoiseSource {
+                    element_name: format!("{}:IBS", mosfet.name),
+                    noise_type: NoiseType::Shot,
+                    positive: source_bulk_positive,
+                    negative: source_bulk_negative,
+                    source_psd: 2.0 * ELECTRON_CHARGE * source_bulk_current.abs(),
+                    frequency_exponent: 0.0,
+                });
+                sources.push(NoiseSource {
+                    element_name: format!("{}:IBD", mosfet.name),
+                    noise_type: NoiseType::Shot,
+                    positive: drain_bulk_positive,
+                    negative: drain_bulk_negative,
+                    source_psd: 2.0 * ELECTRON_CHARGE * drain_bulk_current.abs(),
+                    frequency_exponent: 0.0,
+                });
                 let drain_resistance = mosfet_drain_resistance(mosfet);
                 if drain_resistance > 0.0 {
                     sources.push(NoiseSource {
@@ -24225,6 +24253,24 @@ fn stamp_mosfet(
     stamp_transconductance(matrix, drain, source, gate, source, result.gm);
     stamp_transconductance(matrix, drain, source, body, source, result.gmb);
     stamp_equivalent_current_source(rhs, drain, source, equivalent_current);
+    stamp_mosfet_bulk_junction(
+        mosfet,
+        source,
+        body,
+        source_voltage,
+        body_voltage,
+        matrix,
+        rhs,
+    );
+    stamp_mosfet_bulk_junction(
+        mosfet,
+        drain,
+        body,
+        drain_voltage,
+        body_voltage,
+        matrix,
+        rhs,
+    );
     stamp_mosfet_charge(mosfet, capacitor_states, node_indices, matrix, rhs)?;
     let drain_resistance = mosfet_drain_resistance(mosfet);
     if drain_resistance > 0.0 {
@@ -24245,6 +24291,57 @@ fn stamp_mosfet(
         );
     }
     Ok(())
+}
+
+fn mosfet_bulk_junction_current_conductance(
+    mosfet: &Mosfet,
+    terminal_voltage: f64,
+    body_voltage: f64,
+) -> (f64, f64) {
+    let junction_voltage = match mosfet.mosfet_type {
+        MosfetType::Nmos => body_voltage - terminal_voltage,
+        MosfetType::Pmos => terminal_voltage - body_voltage,
+    };
+    let thermal_voltage = BOLTZMANN * mosfet.params.t_nom / ELECTRON_CHARGE;
+    let normalized_voltage = junction_voltage / thermal_voltage;
+    let limited_exp = normalized_voltage.clamp(-40.0, 40.0).exp();
+    let (current_factor, conductance_factor) = if normalized_voltage > 40.0 {
+        (limited_exp * (1.0 + normalized_voltage - 40.0), limited_exp)
+    } else {
+        (limited_exp, limited_exp)
+    };
+    (
+        mosfet.params.saturation_current * (current_factor - 1.0),
+        mosfet.params.saturation_current / thermal_voltage * conductance_factor,
+    )
+}
+
+fn stamp_mosfet_bulk_junction(
+    mosfet: &Mosfet,
+    terminal: Option<usize>,
+    body: Option<usize>,
+    terminal_voltage: f64,
+    body_voltage: f64,
+    matrix: &mut [Vec<f64>],
+    rhs: &mut [f64],
+) {
+    let (current, conductance) =
+        mosfet_bulk_junction_current_conductance(mosfet, terminal_voltage, body_voltage);
+    let junction_voltage = match mosfet.mosfet_type {
+        MosfetType::Nmos => body_voltage - terminal_voltage,
+        MosfetType::Pmos => terminal_voltage - body_voltage,
+    };
+    let (positive, negative) = match mosfet.mosfet_type {
+        MosfetType::Nmos => (body, terminal),
+        MosfetType::Pmos => (terminal, body),
+    };
+    stamp_conductance(matrix, positive, negative, conductance);
+    stamp_equivalent_current_source(
+        rhs,
+        positive,
+        negative,
+        current - conductance * junction_voltage,
+    );
 }
 
 fn stamp_mosfet_charge(
@@ -24432,7 +24529,13 @@ fn stamp_mosfet_small_signal(
     let vds = drain_voltage - source_voltage;
     let vbs = body_voltage - source_voltage;
     let result = evaluate_mosfet_level1(mosfet, vgs, vds, vbs);
+    let (_, source_bulk_conductance) =
+        mosfet_bulk_junction_current_conductance(mosfet, source_voltage, body_voltage);
+    let (_, drain_bulk_conductance) =
+        mosfet_bulk_junction_current_conductance(mosfet, drain_voltage, body_voltage);
     stamp_conductance(matrix, drain, source, result.gds);
+    stamp_conductance(matrix, body, source, source_bulk_conductance);
+    stamp_conductance(matrix, body, drain, drain_bulk_conductance);
     stamp_transconductance(matrix, drain, source, gate, source, result.gm);
     stamp_transconductance(matrix, drain, source, body, source, result.gmb);
     let drain_resistance = mosfet_drain_resistance(mosfet);
@@ -24525,12 +24628,26 @@ fn stamp_ac_mosfet_small_signal(
     let vds = drain_voltage - source_voltage;
     let vbs = body_voltage - source_voltage;
     let result = evaluate_mosfet_level1(mosfet, vgs, vds, vbs);
+    let (_, source_bulk_conductance) =
+        mosfet_bulk_junction_current_conductance(mosfet, source_voltage, body_voltage);
+    let (_, drain_bulk_conductance) =
+        mosfet_bulk_junction_current_conductance(mosfet, drain_voltage, body_voltage);
     stamp_complex_conductance(matrix, drain, source, Complex::new(result.gds, 0.0));
     stamp_complex_conductance(matrix, gate, source, Complex::new(0.0, omega * result.cgs));
     stamp_complex_conductance(matrix, gate, drain, Complex::new(0.0, omega * result.cgd));
     stamp_complex_conductance(matrix, gate, body, Complex::new(0.0, omega * result.cgb));
-    stamp_complex_conductance(matrix, body, source, Complex::new(0.0, omega * result.cbs));
-    stamp_complex_conductance(matrix, body, drain, Complex::new(0.0, omega * result.cbd));
+    stamp_complex_conductance(
+        matrix,
+        body,
+        source,
+        Complex::new(source_bulk_conductance, omega * result.cbs),
+    );
+    stamp_complex_conductance(
+        matrix,
+        body,
+        drain,
+        Complex::new(drain_bulk_conductance, omega * result.cbd),
+    );
     stamp_complex_transconductance(
         matrix,
         drain,

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -1644,6 +1644,42 @@ fn dc_mosfet_drain_resistance_drops_intrinsic_drain_voltage() {
 }
 
 #[test]
+fn dc_mosfet_bulk_junction_saturation_current_sets_reverse_leakage() {
+    let bias_current = |mosfet_type: MosfetType, bias_voltage: f64, saturation_current: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vbias",
+            "body",
+            "0",
+            bias_voltage,
+        )));
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "M1",
+            "0",
+            "0",
+            "0",
+            "body",
+            mosfet_type,
+            MosfetLevel1Params {
+                saturation_current,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+        dc_op(&circuit)
+            .unwrap()
+            .branch_current("Vbias")
+            .unwrap()
+            .abs()
+    };
+
+    for (mosfet_type, bias_voltage) in [(MosfetType::Nmos, -0.3), (MosfetType::Pmos, 0.3)] {
+        let unloaded = bias_current(mosfet_type, bias_voltage, 1.0e-30);
+        let loaded = bias_current(mosfet_type, bias_voltage, 1.0e-12);
+        assert!(loaded > unloaded);
+    }
+}
+
+#[test]
 fn dc_mosfet_source_resistance_raises_intrinsic_source_voltage() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(

--- a/code/packages/rust/spice-engine/tests/noise_tests.rs
+++ b/code/packages/rust/spice-engine/tests/noise_tests.rs
@@ -706,6 +706,36 @@ fn jfet_gate_junctions_emit_distinct_shot_noise_sources() {
 }
 
 #[test]
+fn mosfet_bulk_junctions_emit_distinct_shot_noise_sources() {
+    let mut circuit = Circuit::new();
+    circuit.add(Element::VoltageSource(VoltageSource::new(
+        "Vbody", "body", "0", -0.3,
+    )));
+    circuit.add(Element::Mosfet(Mosfet::with_model(
+        "M1",
+        "0",
+        "0",
+        "0",
+        "body",
+        MosfetType::Nmos,
+        MosfetLevel1Params {
+            saturation_current: 1.0e-12,
+            ..MosfetLevel1Params::default()
+        },
+    )));
+
+    let result = noise_ac(&circuit, "body", "Vbody", &[1_000.0], 300.0).unwrap();
+    let entries = &result.points[0].entries;
+    for name in ["M1:IBS", "M1:IBD"] {
+        let entry = entries
+            .iter()
+            .find(|entry| entry.element_name == name && entry.noise_type == NoiseType::Shot)
+            .unwrap();
+        assert!(entry.source_psd > 0.0);
+    }
+}
+
+#[test]
 fn jfet_flicker_noise_uses_af_current_exponent() {
     let source_psd = |exponent: f64| {
         let mut circuit = Circuit::new();

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Apply Level-1 MOS model-card `IS` to the source-body and drain-body junctions
+  in DC, transient, transfer-function, and AC analysis, and emit distinct
+  `IBS` / `IBD` shot-noise sources.
 - Add Level-1 MOS model-card `MJSW`, defaulting to `0.33`, to shape `CJSW`
   sidewall depletion independently from `MJ` bottom-junction capacitance.
 - Add the Level-1 MOS `PS` instance parameter. With model-card `CJSW`, its

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -81,6 +81,9 @@ noise model. `NLEV >= 3` selects the Berkeley linear-region equation, with
 `GDSNOI` (default `1`) scaling its channel-noise conductance.
 Level-1 MOS model cards accept `KF` (default `0`) and `AF` (default `1`) and add
 `KF * abs(Id)^AF / frequency` flicker noise alongside channel thermal noise.
+Their `IS` value also drives source-body and drain-body junction leakage in
+DC, transient, transfer-function, and AC analysis, with separate `IBS` and
+`IBD` shot-noise contributions.
 `LD` defaults to zero and applies `L_eff = L - 2*LD` to channel current and
 length-scaled intrinsic/`CGBO` capacitance.
 `TOX` defaults to `1e-7 m`, must be finite and positive, and derives intrinsic

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -19036,6 +19036,33 @@ function collectNoiseSources(
           frequencyExponent: 1.0,
         });
       }
+      const [sourceBulkCurrent] = mosfetBulkJunctionCurrentConductance(
+        element,
+        sourceVoltage,
+        bodyVoltage,
+      );
+      const [drainBulkCurrent] = mosfetBulkJunctionCurrentConductance(
+        element,
+        drainVoltage,
+        bodyVoltage,
+      );
+      const isNmos = element.type === "NMOS";
+      sources.push({
+        elementName: `${element.name}:IBS`,
+        noiseType: "shot",
+        positive: isNmos ? body : source,
+        negative: isNmos ? source : body,
+        sourcePsd: 2.0 * ELECTRON_CHARGE * Math.abs(sourceBulkCurrent),
+        frequencyExponent: 0.0,
+      });
+      sources.push({
+        elementName: `${element.name}:IBD`,
+        noiseType: "shot",
+        positive: isNmos ? body : drain,
+        negative: isNmos ? drain : body,
+        sourcePsd: 2.0 * ELECTRON_CHARGE * Math.abs(drainBulkCurrent),
+        frequencyExponent: 0.0,
+      });
       const drainResistance = mosfetDrainResistance(element);
       if (drainResistance > 0.0) {
         sources.push({
@@ -20246,6 +20273,24 @@ function stampMosfet(
   stampTransconductance(matrix, drain, source, gate, source, result.gm);
   stampTransconductance(matrix, drain, source, body, source, result.gmb);
   stampCurrentSourceEquivalent(rhs, drain, source, equivalentCurrent);
+  stampMosfetBulkJunction(
+    element,
+    source,
+    body,
+    sourceVoltage,
+    bodyVoltage,
+    matrix,
+    rhs,
+  );
+  stampMosfetBulkJunction(
+    element,
+    drain,
+    body,
+    drainVoltage,
+    bodyVoltage,
+    matrix,
+    rhs,
+  );
   stampMosfetCharge(element, capacitorStates, nodeIndices, matrix, rhs);
   const drainResistance = mosfetDrainResistance(element);
   if (drainResistance > 0.0) {
@@ -20265,6 +20310,58 @@ function stampMosfet(
       1.0 / sourceResistance,
     );
   }
+}
+
+function mosfetBulkJunctionCurrentConductance(
+  element: Mosfet,
+  terminalVoltage: number,
+  bodyVoltage: number,
+): readonly [number, number] {
+  const junctionVoltage =
+    element.type === "NMOS"
+      ? bodyVoltage - terminalVoltage
+      : terminalVoltage - bodyVoltage;
+  const thermalVoltage = BOLTZMANN * element.params.T_NOM / ELECTRON_CHARGE;
+  const normalizedVoltage = junctionVoltage / thermalVoltage;
+  const limitedExp = Math.exp(Math.max(-40.0, Math.min(40.0, normalizedVoltage)));
+  const currentFactor =
+    normalizedVoltage > 40.0
+      ? limitedExp * (1.0 + normalizedVoltage - 40.0)
+      : limitedExp;
+  const conductanceFactor = limitedExp;
+  return [
+    element.params.IS * (currentFactor - 1.0),
+    (element.params.IS / thermalVoltage) * conductanceFactor,
+  ];
+}
+
+function stampMosfetBulkJunction(
+  element: Mosfet,
+  terminal: number | undefined,
+  body: number | undefined,
+  terminalVoltage: number,
+  bodyVoltage: number,
+  matrix: number[][],
+  rhs: number[],
+): void {
+  const [current, conductance] = mosfetBulkJunctionCurrentConductance(
+    element,
+    terminalVoltage,
+    bodyVoltage,
+  );
+  const isNmos = element.type === "NMOS";
+  const junctionVoltage = isNmos
+    ? bodyVoltage - terminalVoltage
+    : terminalVoltage - bodyVoltage;
+  const positive = isNmos ? body : terminal;
+  const negative = isNmos ? terminal : body;
+  stampConductance(matrix, positive, negative, conductance);
+  stampCurrentSourceEquivalent(
+    rhs,
+    positive,
+    negative,
+    current - conductance * junctionVoltage,
+  );
 }
 
 function stampMosfetCharge(
@@ -22636,7 +22733,19 @@ function stampMosfetSmallSignal(
     drainVoltage - sourceVoltage,
     bodyVoltage - sourceVoltage,
   );
+  const [, sourceBulkConductance] = mosfetBulkJunctionCurrentConductance(
+    element,
+    sourceVoltage,
+    bodyVoltage,
+  );
+  const [, drainBulkConductance] = mosfetBulkJunctionCurrentConductance(
+    element,
+    drainVoltage,
+    bodyVoltage,
+  );
   stampConductance(matrix, drain, source, result.gds);
+  stampConductance(matrix, body, source, sourceBulkConductance);
+  stampConductance(matrix, body, drain, drainBulkConductance);
   stampTransconductance(matrix, drain, source, gate, source, result.gm);
   stampTransconductance(matrix, drain, source, body, source, result.gmb);
   const drainResistance = mosfetDrainResistance(element);
@@ -23394,6 +23503,16 @@ function stampAcMosfetSmallSignal(
     drainVoltage - sourceVoltage,
     bodyVoltage - sourceVoltage,
   );
+  const [, sourceBulkConductance] = mosfetBulkJunctionCurrentConductance(
+    element,
+    sourceVoltage,
+    bodyVoltage,
+  );
+  const [, drainBulkConductance] = mosfetBulkJunctionCurrentConductance(
+    element,
+    drainVoltage,
+    bodyVoltage,
+  );
   stampComplexConductance(matrix, drain, source, complex(result.gds, 0.0));
   stampComplexTransconductance(
     matrix,
@@ -23406,8 +23525,18 @@ function stampAcMosfetSmallSignal(
   stampComplexConductance(matrix, gate, source, complex(0.0, omega * result.cgs));
   stampComplexConductance(matrix, gate, drain, complex(0.0, omega * result.cgd));
   stampComplexConductance(matrix, gate, body, complex(0.0, omega * result.cgb));
-  stampComplexConductance(matrix, body, source, complex(0.0, omega * result.cbs));
-  stampComplexConductance(matrix, body, drain, complex(0.0, omega * result.cbd));
+  stampComplexConductance(
+    matrix,
+    body,
+    source,
+    complex(sourceBulkConductance, omega * result.cbs),
+  );
+  stampComplexConductance(
+    matrix,
+    body,
+    drain,
+    complex(drainBulkConductance, omega * result.cbd),
+  );
   stampComplexTransconductance(
     matrix,
     drain,

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -1171,6 +1171,30 @@ describe("dcOp", () => {
     expect(result.nodeVoltages.get("__spice_M1_drain")!).toBeLessThan(5.0);
   });
 
+  it("sets reverse-biased MOSFET bulk-junction leakage from IS", () => {
+    const biasCurrent = (
+      type: "NMOS" | "PMOS",
+      biasVoltage: number,
+      saturationCurrent: number,
+    ): number => {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vbias", "body", "0", biasVoltage));
+      circuit.add(mosfet("M1", "0", "0", "0", "body", type, {
+        IS: saturationCurrent,
+      }));
+      return Math.abs(dcOp(circuit).branchCurrent("Vbias")!);
+    };
+
+    for (const [type, biasVoltage] of [
+      ["NMOS", -0.3],
+      ["PMOS", 0.3],
+    ] as const) {
+      const unloaded = biasCurrent(type, biasVoltage, 1.0e-30);
+      const loaded = biasCurrent(type, biasVoltage, 1.0e-12);
+      expect(loaded).toBeGreaterThan(unloaded);
+    }
+  });
+
   it("raises the intrinsic MOSFET source voltage across RS", () => {
     const circuit = new Circuit();
     circuit.add(voltageSource("Vdrain", "drain", "0", 5.0));

--- a/code/packages/typescript/spice-engine/tests/noise.test.ts
+++ b/code/packages/typescript/spice-engine/tests/noise.test.ts
@@ -262,6 +262,22 @@ describe("noiseAc", () => {
     }
   });
 
+  it("emits distinct MOSFET bulk-junction shot-noise sources", () => {
+    const circuit = new Circuit();
+    circuit.add(voltageSource("Vbody", "body", "0", -0.3));
+    circuit.add(mosfet("M1", "0", "0", "0", "body", "NMOS", {
+      IS: 1.0e-12,
+    }));
+
+    const entries = noiseAc(circuit, "body", "Vbody", [1_000.0], 300.0).points[0]!.entries;
+    for (const name of ["M1:IBS", "M1:IBD"]) {
+      const entry = entries.find(
+        (candidate) => candidate.elementName === name && candidate.noiseType === "shot",
+      );
+      expect(entry?.sourcePsd).toBeGreaterThan(0.0);
+    }
+  });
+
   it("uses JFET AF as the current exponent", () => {
     function sourcePsd(exponent: number): number {
       const circuit = new Circuit();

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,13 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Berkeley netlist lowering for remaining Level-1 MOS model fields.
+1. Cross-language Level-1 MOS bulk-junction saturation current.
    - Status: current PR completion candidate.
-   - Preserve canonical `LD`, `TOX`, `RD`, `RS`, `KF`, and `AF` values plus
-     the supported `VTH`, `LAM`, `CJS`, and `CJD` aliases when the Rust
-     Berkeley facade lowers Level-1 MOS devices.
-   - Prove canonical and alias forms reach their existing engine fields instead
-     of silently falling back to defaults.
+   - Route existing model-card `IS` into source-body and drain-body junction
+     leakage for NMOS and PMOS across DC, transient, transfer-function, and AC.
+   - Emit distinct `IBS` and `IBD` shot-noise sources while preserving existing
+     model-card and hierarchy contracts.
 
 ## Completed Slices
 
@@ -3533,6 +3532,13 @@ the Rust, Python, and TypeScript surfaces together.
      `FC` in the Level-1 engine parameter bundle.
    - Source-deck integration coverage proves all three values reach the existing
      cross-language depletion-capacitance behavior.
+
+280. Berkeley netlist lowering for remaining Level-1 MOS model fields.
+   - Status: completed in PR 9094.
+   - The Rust Berkeley netlist facade now preserves canonical `LD`, `TOX`,
+     `RD`, `RS`, `KF`, and `AF` plus aliases `VTH`, `LAM`, `CJS`, and `CJD`.
+   - Source-deck tests prove the values reach their existing engine fields
+     instead of silently falling back to defaults.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- stamp Level-1 MOS `IS` through source-body and drain-body junctions in DC, transient, TF, and AC analyses across Rust, Python, and TypeScript
- use temperature-aware thermal voltage and a continuous upper-exponential continuation for stable Newton linearization
- emit distinct `M*:IBS` and `M*:IBD` shot-noise contributions and refresh the SPICE completion plan

## Verification
- Rust: `cargo fmt -p spice-engine -- --check`
- Rust: `cargo clippy -p spice-engine --all-targets -- -D warnings`
- Rust: AC 59, DC 157, noise 46, TF 27, transient 113 tests passed
- Python: 664 tests passed; Ruff lint passed
- TypeScript: 406 tests passed; `tsc` passed
- `git diff --check`