### PR TITLE
feat(adj-formula-stdlib): coronary perfusion pressure — StatPearls CPP = ADP − LVEDP definition library

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_coronary_perfusion_pressure_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_coronary_perfusion_pressure_e2e.rs
@@ -1,0 +1,140 @@
+//! End-to-end tests for the `clinical/coronary-perfusion-pressure.adj` library — the definition
+//! of coronary perfusion pressure (CPP = aortic diastolic pressure − left ventricular
+//! end-diastolic pressure) and its two exact rearrangements — driven through the built CLI binary
+//! against the SHIPPED stdlib. The same invariant as every other formula library: a consumer
+//! states NO arithmetic; it imports the grounded library, binds the measured pressures with
+//! `observe`, and the engine applies the cited relation on the CPU, computing the EXACT value and
+//! rendering the relation's citation and trust tier in the `derived` section (the auditable
+//! answer). The three formulas INVERT around the worked case ADP = 80 mmHg, LVEDP = 12 mmHg:
+//! 80 − 12 = 68, 68 + 12 = 80, and 80 − 68 = 12. This is the cardiology counterpart of the
+//! shipped cerebral-perfusion-pressure.adj (CPP = MAP − ICP).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped coronary-perfusion-pressure library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_cpp_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/coronary-perfusion-pressure.adj")
+        .canonicalize()
+        .expect("shipped coronary-perfusion-pressure.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_coronarycpp_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_cpp_lib()).unwrap();
+    std::fs::write(dir.join("coronary-perfusion-pressure.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// coronary_perfusion_pressure — the definition: aortic diastolic pressure minus LVEDP.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_coronary_perfusion_pressure_library_and_computes_it_with_citation() {
+    let dir = scratch("cpp");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"coronary-perfusion-pressure.adj\"\n\
+         observe aortic_diastolic_pressure(80)\n\
+         observe left_ventricular_end_diastolic_pressure(12)\n\
+         ? coronary_perfusion_pressure(aortic_diastolic_pressure, left_ventricular_end_diastolic_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 80 − 12 = 68.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"coronary_perfusion_pressure\"") && s.contains("\"value\":68"),
+        "coronary_perfusion_pressure(80, 12) = 68: {s}"
+    );
+    // … AND the StatPearls/NCBI Bookshelf citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// aortic_diastolic_pressure — the same relation solved for ADP: CPP + LVEDP.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_aortic_diastolic_pressure_from_cpp_and_lvedp_with_citation() {
+    let dir = scratch("adp");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"coronary-perfusion-pressure.adj\"\n\
+         observe coronary_perfusion_pressure(68)\n\
+         observe left_ventricular_end_diastolic_pressure(12)\n\
+         ? aortic_diastolic_pressure(coronary_perfusion_pressure, left_ventricular_end_diastolic_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 68 + 12 = 80, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"aortic_diastolic_pressure\"") && s.contains("\"value\":80"),
+        "aortic_diastolic_pressure(68, 12) = 80: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "aortic_diastolic_pressure carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// left_ventricular_end_diastolic_pressure — the same relation solved for LVEDP: ADP − CPP, the
+// third reading of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_lvedp_from_adp_and_cpp_with_citation() {
+    let dir = scratch("lvedp");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"coronary-perfusion-pressure.adj\"\n\
+         observe aortic_diastolic_pressure(80)\n\
+         observe coronary_perfusion_pressure(68)\n\
+         ? left_ventricular_end_diastolic_pressure(aortic_diastolic_pressure, coronary_perfusion_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 80 − 68 = 12, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"left_ventricular_end_diastolic_pressure\"") && s.contains("\"value\":12"),
+        "left_ventricular_end_diastolic_pressure(80, 68) = 12: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "left_ventricular_end_diastolic_pressure carries its StatPearls citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/coronary-perfusion-pressure.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/coronary-perfusion-pressure.adj
@@ -1,0 +1,106 @@
+% ============================================================================
+% coronary-perfusion-pressure.adj — the definition of coronary perfusion pressure
+% (CPP = aortic diastolic pressure − left ventricular end-diastolic pressure) in the ADJ
+% standard library.
+% ============================================================================
+% The coronary-perfusion-pressure entry of the *clinical* track, a cardiology sibling of the
+% NEURO/critical-care `cerebral-perfusion-pressure.adj`. Where `cerebral-perfusion-pressure.adj`
+% grounds the pressure driving blood into the brain (MAP − ICP), this grounds the pressure
+% driving blood into the HEART MUSCLE: CORONARY PERFUSION PRESSURE IS THE AORTIC DIASTOLIC
+% PRESSURE MINUS THE LEFT VENTRICULAR END-DIASTOLIC PRESSURE — the net pressure gradient across
+% the coronary bed during DIASTOLE (the left ventricle perfuses in diastole, because systolic
+% contraction squeezes its own intramural arteries shut). LVEDP is the back-pressure the
+% coronary flow works against; subtracting it from the aortic diastolic pressure gives the
+% pressure actually available to perfuse the myocardium (a CPP that falls — from hypotension, or
+% from a rising LVEDP in acute heart failure — starves the subendocardium first). It ships as an
+% importable, byte-provenanced, PARAMETERIZED `formula`, together with its two exact
+% rearrangements (the aortic diastolic pressure a CPP implies for a given LVEDP, and the LVEDP
+% the other two imply). As with every compute library, a consumer states NO arithmetic: it
+% `import`s this file, binds the measured pressures from its own byte-provenance decomposition,
+% and asks the engine to APPLY the cited definition on the CPU. Zero math is performed by the
+% model; the engine computes each value EXACTLY, carrying the definition's citation.
+%
+%     import "coronary-perfusion-pressure.adj"
+%     observe aortic_diastolic_pressure(80)                 % "…aortic diastolic 80 mmHg…"  (span cited by the model)
+%     observe left_ventricular_end_diastolic_pressure(12)   % "…LVEDP 12 mmHg…"              (span cited by the model)
+%     ? coronary_perfusion_pressure(aortic_diastolic_pressure, left_ventricular_end_diastolic_pressure)
+%                                                              % engine → 68, carrying CPP = ADP − LVEDP
+%
+% All three formulas are EXACT over their parameters (a difference and two of its inverse
+% readings), so every value the engine returns is exact. The three COMPOSE and invert cleanly
+% around the worked case aortic diastolic pressure = 80 mmHg, LVEDP = 12 mmHg (CPP = 80 − 12 =
+% 68 mmHg): the `coronary_perfusion_pressure` a consumer computes from the two pressures is
+% exactly the `coronary_perfusion_pressure` the `aortic_diastolic_pressure` formula adds the
+% LVEDP back to, to recover the 80 mmHg aortic diastolic pressure, and exactly the
+% `coronary_perfusion_pressure` the `left_ventricular_end_diastolic_pressure` formula subtracts
+% from the aortic diastolic pressure to recover the 12 mmHg LVEDP.
+%
+%   coronary_perfusion_pressure(aortic_diastolic_pressure, left_ventricular_end_diastolic_pressure)
+%       = aortic_diastolic_pressure - left_ventricular_end_diastolic_pressure   % CPP = ADP − LVEDP   (definition)
+%   aortic_diastolic_pressure(coronary_perfusion_pressure, left_ventricular_end_diastolic_pressure)
+%       = coronary_perfusion_pressure + left_ventricular_end_diastolic_pressure % ADP = CPP + LVEDP   (solved for ADP)
+%   left_ventricular_end_diastolic_pressure(aortic_diastolic_pressure, coronary_perfusion_pressure)
+%       = aortic_diastolic_pressure - coronary_perfusion_pressure               % LVEDP = ADP − CPP   (solved for LVEDP)
+%
+% NOTE ON UNITS: the two pressures must be in the SAME unit (both millimetres of mercury, as in
+% the worked case), and the coronary perfusion pressure comes out in that same unit; this library
+% computes the exact value over whatever consistent unit it is given. NOTE ON DIASTOLE: this uses
+% the AORTIC DIASTOLIC pressure (not the mean or systolic), because myocardial perfusion of the
+% left ventricle happens in diastole; the definition is the coronary counterpart of the cerebral
+% perfusion pressure in `cerebral-perfusion-pressure.adj`, which uses the MEAN arterial pressure.
+%
+% All three formulas are defended by the SAME equation — "CPP = ADP – LVEDP" — because that one
+% definition (coronary perfusion pressure IS the aortic diastolic minus the left ventricular
+% end-diastolic pressure) sanctions the relation read every way (the CPP from the two pressures,
+% the ADP from the CPP and LVEDP, or the LVEDP from the ADP and CPP). The quote is transcribed
+% verbatim from the StatPearls "Coronary Perfusion Pressure" article on the NCBI Bookshelf, so
+% each `formula` carries the provenance envelope every shipped grounded clause carries; the
+% linter rejects an unsourced one. (See feedback_nothing_human_authored — the equation is a
+% verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable pressure the definition ranges over, and each
+% result is a derived quantity. `coronary_perfusion_pressure`, `aortic_diastolic_pressure` and
+% `left_ventricular_end_diastolic_pressure` each appear BOTH as a derived result and as an input
+% (of the other formulas), so each is a single dictionary term used in both roles. The `surface`
+% lists are the everyday names a decomposer maps onto the canonical term; the trailing comment
+% records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary coronary_perfusion_pressure_vocab {
+    define aortic_diastolic_pressure               : finding  surface "aortic diastolic pressure", "ADP"                              % millimetres of mercury (mmHg)
+    define left_ventricular_end_diastolic_pressure : finding  surface "left ventricular end-diastolic pressure", "LVEDP"              % millimetres of mercury (mmHg)
+    define coronary_perfusion_pressure             : finding  surface "coronary perfusion pressure", "CPP"                            % millimetres of mercury (mmHg)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the equation from StatPearls on the NCBI
+% Bookshelf (a quote is required on a shipped formula). Each is an exact difference/sum of
+% measured quantities, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook coronary_perfusion_pressure_laws {
+    use coronary_perfusion_pressure_vocab
+
+    % Coronary perfusion pressure — the aortic diastolic pressure less the left ventricular
+    % end-diastolic pressure, i.e. CPP = ADP − LVEDP.
+    formula coronary_perfusion_pressure(aortic_diastolic_pressure, left_ventricular_end_diastolic_pressure) = aortic_diastolic_pressure - left_ventricular_end_diastolic_pressure
+        source "CPP = ADP – LVEDP"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK551531/"
+        trust authoritative
+
+    % Aortic diastolic pressure — the same definition solved for the aortic diastolic pressure a
+    % coronary perfusion pressure implies for an LVEDP (ADP = CPP + LVEDP). Defended by the SAME
+    % equation, read the other way.
+    formula aortic_diastolic_pressure(coronary_perfusion_pressure, left_ventricular_end_diastolic_pressure) = coronary_perfusion_pressure + left_ventricular_end_diastolic_pressure
+        source "CPP = ADP – LVEDP"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK551531/"
+        trust authoritative
+
+    % Left ventricular end-diastolic pressure — the same definition solved for the LVEDP the other
+    % two imply (LVEDP = ADP − CPP). Again the SAME equation, read the third way.
+    formula left_ventricular_end_diastolic_pressure(aortic_diastolic_pressure, coronary_perfusion_pressure) = aortic_diastolic_pressure - coronary_perfusion_pressure
+        source "CPP = ADP – LVEDP"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK551531/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/coronary-perfusion-pressure.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/coronary-perfusion-pressure.query.adj
@@ -1,0 +1,37 @@
+% ============================================================================
+% coronary-perfusion-pressure.query.adj — worked lookups over the coronary perfusion pressure
+% definition.
+% ============================================================================
+% The shape a consumer produces to compute coronary perfusion pressure at the bedside: it
+% `import`s the grounded library, `observe`s the aortic diastolic pressure and the left
+% ventricular end-diastolic pressure it decomposed from its own source bytes, and asks the engine
+% to APPLY the cited definition. No arithmetic is stated by the consumer; the engine computes the
+% exact value WITH the definition's StatPearls citation as its proof, on the CPU, with zero model
+% calls.
+%
+% Worked case (aortic diastolic pressure = 80 mmHg, LVEDP = 12 mmHg):
+%
+%   ? coronary_perfusion_pressure(aortic_diastolic_pressure, left_ventricular_end_diastolic_pressure)   % 68  (80 − 12, CPP = ADP − LVEDP)
+%
+% and the same one definition, inverted both other ways:
+%
+%   ? aortic_diastolic_pressure(coronary_perfusion_pressure, left_ventricular_end_diastolic_pressure)   % 80  (68 + 12, ADP = CPP + LVEDP)
+%   ? left_ventricular_end_diastolic_pressure(aortic_diastolic_pressure, coronary_perfusion_pressure)   % 12  (80 − 68, LVEDP = ADP − CPP)
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli coronary-perfusion-pressure.query.adj
+% ============================================================================
+
+import "coronary-perfusion-pressure.adj"
+
+% Forward: coronary perfusion pressure from the two pressures.
+observe aortic_diastolic_pressure(80)
+observe left_ventricular_end_diastolic_pressure(12)
+? coronary_perfusion_pressure(aortic_diastolic_pressure, left_ventricular_end_diastolic_pressure)   % expect 68
+
+% Inverse 1: the aortic diastolic pressure a CPP implies for an LVEDP.
+observe coronary_perfusion_pressure(68)
+? aortic_diastolic_pressure(coronary_perfusion_pressure, left_ventricular_end_diastolic_pressure)   % expect 80
+
+% Inverse 2: the LVEDP the other two imply.
+? left_ventricular_end_diastolic_pressure(aortic_diastolic_pressure, coronary_perfusion_pressure)   % expect 12


### PR DESCRIPTION
## What

Grounds **coronary perfusion pressure** as a byte-provenanced, importable formula library on the *clinical/cardiology* track: `CPP = aortic diastolic pressure − left ventricular end-diastolic pressure`, plus its two exact rearrangements (`ADP = CPP + LVEDP`, `LVEDP = ADP − CPP`).

The **cardiology counterpart** of the shipped [`cerebral-perfusion-pressure.adj`](https://www.ncbi.nlm.nih.gov/books/NBK537271/) (CPP = MAP − ICP): the net pressure driving blood into the heart muscle during diastole (LVEDP is the back-pressure the coronary flow works against). A consumer states no arithmetic; it `observe`s the two pressures and the engine applies the cited relation on the CPU.

## Provenance

All three formulas carry the **same verbatim equation** from StatPearls *Coronary Perfusion Pressure* ([NBK551531](https://www.ncbi.nlm.nih.gov/books/NBK551531/)):

> CPP = ADP – LVEDP

Byte-verified against the source page before shipping.

## Worked case

`ADP = 80 mmHg`, `LVEDP = 12 mmHg` → `CPP = 68 mmHg`; the three formulas invert cleanly (68 + 12 = 80; 80 − 68 = 12).

## Tests

Dedicated e2e file `formula_coronary_perfusion_pressure_e2e.rs` (3 tests, all green) drives the shipped library through the built CLI against the stdlib. `cargo clippy --tests -D warnings` clean. Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)