### PR TITLE
Import conforming WPT tree cases

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,10 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- The current WPT void-in-phrasing and foreign-content CDATA cases are now
+  mirrored in the canonical tree-construction corpus and its focused void and
+  foreign-content audits, leaving only processing-instruction signatures in
+  the checked upstream debt.
 - The conformance coverage audit now reads tree-construction cases from WPT and
   tokenizer cases from html5lib-tests, pins every missing WPT source signature,
   and accepts only explicit missing-case debt counts so the current 156-case gap

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -134,8 +134,8 @@ focused regression test in `tests/browser_readiness_test.rs`. The
 executable source of truth for that boundary and should fail if a future field
 is added without coverage evidence.
 
-The checked-in tree-construction smoke corpus contains 2,494 passing DOM cases.
-Current WPT contains 1,934 upstream tree-construction cases, with 147 source
+The checked-in tree-construction smoke corpus contains 2,513 passing DOM cases.
+Current WPT contains 1,934 upstream tree-construction cases, with 128 source
 signatures not yet mirrored locally. The checked audit report makes that debt
 explicit so follow-up conformance slices can ratchet it to zero. A separate
 adapter can project DOM into `document-ast` for existing native document
@@ -152,7 +152,7 @@ tests moved from html5lib-tests to WPT, so a current audit uses both checkouts:
 HTML5LIB_TESTS_ROOT=/path/to/html5lib-tests \
 WPT_ROOT=/path/to/wpt \
   python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py \
-  --expect-tree-missing 147 \
+  --expect-tree-missing 128 \
   --expect-tokenizer-missing 0
 ```
 
@@ -170,8 +170,8 @@ python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
   /path/to/html5lib-tests \
   --wpt-root /path/to/wpt \
   --expect-tree-upstream-cases 1934 \
-  --expect-tree-local-cases 2494 \
-  --expect-tree-missing 147 \
+  --expect-tree-local-cases 2513 \
+  --expect-tree-missing 128 \
   --expect-tokenizer-upstream-cases 6806 \
   --expect-tokenizer-local-raw-cases 7015 \
   --expect-tokenizer-missing 0 \

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -185,7 +185,7 @@ source signature:
 HTML5LIB_TESTS_ROOT=/path/to/html5lib-tests \
 WPT_ROOT=/path/to/wpt \
   python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py \
-  --expect-tree-missing 147 \
+  --expect-tree-missing 128 \
   --expect-tokenizer-missing 0
 ```
 
@@ -201,8 +201,8 @@ python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py
   /path/to/html5lib-tests \
   --wpt-root /path/to/wpt \
   --expect-tree-upstream-cases 1934 \
-  --expect-tree-local-cases 2494 \
-  --expect-tree-missing 147 \
+  --expect-tree-local-cases 2513 \
+  --expect-tree-missing 128 \
   --expect-tokenizer-upstream-cases 6806 \
   --expect-tokenizer-local-raw-cases 7015 \
   --expect-tokenizer-missing 0 \
