### PR TITLE
feat(task-app): render nested projects as a hierarchy

### DIFF
--- a/code/programs/mosaic/task-app/CHANGELOG.md
+++ b/code/programs/mosaic/task-app/CHANGELOG.md
@@ -37,8 +37,27 @@ All notable changes to the `task-app` web program are documented here.
   nested project present it would have proposed an id the engine rejects, and "+ Project"
   would have become a permanent silent no-op. It now probes every project, and surfaces
   a failed create instead of swallowing it.
-- Follow-on: rendering *nested* projects as a hierarchy (the engine supports nesting; the
-  bar lists top-level projects only).
+- **Nested projects render as a hierarchy.** The bar now lists *every* project, walked
+  depth-first so a sub-project immediately follows its parent, with an indent glyph
+  marking the nesting. `project-rows` gains a third cell (`indent`, empty for top-level,
+  so the layout's `If` hides it and the row stays flush left), and a **"+ Sub"** button
+  creates a project nested under whichever one is shown — making the engine's hierarchy
+  reachable from the UI for the first time.
+  - The engine stores nesting as a `parent` on a flat project map (a parent doesn't list
+    its children), so the host derives the child lists — bucketing every project under
+    its parent once, which keeps the walk O(n) instead of re-filtering the whole map per
+    node. Siblings are ordered by name (sorting by raw id would put `p10` before `p2`).
+  - The walk uses an **explicit stack, not recursion**, and carries a `seen` guard: a
+    deeply nested chain can't blow the JS call stack inside `getProps` and take the whole
+    render down, and a malformed snapshot containing a parent cycle terminates with each
+    project listed once. It also sweeps up any project the `roots` list missed — an
+    orphan whose `parent` names a project that no longer exists — so nothing is
+    unreachable. (Both hardened in security review; verified with a 50 000-deep chain, a
+    parent cycle, and a dangling-parent orphan.)
+  - Verified against a real `wasm32` build driven from Node: depth-first ordering, depths
+    (0/1/2), a nested project being selectable and owning its own tasks, its tasks *not*
+    leaking into the parent, and the engine's refusal to delete a project that still has
+    children.
 
 ### Changed - structured task rows (UI design, step 2)
 

--- a/code/programs/mosaic/task-app/host/web/src/main.tsx
+++ b/code/programs/mosaic/task-app/host/web/src/main.tsx
@@ -75,18 +75,65 @@ function makeController(engine: any, init: ControllerInit = {}) {
   let counter = initialCounter;
   const today = Math.floor(Date.now() / DAY_MS);
 
-  // The workspace's top-level projects, in the engine's own display order, plus which
-  // one is active. Nested projects are a later increment — the engine supports them,
-  // this bar doesn't render the hierarchy yet.
-  const projects = (): { ids: string[]; names: string[]; activeId: string } => {
+  // Every project, flattened depth-first so a sub-project immediately follows its
+  // parent, carrying the depth so the bar can show the hierarchy. The engine stores
+  // nesting by `parent` on a flat map (children aren't listed on the parent), so the
+  // child lists are derived here.
+  //
+  // A malformed snapshot could in principle contain a parent cycle; the `seen` guard
+  // means we'd render such projects once rather than recursing forever.
+  const projects = (): {
+    ids: string[];
+    names: string[];
+    depths: number[];
+    activeId: string;
+  } => {
     const ws = engine.workspace().data;
     const activeId = engine.activeProject().data as string;
-    const ids: string[] = ws.roots ?? [];
-    return {
-      ids,
-      names: ids.map((id) => ws.projects?.[id]?.name || id),
-      activeId,
+    const all: Record<string, any> = ws.projects ?? {};
+    // Bucket every project under its parent ONCE. Filtering the whole map per node
+    // instead would make the walk O(n^2) — fine for a dozen projects, needlessly
+    // quadratic for a big workspace.
+    // Siblings read in name order — sorting by raw id would put `p10` before `p2`.
+    const byParent = new Map<string | null, string[]>();
+    for (const id of Object.keys(all)) {
+      const parent = (all[id]?.parent ?? null) as string | null;
+      const bucket = byParent.get(parent);
+      if (bucket) bucket.push(id);
+      else byParent.set(parent, [id]);
+    }
+    for (const bucket of byParent.values()) {
+      bucket.sort((a, b) => String(all[a]?.name ?? a).localeCompare(String(all[b]?.name ?? b)));
+    }
+    const childrenOf = (parent: string | null): string[] => byParent.get(parent) ?? [];
+
+    const ids: string[] = [];
+    const depths: number[] = [];
+    const seen = new Set<string>();
+    // An explicit stack rather than recursion: a deeply nested chain (or a tampered
+    // snapshot) would otherwise blow the JS call stack inside getProps and take the
+    // whole render down. `seen` also makes a parent cycle terminate.
+    const walk = (rootId: string) => {
+      const stack: Array<[string, number]> = [[rootId, 0]];
+      while (stack.length > 0) {
+        const [id, depth] = stack.pop()!;
+        if (seen.has(id)) continue;
+        seen.add(id);
+        ids.push(id);
+        depths.push(depth);
+        // Reversed, so popping yields the children in name order.
+        const kids = childrenOf(id);
+        for (let i = kids.length - 1; i >= 0; i -= 1) stack.push([kids[i], depth + 1]);
+      }
     };
+    // Roots first, in the engine's explicit display order...
+    for (const root of (ws.roots ?? []) as string[]) walk(root);
+    // ...then anything the roots list somehow missed, so no project is unreachable
+    // (an orphan whose `parent` names a project that no longer exists, say).
+    for (const id of childrenOf(null)) walk(id);
+    for (const id of Object.keys(all)) walk(id);
+
+    return { ids, names: ids.map((id) => all[id]?.name || id), depths, activeId };
   };
 
   // Snapshot the engine + host state and hand it to the persistence sink. Called
@@ -142,6 +189,9 @@ function makeController(engine: any, init: ControllerInit = {}) {
       const projectRows: string[][] = p.ids.map((id, i) => [
         p.names[i],
         id === p.activeId ? "active" : "",
+        // Non-empty only for a nested project; the layout hides an empty cell, so a
+        // top-level row stays flush left.
+        p.depths[i] > 0 ? `${" ".repeat((p.depths[i] - 1) * 2)}↳` : "",
       ]);
       return {
         appTitle: "Tasks — auto-scheduled",
@@ -167,9 +217,13 @@ function makeController(engine: any, init: ControllerInit = {}) {
         case "newProjectNameChange":
           newProject = event.value;
           break;
-        case "addProject": {
+        case "addProject":
+        case "addSubproject": {
           const name = newProject.trim();
           if (!name) break;
+          // "+ Sub" nests under whatever is currently shown; "+ Project" stays top-level.
+          const parent =
+            event.type === "addSubproject" ? engine.activeProject()?.data ?? null : null;
           // Project ids must be unique across the WHOLE workspace, so probe every
           // project — not just the top-level ones. A nested project is in `projects`
           // but not in `roots`; probing `roots` alone would keep proposing an id the
@@ -178,7 +232,7 @@ function makeController(engine: any, init: ControllerInit = {}) {
           let n = taken.size + 1;
           while (taken.has(`p${n}`)) n += 1;
           const id = `p${n}`;
-          const res = engine.createProject({ id, name, parent: null });
+          const res = engine.createProject({ id, name, parent });
           if (res?.ok === false) {
             // Don't fail silently — the user pressed a button and nothing happened.
             console.error("Could not create the project:", res.error ?? res);

--- a/code/programs/mosaic/task-app/src/TaskApp.dark.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.dark.msl
@@ -64,6 +64,21 @@ style TaskApp {
       background : "#3a2c17" ;
     }
   }
+  part project-indent {
+    color : "#867c70" ;
+    font-size : 13 ;
+  }
+  part project-sub {
+    background : "#2d271f" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 8 ;
+    border-radius : 9 ;
+    state hover {
+      background : "#3a2c17" ;
+      color : "#eaa63f" ;
+    }
+  }
   part title {
     font-size : 22 ;
     font-weight : bold ;

--- a/code/programs/mosaic/task-app/src/TaskApp.light.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.light.msl
@@ -64,6 +64,21 @@ style TaskApp {
       background : "#faedd6" ;
     }
   }
+  part project-indent {
+    color : "#9b9289" ;
+    font-size : 13 ;
+  }
+  part project-sub {
+    background : "#f7f2ea" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 8 ;
+    border-radius : 9 ;
+    state hover {
+      background : "#faedd6" ;
+      color : "#b6741a" ;
+    }
+  }
   part title {
     font-size : 22 ;
     font-weight : bold ;

--- a/code/programs/mosaic/task-app/src/TaskApp.mil
+++ b/code/programs/mosaic/task-app/src/TaskApp.mil
@@ -14,10 +14,12 @@ component TaskApp {
   slot new-task-name : text ;
   slot new-task-due  : text ;
 
-  // The workspace's projects, in workspace order. Each row is [ name, active-marker ],
-  // where the marker is non-empty for exactly the project currently being shown — the
-  // layout uses it to render that one as selected. Everything else in this interface
-  // (tasks, summary, schedule) describes the active project.
+  // The workspace's projects, depth-first so a sub-project follows its parent. Each row
+  // is [ name, active-marker, indent ]: the marker is non-empty for exactly the project
+  // being shown (the layout renders that one as selected), and `indent` is a non-empty
+  // glyph for a *nested* project, empty for a top-level one — which is what turns a
+  // flat list into a visible hierarchy. Everything else in this interface (tasks,
+  // summary, schedule) describes the active project.
   slot project-rows     : list<list<text>> ;
   slot new-project-name : text ;
 
@@ -34,8 +36,10 @@ component TaskApp {
   emit onNewTaskDueChange ( value : text ) ;
   emit onNewProjectNameChange ( value : text ) ;
 
-  // Create a project, and switch which one is shown (by row index).
+  // Create a project (top-level, or nested under the one currently shown), and switch
+  // which one is shown (by row index).
   emit onAddProject ;
+  emit onAddSubproject ;
   emit onSelectProject ( index : number ) ;
 
   // Add the typed task; toggle/delete a row (the row index is delivered as the number

--- a/code/programs/mosaic/task-app/src/TaskApp.mll
+++ b/code/programs/mosaic/task-app/src/TaskApp.mll
@@ -10,6 +10,11 @@ layout TaskApp {
     // by row index, matching how task rows report which row was acted on.
     Row [ project-bar ] {
       For ( each: slot: project-rows , as: p , index: pi ) {
+        // A nested project gets a leading glyph; a top-level one has an empty indent
+        // cell and so renders nothing, keeping the row flush left.
+        If ( when: ( p[2] ) ) {
+          Text [ project-indent ] ( content : ( p[2] ) )
+        }
         If ( when: ( p[1] ) ) {
           HostButton [ project-on ] ( label : ( p[0] ) , onClick : emit: onSelectProject )
         }
@@ -23,6 +28,7 @@ layout TaskApp {
         onChange : emit: onNewProjectNameChange
       )
       HostButton [ project-add ] ( label : "+ Project" , onClick : emit: onAddProject )
+      HostButton [ project-sub ] ( label : "+ Sub" , onClick : emit: onAddSubproject )
     }
 
     Text [ title ] ( content : slot: app-title , a11y-role : heading )

--- a/lessons.md
+++ b/lessons.md
@@ -1755,3 +1755,28 @@ on a signature, move the doc block down with the insertion. Also worth knowing:
 the clippy message names the function it thinks you meant to document, which is
 your *new* function, not the one that actually lost its docs — read the line
 number, not the name.
+
+## Rewriting a CRLF file with Python can break a compiler — and `grep -c $'\r'` lies about it
+
+Editing `TaskApp.light.msl` (CRLF in the working tree, `eol=lf` in `.gitattributes`)
+by reading + rewriting it in Python produced a file the mosstyle lexer rejected:
+
+```
+mosstyle tokenization failed: LexerError at 8:1: Unexpected sequence '\r'
+```
+
+Two traps, one after the other:
+
+1. **Mixed endings.** Python's text mode translates on read *and* write, so a
+   partial rewrite can leave the original CRLF lines alongside freshly written LF
+   ones. Some hand-written lexers (mosstyle's included) accept a consistent file
+   but choke on the mix.
+2. **The obvious check gives a false negative.** `grep -c $'\r' file` reported
+   **0** under Git Bash while `od -c file | grep -c '\r'` reported **238**. I
+   nearly concluded the file was clean. Verify with `od -c`, or
+   `python -c "print(open('f','rb').read().count(b'\r'))"` — not `grep`.
+
+Fix: normalize to LF on disk, which is what git stores and what CI sees anyway
+(`git check-attr text eol -- <file>` to confirm). When scripting an edit to a
+tracked file, read and write **binary** (`open(p,'rb')` / `'wb'`) so you never
+silently re-encode line endings you weren't asked to touch.


### PR DESCRIPTION
The engine has supported nesting since Phase 2, but the project bar only listed *top-level* projects — so a sub-project was both invisible and uncreatable from the UI. This closes that.

## What changed

- **The bar lists every project**, walked depth-first so a sub-project follows its parent, with an indent glyph marking the nesting. `project-rows` gains a third cell (`indent`) — empty for a top-level project, so the layout's existing `If` hides it and the row stays flush left.
- **A "+ Sub" button** creates a project nested under whichever one is shown, making the hierarchy reachable from the UI for the first time. It shares the create path with "+ Project"; only the `parent` differs.
- The engine stores nesting as a `parent` on a flat map (a parent doesn't list its children), so the host derives child lists — **bucketed once**, making the walk O(n) rather than re-filtering the whole map per node. Siblings sort by **name**, since raw id order puts `p10` before `p2`.

## Hardened from security review before pushing

- **The walk is an explicit stack, not recursion.** A deeply nested chain would otherwise blow the JS call stack inside `getProps` and take the whole render down. Verified with a **50 000-deep chain** — the recursive version threw `RangeError`.
- `seen` makes a **parent cycle** terminate with each project listed once, and a final sweep picks up any project `roots` missed (an orphan whose `parent` names a project that no longer exists), so nothing is unreachable.

## Verification

Against a real `wasm32` build driven from Node: depth-first ordering, depths 0/1/2, name-ordered siblings, a nested project being selectable and owning its own tasks, its tasks **not** leaking into the parent, and the engine's refusal to delete a project that still has children. Sources compile in both themes; host typechecks; vitest 6/6. A separate review pass confirmed the new indent cell reaches the DOM only as escaped JSX text.

## Also

`lessons.md`: rewriting a CRLF file with Python broke the mosstyle lexer with mixed line endings — and `grep -c $'\r'` reported **0** while `od -c` found **238**. Normalize to LF (what git stores and CI sees) and script edits in binary mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)