### PR TITLE
feat(spice): scale MOS junction leakage with temperature

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Scale Level-1 MOS bulk-junction `IS` and `JS` with temperature using the
+  silicon energy-gap law already shared by semiconductor junction models.
 - Scale Level-1 MOS `U0` alongside `KP` by `(T / T_NOM)^-3/2` so temperature
   helpers preserve Berkeley surface-mobility state and their nominal ratio.
 - Add Level-1 MOS model-card `U0` / `UO` surface mobility and derive `KP` from

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -92,6 +92,8 @@ Level-1 MOS model cards accept `KF` (default `0`) and `AF` (default `1`) and add
 Their `IS` value also drives source-body and drain-body junction leakage in
 DC, transient, transfer-function, and AC analysis, with separate `IBS` and
 `IBD` shot-noise contributions.
+MOS temperature helpers scale both scalar `IS` and area-density `JS` with the
+configured silicon energy-gap law before evaluating those bulk junctions.
 `LD` defaults to zero and applies `L_eff = L - 2*LD` to channel current and
 length-scaled intrinsic/`CGBO` capacitance.
 `TOX` defaults to `1e-7 m`, must be finite and positive, and derives intrinsic

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -375,6 +375,7 @@ def mosfet_at_temperature(
     temperature_kelvin: float,
     *,
     nominal_temperature_kelvin: float = 300.15,
+    energy_gap_ev: float = 1.11,
 ) -> Mosfet:
     """Return a Level-1 MOSFET adjusted from its nominal model temperature."""
 
@@ -382,6 +383,8 @@ def mosfet_at_temperature(
         raise ValueError("temperature_kelvin must be finite and positive")
     if not math.isfinite(nominal_temperature_kelvin) or nominal_temperature_kelvin <= 0.0:
         raise ValueError("nominal_temperature_kelvin must be finite and positive")
+    if not math.isfinite(energy_gap_ev) or energy_gap_ev <= 0.0:
+        raise ValueError("energy_gap_ev must be finite and positive")
     model = mosfet.model
     if not isinstance(model, MOSFET) or not isinstance(model.model, Level1Model):
         raise ValueError(f"{mosfet.name}: only Level-1 MOSFET temperature scaling is supported")
@@ -390,11 +393,22 @@ def mosfet_at_temperature(
         raise ValueError(f"{mosfet.name}: only Level-1 MOSFET parameters are supported")
     ratio = temperature_kelvin / nominal_temperature_kelvin
     threshold_shift = -2.0e-3 * (temperature_kelvin - nominal_temperature_kelvin)
+    saturation_exponent = (
+        energy_gap_ev
+        * _ELECTRON_CHARGE
+        / _BOLTZMANN
+        * (1.0 / nominal_temperature_kelvin - 1.0 / temperature_kelvin)
+    )
+    saturation_scale = ratio**3 * math.exp(
+        max(-100.0, min(100.0, saturation_exponent))
+    )
     adjusted_params = replace(
         params,
         VT0=params.VT0 + threshold_shift,
         KP=params.KP * ratio**-1.5,
         U0=params.U0 * ratio**-1.5,
+        IS=params.IS * saturation_scale,
+        JS=params.JS * saturation_scale,
         T_NOM=temperature_kelvin,
     )
     return replace(
@@ -496,6 +510,7 @@ def circuit_at_temperature(
                 element,
                 temperature_kelvin,
                 nominal_temperature_kelvin=nominal_temperature_kelvin,
+                energy_gap_ev=energy_gap_ev,
             )
         return element
 

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -4258,6 +4258,41 @@ def test_mosfet_temperature_scaling_keeps_surface_mobility_and_kp_aligned():
     )
 
 
+def test_mosfet_temperature_scaling_adjusts_bulk_junction_saturation_currents():
+    nominal = Mosfet(
+        "M1",
+        "d",
+        "g",
+        "s",
+        "b",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(Level1Params(IS=2.0e-15, JS=3.0e-12)),
+        ),
+    )
+    hot = mosfet_at_temperature(nominal, 350.0)
+    ratio = 350.0 / 300.15
+    exponent = (
+        1.11
+        * 1.602_176_634e-19
+        / 1.380_649e-23
+        * (1.0 / 300.15 - 1.0 / 350.0)
+    )
+    scale = ratio**3 * math.exp(exponent)
+    params = hot.model.model.params
+
+    assert pytest.approx(2.0e-15 * scale) == params.IS
+    assert pytest.approx(3.0e-12 * scale) == params.JS
+    assert pytest.approx(1_500.0) == params.JS / params.IS
+
+    circuit = Circuit([nominal])
+    silicon = circuit_at_temperature(circuit, 350.0, energy_gap_ev=1.11)
+    lower_gap = circuit_at_temperature(circuit, 350.0, energy_gap_ev=0.8)
+    silicon_params = silicon.elements[0].model.model.params
+    lower_gap_params = lower_gap.elements[0].model.model.params
+    assert silicon_params.IS > lower_gap_params.IS
+
+
 # ---- DC: Capacitor (open in DC) ----
 
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Scale Level-1 MOS bulk-junction `IS` and `JS` with temperature using the
+  silicon energy-gap law already shared by semiconductor junction models.
 - Scale Level-1 MOS `U0` alongside `KP` by `(T / T_NOM)^-3/2` so temperature
   helpers preserve Berkeley surface-mobility state and their nominal ratio.
 - Add Level-1 MOS model-card `U0` / `UO` surface mobility with the Berkeley

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -133,6 +133,8 @@ Level-1 MOS model cards accept `KF` (default `0`) and `AF` (default `1`) and add
 Their `IS` value also drives source-body and drain-body junction leakage in
 DC, transient, transfer-function, and AC analysis, with separate `IBS` and
 `IBD` shot-noise contributions.
+MOS temperature helpers scale both scalar `IS` and area-density `JS` with the
+configured silicon energy-gap law before evaluating those bulk junctions.
 `LD` defaults to zero and applies `L_eff = L - 2*LD` to channel current and
 length-scaled intrinsic/`CGBO` capacitance.
 `TOX` defaults to `1e-7 m`, must be finite and positive, and derives intrinsic

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -2759,6 +2759,7 @@ pub fn mosfet_at_temperature(
     mosfet: &Mosfet,
     temperature_kelvin: f64,
     nominal_temperature_kelvin: f64,
+    energy_gap_electron_volts: f64,
 ) -> Result<Mosfet, SpiceError> {
     if !temperature_kelvin.is_finite() || temperature_kelvin <= 0.0 {
         return Err(SpiceError::InvalidElement {
@@ -2772,12 +2773,23 @@ pub fn mosfet_at_temperature(
             reason: "nominal temperature must be finite and positive".to_string(),
         });
     }
+    if !energy_gap_electron_volts.is_finite() || energy_gap_electron_volts <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "energy gap must be finite and positive".to_string(),
+        });
+    }
     let ratio = temperature_kelvin / nominal_temperature_kelvin;
     let threshold_shift = -2.0e-3 * (temperature_kelvin - nominal_temperature_kelvin);
