### PR TITLE
feat(spice): derive MOS KP from surface mobility

### DIFF
--- a/code/packages/python/mosfet-models/CHANGELOG.md
+++ b/code/packages/python/mosfet-models/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [0.1.0] — Unreleased
 
 ### Added
+- `Level1Params.U0` adds Berkeley zero-bias surface mobility with a
+  600 cm^2/V/s default and finite, non-negative validation.
 - `Level1Params.JS` adds zero-default Berkeley bulk-junction saturation-current
   density for source/drain area scaling while preserving scalar `IS`.
 - `Level1Params.MJSW` adds Berkeley sidewall-junction depletion grading,

--- a/code/packages/python/mosfet-models/src/mosfet_models/level1.py
+++ b/code/packages/python/mosfet-models/src/mosfet_models/level1.py
@@ -29,6 +29,7 @@ class Level1Params:
     L: float = 130e-9  # channel length (m)
     LD: float = 0.0  # source/drain lateral diffusion length (m)
     TOX: float = 1e-7  # gate oxide thickness (m)
+    U0: float = 600.0  # zero-bias surface mobility (cm^2/V/s)
     RD: float = 0.0  # external drain resistance (ohm)
     RS: float = 0.0  # external source resistance (ohm)
     RSH: float = 0.0  # drain/source sheet resistance (ohm per square)
@@ -135,6 +136,8 @@ def evaluate_level1(
         )
     if not isfinite(p.TOX) or p.TOX <= 0.0:
         raise ValueError("MOSFET TOX must be finite and positive")
+    if not isfinite(p.U0) or p.U0 < 0.0:
+        raise ValueError("MOSFET U0 must be finite and non-negative")
     if not isfinite(p.RD) or p.RD < 0.0:
         raise ValueError("MOSFET RD must be finite and non-negative")
     if not isfinite(p.RS) or p.RS < 0.0:

--- a/code/packages/python/mosfet-models/tests/test_models.py
+++ b/code/packages/python/mosfet-models/tests/test_models.py
@@ -81,6 +81,7 @@ def test_triode_id_formula():
 
 def test_id_increases_with_vgs_in_saturation():
     p = Level1Params()
+    assert p.U0 == 600.0
     r1 = evaluate_level1(p, V_GS=0.8, V_DS=1.8)
     r2 = evaluate_level1(p, V_GS=1.4, V_DS=1.8)
     assert r2.Id > r1.Id
@@ -165,6 +166,19 @@ def test_oxide_thickness_scales_intrinsic_gate_capacitance():
 def test_oxide_thickness_validates_positive_finite_value(tox):
     with pytest.raises(ValueError, match="MOSFET TOX must be finite and positive"):
         evaluate_level1(Level1Params(TOX=tox), V_GS=1.8, V_DS=1.8)
+
+
+@pytest.mark.parametrize("surface_mobility", [float("nan"), -1.0])
+def test_surface_mobility_validates_non_negative_finite_value(surface_mobility):
+    with pytest.raises(
+        ValueError,
+        match="MOSFET U0 must be finite and non-negative",
+    ):
+        evaluate_level1(
+            Level1Params(U0=surface_mobility),
+            V_GS=1.8,
+            V_DS=1.8,
+        )
 
 
 def test_drain_resistance_rejects_negative_value():

--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add Level-1 MOS model-card `U0` / `UO` surface mobility and derive `KP` from
+  explicit `TOX` when `KP` is omitted, preserving explicit-`KP` precedence.
 - Add Level-1 MOS model-card `JS` as bulk-junction saturation-current density,
   scaling source/drain leakage and shot noise by `AS` / `AD` when both areas
   are present and otherwise retaining Berkeley-compatible `IS` fallback.

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -11,6 +11,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
 
 from mosfet_models import MOSFET, Level1Model, Level1Params, MosfetType
+from mosfet_models.level1 import OXIDE_PERMITTIVITY
 
 from spice_engine.elements import (
     BJT,
@@ -311,8 +312,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "PNP": (41, 58, 13, 4),
     "NJF": (22, 30, 7, 3),
     "PJF": (22, 30, 7, 3),
-    "NMOS": (30, 37, 6, 3),
-    "PMOS": (30, 37, 6, 3),
+    "NMOS": (31, 39, 7, 3),
+    "PMOS": (31, 39, 7, 3),
 }
 
 
@@ -465,6 +466,8 @@ _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
     "L": "L",
     "LD": "LD",
     "TOX": "TOX",
+    "U0": "U0",
+    "UO": "U0",
     "RD": "RD",
     "RS": "RS",
     "RSH": "RSH",
