### PR TITLE
feat(spice): model MOS junction current density

### DIFF
--- a/code/packages/python/mosfet-models/CHANGELOG.md
+++ b/code/packages/python/mosfet-models/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [0.1.0] — Unreleased
 
 ### Added
+- `Level1Params.JS` adds zero-default Berkeley bulk-junction saturation-current
+  density for source/drain area scaling while preserving scalar `IS`.
 - `Level1Params.MJSW` adds Berkeley sidewall-junction depletion grading,
   defaulting to `0.33` independently from bottom-junction `MJ`.
 - `Level1Params.PS` adds zero-default Berkeley source diffusion perimeter,

--- a/code/packages/python/mosfet-models/src/mosfet_models/level1.py
+++ b/code/packages/python/mosfet-models/src/mosfet_models/level1.py
@@ -41,6 +41,7 @@ class Level1Params:
     CJ: float = 0.0  # bottom junction capacitance per area (F/m^2)
     CJSW: float = 0.0  # sidewall junction capacitance per perimeter (F/m)
     IS: float = 1e-15  # saturation current (A)
+    JS: float = 0.0  # saturation current density (A/m^2)
     N_SUB: float = 1.4  # subthreshold slope factor
     T_NOM: float = 300.15  # nominal temperature (K)
     CGSO: float = 0.0  # gate-source overlap capacitance per width (F/m)