+    let saturation_exponent = energy_gap_electron_volts * ELECTRON_CHARGE / BOLTZMANN
+        * (1.0 / nominal_temperature_kelvin - 1.0 / temperature_kelvin);
+    let saturation_scale = ratio.powi(3) * saturation_exponent.clamp(-100.0, 100.0).exp();
     let mut adjusted = mosfet.clone();
     adjusted.params.vt0 += threshold_shift;
     adjusted.params.kp *= ratio.powf(-1.5);
     adjusted.params.surface_mobility *= ratio.powf(-1.5);
+    adjusted.params.saturation_current *= saturation_scale;
+    adjusted.params.saturation_current_density *= saturation_scale;
     adjusted.params.t_nom = temperature_kelvin;
     Ok(adjusted)
 }
@@ -2902,7 +2914,7 @@ pub fn circuit_at_temperature(
     circuit: &Circuit,
     temperature_kelvin: f64,
     nominal_temperature_kelvin: f64,
-    _energy_gap_electron_volts: f64,
+    energy_gap_electron_volts: f64,
 ) -> Result<Circuit, SpiceError> {
     let mut adjusted = Circuit {
         elements: Vec::new(),
@@ -2931,6 +2943,7 @@ pub fn circuit_at_temperature(
                 mosfet,
                 temperature_kelvin,
                 nominal_temperature_kelvin,
+                energy_gap_electron_volts,
             )?),
             _ => element.clone(),
         });

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -3521,7 +3521,7 @@ fn mosfet_temperature_scaling_keeps_surface_mobility_and_kp_aligned() {
             ..MosfetLevel1Params::default()
         },
     );
-    let hot = mosfet_at_temperature(&nominal, 600.3, 300.15).unwrap();
+    let hot = mosfet_at_temperature(&nominal, 600.3, 300.15, 1.11).unwrap();
     let scale = 2.0_f64.powf(-1.5);
 
     assert_close(hot.params.kp, nominal.params.kp * scale);
@@ -3533,6 +3533,50 @@ fn mosfet_temperature_scaling_keeps_surface_mobility_and_kp_aligned() {
         hot.params.kp / hot.params.surface_mobility,
         nominal.params.kp / nominal.params.surface_mobility,
     );
