### PR TITLE
Add HTML processing instruction plumbing

### DIFF
--- a/code/packages/rust/dom-core/CHANGELOG.md
+++ b/code/packages/rust/dom-core/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the `dom-core` crate will be documented in this file.
 
+## Unreleased
+
+### Added
+- Added first-class processing-instruction nodes with target and data fields.
+
 ## [0.1.0] - 2026-05-02
 
 ### Added

--- a/code/packages/rust/dom-core/README.md
+++ b/code/packages/rust/dom-core/README.md
@@ -3,6 +3,6 @@
 Small DOM tree model for Venture browser packages.
 
 This crate preserves browser-facing structure: document type nodes, elements,
-attributes, text, and comments. Higher layers can project this tree into
-`document-ast` for document rendering or combine it with CSS/layout packages
-for browser rendering.
+attributes, text, comments, and processing instructions. Higher layers can
+project this tree into `document-ast` for document rendering or combine it with
+CSS/layout packages for browser rendering.

--- a/code/packages/rust/dom-core/src/lib.rs
+++ b/code/packages/rust/dom-core/src/lib.rs
@@ -1,8 +1,9 @@
 //! Small DOM tree model for Venture browser packages.
 //!
 //! This crate is intentionally lower-level than `document-ast`: it preserves
-//! HTML element names, attributes, comments, and doctypes so browser-facing
-//! packages can later layer CSS, layout, and scripting semantics on top.
+//! HTML element names, attributes, comments, processing instructions, and
+//! doctypes so browser-facing packages can later layer CSS, layout, and
+//! scripting semantics on top.
 
 /// A parsed DOM document.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -27,6 +28,7 @@ pub enum Node {
     Element(Element),
     Text(Text),
     Comment(Comment),
