### PR TITLE
feat(adj-formula-stdlib): electric-inductance-conversions — NIST SP 811 B.9 abhenry→henry definition table (facts track, b27)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -1219,6 +1219,47 @@ fn shipped_electric_capacitance_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b27) The shipped NIST SP 811 B.9 electric-inductance → henry table resolves the exact abhenry
+//       factor with its citation, and ABSTAINS on a wrong-dimension unit. This CLOSES the
+//       electromagnetic-EMU family (charge/potential/resistance/capacitance) with inductance. The
+//       abhenry (inductance) and the abfarad (capacitance) are DIFFERENT quantities that convert
+//       to DIFFERENT SI units (henry vs farad), so the abstain proves dimension safety, not mere
+//       absence of a value: the henry is flux linkage per unit current.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_electric_inductance_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_inductance");
+    let src = stdlib().join("reference/electric-inductance-conversions.adj");
+    std::fs::copy(&src, dir.join("electric-inductance-conversions.adj"))
+        .expect("copy shipped electric-inductance-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"electric-inductance-conversions.adj\"\n\
+         ? electric_inductance_to_henry(abhenry, $v)\n\
+         ? electric_inductance_to_henry(abfarad, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 exact factor resolves, character-for-character from the table
+    // (boldface = exact; the abhenry is defined as exactly 1.0 E-09 henry).
+    assert!(out.contains("\"v\":\"0.000000001\""), "abhenry = 1.0 E-09 H: {out}");
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `abfarad` is a CAPACITANCE unit (it converts to the farad, a DIFFERENT quantity), so this
+    // inductance table has no row for it — the engine abstains rather than mis-converting a
+    // capacitance unit as if it were an inductance unit.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a wrong-dimension unit abstains, never a cross-dimension fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/electric-inductance-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/electric-inductance-conversions.adj
@@ -1,0 +1,59 @@
+% ============================================================================
+% electric-inductance-conversions — electric-inductance-unit → henry factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of electric-charge-conversions.adj, electric-potential-conversions.adj,
+% electric-resistance-conversions.adj, electric-capacitance-conversions.adj and the other
+% NIST-cited conversion tables: a native tabular relation ingested VERBATIM from a published NIST
+% conversion table. The row states the factor converting the traditional (CGS-EMU) unit of
+% ELECTRIC INDUCTANCE to the SI coherent derived unit, the henry (H):
+%
+%     ? electric_inductance_to_henry(abhenry, $v)   % 0.000000001
+%
+% This CLOSES the electromagnetic-EMU family alongside electric-charge (the abcoulomb → the
+% coulomb), electric-potential (the abvolt → the volt), electric-resistance (the abohm → the ohm)
+% and electric-capacitance (the abfarad → the farad), and is a NEW dimension alongside the
+% length/mass/area/volume/time/speed/energy/pressure/force/acceleration/dynamic-viscosity/
+% kinematic-viscosity/magnetic-flux-density/magnetic-flux/illuminance/luminance/radioactivity/
+% absorbed-dose/dose-equivalent/exposure/power tables. Do NOT confuse ELECTRIC INDUCTANCE (the
+% abhenry → the henry) with ELECTRIC CAPACITANCE (the abfarad → the farad), ELECTRIC RESISTANCE
+% (the abohm → the ohm) or ELECTRIC POTENTIAL (the abvolt → the volt): those are DIFFERENT
+% quantities that convert to DIFFERENT SI units. Inductance (the henry) is the flux linkage per
+% unit current (one henry is one weber per ampere); the abhenry is its traditional (EMU) unit.
+% Put an inductance given in abhenries into SI first, then reason (write-once-use-many). Why a
+% `table` and not a hand-written `relate` clause: this is exactly the shape reference data comes
+% in — a published table, not prose. The citable artifact IS the NIST conversion-factors table at
+% the `locator` below; the factor here is a CELL of NIST Special Publication 811, Appendix B.9
+% ("Factors for units listed alphabetically"), defended by one provenance envelope. Each `row`
+% lowers to a ground relation `electric_inductance_to_henry(unit, v)`, so the exact lookup above
+% is the ordinary SLD binding query — the engine returns the factor WITH this table's citation as
+% its proof, on the CPU, with zero model calls.
+%
+% HONESTY NOTE (like the electric-charge / electric-potential / electric-resistance /
+% electric-capacitance / power tables, only the EXACT defined factor gets a row): NIST SP 811 B.9
+% prints the "abhenry" inductance factor in BOLDFACE, its convention for factors that are EXACT
+% by definition, transcribed here as the plain decimal number of henries it names:
+%
+%     abhenry (abH)   1.0 E-09  →  0.000000001
+%
+% This is exact because the abhenry is DEFINED as exactly 1.0 E-09 henry (the EMU of inductance).
+% It terminates; nothing here is a rounded measurement. This table is SPECIFIC to electric
+% inductance: a unit of a DIFFERENT quantity — e.g. the "abfarad", which NIST SP 811 B.9 lists
+% separately as an electric-CAPACITANCE unit converting to the farad, NOT the henry — therefore
+% gets no row here, and a `? electric_inductance_to_henry(abfarad, $v)` ABSTAINS rather than
+% mis-converting a capacitance unit as if it were an inductance unit. The only claim this table
+% makes is "this is the exact factor NIST SP 811 B.9 prints for the abhenry's conversion to the
+% henry" — which is exactly what a byte-check against the cited table verifies. `trust authoritative`
+% — a primary, re-fetchable standards reference. (See ADJ-TABLES.md; and
+% feedback_nothing_human_authored — the factor is a verbatim cell of the cited table, nothing
+% asserted from memory.)
+% ============================================================================
+
+table electric_inductance_to_henry {
+    columns unit, henry
+
+    row (abhenry, 0.000000001)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/electric-inductance-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/electric-inductance-conversions.query.adj
@@ -1,0 +1,24 @@
+% ============================================================================
+% electric-inductance-conversions.query.adj — worked lookups over the NIST inductance → henry table.
+% ============================================================================
+% The shape a consumer produces to convert an inductance given in a traditional CGS-EMU unit into
+% SI: it `import`s the grounded table and asks the engine to bind the factor. No arithmetic and
+% no factor is stated by the consumer; the engine returns the cell WITH the table's NIST citation
+% as its proof, on the CPU.
+%
+%   ? electric_inductance_to_henry(abhenry, $v)   % 0.000000001   (abhenry = 1.0 E-09 H, exact)
+%
+% And the dimension guard: a unit of a DIFFERENT quantity has no row, so the lookup ABSTAINS
+% rather than mis-converting across dimensions. The "abfarad" is an electric-CAPACITANCE unit (it
+% converts to the farad), NOT an inductance unit:
+%
+%   ? electric_inductance_to_henry(abfarad, $v)   % abstains (abfarad is capacitance → farad)
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli electric-inductance-conversions.query.adj
+% ============================================================================
+
+import "electric-inductance-conversions.adj"
+
+? electric_inductance_to_henry(abhenry, $v)   % expect 0.000000001  (exact NIST SP 811 B.9 factor)
+? electric_inductance_to_henry(abfarad, $v)   % expect abstain      (capacitance unit, wrong dimension)


### PR DESCRIPTION
## What

Adds `reference/electric-inductance-conversions.adj` to the ADJ formula standard library — a native RS-5 `table` giving the exact NIST factor converting the traditional CGS-EMU unit of **electric inductance** (the abhenry) to the SI henry — plus a worked `.query.adj` and a new `b27` block in the shared `rs5_table_e2e.rs` anchor.

**abhenry → henry = 1.0 E-09** → `0.000000001`

This **closes the electromagnetic-EMU conversion family**: charge (b23, abcoulomb→coulomb) / potential (b24, abvolt→volt) / resistance (b25, abohm→ohm) / capacitance (b26, abfarad→farad) / **inductance (b27, abhenry→henry)**.

## Provenance (byte-verified)

The row is a verbatim cell of **NIST SP 811, Appendix B.9** ("Factors for units listed alphabetically"). NIST prints the abhenry factor in **boldface** — its convention for factors exact by definition — because the abhenry is defined as exactly 1.0 E-09 henry (the EMU of inductance). It terminates; nothing is a rounded measurement.

- `locator`: https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9
- `trust authoritative` — primary, re-fetchable standards reference.

## Dimension safety (the abstain)

The `b27` test proves two things through the built CLI:
- **Exact lookup**: `? electric_inductance_to_henry(abhenry, $v)` binds `0.000000001` **with the NIST citation** riding on the answer.
- **Abstention**: `? electric_inductance_to_henry(abfarad, $v)` → `"abstained":true`. The abfarad is a *capacitance* unit (it converts to the farad, a DIFFERENT quantity), so this inductance table has no row for it — the engine abstains rather than mis-converting across dimensions, never a fabricated cross-dimension factor.

## Testing

- `cargo test -p adj-lang-cli --test rs5_table_e2e` — **32 passed** (b27 added).
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean.
- Render-probed against the built CLI: abhenry → `0.000000001` (with NIST locator + `authoritative`), abfarad → `abstained:true`.
- NUL-scanned both new files (0 NUL bytes).
- `/security-review` — passed, no findings.

Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)