@@ -156,6 +157,8 @@ def evaluate_level1(
         raise ValueError("MOSFET CJ must be finite and non-negative")
     if not isfinite(p.CJSW) or p.CJSW < 0.0:
         raise ValueError("MOSFET CJSW must be finite and non-negative")
+    if not isfinite(p.JS) or p.JS < 0.0:
+        raise ValueError("MOSFET JS must be finite and non-negative")
     if not isfinite(p.MJSW) or p.MJSW < 0.0:
         raise ValueError("MOSFET MJSW must be finite and non-negative")
     beta = p.KP * (p.W / effective_length)

--- a/code/packages/python/mosfet-models/tests/test_models.py
+++ b/code/packages/python/mosfet-models/tests/test_models.py
@@ -386,5 +386,11 @@ def test_default_params_match_spec():
     assert p.KP == 220e-6
     assert p.W == 1e-6
     assert p.L == 130e-9
+    assert p.JS == 0.0
     assert p.KF == 0.0
     assert p.AF == 1.0
+
+
+def test_rejects_negative_bulk_junction_saturation_current_density():
+    with pytest.raises(ValueError, match="MOSFET JS must be finite and non-negative"):
+        evaluate_level1(Level1Params(JS=-1.0), V_GS=1.0, V_DS=1.0)

--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add Level-1 MOS model-card `JS` as bulk-junction saturation-current density,
+  scaling source/drain leakage and shot noise by `AS` / `AD` when both areas
+  are present and otherwise retaining Berkeley-compatible `IS` fallback.
 - Apply Level-1 MOS model-card `IS` to the source-body and drain-body junctions
   in DC, transient, transfer-function, and AC analysis, and emit distinct
   `IBS` / `IBD` shot-noise sources.

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -9285,6 +9285,7 @@ def _stamp_mosfet(
         intrinsic_source,
         Vs,
         Vb,
+        el.model.model.params.AS,  # type: ignore[attr-defined]
     )
     _stamp_mosfet_bulk_junction(
         G,
@@ -9294,6 +9295,7 @@ def _stamp_mosfet(
         intrinsic_drain,
         Vd,
         Vb,
+        el.model.model.params.AD,  # type: ignore[attr-defined]
     )
     drain_resistance = _mosfet_drain_resistance(el)
     if drain_resistance > 0.0:
@@ -9319,8 +9321,14 @@ def _mosfet_bulk_junction_current_conductance(
     el: Mosfet,
     terminal_voltage: float,
     body_voltage: float,
+    terminal_area: float,
 ) -> tuple[float, float]:
     params = el.model.model.params  # type: ignore[attr-defined]
+    saturation_current = (
+        params.JS * terminal_area
+        if params.JS > 0.0 and params.AD > 0.0 and params.AS > 0.0
+        else params.IS
+    )
     junction_voltage = (
         body_voltage - terminal_voltage
         if el.model.type == MosfetType.NMOS  # type: ignore[attr-defined]
@@ -9336,8 +9344,8 @@ def _mosfet_bulk_junction_current_conductance(
         current_factor = limited_exp
         conductance_factor = limited_exp
     return (
-        params.IS * (current_factor - 1.0),
-        params.IS / thermal_voltage * conductance_factor,
+        saturation_current * (current_factor - 1.0),
+        saturation_current / thermal_voltage * conductance_factor,
     )
 
 
@@ -9349,11 +9357,13 @@ def _stamp_mosfet_bulk_junction(
     terminal: str,
     terminal_voltage: float,
     body_voltage: float,
+    terminal_area: float,
 ) -> None:
     current, conductance = _mosfet_bulk_junction_current_conductance(
         el,
         terminal_voltage,
         body_voltage,
+        terminal_area,
     )
     is_nmos = el.model.type == MosfetType.NMOS  # type: ignore[attr-defined]
     junction_voltage = (
@@ -13256,10 +13266,10 @@ def _stamp_ac(
         gm_m: float = r.gm
         gds_m: float = r.gds
         _, source_bulk_conductance = _mosfet_bulk_junction_current_conductance(
-            el, Vs, Vb
+            el, Vs, Vb, el.model.model.params.AS  # type: ignore[attr-defined]
         )
         _, drain_bulk_conductance = _mosfet_bulk_junction_current_conductance(
-            el, Vd, Vb
+            el, Vd, Vb, el.model.model.params.AD  # type: ignore[attr-defined]
         )
         _stamp_g_c(G, node_to_idx, intrinsic_drain, intrinsic_source, gds_m + 0j)
         _stamp_g_c(G, node_to_idx, el.gate, intrinsic_source, 1j * omega * r.Cgs)
@@ -14029,10 +14039,10 @@ def _build_ss_matrix(
             gm_m: float = r.gm
             gds_m: float = r.gds
             _, source_bulk_conductance = _mosfet_bulk_junction_current_conductance(
-                el, Vs, Vb
+                el, Vs, Vb, el.model.model.params.AS  # type: ignore[attr-defined]
             )
             _, drain_bulk_conductance = _mosfet_bulk_junction_current_conductance(
-                el, Vd, Vb
+                el, Vd, Vb, el.model.model.params.AD  # type: ignore[attr-defined]
             )
             _stamp_g(G, node_to_idx, intrinsic_drain, intrinsic_source, gds_m)
             _stamp_g(
@@ -15958,10 +15968,10 @@ def _collect_noise_sources(
                     )
                 )
             source_bulk_current, _ = _mosfet_bulk_junction_current_conductance(
-                el, Vs, Vb
+                el, Vs, Vb, el.model.model.params.AS  # type: ignore[attr-defined]
             )
             drain_bulk_current, _ = _mosfet_bulk_junction_current_conductance(
-                el, Vd, Vb
+                el, Vd, Vb, el.model.model.params.AD  # type: ignore[attr-defined]
             )
             n_b = None if _is_ground(el.body) else node_to_idx[el.body]
             is_nmos = el.model.type == MosfetType.NMOS  # type: ignore[attr-defined]

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -311,8 +311,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "PNP": (41, 58, 13, 4),
     "NJF": (22, 30, 7, 3),
     "PJF": (22, 30, 7, 3),
-    "NMOS": (29, 36, 6, 3),
-    "PMOS": (29, 36, 6, 3),
+    "NMOS": (30, 37, 6, 3),
+    "PMOS": (30, 37, 6, 3),
 }
 
 
@@ -469,6 +469,7 @@ _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
     "RS": "RS",
     "RSH": "RSH",
     "IS": "IS",
+    "JS": "JS",
     "NSUB": "N_SUB",
     "N_SUB": "N_SUB",
     "TNOM": "T_NOM",
@@ -1081,6 +1082,7 @@ def mosfet_from_model_card(
         RS=p.get("RS", defaults.RS),
         RSH=p.get("RSH", defaults.RSH),
         IS=p.get("IS", defaults.IS),
+        JS=p.get("JS", defaults.JS),
         N_SUB=p.get("N_SUB", defaults.N_SUB),
         T_NOM=p.get("T_NOM", defaults.T_NOM),
         CGSO=p.get("CGSO", defaults.CGSO),

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -408,7 +408,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 199
+    assert len(coverage) == 201
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -423,7 +423,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tAF\tAF\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 199
+    assert len(records) == 201
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -446,8 +446,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert summary[0].max_alias_count == 3
     assert summary[0].aliased_parameters == ("IS", "VT", "CJO", "VJ", "M")
     assert summary[5].kind == "NMOS"
-    assert summary[5].canonical_parameter_count == 29
-    assert summary[5].accepted_name_count == 36
+    assert summary[5].canonical_parameter_count == 30
+    assert summary[5].accepted_name_count == 37
     assert summary[5].aliased_parameter_count == 6
     assert summary[5].max_alias_count == 3
     assert summary[5].aliased_parameters == (
@@ -469,7 +469,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert table.splitlines()[1] == "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M"
     assert (
         table.splitlines()[-1]
-        == "PMOS\t29\t36\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        == "PMOS\t30\t37\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
     )
     records = model_card_supported_parameter_coverage_summary_records()
     assert len(records) == 7
@@ -497,9 +497,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 199
-    assert report.expected_canonical_parameter_count == 199
-    assert report.accepted_name_count == 269
+    assert report.canonical_parameter_count == 201
+    assert report.expected_canonical_parameter_count == 201
+    assert report.accepted_name_count == 271
     assert report.aliased_parameter_count == 57
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -507,7 +507,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t199\t199\t269\t57\t4\t0"
+        "true\t7\t7\t201\t201\t271\t57\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -535,15 +535,15 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 198
-    assert report.accepted_name_count == 266
+    assert report.canonical_parameter_count == 200
+    assert report.accepted_name_count == 268
     assert report.aliased_parameter_count == 56
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
     assert report.issues[0].field == "canonical_parameter_count"
     assert report.issues[0].message == (
-        "expected NMOS to expose 29 canonical supported parameters, found 28"
+        "expected NMOS to expose 30 canonical supported parameters, found 29"
     )
     assert report.issues[-1].field == "max_alias_count"
     assert report.issues[-1].message == "expected NMOS max alias count 3, found 2"
@@ -551,12 +551,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t198\t199\t266\t56\t4\t4\n"
+        "false\t7\t7\t200\t201\t268\t56\t4\t4\n"
         "kind\tfield\tmessage\n"
-        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 29 canonical "
-        "supported parameters, found 28\n"
-        "NMOS\taccepted_name_count\texpected NMOS to expose 36 accepted model-card "
-        "names, found 33\n"
+        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 30 canonical "
+        "supported parameters, found 29\n"
+        "NMOS\taccepted_name_count\texpected NMOS to expose 37 accepted model-card "
+        "names, found 34\n"
         "NMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing "
         "parameters, found 5\n"
         "NMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
@@ -565,12 +565,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
     assert records[0] == {
         "kind": "NMOS",
         "field": "canonical_parameter_count",
-        "message": "expected NMOS to expose 29 canonical supported parameters, found 28",
+        "message": "expected NMOS to expose 30 canonical supported parameters, found 29",
     }
     assert format_model_card_supported_parameter_coverage_gate_issue_csv(report).startswith(
         "kind,field,message\n"
-        'NMOS,canonical_parameter_count,"expected NMOS to expose 29 canonical '
-        'supported parameters, found 28"\n'
+        'NMOS,canonical_parameter_count,"expected NMOS to expose 30 canonical '
+        'supported parameters, found 29"\n'
     )
     assert (
         json.loads(format_model_card_supported_parameter_coverage_gate_issue_json(report))
@@ -753,6 +753,8 @@ def test_model_card_aliases_build_device_instances() -> None:
             "RS": 75.0,
             "RSH": 50.0,
             "CJ": 2.0e-3,
+            "IS": 4.0e-12,
+            "JS": 2.0e-6,
             "TOX": 25.0e-9,
             "KF": 2.0e-24,
             "AF": 1.4,
@@ -774,6 +776,8 @@ def test_model_card_aliases_build_device_instances() -> None:
         "RS": 75.0,
         "RSH": 50.0,
         "CJ": 2.0e-3,
+        "IS": 4.0e-12,
+        "JS": 2.0e-6,
         "TOX": 25.0e-9,
         "KF": 2.0e-24,
         "AF": 1.4,
@@ -796,6 +800,8 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(1.0) == mos_model.model.model.params.NRD
     assert pytest.approx(1.0) == mos_model.model.model.params.NRS
     assert pytest.approx(2.0e-3) == mos_model.model.model.params.CJ
+    assert pytest.approx(4.0e-12) == mos_model.model.model.params.IS
+    assert pytest.approx(2.0e-6) == mos_model.model.model.params.JS
     assert pytest.approx(25.0e-9) == mos_model.model.model.params.TOX
     assert pytest.approx(2.0e-24) == mos_model.model.model.params.KF
     assert pytest.approx(1.4) == mos_model.model.model.params.AF
@@ -965,6 +971,47 @@ def test_dc_mosfet_bulk_junction_saturation_current_sets_reverse_leakage() -> No
         unloaded = bias_current(mosfet_type, bias_voltage, 1.0e-30)
         loaded = bias_current(mosfet_type, bias_voltage, 1.0e-12)
         assert loaded > unloaded
+
+
+def test_dc_mosfet_bulk_junction_current_density_scales_diffusion_areas() -> None:
+    def bias_current(params: Level1Params) -> float:
+        circuit = Circuit()
+        circuit.add(VoltageSource("Vbias", "body", "0", -0.3))
+        circuit.add(
+            Mosfet(
+                "M1",
+                "0",
+                "0",
+                "0",
+                "body",
+                MOSFET(MosfetType.NMOS, Level1Model(params)),
+            )
+        )
+        return abs(dc_op(circuit).branch_currents["I(Vbias)"])
+
+    scalar = bias_current(Level1Params(IS=1.0e-12))
+    density = bias_current(Level1Params(IS=1.0e-30, JS=1.0e-6, AS=0.5e-6, AD=1.5e-6))
+    missing_area = bias_current(Level1Params(IS=1.0e-12, JS=1.0, AS=0.0, AD=1.0))
+
+    assert density == pytest.approx(scalar, rel=1.0e-6)
+    assert missing_area == pytest.approx(scalar, rel=1.0e-6)
+
+
+def test_dc_rejects_negative_mosfet_bulk_junction_current_density() -> None:
+    circuit = Circuit()
+    circuit.add(
+        Mosfet(
+            "M1",
+            "drain",
+            "gate",
+            "0",
+            "0",
+            MOSFET(MosfetType.NMOS, Level1Model(Level1Params(JS=-1.0))),
+        )
+    )
+
+    with pytest.raises(ValueError, match="MOSFET JS must be finite and non-negative"):
+        dc_op(circuit)
 
 
 def test_dc_mosfet_source_resistance_raises_intrinsic_source_voltage() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add Level-1 MOS model-card `JS` as bulk-junction saturation-current density,
+  scaling source/drain leakage and shot noise by `AS` / `AD` when both areas
+  are present and otherwise retaining Berkeley-compatible `IS` fallback.
 - Apply Level-1 MOS model-card `IS` to the source-body and drain-body junctions
   in DC, transient, transfer-function, and AC analysis, and emit distinct
   `IBS` / `IBD` shot-noise sources.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3621,6 +3621,7 @@ pub struct MosfetLevel1Params {
     pub bottom_junction_capacitance: f64,
     pub sidewall_junction_capacitance: f64,
     pub saturation_current: f64,
+    pub saturation_current_density: f64,
     pub n_sub: f64,
     pub t_nom: f64,
     pub gate_source_overlap_capacitance: f64,
@@ -3660,6 +3661,7 @@ impl Default for MosfetLevel1Params {
             bottom_junction_capacitance: 0.0,
             sidewall_junction_capacitance: 0.0,
             saturation_current: 1.0e-15,
+            saturation_current_density: 0.0,
             n_sub: 1.4,
             t_nom: 300.15,
             gate_source_overlap_capacitance: 0.0,
@@ -4016,8 +4018,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     (ModelCardKind::Pnp, 41, 58, 13, 4),
     (ModelCardKind::Njf, 22, 30, 7, 3),
     (ModelCardKind::Pjf, 22, 30, 7, 3),
-    (ModelCardKind::Nmos, 29, 36, 6, 3),
-    (ModelCardKind::Pmos, 29, 36, 6, 3),
+    (ModelCardKind::Nmos, 30, 37, 6, 3),
+    (ModelCardKind::Pmos, 30, 37, 6, 3),
 ];
 const DIODE_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IS", "IS"),
@@ -4152,6 +4154,7 @@ const MOS_LEVEL1_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("RS", "RS"),
     ("RSH", "RSH"),
     ("IS", "IS"),
+    ("JS", "JS"),
     ("NSUB", "N_SUB"),
     ("N_SUB", "N_SUB"),
     ("TNOM", "T_NOM"),
@@ -4947,6 +4950,9 @@ pub fn mosfet_from_model_card(
     }
     if let Some(value) = model.parameters.get("IS") {
         params.saturation_current = *value;
+    }
+    if let Some(value) = model.parameters.get("JS") {
+        params.saturation_current_density = *value;
     }
     if let Some(value) = model.parameters.get("N_SUB") {
         params.n_sub = *value;
@@ -22881,10 +22887,18 @@ fn collect_noise_sources(
                         frequency_exponent: 1.0,
                     });
                 }
-                let (source_bulk_current, _) =
-                    mosfet_bulk_junction_current_conductance(mosfet, source_voltage, body_voltage);
-                let (drain_bulk_current, _) =
-                    mosfet_bulk_junction_current_conductance(mosfet, drain_voltage, body_voltage);
+                let (source_bulk_current, _) = mosfet_bulk_junction_current_conductance(
+                    mosfet,
+                    source_voltage,
+                    body_voltage,
+                    mosfet.params.source_area,
+                );
+                let (drain_bulk_current, _) = mosfet_bulk_junction_current_conductance(
+                    mosfet,
+                    drain_voltage,
+                    body_voltage,
+                    mosfet.params.drain_area,
+                );
                 let (source_bulk_positive, source_bulk_negative) = match mosfet.mosfet_type {
                     MosfetType::Nmos => (body, source),
                     MosfetType::Pmos => (source, body),
@@ -24259,6 +24273,7 @@ fn stamp_mosfet(
         body,
         source_voltage,
         body_voltage,
+        mosfet.params.source_area,
         matrix,
         rhs,
     );
@@ -24268,6 +24283,7 @@ fn stamp_mosfet(
         body,
         drain_voltage,
         body_voltage,
+        mosfet.params.drain_area,
         matrix,
         rhs,
     );
@@ -24297,7 +24313,16 @@ fn mosfet_bulk_junction_current_conductance(
     mosfet: &Mosfet,
     terminal_voltage: f64,
     body_voltage: f64,
+    terminal_area: f64,
 ) -> (f64, f64) {
+    let saturation_current = if mosfet.params.saturation_current_density > 0.0
+        && mosfet.params.drain_area > 0.0
+        && mosfet.params.source_area > 0.0
+    {
+        mosfet.params.saturation_current_density * terminal_area
+    } else {
+        mosfet.params.saturation_current
+    };
     let junction_voltage = match mosfet.mosfet_type {
         MosfetType::Nmos => body_voltage - terminal_voltage,
         MosfetType::Pmos => terminal_voltage - body_voltage,
@@ -24311,8 +24336,8 @@ fn mosfet_bulk_junction_current_conductance(
         (limited_exp, limited_exp)
     };
     (
-        mosfet.params.saturation_current * (current_factor - 1.0),
-        mosfet.params.saturation_current / thermal_voltage * conductance_factor,
+        saturation_current * (current_factor - 1.0),
+        saturation_current / thermal_voltage * conductance_factor,
     )
 }
 
@@ -24322,11 +24347,16 @@ fn stamp_mosfet_bulk_junction(
     body: Option<usize>,
     terminal_voltage: f64,
     body_voltage: f64,
+    terminal_area: f64,
     matrix: &mut [Vec<f64>],
     rhs: &mut [f64],
 ) {
-    let (current, conductance) =
-        mosfet_bulk_junction_current_conductance(mosfet, terminal_voltage, body_voltage);
+    let (current, conductance) = mosfet_bulk_junction_current_conductance(
+        mosfet,
+        terminal_voltage,
+        body_voltage,
+        terminal_area,
+    );
     let junction_voltage = match mosfet.mosfet_type {
         MosfetType::Nmos => body_voltage - terminal_voltage,
         MosfetType::Pmos => terminal_voltage - body_voltage,
@@ -24529,10 +24559,18 @@ fn stamp_mosfet_small_signal(
     let vds = drain_voltage - source_voltage;
     let vbs = body_voltage - source_voltage;
     let result = evaluate_mosfet_level1(mosfet, vgs, vds, vbs);
-    let (_, source_bulk_conductance) =
-        mosfet_bulk_junction_current_conductance(mosfet, source_voltage, body_voltage);
-    let (_, drain_bulk_conductance) =
-        mosfet_bulk_junction_current_conductance(mosfet, drain_voltage, body_voltage);
+    let (_, source_bulk_conductance) = mosfet_bulk_junction_current_conductance(
+        mosfet,
+        source_voltage,
+        body_voltage,
+        mosfet.params.source_area,
+    );
+    let (_, drain_bulk_conductance) = mosfet_bulk_junction_current_conductance(
+        mosfet,
+        drain_voltage,
+        body_voltage,
+        mosfet.params.drain_area,
+    );
     stamp_conductance(matrix, drain, source, result.gds);
     stamp_conductance(matrix, body, source, source_bulk_conductance);
     stamp_conductance(matrix, body, drain, drain_bulk_conductance);
@@ -24628,10 +24666,18 @@ fn stamp_ac_mosfet_small_signal(
     let vds = drain_voltage - source_voltage;
     let vbs = body_voltage - source_voltage;
     let result = evaluate_mosfet_level1(mosfet, vgs, vds, vbs);
-    let (_, source_bulk_conductance) =
-        mosfet_bulk_junction_current_conductance(mosfet, source_voltage, body_voltage);
-    let (_, drain_bulk_conductance) =
-        mosfet_bulk_junction_current_conductance(mosfet, drain_voltage, body_voltage);
+    let (_, source_bulk_conductance) = mosfet_bulk_junction_current_conductance(
+        mosfet,
+        source_voltage,
+        body_voltage,
+        mosfet.params.source_area,
+    );
+    let (_, drain_bulk_conductance) = mosfet_bulk_junction_current_conductance(
+        mosfet,
+        drain_voltage,
+        body_voltage,
+        mosfet.params.drain_area,
+    );
     stamp_complex_conductance(matrix, drain, source, Complex::new(result.gds, 0.0));
     stamp_complex_conductance(matrix, gate, source, Complex::new(0.0, omega * result.cgs));
     stamp_complex_conductance(matrix, gate, drain, Complex::new(0.0, omega * result.cgd));
@@ -25855,6 +25901,7 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         ("CJSW", params.sidewall_junction_capacitance),
         ("TOX", params.oxide_thickness),
         ("IS", params.saturation_current),
+        ("JS", params.saturation_current_density),
         ("N_SUB", params.n_sub),
         ("T_NOM", params.t_nom),
         ("CGSO", params.gate_source_overlap_capacitance),
@@ -25978,6 +26025,12 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: mosfet.name.clone(),
             reason: "MOSFET IS, N_SUB, and T_NOM must be positive".to_string(),
+        });
+    }
+    if params.saturation_current_density < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET JS must be non-negative".to_string(),
         });
     }
     if params.bulk_junction_potential <= 0.0 || params.bulk_junction_grading_coefficient < 0.0 {

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -95,7 +95,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 199);
+    assert_eq!(coverage.len(), 201);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -114,7 +114,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tAF\tAF\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 199);
+    assert_eq!(records.len(), 201);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -147,8 +147,8 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         vec!["IS", "VT", "CJO", "VJ", "M"]
     );
     assert_eq!(summary[5].kind, ModelCardKind::Nmos);
-    assert_eq!(summary[5].canonical_parameter_count, 29);
-    assert_eq!(summary[5].accepted_name_count, 36);
+    assert_eq!(summary[5].canonical_parameter_count, 30);
+    assert_eq!(summary[5].accepted_name_count, 37);
     assert_eq!(summary[5].aliased_parameter_count, 6);
     assert_eq!(summary[5].max_alias_count, 3);
     assert_eq!(
@@ -166,7 +166,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     assert_eq!(lines[1], "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\t29\t36\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        &"PMOS\t30\t37\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
     );
     let records = model_card_supported_parameter_coverage_summary_records();
     assert_eq!(records.len(), 7);
@@ -184,7 +184,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         "[{\"kind\":\"D\",\"canonical_parameter_count\":\"15\",\"accepted_name_count\":\"21\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
     ));
     assert!(json.ends_with(
-        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"29\",\"accepted_name_count\":\"36\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
+        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"30\",\"accepted_name_count\":\"37\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
     ));
 }
 
@@ -195,15 +195,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 199);
-    assert_eq!(report.expected_canonical_parameter_count, 199);
-    assert_eq!(report.accepted_name_count, 269);
+    assert_eq!(report.canonical_parameter_count, 201);
+    assert_eq!(report.expected_canonical_parameter_count, 201);
+    assert_eq!(report.accepted_name_count, 271);
     assert_eq!(report.aliased_parameter_count, 57);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t199\t199\t269\t57\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t201\t201\t271\t57\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -230,8 +230,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 198);
-    assert_eq!(report.accepted_name_count, 266);
+    assert_eq!(report.canonical_parameter_count, 200);
+    assert_eq!(report.accepted_name_count, 268);
     assert_eq!(report.aliased_parameter_count, 56);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -239,7 +239,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     assert_eq!(report.issues[0].field, "canonical_parameter_count");
     assert_eq!(
         report.issues[0].message,
-        "expected NMOS to expose 29 canonical supported parameters, found 28"
+        "expected NMOS to expose 30 canonical supported parameters, found 29"
     );
     assert_eq!(report.issues.last().unwrap().field, "max_alias_count");
     assert_eq!(
@@ -248,20 +248,20 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t198\t199\t266\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 29 canonical supported parameters, found 28\nNMOS\taccepted_name_count\texpected NMOS to expose 36 accepted model-card names, found 33\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t200\t201\t268\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 30 canonical supported parameters, found 29\nNMOS\taccepted_name_count\texpected NMOS to expose 37 accepted model-card names, found 34\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
     assert_eq!(records[0]["field"], "canonical_parameter_count");
     assert_eq!(
         records[0]["message"],
-        "expected NMOS to expose 29 canonical supported parameters, found 28"
+        "expected NMOS to expose 30 canonical supported parameters, found 29"
     );
     assert!(format_model_card_supported_parameter_coverage_gate_issue_csv(&report).starts_with(
-        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 29 canonical supported parameters, found 28\"\n"
+        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 30 canonical supported parameters, found 29\"\n"
     ));
     assert!(format_model_card_supported_parameter_coverage_gate_issue_json(&report).starts_with(
-        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 29 canonical supported parameters, found 28\"}"
+        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 30 canonical supported parameters, found 29\"}"
     ));
 }
 
@@ -283,8 +283,8 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(dashboard[0].issue_count, 0);
     assert!(dashboard[0].issue_fields.is_empty());
     assert_eq!(dashboard[5].kind, ModelCardKind::Nmos);
-    assert_eq!(dashboard[5].canonical_parameter_count, 29);
-    assert_eq!(dashboard[5].accepted_name_count, 36);
+    assert_eq!(dashboard[5].canonical_parameter_count, 30);
+    assert_eq!(dashboard[5].accepted_name_count, 37);
     assert_eq!(dashboard[5].issue_count, 0);
 
     let table = format_model_card_supported_parameter_coverage_dashboard_table(&coverage);
@@ -296,7 +296,7 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(lines[1], "D\ttrue\t15\t15\t21\t21\t5\t5\t3\t3\t0\t");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\ttrue\t29\t29\t36\t36\t6\t6\t3\t3\t0\t"
+        &"PMOS\ttrue\t30\t30\t37\t37\t6\t6\t3\t3\t0\t"
     );
     let records = model_card_supported_parameter_coverage_dashboard_records(&coverage);
     assert_eq!(records.len(), 7);
@@ -328,10 +328,10 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         .unwrap();
 
     assert!(!nmos.passed);
-    assert_eq!(nmos.canonical_parameter_count, 28);
-    assert_eq!(nmos.expected_canonical_parameter_count, 29);
-    assert_eq!(nmos.accepted_name_count, 33);
-    assert_eq!(nmos.expected_accepted_name_count, 36);
+    assert_eq!(nmos.canonical_parameter_count, 29);
+    assert_eq!(nmos.expected_canonical_parameter_count, 30);
+    assert_eq!(nmos.accepted_name_count, 34);
+    assert_eq!(nmos.expected_accepted_name_count, 37);
     assert_eq!(nmos.aliased_parameter_count, 5);
     assert_eq!(nmos.expected_aliased_parameter_count, 6);
     assert_eq!(nmos.max_alias_count, 2);
@@ -347,7 +347,7 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         ]
     );
     assert!(format_model_card_supported_parameter_coverage_dashboard_table(&coverage).contains(
-        "NMOS\tfalse\t28\t29\t33\t36\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
+        "NMOS\tfalse\t29\t30\t34\t37\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
     ));
 }
 
