### PR TITLE
feat(adj-formula-stdlib): alveolar ventilation — StatPearls VA = (VT − VD) × RR definition library

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_alveolar_ventilation_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_alveolar_ventilation_e2e.rs
@@ -1,0 +1,176 @@
+//! End-to-end tests for the `clinical/alveolar-ventilation.adj` library — the definition of
+//! alveolar ventilation (VA = (tidal volume − dead space) × respiratory rate) and its three
+//! exact rearrangements — driven through the built CLI binary against the SHIPPED stdlib. This
+//! is the first clinical inverter of the PRODUCT-OF-A-DIFFERENCE shape: a subtraction inside, a
+//! multiplication (or its inverse division) outside, evaluated exactly over rationals. The same
+//! invariant as every other formula library: a consumer states NO arithmetic; it imports the
+//! grounded library, binds the measured quantities with `observe`, and the engine applies the
+//! cited relation on the CPU, computing the EXACT value and rendering the relation's citation
+//! and trust tier in the `derived` section. The four formulas INVERT around the worked case
+//! VT = 500, VD = 150, RR = 12: (500 − 150) × 12 = 4200; 4200 / (500 − 150) = 12;
+//! 4200/12 + 150 = 500; 500 − 4200/12 = 150.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped alveolar-ventilation library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_alveolar_ventilation_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/alveolar-ventilation.adj")
+        .canonicalize()
+        .expect("shipped alveolar-ventilation.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_alvvent_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_alveolar_ventilation_lib()).unwrap();
+    std::fs::write(dir.join("alveolar-ventilation.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// alveolar_ventilation — the definition: (tidal volume − dead space) × respiratory rate.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_alveolar_ventilation_library_and_computes_it_with_citation() {
+    let dir = scratch("va");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"alveolar-ventilation.adj\"\n\
+         observe tidal_volume(500)\n\
+         observe dead_space(150)\n\
+         observe respiratory_rate(12)\n\
+         ? alveolar_ventilation(tidal_volume, dead_space, respiratory_rate)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied equation's result: (500 − 150) × 12 = 4200.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"alveolar_ventilation\"") && s.contains("\"value\":4200"),
+        "alveolar_ventilation(500, 150, 12) = 4200: {s}"
+    );
+    // … AND the StatPearls/NCBI Bookshelf citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied equation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// respiratory_rate — the same equation solved for RR: VA / (VT − VD).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_respiratory_rate_from_va_vt_vd_with_citation() {
+    let dir = scratch("rr");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"alveolar-ventilation.adj\"\n\
+         observe alveolar_ventilation(4200)\n\
+         observe tidal_volume(500)\n\
+         observe dead_space(150)\n\
+         ? respiratory_rate(alveolar_ventilation, tidal_volume, dead_space)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 4200 / (500 − 150) = 12, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"respiratory_rate\"") && s.contains("\"value\":12"),
+        "respiratory_rate(4200, 500, 150) = 12: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "respiratory_rate carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// tidal_volume — the same equation solved for VT: VA/RR + VD.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_tidal_volume_from_va_rr_vd_with_citation() {
+    let dir = scratch("vt");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"alveolar-ventilation.adj\"\n\
+         observe alveolar_ventilation(4200)\n\
+         observe respiratory_rate(12)\n\
+         observe dead_space(150)\n\
+         ? tidal_volume(alveolar_ventilation, respiratory_rate, dead_space)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 4200/12 + 150 = 350 + 150 = 500, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"tidal_volume\"") && s.contains("\"value\":500"),
+        "tidal_volume(4200, 12, 150) = 500: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "tidal_volume carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// dead_space — the same equation solved for VD: VT − VA/RR, the fourth reading of the one
+// definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_dead_space_from_vt_va_rr_with_citation() {
+    let dir = scratch("vd");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"alveolar-ventilation.adj\"\n\
+         observe tidal_volume(500)\n\
+         observe alveolar_ventilation(4200)\n\
+         observe respiratory_rate(12)\n\
+         ? dead_space(tidal_volume, alveolar_ventilation, respiratory_rate)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 500 − 4200/12 = 500 − 350 = 150, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"dead_space\"") && s.contains("\"value\":150"),
+        "dead_space(500, 4200, 12) = 150: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "dead_space carries its StatPearls citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/alveolar-ventilation.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/alveolar-ventilation.adj
@@ -1,0 +1,120 @@
+% ============================================================================
+% alveolar-ventilation.adj — the definition of alveolar ventilation
+% (VA = (tidal volume − dead space) × respiratory rate) in the ADJ standard library.
+% ============================================================================
+% The alveolar-ventilation entry of the *clinical* track, a respiratory sibling of
+% `minute-ventilation.adj` and `alveolar-arterial-gradient.adj`. Where `minute-ventilation.adj`
+% grounds the TOTAL air moved per minute (respiratory rate × tidal volume), this grounds the
+% part of that air that actually reaches the alveoli for gas exchange: ALVEOLAR VENTILATION IS
+% THE DEAD-SPACE-SUBTRACTED TIDAL VOLUME, TIMES THE RESPIRATORY RATE — only the tidal volume
+% left after the anatomic/physiologic dead space is removed participates in gas exchange, and
+% that effective per-breath volume is multiplied by the breathing frequency to give the
+% per-minute alveolar ventilation. It is the bedside quantity that governs CO2 clearance (a
+% rise in dead space, or a fall in effective tidal volume, drops alveolar ventilation even at an
+% unchanged minute ventilation). It ships as an importable, byte-provenanced, PARAMETERIZED
+% `formula`, together with its three exact rearrangements (the respiratory rate an alveolar
+% ventilation implies, the tidal volume it implies, and the dead space it implies). This is the
+% first clinical inverter of the PRODUCT-OF-A-DIFFERENCE shape (a − subtraction inside, a ×
+% multiplication outside): where the Glasgow Coma Scale is a pure sum and the cerebral perfusion
+% pressure a pure difference, this composes a difference and a product, and the engine inverts
+% it every way exactly. As with every compute library, a consumer states NO arithmetic: it
+% `import`s this file, binds the measured respiratory quantities from its own byte-provenance
+% decomposition, and asks the engine to APPLY the cited definition on the CPU. Zero math is
+% performed by the model; the engine computes each value EXACTLY (over exact rationals),
+% carrying the definition's citation.
+%
+%     import "alveolar-ventilation.adj"
+%     observe tidal_volume(500)         % "…tidal volume 500 mL…"       (span cited by the model)
+%     observe dead_space(150)           % "…dead space 150 mL…"         (span cited by the model)
+%     observe respiratory_rate(12)      % "…respiratory rate 12 /min…"  (span cited by the model)
+%     ? alveolar_ventilation(tidal_volume, dead_space, respiratory_rate)
+%                                          % engine → 4200, carrying VA = (VT − VD) × RR
+%
+% All four formulas are EXACT over their parameters, so every value the engine returns is exact.
+% The four COMPOSE and invert cleanly around the worked case tidal volume = 500 mL, dead space =
+% 150 mL, respiratory rate = 12 /min (VA = (500 − 150) × 12 = 350 × 12 = 4200 mL/min): the
+% `alveolar_ventilation` a consumer computes from the three quantities is exactly the
+% `alveolar_ventilation` the `respiratory_rate` formula divides by the effective tidal volume to
+% recover 12, exactly the value the `tidal_volume` formula divides by the rate and adds the dead
+% space back to (recovering 500), and exactly the value the `dead_space` formula subtracts the
+% per-breath alveolar volume from the tidal volume to recover (150).
+%
+%   alveolar_ventilation(tidal_volume, dead_space, respiratory_rate)
+%       = (tidal_volume - dead_space) * respiratory_rate      % VA = (VT − VD) × RR   (definition)
+%   respiratory_rate(alveolar_ventilation, tidal_volume, dead_space)
+%       = alveolar_ventilation / (tidal_volume - dead_space)  % RR = VA / (VT − VD)   (solved for RR)
+%   tidal_volume(alveolar_ventilation, respiratory_rate, dead_space)
+%       = alveolar_ventilation / respiratory_rate + dead_space% VT = VA/RR + VD       (solved for VT)
+%   dead_space(tidal_volume, alveolar_ventilation, respiratory_rate)
+%       = tidal_volume - alveolar_ventilation / respiratory_rate % VD = VT − VA/RR    (solved for VD)
+%
+% NOTE ON UNITS: the two volumes (tidal volume and dead space) must be in the SAME unit
+% (millilitres, as in the worked case), the respiratory rate is per minute, and the alveolar
+% ventilation comes out in volume-per-minute (mL/min); this library computes the exact value
+% over whatever consistent units it is given. (The minute ventilation — the total, dead space
+% included — is grounded separately in `minute-ventilation.adj`; this library grounds only the
+% ALVEOLAR part that subtracts the dead space first.)
+%
+% All four formulas are defended by the SAME equation — "VA = (VT − VD) × RR" — because that one
+% definition (alveolar ventilation IS the dead-space-subtracted tidal volume times the rate)
+% sanctions the relation read every way. The quote is transcribed verbatim from the StatPearls
+% "Physiology, Lung Dead Space" article on the NCBI Bookshelf, so each `formula` carries the
+% provenance envelope every shipped grounded clause carries; the linter rejects an unsourced
+% one. (See feedback_nothing_human_authored — the equation is a verbatim span of the cited page,
+% not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable respiratory quantity the definition ranges over,
+% and each result is a derived quantity. `alveolar_ventilation`, `tidal_volume`, `dead_space`
+% and `respiratory_rate` each appear BOTH as a derived result and as an input (of the other
+% formulas), so each is a single dictionary term used in both roles. The `surface` lists are the
+% everyday names a decomposer maps onto the canonical term; the trailing comment records the
+% intended unit.
+% ----------------------------------------------------------------------------
+dictionary alveolar_ventilation_vocab {
+    define tidal_volume         : finding  surface "tidal volume", "VT"                          % millilitres (mL)
+    define dead_space           : finding  surface "dead space", "VD", "physiologic dead space"  % millilitres (mL)
+    define respiratory_rate     : finding  surface "respiratory rate", "RR", "breathing rate"    % breaths per minute (/min)
+    define alveolar_ventilation : finding  surface "alveolar ventilation", "VA"                  % millilitres per minute (mL/min)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all four ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the equation from StatPearls on the NCBI
+% Bookshelf (a quote is required on a shipped formula). Each is an exact composition of a
+% difference and a product/quotient of measured quantities, so the engine returns each value
+% EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook alveolar_ventilation_laws {
+    use alveolar_ventilation_vocab
+
+    % Alveolar ventilation — the dead-space-subtracted tidal volume, times the respiratory rate,
+    % i.e. VA = (VT − VD) × RR.
+    formula alveolar_ventilation(tidal_volume, dead_space, respiratory_rate) = (tidal_volume - dead_space) * respiratory_rate
+        source "VA = (VT − VD) × RR"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482501/"
+        trust authoritative
+
+    % Respiratory rate — the same definition solved for the rate an alveolar ventilation implies
+    % for a given effective tidal volume (RR = VA / (VT − VD)). Defended by the SAME equation.
+    formula respiratory_rate(alveolar_ventilation, tidal_volume, dead_space) = alveolar_ventilation / (tidal_volume - dead_space)
+        source "VA = (VT − VD) × RR"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482501/"
+        trust authoritative
+
+    % Tidal volume — the same definition solved for the tidal volume (VT = VA/RR + VD): the
+    % per-breath alveolar volume plus the dead space that must be re-added. The SAME equation,
+    % read the third way.
+    formula tidal_volume(alveolar_ventilation, respiratory_rate, dead_space) = alveolar_ventilation / respiratory_rate + dead_space
+        source "VA = (VT − VD) × RR"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482501/"
+        trust authoritative
+
+    % Dead space — the same definition solved for the dead space (VD = VT − VA/RR): the tidal
+    % volume less the per-breath alveolar volume. The SAME equation, read the fourth way.
+    formula dead_space(tidal_volume, alveolar_ventilation, respiratory_rate) = tidal_volume - alveolar_ventilation / respiratory_rate
+        source "VA = (VT − VD) × RR"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482501/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/alveolar-ventilation.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/alveolar-ventilation.query.adj
@@ -1,0 +1,40 @@
+% ============================================================================
+% alveolar-ventilation.query.adj — worked lookups over the alveolar ventilation definition.
+% ============================================================================
+% The shape a consumer produces to compute alveolar ventilation at the bedside: it `import`s the
+% grounded library, `observe`s the tidal volume, dead space and respiratory rate it decomposed
+% from its own source bytes, and asks the engine to APPLY the cited equation. No arithmetic is
+% stated by the consumer; the engine computes the exact value WITH the StatPearls citation as
+% its proof, on the CPU, with zero model calls.
+%
+% Worked case (tidal volume = 500 mL, dead space = 150 mL, respiratory rate = 12 /min):
+%
+%   ? alveolar_ventilation(tidal_volume, dead_space, respiratory_rate)   % 4200  ((500 − 150) × 12, VA = (VT − VD) × RR)
+%
+% and the same one definition, inverted the three other ways:
+%
+%   ? respiratory_rate(alveolar_ventilation, tidal_volume, dead_space)   % 12   (4200 / (500 − 150), RR = VA / (VT − VD))
+%   ? tidal_volume(alveolar_ventilation, respiratory_rate, dead_space)   % 500  (4200/12 + 150, VT = VA/RR + VD)
+%   ? dead_space(tidal_volume, alveolar_ventilation, respiratory_rate)   % 150  (500 − 4200/12, VD = VT − VA/RR)
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli alveolar-ventilation.query.adj
+% ============================================================================
+
+import "alveolar-ventilation.adj"
+
+% Forward: alveolar ventilation from the three respiratory quantities.
+observe tidal_volume(500)
+observe dead_space(150)
+observe respiratory_rate(12)
+? alveolar_ventilation(tidal_volume, dead_space, respiratory_rate)   % expect 4200
+
+% Inverse 1: the respiratory rate the other three imply.
+observe alveolar_ventilation(4200)
+? respiratory_rate(alveolar_ventilation, tidal_volume, dead_space)   % expect 12
+
+% Inverse 2: the tidal volume the other three imply.
+? tidal_volume(alveolar_ventilation, respiratory_rate, dead_space)   % expect 500
+
+% Inverse 3: the dead space the other three imply.
+? dead_space(tidal_volume, alveolar_ventilation, respiratory_rate)   % expect 150


### PR DESCRIPTION
## What

Grounds **alveolar ventilation** as a byte-provenanced, importable formula library on the *clinical/respiratory* track: `VA = (tidal volume − dead space) × respiratory rate`, plus its three exact rearrangements (`RR = VA/(VT−VD)`, `VT = VA/RR + VD`, `VD = VT − VA/RR`).

**First clinical inverter of the product-of-a-difference shape** — a subtraction inside, a multiplication (or its inverse division) outside — evaluated **exactly over rationals**. A consumer states no arithmetic; it `observe`s the three respiratory quantities and the engine applies the cited equation on the CPU.

## Provenance

All four formulas carry the **same verbatim equation** from StatPearls *Physiology, Lung Dead Space* ([NBK482501](https://www.ncbi.nlm.nih.gov/books/NBK482501/)):

> VA = (VT − VD) × RR

Byte-verified against the source page before shipping.

## Worked case

`VT = 500 mL`, `VD = 150 mL`, `RR = 12 /min` → `VA = (500 − 150) × 12 = 4200 mL/min`; the four formulas invert cleanly (4200/(500−150) = 12; 4200/12 + 150 = 500; 500 − 4200/12 = 150).

## Relationship

Respiratory sibling of [`clinical/minute-ventilation.adj`](https://www.ncbi.nlm.nih.gov/books/NBK482501/) — the *total* air moved per minute (dead space included); this grounds the **alveolar** part that subtracts the dead space first.

## Tests

Dedicated e2e file `formula_alveolar_ventilation_e2e.rs` (4 tests, all green) drives the shipped library through the built CLI against the stdlib. `cargo clippy --tests -D warnings` clean. Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)