### PR TITLE
feat(adj-formula-stdlib): glomerular-filtration-rate — Starling GFR = Kf × [(P_GC − P_BS) − (π_GC − π_BS)] definition library (clinical/renal)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_glomerular_filtration_rate_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_glomerular_filtration_rate_e2e.rs
@@ -1,0 +1,258 @@
+//! End-to-end tests for the `clinical/glomerular-filtration-rate.adj` library — the Starling
+//! determination of the glomerular filtration rate (GFR = Kf × [(P_GC − P_BS) − (π_GC − π_BS)])
+//! and its five exact rearrangements — driven through the built CLI binary against the SHIPPED
+//! stdlib. The same invariant as every other formula library: a consumer states NO arithmetic; it
+//! imports the grounded library, binds the measured quantities with `observe`, and the engine
+//! applies the cited relation on the CPU, computing the EXACT value and rendering the relation's
+//! citation and trust tier in the `derived` section (the auditable answer).
+//!
+//! This is the first FIVE-input clinical inverter and the first of the PRODUCT-OF-A-DIFFERENCE-
+//! OF-TWO-DIFFERENCES shape: an outer × (the filtration coefficient) multiplying an inner
+//! subtraction of one pressure-difference from another. The six formulas INVERT around the
+//! worked case Kf = 14, P_GC = 60 mmHg, P_BS = 17 mmHg, π_GC = 42 mmHg, π_BS = 12 mmHg, whose net
+//! filtration pressure is (60 − 17) − (42 − 12) = 13 mmHg, so GFR = 14 × 13 = 182. Each test
+//! fixes five quantities and recovers the sixth exactly. The six asserted values (182, 14, 60,
+//! 17, 42, 12) are chosen so none is a substring of another rendered value, so each
+//! `"value":N` assertion is unambiguous.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped glomerular-filtration-rate library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_gfr_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/glomerular-filtration-rate.adj")
+        .canonicalize()
+        .expect("shipped glomerular-filtration-rate.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_gfr_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_gfr_lib()).unwrap();
+    std::fs::write(dir.join("glomerular-filtration-rate.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// glomerular_filtration_rate — the determination: Kf × [(P_GC − P_BS) − (π_GC − π_BS)].
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_gfr_library_and_computes_it_with_citation() {
+    let dir = scratch("gfr");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"glomerular-filtration-rate.adj\"\n\
+         observe filtration_coefficient(14)\n\
+         observe glomerular_capillary_hydrostatic_pressure(60)\n\
+         observe bowman_space_hydrostatic_pressure(17)\n\
+         observe glomerular_capillary_oncotic_pressure(42)\n\
+         observe bowman_space_oncotic_pressure(12)\n\
+         ? glomerular_filtration_rate(filtration_coefficient, glomerular_capillary_hydrostatic_pressure, bowman_space_hydrostatic_pressure, glomerular_capillary_oncotic_pressure, bowman_space_oncotic_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result:
+    // 14 × [(60 − 17) − (42 − 12)] = 14 × 13 = 182.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"glomerular_filtration_rate\"") && s.contains("\"value\":182"),
+        "glomerular_filtration_rate(14, 60, 17, 42, 12) = 182: {s}"
+    );
+    // … AND the StatPearls/NCBI Bookshelf citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// filtration_coefficient — the same relation solved for Kf: GFR / net filtration pressure.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_filtration_coefficient_from_gfr_and_pressures_with_citation() {
+    let dir = scratch("kf");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"glomerular-filtration-rate.adj\"\n\
+         observe glomerular_filtration_rate(182)\n\
+         observe glomerular_capillary_hydrostatic_pressure(60)\n\
+         observe bowman_space_hydrostatic_pressure(17)\n\
+         observe glomerular_capillary_oncotic_pressure(42)\n\
+         observe bowman_space_oncotic_pressure(12)\n\
+         ? filtration_coefficient(glomerular_filtration_rate, glomerular_capillary_hydrostatic_pressure, bowman_space_hydrostatic_pressure, glomerular_capillary_oncotic_pressure, bowman_space_oncotic_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 182 / [(60 − 17) − (42 − 12)] = 182 / 13 = 14, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"filtration_coefficient\"") && s.contains("\"value\":14"),
+        "filtration_coefficient(182, 60, 17, 42, 12) = 14: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "filtration_coefficient carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// glomerular_capillary_hydrostatic_pressure — solved for P_GC: GFR/Kf + P_BS + π_GC − π_BS.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_glomerular_capillary_hydrostatic_pressure_with_citation() {
+    let dir = scratch("pgc");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"glomerular-filtration-rate.adj\"\n\
+         observe glomerular_filtration_rate(182)\n\
+         observe filtration_coefficient(14)\n\
+         observe bowman_space_hydrostatic_pressure(17)\n\
+         observe glomerular_capillary_oncotic_pressure(42)\n\
+         observe bowman_space_oncotic_pressure(12)\n\
+         ? glomerular_capillary_hydrostatic_pressure(glomerular_filtration_rate, filtration_coefficient, bowman_space_hydrostatic_pressure, glomerular_capillary_oncotic_pressure, bowman_space_oncotic_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 182/14 + 17 + 42 − 12 = 13 + 17 + 42 − 12 = 60, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"glomerular_capillary_hydrostatic_pressure\"") && s.contains("\"value\":60"),
+        "glomerular_capillary_hydrostatic_pressure(182, 14, 17, 42, 12) = 60: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "glomerular_capillary_hydrostatic_pressure carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// bowman_space_hydrostatic_pressure — solved for P_BS: P_GC − π_GC + π_BS − GFR/Kf.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_bowman_space_hydrostatic_pressure_with_citation() {
+    let dir = scratch("pbs");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"glomerular-filtration-rate.adj\"\n\
+         observe glomerular_filtration_rate(182)\n\
+         observe filtration_coefficient(14)\n\
+         observe glomerular_capillary_hydrostatic_pressure(60)\n\
+         observe glomerular_capillary_oncotic_pressure(42)\n\
+         observe bowman_space_oncotic_pressure(12)\n\
+         ? bowman_space_hydrostatic_pressure(glomerular_filtration_rate, filtration_coefficient, glomerular_capillary_hydrostatic_pressure, glomerular_capillary_oncotic_pressure, bowman_space_oncotic_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 60 − 42 + 12 − 182/14 = 60 − 42 + 12 − 13 = 17, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"bowman_space_hydrostatic_pressure\"") && s.contains("\"value\":17"),
+        "bowman_space_hydrostatic_pressure(182, 14, 60, 42, 12) = 17: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "bowman_space_hydrostatic_pressure carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// glomerular_capillary_oncotic_pressure — solved for π_GC: P_GC − P_BS + π_BS − GFR/Kf.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_glomerular_capillary_oncotic_pressure_with_citation() {
+    let dir = scratch("pigc");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"glomerular-filtration-rate.adj\"\n\
+         observe glomerular_filtration_rate(182)\n\
+         observe filtration_coefficient(14)\n\
+         observe glomerular_capillary_hydrostatic_pressure(60)\n\
+         observe bowman_space_hydrostatic_pressure(17)\n\
+         observe bowman_space_oncotic_pressure(12)\n\
+         ? glomerular_capillary_oncotic_pressure(glomerular_filtration_rate, filtration_coefficient, glomerular_capillary_hydrostatic_pressure, bowman_space_hydrostatic_pressure, bowman_space_oncotic_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 60 − 17 + 12 − 182/14 = 60 − 17 + 12 − 13 = 42, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"glomerular_capillary_oncotic_pressure\"") && s.contains("\"value\":42"),
+        "glomerular_capillary_oncotic_pressure(182, 14, 60, 17, 12) = 42: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "glomerular_capillary_oncotic_pressure carries its StatPearls citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// bowman_space_oncotic_pressure — solved for π_BS: GFR/Kf − P_GC + P_BS + π_GC, the sixth reading
+// of the one sentence.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_bowman_space_oncotic_pressure_with_citation() {
+    let dir = scratch("pibs");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"glomerular-filtration-rate.adj\"\n\
+         observe glomerular_filtration_rate(182)\n\
+         observe filtration_coefficient(14)\n\
+         observe glomerular_capillary_hydrostatic_pressure(60)\n\
+         observe bowman_space_hydrostatic_pressure(17)\n\
+         observe glomerular_capillary_oncotic_pressure(42)\n\
+         ? bowman_space_oncotic_pressure(glomerular_filtration_rate, filtration_coefficient, glomerular_capillary_hydrostatic_pressure, bowman_space_hydrostatic_pressure, glomerular_capillary_oncotic_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 182/14 − 60 + 17 + 42 = 13 − 60 + 17 + 42 = 12, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"bowman_space_oncotic_pressure\"") && s.contains("\"value\":12"),
+        "bowman_space_oncotic_pressure(182, 14, 60, 17, 42) = 12: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "bowman_space_oncotic_pressure carries its StatPearls citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/glomerular-filtration-rate.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/glomerular-filtration-rate.adj
@@ -1,0 +1,143 @@
+% ============================================================================
+% glomerular-filtration-rate.adj — the Starling determination of the glomerular
+% filtration rate (GFR = Kf × [(P_GC − P_BS) − (π_GC − π_BS)]) in the ADJ standard library.
+% ============================================================================
+% The glomerular-filtration-rate entry of the *clinical* track, a renal-physiology sibling of
+% `starling-net-filtration-pressure.adj` (rung-31) and `cockcroft-gault.adj`. Where the net
+% filtration pressure grounds the driving pressure ALONE (the balance of hydrostatic and oncotic
+% forces across the glomerular capillary wall), this grounds the FLOW that driving pressure
+% produces: THE GLOMERULAR FILTRATION RATE IS THE FILTRATION COEFFICIENT TIMES THE NET
+% FILTRATION PRESSURE — where the net filtration pressure is itself the difference between the
+% two hydrostatic pressures, LESS the difference between the two oncotic pressures. So the whole
+% relation is a product of a difference OF two differences: an outer × (the filtration
+% coefficient Kf, the wall's permeability × area) multiplying an inner subtraction of one
+% pressure-difference from another. This is the first clinical inverter of that
+% PRODUCT-OF-A-DIFFERENCE-OF-TWO-DIFFERENCES shape and the first FIVE-input clinical formula:
+% where alveolar ventilation composes ONE difference inside a product, this composes TWO
+% differences inside the subtraction and then multiplies. It ships as an importable,
+% byte-provenanced, PARAMETERIZED `formula`, together with its five exact rearrangements (the
+% filtration coefficient a GFR implies, and each of the four pressures the relation implies). As
+% with every compute library, a consumer states NO arithmetic: it `import`s this file, binds the
+% measured quantities from its own byte-provenance decomposition, and asks the engine to APPLY
+% the cited definition on the CPU. Zero math is performed by the model; the engine computes each
+% value EXACTLY (over exact rationals), carrying the definition's citation.
+%
+%     import "glomerular-filtration-rate.adj"
+%     observe filtration_coefficient(14)                        % "…filtration coefficient Kf 14…"
+%     observe glomerular_capillary_hydrostatic_pressure(60)     % "…P_GC 60 mmHg…"   (span cited)
+%     observe bowman_space_hydrostatic_pressure(17)             % "…P_BS 17 mmHg…"   (span cited)
+%     observe glomerular_capillary_oncotic_pressure(42)         % "…π_GC 42 mmHg…"   (span cited)
+%     observe bowman_space_oncotic_pressure(12)                 % "…π_BS 12 mmHg…"   (span cited)
+%     ? glomerular_filtration_rate(filtration_coefficient,
+%           glomerular_capillary_hydrostatic_pressure, bowman_space_hydrostatic_pressure,
+%           glomerular_capillary_oncotic_pressure, bowman_space_oncotic_pressure)
+%                    % engine → 182, carrying GFR = Kf × [(P_GC − P_BS) − (π_GC − π_BS)]
+%
+% All six formulas are EXACT over their parameters, so every value the engine returns is exact.
+% They COMPOSE and invert cleanly around the worked case Kf = 14, P_GC = 60 mmHg, P_BS = 17 mmHg,
+% π_GC = 42 mmHg, π_BS = 12 mmHg. The net filtration pressure is (60 − 17) − (42 − 12) = 43 − 30
+% = 13 mmHg, so GFR = 14 × 13 = 182: the `glomerular_filtration_rate` a consumer computes from
+% the five quantities is exactly the value the `filtration_coefficient` formula divides by the
+% net filtration pressure to recover 14, and exactly the value each of the four pressure formulas
+% rearranges to recover its own pressure (60, 17, 42, 12 respectively).
+%
+%   glomerular_filtration_rate(Kf, P_GC, P_BS, π_GC, π_BS)
+%       = Kf * ((P_GC - P_BS) - (π_GC - π_BS))                  % GFR = Kf × [(P_GC−P_BS)−(π_GC−π_BS)]
+%   filtration_coefficient(GFR, P_GC, P_BS, π_GC, π_BS)
+%       = GFR / ((P_GC - P_BS) - (π_GC - π_BS))                 % Kf  = GFR / net filtration pressure
+%   glomerular_capillary_hydrostatic_pressure(GFR, Kf, P_BS, π_GC, π_BS)
+%       = GFR / Kf + P_BS + π_GC - π_BS                         % P_GC solved out of the relation
+%   bowman_space_hydrostatic_pressure(GFR, Kf, P_GC, π_GC, π_BS)
+%       = P_GC - π_GC + π_BS - GFR / Kf                         % P_BS solved out of the relation
+%   glomerular_capillary_oncotic_pressure(GFR, Kf, P_GC, P_BS, π_BS)
+%       = P_GC - P_BS + π_BS - GFR / Kf                         % π_GC solved out of the relation
+%   bowman_space_oncotic_pressure(GFR, Kf, P_GC, P_BS, π_GC)
+%       = GFR / Kf - P_GC + P_BS + π_GC                         % π_BS solved out of the relation
+%
+% NOTE ON UNITS: the four pressures must be in the SAME unit (millimetres of mercury, as in the
+% worked case); the filtration coefficient carries the flow-per-pressure units (e.g. mL/min per
+% mmHg), so the glomerular filtration rate comes out in the corresponding flow unit (e.g.
+% mL/min). This library computes the exact value over whatever consistent units it is given. The
+% inner bracket — (P_GC − P_BS) − (π_GC − π_BS) — is exactly the net filtration pressure grounded
+% on its own in `starling-net-filtration-pressure.adj`; this library grounds the FLOW the
+% filtration coefficient turns that pressure into.
+%
+% All six formulas are defended by the SAME sentence — the StatPearls determination of the GFR by
+% the Starling equation — because that one statement (the GFR IS the filtration coefficient times
+% the oncotic-pressure difference subtracted from the hydrostatic-pressure difference) sanctions
+% the relation read every way. The quote is transcribed verbatim from the StatPearls "Physiology,
+% Renal Blood Flow and Filtration" article on the NCBI Bookshelf, so each `formula` carries the
+% provenance envelope every shipped grounded clause carries; the linter rejects an unsourced one.
+% (See feedback_nothing_human_authored — the sentence is a verbatim span of the cited page, not
+% asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable renal-physiology quantity the determination ranges
+% over, and each result is a derived quantity. Every term appears BOTH as a derived result and as
+% an input (of the other formulas), so each is a single dictionary term used in both roles. The
+% `surface` lists are the everyday names a decomposer maps onto the canonical term; the trailing
+% comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary glomerular_filtration_rate_vocab {
+    define filtration_coefficient                     : finding  surface "filtration coefficient", "Kf"                                        % flow per pressure (e.g. mL/min per mmHg)
+    define glomerular_capillary_hydrostatic_pressure  : finding  surface "glomerular capillary hydrostatic pressure", "P_GC", "PGC"            % millimetres of mercury (mmHg)
+    define bowman_space_hydrostatic_pressure          : finding  surface "Bowman space hydrostatic pressure", "P_BS", "PBS"                    % millimetres of mercury (mmHg)
+    define glomerular_capillary_oncotic_pressure      : finding  surface "glomerular capillary oncotic pressure", "pi_GC", "piGC"              % millimetres of mercury (mmHg)
+    define bowman_space_oncotic_pressure              : finding  surface "Bowman space oncotic pressure", "pi_BS", "piBS"                      % millimetres of mercury (mmHg)
+    define glomerular_filtration_rate                 : finding  surface "glomerular filtration rate", "GFR"                                   % flow (e.g. mL/min)
+}
+
+% ----------------------------------------------------------------------------
+% The determination, all six ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the Starling-equation sentence from StatPearls
+% on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an exact composition
+% of differences with a product or quotient of measured quantities, so the engine returns each
+% value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook glomerular_filtration_rate_laws {
+    use glomerular_filtration_rate_vocab
+
+    % Glomerular filtration rate — the filtration coefficient times the net filtration pressure,
+    % i.e. GFR = Kf × [(P_GC − P_BS) − (π_GC − π_BS)].
+    formula glomerular_filtration_rate(filtration_coefficient, glomerular_capillary_hydrostatic_pressure, bowman_space_hydrostatic_pressure, glomerular_capillary_oncotic_pressure, bowman_space_oncotic_pressure) = filtration_coefficient * ((glomerular_capillary_hydrostatic_pressure - bowman_space_hydrostatic_pressure) - (glomerular_capillary_oncotic_pressure - bowman_space_oncotic_pressure))
+        source "The GFR can be determined by the Starling equation, which is the filtration coefficient multiplied by the difference between glomerular capillary oncotic pressure and Bowman space oncotic pressure subtracted from the difference between glomerular capillary hydrostatic pressure and Bowman space hydrostatic pressure."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482248/"
+        trust authoritative
+
+    % Filtration coefficient — the same determination solved for Kf: the glomerular filtration
+    % rate divided by the net filtration pressure it produces. Defended by the SAME sentence.
+    formula filtration_coefficient(glomerular_filtration_rate, glomerular_capillary_hydrostatic_pressure, bowman_space_hydrostatic_pressure, glomerular_capillary_oncotic_pressure, bowman_space_oncotic_pressure) = glomerular_filtration_rate / ((glomerular_capillary_hydrostatic_pressure - bowman_space_hydrostatic_pressure) - (glomerular_capillary_oncotic_pressure - bowman_space_oncotic_pressure))
+        source "The GFR can be determined by the Starling equation, which is the filtration coefficient multiplied by the difference between glomerular capillary oncotic pressure and Bowman space oncotic pressure subtracted from the difference between glomerular capillary hydrostatic pressure and Bowman space hydrostatic pressure."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482248/"
+        trust authoritative
+
+    % Glomerular capillary hydrostatic pressure — the same determination solved for P_GC
+    % (P_GC = GFR/Kf + P_BS + π_GC − π_BS): the net filtration pressure the flow implies, with the
+    % other three pressures moved across. The SAME sentence, read the third way.
+    formula glomerular_capillary_hydrostatic_pressure(glomerular_filtration_rate, filtration_coefficient, bowman_space_hydrostatic_pressure, glomerular_capillary_oncotic_pressure, bowman_space_oncotic_pressure) = glomerular_filtration_rate / filtration_coefficient + bowman_space_hydrostatic_pressure + glomerular_capillary_oncotic_pressure - bowman_space_oncotic_pressure
+        source "The GFR can be determined by the Starling equation, which is the filtration coefficient multiplied by the difference between glomerular capillary oncotic pressure and Bowman space oncotic pressure subtracted from the difference between glomerular capillary hydrostatic pressure and Bowman space hydrostatic pressure."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482248/"
+        trust authoritative
+
+    % Bowman space hydrostatic pressure — the same determination solved for P_BS
+    % (P_BS = P_GC − π_GC + π_BS − GFR/Kf). The SAME sentence, read the fourth way.
+    formula bowman_space_hydrostatic_pressure(glomerular_filtration_rate, filtration_coefficient, glomerular_capillary_hydrostatic_pressure, glomerular_capillary_oncotic_pressure, bowman_space_oncotic_pressure) = glomerular_capillary_hydrostatic_pressure - glomerular_capillary_oncotic_pressure + bowman_space_oncotic_pressure - glomerular_filtration_rate / filtration_coefficient
+        source "The GFR can be determined by the Starling equation, which is the filtration coefficient multiplied by the difference between glomerular capillary oncotic pressure and Bowman space oncotic pressure subtracted from the difference between glomerular capillary hydrostatic pressure and Bowman space hydrostatic pressure."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482248/"
+        trust authoritative
+
+    % Glomerular capillary oncotic pressure — the same determination solved for π_GC
+    % (π_GC = P_GC − P_BS + π_BS − GFR/Kf). The SAME sentence, read the fifth way.
+    formula glomerular_capillary_oncotic_pressure(glomerular_filtration_rate, filtration_coefficient, glomerular_capillary_hydrostatic_pressure, bowman_space_hydrostatic_pressure, bowman_space_oncotic_pressure) = glomerular_capillary_hydrostatic_pressure - bowman_space_hydrostatic_pressure + bowman_space_oncotic_pressure - glomerular_filtration_rate / filtration_coefficient
+        source "The GFR can be determined by the Starling equation, which is the filtration coefficient multiplied by the difference between glomerular capillary oncotic pressure and Bowman space oncotic pressure subtracted from the difference between glomerular capillary hydrostatic pressure and Bowman space hydrostatic pressure."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482248/"
+        trust authoritative
+
+    % Bowman space oncotic pressure — the same determination solved for π_BS
+    % (π_BS = GFR/Kf − P_GC + P_BS + π_GC). The SAME sentence, read the sixth way.
+    formula bowman_space_oncotic_pressure(glomerular_filtration_rate, filtration_coefficient, glomerular_capillary_hydrostatic_pressure, bowman_space_hydrostatic_pressure, glomerular_capillary_oncotic_pressure) = glomerular_filtration_rate / filtration_coefficient - glomerular_capillary_hydrostatic_pressure + bowman_space_hydrostatic_pressure + glomerular_capillary_oncotic_pressure
+        source "The GFR can be determined by the Starling equation, which is the filtration coefficient multiplied by the difference between glomerular capillary oncotic pressure and Bowman space oncotic pressure subtracted from the difference between glomerular capillary hydrostatic pressure and Bowman space hydrostatic pressure."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK482248/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/glomerular-filtration-rate.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/glomerular-filtration-rate.query.adj
@@ -1,0 +1,32 @@
+% ============================================================================
+% glomerular-filtration-rate.query.adj — worked applications of the Starling GFR determination.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a renal-physiology vignette into observed
+% quantities: it `import`s the grounded formulabook, `observe`s the measured pressures (and the
+% filtration coefficient), and asks the engine to APPLY the cited determination. No arithmetic is
+% stated by the consumer; the engine computes each value EXACTLY (over exact rationals) and
+% carries the StatPearls Starling-equation citation as its proof, on the CPU, with zero model
+% calls.
+%
+% Worked case (Kf = 14, P_GC = 60 mmHg, P_BS = 17 mmHg, π_GC = 42 mmHg, π_BS = 12 mmHg): the net
+% filtration pressure is (60 − 17) − (42 − 12) = 43 − 30 = 13 mmHg, so GFR = 14 × 13 = 182. Each
+% query below fixes five of the six quantities and asks the engine to recover the sixth; every
+% answer is exact and the six COMPOSE (each inversion recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli glomerular-filtration-rate.query.adj
+% ============================================================================
+
+import "glomerular-filtration-rate.adj"
+
+% --- Forward: the glomerular filtration rate the five quantities imply (expect 182). ----------
+observe filtration_coefficient(14)
+observe glomerular_capillary_hydrostatic_pressure(60)
+observe bowman_space_hydrostatic_pressure(17)
+observe glomerular_capillary_oncotic_pressure(42)
+observe bowman_space_oncotic_pressure(12)
+? glomerular_filtration_rate(filtration_coefficient, glomerular_capillary_hydrostatic_pressure, bowman_space_hydrostatic_pressure, glomerular_capillary_oncotic_pressure, bowman_space_oncotic_pressure)   % expect 182
+
+% --- Inverse: the filtration coefficient a GFR of 182 implies for that pressure balance (14). --
+observe glomerular_filtration_rate(182)
+? filtration_coefficient(glomerular_filtration_rate, glomerular_capillary_hydrostatic_pressure, bowman_space_hydrostatic_pressure, glomerular_capillary_oncotic_pressure, bowman_space_oncotic_pressure)   % expect 14


### PR DESCRIPTION
## What

Adds `clinical/glomerular-filtration-rate.adj` to the ADJ formula standard library — the Starling determination of the glomerular filtration rate — plus a worked `.query.adj` and a dedicated end-to-end test.

**GFR = Kf × [(P_GC − P_BS) − (π_GC − π_BS)]**

This is the **first five-input clinical inverter** and the first of the **product-of-a-difference-of-two-differences** shape: an outer × (the filtration coefficient Kf) multiplying an inner subtraction of one pressure-difference (oncotic) from another (hydrostatic) — the net filtration pressure. Where `alveolar-ventilation.adj` composes one difference inside a product, this composes *two* differences inside the subtraction, then multiplies, and the engine inverts it every way exactly.

Ships the forward formula plus **five exact rearrangements** — the filtration coefficient and each of the four pressures — every one carrying the SAME verbatim source sentence, so the definition read any of six ways is one provenance envelope.

## Provenance (byte-verified)

Grounded verbatim in the StatPearls *"Physiology, Renal Blood Flow and Filtration"* article on the NCBI Bookshelf:

> "The GFR can be determined by the Starling equation, which is the filtration coefficient multiplied by the difference between glomerular capillary oncotic pressure and Bowman space oncotic pressure subtracted from the difference between glomerular capillary hydrostatic pressure and Bowman space hydrostatic pressure."

- `locator`: https://www.ncbi.nlm.nih.gov/books/NBK482248/
- `trust authoritative` — primary, re-fetchable reference.

## Worked case (all six invert exactly)

Kf = 14, P_GC = 60 mmHg, P_BS = 17 mmHg, π_GC = 42 mmHg, π_BS = 12 mmHg → net filtration pressure (60 − 17) − (42 − 12) = 13 mmHg → **GFR = 14 × 13 = 182**. Each e2e test fixes five quantities and recovers the sixth. The six asserted values (182, 14, 60, 17, 42, 12) are chosen so none is a substring of another rendered value.

## Invariant

A consumer states NO arithmetic: it `import`s the library, `observe`s its byte-provenance-decomposed quantities, and the engine APPLIES the cited relation on the CPU, computing each value EXACTLY (over exact rationals) and rendering the citation + trust tier in the auditable `derived` section. Zero model math.

## Testing

- `cargo test -p adj-lang-cli --test formula_glomerular_filtration_rate_e2e` — 6/6 pass.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean.
- Render-probed against the built CLI (parses the new lib at runtime): forward → 182, inverse → 14, derivation tree exact.
- NUL-scanned all three new files (0 NUL bytes).
- `/security-review` — passed, no findings.

Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)