### PR TITLE
feat(adj-formula-stdlib): electric-resistance-conversions — NIST SP 811 B.9 abohm→ohm table (facts, b25)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -1137,6 +1137,47 @@ fn shipped_electric_potential_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b25) The shipped NIST SP 811 B.9 electric-resistance → ohm table resolves the exact abohm
+//       factor with its citation, and ABSTAINS on a wrong-dimension unit. This completes the
+//       electromagnetic-EMU trio (charge/potential/resistance). The abohm (resistance) and the
+//       abvolt (potential) are DIFFERENT quantities that convert to DIFFERENT SI units (ohm vs
+//       volt), so the abstain proves dimension safety, not mere absence of a value: the ohm is
+//       potential per unit current.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_electric_resistance_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_resistance");
+    let src = stdlib().join("reference/electric-resistance-conversions.adj");
+    std::fs::copy(&src, dir.join("electric-resistance-conversions.adj"))
+        .expect("copy shipped electric-resistance-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"electric-resistance-conversions.adj\"\n\
+         ? electric_resistance_to_ohm(abohm, $v)\n\
+         ? electric_resistance_to_ohm(abvolt, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 exact factor resolves, character-for-character from the table
+    // (boldface = exact; the abohm is defined as exactly 1.0 E-09 ohm).
+    assert!(out.contains("\"v\":\"0.000000001\""), "abohm = 1.0 E-09 ohm: {out}");
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `abvolt` is an electric-POTENTIAL unit (it converts to the volt, a DIFFERENT quantity), so
+    // this resistance table has no row for it — the engine abstains rather than mis-converting a
+    // potential unit as if it were a resistance unit.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a wrong-dimension unit abstains, never a cross-dimension fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/electric-resistance-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/electric-resistance-conversions.adj
@@ -1,0 +1,57 @@
+% ============================================================================
+% electric-resistance-conversions — electric-resistance-unit → ohm factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of electric-charge-conversions.adj, electric-potential-conversions.adj and
+% the other NIST-cited conversion tables: a native tabular relation ingested VERBATIM from a
+% published NIST conversion table. The row states the factor converting the traditional (CGS-EMU)
+% unit of ELECTRIC RESISTANCE to the SI coherent derived unit, the ohm (Ω):
+%
+%     ? electric_resistance_to_ohm(abohm, $v)   % 0.000000001
+%
+% This COMPLETES the electromagnetic-EMU trio alongside electric-charge (the abcoulomb → the
+% coulomb) and electric-potential (the abvolt → the volt), and is a NEW dimension alongside the
+% length/mass/area/volume/time/speed/energy/pressure/force/acceleration/dynamic-viscosity/
+% kinematic-viscosity/magnetic-flux-density/magnetic-flux/illuminance/luminance/radioactivity/
+% absorbed-dose/dose-equivalent/exposure/power tables. Do NOT confuse ELECTRIC RESISTANCE (the
+% abohm → the ohm) with ELECTRIC POTENTIAL (the abvolt → the volt) or ELECTRIC CHARGE (the
+% abcoulomb → the coulomb): those are DIFFERENT quantities that convert to DIFFERENT SI units.
+% Electric resistance (the ohm) is potential per unit current (one ohm is one volt per ampere);
+% the abohm is its traditional (EMU) unit. Put a resistance given in abohms into SI first, then
+% reason (write-once-use-many). Why a `table` and not a hand-written `relate` clause: this is
+% exactly the shape reference data comes in — a published table, not prose. The citable artifact
+% IS the NIST conversion-factors table at the `locator` below; the factor here is a CELL of NIST
+% Special Publication 811, Appendix B.9 ("Factors for units listed alphabetically"), defended by
+% one provenance envelope. Each `row` lowers to a ground relation
+% `electric_resistance_to_ohm(unit, v)`, so the exact lookup above is the ordinary SLD binding
+% query — the engine returns the factor WITH this table's citation as its proof, on the CPU, with
+% zero model calls.
+%
+% HONESTY NOTE (like the electric-charge / electric-potential / power tables, only the EXACT
+% defined factor gets a row): NIST SP 811 B.9 prints the "abohm" resistance factor in BOLDFACE,
+% its convention for factors that are EXACT by definition, transcribed here as the plain decimal
+% number of ohms it names:
+%
+%     abohm (abΩ)   1.0 E-09  →  0.000000001
+%
+% This is exact because the abohm is DEFINED as exactly 1.0 E-09 ohm (the EMU of resistance). It
+% terminates; nothing here is a rounded measurement. This table is SPECIFIC to electric
+% resistance: a unit of a DIFFERENT quantity — e.g. the "abvolt", which NIST SP 811 B.9 lists
+% separately as an electric-POTENTIAL unit converting to the volt, NOT the ohm — therefore gets
+% no row here, and a `? electric_resistance_to_ohm(abvolt, $v)` ABSTAINS rather than
+% mis-converting a potential unit as if it were a resistance unit. The only claim this table
+% makes is "this is the exact factor NIST SP 811 B.9 prints for the abohm's conversion to the
+% ohm" — which is exactly what a byte-check against the cited table verifies. `trust authoritative`
+% — a primary, re-fetchable standards reference. (See ADJ-TABLES.md; and
+% feedback_nothing_human_authored — the factor is a verbatim cell of the cited table, nothing
+% asserted from memory.)
+% ============================================================================
+
+table electric_resistance_to_ohm {
+    columns unit, ohm
+
+    row (abohm, 0.000000001)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/electric-resistance-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/electric-resistance-conversions.query.adj
@@ -1,0 +1,24 @@
+% ============================================================================
+% electric-resistance-conversions.query.adj — worked lookups over the NIST resistance → ohm table.
+% ============================================================================
+% The shape a consumer produces to convert a resistance given in a traditional CGS-EMU unit into
+% SI: it `import`s the grounded table and asks the engine to bind the factor. No arithmetic and
+% no factor is stated by the consumer; the engine returns the cell WITH the table's NIST citation
+% as its proof, on the CPU.
+%
+%   ? electric_resistance_to_ohm(abohm, $v)   % 0.000000001   (abohm = 1.0 E-09 Ω, exact)
+%
+% And the dimension guard: a unit of a DIFFERENT quantity has no row, so the lookup ABSTAINS
+% rather than mis-converting across dimensions. The "abvolt" is an electric-POTENTIAL unit (it
+% converts to the volt), NOT a resistance unit:
+%
+%   ? electric_resistance_to_ohm(abvolt, $v)   % abstains (abvolt is potential → volt)
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli electric-resistance-conversions.query.adj
+% ============================================================================
+
+import "electric-resistance-conversions.adj"
+
+? electric_resistance_to_ohm(abohm, $v)    % expect 0.000000001  (exact NIST SP 811 B.9 factor)
+? electric_resistance_to_ohm(abvolt, $v)   % expect abstain      (potential unit, wrong dimension)


### PR DESCRIPTION
## What

Adds a native RS-5 `table` grounding the **NIST SP 811 Appendix B.9** exact factor converting the CGS-EMU unit of **electric resistance** to the SI ohm:

```
abohm (abΩ)   1.0 E-09  →  0.000000001
```

**Completes the electromagnetic-EMU trio** alongside electric-charge (b23) and electric-potential (b24) — the ohm is potential per unit current (one ohm = one volt per ampere). NIST prints the factor in **boldface** (its convention for factors exact by definition), transcribed verbatim as the decimal cell.

## Behaviour

- Exact lookup `? electric_resistance_to_ohm(abohm, $v)` → `0.000000001`, ordinary SLD binding, carrying the table's NIST citation as its proof — zero model calls.
- **Dimension guard:** `abvolt` is an electric-**potential** unit (→ volt, a different quantity), so it has no row and the lookup **abstains** rather than mis-converting across dimensions.

## Provenance

Source: *"Factors for units listed alphabetically"*, [NIST SP 811 Appendix B.9](https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9). Byte-verified against the cited table before shipping.

## Tests

Appends the **b25** block to the shared `rs5_table_e2e.rs` anchor (asserts the exact value string `"v":"0.000000001"`, the NIST locator, and `"abstained":true` for abvolt). Full rs5 suite **30 passed**; `cargo clippy --tests -D warnings` clean. Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)