@@ -598,6 +598,8 @@ fn model_card_aliases_build_device_instances() {
             ("RD", 125.0),
             ("RS", 75.0),
             ("RSH", 50.0),
+            ("IS", 4.0e-15),
+            ("JS", 2.0e-3),
             ("CJ", 2.0e-3),
             ("TOX", 25.0e-9),
             ("KF", 2.0e-24),
@@ -618,6 +620,8 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*mos_card.parameters.get("RD").unwrap(), 125.0);
     assert_close(*mos_card.parameters.get("RS").unwrap(), 75.0);
     assert_close(*mos_card.parameters.get("RSH").unwrap(), 50.0);
+    assert_close(*mos_card.parameters.get("IS").unwrap(), 4.0e-15);
+    assert_close(*mos_card.parameters.get("JS").unwrap(), 2.0e-3);
     assert_close(*mos_card.parameters.get("CJ").unwrap(), 2.0e-3);
     assert_close(*mos_card.parameters.get("TOX").unwrap(), 25.0e-9);
     assert_close(*mos_card.parameters.get("KF").unwrap(), 2.0e-24);
@@ -633,6 +637,8 @@ fn model_card_aliases_build_device_instances() {
     assert_close(mos_model.params.forward_bias_depletion_coefficient, 0.4);
     assert_close(mos_model.params.lateral_diffusion_length, 50.0e-9);
     assert_close(mos_model.params.drain_resistance, 125.0);
+    assert_close(mos_model.params.saturation_current, 4.0e-15);
+    assert_close(mos_model.params.saturation_current_density, 2.0e-3);
     assert_close(mos_model.params.source_resistance, 75.0);
     assert_close(mos_model.params.sheet_resistance, 50.0);
     assert_close(mos_model.params.drain_squares, 1.0);
@@ -1677,6 +1683,47 @@ fn dc_mosfet_bulk_junction_saturation_current_sets_reverse_leakage() {
         let loaded = bias_current(mosfet_type, bias_voltage, 1.0e-12);
         assert!(loaded > unloaded);
     }
+}
+
+#[test]
+fn dc_mosfet_bulk_junction_current_density_scales_complete_diffusion_areas() {
+    let bias_current = |saturation_current: f64,
+                        saturation_current_density: f64,
+                        drain_area: f64,
+                        source_area: f64| {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::VoltageSource(VoltageSource::new(
+            "Vbias", "body", "0", -0.3,
+        )));
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "M1",
+            "0",
+            "0",
+            "0",
+            "body",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                saturation_current,
+                saturation_current_density,
+                drain_area,
+                source_area,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+        dc_op(&circuit)
+            .unwrap()
+            .branch_current("Vbias")
+            .unwrap()
+            .abs()
+    };
+
+    let density_scaled = bias_current(1.0e-30, 1.0, 2.0e-12, 3.0e-12);
+    let equivalent_scalar = bias_current(2.5e-12, 0.0, 2.0e-12, 3.0e-12);
+    assert!((density_scaled / equivalent_scalar - 1.0).abs() < 1.0e-9);
+
+    let incomplete_areas = bias_current(4.0e-13, 1.0, 0.0, 3.0e-12);
+    let scalar_fallback = bias_current(4.0e-13, 0.0, 0.0, 3.0e-12);
+    assert!((incomplete_areas / scalar_fallback - 1.0).abs() < 1.0e-9);
 }
 
 #[test]