+}
+
+#[test]
+fn mosfet_temperature_scaling_adjusts_bulk_junction_saturation_currents() {
+    let nominal = Mosfet::with_model(
+        "M1",
+        "d",
+        "g",
+        "s",
+        "b",
+        MosfetType::Nmos,
+        MosfetLevel1Params {
+            saturation_current: 2.0e-15,
+            saturation_current_density: 3.0e-12,
+            ..MosfetLevel1Params::default()
+        },
+    );
+    let hot = mosfet_at_temperature(&nominal, 350.0, 300.15, 1.11).unwrap();
+    let ratio: f64 = 350.0 / 300.15;
+    let exponent: f64 = 1.11 * 1.602_176_634e-19 / 1.380_649e-23 * (1.0 / 300.15 - 1.0 / 350.0);
+    let scale = ratio.powi(3) * exponent.exp();
+
+    assert_close(hot.params.saturation_current, 2.0e-15 * scale);
+    assert_close(hot.params.saturation_current_density, 3.0e-12 * scale);
+    assert_close(
+        hot.params.saturation_current_density / hot.params.saturation_current,
+        1_500.0,
+    );
+
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Mosfet(nominal));
+    let silicon = circuit_at_temperature(&circuit, 350.0, 300.15, 1.11).unwrap();
+    let lower_gap = circuit_at_temperature(&circuit, 350.0, 300.15, 0.8).unwrap();
+    let junction_current = |adjusted: &Circuit| {
+        adjusted
+            .elements()
+            .iter()
+            .find_map(|element| match element {
+                Element::Mosfet(mosfet) => Some(mosfet.params.saturation_current),
+                _ => None,
+            })
+            .unwrap()
+    };
+    assert!(junction_current(&silicon) > junction_current(&lower_gap));
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Scale Level-1 MOS bulk-junction `IS` and `JS` with temperature using the
+  silicon energy-gap law already shared by semiconductor junction models.
 - Scale Level-1 MOS `U0` alongside `KP` by `(T / T_NOM)^-3/2` so temperature
   helpers preserve Berkeley surface-mobility state and their nominal ratio.
 - Add Level-1 MOS model-card `U0` / `UO` surface mobility and derive `KP` from

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -84,6 +84,8 @@ Level-1 MOS model cards accept `KF` (default `0`) and `AF` (default `1`) and add
 Their `IS` value also drives source-body and drain-body junction leakage in
 DC, transient, transfer-function, and AC analysis, with separate `IBS` and
 `IBD` shot-noise contributions.