@@ -1067,10 +1070,16 @@ def mosfet_from_model_card(
         raise ValueError(f"{name}: expected MOSFET model card, got {model.kind}")
     p = model.parameters
     defaults = Level1Params()
+    surface_mobility = p.get("U0", defaults.U0)
+    transconductance = p.get("KP", defaults.KP)
+    if "KP" not in p and "TOX" in p and p["TOX"] > 0.0:
+        transconductance = (
+            surface_mobility * 1.0e-4 * OXIDE_PERMITTIVITY / p["TOX"]
+        )
     params = replace(
         defaults,
         VT0=p.get("VT0", defaults.VT0),
-        KP=p.get("KP", defaults.KP),
+        KP=transconductance,
         LAMBDA=p.get("LAMBDA", defaults.LAMBDA),
         GAMMA=p.get("GAMMA", defaults.GAMMA),
         PHI=p.get("PHI", defaults.PHI),
@@ -1078,6 +1087,7 @@ def mosfet_from_model_card(
         L=p.get("L", defaults.L),
         LD=p.get("LD", defaults.LD),
         TOX=p.get("TOX", defaults.TOX),
+        U0=surface_mobility,
         RD=p.get("RD", defaults.RD),
         RS=p.get("RS", defaults.RS),
         RSH=p.get("RSH", defaults.RSH),

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -408,7 +408,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 201
+    assert len(coverage) == 203
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -423,7 +423,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tAF\tAF\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 201
+    assert len(records) == 203
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -446,13 +446,14 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert summary[0].max_alias_count == 3
     assert summary[0].aliased_parameters == ("IS", "VT", "CJO", "VJ", "M")
     assert summary[5].kind == "NMOS"
-    assert summary[5].canonical_parameter_count == 30
-    assert summary[5].accepted_name_count == 37
-    assert summary[5].aliased_parameter_count == 6
+    assert summary[5].canonical_parameter_count == 31
+    assert summary[5].accepted_name_count == 39
+    assert summary[5].aliased_parameter_count == 7
     assert summary[5].max_alias_count == 3
     assert summary[5].aliased_parameters == (
         "VT0",
         "LAMBDA",
+        "U0",
         "N_SUB",
         "T_NOM",
         "CBS",
@@ -469,7 +470,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert table.splitlines()[1] == "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M"
     assert (
         table.splitlines()[-1]
-        == "PMOS\t30\t37\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        == "PMOS\t31\t39\t7\t3\tVT0|LAMBDA|U0|N_SUB|T_NOM|CBS|CBD"
     )
     records = model_card_supported_parameter_coverage_summary_records()
     assert len(records) == 7
@@ -497,17 +498,17 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 201
-    assert report.expected_canonical_parameter_count == 201
-    assert report.accepted_name_count == 271
-    assert report.aliased_parameter_count == 57
+    assert report.canonical_parameter_count == 203
+    assert report.expected_canonical_parameter_count == 203
+    assert report.accepted_name_count == 275
+    assert report.aliased_parameter_count == 59
     assert report.max_alias_count == 4
     assert report.issues == ()
     assert format_model_card_supported_parameter_coverage_gate_report(report) == (
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t201\t201\t271\t57\t4\t0"
+        "true\t7\t7\t203\t203\t275\t59\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -535,15 +536,15 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 200
-    assert report.accepted_name_count == 268
-    assert report.aliased_parameter_count == 56
+    assert report.canonical_parameter_count == 202
+    assert report.accepted_name_count == 272
+    assert report.aliased_parameter_count == 58
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
     assert report.issues[0].field == "canonical_parameter_count"
     assert report.issues[0].message == (
-        "expected NMOS to expose 30 canonical supported parameters, found 29"
+        "expected NMOS to expose 31 canonical supported parameters, found 30"
     )
     assert report.issues[-1].field == "max_alias_count"
     assert report.issues[-1].message == "expected NMOS max alias count 3, found 2"
@@ -551,26 +552,26 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t200\t201\t268\t56\t4\t4\n"
+        "false\t7\t7\t202\t203\t272\t58\t4\t4\n"
         "kind\tfield\tmessage\n"
-        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 30 canonical "
-        "supported parameters, found 29\n"
-        "NMOS\taccepted_name_count\texpected NMOS to expose 37 accepted model-card "
-        "names, found 34\n"
-        "NMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing "
-        "parameters, found 5\n"
+        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 31 canonical "
+        "supported parameters, found 30\n"
+        "NMOS\taccepted_name_count\texpected NMOS to expose 39 accepted model-card "
+        "names, found 36\n"
+        "NMOS\taliased_parameter_count\texpected NMOS to expose 7 alias-bearing "
+        "parameters, found 6\n"
         "NMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     )
     records = model_card_supported_parameter_coverage_gate_issue_records(report)
     assert records[0] == {
         "kind": "NMOS",
         "field": "canonical_parameter_count",
-        "message": "expected NMOS to expose 30 canonical supported parameters, found 29",
+        "message": "expected NMOS to expose 31 canonical supported parameters, found 30",
     }
     assert format_model_card_supported_parameter_coverage_gate_issue_csv(report).startswith(
         "kind,field,message\n"
-        'NMOS,canonical_parameter_count,"expected NMOS to expose 30 canonical '
-        'supported parameters, found 29"\n'
+        'NMOS,canonical_parameter_count,"expected NMOS to expose 31 canonical '
+        'supported parameters, found 30"\n'
     )
     assert (
         json.loads(format_model_card_supported_parameter_coverage_gate_issue_json(report))
@@ -756,6 +757,7 @@ def test_model_card_aliases_build_device_instances() -> None:
             "IS": 4.0e-12,
             "JS": 2.0e-6,
             "TOX": 25.0e-9,
+            "UO": 500.0,
             "KF": 2.0e-24,
             "AF": 1.4,
         },
@@ -779,6 +781,7 @@ def test_model_card_aliases_build_device_instances() -> None:
         "IS": 4.0e-12,
         "JS": 2.0e-6,
         "TOX": 25.0e-9,
+        "U0": 500.0,
         "KF": 2.0e-24,
         "AF": 1.4,
     }
@@ -803,8 +806,42 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert pytest.approx(4.0e-12) == mos_model.model.model.params.IS
     assert pytest.approx(2.0e-6) == mos_model.model.model.params.JS
     assert pytest.approx(25.0e-9) == mos_model.model.model.params.TOX
+    assert pytest.approx(500.0) == mos_model.model.model.params.U0
+    assert pytest.approx(500.0 * 1.0e-4 * 3.453133e-11 / 25.0e-9) == (
+        mos_model.model.model.params.KP
+    )
     assert pytest.approx(2.0e-24) == mos_model.model.model.params.KF
     assert pytest.approx(1.4) == mos_model.model.model.params.AF
+
+
+def test_mos_model_card_surface_mobility_derives_kp_with_explicit_precedence() -> None:
+    default_mobility = mosfet_from_model_card(
+        "M1",
+        "d",
+        "g",
+        "s",
+        "b",
+        normalize_model_card("Mdefault", "nmos", {"TOX": 100.0e-9}),
+    )
+    assert pytest.approx(600.0) == default_mobility.model.model.params.U0
+    assert pytest.approx(600.0 * 1.0e-4 * 3.453133e-11 / 100.0e-9) == (
+        default_mobility.model.model.params.KP
+    )
+
+    explicit = mosfet_from_model_card(
+        "M2",
+        "d",
+        "g",
+        "s",
+        "b",
+        normalize_model_card(
+            "Mexplicit",
+            "nmos",
+            {"TOX": 100.0e-9, "U0": 500.0, "KP": 250.0e-6},
+        ),
+    )
+    assert pytest.approx(500.0) == explicit.model.model.params.U0
+    assert pytest.approx(250.0e-6) == explicit.model.model.params.KP
 
 
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Add Level-1 MOS model-card `U0` / `UO` surface mobility with the Berkeley
+  default of 600 cm^2/V/s. When `TOX` is explicit and `KP` is omitted, derive
+  `KP = U0 * Cox * 1e-4`; explicit `KP` retains precedence.
 - Add Level-1 MOS model-card `JS` as bulk-junction saturation-current density,
   scaling source/drain leakage and shot noise by `AS` / `AD` when both areas
   are present and otherwise retaining Berkeley-compatible `IS` fallback.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -3609,6 +3609,7 @@ pub struct MosfetLevel1Params {
     pub l: f64,
     pub lateral_diffusion_length: f64,
     pub oxide_thickness: f64,
+    pub surface_mobility: f64,
     pub drain_resistance: f64,
     pub source_resistance: f64,
     pub sheet_resistance: f64,
@@ -3649,6 +3650,7 @@ impl Default for MosfetLevel1Params {
             l: 130.0e-9,
             lateral_diffusion_length: 0.0,
             oxide_thickness: 1.0e-7,
+            surface_mobility: 600.0,
             drain_resistance: 0.0,
             source_resistance: 0.0,
             sheet_resistance: 0.0,
@@ -4018,8 +4020,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     (ModelCardKind::Pnp, 41, 58, 13, 4),
     (ModelCardKind::Njf, 22, 30, 7, 3),
     (ModelCardKind::Pjf, 22, 30, 7, 3),
-    (ModelCardKind::Nmos, 30, 37, 6, 3),
-    (ModelCardKind::Pmos, 30, 37, 6, 3),
+    (ModelCardKind::Nmos, 31, 39, 7, 3),
+    (ModelCardKind::Pmos, 31, 39, 7, 3),
 ];
 const DIODE_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IS", "IS"),
@@ -4150,6 +4152,8 @@ const MOS_LEVEL1_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("L", "L"),
     ("LD", "LD"),
     ("TOX", "TOX"),
+    ("U0", "U0"),
+    ("UO", "U0"),
     ("RD", "RD"),
     ("RS", "RS"),
     ("RSH", "RSH"),
@@ -4915,9 +4919,6 @@ pub fn mosfet_from_model_card(
     if let Some(value) = model.parameters.get("VT0") {
         params.vt0 = *value;
     }
-    if let Some(value) = model.parameters.get("KP") {
-        params.kp = *value;
-    }
     if let Some(value) = model.parameters.get("LAMBDA") {
         params.lambda = *value;
     }
@@ -4938,6 +4939,14 @@ pub fn mosfet_from_model_card(
     }
     if let Some(value) = model.parameters.get("TOX") {
         params.oxide_thickness = *value;
+    }
+    if let Some(value) = model.parameters.get("U0") {
+        params.surface_mobility = *value;
+    }
+    if let Some(value) = model.parameters.get("KP") {
+        params.kp = *value;
+    } else if model.parameters.contains_key("TOX") && params.oxide_thickness > 0.0 {
+        params.kp = params.surface_mobility * 1.0e-4 * OXIDE_PERMITTIVITY / params.oxide_thickness;
     }
     if let Some(value) = model.parameters.get("RD") {
         params.drain_resistance = *value;
@@ -25900,6 +25909,7 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         ("CJ", params.bottom_junction_capacitance),
         ("CJSW", params.sidewall_junction_capacitance),
         ("TOX", params.oxide_thickness),
+        ("U0", params.surface_mobility),
         ("IS", params.saturation_current),
         ("JS", params.saturation_current_density),
         ("N_SUB", params.n_sub),
@@ -26013,6 +26023,12 @@ fn validate_mosfet(mosfet: &Mosfet) -> Result<(), SpiceError> {
         return Err(SpiceError::InvalidElement {
             name: mosfet.name.clone(),
             reason: "MOSFET TOX must be positive".to_string(),
+        });
+    }
+    if params.surface_mobility < 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "MOSFET U0 must be non-negative".to_string(),
         });
     }
     if params.phi <= 0.0 {

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -95,7 +95,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 201);
+    assert_eq!(coverage.len(), 203);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -114,7 +114,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tAF\tAF\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 201);
+    assert_eq!(records.len(), 203);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -147,13 +147,13 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         vec!["IS", "VT", "CJO", "VJ", "M"]
     );
     assert_eq!(summary[5].kind, ModelCardKind::Nmos);
-    assert_eq!(summary[5].canonical_parameter_count, 30);
-    assert_eq!(summary[5].accepted_name_count, 37);
-    assert_eq!(summary[5].aliased_parameter_count, 6);
+    assert_eq!(summary[5].canonical_parameter_count, 31);
+    assert_eq!(summary[5].accepted_name_count, 39);
+    assert_eq!(summary[5].aliased_parameter_count, 7);
     assert_eq!(summary[5].max_alias_count, 3);
     assert_eq!(
         summary[5].aliased_parameters,
-        vec!["VT0", "LAMBDA", "N_SUB", "T_NOM", "CBS", "CBD"]
+        vec!["VT0", "LAMBDA", "U0", "N_SUB", "T_NOM", "CBS", "CBD"]
     );
     assert_eq!(summary.last().unwrap().kind, ModelCardKind::Pmos);
 
@@ -166,7 +166,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     assert_eq!(lines[1], "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\t30\t37\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD"
+        &"PMOS\t31\t39\t7\t3\tVT0|LAMBDA|U0|N_SUB|T_NOM|CBS|CBD"
     );
     let records = model_card_supported_parameter_coverage_summary_records();
     assert_eq!(records.len(), 7);
@@ -184,7 +184,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         "[{\"kind\":\"D\",\"canonical_parameter_count\":\"15\",\"accepted_name_count\":\"21\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
     ));
     assert!(json.ends_with(
-        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"30\",\"accepted_name_count\":\"37\",\"aliased_parameter_count\":\"6\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|N_SUB|T_NOM|CBS|CBD\"}]\n"
+        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"31\",\"accepted_name_count\":\"39\",\"aliased_parameter_count\":\"7\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|U0|N_SUB|T_NOM|CBS|CBD\"}]\n"
     ));
 }
 