@@ -216,10 +216,10 @@ Regenerate or check it with:
 ```bash
 python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py \
   /path/to/html5lib-tests --wpt-root /path/to/wpt \
-  --expect-tree-missing 147 --expect-tokenizer-missing 0 --write-report
+  --expect-tree-missing 128 --expect-tokenizer-missing 0 --write-report
 python3 code/packages/rust/html-parser/tests/fixtures/audit_html5lib_coverage.py \
   /path/to/html5lib-tests --wpt-root /path/to/wpt \
-  --expect-tree-missing 147 --expect-tokenizer-missing 0 --check-report
+  --expect-tree-missing 128 --expect-tokenizer-missing 0 --check-report
 ```
 
 `whatwg-tree-insertion-audit.json` is a generated index over the high-signal

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-coverage-audit.json
@@ -9,16 +9,10 @@
     "upstream_source": "html5lib-tests/tokenizer"
   },
   "tree_construction": {
-    "local_cases": 2494,
-    "missing": 147,
+    "local_cases": 2513,
+    "missing": 128,
     "missing_sources": [
       "html5test-com.dat:12",
-      "html5test-com.dat:14",
-      "html5test-com.dat:15",
-      "html5test-com.dat:16",
-      "html5test-com.dat:17",
-      "html5test-com.dat:18",
-      "html5test-com.dat:19",
       "processing-instructions.dat:1",
       "processing-instructions.dat:2",
       "processing-instructions.dat:3",
@@ -145,20 +139,7 @@
       "processing-instructions.dat:124",
       "tests1.dat:40",
       "tests1.dat:44",
-      "tests1.dat:47",
-      "void-in-phrasing.dat:1",
-      "void-in-phrasing.dat:2",
-      "void-in-phrasing.dat:3",
-      "void-in-phrasing.dat:4",
-      "void-in-phrasing.dat:5",
-      "void-in-phrasing.dat:6",
-      "void-in-phrasing.dat:7",
-      "void-in-phrasing.dat:8",
-      "void-in-phrasing.dat:9",
-      "void-in-phrasing.dat:10",
-      "void-in-phrasing.dat:11",
-      "void-in-phrasing.dat:12",
-      "void-in-phrasing.dat:13"
+      "tests1.dat:47"
     ],
     "upstream_cases": 1934,
     "upstream_source": "wpt/html/syntax/parsing/resources"

--- a/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
+++ b/code/packages/rust/html-parser/tests/fixtures/html5lib-tree-construction-smoke.dat
@@ -40521,3 +40521,241 @@ math annotation-xml
 |       <marquee>
 |       <table>
 |     <nobr>
+
+#source void-in-phrasing.dat:1
+#data
+<!DOCTYPE html><body><p><br></p>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <br>
+
+#source void-in-phrasing.dat:2
+#data
+<!DOCTYPE html><body><p><br>text</p>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <br>
+|       "text"
+
+#source void-in-phrasing.dat:3
+#data
+<!DOCTYPE html><body><p>before<br>after</p>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       "before"
+|       <br>
+|       "after"
+
+#source void-in-phrasing.dat:4
+#data
+<!DOCTYPE html><body><p><br><br></p>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <br>
+|       <br>
+
+#source void-in-phrasing.dat:5
+#data
+<!DOCTYPE html><body><p>a<br>b<br>c</p>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       "a"
+|       <br>
+|       "b"
+|       <br>
+|       "c"
+
+#source void-in-phrasing.dat:6
+#data
+<!DOCTYPE html><body><h1><br></h1>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <h1>
+|       <br>
+
+#source void-in-phrasing.dat:7
+#data
+<!DOCTYPE html><body><p><input></p>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <input>
+
+#source void-in-phrasing.dat:8
+#data
+<!DOCTYPE html><body><p><img></p>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <img>
+
+#source void-in-phrasing.dat:9
+#data
+<!DOCTYPE html><body><p><wbr></p>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <wbr>
+
+#source void-in-phrasing.dat:10
+#data
+<!DOCTYPE html><body><p><embed></p>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <p>
+|       <embed>
+
+#source void-in-phrasing.dat:11
+#data
+<!DOCTYPE html><body><h2><input></h2>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <h2>
+|       <input>
+
+#source void-in-phrasing.dat:12
+#data
+<!DOCTYPE html><body><em><br></em>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <em>
+|       <br>
+
+#source void-in-phrasing.dat:13
+#data
+<!DOCTYPE html><body><strong><br>text</strong>
+#errors
+#document
+| <!DOCTYPE html>
+| <html>
+|   <head>
+|   <body>
+|     <strong>
+|       <br>
+|       "text"
+
+#source html5test-com.dat:14
+#data
+<svg><title><![CDATA[x]]>
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     <svg svg>
+|       <svg title>
+|         "x"
+
+#source html5test-com.dat:15
+#data
+<svg><foreignobject><![CDATA[x]]>
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     <svg svg>
+|       <svg foreignObject>
+|         "x"
+
+#source html5test-com.dat:16
+#data
+<svg><foreignobject><p><![CDATA[x]]>
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     <svg svg>
+|       <svg foreignObject>
+|         <p>
+|           <!-- [CDATA[x]] -->
+
+#source html5test-com.dat:17
+#data
+<math><![CDATA[x]]>
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     <math math>
+|       "x"
+
+#source html5test-com.dat:18
+#data
+<math><mtext><![CDATA[x]]>
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     <math math>
+|       <math mtext>
+|         "x"
+
+#source html5test-com.dat:19
+#data
+<math><mtext><i><![CDATA[x]]>
+#errors
+#document
+| <html>
+|   <head>
+|   <body>
+|     <math math>
+|       <math mtext>
+|         <i>
+|           <!-- [CDATA[x]] -->

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-block-boundary-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-block-boundary-audit.json
@@ -1,5 +1,5 @@
 {
-  "case_count": 429,
+  "case_count": 431,
   "cases": [
     {
       "axis": "block-formatting-boundary",
@@ -2574,15 +2574,27 @@
       "id": "template-dat-109",
       "reason": "block boundary handling inside html5lib fragment contexts",
       "source": "template.dat:109"
+    },
+    {
+      "axis": "block-heading-boundary",
+      "id": "void-in-phrasing-dat-6",
+      "reason": "heading start/end recovery and nested heading boundaries",
+      "source": "void-in-phrasing.dat:6"
+    },
+    {
+      "axis": "block-form-boundary",
+      "id": "void-in-phrasing-dat-11",
+      "reason": "block boundaries around form controls and button scope recovery",
+      "source": "void-in-phrasing.dat:11"
     }
   ],
   "counts_by_axis": {
     "block-foreign-boundary": 56,
-    "block-form-boundary": 54,
+    "block-form-boundary": 55,
     "block-formatting-boundary": 66,
     "block-fragment-context": 32,
     "block-grouping-boundary": 87,
-    "block-heading-boundary": 12,
+    "block-heading-boundary": 13,
     "block-list-container-boundary": 18,
     "block-ruby-boundary": 10,
     "block-sectioning-boundary": 20,

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-document-shell-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-document-shell-audit.json
@@ -1,5 +1,5 @@
 {
-  "case_count": 731,
+  "case_count": 744,
   "cases": [
     {
       "axis": "comment-whitespace-shell",
@@ -4386,10 +4386,88 @@
       "id": "webkit02-dat-5",
       "reason": "explicit html start/end tags and late html-tag recovery",
       "source": "webkit02.dat:5"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "void-in-phrasing-dat-1",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "void-in-phrasing.dat:1"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "void-in-phrasing-dat-2",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "void-in-phrasing.dat:2"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "void-in-phrasing-dat-3",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "void-in-phrasing.dat:3"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "void-in-phrasing-dat-4",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "void-in-phrasing.dat:4"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "void-in-phrasing-dat-5",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "void-in-phrasing.dat:5"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "void-in-phrasing-dat-6",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "void-in-phrasing.dat:6"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "void-in-phrasing-dat-7",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "void-in-phrasing.dat:7"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "void-in-phrasing-dat-8",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "void-in-phrasing.dat:8"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "void-in-phrasing-dat-9",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "void-in-phrasing.dat:9"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "void-in-phrasing-dat-10",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "void-in-phrasing.dat:10"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "void-in-phrasing-dat-11",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "void-in-phrasing.dat:11"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "void-in-phrasing-dat-12",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "void-in-phrasing.dat:12"
+    },
+    {
+      "axis": "body-frameset-boundary",
+      "id": "void-in-phrasing-dat-13",
+      "reason": "body, frameset, and frame transitions around the document shell",
+      "source": "void-in-phrasing.dat:13"
     }
   ],
   "counts_by_axis": {
-    "body-frameset-boundary": 310,
+    "body-frameset-boundary": 323,
     "comment-whitespace-shell": 15,
     "doctype-and-quirks": 37,
     "head-element-boundary": 132,

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-foreign-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-foreign-audit.json
@@ -1,5 +1,5 @@
 {
-  "case_count": 435,
+  "case_count": 441,
   "cases": [
     {
       "axis": "table-foreign-boundary",
@@ -2610,12 +2610,48 @@
       "id": "plain-text-unsafe-dat-41",
       "reason": "SVG and MathML fragment parsing with foreign-content context seeding",
       "source": "plain-text-unsafe.dat:41"
+    },
+    {
+      "axis": "html-integration-point",
+      "id": "html5test-com-dat-14",
+      "reason": "foreignObject, desc/title, and annotation-xml HTML integration points",
+      "source": "html5test-com.dat:14"
+    },
+    {
+      "axis": "html-integration-point",
+      "id": "html5test-com-dat-15",
+      "reason": "foreignObject, desc/title, and annotation-xml HTML integration points",
+      "source": "html5test-com.dat:15"
+    },
+    {
+      "axis": "html-integration-point",
+      "id": "html5test-com-dat-16",
+      "reason": "foreignObject, desc/title, and annotation-xml HTML integration points",
+      "source": "html5test-com.dat:16"
+    },
+    {
+      "axis": "mathml-boundary",
+      "id": "html5test-com-dat-17",
+      "reason": "MathML insertion-mode boundaries and text-integration recovery",
+      "source": "html5test-com.dat:17"
+    },
+    {
+      "axis": "mathml-boundary",
+      "id": "html5test-com-dat-18",
+      "reason": "MathML insertion-mode boundaries and text-integration recovery",
+      "source": "html5test-com.dat:18"
+    },
+    {
+      "axis": "mathml-boundary",
+      "id": "html5test-com-dat-19",
+      "reason": "MathML insertion-mode boundaries and text-integration recovery",
+      "source": "html5test-com.dat:19"
     }
   ],
   "counts_by_axis": {
     "foreign-fragment": 70,
-    "html-integration-point": 98,
-    "mathml-boundary": 80,
+    "html-integration-point": 101,
+    "mathml-boundary": 83,
     "svg-boundary": 130,
     "table-foreign-boundary": 57
   },

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-form-interactive-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-form-interactive-audit.json
@@ -1,5 +1,5 @@
 {
-  "case_count": 411,
+  "case_count": 413,
   "cases": [
     {
       "axis": "interactive-formatting",
@@ -2466,11 +2466,23 @@
       "id": "adoption02-dat-3",
       "reason": "anchor and nobr adoption-agency or repeated-interactive recovery",
       "source": "adoption02.dat:3"
+    },
+    {
+      "axis": "form-control",
+      "id": "void-in-phrasing-dat-7",
+      "reason": "form, input, label, and fieldset insertion recovery",
+      "source": "void-in-phrasing.dat:7"
+    },
+    {
+      "axis": "form-control",
+      "id": "void-in-phrasing-dat-11",
+      "reason": "form, input, label, and fieldset insertion recovery",
+      "source": "void-in-phrasing.dat:11"
     }
   ],
   "counts_by_axis": {
     "button-boundary": 96,
-    "form-control": 33,
+    "form-control": 35,
     "fragment-context": 7,
     "interactive-formatting": 124,
     "select-option": 123,

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-formatting-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-formatting-audit.json
@@ -1,5 +1,5 @@
 {
-  "case_count": 639,
+  "case_count": 654,
   "cases": [
     {
       "axis": "interactive-formatting-boundary",
@@ -3834,15 +3834,105 @@
       "id": "adoption02-dat-3",
       "reason": "anchor and nobr formatting boundaries through adoption-agency recovery",
       "source": "adoption02.dat:3"
+    },
+    {
+      "axis": "paragraph-boundary",
+      "id": "void-in-phrasing-dat-1",
+      "reason": "paragraph implied end tags around block and phrasing boundaries",
+      "source": "void-in-phrasing.dat:1"
+    },
+    {
+      "axis": "paragraph-boundary",
+      "id": "void-in-phrasing-dat-2",
+      "reason": "paragraph implied end tags around block and phrasing boundaries",
+      "source": "void-in-phrasing.dat:2"
+    },
+    {
+      "axis": "paragraph-boundary",
+      "id": "void-in-phrasing-dat-3",
+      "reason": "paragraph implied end tags around block and phrasing boundaries",
+      "source": "void-in-phrasing.dat:3"
+    },
+    {
+      "axis": "paragraph-boundary",
+      "id": "void-in-phrasing-dat-4",
+      "reason": "paragraph implied end tags around block and phrasing boundaries",
+      "source": "void-in-phrasing.dat:4"
+    },
+    {
+      "axis": "paragraph-boundary",
+      "id": "void-in-phrasing-dat-5",
+      "reason": "paragraph implied end tags around block and phrasing boundaries",
+      "source": "void-in-phrasing.dat:5"
+    },
+    {
+      "axis": "heading-boundary",
+      "id": "void-in-phrasing-dat-6",
+      "reason": "heading implied end tags and nested heading recovery",
+      "source": "void-in-phrasing.dat:6"
+    },
+    {
+      "axis": "paragraph-boundary",
+      "id": "void-in-phrasing-dat-7",
+      "reason": "paragraph implied end tags around block and phrasing boundaries",
+      "source": "void-in-phrasing.dat:7"
+    },
+    {
+      "axis": "paragraph-boundary",
+      "id": "void-in-phrasing-dat-8",
+      "reason": "paragraph implied end tags around block and phrasing boundaries",
+      "source": "void-in-phrasing.dat:8"
+    },
+    {
+      "axis": "paragraph-boundary",
+      "id": "void-in-phrasing-dat-9",
+      "reason": "paragraph implied end tags around block and phrasing boundaries",
+      "source": "void-in-phrasing.dat:9"
+    },
+    {
+      "axis": "paragraph-boundary",
+      "id": "void-in-phrasing-dat-10",
+      "reason": "paragraph implied end tags around block and phrasing boundaries",
+      "source": "void-in-phrasing.dat:10"
+    },
+    {
+      "axis": "heading-boundary",
+      "id": "void-in-phrasing-dat-11",
+      "reason": "heading implied end tags and nested heading recovery",
+      "source": "void-in-phrasing.dat:11"
+    },
+    {
+      "axis": "formatting-reconstruction",
+      "id": "void-in-phrasing-dat-12",
+      "reason": "standalone active formatting element reconstruction and stack cleanup",
+      "source": "void-in-phrasing.dat:12"
+    },
+    {
+      "axis": "formatting-reconstruction",
+      "id": "void-in-phrasing-dat-13",
+      "reason": "standalone active formatting element reconstruction and stack cleanup",
+      "source": "void-in-phrasing.dat:13"
+    },
+    {
+      "axis": "paragraph-boundary",
+      "id": "html5test-com-dat-16",
+      "reason": "paragraph implied end tags around block and phrasing boundaries",
+      "source": "html5test-com.dat:16"
+    },
+    {
+      "axis": "formatting-reconstruction",
+      "id": "html5test-com-dat-19",
+      "reason": "standalone active formatting element reconstruction and stack cleanup",
+      "source": "html5test-com.dat:19"
     }
   ],
   "counts_by_axis": {
     "adoption-agency-formatting": 114,
-    "formatting-reconstruction": 30,
-    "heading-boundary": 26,
+    "formatting-reconstruction": 33,
+    "heading-boundary": 28,
     "interactive-formatting-boundary": 151,
     "list-definition-boundary": 57,
-    "paragraph-boundary": 218,
+    "paragraph-boundary": 228,
     "ruby-implied-end-tags": 43
   },
   "description": "Focused parser audit over selected html5lib tree-construction cases that stress active formatting elements, implied end tags, ruby scopes, headings, and paragraph/list boundaries.",

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-head-body-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-head-body-audit.json
@@ -1,5 +1,5 @@
 {
-  "case_count": 1086,
+  "case_count": 1100,
   "cases": [
     {
       "axis": "head-text-mode",
@@ -6516,14 +6516,98 @@
       "id": "webkit02-dat-21",
       "reason": "title, style, and script handoff around document shell boundaries",
       "source": "webkit02.dat:21"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "void-in-phrasing-dat-1",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "void-in-phrasing.dat:1"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "void-in-phrasing-dat-2",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "void-in-phrasing.dat:2"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "void-in-phrasing-dat-3",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "void-in-phrasing.dat:3"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "void-in-phrasing-dat-4",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "void-in-phrasing.dat:4"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "void-in-phrasing-dat-5",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "void-in-phrasing.dat:5"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "void-in-phrasing-dat-6",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "void-in-phrasing.dat:6"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "void-in-phrasing-dat-7",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "void-in-phrasing.dat:7"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "void-in-phrasing-dat-8",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "void-in-phrasing.dat:8"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "void-in-phrasing-dat-9",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "void-in-phrasing.dat:9"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "void-in-phrasing-dat-10",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "void-in-phrasing.dat:10"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "void-in-phrasing-dat-11",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "void-in-phrasing.dat:11"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "void-in-phrasing-dat-12",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "void-in-phrasing.dat:12"
+    },
+    {
+      "axis": "body-boundary",
+      "id": "void-in-phrasing-dat-13",
+      "reason": "explicit body start/end tags and late body handling",
+      "source": "void-in-phrasing.dat:13"
+    },
+    {
+      "axis": "head-text-mode",
+      "id": "html5test-com-dat-14",
+      "reason": "title, style, and script handoff around document shell boundaries",
+      "source": "html5test-com.dat:14"
     }
   ],
   "counts_by_axis": {
-    "body-boundary": 280,
+    "body-boundary": 293,
     "body-frameset-transition": 153,
     "head-boundary": 49,
     "head-metadata-boundary": 50,
-    "head-text-mode": 481,
+    "head-text-mode": 482,
     "html-boundary": 73
   },
   "description": "Focused parser audit over selected html5lib tree-construction cases that stress html/head/body shell transitions, metadata relocation, head text-mode handoff, frameset/body compatibility, and late shell tags.",

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-paragraph-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-paragraph-audit.json
@@ -1,5 +1,5 @@
 {
-  "case_count": 380,
+  "case_count": 390,
   "cases": [
     {
       "axis": "paragraph-formatting-boundary",
@@ -2280,16 +2280,76 @@
       "id": "webkit02-dat-3",
       "reason": "paragraph boundaries with active formatting reconstruction",
       "source": "webkit02.dat:3"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "void-in-phrasing-dat-1",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "void-in-phrasing.dat:1"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "void-in-phrasing-dat-2",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "void-in-phrasing.dat:2"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "void-in-phrasing-dat-3",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "void-in-phrasing.dat:3"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "void-in-phrasing-dat-4",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "void-in-phrasing.dat:4"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "void-in-phrasing-dat-5",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "void-in-phrasing.dat:5"
+    },
+    {
+      "axis": "paragraph-form-boundary",
+      "id": "void-in-phrasing-dat-7",
+      "reason": "paragraph boundaries around form controls and interactive descendants",
+      "source": "void-in-phrasing.dat:7"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "void-in-phrasing-dat-8",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "void-in-phrasing.dat:8"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "void-in-phrasing-dat-9",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "void-in-phrasing.dat:9"
+    },
+    {
+      "axis": "paragraph-special-end-tag",
+      "id": "void-in-phrasing-dat-10",
+      "reason": "special paragraph and br end-tag recovery paths",
+      "source": "void-in-phrasing.dat:10"
+    },
+    {
+      "axis": "paragraph-basic-boundary",
+      "id": "html5test-com-dat-16",
+      "reason": "standalone paragraph starts, ends, and omitted-end-tag recovery",
+      "source": "html5test-com.dat:16"
     }
   ],
   "counts_by_axis": {
-    "paragraph-basic-boundary": 51,
+    "paragraph-basic-boundary": 52,
     "paragraph-block-boundary": 56,
-    "paragraph-form-boundary": 75,
+    "paragraph-form-boundary": 76,
     "paragraph-formatting-boundary": 73,
     "paragraph-fragment-context": 6,
     "paragraph-heading-boundary": 12,
-    "paragraph-special-end-tag": 25,
+    "paragraph-special-end-tag": 33,
     "paragraph-table-boundary": 48,
     "paragraph-text-mode-boundary": 34
   },

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-text-control-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-text-control-audit.json
@@ -1,5 +1,5 @@
 {
-  "case_count": 698,
+  "case_count": 699,
   "cases": [
     {
       "axis": "rawtext-elements",
@@ -4188,6 +4188,12 @@
       "id": "webkit02-dat-22",
       "reason": "plaintext insertion and consume-through-EOF recovery",
       "source": "webkit02.dat:22"
+    },
+    {
+      "axis": "rcdata-controls",
+      "id": "html5test-com-dat-14",
+      "reason": "title and textarea RCDATA handoff and character-reference recovery",
+      "source": "html5test-com.dat:14"
     }
   ],
   "counts_by_axis": {
@@ -4196,7 +4202,7 @@
     "plaintext-recovery": 56,
     "pre-listing-newline": 29,
     "rawtext-elements": 99,
-    "rcdata-controls": 86,
+    "rcdata-controls": 87,
     "script-rawtext": 367,
     "stray-text-control-end-tags": 7
   },

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-void-element-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-void-element-audit.json
@@ -1,5 +1,5 @@
 {
-  "case_count": 227,
+  "case_count": 240,
   "cases": [
     {
       "axis": "void-in-table",
@@ -1362,10 +1362,88 @@
       "id": "tests-innerhtml-1-dat-76",
       "reason": "void elements in html5lib fragment contexts",
       "source": "tests_innerHTML_1.dat:76"
+    },
+    {
+      "axis": "body-void-elements",
+      "id": "void-in-phrasing-dat-1",
+      "reason": "body void elements such as area, br, embed, hr, img, input, and wbr",
+      "source": "void-in-phrasing.dat:1"
+    },
+    {
+      "axis": "body-void-elements",
+      "id": "void-in-phrasing-dat-2",
+      "reason": "body void elements such as area, br, embed, hr, img, input, and wbr",
+      "source": "void-in-phrasing.dat:2"
+    },
+    {
+      "axis": "body-void-elements",
+      "id": "void-in-phrasing-dat-3",
+      "reason": "body void elements such as area, br, embed, hr, img, input, and wbr",
+      "source": "void-in-phrasing.dat:3"
+    },
+    {
+      "axis": "body-void-elements",
+      "id": "void-in-phrasing-dat-4",
+      "reason": "body void elements such as area, br, embed, hr, img, input, and wbr",
+      "source": "void-in-phrasing.dat:4"
+    },
+    {
+      "axis": "body-void-elements",
+      "id": "void-in-phrasing-dat-5",
+      "reason": "body void elements such as area, br, embed, hr, img, input, and wbr",
+      "source": "void-in-phrasing.dat:5"
+    },
+    {
+      "axis": "body-void-elements",
+      "id": "void-in-phrasing-dat-6",
+      "reason": "body void elements such as area, br, embed, hr, img, input, and wbr",
+      "source": "void-in-phrasing.dat:6"
+    },
+    {
+      "axis": "body-void-elements",
+      "id": "void-in-phrasing-dat-7",
+      "reason": "body void elements such as area, br, embed, hr, img, input, and wbr",
+      "source": "void-in-phrasing.dat:7"
+    },
+    {
+      "axis": "body-void-elements",
+      "id": "void-in-phrasing-dat-8",
+      "reason": "body void elements such as area, br, embed, hr, img, input, and wbr",
+      "source": "void-in-phrasing.dat:8"
+    },
+    {
+      "axis": "body-void-elements",
+      "id": "void-in-phrasing-dat-9",
+      "reason": "body void elements such as area, br, embed, hr, img, input, and wbr",
+      "source": "void-in-phrasing.dat:9"
+    },
+    {
+      "axis": "body-void-elements",
+      "id": "void-in-phrasing-dat-10",
+      "reason": "body void elements such as area, br, embed, hr, img, input, and wbr",
+      "source": "void-in-phrasing.dat:10"
+    },
+    {
+      "axis": "body-void-elements",
+      "id": "void-in-phrasing-dat-11",
+      "reason": "body void elements such as area, br, embed, hr, img, input, and wbr",
+      "source": "void-in-phrasing.dat:11"
+    },
+    {
+      "axis": "body-void-elements",
+      "id": "void-in-phrasing-dat-12",
+      "reason": "body void elements such as area, br, embed, hr, img, input, and wbr",
+      "source": "void-in-phrasing.dat:12"
+    },
+    {
+      "axis": "body-void-elements",
+      "id": "void-in-phrasing-dat-13",
+      "reason": "body void elements such as area, br, embed, hr, img, input, and wbr",
+      "source": "void-in-phrasing.dat:13"
     }
   ],
   "counts_by_axis": {
-    "body-void-elements": 61,
+    "body-void-elements": 74,
     "legacy-void-elements": 15,
     "metadata-void-elements": 56,
     "stray-void-end-tags": 5,

--- a/code/packages/rust/html-parser/tests/html5lib_coverage_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/html5lib_coverage_audit_test.rs
@@ -74,8 +74,8 @@ fn html5lib_coverage_audit_fixture_matches_checked_local_corpora() {
     );
     assert_eq!(audit.tree_construction.upstream_cases, 1934);
     assert_eq!(audit.tree_construction.local_cases, tree_cases.len());
-    assert_eq!(audit.tree_construction.local_cases, 2494);
-    assert_eq!(audit.tree_construction.missing, 147);
+    assert_eq!(audit.tree_construction.local_cases, 2513);
+    assert_eq!(audit.tree_construction.missing, 128);
     assert_eq!(
         audit.tree_construction.missing_sources.len(),
         audit.tree_construction.missing
@@ -86,7 +86,7 @@ fn html5lib_coverage_audit_fixture_matches_checked_local_corpora() {
     );
     assert_eq!(
         missing_source_count(&audit.tree_construction, "void-in-phrasing.dat:"),
-        13
+        0
     );
     assert_eq!(
         missing_source_count(&audit.tree_construction, "plain-text-unsafe.dat:"),
@@ -94,7 +94,7 @@ fn html5lib_coverage_audit_fixture_matches_checked_local_corpora() {
     );
     assert_eq!(
         missing_source_count(&audit.tree_construction, "html5test-com.dat:"),
-        7
+        1
     );
     assert_eq!(
         missing_source_count(&audit.tree_construction, "tests1.dat:"),


### PR DESCRIPTION
## What changed

- Import 19 current WPT tree-construction cases whose DOM results already match the Rust parser.
- Regenerate the focused block-boundary, document-shell, foreign, form, formatting, head/body, paragraph, text-control, and void-element audit indexes.
- Ratchet the checked current-WPT debt from 147 to 128 missing source signatures while keeping tokenizer debt at zero.

## Why

These upstream cases were behaviorally conforming but absent from the checked local corpus, so the explicit WPT coverage report continued to count them as debt. Adding them makes that coverage executable and prevents regressions in the affected tree-construction families.

## Impact

The canonical tree corpus grows from 2,494 to 2,513 passing cases. This is fixture-only: parser behavior does not change.

## Validation

- `cargo test -p coding-adventures-html-parser --test tree_construction_test --test html5lib_coverage_audit_test`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- Fresh upstream audit: WPT tree 1,934 / local 2,513 / missing 128; html5lib tokenizer 6,806 / missing 0; normalized tokenizer 7,242 / skipped 0
- Focused audit coverage: 2,513 indexed cases, zero missing, zero stale