+MOS temperature helpers scale both scalar `IS` and area-density `JS` with the
+configured silicon energy-gap law before evaluating those bulk junctions.
 `LD` defaults to zero and applies `L_eff = L - 2*LD` to channel current and
 length-scaled intrinsic/`CGBO` capacitance.
 `TOX` defaults to `1e-7 m`, must be finite and positive, and derives intrinsic

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -7724,6 +7724,7 @@ export function mosfetAtTemperature(
   element: Mosfet,
   temperatureKelvin: number,
   nominalTemperatureKelvin = 300.15,
+  energyGapElectronVolts = 1.11,
 ): Mosfet {
   if (!Number.isFinite(temperatureKelvin) || temperatureKelvin <= 0.0) {
     throw invalidElement(element.name, "temperature must be finite and positive");
@@ -7731,8 +7732,17 @@ export function mosfetAtTemperature(
   if (!Number.isFinite(nominalTemperatureKelvin) || nominalTemperatureKelvin <= 0.0) {
     throw invalidElement(element.name, "nominal temperature must be finite and positive");
   }
+  if (!Number.isFinite(energyGapElectronVolts) || energyGapElectronVolts <= 0.0) {
+    throw invalidElement(element.name, "energy gap must be finite and positive");
+  }
   const ratio = temperatureKelvin / nominalTemperatureKelvin;
   const thresholdShift = -2.0e-3 * (temperatureKelvin - nominalTemperatureKelvin);
+  const saturationExponent =
+    (energyGapElectronVolts * ELECTRON_CHARGE) /
+    BOLTZMANN *
+    (1.0 / nominalTemperatureKelvin - 1.0 / temperatureKelvin);
+  const saturationScale =
+    ratio ** 3 * Math.exp(Math.max(-100.0, Math.min(100.0, saturationExponent)));
   return {
     ...element,
     params: {
@@ -7740,6 +7750,8 @@ export function mosfetAtTemperature(
       VT0: element.params.VT0 + thresholdShift,
       KP: element.params.KP * ratio ** -1.5,
       U0: element.params.U0 * ratio ** -1.5,
+      IS: element.params.IS * saturationScale,
+      JS: element.params.JS * saturationScale,
       T_NOM: temperatureKelvin,
     },
   };
@@ -7874,7 +7886,14 @@ export function circuitAtTemperature(
     } else if (element.kind === "jfet") {
       adjusted.add(jfetAtTemperature(element, temperatureKelvin, nominalTemperatureKelvin));
     } else if (element.kind === "mosfet") {
-      adjusted.add(mosfetAtTemperature(element, temperatureKelvin, nominalTemperatureKelvin));
+      adjusted.add(
+        mosfetAtTemperature(
+          element,
+          temperatureKelvin,
+          nominalTemperatureKelvin,
+          energyGapElectronVolts,
+        ),
+      );
     } else {
       adjusted.add(element);
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -2342,6 +2342,36 @@ describe("dcOp", () => {
     );
   });
 
+  it("scales MOSFET bulk-junction saturation currents with temperature", () => {
+    const nominal = mosfet("M1", "d", "g", "s", "b", "NMOS", {
+      IS: 2.0e-15,
+      JS: 3.0e-12,
+    });
+    const hot = mosfetAtTemperature(nominal, 350.0);
+    const ratio = 350.0 / 300.15;
+    const exponent =
+      (1.11 * 1.602_176_634e-19) /
+      1.380_649e-23 *
+      (1.0 / 300.15 - 1.0 / 350.0);
+    const scale = ratio ** 3 * Math.exp(exponent);
+
+    expectClose(hot.params.IS, 2.0e-15 * scale);
+    expectClose(hot.params.JS, 3.0e-12 * scale);
+    expectClose(hot.params.JS / hot.params.IS, 1_500.0);
+
+    const circuit = new Circuit();
+    circuit.add(nominal);
+    const silicon = circuitAtTemperature(circuit, 350.0, 300.15, 1.11);
+    const lowerGap = circuitAtTemperature(circuit, 350.0, 300.15, 0.8);
+    const siliconMosfet = silicon.elements().find(
+      (element): element is Mosfet => element.kind === "mosfet",
+    );
+    const lowerGapMosfet = lowerGap.elements().find(
+      (element): element is Mosfet => element.kind === "mosfet",
+    );
+    expect(siliconMosfet!.params.IS).toBeGreaterThan(lowerGapMosfet!.params.IS);
+  });
+
   it("preserves subcircuits when applying temperature helpers", () => {
     const nominal = new Circuit();
     nominal.defineSubcircuit(

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,14 +33,14 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS mobility temperature scaling.
+1. Cross-language Level-1 MOS bulk-junction leakage temperature scaling.
    - Status: current PR completion candidate.
-   - Scale Level-1 MOS `U0` with the same Berkeley `(T / T_NOM)^-3/2`
-     mobility law already applied to `KP`.
-   - Preserve the nominal `KP / U0` relationship through direct MOS
-     temperature helpers and circuit-level temperature transforms.
-   - Keep Rust, Python, and TypeScript helper behavior, tests, and changelogs
-     aligned.
+   - Scale scalar `IS` and area-density `JS` through Level-1 MOS temperature
+     transforms using the shared silicon energy-gap saturation-current law.
+   - Preserve the nominal `JS / IS` relationship and route circuit-level
+     energy-gap configuration through MOS transforms.
+   - Keep Rust, Python, and TypeScript helper behavior, validation, tests, and
+     changelogs aligned.
 
 ## Completed Slices
 
@@ -3567,6 +3567,13 @@ the Rust, Python, and TypeScript surfaces together.
      derive `KP = U0 * Cox * 1e-4` while preserving explicit `KP` precedence.
    - Normalized model-card coverage, validation, changelogs, and the Rust
      Berkeley netlist facade preserve the parameter.
+
+284. Cross-language Level-1 MOS mobility temperature scaling.
+   - Status: completed in PR 9121.
+   - Level-1 MOS `U0` scales with the same Berkeley `(T / T_NOM)^-3/2`
+     mobility law already applied to `KP`.
+   - Direct MOS temperature helpers and circuit-level transforms preserve the
+     nominal `KP / U0` relationship in Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- scale Level-1 MOS scalar `IS` and area-density `JS` through temperature transforms using the shared silicon energy-gap law
- route circuit-level energy-gap configuration through MOS transforms in Rust, Python, and TypeScript
- document the behavior and reconcile the SPICE implementation plan after PR #9121

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- `.venv/bin/python -m ruff check src tests`
- `.venv/bin/python -m pytest tests -q` (669 passed, 88.76% coverage)
- `npm run build`
- `npm test -- --run` (412 passed)