### PR TITLE
feat(adj-formula-stdlib): shock-index — SI = heart rate ÷ systolic blood pressure definition library (clinical/hemodynamics)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_shock_index_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_shock_index_e2e.rs
@@ -1,0 +1,139 @@
+//! End-to-end tests for the `clinical/shock-index.adj` library — the definition of the shock
+//! index (SI = heart rate ÷ systolic blood pressure) and its two exact rearrangements — driven
+//! through the built CLI binary against the SHIPPED stdlib. The same invariant as every other
+//! formula library: a consumer states NO arithmetic; it imports the grounded library, binds the
+//! measured vitals with `observe`, and the engine applies the cited relation on the CPU,
+//! computing the EXACT value and rendering the relation's citation and trust tier in the
+//! `derived` section (the auditable answer). The three formulas INVERT around the worked case
+//! HR = 140 /min, SBP = 70 mmHg: 140 ÷ 70 = 2, 2 × 70 = 140, and 140 ÷ 2 = 70. The three
+//! asserted values (2, 140, 70) are chosen so none is a substring of another rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped shock-index library, resolved from this crate's manifest dir so
+/// the test is location-independent.
+fn shipped_si_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/shock-index.adj")
+        .canonicalize()
+        .expect("shipped shock-index.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_si_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_si_lib()).unwrap();
+    std::fs::write(dir.join("shock-index.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// shock_index — the definition: heart rate divided by systolic blood pressure.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_shock_index_library_and_computes_it_with_citation() {
+    let dir = scratch("si");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"shock-index.adj\"\n\
+         observe heart_rate(140)\n\
+         observe systolic_blood_pressure(70)\n\
+         ? shock_index(heart_rate, systolic_blood_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 140 ÷ 70 = 2.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"shock_index\"") && s.contains("\"value\":2"),
+        "shock_index(140, 70) = 2: {s}"
+    );
+    // … AND the review-article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// heart_rate — the same relation solved for HR: SI × SBP.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_heart_rate_from_shock_index_and_sbp_with_citation() {
+    let dir = scratch("hr");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"shock-index.adj\"\n\
+         observe shock_index(2)\n\
+         observe systolic_blood_pressure(70)\n\
+         ? heart_rate(shock_index, systolic_blood_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 2 × 70 = 140, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"heart_rate\"") && s.contains("\"value\":140"),
+        "heart_rate(2, 70) = 140: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "heart_rate carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// systolic_blood_pressure — the same relation solved for SBP: HR ÷ SI, the third reading of the
+// one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_sbp_from_heart_rate_and_shock_index_with_citation() {
+    let dir = scratch("sbp");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"shock-index.adj\"\n\
+         observe heart_rate(140)\n\
+         observe shock_index(2)\n\
+         ? systolic_blood_pressure(heart_rate, shock_index)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 140 ÷ 2 = 70, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"systolic_blood_pressure\"") && s.contains("\"value\":70"),
+        "systolic_blood_pressure(140, 2) = 70: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "systolic_blood_pressure carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/shock-index.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/shock-index.adj
@@ -1,0 +1,95 @@
+% ============================================================================
+% shock-index.adj — the definition of the shock index (SI = heart rate ÷ systolic
+% blood pressure) in the ADJ standard library.
+% ============================================================================
+% The shock-index entry of the *clinical* track, a hemodynamic bedside sibling of
+% `mean-arterial-pressure.adj` and `pulse-pressure.adj`. Where those combine the two cuff
+% pressures, this pairs the heart rate against the systolic pressure: THE SHOCK INDEX IS THE
+% HEART RATE DIVIDED BY THE SYSTOLIC BLOOD PRESSURE — a single dimensionless ratio that rises
+% as the heart rate climbs and the pressure falls, the classic early-shock signature (a normal
+% SI sits below ~0.8; higher values flag occult hypoperfusion before frank hypotension). It is
+% computed at the bedside with no equipment beyond the vitals already in hand, which is exactly
+% why it is a first-line triage number. It ships as an importable, byte-provenanced,
+% PARAMETERIZED `formula`, together with its two exact rearrangements (the heart rate a shock
+% index implies for a given pressure, and the systolic pressure it implies for a given rate). As
+% with every compute library, a consumer states NO arithmetic: it `import`s this file, binds the
+% measured vitals from its own byte-provenance decomposition, and asks the engine to APPLY the
+% cited definition on the CPU. Zero math is performed by the model; the engine computes each
+% value EXACTLY (over exact rationals), carrying the definition's citation.
+%
+%     import "shock-index.adj"
+%     observe heart_rate(140)              % "…heart rate 140 /min…"       (span cited by the model)
+%     observe systolic_blood_pressure(70)  % "…systolic BP 70 mmHg…"       (span cited by the model)
+%     ? shock_index(heart_rate, systolic_blood_pressure)
+%                                          % engine → 2, carrying SI = HR ÷ SBP
+%
+% All three formulas are EXACT over their parameters, so every value the engine returns is exact.
+% They COMPOSE and invert cleanly around the worked case heart rate = 140 /min, systolic blood
+% pressure = 70 mmHg (SI = 140 ÷ 70 = 2): the `shock_index` a consumer computes from the two
+% vitals is exactly the value the `heart_rate` formula multiplies back by the systolic pressure
+% to recover 140, and exactly the value the `systolic_blood_pressure` formula divides the heart
+% rate by to recover 70.
+%
+%   shock_index(heart_rate, systolic_blood_pressure)
+%       = heart_rate / systolic_blood_pressure      % SI  = HR ÷ SBP   (definition)
+%   heart_rate(shock_index, systolic_blood_pressure)
+%       = shock_index * systolic_blood_pressure     % HR  = SI × SBP   (solved for HR)
+%   systolic_blood_pressure(heart_rate, shock_index)
+%       = heart_rate / shock_index                  % SBP = HR ÷ SI    (solved for SBP)
+%
+% NOTE ON UNITS: the heart rate is per minute and the systolic blood pressure is in millimetres
+% of mercury; the shock index is DIMENSIONLESS (the units are conventionally dropped), and this
+% library computes the exact ratio over whatever consistent inputs it is given.
+%
+% All three formulas are defended by the SAME sentence — "Shock index (SI) is defined as the
+% heart rate (HR) divided by systolic blood pressure (SBP)" — because that one definition
+% (the shock index IS the heart-rate-over-systolic-pressure ratio) sanctions the relation read
+% every way. The quote is transcribed verbatim from a peer-reviewed review article archived on
+% the NCBI PMC repository, so each `formula` carries the provenance envelope every shipped
+% grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the sentence is a verbatim span of the cited page, not
+% asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable vital sign the definition ranges over, and each
+% result is a derived quantity. `heart_rate`, `systolic_blood_pressure` and `shock_index` each
+% appear BOTH as a derived result and as an input (of the other formulas), so each is a single
+% dictionary term used in both roles. The `surface` lists are the everyday names a decomposer
+% maps onto the canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary shock_index_vocab {
+    define heart_rate               : finding  surface "heart rate", "HR", "pulse"                          % beats per minute (/min)
+    define systolic_blood_pressure  : finding  surface "systolic blood pressure", "SBP", "systolic BP"      % millimetres of mercury (mmHg)
+    define shock_index              : finding  surface "shock index", "SI"                                  % dimensionless ratio
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the definitional sentence from the cited
+% review on the NCBI PMC repository (a quote is required on a shipped formula). Each is an exact
+% ratio or product of measured vitals, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook shock_index_laws {
+    use shock_index_vocab
+
+    % Shock index — the heart rate divided by the systolic blood pressure, i.e. SI = HR ÷ SBP.
+    formula shock_index(heart_rate, systolic_blood_pressure) = heart_rate / systolic_blood_pressure
+        source "Shock index (SI) is defined as the heart rate (HR) divided by systolic blood pressure (SBP)."
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC6698590/"
+        trust authoritative
+
+    % Heart rate — the same definition solved for the rate a shock index implies for a given
+    % systolic pressure (HR = SI × SBP). Defended by the SAME sentence.
+    formula heart_rate(shock_index, systolic_blood_pressure) = shock_index * systolic_blood_pressure
+        source "Shock index (SI) is defined as the heart rate (HR) divided by systolic blood pressure (SBP)."
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC6698590/"
+        trust authoritative
+
+    % Systolic blood pressure — the same definition solved for the pressure (SBP = HR ÷ SI): the
+    % heart rate divided by the shock index. The SAME sentence, read the third way.
+    formula systolic_blood_pressure(heart_rate, shock_index) = heart_rate / shock_index
+        source "Shock index (SI) is defined as the heart rate (HR) divided by systolic blood pressure (SBP)."
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC6698590/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/shock-index.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/shock-index.query.adj
@@ -1,0 +1,27 @@
+% ============================================================================
+% shock-index.query.adj — worked applications of the shock-index definition.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a triage vignette into observed vitals:
+% it `import`s the grounded formulabook, `observe`s the measured heart rate and systolic
+% pressure, and asks the engine to APPLY the cited definition. No arithmetic is stated by the
+% consumer; the engine computes each value EXACTLY (over exact rationals) and carries the review
+% article's citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (heart rate = 140 /min, systolic blood pressure = 70 mmHg): SI = 140 ÷ 70 = 2.
+% Each query below fixes two of the three quantities and asks the engine to recover the third;
+% every answer is exact and the three COMPOSE (each inversion recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli shock-index.query.adj
+% ============================================================================
+
+import "shock-index.adj"
+
+% --- Forward: the shock index the two vitals imply (expect 2). --------------------------------
+observe heart_rate(140)
+observe systolic_blood_pressure(70)
+? shock_index(heart_rate, systolic_blood_pressure)   % expect 2
+
+% --- Inverse: the heart rate a shock index of 2 implies at that pressure (expect 140). ---------
+observe shock_index(2)
+? heart_rate(shock_index, systolic_blood_pressure)   % expect 140


### PR DESCRIPTION
## What

Adds `clinical/shock-index.adj` to the ADJ formula standard library — the definition of the **shock index** — plus a worked `.query.adj` and a dedicated end-to-end test.

**SI = heart rate ÷ systolic blood pressure**

A high-yield bedside triage ratio: it rises as the heart rate climbs and the pressure falls, flagging occult hypoperfusion before frank hypotension (normal SI < ~0.8). Constant-free, directional, two-input. Ships the forward formula plus **two exact rearrangements** — HR = SI × SBP and SBP = HR ÷ SI — each carrying the same verbatim source, so the definition read any of three ways is one provenance envelope.

## Provenance (byte-verified)

Grounded verbatim in a peer-reviewed review archived on the NCBI PMC repository:

> "Shock index (SI) is defined as the heart rate (HR) divided by systolic blood pressure (SBP)."

- `locator`: https://pmc.ncbi.nlm.nih.gov/articles/PMC6698590/
- `trust authoritative` — primary, re-fetchable peer-reviewed reference.

## Worked case (all three invert exactly)

HR = 140 /min, SBP = 70 mmHg → **SI = 140 ÷ 70 = 2**. Each e2e test fixes two quantities and recovers the third. The three asserted values (2, 140, 70) are chosen so none is a substring of another rendered value.

## Invariant

A consumer states NO arithmetic: it `import`s the library, `observe`s its byte-provenance-decomposed vitals, and the engine APPLIES the cited relation on the CPU, computing each value EXACTLY (over exact rationals) and rendering the citation + trust tier in the auditable `derived` section. Zero model math.

## Testing

- `cargo test -p adj-lang-cli --test formula_shock_index_e2e` — 3/3 pass.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean.
- Render-probed against the built CLI (parses the new lib at runtime): forward → 2, inverse → 140, both carrying the PMC locator + `authoritative`.
- NUL-scanned all three new files (0 NUL bytes).
- `/security-review` — passed, no findings.

Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)