### PR TITLE
feat(c-to-sir): E9b — floating-point value track (double) across all three legs

### DIFF
--- a/code/packages/rust/c-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/c-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## Unreleased
 
+### Milestone 9b — floating-point value track
+
+The lowering gains a **second value track** for floating point.  Each expression
+now carries a `CType` (`Int(IntSpec)` or `Double`) instead of a bare `IntSpec`;
+`float`/`double` map to `CType::Double` → `SirType::Float` (SIR's single 64-bit
+IEEE float, so `float` is treated as `double`).
+
+- **Float literals** (`3.14`, `.5`, `1e10`, `1.0f`) now lower to `Expr::FloatLit`
+  (the `f`/`l` suffix is dropped) rather than being rejected.
+- **Mixed int/double arithmetic** promotes the integer operand to `double` with a
+  `to_f` builtin (the usual arithmetic conversions), and the float op emits the
+  bare `+`/`-`/`*`/`/` builtin with **no** width `Convert` (a `double` has no
+  width to wrap to).
+- **`/` on `double` is true division** (the plain `/` builtin), not the integer
+  truncating `tdiv`/`utdiv`.  `%`, `&`, `|`, `^`, `<<`, `>>`, `~` are **rejected**
+  on `double` (undefined on floating point in C).
+- **Conversions:** a float↔int cast flows through `to_f` (int→double) and `to_i`
+  (double→int, truncating toward zero like C's `(int)double`); a double→int cast
+  is `Convert(to_i(e), spec)` — truncate then narrow.
+- **`Feature::Floats` is declared only when the program uses floating point**, so
+  an integer-only program's SIR (and every backend's output) is unchanged.
+- Verified by the three-way conformance corpus (8 new float cases: mixed
+  promotion, true division, loop accumulation, float→int truncation, `double`
+  parameters/returns) — byte-identical across reference C (`clang -fwrapv`),
+  emitted Ruby, and emitted C, the last also compile-clean on clang + gcc + MSVC.
+- Supersedes the milestone-9a "lowering rejects floats" boundary below.
+
 ### Milestone 9a — floating-point grammar (foundation)
 
 - The C grammar now recognises **`float`/`double`** type keywords and

--- a/code/packages/rust/c-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/c-to-semantic-ir/src/lib.rs
@@ -25,6 +25,12 @@
 //! - **Milestone 7** — per-block scoping (a scope stack with unique SIR names),
 //!   so shadowing and re-used names (e.g. two sequential `for (int i …)` loops)
 //!   compile instead of being rejected.
+//! - **Milestone 9** — floating point (`float`/`double`): a second value track
+//!   (`CType::Double` → `SirType::Float`) alongside the integer one.  Mixed
+//!   int/double arithmetic promotes the integer operand with `to_f`; `/` is true
+//!   division (not the integer truncating `tdiv`); a float↔int cast goes through
+//!   `to_f`/`to_i`.  The `Feature::Floats` flag is declared only when the program
+//!   actually uses floating point, so integer-only output is unchanged.
 
 mod lower;
 
@@ -60,20 +66,74 @@ mod tests {
         compile_source(src, "test").expect("C lowering succeeded")
     }
 
+    // ── milestone 9: floating point ─────────────────────────────────────────
+
     #[test]
