### PR TITLE
feat(adj-formula-stdlib): electric-capacitance-conversions — NIST SP 811 B.9 abfarad→farad table (facts, b26)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -1178,6 +1178,47 @@ fn shipped_electric_resistance_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b26) The shipped NIST SP 811 B.9 electric-capacitance → farad table resolves the exact abfarad
+//       factor with its citation, and ABSTAINS on a wrong-dimension unit. This EXTENDS the
+//       electromagnetic-EMU family (charge/potential/resistance) with capacitance. The abfarad
+//       (capacitance) and the abhenry (inductance) are DIFFERENT quantities that convert to
+//       DIFFERENT SI units (farad vs henry), so the abstain proves dimension safety, not mere
+//       absence of a value: the farad is charge per unit potential.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_electric_capacitance_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_capacitance");
+    let src = stdlib().join("reference/electric-capacitance-conversions.adj");
+    std::fs::copy(&src, dir.join("electric-capacitance-conversions.adj"))
+        .expect("copy shipped electric-capacitance-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"electric-capacitance-conversions.adj\"\n\
+         ? electric_capacitance_to_farad(abfarad, $v)\n\
+         ? electric_capacitance_to_farad(abhenry, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 exact factor resolves, character-for-character from the table
+    // (boldface = exact; the abfarad is defined as exactly 1.0 E+09 farad).
+    assert!(out.contains("\"v\":\"1000000000\""), "abfarad = 1.0 E+09 F: {out}");
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `abhenry` is an INDUCTANCE unit (it converts to the henry, a DIFFERENT quantity), so this
+    // capacitance table has no row for it — the engine abstains rather than mis-converting an
+    // inductance unit as if it were a capacitance unit.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a wrong-dimension unit abstains, never a cross-dimension fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/electric-capacitance-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/electric-capacitance-conversions.adj
@@ -1,0 +1,58 @@
+% ============================================================================
+% electric-capacitance-conversions — electric-capacitance-unit → farad factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of electric-charge-conversions.adj, electric-potential-conversions.adj,
+% electric-resistance-conversions.adj and the other NIST-cited conversion tables: a native
+% tabular relation ingested VERBATIM from a published NIST conversion table. The row states the
+% factor converting the traditional (CGS-EMU) unit of ELECTRIC CAPACITANCE to the SI coherent
+% derived unit, the farad (F):
+%
+%     ? electric_capacitance_to_farad(abfarad, $v)   % 1000000000
+%
+% This EXTENDS the electromagnetic-EMU family — electric-charge (the abcoulomb → the coulomb),
+% electric-potential (the abvolt → the volt) and electric-resistance (the abohm → the ohm) — with
+% CAPACITANCE, and is a NEW dimension alongside the length/mass/area/volume/time/speed/energy/
+% pressure/force/acceleration/dynamic-viscosity/kinematic-viscosity/magnetic-flux-density/
+% magnetic-flux/illuminance/luminance/radioactivity/absorbed-dose/dose-equivalent/exposure/power
+% tables. Do NOT confuse ELECTRIC CAPACITANCE (the abfarad → the farad) with ELECTRIC RESISTANCE
+% (the abohm → the ohm), ELECTRIC POTENTIAL (the abvolt → the volt) or ELECTRIC CHARGE (the
+% abcoulomb → the coulomb): those are DIFFERENT quantities that convert to DIFFERENT SI units.
+% Electric capacitance (the farad) is charge per unit potential (one farad is one coulomb per
+% volt); the abfarad is its traditional (EMU) unit. Put a capacitance given in abfarads into SI
+% first, then reason (write-once-use-many). Why a `table` and not a hand-written `relate` clause:
+% this is exactly the shape reference data comes in — a published table, not prose. The citable
+% artifact IS the NIST conversion-factors table at the `locator` below; the factor here is a CELL
+% of NIST Special Publication 811, Appendix B.9 ("Factors for units listed alphabetically"),
+% defended by one provenance envelope. Each `row` lowers to a ground relation
+% `electric_capacitance_to_farad(unit, v)`, so the exact lookup above is the ordinary SLD binding
+% query — the engine returns the factor WITH this table's citation as its proof, on the CPU, with
+% zero model calls.
+%
+% HONESTY NOTE (like the electric-resistance / electric-potential / power tables, only the EXACT
+% defined factor gets a row): NIST SP 811 B.9 prints the "abfarad" capacitance factor in BOLDFACE,
+% its convention for factors that are EXACT by definition, transcribed here as the plain decimal
+% number of farads it names:
+%
+%     abfarad (abF)   1.0 E+09  →  1000000000
+%
+% This is exact because the abfarad is DEFINED as exactly 1.0 E+09 farad (the EMU of capacitance).
+% It terminates; nothing here is a rounded measurement. This table is SPECIFIC to electric
+% capacitance: a unit of a DIFFERENT quantity — e.g. the "abhenry", which NIST SP 811 B.9 lists
+% separately as an INDUCTANCE unit converting to the henry, NOT the farad — therefore gets no row
+% here, and a `? electric_capacitance_to_farad(abhenry, $v)` ABSTAINS rather than mis-converting
+% an inductance unit as if it were a capacitance unit. The only claim this table makes is "this is
+% the exact factor NIST SP 811 B.9 prints for the abfarad's conversion to the farad" — which is
+% exactly what a byte-check against the cited table verifies. `trust authoritative` — a primary,
+% re-fetchable standards reference. (See ADJ-TABLES.md; and feedback_nothing_human_authored — the
+% factor is a verbatim cell of the cited table, nothing asserted from memory.)
+% ============================================================================
+
+table electric_capacitance_to_farad {
+    columns unit, farad
+
+    row (abfarad, 1000000000)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/electric-capacitance-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/electric-capacitance-conversions.query.adj
@@ -1,0 +1,24 @@
+% ============================================================================
+% electric-capacitance-conversions.query.adj — worked lookups over the NIST capacitance → farad table.
+% ============================================================================
+% The shape a consumer produces to convert a capacitance given in a traditional CGS-EMU unit into
+% SI: it `import`s the grounded table and asks the engine to bind the factor. No arithmetic and
+% no factor is stated by the consumer; the engine returns the cell WITH the table's NIST citation
+% as its proof, on the CPU.
+%
+%   ? electric_capacitance_to_farad(abfarad, $v)   % 1000000000   (abfarad = 1.0 E+09 F, exact)
+%
+% And the dimension guard: a unit of a DIFFERENT quantity has no row, so the lookup ABSTAINS
+% rather than mis-converting across dimensions. The "abhenry" is an INDUCTANCE unit (it converts
+% to the henry), NOT a capacitance unit:
+%
+%   ? electric_capacitance_to_farad(abhenry, $v)   % abstains (abhenry is inductance → henry)
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli electric-capacitance-conversions.query.adj
+% ============================================================================
+
+import "electric-capacitance-conversions.adj"
+
+? electric_capacitance_to_farad(abfarad, $v)   % expect 1000000000  (exact NIST SP 811 B.9 factor)
+? electric_capacitance_to_farad(abhenry, $v)   % expect abstain     (inductance unit, wrong dimension)


### PR DESCRIPTION
## What

Adds a native RS-5 `table` grounding the **NIST SP 811 Appendix B.9** exact factor converting the CGS-EMU unit of **electric capacitance** to the SI farad:

```
abfarad (abF)   1.0 E+09  →  1000000000
```

**Extends the electromagnetic-EMU family** — electric-charge (b23), electric-potential (b24), electric-resistance (b25) — with **capacitance**. The farad is charge per unit potential (one farad = one coulomb per volt). NIST prints the factor in **boldface** (its convention for factors exact by definition), transcribed verbatim as the decimal cell.

## Behaviour

- Exact lookup `? electric_capacitance_to_farad(abfarad, $v)` → `1000000000`, ordinary SLD binding, carrying the table's NIST citation as its proof — zero model calls.
- **Dimension guard:** `abhenry` is an **inductance** unit (→ henry, a different quantity), so it has no row and the lookup **abstains** rather than mis-converting across dimensions.

## Provenance

Source: *"Factors for units listed alphabetically"*, [NIST SP 811 Appendix B.9](https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9). Byte-verified against the cited table before shipping.

## Tests

Appends the **b26** block to the shared `rs5_table_e2e.rs` anchor (asserts the exact value string `"v":"1000000000"`, the NIST locator, and `"abstained":true` for abhenry). Full rs5 suite **31 passed**; `cargo clippy --tests -D warnings` clean. Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)