### PR TITLE
feat(adj-formula-stdlib): rate-pressure-product — RPP = heart rate × systolic blood pressure definition library (clinical/cardiology)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_rate_pressure_product_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_rate_pressure_product_e2e.rs
@@ -1,0 +1,141 @@
+//! End-to-end tests for the `clinical/rate-pressure-product.adj` library — the definition of the
+//! rate pressure product (RPP = heart rate × systolic blood pressure) and its two exact
+//! rearrangements — driven through the built CLI binary against the SHIPPED stdlib. The same
+//! invariant as every other formula library: a consumer states NO arithmetic; it imports the
+//! grounded library, binds the measured vitals with `observe`, and the engine applies the cited
+//! relation on the CPU, computing the EXACT value and rendering the relation's citation and trust
+//! tier in the `derived` section (the auditable answer). The three formulas INVERT around the
+//! worked case HR = 80 /min, SBP = 120 mmHg: 80 × 120 = 9600, 9600 ÷ 120 = 80, and 9600 ÷ 80 =
+//! 120. The three asserted values (9600, 80, 120) are chosen so none is a substring of another
+//! rendered value. This is the cardiology product-cousin of the shipped shock-index.adj (SI = HR
+//! ÷ SBP), pairing the same two vitals the other way.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped rate-pressure-product library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_rpp_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/rate-pressure-product.adj")
+        .canonicalize()
+        .expect("shipped rate-pressure-product.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_rpp_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_rpp_lib()).unwrap();
+    std::fs::write(dir.join("rate-pressure-product.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// rate_pressure_product — the definition: heart rate times systolic blood pressure.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_rate_pressure_product_library_and_computes_it_with_citation() {
+    let dir = scratch("rpp");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"rate-pressure-product.adj\"\n\
+         observe heart_rate(80)\n\
+         observe systolic_blood_pressure(120)\n\
+         ? rate_pressure_product(heart_rate, systolic_blood_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 80 × 120 = 9600.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"rate_pressure_product\"") && s.contains("\"value\":9600"),
+        "rate_pressure_product(80, 120) = 9600: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// heart_rate — the same relation solved for HR: RPP ÷ SBP.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_heart_rate_from_rpp_and_sbp_with_citation() {
+    let dir = scratch("hr");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"rate-pressure-product.adj\"\n\
+         observe rate_pressure_product(9600)\n\
+         observe systolic_blood_pressure(120)\n\
+         ? heart_rate(rate_pressure_product, systolic_blood_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 9600 ÷ 120 = 80, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"heart_rate\"") && s.contains("\"value\":80"),
+        "heart_rate(9600, 120) = 80: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "heart_rate carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// systolic_blood_pressure — the same relation solved for SBP: RPP ÷ HR, the third reading of the
+// one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_sbp_from_rpp_and_heart_rate_with_citation() {
+    let dir = scratch("sbp");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"rate-pressure-product.adj\"\n\
+         observe rate_pressure_product(9600)\n\
+         observe heart_rate(80)\n\
+         ? systolic_blood_pressure(rate_pressure_product, heart_rate)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 9600 ÷ 80 = 120, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"systolic_blood_pressure\"") && s.contains("\"value\":120"),
+        "systolic_blood_pressure(9600, 80) = 120: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "systolic_blood_pressure carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/rate-pressure-product.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/rate-pressure-product.adj
@@ -1,0 +1,97 @@
+% ============================================================================
+% rate-pressure-product.adj — the definition of the rate pressure product (RPP = heart
+% rate × systolic blood pressure) in the ADJ standard library.
+% ============================================================================
+% The rate-pressure-product entry of the *clinical* track, a cardiology bedside sibling of
+% `shock-index.adj`. Where the shock index DIVIDES the heart rate by the systolic pressure (a
+% perfusion-collapse signature), the rate pressure product MULTIPLIES the same two vitals: THE
+% RATE PRESSURE PRODUCT IS THE HEART RATE TIMES THE SYSTOLIC BLOOD PRESSURE — a non-invasive
+% surrogate for myocardial oxygen demand / cardiac work, because ventricular wall tension tracks
+% systolic pressure and the number of tension cycles per minute tracks heart rate, so their
+% product scales with how hard the heart is working. It rises with exertion, tachycardia, or
+% hypertension and is used in exercise testing and ischaemia risk. It ships as an importable,
+% byte-provenanced, PARAMETERIZED `formula`, together with its two exact rearrangements (the
+% heart rate a rate pressure product implies for a given pressure, and the systolic pressure it
+% implies for a given rate). As with every compute library, a consumer states NO arithmetic: it
+% `import`s this file, binds the measured vitals from its own byte-provenance decomposition, and
+% asks the engine to APPLY the cited definition on the CPU. Zero math is performed by the model;
+% the engine computes each value EXACTLY (over exact rationals), carrying the definition's
+% citation.
+%
+%     import "rate-pressure-product.adj"
+%     observe heart_rate(80)                % "…heart rate 80 /min…"        (span cited by the model)
+%     observe systolic_blood_pressure(120)  % "…systolic BP 120 mmHg…"      (span cited by the model)
+%     ? rate_pressure_product(heart_rate, systolic_blood_pressure)
+%                                           % engine → 9600, carrying RPP = HR × SBP
+%
+% All three formulas are EXACT over their parameters, so every value the engine returns is exact.
+% They COMPOSE and invert cleanly around the worked case heart rate = 80 /min, systolic blood
+% pressure = 120 mmHg (RPP = 80 × 120 = 9600): the `rate_pressure_product` a consumer computes
+% from the two vitals is exactly the value the `heart_rate` formula divides by the systolic
+% pressure to recover 80, and exactly the value the `systolic_blood_pressure` formula divides by
+% the heart rate to recover 120.
+%
+%   rate_pressure_product(heart_rate, systolic_blood_pressure)
+%       = heart_rate * systolic_blood_pressure       % RPP = HR × SBP   (definition)
+%   heart_rate(rate_pressure_product, systolic_blood_pressure)
+%       = rate_pressure_product / systolic_blood_pressure  % HR = RPP ÷ SBP  (solved for HR)
+%   systolic_blood_pressure(rate_pressure_product, heart_rate)
+%       = rate_pressure_product / heart_rate          % SBP = RPP ÷ HR   (solved for SBP)
+%
+% NOTE ON UNITS: the heart rate is per minute and the systolic blood pressure is in millimetres
+% of mercury; the rate pressure product comes out in mmHg/min (the units are conventionally
+% dropped, and it is often reported ×10⁻³), and this library computes the exact product over
+% whatever consistent inputs it is given.
+%
+% All three formulas are defended by the SAME clause — "the rate-pressure product (RPP)
+% calculated by multiplying heart rate by systolic blood pressure" — because that one definition
+% (the rate pressure product IS the heart-rate-times-systolic-pressure product) sanctions the
+% relation read every way. The quote is transcribed verbatim from a peer-reviewed article
+% archived on the NCBI PMC repository, so each `formula` carries the provenance envelope every
+% shipped grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the clause is a verbatim span of the cited page, not asserted
+% from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable vital sign the definition ranges over, and each
+% result is a derived quantity. `heart_rate`, `systolic_blood_pressure` and `rate_pressure_product`
+% each appear BOTH as a derived result and as an input (of the other formulas), so each is a
+% single dictionary term used in both roles. The `surface` lists are the everyday names a
+% decomposer maps onto the canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary rate_pressure_product_vocab {
+    define heart_rate               : finding  surface "heart rate", "HR", "pulse"                          % beats per minute (/min)
+    define systolic_blood_pressure  : finding  surface "systolic blood pressure", "SBP", "systolic BP"      % millimetres of mercury (mmHg)
+    define rate_pressure_product    : finding  surface "rate pressure product", "RPP", "double product"     % mmHg per minute (mmHg/min)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the definitional clause from the cited article
+% on the NCBI PMC repository (a quote is required on a shipped formula). Each is an exact product
+% or ratio of measured vitals, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook rate_pressure_product_laws {
+    use rate_pressure_product_vocab
+
+    % Rate pressure product — the heart rate times the systolic blood pressure, i.e. RPP = HR × SBP.
+    formula rate_pressure_product(heart_rate, systolic_blood_pressure) = heart_rate * systolic_blood_pressure
+        source "the rate-pressure product (RPP) calculated by multiplying heart rate by systolic blood pressure"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC10968938/"
+        trust authoritative
+
+    % Heart rate — the same definition solved for the rate a rate pressure product implies for a
+    % given systolic pressure (HR = RPP ÷ SBP). Defended by the SAME clause.
+    formula heart_rate(rate_pressure_product, systolic_blood_pressure) = rate_pressure_product / systolic_blood_pressure
+        source "the rate-pressure product (RPP) calculated by multiplying heart rate by systolic blood pressure"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC10968938/"
+        trust authoritative
+
+    % Systolic blood pressure — the same definition solved for the pressure (SBP = RPP ÷ HR): the
+    % rate pressure product divided by the heart rate. The SAME clause, read the third way.
+    formula systolic_blood_pressure(rate_pressure_product, heart_rate) = rate_pressure_product / heart_rate
+        source "the rate-pressure product (RPP) calculated by multiplying heart rate by systolic blood pressure"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC10968938/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/rate-pressure-product.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/rate-pressure-product.query.adj
@@ -1,0 +1,27 @@
+% ============================================================================
+% rate-pressure-product.query.adj — worked applications of the rate-pressure-product definition.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a cardiology/exercise vignette into
+% observed vitals: it `import`s the grounded formulabook, `observe`s the measured heart rate and
+% systolic pressure, and asks the engine to APPLY the cited definition. No arithmetic is stated
+% by the consumer; the engine computes each value EXACTLY (over exact rationals) and carries the
+% article's citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (heart rate = 80 /min, systolic blood pressure = 120 mmHg): RPP = 80 × 120 = 9600.
+% Each query below fixes two of the three quantities and asks the engine to recover the third;
+% every answer is exact and the three COMPOSE (each inversion recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli rate-pressure-product.query.adj
+% ============================================================================
+
+import "rate-pressure-product.adj"
+
+% --- Forward: the rate pressure product the two vitals imply (expect 9600). -------------------
+observe heart_rate(80)
+observe systolic_blood_pressure(120)
+? rate_pressure_product(heart_rate, systolic_blood_pressure)   % expect 9600
+
+% --- Inverse: the heart rate a rate pressure product of 9600 implies at that pressure (80). ----
+observe rate_pressure_product(9600)
+? heart_rate(rate_pressure_product, systolic_blood_pressure)   % expect 80


### PR DESCRIPTION
## What

Adds `clinical/rate-pressure-product.adj` to the ADJ formula standard library — the definition of the **rate pressure product** (RPP), a non-invasive surrogate for myocardial oxygen demand / cardiac work — plus a worked `.query.adj` and a dedicated end-to-end test.

**RPP = heart rate × systolic blood pressure**

Constant-free, directional, two-input. This is the **product-cousin of the shipped [shock-index.adj](../blob/main/code/specs/data/adj-formula-stdlib/clinical/shock-index.adj)** (SI = HR ÷ SBP): the same two vitals, multiplied instead of divided. Ships the forward formula plus **two exact rearrangements** — HR = RPP ÷ SBP and SBP = RPP ÷ HR — each carrying the same verbatim source, so the definition read any of three ways is one provenance envelope.

## Provenance (byte-verified)

Grounded verbatim in a peer-reviewed article archived on the NCBI PMC repository:

> "the rate-pressure product (RPP) calculated by multiplying heart rate by systolic blood pressure"

- `locator`: https://pmc.ncbi.nlm.nih.gov/articles/PMC10968938/
- `trust authoritative` — primary, re-fetchable peer-reviewed reference.

## Worked case (all three invert exactly)

HR = 80 /min, SBP = 120 mmHg → **RPP = 80 × 120 = 9600**. Each e2e test fixes two quantities and recovers the third. The three asserted values (9600, 80, 120) are chosen so none is a substring of another rendered value.

## Invariant

A consumer states NO arithmetic: it `import`s the library, `observe`s its byte-provenance-decomposed vitals, and the engine APPLIES the cited relation on the CPU, computing each value EXACTLY (over exact rationals) and rendering the citation + trust tier in the auditable `derived` section. Zero model math.

## Testing

- `cargo test -p adj-lang-cli --test formula_rate_pressure_product_e2e` — 3/3 pass.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean.
- Render-probed against the built CLI: forward → 9600, inverse → 80, both carrying the PMC locator + `authoritative`.
- NUL-scanned all three new files (0 NUL bytes).
- `/security-review` — passed, no findings.

Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)