+    ProcessingInstruction(ProcessingInstruction),
 }
 
 impl Node {
@@ -58,6 +60,13 @@ impl Node {
 
     pub fn comment(data: impl Into<String>) -> Self {
         Self::Comment(Comment { data: data.into() })
+    }
+
+    pub fn processing_instruction(target: impl Into<String>, data: impl Into<String>) -> Self {
+        Self::ProcessingInstruction(ProcessingInstruction {
+            target: target.into(),
+            data: data.into(),
+        })
     }
 
     pub fn children(&self) -> Option<&[Node]> {
@@ -121,12 +130,19 @@ pub struct Comment {
     pub data: String,
 }
 
+/// A processing instruction node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessingInstruction {
+    pub target: String,
+    pub data: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn document_can_hold_element_text_and_comment_nodes() {
+    fn document_can_hold_browser_facing_node_types() {
         let mut document = Document::new();
         document.push_child(Node::element(
             "p",
@@ -137,8 +153,12 @@ mod tests {
         ));
         document.push_child(Node::text("hello"));
         document.push_child(Node::comment("note"));
+        document.push_child(Node::processing_instruction(
+            "xml-model",
+            "href=\"schema.rng\"",
+        ));
 
-        assert_eq!(document.children.len(), 3);
+        assert_eq!(document.children.len(), 4);
         match &document.children[0] {
             Node::Element(element) => {
                 assert_eq!(element.name, "p");
@@ -146,5 +166,12 @@ mod tests {
             }
             other => panic!("expected element, got {other:?}"),
         }
+        assert_eq!(
+            document.children[3],
+            Node::ProcessingInstruction(ProcessingInstruction {
+                target: "xml-model".to_string(),
+                data: "href=\"schema.rng\"".to_string(),
+            })
+        );
     }
 }

--- a/code/packages/rust/html-lexer/tests/common/mod.rs
+++ b/code/packages/rust/html-lexer/tests/common/mod.rs
@@ -116,6 +116,9 @@ fn token_summary(token: Token) -> String {
         ),
         Token::EndTag { name } => format!("EndTag(name={name})"),
         Token::Comment(data) => format!("Comment(data={data})"),
+        Token::ProcessingInstruction { target, data } => {
+            format!("ProcessingInstruction(target={target}, data={data})")
+        }
         Token::Doctype {
             name,
             public_identifier,

--- a/code/packages/rust/html-lexer/tests/conformance_test.rs
+++ b/code/packages/rust/html-lexer/tests/conformance_test.rs
@@ -731,6 +731,9 @@ fn token_summary(token: Token) -> String {
         ),
         Token::EndTag { name } => format!("EndTag(name={name})"),
         Token::Comment(data) => format!("Comment(data={data})"),
+        Token::ProcessingInstruction { target, data } => {
+            format!("ProcessingInstruction(target={target}, data={data})")
+        }
         Token::Doctype {
             name,
             public_identifier,

--- a/code/packages/rust/html-lexer/tests/html1_authoring_test.rs
+++ b/code/packages/rust/html-lexer/tests/html1_authoring_test.rs
@@ -212,6 +212,9 @@ fn token_summary(token: Token) -> String {
         ),
         Token::EndTag { name } => format!("EndTag(name={name})"),
         Token::Comment(data) => format!("Comment(data={data})"),
+        Token::ProcessingInstruction { target, data } => {
+            format!("ProcessingInstruction(target={target}, data={data})")
+        }
         Token::Doctype {
             name,
             public_identifier,

--- a/code/packages/rust/html-lexer/tests/html_lexer_test.rs
+++ b/code/packages/rust/html-lexer/tests/html_lexer_test.rs
@@ -6432,6 +6432,9 @@ fn token_summary(token: Token) -> String {
         ),
         Token::EndTag { name } => format!("EndTag(name={name})"),
         Token::Comment(data) => format!("Comment(data={data})"),
+        Token::ProcessingInstruction { target, data } => {
+            format!("ProcessingInstruction(target={target}, data={data})")
+        }
         Token::Doctype {
             name,
             public_identifier,

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,8 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Processing instructions now have first-class tokenizer and DOM plumbing,
+  ready for the declarative HTML tokenizer states to emit target/data nodes.
 - The current WPT void-in-phrasing and foreign-content CDATA cases are now
   mirrored in the canonical tree-construction corpus and its focused void and
   foreign-content audits, leaving only processing-instruction signatures in

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -4544,6 +4544,9 @@ impl HtmlParser {
                     } => self.append_start_tag(name, attributes, self_closing),
                     Token::EndTag { name } => self.handle_end_tag(&name),
                     Token::Comment(comment) => self.append_comment(comment),
+                    Token::ProcessingInstruction { target, data } => {
+                        self.append_processing_instruction(target, data)
+                    }
                     Token::Doctype {
                         name,
                         public_identifier,
@@ -4641,6 +4644,9 @@ impl HtmlParser {
             Token::EndTag { name } => self.consume_foreign_cdata_text(format!("</{name}>")),
             Token::Comment(comment) => {
                 self.consume_foreign_cdata_text(format!("<!--{comment}-->"));
+            }
+            Token::ProcessingInstruction { target, data } => {
+                self.consume_foreign_cdata_text(format!("<?{target} {data}?>"));
             }
             Token::Doctype { name, .. } => {
                 self.consume_foreign_cdata_text(format!("<!DOCTYPE {}>", name.unwrap_or_default()));
@@ -5654,7 +5660,14 @@ impl HtmlParser {
                 return;
             }
         }
-        let node = Node::comment(comment);
+        self.append_comment_or_processing_instruction(Node::comment(comment));
+    }
+
+    fn append_processing_instruction(&mut self, target: String, data: String) {
+        self.append_comment_or_processing_instruction(Node::processing_instruction(target, data));
+    }
+
+    fn append_comment_or_processing_instruction(&mut self, node: Node) {
         if self.explicit_head_end_seen
             && self.current_element_is("head")
             && self.has_document_element()
@@ -7926,7 +7939,7 @@ impl HtmlParser {
         self.document
             .children
             .iter()
-            .any(|node| !matches!(node, Node::Comment(_)))
+            .any(|node| !matches!(node, Node::Comment(_) | Node::ProcessingInstruction(_)))
     }
 
     fn reopen_document_body(&mut self) {
@@ -8315,8 +8328,10 @@ impl HtmlParser {
 
     fn document_has_non_frameset_compatible_body_content(&self) -> bool {
         self.document.children.iter().any(|node| {
-            !matches!(node, Node::DocumentType(_) | Node::Comment(_))
-                && !is_ignorable_before_frameset_node(node)
+            !matches!(
+                node,
+                Node::DocumentType(_) | Node::Comment(_) | Node::ProcessingInstruction(_)
+            ) && !is_ignorable_before_frameset_node(node)
         })
     }
 
@@ -9007,7 +9022,7 @@ fn collect_text_content(nodes: &[Node], text: &mut String) {
         match node {
             Node::Text(data) => text.push_str(&data.data),
             Node::Element(element) => collect_text_content(&element.children, text),
-            Node::Comment(_) | Node::DocumentType(_) => {}
+            Node::Comment(_) | Node::ProcessingInstruction(_) | Node::DocumentType(_) => {}
         }
     }
 }
@@ -9335,7 +9350,9 @@ fn normalize_document_shell(document: Document) -> Document {
     for node in document.children {
         match node {
             Node::DocumentType(_) => normalized.push_child(node),
-            Node::Comment(_) if !builder.seen_document_element => normalized.push_child(node),
+            Node::Comment(_) | Node::ProcessingInstruction(_) if !builder.seen_document_element => {
+                normalized.push_child(node)
+            }
             Node::Element(mut element) if element.name == "html" => {
                 builder.seen_document_element = true;
                 builder.seen_html_element_node = true;
@@ -9344,7 +9361,7 @@ fn normalize_document_shell(document: Document) -> Document {
                     builder.push_html_child(child);
                 }
             }
-            Node::Comment(_) if builder.seen_html_element_node => {
+            Node::Comment(_) | Node::ProcessingInstruction(_) if builder.seen_html_element_node => {
                 builder.trailing_document_children.push(node);
             }
             node => {
@@ -9378,7 +9395,9 @@ fn body_fragment_nodes(mut document: Document) -> Vec<Node> {
     for node in document.children.drain(..) {
         match node {
             Node::DocumentType(_) => {}
-            Node::Comment(_) | Node::Text(_) => fragment.push(node),
+            Node::Comment(_) | Node::ProcessingInstruction(_) | Node::Text(_) => {
+                fragment.push(node)
+            }
             Node::Element(mut element) if element.name == "html" => {
                 for child in element.children.drain(..) {
                     match child {
@@ -9389,7 +9408,9 @@ fn body_fragment_nodes(mut document: Document) -> Vec<Node> {
                                     .filter(|node| !matches!(node, Node::DocumentType(_))),
                             );
                         }
-                        Node::Comment(_) | Node::Text(_) => fragment.push(child),
+                        Node::Comment(_) | Node::ProcessingInstruction(_) | Node::Text(_) => {
+                            fragment.push(child)
+                        }
                         _ => {}
                     }
                 }
@@ -9680,7 +9701,10 @@ fn move_leading_html_fragment_misc_after_body(nodes: &mut Vec<Node>) {
     };
 
     let mut leading_misc = Vec::new();
-    while matches!(nodes.first(), Some(Node::Comment(_) | Node::Text(_))) {
+    while matches!(
+        nodes.first(),
+        Some(Node::Comment(_) | Node::ProcessingInstruction(_) | Node::Text(_))
+    ) {
         leading_misc.push(nodes.remove(0));
     }
     if leading_misc.is_empty() {
@@ -9740,13 +9764,15 @@ impl DocumentShellBuilder {
                 append_missing_attributes(&mut self.body_attributes, element.attributes);
                 self.body_children.append(&mut element.children);
             }
-            Node::Comment(_) if self.seen_body_content && !self.seen_body_element => {
+            Node::Comment(_) | Node::ProcessingInstruction(_)
+                if self.seen_body_content && !self.seen_body_element =>
+            {
                 self.body_children.push(node);
             }
-            Node::Comment(_) if self.seen_body_content => {
+            Node::Comment(_) | Node::ProcessingInstruction(_) if self.seen_body_content => {
                 self.trailing_html_children.push(node);
             }
-            Node::Comment(_) if !self.seen_body_content => {
+            Node::Comment(_) | Node::ProcessingInstruction(_) if !self.seen_body_content => {
                 if !self.seen_head_element && self.head_children.is_empty() {
                     self.pre_head_html_children.push(node);
                 } else if !self.seen_head_element {
@@ -10019,14 +10045,14 @@ fn starts_body_after_head(name: &str) -> bool {
 fn is_ignorable_before_body(node: &Node) -> bool {
     match node {
         Node::Text(text) => text.data.chars().all(char::is_whitespace),
-        Node::Comment(_) => true,
+        Node::Comment(_) | Node::ProcessingInstruction(_) => true,
         _ => false,
     }
 }
 
 fn is_body_content_node(node: &Node) -> bool {
     match node {
-        Node::DocumentType(_) | Node::Comment(_) => false,
+        Node::DocumentType(_) | Node::Comment(_) | Node::ProcessingInstruction(_) => false,
         Node::Text(text) => !text.data.chars().all(char::is_whitespace),
         Node::Element(_) => true,
     }
@@ -13830,7 +13856,7 @@ fn collect_browser_content_nodes_with_mode(
                     output.push(content_node);
                 }
             }
-            Node::DocumentType(_) | Node::Comment(_) => {}
+            Node::DocumentType(_) | Node::Comment(_) | Node::ProcessingInstruction(_) => {}
         }
     }
 }
@@ -24436,7 +24462,7 @@ fn collect_visible_text(nodes: &[Node], text: &mut String) {
                 collect_visible_text(&element.children, text);
                 text.push(' ');
             }
-            Node::DocumentType(_) | Node::Comment(_) => {}
+            Node::DocumentType(_) | Node::Comment(_) | Node::ProcessingInstruction(_) => {}
         }
     }
 }
@@ -24452,7 +24478,7 @@ fn collect_browser_text_content(nodes: &[Node], text: &mut String) {
         match node {
             Node::Text(value) => text.push_str(&value.data),
             Node::Element(element) => collect_browser_text_content(&element.children, text),
-            Node::DocumentType(_) | Node::Comment(_) => {}
+            Node::DocumentType(_) | Node::Comment(_) | Node::ProcessingInstruction(_) => {}
         }
     }
 }
@@ -24830,6 +24856,24 @@ mod tests {
 
     fn body(document: &Document) -> &Element {
         element(&html(document).children[1])
+    }
+
+    #[test]
+    fn parser_preserves_processing_instruction_target_and_data() {
+        let mut parser = HtmlParser::with_options(HtmlParseOptions::default());
+        parser.process_token(Token::ProcessingInstruction {
+            target: "xml-model".to_string(),
+            data: "href=\"schema.rng\"".to_string(),
+        });
+        parser.process_token(Token::Eof);
+
+        let document = parser.finish_document();
+
+        assert!(matches!(
+            &document.children[0],
+            Node::ProcessingInstruction(pi)
+                if pi.target == "xml-model" && pi.data == "href=\"schema.rng\""
+        ));
     }
 
     #[test]

--- a/code/packages/rust/html-parser/tests/common/mod.rs
+++ b/code/packages/rust/html-parser/tests/common/mod.rs
@@ -117,6 +117,9 @@ fn dump_node(node: &Node, depth: usize, lines: &mut Vec<String>) {
         Node::Element(element) => dump_element(element, depth, lines),
         Node::Text(text) => dump_text(&text.data, depth, lines),
         Node::Comment(comment) => dump_comment(&comment.data, depth, lines),
+        Node::ProcessingInstruction(pi) => {
+            lines.push(format!("{}<?{} {}?>", prefix(depth), pi.target, pi.data));
+        }
     }
 }
 

--- a/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
+++ b/code/packages/rust/state-machine-tokenizer/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `state-machine-tokenizer` crate will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- Added processing-instruction token construction, data accumulation, target
+  finalization, comment recovery, and continuation-state seeding actions for
+  declarative HTML tokenizer definitions.
+
 ## [0.1.0] - 2026-04-23
 
 ### Added

--- a/code/packages/rust/state-machine-tokenizer/README.md
+++ b/code/packages/rust/state-machine-tokenizer/README.md
@@ -61,6 +61,7 @@ Comments and doctypes:
 - `append_comment(current_lowercase)`
 - `append_comment(literal)`
 - `append_comment_replacement`
+- `convert_temporary_buffer_to_comment`
 - `create_doctype`
 - `append_doctype_name(current)`
 - `append_doctype_name(current_lowercase)`
@@ -75,6 +76,12 @@ Comments and doctypes:
 - `append_doctype_system_identifier(literal)`
 - `append_doctype_system_identifier_replacement`
 - `mark_force_quirks`
+
+Processing instructions:
+
+- `finalize_processing_instruction_target`
+- `append_processing_instruction_data(current)`
+- `append_processing_instruction_data(literal)`
 
 Temporary buffers and controlled state changes:
 
@@ -128,6 +135,7 @@ The runtime also exposes context-seeding helpers such as
 `Tokenizer::set_initial_state`, `Tokenizer::set_last_start_tag`,
 `Tokenizer::set_current_start_tag` with `StartTagSeed`,
 `Tokenizer::set_current_end_tag`, `Tokenizer::set_current_comment`, and
+`Tokenizer::set_current_processing_instruction`,
 `Tokenizer::set_current_doctype` with `DoctypeSeed`, plus
 `Tokenizer::set_temporary_buffer` and `Tokenizer::set_return_state`, so wrapper
 packages can execute HTML submodes and continuation states like attribute value

--- a/code/packages/rust/state-machine-tokenizer/src/lib.rs
+++ b/code/packages/rust/state-machine-tokenizer/src/lib.rs
@@ -32,6 +32,13 @@ pub enum Token {
     },
     /// Comment token.
     Comment(String),
+    /// Processing instruction token.
+    ProcessingInstruction {
+        /// Processing-instruction target.
+        target: String,
+        /// Processing-instruction data.
+        data: String,
+    },
     /// Doctype token.
     Doctype {
         /// Optional doctype name.
@@ -396,6 +403,29 @@ impl Tokenizer {
         self.current_attribute = None;
     }
 
+    /// Seed the in-progress processing-instruction token used by continuation states.
+    pub fn with_current_processing_instruction(
+        mut self,
+        target: impl Into<String>,
+        data: impl Into<String>,
+    ) -> Self {
+        self.set_current_processing_instruction(target, data);
+        self
+    }
+
+    /// Store the in-progress processing-instruction token used by continuation states.
+    pub fn set_current_processing_instruction(
+        &mut self,
+        target: impl Into<String>,
+        data: impl Into<String>,
+    ) {
+        self.current_token = Some(CurrentToken::ProcessingInstruction {
+            target: target.into(),
+            data: data.into(),
+        });
+        self.current_attribute = None;
+    }
+
     /// Seed the in-progress DOCTYPE token used by tokenizer continuation states.
     pub fn with_current_doctype(mut self, doctype: DoctypeSeed) -> Self {
         self.set_current_doctype(doctype);
@@ -653,6 +683,37 @@ impl Tokenizer {
                     });
                     self.current_attribute = None;
                 }
+                "convert_temporary_buffer_to_comment" => {
+                    let mut data = String::from("?");
+                    data.push_str(&std::mem::take(&mut self.temporary_buffer));
+                    self.current_token = Some(CurrentToken::Comment { data });
+                    self.current_attribute = None;
+                }
+                "finalize_processing_instruction_target" => {
+                    let target = std::mem::take(&mut self.temporary_buffer);
+                    if target.eq_ignore_ascii_case("xml")
+                        || target.eq_ignore_ascii_case("xml-stylesheet")
+                    {
+                        let mut data = String::from("?");
+                        data.push_str(&target);
+                        self.current_token = Some(CurrentToken::Comment { data });
+                        self.current_attribute = None;
+                        self.diagnostics.push(Diagnostic {
+                            code: "disallowed-processing-instruction-target".to_string(),
+                            position,
+                            state: state.to_string(),
+                        });
+                        self.machine
+                            .set_current_state("bogus_comment".to_string())
+                            .map_err(TokenizerError::Machine)?;
+                    } else {
+                        self.current_token = Some(CurrentToken::ProcessingInstruction {
+                            target,
+                            data: String::new(),
+                        });
+                        self.current_attribute = None;
+                    }
+                }
                 "create_doctype" => {
                     self.current_token = Some(CurrentToken::Doctype {
                         name: None,
@@ -721,6 +782,12 @@ impl Tokenizer {
                 }
                 "append_comment_replacement" => {
                     self.append_comment(action, '\u{FFFD}', false)?;
+                }
+                "append_processing_instruction_data(current)" => {
+                    let ch = current.ok_or_else(|| TokenizerError::MissingCurrentCodePoint {
+                        action: action.clone(),
+                    })?;
+                    self.processing_instruction_data_mut(action)?.push(ch);
                 }
                 "append_doctype_name(current)" => {
                     let ch = current.ok_or_else(|| TokenizerError::MissingCurrentCodePoint {
@@ -986,6 +1053,15 @@ impl Tokenizer {
                         .trim_start_matches("append_comment(")
                         .trim_end_matches(')');
                     self.comment_data_mut(action)?.push_str(literal);
+                }
+                _ if action.starts_with("append_processing_instruction_data(")
+                    && action.ends_with(')') =>
+                {
+                    let literal = action
+                        .trim_start_matches("append_processing_instruction_data(")
+                        .trim_end_matches(')');
+                    self.processing_instruction_data_mut(action)?
+                        .push_str(literal);
                 }
                 _ if action.starts_with("append_doctype_name(") && action.ends_with(')') => {
                     let literal = action
@@ -1265,6 +1341,9 @@ impl Tokenizer {
             }
             CurrentToken::EndTag { name } => self.tokens.push_back(Token::EndTag { name }),
             CurrentToken::Comment { data } => self.tokens.push_back(Token::Comment(data)),
+            CurrentToken::ProcessingInstruction { target, data } => self
+                .tokens
+                .push_back(Token::ProcessingInstruction { target, data }),
             CurrentToken::Doctype {
                 name,
                 public_identifier,
@@ -1493,6 +1572,17 @@ impl Tokenizer {
         }
     }
 
+    fn processing_instruction_data_mut(&mut self, action: &str) -> Result<&mut String> {
+        match self.current_token_mut(action)? {
+            CurrentToken::ProcessingInstruction { data, .. } => Ok(data),
+            other => Err(TokenizerError::InvalidCurrentToken {
+                action: action.to_string(),
+                expected: "processing-instruction",
+                actual: other.kind_name(),
+            }),
+        }
+    }
+
     fn doctype_name_mut(&mut self, action: &str) -> Result<&mut String> {
         match self.current_token_mut(action)? {
             CurrentToken::Doctype { name, .. } => Ok(name.get_or_insert_with(String::new)),
@@ -1560,6 +1650,10 @@ enum CurrentToken {
     Comment {
         data: String,
     },
+    ProcessingInstruction {
+        target: String,
+        data: String,
+    },
     Doctype {
         name: Option<String>,
         public_identifier: Option<String>,
@@ -1574,6 +1668,7 @@ impl CurrentToken {
             Self::StartTag { .. } => "start-tag",
             Self::EndTag { .. } => "end-tag",
             Self::Comment { .. } => "comment",
+            Self::ProcessingInstruction { .. } => "processing-instruction",
             Self::Doctype { .. } => "doctype",
         }
     }

--- a/code/packages/rust/state-machine-tokenizer/tests/tokenizer_test.rs
+++ b/code/packages/rust/state-machine-tokenizer/tests/tokenizer_test.rs
@@ -369,6 +369,192 @@ fn tokenizer_appends_replacement_character_to_comments() {
 }
 
 #[test]
+fn tokenizer_builds_processing_instruction_tokens() {
+    let mut tokenizer = Tokenizer::new(
+        EffectfulStateMachine::new(
+            set(&[
+                "target",
+                "after_processing_instruction_target",
+                "processing_instruction_data",
+                "processing_instruction_questionable",
+                "bogus_comment",
+                "done",
+            ]),
+            set(&[" ", "d", "a", "t", "?", "x", ">"]),
+            vec![
+                EffectfulTransition::new(
+                    "target",
+                    EffectfulMatcher::Event(" ".to_string()),
+                    "after_processing_instruction_target",
+                )
+                .consuming(false)
+                .with_effects(&["finalize_processing_instruction_target"]),
+                EffectfulTransition::new(
+                    "after_processing_instruction_target",
+                    EffectfulMatcher::Event(" ".to_string()),
+                    "after_processing_instruction_target",
+                ),
+                EffectfulTransition::new(
+                    "after_processing_instruction_target",
+                    EffectfulMatcher::Event("d".to_string()),
+                    "processing_instruction_data",
+                )
+                .consuming(false),
+                EffectfulTransition::new(
+                    "processing_instruction_data",
+                    EffectfulMatcher::Event("d".to_string()),
+                    "processing_instruction_data",
+                )
+                .with_effects(&["append_processing_instruction_data(current)"]),
+                EffectfulTransition::new(
+                    "processing_instruction_data",
+                    EffectfulMatcher::Event("a".to_string()),
+                    "processing_instruction_data",
+                )
+                .with_effects(&["append_processing_instruction_data(current)"]),
+                EffectfulTransition::new(
+                    "processing_instruction_data",
+                    EffectfulMatcher::Event("t".to_string()),
+                    "processing_instruction_data",
+                )
+                .with_effects(&["append_processing_instruction_data(current)"]),
+                EffectfulTransition::new(
+                    "processing_instruction_data",
+                    EffectfulMatcher::Event("?".to_string()),
+                    "processing_instruction_questionable",
+                ),
+                EffectfulTransition::new(
+                    "processing_instruction_questionable",
+                    EffectfulMatcher::Event("x".to_string()),
+                    "processing_instruction_data",
+                )
+                .consuming(false)
+                .with_effects(&["append_processing_instruction_data(?)"]),
+                EffectfulTransition::new(
+                    "processing_instruction_data",
+                    EffectfulMatcher::Event("x".to_string()),
+                    "processing_instruction_data",
+                )
+                .with_effects(&["append_processing_instruction_data(current)"]),
+                EffectfulTransition::new(
+                    "processing_instruction_data",
+                    EffectfulMatcher::Event(">".to_string()),
+                    "done",
+                )
+                .with_effects(&["emit_current_token"]),
+            ],
+            "target".to_string(),
+            set(&["done"]),
+        )
+        .unwrap(),
+    )
+    .with_temporary_buffer("xml-model");
+
+    tokenizer.push(" data?x>").unwrap();
+
+    assert_eq!(
+        tokenizer.drain_tokens(),
+        vec![Token::ProcessingInstruction {
+            target: "xml-model".to_string(),
+            data: "data?x".to_string(),
+        }]
+    );
+}
+
+#[test]
+fn tokenizer_recovers_disallowed_processing_instruction_target_as_comment() {
+    let mut tokenizer = Tokenizer::new(
+        EffectfulStateMachine::new(
+            set(&[
+                "target",
+                "after_processing_instruction_target",
+                "bogus_comment",
+                "done",
+            ]),
+            set(&[" ", "d", "a", "t", ">"]),
+            vec![
+                EffectfulTransition::new(
+                    "target",
+                    EffectfulMatcher::Event(" ".to_string()),
+                    "after_processing_instruction_target",
+                )
+                .consuming(false)
+                .with_effects(&["finalize_processing_instruction_target"]),
+                EffectfulTransition::new(
+                    "bogus_comment",
+                    EffectfulMatcher::Event(">".to_string()),
+                    "done",
+                )
+                .with_effects(&["emit_current_token"]),
+                EffectfulTransition::new("bogus_comment", EffectfulMatcher::Any, "bogus_comment")
+                    .with_effects(&["append_comment(current)"]),
+            ],
+            "target".to_string(),
+            set(&["done"]),
+        )
+        .unwrap(),
+    )
+    .with_temporary_buffer("XmL");
+
+    tokenizer.push(" data>").unwrap();
+
+    assert_eq!(
+        tokenizer.drain_tokens(),
+        vec![Token::Comment("?XmL data".to_string())]
+    );
+    assert_eq!(
+        tokenizer
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| diagnostic.code.as_str())
+            .collect::<Vec<_>>(),
+        vec!["disallowed-processing-instruction-target"]
+    );
+}
+
+#[test]
+fn tokenizer_comment_recovery_preserves_processing_instruction_opener() {
+    let mut tokenizer = Tokenizer::new(
+        EffectfulStateMachine::new(
+            set(&["target", "bogus_comment", "done"]),
+            set(&["!", ">"]),
+            vec![
+                EffectfulTransition::new(
+                    "target",
+                    EffectfulMatcher::Event("!".to_string()),
+                    "bogus_comment",
+                )
+                .consuming(false)
+                .with_effects(&["convert_temporary_buffer_to_comment"]),
+                EffectfulTransition::new(
+                    "bogus_comment",
+                    EffectfulMatcher::Event("!".to_string()),
+                    "bogus_comment",
+                )
+                .with_effects(&["append_comment(current)"]),
+                EffectfulTransition::new(
+                    "bogus_comment",
+                    EffectfulMatcher::Event(">".to_string()),
+                    "done",
+                )
+                .with_effects(&["emit_current_token"]),
+            ],
+            "target".to_string(),
+            set(&["done"]),
+        )
+        .unwrap(),
+    )
+    .with_temporary_buffer("bad");
+
+    tokenizer.push("!>").unwrap();
+
+    assert_eq!(
+        tokenizer.drain_tokens(),
+        vec![Token::Comment("?bad!".to_string())]
+    );
+}
+
+#[test]
 fn tokenizer_builds_doctypes_and_marks_force_quirks() {
     let mut tokenizer = Tokenizer::new(
         EffectfulStateMachine::new(


### PR DESCRIPTION
## What changed

- add a browser-facing processing-instruction node to `dom-core`
- add processing-instruction token state and emission support to `state-machine-tokenizer`
- teach the HTML parser to preserve processing instructions anywhere comments are structurally permitted
- update lexer and parser test harnesses for exhaustive handling of the new token variant

## Why

The remaining upstream WPT tree-construction debt is dominated by processing-instruction cases. The parser previously had no DOM or token representation for them, so the conformance implementation could not be added without collapsing processing instructions into comments. This PR establishes the representation and transport seam while intentionally leaving WPT fixture import and conformance behavior to the next slice.

## Impact

There is no change to the explicit WPT missing-case ratchet in this plumbing-only PR. Existing tokenizer and parser behavior remains intact, while downstream code can now carry processing-instruction target/data losslessly.

## Validation

- `git diff --check origin/main...HEAD`
- affected crates compile from an isolated Cargo target: `dom-core`, `state-machine-tokenizer`, `coding-adventures-html-lexer`, and `coding-adventures-html-parser`
- lexer normalized-html5lib conformance: 9 passed
- HTML1 authoring coverage: 8 passed
- lexer regression suite: 201 passed

Workspace-wide and package-scoped `cargo fmt --check` currently report formatting drift on unchanged files already present on `main`; this PR does not include those unrelated rewrites.