@@ -195,15 +195,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 201);
-    assert_eq!(report.expected_canonical_parameter_count, 201);
-    assert_eq!(report.accepted_name_count, 271);
-    assert_eq!(report.aliased_parameter_count, 57);
+    assert_eq!(report.canonical_parameter_count, 203);
+    assert_eq!(report.expected_canonical_parameter_count, 203);
+    assert_eq!(report.accepted_name_count, 275);
+    assert_eq!(report.aliased_parameter_count, 59);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t201\t201\t271\t57\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t203\t203\t275\t59\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -230,16 +230,16 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 200);
-    assert_eq!(report.accepted_name_count, 268);
-    assert_eq!(report.aliased_parameter_count, 56);
+    assert_eq!(report.canonical_parameter_count, 202);
+    assert_eq!(report.accepted_name_count, 272);
+    assert_eq!(report.aliased_parameter_count, 58);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
     assert_eq!(report.issues[0].kind, "NMOS");
     assert_eq!(report.issues[0].field, "canonical_parameter_count");
     assert_eq!(
         report.issues[0].message,
-        "expected NMOS to expose 30 canonical supported parameters, found 29"
+        "expected NMOS to expose 31 canonical supported parameters, found 30"
     );
     assert_eq!(report.issues.last().unwrap().field, "max_alias_count");
     assert_eq!(
@@ -248,20 +248,20 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t200\t201\t268\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 30 canonical supported parameters, found 29\nNMOS\taccepted_name_count\texpected NMOS to expose 37 accepted model-card names, found 34\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t202\t203\t272\t58\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 31 canonical supported parameters, found 30\nNMOS\taccepted_name_count\texpected NMOS to expose 39 accepted model-card names, found 36\nNMOS\taliased_parameter_count\texpected NMOS to expose 7 alias-bearing parameters, found 6\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
     assert_eq!(records[0]["field"], "canonical_parameter_count");
     assert_eq!(
         records[0]["message"],
-        "expected NMOS to expose 30 canonical supported parameters, found 29"
+        "expected NMOS to expose 31 canonical supported parameters, found 30"
     );
     assert!(format_model_card_supported_parameter_coverage_gate_issue_csv(&report).starts_with(
-        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 30 canonical supported parameters, found 29\"\n"
+        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 31 canonical supported parameters, found 30\"\n"
     ));
     assert!(format_model_card_supported_parameter_coverage_gate_issue_json(&report).starts_with(
-        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 30 canonical supported parameters, found 29\"}"
+        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 31 canonical supported parameters, found 30\"}"
     ));
 }
 