@@ -3874,6 +3921,38 @@ fn dc_mosfet_rejects_invalid_forward_bias_depletion_coefficient() {
                     "MOSFET FC must be in [0, 1)".to_string()
                 } else {
                     "MOSFET FC must be finite".to_string()
+                },
+            }
+        );
+    }
+}
+
+#[test]
+fn dc_mosfet_rejects_invalid_saturation_current_density() {
+    for saturation_current_density in [f64::NAN, -1.0] {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "Mbad",
+            "drain",
+            "gate",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                saturation_current_density,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+
+        let err = dc_op(&circuit).unwrap_err();
+        assert_eq!(
+            err,
+            SpiceError::InvalidElement {
+                name: "Mbad".to_string(),
+                reason: if saturation_current_density.is_finite() {
+                    "MOSFET JS must be non-negative".to_string()
+                } else {
+                    "MOSFET JS must be finite".to_string()
                 },
             }
         );

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Preserve Level-1 MOS model-card `JS` independently from scalar `IS` so
+  Berkeley netlists can drive diffusion-area-scaled bulk-junction leakage.
 - Preserve the remaining supported Level-1 MOS model-card fields `LD`, `TOX`,
   `RD`, `RS`, `KF`, and `AF`, plus `VTH`, `LAM`, `CJS`, and `CJD` aliases,
   when lowering Berkeley netlists into engine parameters.

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -759,7 +759,7 @@ parameters, `.model <name> NPN|PNP(...)` BJT cards with `IS`, `BF` /
 `BETA_F`, `VT`, `CJE`, `CJC`, `TF`, and `TR` parameters,
 `.model <name> NMOS|PMOS(...)` Level-1 MOSFET
 cards with common SPICE aliases (`VT0` / `VTO` / `VTH`, `KP`, `LAMBDA` /
-`LAM`, `GAMMA`, `PHI`, `W`, `L`, `LD`, `TOX`, `RD`, `RS`, `RSH`, `IS`,
+`LAM`, `GAMMA`, `PHI`, `W`, `L`, `LD`, `TOX`, `RD`, `RS`, `RSH`, `IS`, `JS`,
 `N_SUB` / `NSUB`, `T_NOM` / `TNOM`, `CGSO`, `CGDO`, `CGBO`, `CBS` / `CJS`,
 `CBD` / `CJD`, `CJ`, `CJSW`, `PB`, `MJ`, `MJSW`, `FC`, `KF`, and `AF`), MOS instance `NRD=<squares>` /
 `NRS=<squares>` / `AD=<area>` / `AS=<area>` / `PD=<perimeter>` /

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -1935,6 +1935,7 @@ fn apply_mosfet_param(params: &mut MosfetLevel1Params, name: &str, value: f64) {
         "RS" => params.source_resistance = value,
         "RSH" => params.sheet_resistance = value,
         "IS" => params.saturation_current = value,
+        "JS" => params.saturation_current_density = value,
         "N_SUB" | "NSUB" | "N" => params.n_sub = value,
         "T_NOM" | "TNOM" => params.t_nom = value,
         "CGSO" => params.gate_source_overlap_capacitance = value,

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1359,7 +1359,7 @@ Jpull drain gate source pch
 fn parses_mosfet_models_into_operating_point_circuits() {
     let parsed = parse_netlist(
         r#"
-.model nch NMOS(VTO=0.45 KP=250u LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n LD=10n TOX=20n RD=10 RS=20 RSH=250 NSUB=1.5 TNOM=300 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p CJ=2m CJSW=5u PB=0.9 MJ=0.45 MJSW=0.25 FC=0.4 KF=1p AF=1.2)
+.model nch NMOS(VTO=0.45 KP=250u LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n LD=10n TOX=20n RD=10 RS=20 RSH=250 IS=4p JS=2m NSUB=1.5 TNOM=300 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p CJ=2m CJSW=5u PB=0.9 MJ=0.45 MJSW=0.25 FC=0.4 KF=1p AF=1.2)
 Vdd vdd 0 DC 5
 Vgate gate 0 DC 2.5
 M1 vdd gate out 0 nch W=4u L=200n NRD=2 NRS=3 AD=3n AS=4n PD=6u PS=7u
@@ -1397,6 +1397,8 @@ Rload out 0 1k
     assert_close(mosfet.params.drain_resistance, 10.0);
     assert_close(mosfet.params.source_resistance, 20.0);
     assert_close(mosfet.params.sheet_resistance, 250.0);
+    assert_close(mosfet.params.saturation_current, 4.0e-12);
+    assert_close(mosfet.params.saturation_current_density, 2.0e-3);
     assert_close(mosfet.params.drain_squares, 2.0);
     assert_close(mosfet.params.source_squares, 3.0);
     assert_close(mosfet.params.drain_area, 3.0e-9);

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add Level-1 MOS model-card `JS` as bulk-junction saturation-current density,
+  scaling source/drain leakage and shot noise by `AS` / `AD` when both areas
+  are present and otherwise retaining Berkeley-compatible `IS` fallback.
 - Apply Level-1 MOS model-card `IS` to the source-body and drain-body junctions
   in DC, transient, transfer-function, and AC analysis, and emit distinct
   `IBS` / `IBD` shot-noise sources.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1789,6 +1789,7 @@ export interface MosfetLevel1Params {
   readonly CJ: number;
   readonly CJSW: number;
   readonly IS: number;
+  readonly JS: number;
   readonly N_SUB: number;
   readonly T_NOM: number;
   readonly CGSO: number;
@@ -2061,8 +2062,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   PNP: [41, 58, 13, 4],
   NJF: [22, 30, 7, 3],
   PJF: [22, 30, 7, 3],
-  NMOS: [29, 36, 6, 3],
-  PMOS: [29, 36, 6, 3],
+  NMOS: [30, 37, 6, 3],
+  PMOS: [30, 37, 6, 3],
 };
 
 export interface Vccs {
@@ -8058,6 +8059,7 @@ export function defaultMosfetLevel1Params(): MosfetLevel1Params {
     CJ: 0.0,
     CJSW: 0.0,
     IS: 1.0e-15,
+    JS: 0.0,
     N_SUB: 1.4,
     T_NOM: 300.15,
     CGSO: 0.0,
@@ -8249,6 +8251,7 @@ const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   RS: "RS",
   RSH: "RSH",
   IS: "IS",
+  JS: "JS",
   NSUB: "N_SUB",
   N_SUB: "N_SUB",
   TNOM: "T_NOM",
@@ -8829,6 +8832,7 @@ export function mosfetFromModelCard(
     ...(p.RS !== undefined ? { RS: p.RS } : {}),
     ...(p.RSH !== undefined ? { RSH: p.RSH } : {}),
     ...(p.IS !== undefined ? { IS: p.IS } : {}),
+    ...(p.JS !== undefined ? { JS: p.JS } : {}),
     ...(p.N_SUB !== undefined ? { N_SUB: p.N_SUB } : {}),
     ...(p.T_NOM !== undefined ? { T_NOM: p.T_NOM } : {}),
     ...(p.CGSO !== undefined ? { CGSO: p.CGSO } : {}),
@@ -19040,11 +19044,13 @@ function collectNoiseSources(
         element,
         sourceVoltage,
         bodyVoltage,
+        element.params.AS,
       );
       const [drainBulkCurrent] = mosfetBulkJunctionCurrentConductance(
         element,
         drainVoltage,
         bodyVoltage,
+        element.params.AD,
       );
       const isNmos = element.type === "NMOS";
       sources.push({
@@ -20279,6 +20285,7 @@ function stampMosfet(
     body,
     sourceVoltage,
     bodyVoltage,
+    element.params.AS,
     matrix,
     rhs,
   );
@@ -20288,6 +20295,7 @@ function stampMosfet(
     body,
     drainVoltage,
     bodyVoltage,
+    element.params.AD,
     matrix,
     rhs,
   );
@@ -20316,7 +20324,12 @@ function mosfetBulkJunctionCurrentConductance(
   element: Mosfet,
   terminalVoltage: number,
   bodyVoltage: number,
+  terminalArea: number,
 ): readonly [number, number] {
+  const saturationCurrent =
+    element.params.JS > 0.0 && element.params.AD > 0.0 && element.params.AS > 0.0
+      ? element.params.JS * terminalArea
+      : element.params.IS;
   const junctionVoltage =
     element.type === "NMOS"
       ? bodyVoltage - terminalVoltage
@@ -20330,24 +20343,26 @@ function mosfetBulkJunctionCurrentConductance(
       : limitedExp;
   const conductanceFactor = limitedExp;
   return [
-    element.params.IS * (currentFactor - 1.0),
-    (element.params.IS / thermalVoltage) * conductanceFactor,
+    saturationCurrent * (currentFactor - 1.0),
+    (saturationCurrent / thermalVoltage) * conductanceFactor,
   ];
 }
 
 function stampMosfetBulkJunction(
-  element: Mosfet,
-  terminal: number | undefined,
-  body: number | undefined,
-  terminalVoltage: number,
-  bodyVoltage: number,
-  matrix: number[][],
-  rhs: number[],
+    element: Mosfet,
+    terminal: number | undefined,
+    body: number | undefined,
+    terminalVoltage: number,
+    bodyVoltage: number,
+    terminalArea: number,
+    matrix: number[][],
+    rhs: number[],
 ): void {
   const [current, conductance] = mosfetBulkJunctionCurrentConductance(
     element,
     terminalVoltage,
     bodyVoltage,
+    terminalArea,
   );
   const isNmos = element.type === "NMOS";
   const junctionVoltage = isNmos
@@ -21307,6 +21322,9 @@ function validateMosfet(element: Mosfet): void {
   }
   if (params.IS <= 0.0 || params.N_SUB <= 0.0 || params.T_NOM <= 0.0) {
     throw invalidElement(element.name, "MOSFET IS, N_SUB, and T_NOM must be positive");
+  }
+  if (params.JS < 0.0) {
+    throw invalidElement(element.name, "MOSFET JS must be non-negative");
   }
   if (params.PB <= 0.0 || params.MJ < 0.0) {
     throw invalidElement(element.name, "MOSFET PB must be positive and MJ must be non-negative");
@@ -22737,11 +22755,13 @@ function stampMosfetSmallSignal(
     element,
     sourceVoltage,
     bodyVoltage,
+    element.params.AS,
   );
   const [, drainBulkConductance] = mosfetBulkJunctionCurrentConductance(
     element,
     drainVoltage,
     bodyVoltage,
+    element.params.AD,
   );
   stampConductance(matrix, drain, source, result.gds);
   stampConductance(matrix, body, source, sourceBulkConductance);
@@ -23507,11 +23527,13 @@ function stampAcMosfetSmallSignal(
     element,
     sourceVoltage,
     bodyVoltage,
+    element.params.AS,
   );
   const [, drainBulkConductance] = mosfetBulkJunctionCurrentConductance(
     element,
     drainVoltage,
     bodyVoltage,
+    element.params.AD,
   );
   stampComplexConductance(matrix, drain, source, complex(result.gds, 0.0));
   stampComplexTransconductance(

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -121,7 +121,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(199);
+    expect(coverage).toHaveLength(201);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -141,7 +141,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tAF\tAF\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(199);
+    expect(records).toHaveLength(201);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -167,8 +167,8 @@ describe("dcOp", () => {
     });
     expect(summary[5]).toStrictEqual({
       kind: "NMOS",
-      canonicalParameterCount: 29,
-      acceptedNameCount: 36,
+      canonicalParameterCount: 30,
+      acceptedNameCount: 37,
       aliasedParameterCount: 6,
       maxAliasCount: 3,
       aliasedParameters: ["VT0", "LAMBDA", "N_SUB", "T_NOM", "CBS", "CBD"],
@@ -181,7 +181,7 @@ describe("dcOp", () => {
     );
     expect(table.split("\n")[1]).toBe("D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     expect(table.split("\n").at(-1)).toBe(
-      "PMOS\t29\t36\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
+      "PMOS\t30\t37\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
     );
     const records = modelCardSupportedParameterCoverageSummaryRecords();
     expect(records).toHaveLength(7);
@@ -206,15 +206,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 199,
-      expectedCanonicalParameterCount: 199,
-      acceptedNameCount: 269,
+      canonicalParameterCount: 201,
+      expectedCanonicalParameterCount: 201,
+      acceptedNameCount: 271,
       aliasedParameterCount: 57,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t199\t199\t269\t57\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t201\t201\t271\t57\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -237,15 +237,15 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(198);
-    expect(report.acceptedNameCount).toBe(266);
+    expect(report.canonicalParameterCount).toBe(200);
+    expect(report.acceptedNameCount).toBe(268);
     expect(report.aliasedParameterCount).toBe(56);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 29 canonical supported parameters, found 28",
+      message: "expected NMOS to expose 30 canonical supported parameters, found 29",
     });
     expect(report.issues.at(-1)).toStrictEqual({
       kind: "NMOS",
@@ -253,16 +253,16 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t198\t199\t266\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 29 canonical supported parameters, found 28\nNMOS\taccepted_name_count\texpected NMOS to expose 36 accepted model-card names, found 33\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t200\t201\t268\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 30 canonical supported parameters, found 29\nNMOS\taccepted_name_count\texpected NMOS to expose 37 accepted model-card names, found 34\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 29 canonical supported parameters, found 28",
+      message: "expected NMOS to expose 30 canonical supported parameters, found 29",
     });
     expect(formatModelCardSupportedParameterCoverageGateIssueCsv(report)).toMatch(
-      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 29 canonical supported parameters, found 28"\n/,
+      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 30 canonical supported parameters, found 29"\n/,
     );
     expect(JSON.parse(formatModelCardSupportedParameterCoverageGateIssueJson(report))).toStrictEqual(
       records,
@@ -423,6 +423,8 @@ describe("dcOp", () => {
       RD: 125.0,
       RS: 75.0,
       RSH: 50.0,
+      IS: 4.0e-15,
+      JS: 2.0e-3,
       CJ: 2.0e-3,
       TOX: 25.0e-9,
       KF: 2.0e-24,
@@ -443,6 +445,8 @@ describe("dcOp", () => {
       RD: 125.0,
       RS: 75.0,
       RSH: 50.0,
+      IS: 4.0e-15,
+      JS: 2.0e-3,
       CJ: 2.0e-3,
       TOX: 25.0e-9,
       KF: 2.0e-24,
@@ -461,6 +465,8 @@ describe("dcOp", () => {
     expectClose(mosModel.params.RD, 125.0);
     expectClose(mosModel.params.RS, 75.0);
     expectClose(mosModel.params.RSH, 50.0);
+    expectClose(mosModel.params.IS, 4.0e-15);
+    expectClose(mosModel.params.JS, 2.0e-3);
     expectClose(mosModel.params.NRD, 1.0);
     expectClose(mosModel.params.NRS, 1.0);
     expectClose(mosModel.params.CJ, 2.0e-3);
@@ -1193,6 +1199,33 @@ describe("dcOp", () => {
       const loaded = biasCurrent(type, biasVoltage, 1.0e-12);
       expect(loaded).toBeGreaterThan(unloaded);
     }
+  });
+
+  it("scales MOSFET JS only when both diffusion areas are present", () => {
+    const biasCurrent = (
+      saturationCurrent: number,
+      saturationCurrentDensity: number,
+      drainArea: number,
+      sourceArea: number,
+    ): number => {
+      const circuit = new Circuit();
+      circuit.add(voltageSource("Vbias", "body", "0", -0.3));
+      circuit.add(mosfet("M1", "0", "0", "0", "body", "NMOS", {
+        IS: saturationCurrent,
+        JS: saturationCurrentDensity,
+        AD: drainArea,
+        AS: sourceArea,
+      }));
+      return Math.abs(dcOp(circuit).branchCurrent("Vbias")!);
+    };
+
+    const densityScaled = biasCurrent(1.0e-30, 1.0, 2.0e-12, 3.0e-12);
+    const equivalentScalar = biasCurrent(2.5e-12, 0.0, 2.0e-12, 3.0e-12);
+    expect(densityScaled / equivalentScalar).toBeCloseTo(1.0, 9);
+
+    const incompleteAreas = biasCurrent(4.0e-13, 1.0, 0.0, 3.0e-12);
+    const scalarFallback = biasCurrent(4.0e-13, 0.0, 0.0, 3.0e-12);
+    expect(incompleteAreas / scalarFallback).toBeCloseTo(1.0, 9);
   });
 
   it("raises the intrinsic MOSFET source voltage across RS", () => {
@@ -2675,6 +2708,20 @@ describe("dcOp", () => {
         Number.isFinite(sidewallCapacitance)
           ? "MOSFET CJSW must be non-negative"
           : "MOSFET CJSW must be finite",
+      );
+    }
+  });
+
+  it("rejects invalid MOSFET bulk-junction saturation-current densities", () => {
+    for (const saturationCurrentDensity of [Number.NaN, -1.0]) {
+      const circuit = new Circuit();
+      circuit.add(mosfet("Mbad", "drain", "gate", "0", "0", "NMOS", {
+        JS: saturationCurrentDensity,
+      }));
+      expect(() => dcOp(circuit)).toThrow(
+        saturationCurrentDensity < 0.0
+          ? "MOSFET JS must be non-negative"
+          : "MOSFET JS must be finite",
       );
     }
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,14 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS bulk-junction saturation current.
+1. Cross-language Level-1 MOS bulk-junction saturation current density.
    - Status: current PR completion candidate.
-   - Route existing model-card `IS` into source-body and drain-body junction
-     leakage for NMOS and PMOS across DC, transient, transfer-function, and AC.
-   - Emit distinct `IBS` and `IBD` shot-noise sources while preserving existing
-     model-card and hierarchy contracts.
+   - Preserve model-card `JS` independently from scalar `IS` and scale it by
+     source/drain diffusion area when both `AS` and `AD` are present.
+   - Match Berkeley MOS1 fallback behavior by using scalar `IS` for both
+     junctions when `JS` is zero or either diffusion area is absent.
+   - Apply the effective terminal currents consistently to nonlinear, AC,
+     transfer-function, and shot-noise behavior in Rust, Python, and TypeScript.
 
 ## Completed Slices
 
@@ -3539,6 +3541,14 @@ the Rust, Python, and TypeScript surfaces together.
      `RD`, `RS`, `KF`, and `AF` plus aliases `VTH`, `LAM`, `CJS`, and `CJD`.
    - Source-deck tests prove the values reach their existing engine fields
      instead of silently falling back to defaults.
+
+281. Cross-language Level-1 MOS bulk-junction saturation current.
+   - Status: completed in PR 9100.
+   - Existing model-card `IS` now drives source-body and drain-body leakage for
+     NMOS and PMOS across DC, transient, transfer-function, and AC analysis.
+   - Junction thermal voltage follows `T_NOM`, forward exponential continuation
+     remains Newton-consistent, and noise emits distinct `IBS` and `IBD` shot
+     sources.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary

- preserve Level-1 MOS `JS` independently from scalar `IS` across Rust, Python, TypeScript, and Berkeley netlist lowering
- scale source/drain bulk-junction current by `AS`/`AD` only when both diffusion areas are present, matching MOS1 fallback to scalar `IS` otherwise
- apply the effective junction currents consistently in nonlinear, AC, transfer-function, and shot-noise paths, with validation and model-card coverage updates

## Verification

- `cargo fmt -p spice-engine -p spice-netlist-parser -- --check`
- `cargo clippy -p spice-engine -p spice-netlist-parser --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- `cargo test -p spice-netlist-parser`
- Python mosfet-models: 49 tests passed; Ruff touched-file lint passed
- Python spice-engine: 666 tests passed; Ruff touched-file lint passed
- TypeScript spice-engine: `npm run build`; 408 tests passed
- `git diff --check`