-    fn floating_point_is_parsed_but_lowering_rejects_it_cleanly() {
-        // The grammar slice (milestone 9a) recognises `float`/`double` and float
-        // literals; the lowering is still integer-only, so it must reject them
-        // with a clear message rather than mis-typing a `double` as `int`.
-        let err = compile_source("double f(double r) { return r; }", "test").unwrap_err();
+    fn float_literal_lowers_to_a_float_node_and_declares_the_feature() {
+        // `double pi = 3.14;` lowers to a `FloatLit` bound at SIR type `float`,
+        // and the module declares `Feature::Floats` (only because it uses one).
+        let m = lower("int main(void) { double pi = 3.14; return 0; }");
+        let text = semantic_ir::print_module(&m);
+        assert!(text.contains("(float 3.14)"), "no float literal:\n{text}");
+        assert!(text.contains("(let* pi float "), "not typed float:\n{text}");
         assert!(
-            err.message.contains("floating-point types"),
-            "wrong error: {}",
-            err.message
+            m.manifest.contains(semantic_ir::Feature::Floats),
+            "Floats feature not declared"
         );
-        let err = compile_source("int main(void) { return 3.14; }", "test").unwrap_err();
+    }
+
+    #[test]
+    fn integer_only_program_stays_float_free() {
+        // The float feature is *conditional*: a program with no float type or
+        // literal must not declare it (so integer-only output is unchanged).
+        let m = lower("int main(void) { int32_t x = 1 + 2; return x; }");
         assert!(
-            err.message.contains("floating-point literals"),
+            !m.manifest.contains(semantic_ir::Feature::Floats),
+            "Floats wrongly declared for an integer-only program"
+        );
+    }
+
+    #[test]
+    fn mixed_int_and_double_arithmetic_promotes_via_to_f() {
+        // `1 + 2.0` — the integer operand is widened to `double` with `to_f`
+        // before the (float) add; the result is a float, no width `Convert`.
+        let m = lower("int main(void) { double r = 1 + 2.0; return 0; }");
+        let text = semantic_ir::print_module(&m);
+        assert!(text.contains("to_f"), "int operand not widened:\n{text}");
+        assert!(text.contains("(builtin-call +"), "no float add:\n{text}");
+    }
+
+    #[test]
+    fn double_division_is_true_division_not_truncating() {
+        // `/` on doubles must be the plain `/` builtin (true division), never the
+        // integer `tdiv`/`utdiv` truncating helpers.
+        let m = lower("int main(void) { double q = 7.0 / 2.0; return 0; }");
+        let text = semantic_ir::print_module(&m);
+        assert!(text.contains("(builtin-call /"), "no true `/`:\n{text}");
+        assert!(!text.contains("tdiv"), "double `/` used tdiv:\n{text}");
+    }
+
+    #[test]
+    fn cast_double_to_int_truncates_via_to_i_then_narrows() {
+        // `(int)3.9` — the double truncates toward zero with `to_i`, then the
+        // int64 is narrowed to the destination width with a `Convert`.
+        let m = lower("int main(void) { int n = (int)3.9; return n; }");
+        let text = semantic_ir::print_module(&m);
+        assert!(text.contains("to_i"), "no truncation:\n{text}");
+        assert!(
+            text.contains("(convert (int i32"),
+            "no width narrow:\n{text}"
+        );
+    }
+
+    #[test]
+    fn bitwise_operator_on_double_is_rejected() {
+        // `%`, `&`, `<<`, `~` etc. are not defined on `double` in C — lowering
+        // must reject them with a clear message, not silently mis-emit.
+        let err = compile_source("int main(void) { double x = 3.0 % 2.0; return 0; }", "test")
+            .unwrap_err();
+        assert!(
+            err.message.contains("not defined on `double`"),
             "wrong error: {}",
             err.message
         );

--- a/code/packages/rust/c-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/c-to-semantic-ir/src/lower.rs
@@ -101,21 +101,17 @@ fn i32_spec() -> IntSpec {
     IntSpec::sized(IntWidth::W32, true, Overflow::Undefined)
 }
 
-/// Resolve a `type_spec` node (a sequence of type-keyword tokens) to an
-/// `IntSpec`, or `None` for `void`.
-fn resolve_type_spec(ts: &GrammarASTNode) -> Result<Option<IntSpec>, CLowerError> {
+/// Resolve a `type_spec` node (a sequence of type-keyword tokens) to a
+/// [`CType`], or `None` for `void`.
+fn resolve_type_spec(ts: &GrammarASTNode) -> Result<Option<CType>, CLowerError> {
     let mut kws: Vec<String> = Vec::new();
     collect_type_kws(ts, &mut kws);
     if kws.iter().any(|k| k == "void") {
         return Ok(None);
     }
-    // The grammar recognises `float`/`double`, but the lowering is still
-    // integer-only — reject them cleanly rather than mis-typing them as `int`.
+    // `float`/`double` (and `long double`) all map to SIR's single 64-bit float.
     if kws.iter().any(|k| k == "float" || k == "double") {
-        return err(
-            "floating-point types (`float`/`double`) are not yet supported in lowering",
-            ts,
-        );
+        return Ok(Some(CType::Double));
     }
     // Fixed-width <stdint.h> names / size_t map directly.
     for k in &kws {
@@ -132,7 +128,7 @@ fn resolve_type_spec(ts: &GrammarASTNode) -> Result<Option<IntSpec>, CLowerError
             _ => None,
         };
         if let Some((w, signed)) = direct {
-            return Ok(Some(spec_of(w, signed)));
+            return Ok(Some(CType::Int(spec_of(w, signed))));
         }
     }
     // Native specifier combination.  Signed unless `unsigned` appears (plain
@@ -147,7 +143,7 @@ fn resolve_type_spec(ts: &GrammarASTNode) -> Result<Option<IntSpec>, CLowerError
     } else {
         IntWidth::W32 // int (or a lone `unsigned`/`signed`)
     };
-    Ok(Some(spec_of(width, !unsigned)))
+    Ok(Some(CType::Int(spec_of(width, !unsigned))))
 }
 
 fn spec_of(width: IntWidth, signed: bool) -> IntSpec {
@@ -208,10 +204,85 @@ fn common_type(a: IntSpec, b: IntSpec) -> IntSpec {
     spec_of(wider.width, !unsigned)
 }
 
+// ── C expression type: integer or double ────────────────────────────────────
+
+/// The C type of an expression.  An integer carries its full `IntSpec` (width,
+/// signedness, overflow); `Double` is the floating-point type.  SIR has a single
+/// 64-bit `Float`, so C `float` and `double` both map to `Double` — a documented
+/// precision approximation (conformance is on `double`).
+#[derive(Clone, Copy, PartialEq)]
+enum CType {
+    Int(IntSpec),
+    Double,
+}
+
+impl CType {
+    fn is_double(self) -> bool {
+        matches!(self, CType::Double)
+    }
+    /// The SIR type this C type lowers to.
+    fn sir(self) -> SirType {
+        match self {
+            CType::Int(s) => SirType::Int(s),
+            CType::Double => SirType::Float,
+        }
+    }
+}
+
+/// The C type `int` (the default for a promoted narrow integer / a comparison).
+fn i32_ct() -> CType {
+    CType::Int(i32_spec())
+}
+
+/// `int → double` conversion (C's implicit widening / `(double)e`).
+fn to_f(e: Expr) -> Expr {
+    builtin("to_f", vec![e])
+}
+
+/// `double → int` conversion, truncating toward zero (C's `(int)e`).
+fn to_i(e: Expr) -> Expr {
+    builtin("to_i", vec![e])
+}
+
+/// Convert `e` from C type `from` to `to`, inserting exactly the right node: an
+/// integer width `Convert`, `to_f` (int→double), or `to_i` then a width
+/// `Convert` (double→int, truncating).
+fn convert_ct(e: Expr, from: CType, to: CType) -> Expr {
+    match (from, to) {
+        (CType::Int(a), CType::Int(b)) => convert_to(e, a, b),
+        (CType::Int(_), CType::Double) => to_f(e),
+        (CType::Double, CType::Int(b)) => convert(to_i(e), b),
+        (CType::Double, CType::Double) => e,
+    }
+}
+
+/// Integer promotion lifted to `CType` — a `double` is unaffected.
+fn promote_ct(t: CType) -> CType {
+    match t {
+        CType::Int(s) => CType::Int(promote(s)),
+        CType::Double => CType::Double,
+    }
+}
+
+/// The usual-arithmetic-conversions common type: `double` wins over any integer.
+fn common_ct(a: CType, b: CType) -> CType {
+    match (a, b) {
+        (CType::Double, _) | (_, CType::Double) => CType::Double,
+        (CType::Int(x), CType::Int(y)) => CType::Int(common_type(x, y)),
+    }
+}
+
 // ── SIR node constructors ────────────────────────────────────────────────────
 
 fn sp() -> Span {
     Span::synthetic()
+}
+
+fn float_lit(v: f64) -> Expr {
+    Expr::FloatLit {
+        value: v,
+        span: sp(),
+    }
 }
 
 fn int_lit(v: i64) -> Expr {
@@ -312,14 +383,14 @@ const MAX_LIFTED_GUARDS: usize = MAX_EXPR_DEPTH;
 /// get a unique suffix (see [`Lowerer::declare`]).
 #[derive(Clone)]
 struct Binding {
-    ty: IntSpec,
+    ty: CType,
     scope: Scope,
     sir_name: String,
 }
 
 struct Lowerer {
     /// Function signatures for call-site type resolution.
-    fns: HashMap<String, (Vec<IntSpec>, Option<IntSpec>)>,
+    fns: HashMap<String, (Vec<CType>, Option<CType>)>,
     /// Lexical **scope stack** (innermost last).  A declaration binds in the top
     /// scope; a reference resolves inner→outer.  Replaces the old flat map, so
     /// C's block scoping works — shadowing an outer variable, and two sequential
@@ -339,6 +410,11 @@ struct Lowerer {
     /// Current *statement* nesting (`if`/`while`/`for` bodies and nested
     /// blocks) — the third dimension of the same budget.
     stmt_depth: usize,
+    /// Set once any `double`/`float` type or floating-point literal is lowered,
+    /// so the module declares [`Feature::Floats`] only when it actually uses
+    /// floating point (an integer-only program stays float-free, and backends
+    /// that gate on the feature are not forced to support it needlessly).
+    uses_floats: bool,
 }
 
 pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, CLowerError> {
@@ -349,6 +425,7 @@ pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, CLowe
         lifted: 0,
         expr_depth: 0,
         stmt_depth: 0,
+        uses_floats: false,
     };
 
     // Pre-pass: collect function signatures.
@@ -368,7 +445,7 @@ pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, CLowe
         }
     }
 
-    let manifest = FeatureManifest::from_features(&[
+    let mut features = vec![
         Feature::OptionalTypeAnnotations,
         Feature::MutualRecursion,
         Feature::Conversions,
@@ -383,7 +460,14 @@ pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, CLowe
         // Milestone 4: `&&`/`||`/`!` lower to the short-circuiting `and`/`or`/
         // `not` builtins.
         Feature::ShortCircuit,
-    ]);
+    ];
+    // Milestone 9 (floating point): only declared when the program actually
+    // used a `double`/`float` type or a floating-point literal, so integer-only
+    // modules stay float-free.
+    if lo.uses_floats {
+        features.push(Feature::Floats);
+    }
+    let manifest = FeatureManifest::from_features(&features);
 
     let module = Module {
         name: module_name.to_string(),
@@ -437,7 +521,7 @@ impl Lowerer {
     /// to.  Re-declaring the same name in the *same* block is a C error;
     /// shadowing an outer scope (or re-using a name a sibling used) is fine and
     /// gets a fresh unique SIR name.
-    fn declare(&mut self, cname: &str, ty: IntSpec, scope: Scope) -> Result<String, CLowerError> {
+    fn declare(&mut self, cname: &str, ty: CType, scope: Scope) -> Result<String, CLowerError> {
         if self
             .scopes
             .last()
@@ -491,7 +575,7 @@ impl Lowerer {
     fn function_header(
         &self,
         f: &GrammarASTNode,
-    ) -> Result<(String, Vec<(String, IntSpec)>, Option<IntSpec>), CLowerError> {
+    ) -> Result<(String, Vec<(String, CType)>, Option<CType>), CLowerError> {
         let toks = child_tokens(f);
         let name = toks
             .iter()
@@ -540,12 +624,14 @@ impl Lowerer {
         self.scopes = vec![HashMap::new()];
         self.used_sir_names.clear();
         self.lifted = 0;
+        self.uses_floats |= ret.map(|t| t.is_double()).unwrap_or(false);
         let mut sir_params = Vec::new();
         for (pname, ty) in &params {
+            self.uses_floats |= ty.is_double();
             self.declare(pname, *ty, Scope::Param)?;
             sir_params.push(Param {
                 name: pname.clone(),
-                sir_type: Some(SirType::Int(*ty)),
+                sir_type: Some(ty.sir()),
                 kind: ParamKind::Required,
                 default: None,
                 span: sp(),
@@ -560,7 +646,7 @@ impl Lowerer {
         Ok(Function {
             name,
             params: sir_params,
-            return_type: ret.map(SirType::Int),
+            return_type: ret.map(|t| t.sir()),
             captures: vec![],
             body,
             effects: EffectSet::PURE,
@@ -573,7 +659,7 @@ impl Lowerer {
     fn lower_body(
         &mut self,
         body: &GrammarASTNode,
-        ret: Option<IntSpec>,
+        ret: Option<CType>,
     ) -> Result<Block, CLowerError> {
         let items = block_items_of(body);
         self.lower_seq(&items, ret)
@@ -601,7 +687,7 @@ impl Lowerer {
     fn lower_seq(
         &mut self,
         items: &[&GrammarASTNode],
-        ret: Option<IntSpec>,
+        ret: Option<CType>,
     ) -> Result<Block, CLowerError> {
         // This walk is **iterative in two dimensions**, and both matter:
         //
@@ -805,13 +891,13 @@ impl Lowerer {
     fn lower_return(
         &mut self,
         s: &GrammarASTNode,
-        ret: Option<IntSpec>,
+        ret: Option<CType>,
     ) -> Result<Expr, CLowerError> {
         Ok(match first_node(s, "expr") {
             Some(e) => {
                 let (ex, ty) = self.lower_expr(e)?;
                 match ret {
-                    Some(rt) => convert_to(ex, ty, rt),
+                    Some(rt) => convert_ct(ex, ty, rt),
                     None => ex,
                 }
             }
@@ -985,7 +1071,7 @@ impl Lowerer {
         Ok(Stmt::Assign {
             name: sir_name,
             scope,
-            value: convert_to(e, et, ty),
+            value: convert_ct(e, et, ty),
             span: sp(),
         })
     }
@@ -1252,7 +1338,7 @@ impl Lowerer {
     }
 
     fn lower_compare_bool_inner(&mut self, n: &GrammarASTNode) -> Result<Expr, CLowerError> {
-        let mut acc: Option<(Expr, IntSpec)> = None;
+        let mut acc: Option<(Expr, CType)> = None;
         let mut pending_op: Option<String> = None;
         let mut last_bool: Option<Expr> = None;
         for c in &n.children {
@@ -1269,7 +1355,7 @@ impl Lowerer {
                             })?;
                             let b = self.compare(&op, le, lt, e, t)?;
                             last_bool = Some(b.clone());
-                            acc = Some((if_int(b), i32_spec()));
+                            acc = Some((if_int(b), i32_ct()));
                         }
                     }
                 }
@@ -1289,17 +1375,21 @@ impl Lowerer {
         &self,
         op: &str,
         le: Expr,
-        lt: IntSpec,
+        lt: CType,
         re: Expr,
-        rt: IntSpec,
+        rt: CType,
     ) -> Result<Expr, CLowerError> {
-        let lp = promote(lt);
-        let rp = promote(rt);
-        let le = convert_to(le, lt, lp);
-        let re = convert_to(re, rt, rp);
-        let c = common_type(lp, rp);
-        let le = convert_to(le, lp, c);
-        let re = convert_to(re, rp, c);
+        let lp = promote_ct(lt);
+        let rp = promote_ct(rt);
+        let le = convert_ct(le, lt, lp);
+        let re = convert_ct(re, rt, rp);
+        // Bring both operands to their common type (`double` if either is), then
+        // compare.  All six relational/equality operators are defined on both
+        // integers and `double`; the builtin is the same, only the operand type
+        // differs.
+        let c = common_ct(lp, rp);
+        let le = convert_ct(le, lp, c);
+        let re = convert_ct(re, rp, c);
         match op {
             "<" | ">" | "<=" | ">=" | "==" | "!=" => Ok(builtin(op, vec![le, re])),
             other => Err(CLowerError {
@@ -1332,6 +1422,7 @@ impl Lowerer {
             line: init.start_line.unwrap_or(0),
             column: init.start_column.unwrap_or(0),
         })?;
+        self.uses_floats |= ty.is_double();
         let name = child_tokens(init)
             .iter()
             .find(|t| t.effective_type_name() == "NAME")
@@ -1342,9 +1433,14 @@ impl Lowerer {
         let value = match first_node(init, "expr") {
             Some(e) => {
                 let (ex, ety) = self.lower_expr(e)?;
-                convert_to(ex, ety, ty) // assignment conversion to the declared type
+                convert_ct(ex, ety, ty) // assignment conversion to the declared type
             }
-            None => convert(int_lit(0), ty), // uninitialised → 0 of the type
+            // Uninitialised → the type's zero: `0.0` for `double`, `0` (wrapped
+            // to the width) for an integer type.
+            None => match ty {
+                CType::Double => float_lit(0.0),
+                CType::Int(s) => convert(int_lit(0), s),
+            },
         };
         // Bind in the current scope; `declare` gives a unique SIR name when this
         // shadows an outer variable or re-uses one a sibling block used.
@@ -1357,14 +1453,14 @@ impl Lowerer {
             })?;
         Ok(Stmt::LetStarBinding {
             name: sir_name,
-            sir_type: Some(SirType::Int(ty)),
+            sir_type: Some(ty.sir()),
             value,
             span: sp(),
         })
     }
 
     /// Lower an expression, returning both the SIR node and its C type.
-    fn lower_expr(&mut self, node: &GrammarASTNode) -> Result<(Expr, IntSpec), CLowerError> {
+    fn lower_expr(&mut self, node: &GrammarASTNode) -> Result<(Expr, CType), CLowerError> {
         // Bound the depth of the tree we emit — see `MAX_EXPR_DEPTH`.  The
         // counter is restored on every path so a rejected sub-expression does
         // not poison the rest of the function.
@@ -1381,7 +1477,7 @@ impl Lowerer {
         result
     }
 
-    fn lower_expr_inner(&mut self, node: &GrammarASTNode) -> Result<(Expr, IntSpec), CLowerError> {
+    fn lower_expr_inner(&mut self, node: &GrammarASTNode) -> Result<(Expr, CType), CLowerError> {
         let n = peel(node);
         match n.rule_name.as_str() {
             // Binary arithmetic / bitwise / shift — left-associative fold.
@@ -1393,11 +1489,11 @@ impl Lowerer {
             // integer from the SIR bool.
             "equality" | "relational" if child_nodes(n).len() >= 2 => {
                 let b = self.lower_compare_bool(n)?;
-                Ok((if_int(b), i32_spec()))
+                Ok((if_int(b), i32_ct()))
             }
             "logical_and" | "logical_or" if child_nodes(n).len() >= 2 => {
                 let b = self.lower_cond(n)?;
-                Ok((if_int(b), i32_spec()))
+                Ok((if_int(b), i32_ct()))
             }
             "cast" => self.lower_cast(n),
             "unary" => self.lower_unary(n),
@@ -1409,7 +1505,7 @@ impl Lowerer {
         }
     }
 
-    fn lower_binary(&mut self, n: &GrammarASTNode) -> Result<(Expr, IntSpec), CLowerError> {
+    fn lower_binary(&mut self, n: &GrammarASTNode) -> Result<(Expr, CType), CLowerError> {
         // A chain is flat in the CST but folds left into a tree as deep as it is
         // wide, so its width is charged against the same budget as nesting — and
         // *held* while its operands are lowered.
@@ -1420,9 +1516,9 @@ impl Lowerer {
         result
     }
 
-    fn lower_binary_inner(&mut self, n: &GrammarASTNode) -> Result<(Expr, IntSpec), CLowerError> {
+    fn lower_binary_inner(&mut self, n: &GrammarASTNode) -> Result<(Expr, CType), CLowerError> {
         // children: operand (op operand)+   — fold left.
-        let mut acc: Option<(Expr, IntSpec)> = None;
+        let mut acc: Option<(Expr, CType)> = None;
         let mut pending_op: Option<String> = None;
         for c in &n.children {
             match c {
@@ -1451,14 +1547,40 @@ impl Lowerer {
         &self,
         op: &str,
         le: Expr,
-        lt: IntSpec,
+        lt: CType,
         re: Expr,
-        rt: IntSpec,
-    ) -> Result<(Expr, IntSpec), CLowerError> {
-        let lp = promote(lt);
-        let rp = promote(rt);
-        let le = convert_to(le, lt, lp);
-        let re = convert_to(re, rt, rp);
+        rt: CType,
+    ) -> Result<(Expr, CType), CLowerError> {
+        let lp = promote_ct(lt);
+        let rp = promote_ct(rt);
+        let le = convert_ct(le, lt, lp);
+        let re = convert_ct(re, rt, rp);
+
+        // Floating point: if *either* promoted operand is `double`, the whole
+        // operation is done in floating point (the usual arithmetic conversions
+        // promote the integer operand to `double`).  There is no width to wrap
+        // to and no truncating/logical distinction — `/` is real division, and
+        // the bit/shift/`%` operators are not defined on `double`.
+        if lp.is_double() || rp.is_double() {
+            let le = convert_ct(le, lp, CType::Double);
+            let re = convert_ct(re, rp, CType::Double);
+            let sir_op = match op {
+                "+" | "-" | "*" | "/" => op,
+                other => {
+                    return Err(CLowerError {
+                        message: format!("operator `{other}` is not defined on `double`"),
+                        line: 0,
+                        column: 0,
+                    })
+                }
+            };
+            return Ok((builtin(sir_op, vec![le, re]), CType::Double));
+        }
+        // From here on both operands are integers; `le`/`re` are already at
+        // their promoted types, so recover the `IntSpec`s for the width logic.
+        let (CType::Int(lp), CType::Int(rp)) = (lp, rp) else {
+            unreachable!("non-double operands are Int by construction")
+        };
 
         // Shifts are the exception to the usual arithmetic conversions: C does
         // *not* bring the operands to a common type.  Each is promoted on its
@@ -1473,7 +1595,7 @@ impl Lowerer {
             // native `>>` would sign-extend it.  Route unsigned `>>` to a
             // distinct `u>>` builtin the backends render as a logical shift.
             let name = if op == ">>" && !lp.signed { "u>>" } else { op };
-            return Ok((convert(builtin(name, vec![le, re]), lp), lp));
+            return Ok((convert(builtin(name, vec![le, re]), lp), CType::Int(lp)));
         }
 
         let c = common_type(lp, rp);
@@ -1518,10 +1640,10 @@ impl Lowerer {
         };
         // The operation is performed at width `c`; its result is a value of
         // type `c`, so wrap it to enforce C's fixed-width overflow.
-        Ok((convert(builtin(sir_op, vec![le, re]), c), c))
+        Ok((convert(builtin(sir_op, vec![le, re]), c), CType::Int(c)))
     }
 
-    fn lower_cast(&mut self, n: &GrammarASTNode) -> Result<(Expr, IntSpec), CLowerError> {
+    fn lower_cast(&mut self, n: &GrammarASTNode) -> Result<(Expr, CType), CLowerError> {
         // cast = LPAREN type_spec RPAREN cast
         let ts = first_node(n, "type_spec").unwrap();
         let to = resolve_type_spec(ts)?.ok_or_else(|| CLowerError {
@@ -1529,15 +1651,16 @@ impl Lowerer {
             line: n.start_line.unwrap_or(0),
             column: n.start_column.unwrap_or(0),
         })?;
+        self.uses_floats |= to.is_double();
         let inner = child_nodes(n)
             .into_iter()
             .find(|x| x.rule_name == "cast")
             .unwrap();
         let (e, from) = self.lower_expr(inner)?;
-        Ok((convert_to(e, from, to), to))
+        Ok((convert_ct(e, from, to), to))
     }
 
-    fn lower_unary(&mut self, n: &GrammarASTNode) -> Result<(Expr, IntSpec), CLowerError> {
+    fn lower_unary(&mut self, n: &GrammarASTNode) -> Result<(Expr, CType), CLowerError> {
         // unary = (PLUS|MINUS|TILDE|BANG) unary
         let op = child_tokens(n).first().map(|t| t.value.clone()).unwrap();
         let operand = child_nodes(n).into_iter().next().unwrap();
@@ -1546,24 +1669,34 @@ impl Lowerer {
         // condition and wrap the resulting bool: `If(not(cond(c)), 1, 0)`.
         if op == "!" {
             let cond = builtin("not", vec![self.lower_cond(operand)?]);
-            return Ok((if_int(cond), i32_spec()));
+            return Ok((if_int(cond), i32_ct()));
         }
 
         let (e, t) = self.lower_expr(operand)?;
-        let tp = promote(t); // unary applies integer promotion
-        let e = convert_to(e, t, tp);
+        // Floating-point unary: no integer promotion, no width-wrapping Convert.
+        if t.is_double() {
+            return match op.as_str() {
+                "+" => Ok((e, CType::Double)),
+                // Unary minus as `0.0 - x` (both backends render binary `-`).
+                "-" => Ok((builtin("-", vec![float_lit(0.0), e]), CType::Double)),
+                "~" => err("unary `~` requires an integer operand", n),
+                other => err(format!("unary `{other}` not yet supported"), n),
+            };
+        }
+        let tp = promote_ct(t); // unary applies integer promotion
+        let e = convert_ct(e, t, tp);
         match op.as_str() {
             "+" => Ok((e, tp)),
             // Unary minus as `0 - x` (both backends render binary `-`); the
             // subtract happens at the promoted type and its result is wrapped.
-            "-" => Ok((convert(builtin("-", vec![int_lit(0), e]), tp), tp)),
+            "-" => Ok((convert_ct(builtin("-", vec![int_lit(0), e]), tp, tp), tp)),
             // Bitwise NOT at the promoted type, wrapped to enforce its width.
-            "~" => Ok((convert(builtin("~", vec![e]), tp), tp)),
+            "~" => Ok((convert_ct(builtin("~", vec![e]), tp, tp), tp)),
             other => err(format!("unary `{other}` not yet supported"), n),
         }
     }
 
-    fn lower_postfix(&mut self, n: &GrammarASTNode) -> Result<(Expr, IntSpec), CLowerError> {
+    fn lower_postfix(&mut self, n: &GrammarASTNode) -> Result<(Expr, CType), CLowerError> {
         // postfix = primary { call_suffix }
         let nodes = child_nodes(n);
         let callee = nodes.first().copied().unwrap();
@@ -1597,7 +1730,7 @@ impl Lowerer {
         name: &str,
         args: &[&GrammarASTNode],
         call: &GrammarASTNode,
-    ) -> Result<(Expr, IntSpec), CLowerError> {
+    ) -> Result<(Expr, CType), CLowerError> {
         // printf("<fmt>", e) → puts(e) when <fmt> ends in \n, else print(e).
         if name == "printf" {
             let fmt = call_string_literal(call);
@@ -1610,7 +1743,7 @@ impl Lowerer {
             })?;
             let (e, _t) = self.lower_expr(val)?;
             let helper = if newline { "puts" } else { "print" };
-            return Ok((builtin(helper, vec![e]), i32_spec()));
+            return Ok((builtin(helper, vec![e]), i32_ct()));
         }
         // Ordinary function call: convert each argument to its parameter type.
         let (ptypes, ret) = self.fns.get(name).cloned().ok_or_else(|| CLowerError {
@@ -1622,12 +1755,12 @@ impl Lowerer {
         for (i, a) in args.iter().enumerate() {
             let (e, t) = self.lower_expr(a)?;
             let e = match ptypes.get(i) {
-                Some(pt) => convert_to(e, t, *pt),
+                Some(pt) => convert_ct(e, t, *pt),
                 None => e,
             };
             sir_args.push(e);
         }
-        let rt = ret.unwrap_or_else(i32_spec);
+        let rt = ret.unwrap_or_else(i32_ct);
         Ok((
             Expr::DirectCall {
                 fn_name: name.to_string(),
@@ -1639,7 +1772,7 @@ impl Lowerer {
         ))
     }
 
-    fn lower_primary(&mut self, n: &GrammarASTNode) -> Result<(Expr, IntSpec), CLowerError> {
+    fn lower_primary(&mut self, n: &GrammarASTNode) -> Result<(Expr, CType), CLowerError> {
         // primary = INT_LIT | CHAR_LIT | STR_LIT | NAME | LPAREN expr RPAREN
         if let Some(inner) = first_node(n, "expr") {
             return self.lower_expr(inner); // parenthesised
@@ -1655,18 +1788,19 @@ impl Lowerer {
         match tok.effective_type_name() {
             "INT_LIT" => {
                 let (v, ty) = parse_int_literal(&tok.value);
-                Ok((int_lit(v), ty))
+                Ok((int_lit(v), CType::Int(ty)))
             }
             "CHAR_LIT" => {
                 let v = parse_char_literal(&tok.value);
-                Ok((int_lit(v), i32_spec())) // a char constant has type int in C
+                Ok((int_lit(v), i32_ct())) // a char constant has type int in C
             }
-            // The grammar accepts float literals; lowering them (and the whole
-            // floating-point value track) is the next slice.
-            "FLOAT_LIT" => err(
-                "floating-point literals are not yet supported in lowering",
-                n,
-            ),
+            // A floating-point literal lowers to a `FloatLit` of C type `double`
+            // (the `f`/`l` suffix only affects storage width, which SIR's single
+            // 64-bit float does not distinguish).
+            "FLOAT_LIT" => {
+                self.uses_floats = true;
+                Ok((float_lit(parse_float_literal(&tok.value)), CType::Double))
+            }
             "NAME" => {
                 let name = tok.value.clone();
                 let b = self.resolve(&name).ok_or_else(|| CLowerError {
@@ -1829,6 +1963,17 @@ fn parse_int_literal(raw: &str) -> (i64, IntSpec) {
     };
     let width = if long { IntWidth::W64 } else { IntWidth::W32 };
     (value, spec_of(width, !unsigned))
+}
+
+/// Parse a C floating-point literal → its `f64` value.  The `f`/`F`/`l`/`L`
+/// storage suffix (if any) is stripped first; SIR's single 64-bit float does
+/// not distinguish `float` from `double`, so all three parse to the same
+/// `f64`.  A malformed literal (the lexer guarantees this cannot happen) folds
+/// to `0.0` rather than panicking.
+fn parse_float_literal(raw: &str) -> f64 {
+    raw.trim_end_matches(['f', 'F', 'l', 'L'])
+        .parse::<f64>()
+        .unwrap_or(0.0)
 }
 
 /// Parse a C char constant like `'A'` or `'\n'` → its code point.

--- a/code/packages/rust/c-to-semantic-ir/tests/three_way_conformance.rs
+++ b/code/packages/rust/c-to-semantic-ir/tests/three_way_conformance.rs
@@ -578,6 +578,57 @@ fn corpus() -> Vec<Case> {
                    int f(int v) { { int v = 5; return v; } }\n\
                    int main(void) { printf(\"%d\\n\", f(99)); return 0; }",
         },
+        // ── milestone 9: floating point ──────────────────────────────────────
+        // Every result is cast to `(int)` *inside the C source* before `printf`,
+        // so the reference `printf("%d", …)`, the emitted C, and the emitted
+        // Ruby all format the same integer — the float display convention (which
+        // diverges: C `%f` == "3.140000" vs Ruby "3.14") never enters the
+        // comparison.  What is tested is the *floating-point arithmetic*: mixed
+        // int/double promotion, true division, and float→int truncation.
+        Case {
+            label: "double literal + int promotion (int)(1 + 2.5) → 3",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int main(void) { double r = 1 + 2.5; printf(\"%d\\n\", (int)r); return 0; }",
+        },
+        Case {
+            label: "true division (int)((7.0 / 2.0) * 10) → 35",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int main(void) { double q = 7.0 / 2.0; printf(\"%d\\n\", (int)(q * 10.0)); return 0; }",
+        },
+        Case {
+            label: "integer / is still truncating, not floated (7 / 2) → 3",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int main(void) { int q = 7 / 2; printf(\"%d\\n\", q); return 0; }",
+        },
+        Case {
+            label: "float→int cast truncates toward zero (int)(-3.9) → -3",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int main(void) { double x = -3.9; printf(\"%d\\n\", (int)x); return 0; }",
+        },
+        Case {
+            label: "double parameter and return, scaled area (int)area(3.0) → 12",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   double area(double r) { return r * r + r; }\n\
+                   int main(void) { printf(\"%d\\n\", (int)area(3.0)); return 0; }",
+        },
+        Case {
+            label: "double comparison as an int value (2.5 > 2.4) → 1",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int main(void) { int c = 2.5 > 2.4; printf(\"%d\\n\", c); return 0; }",
+        },
+        Case {
+            label: "accumulate doubles in a loop, (int)sum(0.5 x 10) → 5",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int main(void) { double s = 0.0; \
+                   for (int i = 0; i < 10; i = i + 1) { s = s + 0.5; } \
+                   printf(\"%d\\n\", (int)s); return 0; }",
+        },
+        Case {
+            label: "int widened to double mid-expression (int)(x / 2.0 * 4) → 10",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int main(void) { int x = 5; double r = x / 2.0 * 4.0; \
+                   printf(\"%d\\n\", (int)r); return 0; }",
+        },
     ]
 }
 

--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.17.0 — numeric conversions: `to_f` / `to_i`
+
+Two numeric-conversion builtins mirroring the Ruby backend, for the C frontend's
+floating-point value track (SIR27 milestone 9b).
+
+- `to_f` → `_sir_to_f` = `_sir_float(_sir_as_num(v))` (numeric → double).
+- `to_i` → `_sir_to_i` = `_sir_int(_sir_as_int(v))` (double → int, **truncating
+  toward zero** like C's `(int)double`; the frontend then narrows to the target
+  width with a `Convert`, i.e. `_sir_iN`/`_sir_uN`).
+
+Float arithmetic itself needs no new code: `_sir_plus/minus/times/divide_v` and
+the comparison helpers already promote to `double` when any operand is a
+`SIR_FLOAT` (so `_sir_divide_v` does true division), and `Feature::Floats` /
+`Expr::FloatLit` were already supported.  The emitted C compiles clean on
+clang + gcc + MSVC and matches the reference / emitted-Ruby legs byte-for-byte.
+
 ## 0.16.0 — OOP mirror slice 4: inheritance + `super`
 
 Class inheritance and `super` — the fourth slice of the C OOP mirror. No new

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -1960,6 +1960,10 @@ fn fixed_helper(name: &str) -> Option<(&'static str, usize)> {
         "tmod" => ("_sir_itmod", 2),
         "utdiv" => ("_sir_utdiv", 2),
         "utmod" => ("_sir_utmod", 2),
+        // Milestone 9 numeric conversions: `to_f` (int → double) and `to_i`
+        // (double → int, truncating toward zero, matching C's `(int)double`).
+        "to_f" => ("_sir_to_f", 1),
+        "to_i" => ("_sir_to_i", 1),
         "cons" => ("_sir_cons", 2),
         "car" => ("_sir_car", 1),
         "cdr" => ("_sir_cdr", 1),

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -240,6 +240,16 @@ int64_t _sir_as_int(SirValue v) {
     return 0;
 }
 
+/* SIR27 milestone 9 numeric conversions (the `to_f`/`to_i` builtins the C
+ * frontend inserts at int<->double boundaries).  `_sir_to_f` widens any numeric
+ * value to a `double` (C's implicit int->double promotion).  `_sir_to_i`
+ * truncates a `double` toward zero, exactly like C's `(int)double` cast — the
+ * frontend then narrows the int64 to the target width with a `Convert`
+ * (`_sir_iN`/`_sir_uN`), so the two together reproduce a C float->integer cast
+ * bit-for-bit for values that fit the destination. */
+SirValue _sir_to_f(SirValue v) { return _sir_float(_sir_as_num(v)); }
+SirValue _sir_to_i(SirValue v) { return _sir_int(_sir_as_int(v)); }
+
 const char *_sir_str_of(SirValue v) {
     return (v.tag == SIR_STR || v.tag == SIR_SYM) ? v.as.s : "";
 }

--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.18.0 — numeric conversions: `to_f` / `to_i`
+
+Two numeric-conversion builtins, for the C frontend's floating-point value track
+(SIR27 milestone 9b) — the int↔double boundaries a C program creates.
+
+- `to_f` → Ruby's native `(x).to_f` (Integer → Float / usual widening).
+- `to_i` → `(x).to_i` (Float → Integer, **truncating toward zero**, matching C's
+  `(int)double` cast; the frontend then masks to the target width with a
+  `Convert`).
+
+Float arithmetic itself needs no new code: `+`/`-`/`*`/`/` and the comparison
+builtins are already native Ruby operators that do the right thing on `Float`
+(so `7.0 / 2.0 == 3.5`), and `Feature::Floats` / `Expr::FloatLit` were already
+supported.  Verified via the C→SIR→Ruby three-way conformance corpus.
+
 ## 0.17.0 — classes slice 7: modules / mixins (OOP arc complete)
 
 Accepts `Feature::Modules` — module definitions and `include`/`extend` mixins.

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -48,6 +48,11 @@ const SUPPORTED_BUILTINS: &[&str] = &[
     "tmod",
     "utdiv",
     "utmod",
+    // Numeric conversions (SIR27 milestone 9, floating point): `to_f` widens an
+    // integer to `double`, `to_i` truncates a `double` toward zero to an integer
+    // (the frontend then masks it to the target width with a `Convert`).
+    "to_f",
+    "to_i",
     "=",
     "==",
     "!=",
@@ -1457,6 +1462,10 @@ fn emit_builtin(name: &str, args: &[Expr]) -> String {
         // non-negative Integer, for which truncation and flooring coincide.
         "tdiv" | "utdiv" => format!("sir_tdiv({}, {})", arg(&a, 0), arg(&a, 1)),
         "tmod" | "utmod" => format!("sir_tmod({}, {})", arg(&a, 0), arg(&a, 1)),
+        // `to_f`/`to_i`: Ruby's native `Numeric#to_f` (int → Float) and
+        // `Float#to_i` (truncates toward zero, matching C's `(int)double` cast).
+        "to_f" => format!("({}).to_f", arg(&a, 0)),
+        "to_i" => format!("({}).to_i", arg(&a, 0)),
         "not" => format!("(!sir_truthy({}))", arg(&a, 0)),
         "<" => format!("({} < {})", arg(&a, 0), arg(&a, 1)),
         ">" => format!("({} > {})", arg(&a, 0), arg(&a, 1)),

--- a/code/specs/SIR27-c-to-semantic-ir.md
+++ b/code/specs/SIR27-c-to-semantic-ir.md
@@ -365,6 +365,60 @@ initializer like `int v = v + 1;` in a shadowing block reads the *uninitialized*
 inner `v` per C's scope rule — that is UB, and not something the translator
 conforms to.)
 
+## Floating point (milestone 9)
+
+Every earlier milestone tracked one thing per expression — an `IntSpec`.  Floats
+add a **second value track**.  The lowering now carries a `CType` for each
+expression:
+
+```
+enum CType { Int(IntSpec), Double }
+```
+
+`float`, `double` (and, conceptually, `long double`) all map to the one
+`CType::Double`, which lowers to `SirType::Float` — SIR has a single 64-bit IEEE
+float, so `float`'s narrower 32-bit rounding is *not* modelled (a `float` is
+treated as a `double`).  A floating-point literal (`3.14`, `.5`, `1e10`, `1.0f`)
+lowers to `Expr::FloatLit`; the `f`/`l` storage suffix is dropped.
+
+**The usual arithmetic conversions, extended.**  When an operator mixes an
+integer and a `double`, C converts the integer operand to `double` and does the
+operation in floating point.  The frontend inserts that conversion explicitly as
+a `to_f` builtin, so `1 + 2.5` lowers to `+(to_f(1), 2.5)` — a *float* add whose
+result is a `double`.  Crucially:
+
+- **No width `Convert`.**  Integer results are wrapped to their width after every
+  op (that is the whole point of the integer track); a `double` has no width to
+  wrap to, so a float op emits the bare `+`/`-`/`*`/`/` builtin.
+- **`/` is true division.**  On integers `/` lowers to the truncating `tdiv`
+  (C truncates toward zero); on `double` it is real division, the plain `/`
+  builtin.  The backends already promote to float when either operand is a float
+  (`_sir_divide_v` in C, native `/` in Ruby), so `7.0 / 2.0 == 3.5`.
+- **`%`, `&`, `|`, `^`, `<<`, `>>`, `~` are rejected on `double`** — they are not
+  defined on floating point in C, so lowering errors with a clear message rather
+  than mis-emitting.
+
+**Casts and conversions** flow through two builtins: `to_f` (int → double, C's
+implicit widening) and `to_i` (double → int, *truncating toward zero*, exactly
+like C's `(int)double`).  A `double`→integer cast is `Convert(to_i(e), spec)` —
+truncate, then narrow to the destination width — so a float→int cast reproduces C
+bit-for-bit for values that fit the destination.  Both backends render these
+natively: Ruby `.to_f`/`.to_i`, C `_sir_to_f`/`_sir_to_i`.
+
+**Conditional feature flag.**  `Feature::Floats` is declared **only** when the
+program actually used a float type or literal.  An integer-only program stays
+float-free, so its SIR — and every backend's output — is byte-for-byte what it
+was before this milestone.
+
+**Conformance and the display convention.**  Reference C's `printf("%f", …)`
+prints `3.140000`; the backends' float display prints `3.14`.  That divergence is
+a *display* question, orthogonal to the arithmetic, so the conformance corpus
+sidesteps it: every float program casts its result to `(int)` **inside the C
+source** before `printf("%d", …)`.  All three legs then format the same integer,
+and what is actually proven is the floating-point *computation* — mixed
+promotion, true division, loop accumulation, and float→int truncation — is
+identical across reference C, emitted Ruby, and emitted C.
+
 ## Pipeline
 
 ```text
@@ -412,10 +466,9 @@ pub struct CLowerError { pub message: String, pub line: usize, pub column: usize
 ## Out of scope (v1)
 
 - Pointers, arrays, structs, unions, enums, `typedef`.
-- Floating point is being added incrementally: milestone 9a wires the **grammar**
-  to recognise `float`/`double` and float literals (`3.14`, `.5`, `1e10`); the
-  lowering still rejects them with a clear "not yet supported" error until the
-  floating-point value track (a following slice) lands.
+- `long double` (SIR has a single 64-bit `Float`; `float`/`double`/`long double`
+  all map to it — see the floating-point section).  Precise `float` (32-bit)
+  rounding is therefore not modelled: `float` is treated as `double`.
 - The full preprocessor (`#define`, macros, conditional compilation).
 - Multiple translation units / real headers (only `#include <stdint.h|stdio.h>`
   is recognised and ignored).


### PR DESCRIPTION
## Milestone 9b — floating point (`double`)

Builds on the merged milestone-9a grammar foundation (#9111). Adds a **second value track** so floating-point C programs translate byte-identically to Ruby and portable C.

The lowering now carries a `CType` (`Int(IntSpec) | Double`) per expression. `float`/`double` map to `CType::Double` → `SirType::Float` (one 64-bit IEEE float; `float` is treated as `double`).

- **Float literals** (`3.14`, `.5`, `1e10`, `1.0f`) lower to `Expr::FloatLit`.
- **Mixed int/double arithmetic** promotes the integer operand via `to_f`; the float op emits a bare `+`/`-`/`*`/`/` with no width `Convert`.
- **`/` on `double` is true division** (plain `/`), not the integer truncating `tdiv`/`utdiv`. `% & | ^ << >> ~` are rejected on `double`.
- **Casts** flow through `to_f` (int→double) / `to_i` (double→int, truncate toward zero like `(int)double`).
- **`Feature::Floats` is declared only when floating point is used**, so integer-only output is byte-for-byte unchanged.

Backends: `semantic-ir-to-ruby` 0.18.0 (`.to_f`/`.to_i`), `semantic-ir-to-c` 0.17.0 (`_sir_to_f`/`_sir_to_i`).

Verified: 43 frontend unit tests (6 new float) + three-way conformance (8 new float cases) byte-identical across reference C (`clang -fwrapv`), emitted Ruby, and emitted C; emitted C compiles clean on clang + gcc + MSVC. Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