@@ -283,8 +283,8 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(dashboard[0].issue_count, 0);
     assert!(dashboard[0].issue_fields.is_empty());
     assert_eq!(dashboard[5].kind, ModelCardKind::Nmos);
-    assert_eq!(dashboard[5].canonical_parameter_count, 30);
-    assert_eq!(dashboard[5].accepted_name_count, 37);
+    assert_eq!(dashboard[5].canonical_parameter_count, 31);
+    assert_eq!(dashboard[5].accepted_name_count, 39);
     assert_eq!(dashboard[5].issue_count, 0);
 
     let table = format_model_card_supported_parameter_coverage_dashboard_table(&coverage);
@@ -296,7 +296,7 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(lines[1], "D\ttrue\t15\t15\t21\t21\t5\t5\t3\t3\t0\t");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\ttrue\t30\t30\t37\t37\t6\t6\t3\t3\t0\t"
+        &"PMOS\ttrue\t31\t31\t39\t39\t7\t7\t3\t3\t0\t"
     );
     let records = model_card_supported_parameter_coverage_dashboard_records(&coverage);
     assert_eq!(records.len(), 7);
@@ -328,12 +328,12 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         .unwrap();
 
     assert!(!nmos.passed);
-    assert_eq!(nmos.canonical_parameter_count, 29);
-    assert_eq!(nmos.expected_canonical_parameter_count, 30);
-    assert_eq!(nmos.accepted_name_count, 34);
-    assert_eq!(nmos.expected_accepted_name_count, 37);
-    assert_eq!(nmos.aliased_parameter_count, 5);
-    assert_eq!(nmos.expected_aliased_parameter_count, 6);
+    assert_eq!(nmos.canonical_parameter_count, 30);
+    assert_eq!(nmos.expected_canonical_parameter_count, 31);
+    assert_eq!(nmos.accepted_name_count, 36);
+    assert_eq!(nmos.expected_accepted_name_count, 39);
+    assert_eq!(nmos.aliased_parameter_count, 6);
+    assert_eq!(nmos.expected_aliased_parameter_count, 7);
     assert_eq!(nmos.max_alias_count, 2);
     assert_eq!(nmos.expected_max_alias_count, 3);
     assert_eq!(nmos.issue_count, 4);
