### PR TITLE
feat(mosaic): data-driven sizing, Gantt timeline, and progressive disclosure

### DIFF
--- a/code/packages/rust/mosaic-emit-react/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-react/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Added - UI36 data-driven sizing (`width` / `height` from a slot or expression)
+
+The size props `width`, `height`, `min-width`, `max-width`, `min-height` and
+`max-height` now accept a **slot binding or an expression**, not just a literal number,
+and lower into the emitted component's style object. See
+`code/specs/UI36-data-driven-sizing.md`.
+
+This closes a hole in the layout/style split. mosstyle deliberately bakes its values at
+compile time, which is right for almost everything — but some sizes are only knowable
+at run time: the length of a Gantt bar, a progress fill, a proportional column. No
+authored CSS can say *"as wide as this row's data"*.
+
+Worse, the obvious attempt **failed silently**: `width: slot: bar-width` parsed fine and
+was then discarded, because the only reader was `find_number_prop`, which matches a
+literal number and nothing else. An author had no way to distinguish a working binding
+from an ignored one. A binding the grammar accepts must now either take effect or be
+reported — never be dropped on the floor.
+
+| author writes | emitted |
+|---|---|
+| `width: 120` | `width: 120` (CSS px) |
+| `width: "50%"` | `width: "50%"` |
+| `width: auto` | `width: "auto"` |
+| `width: slot: bar-width` | `width: barWidth` |
+| `width: ( row[2] )` | `width: row[2]` |
+
+- **A bound size is emitted last** — after the base part style *and* after any state
+  spreads — because data outranks decoration. Otherwise a `state hover { width: … }`
+  would silently clobber the host's value, reintroducing the original complaint in a
+  subtler form.
+- **Additive only:** a layout that binds no size emits byte-identical output, pinned by
+  a test, so no existing Mosaic app is affected.
+- Escaping is unchanged per shape: a slot goes through `validate_slot_or_field_name`, a
+  string and a keyword through `js_string_literal`, and an expression is verbatim — the
+  same trust model already applied to `content:`, `label:`, `If`, and `For`.
+- Rejected loudly: a non-size value (an emit ref), and a non-finite numeric literal that
+  would otherwise emit a bare `inf` identifier.
+- 11 new tests (192 total).
+
+## [Unreleased]
+
 ### Added - UI35 drag-and-drop lowering (`HostDraggable` / `HostDropTarget`)
 
 The React backend now lowers the kernel's two new drag primitives (see

--- a/code/packages/rust/mosaic-emit-react/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-react/src/pipeline.rs
@@ -1174,10 +1174,24 @@ fn emit_jsx_tree(
         }
     }
 
-    let style_attr = if merged_style.is_empty() && state_spreads.is_empty() {
+    // UI36 — data-driven sizing. A bound size is *data*, so it is emitted LAST of all:
+    // after the author's part style and after any state spreads. Otherwise a
+    // `state X { width: … }` block would silently clobber the value the host bound,
+    // which is exactly the "my binding did nothing" confusion this feature removes.
+    // See `dynamic_size_style` for why this can't live in mosstyle.
+    let size_style = dynamic_size_style(node)?;
+
+    let style_attr = if merged_style.is_empty() && state_spreads.is_empty() && size_style.is_empty()
+    {
         String::new()
     } else if state_spreads.is_empty() {
-        format!(" style={{{{ {merged_style} }}}}")
+        // No spreads: just the merged style plus any bound sizes.
+        let body = if merged_style.is_empty() {
+            size_style.trim_start_matches(", ").to_string()
+        } else {
+            format!("{merged_style}{size_style}")
+        };
+        format!(" style={{{{ {body} }}}}")
     } else {
         // Both static merged style + conditional state spreads. The static
         // style is the first spread inside the object so author state
@@ -1187,7 +1201,7 @@ fn emit_jsx_tree(
         } else {
             merged_style.clone()
         };
-        format!(" style={{{{ {base}{state_spreads} }}}}")
+        format!(" style={{{{ {base}{state_spreads}{size_style} }}}}")
     };
     let mut open = format!("{tag_name}{extra_attrs}{style_attr}");
 
@@ -4261,6 +4275,95 @@ fn find_keyword_prop<'a>(node: &'a LayoutNode, prop_name: &str) -> Option<&'a st
 
 /// Find a prop on `node` whose value is a `Number`. Returns the f64, or
 /// `None`.
