### PR TITLE
feat(adj-formula-stdlib): electric-potential-conversions — NIST SP 811 B.9 abvolt→volt table (facts, b24)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -1097,6 +1097,46 @@ fn shipped_electric_charge_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b24) The shipped NIST SP 811 B.9 electric-potential → volt table resolves the exact abvolt
+//       factor with its citation, and ABSTAINS on a wrong-dimension unit. The abvolt (potential)
+//       and the abohm (resistance) are DIFFERENT quantities that convert to DIFFERENT SI units
+//       (volt vs ohm), so the abstain proves dimension safety, not mere absence of a value: the
+//       volt is energy per unit charge; the ohm is potential per unit current.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_electric_potential_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_potential");
+    let src = stdlib().join("reference/electric-potential-conversions.adj");
+    std::fs::copy(&src, dir.join("electric-potential-conversions.adj"))
+        .expect("copy shipped electric-potential-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"electric-potential-conversions.adj\"\n\
+         ? electric_potential_to_volt(abvolt, $v)\n\
+         ? electric_potential_to_volt(abohm, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 exact factor resolves, character-for-character from the table
+    // (boldface = exact; the abvolt is defined as exactly 1.0 E-08 V).
+    assert!(out.contains("\"v\":\"0.00000001\""), "abvolt = 1.0 E-08 V: {out}");
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `abohm` is an electric-RESISTANCE unit (it converts to the ohm, a DIFFERENT quantity), so
+    // this potential table has no row for it — the engine abstains rather than mis-converting a
+    // resistance unit as if it were a potential unit.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a wrong-dimension unit abstains, never a cross-dimension fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/electric-potential-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/electric-potential-conversions.adj
@@ -1,0 +1,55 @@
+% ============================================================================
+% electric-potential-conversions — electric-potential-unit → volt factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of energy-conversions.adj, power-conversions.adj, electric-charge-conversions.adj
+% and the other NIST-cited conversion tables: a native tabular relation ingested VERBATIM from a
+% published NIST conversion table. The row states the factor converting the traditional (CGS-EMU)
+% unit of ELECTRIC POTENTIAL — the electromotive force / potential difference — to the SI coherent
+% derived unit, the volt (V):
+%
+%     ? electric_potential_to_volt(abvolt, $v)   % 0.00000001
+%
+% This is a NEW dimension alongside the length/mass/area/volume/time/speed/energy/pressure/
+% force/acceleration/dynamic-viscosity/kinematic-viscosity/magnetic-flux-density/magnetic-flux/
+% illuminance/luminance/radioactivity/absorbed-dose/dose-equivalent/exposure/power/electric-charge
+% tables. Do NOT confuse ELECTRIC POTENTIAL (the abvolt → the volt) with ELECTRIC CHARGE (the
+% abcoulomb → the coulomb) or ELECTRIC RESISTANCE (the abohm → the ohm): those are DIFFERENT
+% quantities that convert to DIFFERENT SI units. Electric potential (the volt) is energy per unit
+% charge (one volt is one joule per coulomb); the abvolt is its traditional (EMU) unit. Put a
+% potential given in abvolts into SI first, then reason (write-once-use-many). Why a `table` and
+% not a hand-written `relate` clause: this is exactly the shape reference data comes in — a
+% published table, not prose. The citable artifact IS the NIST conversion-factors table at the
+% `locator` below; the factor here is a CELL of NIST Special Publication 811, Appendix B.9
+% ("Factors for units listed alphabetically"), defended by one provenance envelope. Each `row`
+% lowers to a ground relation `electric_potential_to_volt(unit, v)`, so the exact lookup above is
+% the ordinary SLD binding query — the engine returns the factor WITH this table's citation as its
+% proof, on the CPU, with zero model calls.
+%
+% HONESTY NOTE (like the power / electric-charge / magnetic-flux tables, only the EXACT defined
+% factor gets a row): NIST SP 811 B.9 prints the "abvolt" potential factor in BOLDFACE, its
+% convention for factors that are EXACT by definition, transcribed here as the plain decimal
+% number of volts it names:
+%
+%     abvolt (abV)   1.0 E-08  →  0.00000001
+%
+% This is exact because the abvolt is DEFINED as exactly 1.0 E-08 volt (the EMU of potential). It
+% terminates; nothing here is a rounded measurement. This table is SPECIFIC to electric potential:
+% a unit of a DIFFERENT quantity — e.g. the "abohm", which NIST SP 811 B.9 lists separately as an
+% electric-RESISTANCE unit converting to the ohm, NOT the volt — therefore gets no row here, and a
+% `? electric_potential_to_volt(abohm, $v)` ABSTAINS rather than mis-converting a resistance unit
+% as if it were a potential unit. The only claim this table makes is "this is the exact factor
+% NIST SP 811 B.9 prints for the abvolt's conversion to the volt" — which is exactly what a
+% byte-check against the cited table verifies. `trust authoritative` — a primary, re-fetchable
+% standards reference. (See ADJ-TABLES.md; and feedback_nothing_human_authored — the factor is a
+% verbatim cell of the cited table, nothing asserted from memory.)
+% ============================================================================
+
+table electric_potential_to_volt {
+    columns unit, volt
+
+    row (abvolt, 0.00000001)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/electric-potential-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/electric-potential-conversions.query.adj
@@ -1,0 +1,24 @@
+% ============================================================================
+% electric-potential-conversions.query.adj — worked lookups over the NIST potential → volt table.
+% ============================================================================
+% The shape a consumer produces to convert a potential given in a traditional CGS-EMU unit into
+% SI: it `import`s the grounded table and asks the engine to bind the factor. No arithmetic and
+% no factor is stated by the consumer; the engine returns the cell WITH the table's NIST citation
+% as its proof, on the CPU.
+%
+%   ? electric_potential_to_volt(abvolt, $v)   % 0.00000001   (abvolt = 1.0 E-08 V, exact)
+%
+% And the dimension guard: a unit of a DIFFERENT quantity has no row, so the lookup ABSTAINS
+% rather than mis-converting across dimensions. The "abohm" is an electric-RESISTANCE unit (it
+% converts to the ohm), NOT a potential unit:
+%
+%   ? electric_potential_to_volt(abohm, $v)    % abstains (abohm is resistance → ohm)
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli electric-potential-conversions.query.adj
+% ============================================================================
+
+import "electric-potential-conversions.adj"
+
+? electric_potential_to_volt(abvolt, $v)   % expect 0.00000001  (exact NIST SP 811 B.9 factor)
+? electric_potential_to_volt(abohm, $v)    % expect abstain     (resistance unit, wrong dimension)


### PR DESCRIPTION
## What

Adds a native RS-5 `table` grounding the **NIST SP 811 Appendix B.9** exact factor converting the CGS-EMU unit of **electric potential** to the SI volt:

```
abvolt (abV)   1.0 E-08  →  0.00000001
```

New electromagnetic dimension alongside electric-charge (b23) — the volt is energy per unit charge (one volt = one joule per coulomb). NIST prints the factor in **boldface** (its convention for factors exact by definition), transcribed verbatim as the decimal cell.

## Behaviour

- Exact lookup `? electric_potential_to_volt(abvolt, $v)` → `0.00000001`, ordinary SLD binding, carrying the table's NIST citation as its proof — zero model calls.
- **Dimension guard:** `abohm` is an electric-**resistance** unit (→ ohm, a different quantity), so it has no row and the lookup **abstains** rather than mis-converting across dimensions.

## Provenance

Source: *"Factors for units listed alphabetically"*, [NIST SP 811 Appendix B.9](https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9). Byte-verified against the cited table before shipping.

## Tests

Appends the **b24** block to the shared `rs5_table_e2e.rs` anchor (asserts the exact value string `"v":"0.00000001"`, the NIST locator, and `"abstained":true` for abohm). Full rs5 suite **29 passed**; `cargo clippy --tests -D warnings` clean. Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)