### PR TITLE
content(ar/hi): please for Arabic and Hindi

### DIFF
--- a/code/learning/human-languages/arabic/lessons/AR-C06-min-fadlik.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C06-min-fadlik.md
@@ -1,0 +1,66 @@
+---
+id: AR-C06-min-fadlik
+chapter: 6
+type: phrase
+headword: من فضلك
+gloss: please (min faḍlik — literally "from your grace")
+concept_tag: COURTESY-PLEASE
+prerequisites: [AR-C01-shukran]
+sounds: [dad-emphatic, arabic-rtl, gendered-ending]
+roots: [fadl]
+etymology_hook: "من فضلك min faḍlik is literally 'from your grace' — faḍl 'grace, bounty', the same courtesy Hindi's kṛpayā invokes"
+est_minutes: 4
+reviews_of: [AR-C01-shukran]
+---
+
+# من فضلك (min faḍlik) — please
+
+## Warm-up
+
+[PAUSE 2s] Arabic doesn't say "please" — it asks for something *from your grace.*
+
+## The phrase
+
+**من فضلك** — read right to left, **min faḍlik** — is two pieces:
+
+> **من** (*min*, "from") + **فضلك** (*faḍl* + *-ik/-ak*, "your grace/bounty")
+> → "**from your grace.**"
+
+*faḍl* is a warm, weighty word — "grace, favour, bounty, generosity" (you'll meet
+it as the name *Faḍl*). Saying *min faḍlik* casts the request as drawing on the
+other person's generosity — not a command, a courtesy.
+
+## A gender note (Arabic marks "you")
+
+The ending changes with **whom you address** — and, unwritten, only the vowel
+moves:
+
+- to a **woman**: *min faḍl**ik*** (the ك said *-ik*)
+- to a **man**: *min faḍl**ak*** (the ك said *-ak*)
+
+The spelling **فضلك** is the same for both; the short vowel that distinguishes
+them isn't normally written. One sound to respect: the **ض** (*ḍ*) is an
+**emphatic** d, said with a heavier, deeper tongue than a plain *d*.
+
+## Another everyday "please"
+
+Just as common, especially getting someone's attention:
+
+> **لو سمحت** — *law samaḥt* — literally "**if you permit**" (*law* "if" +
+> *samaḥt* "you permitted"). Same politeness, a different image — permission
+> rather than grace.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "min faḍlik" — feel the heavy ض]
+- [YOU SAY: taken apart — "from your grace"]
+- [YOU SAY: the alternative — "law samaḥt" = "if you permit"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] How do you say please in Arabic? (**min faḍlik**, من فضلك.) What does
+it literally mean? ("**From your grace**" — *faḍl* = grace/bounty.) What changes
+between saying it to a man vs a woman? (The ك ending — *-ak* to a man, *-ik* to a
+woman; spelling unchanged.) What's the other common "please," and what does it
+mean? (**law samaḥt** — "if you permit.")

--- a/code/learning/human-languages/hindi/lessons/HI-C08-kripaya.md
+++ b/code/learning/human-languages/hindi/lessons/HI-C08-kripaya.md
@@ -1,0 +1,63 @@
+---
+id: HI-C08-kripaya
+chapter: 8
+type: word
+headword: कृपया
+gloss: please (kṛpayā — "kindly," from kṛpā "grace/compassion")
+concept_tag: COURTESY-PLEASE
+prerequisites: [HI-C01-dhanyavad]
+sounds: [vocalic-r-matra, retroflex-flap]
+roots: [krpa-sanskrit]
+etymology_hook: "कृपया kṛpayā is 'kindly', from Sanskrit kṛpā 'grace, compassion' — the same 'invoke grace' idea as Arabic min faḍlik"
+est_minutes: 4
+reviews_of: [HI-C01-dhanyavad]
+---
+
+# कृपया (kṛpayā) — please (kindly)
+
+## Warm-up
+
+[PAUSE 2s] Hindi's dictionary word for "please" is really the word **compassion**
+in disguise — and it's more formal than you might expect.
+
+## The word
+
+**कृपया** = **please**, literally "**kindly / graciously**." It's built on the
+Sanskrit noun **कृपा** (*kṛpā*), "**grace, compassion, mercy**" — so asking with
+*kṛpayā* means, at heart, "of your compassion."
+
+That places Hindi in good company: **Arabic** asks *min faḍlik* ("from your
+**grace**"), and the Dravidian languages ask with *daya* ("**compassion**"). A
+whole swathe of Asia says *please* by naming the kindness it hopes for — a
+different instinct from French's "if it **pleases** you."
+
+The first letter hides a sound you met in the syllabary track: **कृ** is *ka*
+carrying the **vocalic r** (the *ृ* mark) — *kṛ*, the same *r̥* vowel Sanskrit and
+the Dravidian scripts share.
+
+## Be honest about how it's used
+
+Here's the catch a textbook often hides: **कृपया is formal and bookish.** You'll
+see it on signs and hear it in announcements ("*kṛpayā* mind the gap"), but in
+everyday speech Hindi speakers rarely say it. Real politeness usually rides on
+**the verb** instead — the respectful request ending **‑इए / ‑इएगा** (*-iye /
+-iyegā*): *baiṭh**iye*** "please sit," *sun**iye*** "please listen." And very
+often, people simply say the English word **"please."**
+
+So learn *kṛpayā* to **read** it and to be formally polite — but know that the
+living "please" of Hindi is baked into the verb.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "kṛpayā" — kṛ with the vocalic r, then -payā]
+- [YOU SAY: the root — "kṛpā = compassion" → "of your compassion"]
+- [YOU SAY: the everyday way — the verb ending: "baiṭhiye" = "please sit"]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is the formal Hindi word for please? (**कृपया** *kṛpayā*.) What
+does its root *kṛpā* mean, and which other languages ask the same way? (**"Grace
+/ compassion"** — like Arabic *min faḍlik* and Dravidian *daya*.) Is *kṛpayā* what
+people usually say out loud? (**No** — it's formal; everyday politeness rides on
+the verb ending *-iye/-iyegā*, or people say English "please.")


### PR DESCRIPTION
Continues the **please** concept (Spanish/German/Latin/French already done): Arabic **من فضلك min faḍlik** and Hindi **कृपया kṛpayā**.

Shared cross-family idea — please as **invoking grace**:
- **Arabic min faḍlik** = 'from your grace' (faḍl 'grace/bounty'); gendered ك ending (-ik female / -ak male, spelling unchanged); emphatic ض; + law samaḥt لو سمحت 'if you permit'.
- **Hindi kṛpayā** = 'kindly' ← Sanskrit kṛpā 'grace/compassion' — same instinct as Arabic faḍl and Dravidian daya. Honest note: kṛpayā is formal/bookish; everyday Hindi uses the verb (-iye/-iyegā, baiṭhiye 'please sit') or the English word 'please'.

This 'invoke grace' strategy (Arabic/Hindi/Dravidian) contrasts with Romance 'if it pleases you' and Latin/German 'I ask'.

Glyphs composed + verified from Unicode. Linguistics subagent: **SHIP IT** — every glyph confirmed at codepoint level, gender rule + cross-language claim correct. Zero errors; 38 + 268 green.

Next: Dravidian please (Tamil for you to verify), completing the concept; then COURTESY-SORRY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)