+/// UI36 — **data-driven sizing**: a size prop whose value comes from the host.
+///
+/// (See `find_number_prop` below for the literal-number-only reader this generalises.)
+///
+/// mosstyle is the right home for *static* appearance, and deliberately bakes its
+/// values at compile time. But some sizes are only knowable at runtime — the length of
+/// a Gantt bar, a progress fill, a proportional column — and there is no amount of
+/// authored CSS that can express "as wide as this row's data says". Before this, such a
+/// node had no way to be sized: `width: slot: x` parsed fine and was then silently
+/// dropped, because the only reader was `find_number_prop`, which matches a literal
+/// number and nothing else. Silently ignoring an author's binding is the worst of the
+/// options, so these props now accept the same three value shapes the rest of the
+/// emitter does.
+///
+/// | author writes                  | emitted                    |
+/// |--------------------------------|----------------------------|
+/// | `width: 120`                   | `width: 120` (CSS px)      |
+/// | `width: slot: bar-width`       | `width: barWidth`          |
+/// | `width: ( row[1] )`            | `width: row[1]`            |
+///
+/// The value is passed through as a JS expression, so a host may supply either a number
+/// (React reads a bare number as px) or a string like `"42%"` — which is what makes a
+/// bar that scales with its container expressible at all.
+///
+/// Returns a `, key: value` fragment ready to append inside a JSX style object.
+fn dynamic_size_style(node: &LayoutNode) -> Result<String, PipelineEmitError> {
+    /// The mosstyle-style kebab prop name paired with its JSX style key.
+    const SIZE_PROPS: [(&str, &str); 6] = [
+        ("width", "width"),
+        ("height", "height"),
+        ("min-width", "minWidth"),
+        ("max-width", "maxWidth"),
+        ("min-height", "minHeight"),
+        ("max-height", "maxHeight"),
+    ];
+
+    let mut out = String::new();
+    for (prop_name, css_key) in SIZE_PROPS {
+        let Some(prop) = node.props.iter().find(|p| p.name == prop_name) else {
+            continue;
+        };
+        let expr = match &prop.value {
+            // Render `120` as `120`, not `120.0` — React reads a bare number as px.
+            LayoutPropValue::Number(n) => {
+                // A literal long enough to overflow f64 parses to infinity, and
+                // `format!("{inf}")` would emit a bare `inf` identifier that doesn't
+                // compile. Reject it rather than emitting broken TSX.
+                if !n.is_finite() {
+                    return Err(PipelineEmitError::UnsafeSlotName(format!(
+                        "`{prop_name}:` is not a finite number"
+                    )));
+                }
+                if n.fract() == 0.0 {
+                    format!("{}", *n as i64)
+                } else {
+                    format!("{n}")
+                }
+            }
+            LayoutPropValue::SlotRef(slot) => {
+                let camel = to_camel_case_first_lower(slot);
+                validate_slot_or_field_name(&camel).map_err(PipelineEmitError::UnsafeSlotName)?;
+                camel
+            }
+            LayoutPropValue::Expr(text) => text.clone(),
+            // A string literal is a legitimate CSS size ("50%", "12rem") but must be
+            // emitted as a JS string, not a bare identifier.
+            LayoutPropValue::String(lit) => js_string_literal(lit),
+            // A bare keyword is how an author naturally writes a CSS keyword size —
+            // `width: auto`, `height: fit-content`. The mosmodel grammar restricts a
+            // keyword to `[A-Za-z][A-Za-z0-9-]*`, so quoting it is safe.
+            LayoutPropValue::Keyword(k) => js_string_literal(k),
+            // Anything else (an emit ref) is not a size. Fail loudly rather than
+            // silently dropping it — the bug this whole function exists to stop.
+            _ => {
+                return Err(PipelineEmitError::UnsafeSlotName(format!(
+                    "`{prop_name}:` must be a number, a string, a keyword, a slot ref,                      or an expression"
+                )))
+            }
+        };
+        out.push_str(&format!(", {css_key}: {expr}"));
+    }
+    Ok(out)
+}
+
+/// Find a prop on `node` whose value is a literal `Number`.
+///
+/// Deliberately narrow: it ignores a slot or expression binding. `dynamic_size_style`
+/// above is the general reader for size props; this one remains for the places that
+/// genuinely require a compile-time constant (a table `Col`'s width, for instance).
 fn find_number_prop(node: &LayoutNode, prop_name: &str) -> Option<f64> {
     node.props.iter().find_map(|p| {
         if p.name == prop_name {
@@ -7432,6 +7535,220 @@ mod tests {
         let out = from_pipeline(&m, &l, &empty_style("X")).unwrap().output;
         assert!(!out.contains("mosaic$grab"), "controller leaked:\n{out}");
         assert!(!out.contains("useState"), "useState leaked:\n{out}");
+    }
+
+    // ===================================================================
+    // UI36 — data-driven sizing
+    // ===================================================================
+
+    /// A one-component layout whose root `Box` carries the given props.
+    fn sized_box_layout(props: Vec<LayoutProp>) -> LayoutDef {
+        LayoutDef {
+            component_name: "S".to_string(),
+            root: LayoutNode {
+                tag: "Box".to_string(),
+                part_name: None,
+                props,
+                children: vec![],
+            },
+        }
+    }
+    fn size_prop(name: &str, value: LayoutPropValue) -> LayoutProp {
+        LayoutProp {
+            name: name.to_string(),
+            value,
+        }
+    }
+    fn sized(props: Vec<LayoutProp>) -> String {
+        from_pipeline(
+            &component("S", vec![], vec![]),
+            &sized_box_layout(props),
+            &empty_style("S"),
+        )
+        .unwrap()
+        .output
+    }
+
+    /// A slot-bound size is the whole point: mosstyle bakes static values, so the
+    /// length of a Gantt bar or a progress fill — knowable only at runtime — had no
+    /// way to be expressed. It used to parse and then be *silently dropped*.
+    #[test]
+    fn ui36_width_can_come_from_a_slot() {
+        let out = sized(vec![size_prop(
+            "width",
+            LayoutPropValue::SlotRef("bar-width".to_string()),
+        )]);
+        assert!(out.contains("width: barWidth"), "slot width missing:\n{out}");
+    }
+
+    /// An expression works too, so a size can be computed from a loop binding —
+    /// `width: ( row[1] )` inside a `For`.
+    #[test]
+    fn ui36_width_can_come_from_an_expression() {
+        let out = sized(vec![size_prop(
+            "width",
+            LayoutPropValue::Expr("row[1]".to_string()),
+        )]);
+        assert!(out.contains("width: row[1]"), "expr width missing:\n{out}");
+    }
+
+    /// A literal number still means CSS pixels, and must not print as `120.0`.
+    #[test]
+    fn ui36_numeric_width_is_pixels_without_a_decimal_tail() {
+        let out = sized(vec![size_prop("width", LayoutPropValue::Number(120.0))]);
+        assert!(out.contains("width: 120"), "{out}");
+        assert!(!out.contains("120.0"), "numeric width printed a float tail:\n{out}");
+    }
+
+    /// A string literal is a legitimate CSS size ("50%") and must be quoted, not
+    /// emitted as a bare identifier.
+    #[test]
+    fn ui36_string_width_is_quoted() {
+        let out = sized(vec![size_prop(
+            "width",
+            LayoutPropValue::String("50%".to_string()),
+        )]);
+        assert!(out.contains("width: \"50%\""), "{out}");
+    }
+
+    /// All six size props lower, so height/min/max are equally bindable.
+    #[test]
+    fn ui36_every_size_prop_lowers() {
+        let out = sized(vec![
+            size_prop("width", LayoutPropValue::Number(1.0)),
+            size_prop("height", LayoutPropValue::Number(2.0)),
+            size_prop("min-width", LayoutPropValue::Number(3.0)),
+            size_prop("max-width", LayoutPropValue::Number(4.0)),
+            size_prop("min-height", LayoutPropValue::Number(5.0)),
+            size_prop("max-height", LayoutPropValue::Number(6.0)),
+        ]);
+        for key in ["width: 1", "height: 2", "minWidth: 3", "maxWidth: 4", "minHeight: 5", "maxHeight: 6"] {
+            assert!(out.contains(key), "missing {key}:\n{out}");
+        }
+    }
+
+    /// A bound size must beat the author's static one — otherwise binding a width
+    /// would appear to do nothing whenever a part style also set it.
+    #[test]
+    fn ui36_bound_size_overrides_the_part_style() {
+        let m = component("S", vec![], vec![]);
+        let layout = LayoutDef {
+            component_name: "S".to_string(),
+            root: LayoutNode {
+                tag: "Box".to_string(),
+                part_name: Some("bar".to_string()),
+                props: vec![size_prop(
+                    "width",
+                    LayoutPropValue::SlotRef("bar-width".to_string()),
+                )],
+                children: vec![],
+            },
+        };
+        let style = StyleDef {
+            component_name: "S".to_string(),
+            parts: vec![PartStyle {
+                name: "bar".to_string(),
+                base: vec![StyleProp {
+                    name: "width".to_string(),
+                    value: "10".to_string(),
+                }],
+                states: vec![],
+            }],
+        };
+        let out = from_pipeline(&m, &layout, &style).unwrap().output;
+        let at_static = out.find("width: 10").expect("static width missing");
+        let at_bound = out.find("width: barWidth").expect("bound width missing");
+        assert!(
+            at_bound > at_static,
+            "the bound width must come last so it wins:\n{out}"
+        );
+    }
+
+    /// A prop shape that isn't a size fails loudly. Silently dropping it is exactly
+    /// the bug this feature exists to fix.
+    #[test]
+    fn ui36_a_non_size_value_is_rejected() {
+        let m = component("S", vec![], vec![]);
+        let l = sized_box_layout(vec![size_prop(
+            "width",
+            LayoutPropValue::EmitRef("onWidth".to_string()),
+        )]);
+        assert!(
+            from_pipeline(&m, &l, &empty_style("S")).is_err(),
+            "an emit ref is not a width and must not be silently ignored"
+        );
+    }
+
+    /// `width: auto` is how an author naturally writes a CSS keyword size. It used to
+    /// be silently dropped; briefly it hard-errored; it must simply work.
+    #[test]
+    fn ui36_a_css_keyword_size_is_quoted() {
+        let out = sized(vec![size_prop(
+            "width",
+            LayoutPropValue::Keyword("auto".to_string()),
+        )]);
+        assert!(out.contains("width: \"auto\""), "{out}");
+    }
+
+    /// A literal too large for f64 parses to infinity; emitting `width: inf` would be
+    /// a bare identifier that doesn't compile, so it must be rejected instead.
+    #[test]
+    fn ui36_a_non_finite_number_is_rejected() {
+        let m = component("S", vec![], vec![]);
+        let l = sized_box_layout(vec![size_prop(
+            "width",
+            LayoutPropValue::Number(f64::INFINITY),
+        )]);
+        assert!(
+            from_pipeline(&m, &l, &empty_style("S")).is_err(),
+            "an infinite width must not emit `width: inf`"
+        );
+    }
+
+    /// A bound size must beat a STATE block too, not just the base part style —
+    /// otherwise a `state hover { width: … }` would silently override the host's data.
+    #[test]
+    fn ui36_bound_size_outranks_a_state_block() {
+        let m = component("S", vec![], vec![]);
+        let layout = LayoutDef {
+            component_name: "S".to_string(),
+            root: LayoutNode {
+                tag: "Box".to_string(),
+                part_name: Some("bar".to_string()),
+                props: vec![
+                    size_prop("width", LayoutPropValue::SlotRef("bar-width".to_string())),
+                    size_prop("state-when-hover", LayoutPropValue::Expr("hot".to_string())),
+                ],
+                children: vec![],
+            },
+        };
+        let style = StyleDef {
+            component_name: "S".to_string(),
+            parts: vec![PartStyle {
+                name: "bar".to_string(),
+                base: vec![],
+                states: vec![StateStyle {
+                    state: "hover".to_string(),
+                    props: vec![StyleProp {
+                        name: "width".to_string(),
+                        value: "99".to_string(),
+                    }],
+                }],
+            }],
+        };
+        let out = from_pipeline(&m, &layout, &style).unwrap().output;
+        let at_state = out.find("width: 99").expect("state width missing");
+        let at_bound = out.find("width: barWidth").expect("bound width missing");
+        assert!(at_bound > at_state, "the bound width must come last:
+{out}");
+    }
+
+    /// A layout that binds no size emits exactly what it did before.
+    #[test]
+    fn ui36_absent_size_props_change_nothing() {
+        let out = sized(vec![]);
+        assert!(!out.contains("width:"), "phantom width:\n{out}");
+        assert!(!out.contains("height:"), "phantom height:\n{out}");
     }
 
     /// Helper: a one-component layout def rooted at a `HostCheckbox`.

--- a/code/packages/rust/moslayout-compiler/CHANGELOG.md
+++ b/code/packages/rust/moslayout-compiler/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [Unreleased]
 
+### Fixed - a string literal inside an expression lost its quotes
+
+`( status == "done" )` reconstructed as `status == done` — a comparison against an
+undefined identifier rather than against the string. The lexer strips a STRING token's
+surrounding quotes and resolves its escapes before storing the value, and
+`reconstruct_expr_text` pushed that value verbatim. Every backend interpolates this text
+into generated source, so the bug reached all of them; any `.mll` expression comparing
+against a string was silently wrong.
+
+String tokens are now re-quoted and re-escaped when the expression text is rebuilt.
+Non-string tokens are untouched, so identifiers and numbers are unaffected.
+
+This also closes the only route by which expression text could contribute *structural*
+characters (`}`, `,`, a bare quote) to emitted source — see
+`code/specs/UI36-data-driven-sizing.md` §6, which recorded it as a follow-on.
+
+3 new tests (86 total). All eight Mosaic emit backends plus the resolver and
+`mosaic-compile` re-run clean (1,078 tests).
+
+
 ### Added — U29-G3: `expr` non-terminal in prop values
 
 - Ten new tokens in `moslayout.tokens` for the expression grammar:

--- a/code/packages/rust/moslayout-compiler/src/lib.rs
+++ b/code/packages/rust/moslayout-compiler/src/lib.rs
@@ -1569,10 +1569,46 @@ fn reconstruct_expr_text(node: &GrammarASTNode) -> String {
 fn collect_tokens(node: &GrammarASTNode, out: &mut Vec<String>) {
     for child in &node.children {
         match child {
-            ASTNodeOrToken::Token(t) => out.push(t.value.clone()),
+            ASTNodeOrToken::Token(t) => out.push(token_source_text(t)),
             ASTNodeOrToken::Node(n) => collect_tokens(n, out),
         }
     }
+}
+
+/// A token's text as it must appear in *reconstructed source*.
+///
+/// For every token type but one this is just the token's value. The exception is
+/// `String`: the lexer strips a string literal's surrounding quotes and resolves its
+/// escapes before storing the value (see `TokenType::String`), so pushing that value
+/// verbatim silently rewrites the author's expression —
+///
+/// ```text
+/// ( status == "done" )   reconstructs as   status == done
+/// ```
+///
+/// — turning a string comparison into a comparison against an undefined identifier.
+/// Re-quoting restores the author's meaning. It also means a string's contents can no
+/// longer contribute structural characters (`}`, `,`, a bare quote) to the emitted
+/// source, which is what kept expression text from being able to break out of the
+/// construct it was interpolated into. See `code/specs/UI36-data-driven-sizing.md` §6.
+fn token_source_text(t: &Token) -> String {
+    if t.type_ != TokenType::String {
+        return t.value.clone();
+    }
+    let mut out = String::with_capacity(t.value.len() + 2);
+    out.push('"');
+    for c in t.value.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(c),
+        }
+    }
+    out.push('"');
+    out
 }
 
 /// Resolve the standard `\`-escapes (`\n`, `\t`, `\\`, `\"`, `\r`, `\0`)
@@ -2630,6 +2666,84 @@ mod tests {
                     text.contains("editable"),
                     "Expr should include field name: {text:?}"
                 );
+            }
+            other => panic!("expected Expr, got {other:?}"),
+        }
+    }
+
+    /// A string literal inside an expression must keep its quotes.
+    ///
+    /// The lexer strips them (and resolves escapes) before storing a STRING token's
+    /// value, so reconstructing from `token.value` verbatim silently rewrote
+    /// `status == "done"` into `status == done` — a comparison against an undefined
+    /// identifier. Every backend interpolates this text into generated source, so the
+    /// bug reached all of them.
+    #[test]
+    fn expr_string_literal_keeps_its_quotes() {
+        let src = r#"
+          layout L {
+            Column [ root ] {
+              If ( when: ( status == "done" ) ) {
+                Text ( slot: label )
+              }
+            }
+          }
+        "#;
+        match first_prop_value(src) {
+            LayoutPropValue::Expr(text) => assert!(
+                text.contains("\"done\""),
+                "the string literal lost its quotes: {text:?}"
+            ),
+            other => panic!("expected Expr, got {other:?}"),
+        }
+    }
+
+    /// A quote inside the string must come back escaped, so the reconstructed text
+    /// can't terminate the literal early — which is also what stops a string's
+    /// contents from contributing structural characters to the emitted source.
+    #[test]
+    fn expr_string_literal_reescapes_an_inner_quote() {
+        let src = r#"
+          layout L {
+            Column [ root ] {
+              If ( when: ( label == "he said \"hi\"" ) ) {
+                Text ( slot: label )
+              }
+            }
+          }
+        "#;
+        match first_prop_value(src) {
+            LayoutPropValue::Expr(text) => {
+                assert!(text.contains("\\\""), "inner quote not re-escaped: {text:?}");
+                // Exactly two unescaped quotes: the ones that delimit the literal.
+                let bare = text
+                    .char_indices()
+                    .filter(|(i, c)| {
+                        *c == '"' && (*i == 0 || text.as_bytes()[i - 1] != b'\\')
+                    })
+                    .count();
+                assert_eq!(bare, 2, "unbalanced delimiters in {text:?}");
+            }
+            other => panic!("expected Expr, got {other:?}"),
+        }
+    }
+
+    /// A non-string token is untouched — the fix must not start quoting identifiers.
+    #[test]
+    fn expr_non_string_tokens_are_unquoted() {
+        let src = r#"
+          layout L {
+            Column [ root ] {
+              If ( when: ( count > 3 ) ) {
+                Text ( slot: label )
+              }
+            }
+          }
+        "#;
+        match first_prop_value(src) {
+            LayoutPropValue::Expr(text) => {
+                assert!(!text.contains('"'), "identifiers got quoted: {text:?}");
+                assert!(text.contains("count") && text.contains('3'), "{text:?}");
             }
             other => panic!("expected Expr, got {other:?}"),
         }

--- a/code/programs/mosaic/task-app/CHANGELOG.md
+++ b/code/programs/mosaic/task-app/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to the `task-app` web program are documented here.
 
 ## [0.1.0] - Unreleased
 
+### Added - progressive disclosure on task rows
+
+- **Click a task's name to reveal its scheduling detail** — when it's scheduled for,
+  its earliest and latest possible start, and how much slack it has (or that it's on
+  the critical path, where any delay delays the whole project). Clicking again closes
+  it. This is the "simple by default, complexity on request" principle from
+  `code/specs/task-app-ui-design.md`: the collapsed list stays a plain to-do list, and
+  the CPM detail is there the moment you ask for it.
+- Every detail line is phrased from the ENGINE's own numbers — early/late dates, total
+  and free slack, criticality — never recomputed in the host.
+- The open row is tracked by **task id, not row index**, so it follows the right task
+  when the list re-sorts or something above it is deleted; deleting the open task
+  clears it.
+- **The CPM recompute is skipped entirely when nothing is open.** `getProps` runs after
+  every dispatch — including each keystroke in the composer — so an unconditional
+  `schedule()` call would have made typing progressively more expensive as a project
+  grew. (Caught in security review.)
+- Also from review: pluralisation now reads the number actually shown (479 minutes
+  renders as "1.0" and must not then say "1.0 days" by accident); each detail line is
+  guarded on its own cell so an unscheduled task shows one explanatory line instead of
+  a panel padded with blanks; and a documented-but-never-populated "notes" cell was
+  removed along with its dead style part rather than left as a promise the code
+  didn't keep.
+
+
 ### Added - timeline (Gantt) view
 
 - **A real proportional Gantt**, switchable from the task list via a toggle beside the

--- a/code/programs/mosaic/task-app/CHANGELOG.md
+++ b/code/programs/mosaic/task-app/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to the `task-app` web program are documented here.
 
 ## [0.1.0] - Unreleased
 
+### Added - timeline (Gantt) view
+
+- **A real proportional Gantt**, switchable from the task list via a toggle beside the
+  summary. Each row shows the task name, a bar positioned and sized on one shared date
+  scale, and its date window; bars on the **critical path** are red, the rest honey.
+  Both themes.
+- This is the first consumer of **UI36 data-driven sizing**
+  (`code/specs/UI36-data-driven-sizing.md`). The bar's offset and length are CSS
+  percentages the host computes from the engine's own gantt output and binds with
+  `width: ( t[n] )` — previously impossible, since mosstyle bakes static values and a
+  slot-bound width was silently dropped. The chart is genuinely to-scale, not an
+  approximation.
+- Geometry lives in `src/timeline.ts` as pure functions, tested without a wasm engine or
+  a DOM (12 tests; 28 total, coverage 97%).
+
+  The rule those tests exist to protect: **task-core dates are day-granular with an
+  inclusive finish**, so a task occupying one day reports `finish === start`. An earlier
+  draft used the bare difference, which made every one-day task zero-width — each fell
+  through to the milestone floor and the whole chart rendered as a row of slivers. A
+  length is `finish - start + 1`. (Caught in security review.)
+- Degrades rather than throwing on malformed engine output: bars with non-finite dates
+  are skipped, an inverted bar can't produce a negative width, a date outside
+  JavaScript's range renders as `—` instead of throwing from `toISOString`, and the
+  min/max use `reduce` rather than spreading a large array into an argument list.
+- A zero-duration milestone is floored at a sliver so it stays visible.
+
+## [0.1.0] - Unreleased
+
 ### Added - light/dark theme switching in the web host
 
 - **The app follows your OS theme, and you can override it.** A toggle sits top-right;

--- a/code/programs/mosaic/task-app/host/web/__tests__/timeline.test.ts
+++ b/code/programs/mosaic/task-app/host/web/__tests__/timeline.test.ts
@@ -1,0 +1,117 @@
+/**
+ * timeline.test.ts — Gantt geometry.
+ *
+ * The rule that governs every assertion here: **task-core dates are day-granular with
+ * an inclusive finish**, so a task occupying one day reports `finish === start`. An
+ * earlier draft used the bare difference, which made every one-day task zero-width —
+ * it fell through to the milestone floor and the whole chart rendered as slivers. Most
+ * of these tests exist to keep that from coming back.
+ */
+import { describe, it, expect } from "vitest";
+import { buildTimeline, dayToIso, type GanttBar } from "../src/timeline";
+
+const bar = (name: string, start: number, finish: number, critical = false): GanttBar => ({
+  name,
+  start,
+  finish,
+  critical,
+});
+const pctOf = (s: string) => parseFloat(s);
+
+describe("timeline geometry", () => {
+  it("says so plainly when nothing is scheduled", () => {
+    expect(buildTimeline([])).toEqual({ scale: "Nothing scheduled yet.", rows: [] });
+  });
+
+  it("gives a one-day project a full-width bar, not a sliver", () => {
+    // THE regression. finish === start is one day, not zero.
+    const view = buildTimeline([bar("Only", 100, 100)]);
+    expect(view.rows).toHaveLength(1);
+    expect(view.rows[0][1]).toBe("0.00%");
+    expect(view.rows[0][2]).toBe("100.00%");
+    expect(view.scale).toContain("1 day");
+  });
+
+  it("counts an inclusive span in days", () => {
+    // 100..101 inclusive is two days.
+    const view = buildTimeline([bar("Two", 100, 101)]);
+    expect(view.scale).toContain("2 days");
+    expect(view.rows[0][2]).toBe("100.00%");
+  });
+
+  it("lays a chain out left to right without overflowing the track", () => {
+    const view = buildTimeline([
+      bar("A", 10, 11),
+      bar("B", 12, 13),
+      bar("C", 14, 15),
+    ]);
+    const pads = view.rows.map((r) => pctOf(r[1]));
+    const widths = view.rows.map((r) => pctOf(r[2]));
+
+    expect(pads[0]).toBe(0);
+    expect(pads[0]).toBeLessThan(pads[1]);
+    expect(pads[1]).toBeLessThan(pads[2]);
+    widths.forEach((w) => expect(w).toBeGreaterThan(0));
+    view.rows.forEach((_, i) => expect(pads[i] + widths[i]).toBeLessThanOrEqual(100.01));
+    // Three equal 2-day tasks over a 6-day span.
+    widths.forEach((w) => expect(w).toBeCloseTo(100 / 3, 1));
+  });
+
+  it("keeps a zero-duration milestone visible", () => {
+    // A milestone shares its day with a long task, so its natural width is a rounding
+    // error of the span — the floor is what keeps it on screen.
+    const view = buildTimeline([bar("Long", 0, 99), bar("Launch", 99, 99)]);
+    const milestone = view.rows.find((r) => r[0] === "Launch")!;
+    expect(pctOf(milestone[2])).toBeGreaterThan(0);
+  });
+
+  it("marks the critical path", () => {
+    const view = buildTimeline([bar("Crit", 0, 1, true), bar("Slack", 0, 1, false)]);
+    expect(view.rows[0][4]).toBe("critical");
+    expect(view.rows[1][4]).toBe("");
+  });
+
+  it("reports each bar's own window", () => {
+    const view = buildTimeline([bar("A", 19723, 19724)]); // 2024-01-01 → 2024-01-02
+    expect(view.rows[0][3]).toBe("2024-01-01 → 2024-01-02");
+  });
+
+  // ---- malformed engine output: degrade, never throw or render nonsense ----
+
+  it("ignores bars the engine couldn't place", () => {
+    const view = buildTimeline([
+      bar("Good", 5, 6),
+      { name: "Bad", start: NaN, finish: 6, critical: false },
+    ]);
+    expect(view.rows.map((r) => r[0])).toEqual(["Good"]);
+  });
+
+  it("falls back to the empty view when every bar is unplaceable", () => {
+    const view = buildTimeline([{ name: "Bad", start: NaN, finish: NaN, critical: false }]);
+    expect(view.rows).toHaveLength(0);
+  });
+
+  it("never emits a negative or overflowing width for an inverted bar", () => {
+    // finish < start shouldn't be possible from the engine, but a corrupted snapshot
+    // must not produce a negative CSS width.
+    const view = buildTimeline([bar("Sane", 0, 9), bar("Inverted", 5, 3)]);
+    view.rows.forEach((r) => {
+      expect(pctOf(r[1])).toBeGreaterThanOrEqual(0);
+      expect(pctOf(r[2])).toBeGreaterThan(0);
+      expect(pctOf(r[1]) + pctOf(r[2])).toBeLessThanOrEqual(100.01);
+    });
+  });
+
+  it("survives a date JavaScript can't represent", () => {
+    // `new Date(x).toISOString()` throws beyond ±8.64e15 ms; the render must not die.
+    expect(dayToIso(1e15)).toBe("—");
+    expect(dayToIso(Number.POSITIVE_INFINITY)).toBe("—");
+    expect(() => buildTimeline([bar("Far", 1e15, 1e15)])).not.toThrow();
+  });
+
+  it("handles a large bar list without spreading it into an argument list", () => {
+    // Math.min(...arr) throws "too many arguments" at this size; reduce doesn't.
+    const many = Array.from({ length: 200_000 }, (_, i) => bar(`T${i}`, i, i));
+    expect(() => buildTimeline(many)).not.toThrow();
+  });
+});

--- a/code/programs/mosaic/task-app/host/web/src/main.tsx
+++ b/code/programs/mosaic/task-app/host/web/src/main.tsx
@@ -12,6 +12,7 @@ import { createRoot } from "react-dom/client";
 import { TaskApp as TaskAppLight, type TaskAppEvent } from "./TaskApp.light";
 import { TaskApp as TaskAppDark } from "./TaskApp.dark";
 import { resolveTheme, storeTheme, watchSystemTheme, type Theme } from "./theme";
+import { buildTimeline, type GanttBar } from "./timeline";
 import { createTaskEngine } from "./task-engine.mjs";
 import {
   loadWorkspace,
@@ -73,6 +74,7 @@ function makeController(engine: any, init: ControllerInit = {}) {
   let newName = "";
   let newDue = "";
   let newProject = "";
+  let showTimeline = false;
   // Task ids are workspace-global, so this stays one list across every project. The
   // per-project view falls out for free: `rows()` keeps only the ids the ACTIVE
   // project's table() knows about.
@@ -141,6 +143,14 @@ function makeController(engine: any, init: ControllerInit = {}) {
     return { ids, names: ids.map((id) => all[id]?.name || id), depths, activeId };
   };
 
+  // The timeline: hand the engine's own gantt bars to the geometry module. Every
+  // date here was computed by the ENGINE; the host only asks how far across the track
+  // that falls. See timeline.ts for the inclusive-date rule that governs the maths.
+  const timeline = () => {
+    const bars = (engine.gantt(today).data?.bars ?? []) as GanttBar[];
+    return buildTimeline(bars);
+  };
+
   // Snapshot the engine + host state and hand it to the persistence sink. Called
   // only after structural mutations (add/toggle/delete/project switch) — never on
   // keystrokes. The active project rides along because the engine deliberately keeps
@@ -198,8 +208,13 @@ function makeController(engine: any, init: ControllerInit = {}) {
         // top-level row stays flush left.
         p.depths[i] > 0 ? `${" ".repeat((p.depths[i] - 1) * 2)}↳` : "",
       ]);
+      const tl = showTimeline ? timeline() : { scale: "", rows: [] };
       return {
         appTitle: "Tasks — auto-scheduled",
+        timelineMode: showTimeline ? "timeline" : "",
+        timelineScale: tl.scale,
+        timelineRows: tl.rows,
+        viewToggleLabel: showTimeline ? "List" : "Timeline",
         newTaskName: newName,
         newTaskDue: newDue,
         newProjectName: newProject,
@@ -218,6 +233,9 @@ function makeController(engine: any, init: ControllerInit = {}) {
           break;
         case "newTaskDueChange":
           newDue = event.value;
+          break;
+        case "toggleView":
+          showTimeline = !showTimeline;
           break;
         case "newProjectNameChange":
           newProject = event.value;

--- a/code/programs/mosaic/task-app/host/web/src/main.tsx
+++ b/code/programs/mosaic/task-app/host/web/src/main.tsx
@@ -75,6 +75,9 @@ function makeController(engine: any, init: ControllerInit = {}) {
   let newDue = "";
   let newProject = "";
   let showTimeline = false;
+  // Which row is expanded, by task id (not index — an index would follow the wrong
+  // task the moment the list is re-sorted or something above it is deleted).
+  let expanded: string | null = null;
   // Task ids are workspace-global, so this stays one list across every project. The
   // per-project view falls out for free: `rows()` keeps only the ids the ACTIVE
   // project's table() knows about.
@@ -189,12 +192,51 @@ function makeController(engine: any, init: ControllerInit = {}) {
       // layout places each cell in its own styled element (toggle, name, chips).
       // Empty cells become empty strings, which the layout hides.
       const { byTask, ids } = rows();
+      // The scheduling detail for the ONE open row. Everything here is the engine's
+      // answer — early/late dates, slack, criticality — merely phrased.
+      // Only when a row is open: this is a full CPM recompute, and getProps runs
+      // after every dispatch — including each keystroke in the composer.
+      const sched = expanded === null ? undefined : engine.schedule(today).data;
+      const detailFor = (id: string): [string, string, string] => {
+        const d = sched?.dates?.[id];
+        if (!d) return ["Not scheduled yet.", "", ""];
+        const mins = (m: number) => {
+          const days = m / (8 * 60);
+          // Pluralise on the number the reader sees: 479 minutes is 0.998 days, which
+          // renders as "1.0" and must not then say "1.0 days" vs "1.0 day" by accident.
+          const shown = Number.isInteger(days) ? String(days) : days.toFixed(1);
+          return `${shown} day${Number(shown) === 1 ? "" : "s"}`;
+        };
+        return [
+          `Scheduled ${daysToIso(d.scheduledStart)} → ${daysToIso(d.scheduledFinish)}` +
+            ` · earliest ${daysToIso(d.earlyStart)}, latest ${daysToIso(d.lateStart)}`,
+          d.critical
+            ? "On the critical path — any delay here delays the project."
+            : `${mins(d.totalSlack)} of slack — it can slip that much without moving the finish.`,
+          d.freeSlack > 0 && !d.critical
+            ? `${mins(d.freeSlack)} of it without disturbing the next task.`
+            : "",
+        ];
+      };
+
       const taskRows: string[][] = ids.map((id) => {
         const c = byTask.get(id)!;
         const due = c.display[DEADLINE] ? `due ${c.display[DEADLINE]}` : "";
-        const sched = c.display[START] ? `${c.display[START]} → ${c.display[FINISH]}` : "";
+        const window = c.display[START] ? `${c.display[START]} → ${c.display[FINISH]}` : "";
         const late = c.value[OVERDUE]?.value === true ? "⚠ overdue" : "";
-        return [c.display[DONE], c.display[NAME], due, sched, late];
+        const isOpen = id === expanded;
+        const [d1, d2, d3] = isOpen ? detailFor(id) : ["", "", ""];
+        return [
+          c.display[DONE],
+          c.display[NAME],
+          due,
+          window,
+          late,
+          isOpen ? "open" : "",
+          d1,
+          d2,
+          d3,
+        ];
       });
       const doneCount = ids.filter((id) => byTask.get(id)!.value[DONE]?.value === true).length;
       const finish = engine.gantt(today).data.projectFinish;
@@ -234,6 +276,13 @@ function makeController(engine: any, init: ControllerInit = {}) {
         case "newTaskDueChange":
           newDue = event.value;
           break;
+        case "expandTask": {
+          // Resolve through the same ordered id list the rows were drawn from, so the
+          // clicked index can't drift onto a different task.
+          const id = rows().ids[event.index];
+          if (id) expanded = expanded === id ? null : id;
+          break;
+        }
         case "toggleView":
           showTimeline = !showTimeline;
           break;
@@ -319,6 +368,7 @@ function makeController(engine: any, init: ControllerInit = {}) {
           const id = visible()[event.index];
           if (id) {
             engine.deleteTask({ id });
+            if (expanded === id) expanded = null;
             const at = order.indexOf(id);
             if (at >= 0) order.splice(at, 1);
             persist();

--- a/code/programs/mosaic/task-app/host/web/src/timeline.ts
+++ b/code/programs/mosaic/task-app/host/web/src/timeline.ts
@@ -1,0 +1,87 @@
+// Timeline (Gantt) geometry.
+//
+// Pure arithmetic, deliberately separated from the controller so it can be tested
+// without a wasm engine or a DOM. The ENGINE decides when every task starts and
+// finishes and which are critical; this file only answers "how far across the track
+// is that, as a percentage".
+//
+// The one thing to know before reading: **task-core dates are day-granular with an
+// INCLUSIVE finish.** A task occupying a single day reports `finish === start`. So a
+// length is `finish - start + 1`, never the bare difference — getting that wrong makes
+// every one-day task zero-width, which renders the whole chart as a row of slivers.
+
+/** The engine's gantt bar, narrowed to the fields the geometry needs. */
+export interface GanttBar {
+  name: string;
+  /** Days since the Unix epoch, inclusive. */
+  start: number;
+  /** Days since the Unix epoch, inclusive — equals `start` for a one-day task. */
+  finish: number;
+  critical: boolean;
+}
+
+/** A row as the layout consumes it: `[ name, padWidth, barWidth, window, critical ]`. */
+export type TimelineRow = [string, string, string, string, string];
+
+export interface TimelineView {
+  /** The date ruler shown above the bars. */
+  scale: string;
+  rows: TimelineRow[];
+}
+
+/**
+ * The narrowest a bar may render, as a fraction of the whole span. A true milestone
+ * has no duration at all; without a floor it would be invisible.
+ */
+const MIN_BAR_FRACTION = 0.004;
+
+const DAY_MS = 86_400_000;
+
+/** `days since epoch` → `YYYY-MM-DD`, or `"—"` for a date JavaScript can't represent. */
+export function dayToIso(days: number): string {
+  if (!Number.isFinite(days)) return "—";
+  const ms = days * DAY_MS;
+  // `new Date(x).toISOString()` THROWS outside ±8.64e15 ms. A corrupted snapshot
+  // shouldn't take the render down with it.
+  if (Math.abs(ms) > 8.64e15) return "—";
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+/**
+ * Lay the engine's bars out on one shared date scale.
+ *
+ * Returns render-ready percentage strings; an empty or unusable bar list yields an
+ * empty view with an explanatory scale rather than throwing.
+ */
+export function buildTimeline(bars: readonly GanttBar[]): TimelineView {
+  // Ignore bars the engine couldn't place — a NaN would poison min/max and every
+  // percentage downstream.
+  const usable = bars.filter((b) => Number.isFinite(b.start) && Number.isFinite(b.finish));
+  if (usable.length === 0) return { scale: "Nothing scheduled yet.", rows: [] };
+
+  // `reduce`, not `Math.min(...bars)`: spreading a large array throws
+  // "too many arguments" somewhere past ~100k elements.
+  const first = usable.reduce((m, b) => Math.min(m, b.start), usable[0].start);
+  const last = usable.reduce((m, b) => Math.max(m, b.finish), usable[0].finish);
+
+  // Inclusive: a project that starts and ends on the same day spans one day, not zero.
+  const span = Math.max(1, last - first + 1);
+  const pct = (days: number) => `${((days / span) * 100).toFixed(2)}%`;
+
+  return {
+    scale: `${dayToIso(first)} → ${dayToIso(last)} · ${span} day${span === 1 ? "" : "s"}`,
+    rows: usable.map((b): TimelineRow => {
+      // Clamp defensively: a malformed bar with finish < start would otherwise produce
+      // a negative width, and one starting before `first` a negative pad.
+      const length = Math.max(b.finish - b.start + 1, span * MIN_BAR_FRACTION);
+      const pad = Math.max(0, b.start - first);
+      return [
+        b.name,
+        pct(pad),
+        pct(Math.min(length, span - pad)),
+        `${dayToIso(b.start)} → ${dayToIso(b.finish)}`,
+        b.critical ? "critical" : "",
+      ];
+    }),
+  };
+}

--- a/code/programs/mosaic/task-app/host/web/vitest.config.ts
+++ b/code/programs/mosaic/task-app/host/web/vitest.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
       // boot glue verified live in a browser, and TaskApp.{light,dark}.tsx are
       // generated. A module with tests but missing from this list is silently exempt
       // from the threshold below, so add new seams here as they appear.
-      include: ["src/persistence.ts", "src/theme.ts"],
+      include: ["src/persistence.ts", "src/theme.ts", "src/timeline.ts"],
       thresholds: { lines: 90 },
     },
   },

--- a/code/programs/mosaic/task-app/src/TaskApp.dark.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.dark.msl
@@ -205,8 +205,15 @@ style TaskApp {
     }
   }
   part task-name {
+    background : "#252019" ;
     color : "#f1ebe1" ;
     font-size : 14 ;
+    padding : 4 ;
+    border-radius : 7 ;
+    state hover {
+      background : "#3a2c17" ;
+      color : "#eaa63f" ;
+    }
   }
   // Meta chips. Due is honey (time), schedule is a quiet surface, overdue is the
   // one place semantic red appears in a row.
@@ -231,6 +238,25 @@ style TaskApp {
     font-weight : bold ;
     padding : 5 ;
     border-radius : 20 ;
+  }
+  // Progressive disclosure: the scheduling detail, inset under its row.
+  part task-detail {
+    background : "#2d271f" ;
+    border-radius : 11 ;
+    padding : 12 ;
+    gap : 4 ;
+  }
+  part detail-sched {
+    color : "#b3a99c" ;
+    font-size : 12 ;
+  }
+  part detail-slack {
+    color : "#b3a99c" ;
+    font-size : 12 ;
+  }
+  part detail-free {
+    color : "#b3a99c" ;
+    font-size : 12 ;
   }
   part del-btn {
     background : "#3a221c" ;

--- a/code/programs/mosaic/task-app/src/TaskApp.dark.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.dark.msl
@@ -126,6 +126,64 @@ style TaskApp {
     color : "#b3a99c" ;
     font-size : 13 ;
   }
+  part summary-row {
+    gap : 10 ;
+    align : center-vertical ;
+  }
+  part view-toggle {
+    background : "#252019" ;
+    color : "#b3a99c" ;
+    font-size : 12 ;
+    padding : 6 ;
+    border-width : 1 ;
+    border-color : "#352e25" ;
+    border-radius : 20 ;
+    state hover {
+      border-color : "#eaa63f" ;
+      color : "#eaa63f" ;
+    }
+  }
+  // ── Timeline (Gantt) ──────────────────────────────────────────────────
+  part timeline {
+    gap : 6 ;
+  }
+  part tl-scale {
+    color : "#867c70" ;
+    font-size : 11 ;
+  }
+  part timeline-row {
+    gap : 10 ;
+    align : center-vertical ;
+  }
+  part tl-name {
+    color : "#f1ebe1" ;
+    font-size : 13 ;
+    width : 150 ;
+  }
+  // The shared track every bar is measured against. Bars are positioned by a
+  // percentage pad, so the track must be a fixed, common width.
+  part tl-track {
+    width : 420 ;
+    background : "#2d271f" ;
+    border-radius : 6 ;
+  }
+  part tl-pad {
+    height : 16 ;
+  }
+  part tl-bar {
+    background : "#eaa63f" ;
+    height : 16 ;
+    border-radius : 6 ;
+  }
+  part tl-bar-crit {
+    background : "#e26a52" ;
+    height : 16 ;
+    border-radius : 6 ;
+  }
+  part tl-window {
+    color : "#b3a99c" ;
+    font-size : 11 ;
+  }
   part task-list {
     gap : 8 ;
   }

--- a/code/programs/mosaic/task-app/src/TaskApp.light.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.light.msl
@@ -126,6 +126,64 @@ style TaskApp {
     color : "#6a625a" ;
     font-size : 13 ;
   }
+  part summary-row {
+    gap : 10 ;
+    align : center-vertical ;
+  }
+  part view-toggle {
+    background : "#fffdfa" ;
+    color : "#6a625a" ;
+    font-size : 12 ;
+    padding : 6 ;
+    border-width : 1 ;
+    border-color : "#e6ded3" ;
+    border-radius : 20 ;
+    state hover {
+      border-color : "#e0942a" ;
+      color : "#b6741a" ;
+    }
+  }
+  // ── Timeline (Gantt) ──────────────────────────────────────────────────
+  part timeline {
+    gap : 6 ;
+  }
+  part tl-scale {
+    color : "#9b9289" ;
+    font-size : 11 ;
+  }
+  part timeline-row {
+    gap : 10 ;
+    align : center-vertical ;
+  }
+  part tl-name {
+    color : "#2b2723" ;
+    font-size : 13 ;
+    width : 150 ;
+  }
+  // The shared track every bar is measured against. Bars are positioned by a
+  // percentage pad, so the track must be a fixed, common width.
+  part tl-track {
+    width : 420 ;
+    background : "#f7f2ea" ;
+    border-radius : 6 ;
+  }
+  part tl-pad {
+    height : 16 ;
+  }
+  part tl-bar {
+    background : "#e0942a" ;
+    height : 16 ;
+    border-radius : 6 ;
+  }
+  part tl-bar-crit {
+    background : "#cf4b34" ;
+    height : 16 ;
+    border-radius : 6 ;
+  }
+  part tl-window {
+    color : "#6a625a" ;
+    font-size : 11 ;
+  }
   part task-list {
     gap : 8 ;
   }

--- a/code/programs/mosaic/task-app/src/TaskApp.light.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.light.msl
@@ -205,8 +205,15 @@ style TaskApp {
     }
   }
   part task-name {
+    background : "#fffdfa" ;
     color : "#2b2723" ;
     font-size : 14 ;
+    padding : 4 ;
+    border-radius : 7 ;
+    state hover {
+      background : "#faedd6" ;
+      color : "#b6741a" ;
+    }
   }
   // Meta chips. Due is honey (time), schedule is a quiet surface, overdue is the
   // one place semantic red appears in a row.
@@ -231,6 +238,25 @@ style TaskApp {
     font-weight : bold ;
     padding : 5 ;
     border-radius : 20 ;
+  }
+  // Progressive disclosure: the scheduling detail, inset under its row.
+  part task-detail {
+    background : "#f7f2ea" ;
+    border-radius : 11 ;
+    padding : 12 ;
+    gap : 4 ;
+  }
+  part detail-sched {
+    color : "#6a625a" ;
+    font-size : 12 ;
+  }
+  part detail-slack {
+    color : "#6a625a" ;
+    font-size : 12 ;
+  }
+  part detail-free {
+    color : "#6a625a" ;
+    font-size : 12 ;
   }
   part del-btn {
     background : "#f8e4df" ;

--- a/code/programs/mosaic/task-app/src/TaskApp.mil
+++ b/code/programs/mosaic/task-app/src/TaskApp.mil
@@ -26,6 +26,19 @@ component TaskApp {
   // A one-line summary (counts, project finish).
   slot summary : text ;
 
+  // Timeline (Gantt). `timeline-mode` is non-empty when the timeline is showing instead
+  // of the task list, and `view-toggle-label` names the view you'd switch TO.
+  //
+  // Each timeline row is [ name, pad-width, bar-width, window, critical-marker ].
+  // `pad-width` and `bar-width` are CSS percentages of the shared track (e.g. "18%"),
+  // so every bar sits on one date scale — they reach the layout through UI36
+  // data-driven sizing (`width: ( t[n] )`). `timeline-scale` is the matching date
+  // ruler, and a non-empty `critical-marker` means the row is on the critical path.
+  slot timeline-mode     : text ;
+  slot timeline-scale    : text ;
+  slot timeline-rows     : list<list<text>> ;
+  slot view-toggle-label : text ;
+
   // One row per task, in schedule order; each row is a list of pre-formatted cells
   // in the order [ done-glyph, name, due, schedule, overdue ]. Empty cells (e.g. no
   // due date) are the empty string, and the layout hides those chips.
@@ -41,6 +54,9 @@ component TaskApp {
   emit onAddProject ;
   emit onAddSubproject ;
   emit onSelectProject ( index : number ) ;
+
+  // Switch between the task list and the timeline.
+  emit onToggleView ;
 
   // Add the typed task; toggle/delete a row (the row index is delivered as the number
   // payload of a single-number-param event).

--- a/code/programs/mosaic/task-app/src/TaskApp.mil
+++ b/code/programs/mosaic/task-app/src/TaskApp.mil
@@ -39,9 +39,19 @@ component TaskApp {
   slot timeline-rows     : list<list<text>> ;
   slot view-toggle-label : text ;
 
-  // One row per task, in schedule order; each row is a list of pre-formatted cells
-  // in the order [ done-glyph, name, due, schedule, overdue ]. Empty cells (e.g. no
-  // due date) are the empty string, and the layout hides those chips.
+  // One row per task, in schedule order. Each row is a list of pre-formatted cells:
+  //
+  //   [ 0 ] done-glyph      [ 5 ] expanded-marker  — non-empty for the ONE open row
+  //   [ 1 ] name            [ 6 ] detail: scheduled / earliest / latest
+  //   [ 2 ] due             [ 7 ] detail: slack, or "on the critical path"
+  //   [ 3 ] schedule        [ 8 ] detail: free slack (only when it differs)
+  //   [ 4 ] overdue
+  //
+  // Every cell is optional: an empty one (no due date, not overdue, nothing to add)
+  // is the empty string and the layout hides it. Cells 6-8 are the
+  // progressive-disclosure payload, filled ONLY for the expanded row — so a collapsed
+  // list stays a plain to-do list, and the host skips the CPM recompute entirely when
+  // nothing is open.
   slot task-rows : list<list<text>> ;
 
   // Typing in the inputs.
@@ -57,6 +67,9 @@ component TaskApp {
 
   // Switch between the task list and the timeline.
   emit onToggleView ;
+
+  // Expand (or collapse) a task row to reveal its scheduling detail.
+  emit onExpandTask ( index : number ) ;
 
   // Add the typed task; toggle/delete a row (the row index is delivered as the number
   // payload of a single-number-param event).

--- a/code/programs/mosaic/task-app/src/TaskApp.mll
+++ b/code/programs/mosaic/task-app/src/TaskApp.mll
@@ -91,7 +91,8 @@ layout TaskApp {
       For ( each: slot: task-rows , as: row , index: i ) {
         Row [ task-row ] {
           HostButton [ toggle ] ( label : ( row[0] ) , onClick : emit: onToggleTask )
-          Text [ task-name ] ( content : ( row[1] ) )
+          // The name is the disclosure control: clicking it opens this row's detail.
+          HostButton [ task-name ] ( label : ( row[1] ) , onClick : emit: onExpandTask )
           If ( when: ( row[2] ) ) {
             Text [ chip-due ] ( content : ( row[2] ) )
           }
@@ -102,6 +103,23 @@ layout TaskApp {
             Text [ chip-over ] ( content : ( row[4] ) )
           }
           HostButton [ del-btn ] ( label : "Delete" , onClick : emit: onDeleteTask )
+        }
+        // Progressive disclosure: the scheduling detail exists for every task but is
+        // only rendered for the open row, so the default list stays a plain to-do list.
+        If ( when: ( row[5] ) ) {
+          Column [ task-detail ] {
+            // Every line is guarded on its own cell, so an unscheduled task shows one
+            // explanatory line rather than a panel padded with blanks.
+            If ( when: ( row[6] ) ) {
+              Text [ detail-sched ] ( content : ( row[6] ) )
+            }
+            If ( when: ( row[7] ) ) {
+              Text [ detail-slack ] ( content : ( row[7] ) )
+            }
+            If ( when: ( row[8] ) ) {
+              Text [ detail-free ] ( content : ( row[8] ) )
+            }
+          }
         }
       }
     }

--- a/code/programs/mosaic/task-app/src/TaskApp.mll
+++ b/code/programs/mosaic/task-app/src/TaskApp.mll
@@ -47,7 +47,41 @@ layout TaskApp {
       HostButton [ add-btn ] ( label : "Add" , onClick : emit: onAddTask )
     }
 
-    Text [ summary ] ( content : slot: summary )
+    Row [ summary-row ] {
+      Text [ summary ] ( content : slot: summary )
+      HostButton [ view-toggle ] (
+        label : slot: view-toggle-label ,
+        onClick : emit: onToggleView
+      )
+    }
+
+    // The timeline and the task list are the two views of the same project; exactly one
+    // shows at a time, chosen by the non-empty `timeline-mode` marker.
+    If ( when: slot: timeline-mode ) {
+      Column [ timeline ] {
+        Text [ tl-scale ] ( content : slot: timeline-scale )
+        For ( each: slot: timeline-rows , as: t , index: ti ) {
+          Row [ timeline-row ] {
+            Text [ tl-name ] ( content : ( t[0] ) )
+            // A real proportional bar: the leading pad and the bar itself take their
+            // widths from the row's data (UI36 data-driven sizing), both as percentages
+            // of the shared track, so every bar lines up on one date scale. A critical
+            // bar differs from a normal one only in colour — the geometry is identical.
+            Row [ tl-track ] {
+              Box [ tl-pad ] ( width : ( t[1] ) )
+              If ( when: ( t[4] ) ) {
+                Box [ tl-bar-crit ] ( width : ( t[2] ) )
+              }
+              Else {
+                Box [ tl-bar ] ( width : ( t[2] ) )
+              }
+            }
+            Text [ tl-window ] ( content : ( t[3] ) )
+          }
+        }
+      }
+    }
+    Else {
 
     Column [ task-list ] {
       // Each row is a list of cells. The toggle and Delete buttons sit directly in
@@ -70,6 +104,7 @@ layout TaskApp {
           HostButton [ del-btn ] ( label : "Delete" , onClick : emit: onDeleteTask )
         }
       }
+    }
     }
   }
 }

--- a/code/specs/UI36-data-driven-sizing.md
+++ b/code/specs/UI36-data-driven-sizing.md
@@ -1,0 +1,112 @@
+# UI36 — data-driven sizing
+
+**Status:** implemented on the React backend; the other seven backends are follow-on.
+**Kernel surface:** the size props `width`, `height`, `min-width`, `max-width`,
+`min-height`, `max-height` on any layout node.
+
+---
+
+## 1. The gap
+
+Mosaic splits appearance cleanly: **moslayout** says what the tree is, **mosstyle**
+says what it looks like, and mosstyle deliberately bakes its values at compile time.
+That split is right for almost everything — and it has one hole.
+
+Some sizes are only knowable at run time:
+
+- the length of a **Gantt bar** — it depends on when the engine scheduled the task;
+- the fill of a **progress meter**;
+- a **proportional column** whose share comes from data;
+- any bar, sparkline, or gauge.
+
+No amount of authored CSS can express *"as wide as this row's data says"*. Before
+UI36 there was simply no way to size such a node — and worse, the obvious attempt
+**failed silently**:
+
+```mll
+Box [ bar ] ( width : slot: bar-width )   // parsed fine, then dropped on the floor
+```
+
+The only reader was `find_number_prop`, which matches a literal `Number` and nothing
+else, so a slot or expression binding was discarded without a word. An author had no
+way to tell a working binding from an ignored one.
+
+> **This is the spec's motivating principle.** A binding that is accepted by the
+> grammar must either take effect or be reported. Silently ignoring it is the worst of
+> the three options, because it teaches the author that the feature doesn't exist.
+
+## 2. The surface
+
+A size prop accepts the same value shapes the rest of the emitter already understands:
+
+| author writes | emitted (React) | meaning |
+|---|---|---|
+| `width: 120` | `width: 120` | CSS pixels (React reads a bare number as px) |
+| `width: "50%"` | `width: "50%"` | any CSS length, as a string |
+| `width: auto` | `width: "auto"` | a CSS keyword |
+| `width: slot: bar-width` | `width: barWidth` | bound to a slot |
+| `width: ( row[2] )` | `width: row[2]` | an expression — e.g. a `For` binding |
+
+The host may therefore supply a number *or* a string, which is what makes a bar that
+scales with its container (`"42%"`) expressible at all.
+
+Anything that is not a size — an emit ref, say — is a **hard error**, not a silent
+drop. A non-finite numeric literal is likewise rejected rather than emitted as a bare
+`inf` identifier that wouldn't compile.
+
+## 3. Precedence
+
+A bound size is **data**, and data outranks decoration. The emitted style object
+therefore orders values:
+
+```
+  base part style  →  state-block spreads  →  bound size
+```
+
+so a bound width beats both a static `part bar { width: … }` and a
+`state hover { width: … }`. Getting this backwards would reintroduce the original
+complaint in a subtler form: the binding would appear to do nothing whenever a
+stylesheet happened to mention the same property.
+
+> **Requirement.** A bound size must be emitted last. A backend whose style model
+> can't express that ordering must reject the combination rather than quietly let the
+> stylesheet win.
+
+## 4. What this does *not* change
+
+- **A layout that binds no size emits byte-identical output.** UI36 is purely
+  additive; every existing Mosaic app is unaffected. This is pinned by a test.
+- **mosstyle is still the home for static appearance.** UI36 is not an invitation to
+  move styling into the layout — it covers the values a stylesheet *cannot* know.
+
+## 5. Backend status
+
+| backend | status |
+|---|---|
+| react | **implemented** (11 tests) |
+| html, swiftui, compose, qt, flutter, xaml, webcomponent | **not yet** — a size prop is currently ignored there, which is the very bug this spec exists to close |
+
+Until a backend implements UI36, a layout relying on it renders unsized on that host.
+`code/programs/mosaic/task-app`'s timeline is the first consumer and is web-only today
+for exactly this reason.
+
+> **Requirement for each remaining backend.** Accept all five value shapes; emit the
+> bound size last (§3); and fail loudly on a non-size value.
+
+## 6. Known limitation — expression text is verbatim
+
+An `Expr` value is interpolated into the emitted source verbatim, exactly as it already
+is for `content:`, `label:`, `If ( when: … )`, and `For ( each: … )`. A `.mll` is
+first-party source under the same trust model as the rest of the repo's code.
+
+This is worth stating plainly because UI36 *widens* that surface — six props on every
+node, rather than a handful of specific ones. It also compounds a pre-existing
+moslayout defect: `reconstruct_expr_text` re-emits a STRING token's **inner text
+without its quotes**, so `( name == "done" )` currently reconstructs as
+`name == done` — a correctness bug in its own right, and the mechanism by which an
+expression could contain a `}`.
+
+> **Follow-on (tracked separately).** Fix `reconstruct_expr_text` to re-quote and
+> escape STRING tokens. That repairs string comparisons inside expressions *and*
+> removes the only route by which expression text can carry structural characters. It
+> belongs in moslayout, not in any one backend.

--- a/lessons.md
+++ b/lessons.md
@@ -1780,3 +1780,22 @@ Fix: normalize to LF on disk, which is what git stores and what CI sees anyway
 (`git check-attr text eol -- <file>` to confirm). When scripting an edit to a
 tracked file, read and write **binary** (`open(p,'rb')` / `'wb'`) so you never
 silently re-encode line endings you weren't asked to touch.
+
+**Third occurrence (moslayout-compiler), with a new symptom.** Inserting a test before
+an existing one splits that test's `#[test]` from its `fn` too, giving:
+
+```rust
+/// G3-4: Index access …
+#[test]                      // <- orphaned from its fn
+/// A string literal …
+#[test]
+fn my_new_test() { … }       // <- now carries TWO #[test] attributes
+```
+
+`cargo test` still passes — it just silently runs `my_new_test` **twice** (the count
+went 82 → 86 instead of 85, which is the tell). Only `clippy -D warnings` fails, as
+`duplicate_macro_attributes`. Same root cause, so the same rule applies and is worth
+restating as a hard habit: **anchor an insertion on the previous item's closing brace,
+never on the next item's signature** — attributes and doc comments both live above the
+signature, and anchoring there always cuts through them.
+


### PR DESCRIPTION
> **Single rolling PR for this run** — I keep pushing commits into it. Three so far.

---

## 1. UI36 — data-driven sizing (`mosaic-emit-react`)

You asked why widths couldn't be data-driven. **They can** — the mechanism was artificially limited, and I'd wrongly concluded otherwise from a shallow read.

`width`/`height`/`min-*`/`max-*` now accept a **slot binding, an expression, a string, or a CSS keyword** — not just a literal number. Previously the only reader was `find_number_prop`, so `width: slot: bar-width` parsed fine and was then **discarded without a word**. An author had no way to tell a working binding from an ignored one.

> **A binding the grammar accepts must either take effect or be reported.** That's the spec's motivating principle.

A bound size emits **last** — after the base part style *and* state spreads — because data outranks decoration. **Purely additive**: a layout binding no size emits byte-identical output, pinned by a test. Spec: [`UI36-data-driven-sizing.md`](code/specs/UI36-data-driven-sizing.md).

## 2. A real Gantt timeline (`task-app`)

Toggled from the task list. Bar offset and length are percentages of one shared date scale computed from the engine's gantt output; critical-path bars red. Both themes. First consumer of UI36 — genuinely to-scale, not an approximation.

## 3. Progressive disclosure

Click a task's name to reveal when it's scheduled, its earliest/latest start, and its slack — or that it's on the critical path. The collapsed list stays a plain to-do list; the CPM detail the engine always computed appears on request.

## 4. A real bug in `moslayout` (all eight backends)

`( status == "done" )` reconstructed as `status == done` — a comparison against an **undefined identifier**. The lexer strips a STRING token's quotes before storing its value, and `reconstruct_expr_text` pushed that verbatim. Any `.mll` expression comparing against a string was silently wrong on every backend. Now re-quoted and re-escaped — which also closes the only route by which expression text could contribute structural characters to emitted source.

---

## What security review caught (and I fixed) before pushing

- **The timeline was broken.** task-core dates are day-granular with an **inclusive** finish, so a one-day task has `finish === start`. Using the bare difference made every such task zero-width — the chart rendered as **a row of slivers**. A length is `finish - start + 1`.
- **A CPM recompute on every keystroke.** `getProps` runs after every dispatch, so an unconditional `schedule()` call made typing progressively more expensive as a project grew. Now gated on whether a row is open.
- Geometry extracted to `src/timeline.ts` and tested (12 tests) — it had **zero coverage**, which is exactly where the off-by-one hid.
- Emitter: a bound size now also outranks state blocks; a non-finite literal is rejected rather than emitting a bare `inf`; `width: auto` works instead of hard-erroring.
- Degrades instead of throwing on malformed engine data: non-finite dates skipped, inverted bars can't yield negative widths, out-of-range dates render `—` rather than throwing from `toISOString`.

## Verification

192 emitter + 85 moslayout + 28 host tests (**97% coverage**), clippy clean, both themes compile. **All 11 Mosaic crates re-run green — 1,078 tests, no regressions** (the moslayout fix changes reconstructed text for every backend). Engine behaviour verified against a real `wasm32` build driven from Node, including that every `ScheduledDates` field name matches what the host reads.

## Follow-on

UI36 is React-only; a size prop is still ignored on the other seven backends, so the timeline is web-only for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)