### PR TITLE
feat(spice): scale MOS mobility with temperature

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Scale Level-1 MOS `U0` alongside `KP` by `(T / T_NOM)^-3/2` so temperature
+  helpers preserve Berkeley surface-mobility state and their nominal ratio.
 - Add Level-1 MOS model-card `U0` / `UO` surface mobility and derive `KP` from
   explicit `TOX` when `KP` is omitted, preserving explicit-`KP` precedence.
 - Add Level-1 MOS model-card `JS` as bulk-junction saturation-current density,

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -394,6 +394,7 @@ def mosfet_at_temperature(
         params,
         VT0=params.VT0 + threshold_shift,
         KP=params.KP * ratio**-1.5,
+        U0=params.U0 * ratio**-1.5,
         T_NOM=temperature_kelvin,
     )
     return replace(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -329,6 +329,7 @@ from spice_engine import (
     model_card_supported_parameter_coverage_records,
     model_card_supported_parameter_coverage_summary,
     model_card_supported_parameter_coverage_summary_records,
+    mosfet_at_temperature,
     mosfet_from_model_card,
     noise_ac,
     noise_ac_corners,
@@ -4227,6 +4228,34 @@ def test_mosfet_temperature_scaling_changes_common_source_bias():
     assert hot_result.converged
     assert cold_result.node_voltages["out"] > nominal_result.node_voltages["out"]
     assert hot_result.node_voltages["out"] < nominal_result.node_voltages["out"]
+
+
+def test_mosfet_temperature_scaling_keeps_surface_mobility_and_kp_aligned():
+    nominal = Mosfet(
+        "M1",
+        "d",
+        "g",
+        "s",
+        "b",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(Level1Params(KP=200.0e-6, U0=500.0)),
+        ),
+    )
+    hot = mosfet_at_temperature(
+        nominal,
+        600.3,
+        nominal_temperature_kelvin=300.15,
+    )
+    scale = 2.0**-1.5
+    nominal_params = nominal.model.model.params
+    hot_params = hot.model.model.params
+
+    assert pytest.approx(nominal_params.KP * scale) == hot_params.KP
+    assert pytest.approx(nominal_params.U0 * scale) == hot_params.U0
+    assert pytest.approx(nominal_params.KP / nominal_params.U0) == (
+        hot_params.KP / hot_params.U0
+    )
 
 
 # ---- DC: Capacitor (open in DC) ----

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Scale Level-1 MOS `U0` alongside `KP` by `(T / T_NOM)^-3/2` so temperature
+  helpers preserve Berkeley surface-mobility state and their nominal ratio.
 - Add Level-1 MOS model-card `U0` / `UO` surface mobility with the Berkeley
   default of 600 cm^2/V/s. When `TOX` is explicit and `KP` is omitted, derive
   `KP = U0 * Cox * 1e-4`; explicit `KP` retains precedence.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -2777,6 +2777,7 @@ pub fn mosfet_at_temperature(
     let mut adjusted = mosfet.clone();
     adjusted.params.vt0 += threshold_shift;
     adjusted.params.kp *= ratio.powf(-1.5);
+    adjusted.params.surface_mobility *= ratio.powf(-1.5);
     adjusted.params.t_nom = temperature_kelvin;
     Ok(adjusted)
 }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -59,13 +59,14 @@ use spice_engine::{
     model_card_supported_parameter_coverage_gate_issue_records,
     model_card_supported_parameter_coverage_records,
     model_card_supported_parameter_coverage_summary,
-    model_card_supported_parameter_coverage_summary_records, mosfet_from_model_card,
-    normalize_model_card, normalize_model_card_type, resolve_deck_initial_conditions, BSource, Bjt,
-    BjtPolarity, Cccs, Ccvs, Circuit, CornerOverride, CornerSpec, CornerTemperatureDcResult,
-    CurrentSource, CustomModel, DcConvergenceAid, DcOpOptions, Diode, Element, Inductor, Jfet,
-    JfetPolarity, ModelCardKind, Mosfet, MosfetLevel1Params, MosfetType, Resistor, SinWaveform,
-    SpiceError, SubcircuitDefinition, SubcircuitElement, TemperatureDcResult, Vccs, Vcvs,
-    VoltageSource, Waveform, XInstance,
+    model_card_supported_parameter_coverage_summary_records, mosfet_at_temperature,
+    mosfet_from_model_card, normalize_model_card, normalize_model_card_type,
+    resolve_deck_initial_conditions, BSource, Bjt, BjtPolarity, Cccs, Ccvs, Circuit,
+    CornerOverride, CornerSpec, CornerTemperatureDcResult, CurrentSource, CustomModel,
+    DcConvergenceAid, DcOpOptions, Diode, Element, Inductor, Jfet, JfetPolarity, ModelCardKind,
+    Mosfet, MosfetLevel1Params, MosfetType, Resistor, SinWaveform, SpiceError,
+    SubcircuitDefinition, SubcircuitElement, TemperatureDcResult, Vccs, Vcvs, VoltageSource,
+    Waveform, XInstance,
 };
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -3503,6 +3504,35 @@ fn dc_mosfet_temperature_scaling_changes_common_source_bias() {
 
     assert!(cold_result.voltage("out").unwrap() > nominal_result.voltage("out").unwrap());
     assert!(hot_result.voltage("out").unwrap() < nominal_result.voltage("out").unwrap());
+}
+
+#[test]
+fn mosfet_temperature_scaling_keeps_surface_mobility_and_kp_aligned() {
+    let nominal = Mosfet::with_model(
+        "M1",
+        "d",
+        "g",
+        "s",
+        "b",
+        MosfetType::Nmos,
+        MosfetLevel1Params {
+            kp: 200.0e-6,
+            surface_mobility: 500.0,
+            ..MosfetLevel1Params::default()
+        },
+    );
+    let hot = mosfet_at_temperature(&nominal, 600.3, 300.15).unwrap();
+    let scale = 2.0_f64.powf(-1.5);
+
+    assert_close(hot.params.kp, nominal.params.kp * scale);
+    assert_close(
+        hot.params.surface_mobility,
+        nominal.params.surface_mobility * scale,
+    );
+    assert_close(
+        hot.params.kp / hot.params.surface_mobility,
+        nominal.params.kp / nominal.params.surface_mobility,
+    );
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Scale Level-1 MOS `U0` alongside `KP` by `(T / T_NOM)^-3/2` so temperature
+  helpers preserve Berkeley surface-mobility state and their nominal ratio.
 - Add Level-1 MOS model-card `U0` / `UO` surface mobility and derive `KP` from
   explicit `TOX` when `KP` is omitted, preserving explicit-`KP` precedence.
 - Add Level-1 MOS model-card `JS` as bulk-junction saturation-current density,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -7739,6 +7739,7 @@ export function mosfetAtTemperature(
       ...element.params,
       VT0: element.params.VT0 + thresholdShift,
       KP: element.params.KP * ratio ** -1.5,
+      U0: element.params.U0 * ratio ** -1.5,
       T_NOM: temperatureKelvin,
     },
   };

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -94,6 +94,7 @@ import {
   modelCardSupportedParameterCoverageSummary,
   modelCardSupportedParameterCoverageSummaryRecords,
   mosfet,
+  mosfetAtTemperature,
   mosfetFromModelCard,
   normalizeModelCard,
   normalizeModelCardType,
@@ -2323,6 +2324,22 @@ describe("dcOp", () => {
 
     expect(coldResult.voltage("out")).toBeGreaterThan(nominalResult.voltage("out")!);
     expect(hotResult.voltage("out")).toBeLessThan(nominalResult.voltage("out")!);
+  });
+
+  it("keeps MOSFET surface mobility and KP aligned across temperature", () => {
+    const nominal = mosfet("M1", "d", "g", "s", "b", "NMOS", {
+      KP: 200.0e-6,
+      U0: 500.0,
+    });
+    const hot = mosfetAtTemperature(nominal, 600.3, 300.15);
+    const scale = 2.0 ** -1.5;
+
+    expectClose(hot.params.KP, nominal.params.KP * scale);
+    expectClose(hot.params.U0, nominal.params.U0 * scale);
+    expectClose(
+      hot.params.KP / hot.params.U0,
+      nominal.params.KP / nominal.params.U0,
+    );
   });
 
   it("preserves subcircuits when applying temperature helpers", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,14 +33,14 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS surface mobility preprocessing.
+1. Cross-language Level-1 MOS mobility temperature scaling.
    - Status: current PR completion candidate.
-   - Accept model-card `U0` and its `UO` alias in Rust, Python, and TypeScript,
-     defaulting to the Berkeley MOS1 value of 600 cm^2/V/s.
-   - When a model card supplies `TOX` but omits `KP`, derive
-     `KP = U0 * Cox * 1e-4`; preserve explicit `KP` precedence.
-   - Keep normalized model-card coverage, validation, changelogs, and Rust
-     Berkeley netlist lowering aligned across the three implementations.
+   - Scale Level-1 MOS `U0` with the same Berkeley `(T / T_NOM)^-3/2`
+     mobility law already applied to `KP`.
+   - Preserve the nominal `KP / U0` relationship through direct MOS
+     temperature helpers and circuit-level temperature transforms.
+   - Keep Rust, Python, and TypeScript helper behavior, tests, and changelogs
+     aligned.
 
 ## Completed Slices
 
@@ -3558,6 +3558,15 @@ the Rust, Python, and TypeScript surfaces together.
      diffusion area is absent.
    - Rust, Python, and TypeScript apply the effective currents consistently to
      nonlinear, AC, transfer-function, and shot-noise behavior.
+
+283. Cross-language Level-1 MOS surface mobility preprocessing.
+   - Status: completed in PR 9117.
+   - Model cards accept `U0` and its `UO` alias in Rust, Python, and TypeScript,
+     defaulting to the Berkeley MOS1 value of 600 cm^2/V/s.
+   - When `TOX` is supplied and `KP` is omitted, all three implementations
+     derive `KP = U0 * Cox * 1e-4` while preserving explicit `KP` precedence.
+   - Normalized model-card coverage, validation, changelogs, and the Rust
+     Berkeley netlist facade preserve the parameter.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- scale Level-1 MOS `U0` with the same `(T / T_NOM)^-3/2` law already applied to `KP`
- preserve the nominal `KP / U0` relationship in Rust, Python, and TypeScript temperature helpers
- reconcile the SPICE completion plan through merged PR #9117 and document this next slice

## Reference
- ngspice MOS1 temperature preprocessing scales both transconductance and surface mobility by the temperature ratio raised to 3/2

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python spice-engine: lint clean, 668 passed, 89% coverage
- TypeScript spice-engine: build clean, 411 passed
