### PR TITLE
feat(fold-control-flow): remove a redundant trailing continue from a loop body (0.39.0)

### DIFF
--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.39.0] - 2026-07-28
+
+### Added - remove a redundant trailing `continue` from a loop body
+
+A bare (unlabeled) `continue` at the tail of a `for`/`while`/`do-while` body is
+removed, matching the reference Closure Compiler at SIMPLE:
+
+```text
+  for (; c;) { a(); continue; }   ->  for(;c;)a();
+  for (; c;) { continue; }        ->  for(;c;);
+  do { a(); continue; } while(c); ->  do a();while(c);
+```
+
+A trailing bare `continue` is a no-op -- it jumps to the next iteration, which
+is exactly what falling off the end of the body already does. After the strip,
+the shortened body unwraps its single statement, comma-fuses, or (when now
+empty) normalizes to `;`, all via the existing machinery. Because `while` is
+rewritten to `for` (0.31.0) and re-folded, the `for` hook covers `while` too;
+the `do-while` arm has its own hook.
+
+Scoped to a bare, unlabeled `continue` that is the LITERAL last statement:
+  * `continue L` (labeled) may target an OUTER loop, so it is kept.
+  * a `continue` with dead code after it (`{a(); continue; b()}`) is left
+    alone -- removing the unreachable `b()` is a separate dead-code-after-jump
+    transform.
+
 ## [0.38.0] - 2026-07-28
 
 ### Added - empty-bodied `do … while` becomes the equivalent `while`/`for`

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.38.0"
+version = "0.39.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -416,6 +416,22 @@ fn fold_tagged_statement(stmt: &TaggedStatement, st: &mut FoldState) -> Statemen
         TaggedStatement::DoWhileStatement(s) => {
             let body = fold_statement(&s.body, st);
 
+            // Strip a redundant trailing bare `continue`
+            // (`do { …; continue } while(c)` → `do { … } while(c)`), then let the
+            // empty-body / fusion steps below simplify the shortened body.
+            let body = match strip_trailing_continue(&body) {
+                Some(stripped) => {
+                    st.record_fold(
+                        &s.cv,
+                        "trailing-continue-removed",
+                        "do { …; continue } while(…)",
+                        "do { … } while(…)",
+                    );
+                    stripped
+                }
+                None => body,
+            };
+
             // Empty-bodied `do … while` ≡ `while`. `do {} while(test)` runs the
             // (empty) body once and then evaluates `test`; because the body is a
             // no-op, its test-evaluation sequence is IDENTICAL to `while(test){}`
@@ -1521,6 +1537,48 @@ fn statement_is_empty(stmt: &Statement) -> bool {
     }
 }
 
+/// If `body` is a loop body ending in a BARE (unlabeled) `continue`, return the
+/// body with that redundant `continue` removed; otherwise `None`.
+///
+/// A bare `continue` at the tail of a loop body is a no-op: it jumps to the next
+/// iteration, which is exactly what falling off the end of the body already
+/// does. Only an UNLABELED `continue` is stripped — `continue L` may target an
+/// OUTER loop, so it must stay. Two shapes are handled:
+///
+///   for (…) { a(); continue; }   →  for (…) { a(); }   (drop the last stmt)
+///   for (…) { continue; }        →  for (…) { }        (block emptied)
+///   for (…) continue;            →  for (…) ;          (bare-continue body)
+///
+/// The enclosing loop fold then unwraps the single-statement block, comma-fuses,
+/// or normalizes the now-empty body as usual. A `continue` that is NOT the
+/// literal last statement (dead code follows, `{a(); continue; b()}`) is left
+/// alone — removing the unreachable `b()` is a separate dead-code-after-jump
+/// transform.
+fn strip_trailing_continue(body: &Statement) -> Option<Statement> {
+    fn is_bare_continue(s: &Statement) -> bool {
+        matches!(
+            s,
+            Statement::Tagged(TaggedStatement::ContinueStatement(c)) if c.label.is_none()
+        )
+    }
+    match body {
+        Statement::Tagged(TaggedStatement::BlockStatement(b))
+            if b.body.last().is_some_and(is_bare_continue) =>
+        {
+            let mut kept = b.body.clone();
+            kept.pop();
+            Some(Statement::Tagged(TaggedStatement::BlockStatement(BlockStatement {
+                cv: b.cv.clone(),
+                body: kept,
+            })))
+        }
+        s if is_bare_continue(s) => {
+            Some(Statement::empty_statement(EmptyStatement { cv: statement_cv(s) }))
+        }
+        _ => None,
+    }
+}
+
 /// Helper for the return-then-return fold (gap-019). Returns the
 /// `argument` expression when `stmt` is exactly one ReturnStatement
 /// whose argument is `Some` (possibly wrapped in single-statement