@@ -347,7 +347,7 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         ]
     );
     assert!(format_model_card_supported_parameter_coverage_dashboard_table(&coverage).contains(
-        "NMOS\tfalse\t29\t30\t34\t37\t5\t6\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
+        "NMOS\tfalse\t30\t31\t36\t39\t6\t7\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
     ));
 }
 
@@ -602,6 +602,7 @@ fn model_card_aliases_build_device_instances() {
             ("JS", 2.0e-3),
             ("CJ", 2.0e-3),
             ("TOX", 25.0e-9),
+            ("UO", 500.0),
             ("KF", 2.0e-24),
             ("AF", 1.4),
         ],
@@ -624,6 +625,7 @@ fn model_card_aliases_build_device_instances() {
     assert_close(*mos_card.parameters.get("JS").unwrap(), 2.0e-3);
     assert_close(*mos_card.parameters.get("CJ").unwrap(), 2.0e-3);
     assert_close(*mos_card.parameters.get("TOX").unwrap(), 25.0e-9);
+    assert_close(*mos_card.parameters.get("U0").unwrap(), 500.0);
     assert_close(*mos_card.parameters.get("KF").unwrap(), 2.0e-24);
     assert_close(*mos_card.parameters.get("AF").unwrap(), 1.4);
     assert_eq!(mos_model.mosfet_type, MosfetType::Nmos);
@@ -645,8 +647,31 @@ fn model_card_aliases_build_device_instances() {
     assert_close(mos_model.params.source_squares, 1.0);
     assert_close(mos_model.params.bottom_junction_capacitance, 2.0e-3);
     assert_close(mos_model.params.oxide_thickness, 25.0e-9);
+    assert_close(mos_model.params.surface_mobility, 500.0);
+    assert_close(
+        mos_model.params.kp,
+        500.0 * 1.0e-4 * 3.453_133e-11 / 25.0e-9,
+    );
     assert_close(mos_model.params.flicker_noise_coefficient, 2.0e-24);
     assert_close(mos_model.params.flicker_noise_exponent, 1.4);
+}
+
+#[test]
+fn mos_model_card_surface_mobility_derives_kp_with_explicit_precedence() {
+    let default_mobility = normalize_model_card("Mdefault", "nmos", &[("TOX", 100.0e-9)]).unwrap();
+    let derived = mosfet_from_model_card("M1", "d", "g", "s", "b", &default_mobility).unwrap();
+    assert_close(derived.params.surface_mobility, 600.0);
+    assert_close(derived.params.kp, 600.0 * 1.0e-4 * 3.453_133e-11 / 100.0e-9);
+
+    let explicit = normalize_model_card(
+        "Mexplicit",
+        "nmos",
+        &[("TOX", 100.0e-9), ("U0", 500.0), ("KP", 250.0e-6)],
+    )
+    .unwrap();
+    let explicit = mosfet_from_model_card("M2", "d", "g", "s", "b", &explicit).unwrap();
+    assert_close(explicit.params.surface_mobility, 500.0);
+    assert_close(explicit.params.kp, 250.0e-6);
 }
 
 #[test]
@@ -4018,6 +4043,38 @@ fn dc_mosfet_rejects_invalid_oxide_thickness() {
                     "MOSFET TOX must be positive".to_string()
                 } else {
                     "MOSFET TOX must be finite".to_string()
+                },
+            }
+        );
+    }
+}
+
+#[test]
+fn dc_mosfet_rejects_invalid_surface_mobility() {
+    for surface_mobility in [f64::NAN, -1.0] {
+        let mut circuit = Circuit::new();
+        circuit.add(Element::Mosfet(Mosfet::with_model(
+            "Mbad",
+            "drain",
+            "gate",
+            "0",
+            "0",
+            MosfetType::Nmos,
+            MosfetLevel1Params {
+                surface_mobility,
+                ..MosfetLevel1Params::default()
+            },
+        )));
+
+        let err = dc_op(&circuit).unwrap_err();
+        assert_eq!(
+            err,
+            SpiceError::InvalidElement {
+                name: "Mbad".to_string(),
+                reason: if surface_mobility.is_finite() {
+                    "MOSFET U0 must be non-negative".to_string()
+                } else {
+                    "MOSFET U0 must be finite".to_string()
                 },
             }
         );

--- a/code/packages/rust/spice-netlist-parser/CHANGELOG.md
+++ b/code/packages/rust/spice-netlist-parser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Preserve Level-1 MOS model-card `U0` / `UO` and derive `KP` from surface
+  mobility and explicit `TOX` when the card omits `KP`.
 - Preserve Level-1 MOS model-card `JS` independently from scalar `IS` so
   Berkeley netlists can drive diffusion-area-scaled bulk-junction leakage.
 - Preserve the remaining supported Level-1 MOS model-card fields `LD`, `TOX`,

--- a/code/packages/rust/spice-netlist-parser/README.md
+++ b/code/packages/rust/spice-netlist-parser/README.md
@@ -758,8 +758,8 @@ This parser supports `R`, `C`, `L`, `V`, `I`, `D`, `Q`, `M`, `G`, `E`, `F`, and
 parameters, `.model <name> NPN|PNP(...)` BJT cards with `IS`, `BF` /
 `BETA_F`, `VT`, `CJE`, `CJC`, `TF`, and `TR` parameters,
 `.model <name> NMOS|PMOS(...)` Level-1 MOSFET
-cards with common SPICE aliases (`VT0` / `VTO` / `VTH`, `KP`, `LAMBDA` /
-`LAM`, `GAMMA`, `PHI`, `W`, `L`, `LD`, `TOX`, `RD`, `RS`, `RSH`, `IS`, `JS`,
+cards with common SPICE aliases (`VT0` / `VTO` / `VTH`, `KP`, `U0` / `UO`,
+`LAMBDA` / `LAM`, `GAMMA`, `PHI`, `W`, `L`, `LD`, `TOX`, `RD`, `RS`, `RSH`, `IS`, `JS`,
 `N_SUB` / `NSUB`, `T_NOM` / `TNOM`, `CGSO`, `CGDO`, `CGBO`, `CBS` / `CJS`,
 `CBD` / `CJD`, `CJ`, `CJSW`, `PB`, `MJ`, `MJSW`, `FC`, `KF`, and `AF`), MOS instance `NRD=<squares>` /
 `NRS=<squares>` / `AD=<area>` / `AS=<area>` / `PD=<perimeter>` /

--- a/code/packages/rust/spice-netlist-parser/src/lib.rs
+++ b/code/packages/rust/spice-netlist-parser/src/lib.rs
@@ -12,6 +12,8 @@ use spice_engine::{
     TransmissionLine, Vccs, Vcvs, VoltageSource, Waveform,
 };
 
+const OXIDE_PERMITTIVITY: f64 = 3.453_133e-11;
+
 mod syntax;
 
 pub use syntax::{
@@ -1899,6 +1901,11 @@ fn build_mosfet_params(
     for (name, value) in model.params.iter().chain(instance_params.iter()) {
         apply_mosfet_param(&mut params, name, *value);
     }
+    if !model.params.contains_key("KP") && !instance_params.contains_key("KP") {
+        if let Some(oxide_thickness) = model.params.get("TOX").filter(|value| **value > 0.0) {
+            params.kp = params.surface_mobility * 1.0e-4 * OXIDE_PERMITTIVITY / oxide_thickness;
+        }
+    }
     if let Some(value) = instance_params.get("NRD") {
         params.drain_squares = *value;
     }
@@ -1931,6 +1938,7 @@ fn apply_mosfet_param(params: &mut MosfetLevel1Params, name: &str, value: f64) {
         "L" => params.l = value,
         "LD" => params.lateral_diffusion_length = value,
         "TOX" => params.oxide_thickness = value,
+        "U0" | "UO" => params.surface_mobility = value,
         "RD" => params.drain_resistance = value,
         "RS" => params.source_resistance = value,
         "RSH" => params.sheet_resistance = value,

--- a/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
+++ b/code/packages/rust/spice-netlist-parser/tests/spice_netlist_parser_test.rs
@@ -1359,7 +1359,7 @@ Jpull drain gate source pch
 fn parses_mosfet_models_into_operating_point_circuits() {
     let parsed = parse_netlist(
         r#"
-.model nch NMOS(VTO=0.45 KP=250u LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n LD=10n TOX=20n RD=10 RS=20 RSH=250 IS=4p JS=2m NSUB=1.5 TNOM=300 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p CJ=2m CJSW=5u PB=0.9 MJ=0.45 MJSW=0.25 FC=0.4 KF=1p AF=1.2)
+.model nch NMOS(VTO=0.45 KP=250u UO=500 LAMBDA=0.02 GAMMA=0.3 PHI=0.8 W=2u L=180n LD=10n TOX=20n RD=10 RS=20 RSH=250 IS=4p JS=2m NSUB=1.5 TNOM=300 CGSO=3p CGDO=4p CGBO=5p CBS=6p CBD=7p CJ=2m CJSW=5u PB=0.9 MJ=0.45 MJSW=0.25 FC=0.4 KF=1p AF=1.2)
 Vdd vdd 0 DC 5
 Vgate gate 0 DC 2.5
 M1 vdd gate out 0 nch W=4u L=200n NRD=2 NRS=3 AD=3n AS=4n PD=6u PS=7u
@@ -1387,6 +1387,7 @@ Rload out 0 1k
     assert_eq!(mosfet.mosfet_type, MosfetType::Nmos);
     assert_close(mosfet.params.vt0, 0.45);
     assert_close(mosfet.params.kp, 250.0e-6);
+    assert_close(mosfet.params.surface_mobility, 500.0);
     assert_close(mosfet.params.lambda, 0.02);
     assert_close(mosfet.params.gamma, 0.3);
     assert_close(mosfet.params.phi, 0.8);
@@ -1425,6 +1426,17 @@ Rload out 0 1k
     let out = result.voltage("out").unwrap();
     assert!(out > 0.0, "expected source follower output, got {out}");
     assert!(out < 2.5, "expected source below gate bias, got {out}");
+}
+
+#[test]
+fn derives_mosfet_transconductance_from_surface_mobility_and_oxide_thickness() {
+    let parsed = parse_netlist(".model mobile NMOS(TOX=100n UO=500)\nM1 d g s b mobile\n").unwrap();
+
+    let Element::Mosfet(mosfet) = &parsed.circuit.elements()[0] else {
+        panic!("expected MOSFET");
+    };
+    assert_close(mosfet.params.surface_mobility, 500.0);
+    assert_close(mosfet.params.kp, 500.0 * 1.0e-4 * 3.453_133e-11 / 100.0e-9);
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add Level-1 MOS model-card `U0` / `UO` surface mobility and derive `KP` from
+  explicit `TOX` when `KP` is omitted, preserving explicit-`KP` precedence.
 - Add Level-1 MOS model-card `JS` as bulk-junction saturation-current density,
   scaling source/drain leakage and shot noise by `AS` / `AD` when both areas
   are present and otherwise retaining Berkeley-compatible `IS` fallback.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -1777,6 +1777,7 @@ export interface MosfetLevel1Params {
   readonly L: number;
   readonly LD: number;
   readonly TOX: number;
+  readonly U0: number;
   readonly RD: number;
   readonly RS: number;
   readonly RSH: number;
@@ -2062,8 +2063,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   PNP: [41, 58, 13, 4],
   NJF: [22, 30, 7, 3],
   PJF: [22, 30, 7, 3],
-  NMOS: [30, 37, 6, 3],
-  PMOS: [30, 37, 6, 3],
+  NMOS: [31, 39, 7, 3],
+  PMOS: [31, 39, 7, 3],
 };
 
 export interface Vccs {
@@ -8047,6 +8048,7 @@ export function defaultMosfetLevel1Params(): MosfetLevel1Params {
     L: 130.0e-9,
     LD: 0.0,
     TOX: 1.0e-7,
+    U0: 600.0,
     RD: 0.0,
     RS: 0.0,
     RSH: 0.0,
@@ -8247,6 +8249,8 @@ const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   L: "L",
   LD: "LD",
   TOX: "TOX",
+  U0: "U0",
+  UO: "U0",
   RD: "RD",
   RS: "RS",
   RSH: "RSH",
@@ -8818,9 +8822,15 @@ export function mosfetFromModelCard(
     throw invalidElement(name, `expected MOSFET model card, got ${model.kind}`);
   }
   const p = model.parameters;
+  const surfaceMobility = p.U0 ?? 600.0;
+  const transconductance =
+    p.KP ??
+    (p.TOX !== undefined && p.TOX > 0.0
+      ? surfaceMobility * 1.0e-4 * OXIDE_PERMITTIVITY / p.TOX
+      : undefined);
   const params: Partial<MosfetLevel1Params> = {
     ...(p.VT0 !== undefined ? { VT0: p.VT0 } : {}),
-    ...(p.KP !== undefined ? { KP: p.KP } : {}),
+    ...(transconductance !== undefined ? { KP: transconductance } : {}),
     ...(p.LAMBDA !== undefined ? { LAMBDA: p.LAMBDA } : {}),
     ...(p.GAMMA !== undefined ? { GAMMA: p.GAMMA } : {}),
     ...(p.PHI !== undefined ? { PHI: p.PHI } : {}),
@@ -8828,6 +8838,7 @@ export function mosfetFromModelCard(
     ...(p.L !== undefined ? { L: p.L } : {}),
     ...(p.LD !== undefined ? { LD: p.LD } : {}),
     ...(p.TOX !== undefined ? { TOX: p.TOX } : {}),
+    U0: surfaceMobility,
     ...(p.RD !== undefined ? { RD: p.RD } : {}),
     ...(p.RS !== undefined ? { RS: p.RS } : {}),
     ...(p.RSH !== undefined ? { RSH: p.RSH } : {}),
@@ -21316,6 +21327,9 @@ function validateMosfet(element: Mosfet): void {
   }
   if (params.TOX <= 0.0) {
     throw invalidElement(element.name, "MOSFET TOX must be positive");
+  }
+  if (params.U0 < 0.0) {
+    throw invalidElement(element.name, "MOSFET U0 must be non-negative");
   }
   if (params.PHI <= 0.0) {
     throw invalidElement(element.name, "MOSFET PHI must be positive");

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -121,7 +121,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(201);
+    expect(coverage).toHaveLength(203);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -141,7 +141,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tAF\tAF\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(201);
+    expect(records).toHaveLength(203);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -167,11 +167,11 @@ describe("dcOp", () => {
     });
     expect(summary[5]).toStrictEqual({
       kind: "NMOS",
-      canonicalParameterCount: 30,
-      acceptedNameCount: 37,
-      aliasedParameterCount: 6,
+      canonicalParameterCount: 31,
+      acceptedNameCount: 39,
+      aliasedParameterCount: 7,
       maxAliasCount: 3,
-      aliasedParameters: ["VT0", "LAMBDA", "N_SUB", "T_NOM", "CBS", "CBD"],
+      aliasedParameters: ["VT0", "LAMBDA", "U0", "N_SUB", "T_NOM", "CBS", "CBD"],
     });
     expect(summary.at(-1)?.kind).toBe("PMOS");
 
@@ -181,7 +181,7 @@ describe("dcOp", () => {
     );
     expect(table.split("\n")[1]).toBe("D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     expect(table.split("\n").at(-1)).toBe(
-      "PMOS\t30\t37\t6\t3\tVT0|LAMBDA|N_SUB|T_NOM|CBS|CBD",
+      "PMOS\t31\t39\t7\t3\tVT0|LAMBDA|U0|N_SUB|T_NOM|CBS|CBD",
     );
     const records = modelCardSupportedParameterCoverageSummaryRecords();
     expect(records).toHaveLength(7);
@@ -206,15 +206,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 201,
-      expectedCanonicalParameterCount: 201,
-      acceptedNameCount: 271,
-      aliasedParameterCount: 57,
+      canonicalParameterCount: 203,
+      expectedCanonicalParameterCount: 203,
+      acceptedNameCount: 275,
+      aliasedParameterCount: 59,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t201\t201\t271\t57\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t203\t203\t275\t59\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -237,15 +237,15 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(200);
-    expect(report.acceptedNameCount).toBe(268);
-    expect(report.aliasedParameterCount).toBe(56);
+    expect(report.canonicalParameterCount).toBe(202);
+    expect(report.acceptedNameCount).toBe(272);
+    expect(report.aliasedParameterCount).toBe(58);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 30 canonical supported parameters, found 29",
+      message: "expected NMOS to expose 31 canonical supported parameters, found 30",
     });
     expect(report.issues.at(-1)).toStrictEqual({
       kind: "NMOS",
@@ -253,16 +253,16 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t200\t201\t268\t56\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 30 canonical supported parameters, found 29\nNMOS\taccepted_name_count\texpected NMOS to expose 37 accepted model-card names, found 34\nNMOS\taliased_parameter_count\texpected NMOS to expose 6 alias-bearing parameters, found 5\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t202\t203\t272\t58\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 31 canonical supported parameters, found 30\nNMOS\taccepted_name_count\texpected NMOS to expose 39 accepted model-card names, found 36\nNMOS\taliased_parameter_count\texpected NMOS to expose 7 alias-bearing parameters, found 6\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 30 canonical supported parameters, found 29",
+      message: "expected NMOS to expose 31 canonical supported parameters, found 30",
     });
     expect(formatModelCardSupportedParameterCoverageGateIssueCsv(report)).toMatch(
-      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 30 canonical supported parameters, found 29"\n/,
+      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 31 canonical supported parameters, found 30"\n/,
     );
     expect(JSON.parse(formatModelCardSupportedParameterCoverageGateIssueJson(report))).toStrictEqual(
       records,
@@ -427,6 +427,7 @@ describe("dcOp", () => {
       JS: 2.0e-3,
       CJ: 2.0e-3,
       TOX: 25.0e-9,
+      UO: 500.0,
       KF: 2.0e-24,
       AF: 1.4,
     });
@@ -449,6 +450,7 @@ describe("dcOp", () => {
       JS: 2.0e-3,
       CJ: 2.0e-3,
       TOX: 25.0e-9,
+      U0: 500.0,
       KF: 2.0e-24,
       AF: 1.4,
     });
@@ -471,8 +473,38 @@ describe("dcOp", () => {
     expectClose(mosModel.params.NRS, 1.0);
     expectClose(mosModel.params.CJ, 2.0e-3);
     expectClose(mosModel.params.TOX, 25.0e-9);
+    expectClose(mosModel.params.U0, 500.0);
+    expectClose(mosModel.params.KP, 500.0 * 1.0e-4 * 3.453133e-11 / 25.0e-9);
     expectClose(mosModel.params.KF, 2.0e-24);
     expectClose(mosModel.params.AF, 1.4);
+  });
+
+  it("derives MOS KP from surface mobility with explicit-KP precedence", () => {
+    const defaultMobility = mosfetFromModelCard(
+      "M1",
+      "d",
+      "g",
+      "s",
+      "b",
+      normalizeModelCard("Mdefault", "nmos", { TOX: 100.0e-9 }),
+    );
+    expectClose(defaultMobility.params.U0, 600.0);
+    expectClose(defaultMobility.params.KP, 600.0 * 1.0e-4 * 3.453133e-11 / 100.0e-9);
+
+    const explicit = mosfetFromModelCard(
+      "M2",
+      "d",
+      "g",
+      "s",
+      "b",
+      normalizeModelCard("Mexplicit", "nmos", {
+        TOX: 100.0e-9,
+        U0: 500.0,
+        KP: 250.0e-6,
+      }),
+    );
+    expectClose(explicit.params.U0, 500.0);
+    expectClose(explicit.params.KP, 250.0e-6);
   });
 
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
@@ -2554,6 +2586,20 @@ describe("dcOp", () => {
         Number.isFinite(oxideThickness)
           ? "MOSFET TOX must be positive"
           : "MOSFET TOX must be finite",
+      );
+    }
+  });
+
+  it("rejects invalid MOSFET surface mobilities", () => {
+    for (const surfaceMobility of [Number.NaN, -1.0]) {
+      const circuit = new Circuit();
+      circuit.add(mosfet("Mbad", "drain", "gate", "0", "0", "NMOS", {
+        U0: surfaceMobility,
+      }));
+      expect(() => dcOp(circuit)).toThrowError(
+        Number.isFinite(surfaceMobility)
+          ? "MOSFET U0 must be non-negative"
+          : "MOSFET U0 must be finite",
       );
     }
   });

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,14 +33,14 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS bulk-junction saturation current density.
+1. Cross-language Level-1 MOS surface mobility preprocessing.
    - Status: current PR completion candidate.
-   - Preserve model-card `JS` independently from scalar `IS` and scale it by
-     source/drain diffusion area when both `AS` and `AD` are present.
-   - Match Berkeley MOS1 fallback behavior by using scalar `IS` for both
-     junctions when `JS` is zero or either diffusion area is absent.
-   - Apply the effective terminal currents consistently to nonlinear, AC,
-     transfer-function, and shot-noise behavior in Rust, Python, and TypeScript.
+   - Accept model-card `U0` and its `UO` alias in Rust, Python, and TypeScript,
+     defaulting to the Berkeley MOS1 value of 600 cm^2/V/s.
+   - When a model card supplies `TOX` but omits `KP`, derive
+     `KP = U0 * Cox * 1e-4`; preserve explicit `KP` precedence.
+   - Keep normalized model-card coverage, validation, changelogs, and Rust
+     Berkeley netlist lowering aligned across the three implementations.
 
 ## Completed Slices
 
@@ -3549,6 +3549,15 @@ the Rust, Python, and TypeScript surfaces together.
    - Junction thermal voltage follows `T_NOM`, forward exponential continuation
      remains Newton-consistent, and noise emits distinct `IBS` and `IBD` shot
      sources.
+
+282. Cross-language Level-1 MOS bulk-junction saturation current density.
+   - Status: completed in PR 9108.
+   - Model-card `JS` is preserved independently from scalar `IS` and scales
+     source/drain junction leakage by `AS` / `AD` when both areas are present.
+   - Berkeley fallback retains scalar `IS` when `JS` is zero or either
+     diffusion area is absent.
+   - Rust, Python, and TypeScript apply the effective currents consistently to
+     nonlinear, AC, transfer-function, and shot-noise behavior.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- add Level-1 MOS `U0` / `UO` surface mobility across Rust, Python, and TypeScript
- derive `KP` from explicit `TOX` when `KP` is omitted, while preserving explicit-`KP` precedence
- align model-card coverage, Rust Berkeley netlist lowering, validation, tests, docs, changelogs, and the SPICE completion plan

## Verification
- `cargo fmt -p spice-engine -p spice-netlist-parser -- --check`
- `cargo clippy -p spice-engine -p spice-netlist-parser --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- `cargo test -p spice-netlist-parser`
- Python mosfet-models: 51 passed, 98% coverage
- Python spice-engine: 667 passed, 89% coverage
- TypeScript spice-engine: build clean, 410 passed