@@ -1879,6 +1937,23 @@ fn fold_for_statement(s: &ForStatement, st: &mut FoldState) -> Statement {
     let test = s.test.as_ref().map(|e| fold_expression(e, st));
     let update = s.update.as_ref().map(|e| fold_expression(e, st));
     let body = fold_statement(&s.body, st);
+
+    // Strip a redundant trailing bare `continue` (`for(…){…;continue}` →
+    // `for(…){…}`). This also covers a `while` loop, since `while` is rewritten
+    // to `for` (0.31.0) and re-folded here. Runs before the empty-body / fusion
+    // steps below so the shortened body then unwraps or normalizes.
+    let body = match strip_trailing_continue(&body) {
+        Some(stripped) => {
+            st.record_fold(
+                &s.cv,
+                "trailing-continue-removed",
+                "for (…) { …; continue }",
+                "for (…) { … }",
+            );
+            stripped
+        }
+        None => body,
+    };
 
     // Always-FALSE test → dead loop: it collapses to just its `init` (which
     // runs once, before the first, failing, test) — BUT only when that collapse
@@ -2809,6 +2884,62 @@ mod tests {
             Statement::Tagged(TaggedStatement::ForStatement(f)) => assert!(
                 statement_is_empty(f.body.as_ref()),
                 "empty do-while must lower to a for with an empty body; got {:?}",
+                f.body
+            ),
+            other => panic!("expected ForStatement; got {other:?}"),
+        }
+    }
+
+    /// `for (;;) { a(); continue; }` → the trailing bare `continue` is stripped,
+    /// leaving a single-statement body that then unwraps to `for (;;) a();`.
+    #[test]
+    fn for_body_trailing_continue_is_stripped() {
+        use coding_adventures_javascript_ast::ContinueStatement;
+        let cont = Statement::Tagged(TaggedStatement::ContinueStatement(ContinueStatement {
+            cv: None,
+            label: None,
+        }));
+        let body = block(Some("blk.1"), vec![expr_stmt(call_expr("a"), None), cont]);
+        let f = for_stmt(None, None, body);
+        let (out, contribs, changed, _) =
+            run_pass(program().with_body(vec![ProgramItem::Statement(f)]));
+        assert!(changed);
+        assert!(contribs.iter().any(|c| c.tag == "trailing-continue-removed"));
+        // The body no longer contains a `continue`; it unwrapped to bare `a()`.
+        match first_stmt(&out) {
+            Statement::Tagged(TaggedStatement::ForStatement(f)) => {
+                assert!(
+                    matches!(
+                        f.body.as_ref(),
+                        Statement::Tagged(TaggedStatement::ExpressionStatement(_))
+                    ),
+                    "expected the `continue` gone and body unwrapped to `a()`; got {:?}",
+                    f.body
+                );
+            }
+            other => panic!("expected ForStatement; got {other:?}"),
+        }
+    }
+
+    /// `for (;;) { a(); continue L; }` — a LABELED `continue` may target an outer
+    /// loop, so it is NOT stripped; the block is kept intact.
+    #[test]
+    fn for_body_labeled_continue_is_kept() {
+        use coding_adventures_javascript_ast::ContinueStatement;
+        let cont = Statement::Tagged(TaggedStatement::ContinueStatement(ContinueStatement {
+            cv: None,
+            label: Some(Identifier { cv: None, name: "L".to_string() }),
+        }));
+        let body = block(Some("blk.1"), vec![expr_stmt(call_expr("a"), None), cont]);
+        let f = for_stmt(None, None, body);
+        let (out, contribs, _changed, _) =
+            run_pass(program().with_body(vec![ProgramItem::Statement(f)]));
+        assert!(!contribs.iter().any(|c| c.tag == "trailing-continue-removed"));
+        match first_stmt(&out) {
+            Statement::Tagged(TaggedStatement::ForStatement(f)) => assert!(
+                matches!(f.body.as_ref(), Statement::Tagged(TaggedStatement::BlockStatement(b))
+                    if b.body.len() == 2),
+                "labeled continue must be kept; got {:?}",
                 f.body
             ),
             other => panic!("expected ForStatement; got {other:?}"),

--- a/code/programs/rust/closurec/tests/diff/simple-trailing-continue/README.md
+++ b/code/programs/rust/closurec/tests/diff/simple-trailing-continue/README.md
@@ -1,0 +1,17 @@
+# simple-trailing-continue
+
+End-to-end oracle for **trailing-`continue` removal** in
+`closure-pass-fold-control-flow` (fcf 0.39.0).
+
+A bare (unlabeled) `continue` at the tail of a for/while/do-while body is removed
+(it is a no-op); the shortened body then unwraps or normalizes. Labeled
+continues and continues with dead code after them are left intact.
+
+## Expected output
+
+```text
+for(;c;)step();for(;d;)work();do tick();while(e);for(;f;);
+```
+
+Byte-identical to the reference Closure Compiler (`v20260712`,
+`SIMPLE_OPTIMIZATIONS`, `ECMASCRIPT_2020`, `NO_TRANSPILE`), verified with `xxd`.

--- a/code/programs/rust/closurec/tests/diff/simple-trailing-continue/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-trailing-continue/expected.stdout
@@ -1,0 +1,1 @@
+for(;c;)step();for(;d;)work();do tick();while(e);for(;f;);

--- a/code/programs/rust/closurec/tests/diff/simple-trailing-continue/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-trailing-continue/flags.txt
@@ -1,0 +1,4 @@
+--compilation_level
+SIMPLE
+--js
+tests/diff/simple-trailing-continue/input/a.js

--- a/code/programs/rust/closurec/tests/diff/simple-trailing-continue/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-trailing-continue/input/a.js
@@ -1,0 +1,17 @@
+// SIMPLE-level trailing-continue removal (fold-control-flow 0.39.0).
+//
+// A bare (unlabeled) `continue` at the tail of a for/while/do-while body is a
+// no-op -- it jumps to the next iteration, exactly what falling off the end of
+// the body already does -- so it is removed; the shortened body then unwraps or
+// normalizes:
+//   for (; c;) { step(); continue; }   -> for(;c;)step();
+//   while (d) { work(); continue; }    -> for(;d;)work();   (while lowers to for)
+//   do { tick(); continue; } while(e); -> do tick();while(e);
+//   for (; f;) { continue; }           -> for(;f;);         (body emptied)
+//
+// A LABELED continue (`continue L`, may target an outer loop) and a `continue`
+// with dead code after it are left alone -- covered by unit tests.
+for (; c;) { step(); continue; }
+while (d) { work(); continue; }
+do { tick(); continue; } while (e);
+for (; f;) { continue; }

--- a/code/programs/rust/closurec/tests/diff_simple_trailing_continue.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_trailing_continue.rs
@@ -1,0 +1,43 @@
+//! Integration test for the `tests/diff/simple-trailing-continue/` fixture.
+//!
+//! End-to-end oracle for trailing-`continue` removal in
+//! `closure-pass-fold-control-flow`: a bare (unlabeled) `continue` at the tail
+//! of a for/while/do-while body is removed (it is a no-op); the shortened body
+//! then unwraps or normalizes. Labeled continues and continues with dead code
+//! after them are left intact.
+//!
+//! At SIMPLE the fixture optimizes to:
+//!
+//! ```text
+//! for(;c;)step();for(;d;)work();do tick();while(e);for(;f;);
+//! ```
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-trailing-continue/flags.txt")
+        .expect("read flags.txt");
+    raw.lines().filter(|l| !l.is_empty()).map(|s| s.to_string()).collect()
+}
+
+#[test]
+fn simple_trailing_continue_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY).args(&flags).output().expect("run closurec");
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-trailing-continue/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nflags: {flags:?}\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+}


### PR DESCRIPTION
## What

`fold-control-flow` (0.39.0): remove a redundant trailing `continue` from a loop body, matching the reference Closure Compiler at SIMPLE.

```text
for (;c;) { step(); continue; }    ->  for(;c;)step();
while (d) { work(); continue; }    ->  for(;d;)work();   (while lowers to for)
do { tick(); continue; } while(e); ->  do tick();while(e);
for (;f;) { continue; }            ->  for(;f;);         (body emptied)
```

A trailing bare `continue` is a no-op — it abandons this iteration to proceed to the loop's next-iteration mechanism, which is exactly what falling off the end of the body already does (identical for C-style `for`'s update+test, `while`'s test, `do-while`'s bottom test). After the strip, the shortened body unwraps its single statement, comma-fuses, or (when now empty) normalizes to `;` via existing machinery. Because `while` is rewritten to `for` (0.31.0) and re-folded, the `for` hook covers `while` too; the `do-while` arm has its own hook.

## Scope

Only a bare, **unlabeled** `continue` that is the **direct** last statement of the loop body:
- `continue L` (labeled) may target an outer loop, so removing it could skip that loop's iterations — **kept**.
- a `continue` with dead code after it (`{a(); continue; b()}`) is left alone — removing the unreachable `b()` is a separate dead-code-after-jump transform.
- a `continue` nested in an inner block/if is not the direct last statement — untouched.

Not handled (separate gap, #229): unwrapping a single-statement block loop body whose statement is a nested loop — `for(;c;){for(;d;)a()}` keeps its braces.

## Verification

- 96 fold-control-flow unit tests (2 new: trailing continue stripped, labeled continue kept) + 13 integration, zero regressions.
- New closurec e2e fixture `simple-trailing-continue`, byte-identical to the oracle jar (`v20260712`, `SIMPLE`, `ECMASCRIPT_2020`, `NO_TRANSPILE`), verified with `xxd`.
- Full closurec suite: **166 suites / 963 tests, zero failures, zero drift.**
- `cargo clippy -- -D warnings` clean in both workspaces.
- Inline security review: **PASSED** — behaviour-preserving for all loop forms; the unlabeled restriction avoids outer-loop mis-targeting; strict structural progress (no non-termination); no panic/allocation issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
