### PR TITLE
feat(adj-formula-stdlib): calcium-phosphate product — CKD-MBD Ca×P definition library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_calcium_phosphate_product_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_calcium_phosphate_product_e2e.rs
@@ -1,0 +1,141 @@
+//! End-to-end tests for the `clinical/calcium-phosphate-product.adj` library — the definition of
+//! the calcium phosphate product (CPP = serum calcium × serum phosphate) and its two exact
+//! rearrangements — driven through the built CLI binary against the SHIPPED stdlib. The same
+//! invariant as every other formula library: a consumer states NO arithmetic; it imports the
+//! grounded library, binds the measured labs with `observe`, and the engine applies the cited
+//! relation on the CPU, computing the EXACT value and rendering the relation's citation and trust
+//! tier in the `derived` section (the auditable answer). The three formulas INVERT around the
+//! worked case Ca = 9 mg/dL, PO4 = 4 mg/dL: 9 × 4 = 36, 36 ÷ 4 = 9, and 36 ÷ 9 = 4. The three
+//! asserted values (36, 9, 4) are chosen so none is a colon-anchored prefix of another rendered
+//! value. This is the renal/bone-mineral product-cousin of the shipped rate-pressure-product.adj
+//! (RPP = HR × SBP), pairing two serum minerals the same multiplicative way.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped calcium-phosphate-product library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_cpp_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/calcium-phosphate-product.adj")
+        .canonicalize()
+        .expect("shipped calcium-phosphate-product.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_cpp_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_cpp_lib()).unwrap();
+    std::fs::write(dir.join("calcium-phosphate-product.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// calcium_phosphate_product — the definition: serum calcium times serum phosphate.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_calcium_phosphate_product_library_and_computes_it_with_citation() {
+    let dir = scratch("cpp");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"calcium-phosphate-product.adj\"\n\
+         observe serum_calcium(9)\n\
+         observe serum_phosphate(4)\n\
+         ? calcium_phosphate_product(serum_calcium, serum_phosphate)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 9 × 4 = 36.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"calcium_phosphate_product\"") && s.contains("\"value\":36"),
+        "calcium_phosphate_product(9, 4) = 36: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// serum_calcium — the same relation solved for calcium: CPP ÷ PO4.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_serum_calcium_from_product_and_phosphate_with_citation() {
+    let dir = scratch("ca");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"calcium-phosphate-product.adj\"\n\
+         observe calcium_phosphate_product(36)\n\
+         observe serum_phosphate(4)\n\
+         ? serum_calcium(calcium_phosphate_product, serum_phosphate)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 36 ÷ 4 = 9, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"serum_calcium\"") && s.contains("\"value\":9"),
+        "serum_calcium(36, 4) = 9: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "serum_calcium carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// serum_phosphate — the same relation solved for phosphate: CPP ÷ Ca, the third reading of the one
+// definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_serum_phosphate_from_product_and_calcium_with_citation() {
+    let dir = scratch("po4");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"calcium-phosphate-product.adj\"\n\
+         observe calcium_phosphate_product(36)\n\
+         observe serum_calcium(9)\n\
+         ? serum_phosphate(calcium_phosphate_product, serum_calcium)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 36 ÷ 9 = 4, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"serum_phosphate\"") && s.contains("\"value\":4"),
+        "serum_phosphate(36, 9) = 4: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "serum_phosphate carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/calcium-phosphate-product.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/calcium-phosphate-product.adj
@@ -1,0 +1,93 @@
+% ============================================================================
+% calcium-phosphate-product.adj — the definition of the calcium phosphate product
+% (CPP = serum calcium × serum phosphate) in the ADJ standard library.
+% ============================================================================
+% The calcium-phosphate-product entry of the *clinical* track, a renal/bone-mineral bedside
+% index (CKD-MBD). Where the rate pressure product multiplies two cardiovascular vitals, the
+% calcium phosphate product MULTIPLIES two serum minerals: THE CALCIUM PHOSPHATE PRODUCT IS THE
+% SERUM CALCIUM TIMES THE SERUM PHOSPHATE — a surrogate for the tendency of calcium and phosphate
+% to precipitate out of solution and deposit in soft tissue and vasculature, because the
+% saturation of the two ions with respect to their mineral phase scales with the product of their
+% concentrations. It rises in chronic kidney disease, hyperphosphataemia and hyperparathyroidism
+% and is watched as a calcification / calciphylaxis risk marker. It ships as an importable,
+% byte-provenanced, PARAMETERIZED `formula`, together with its two exact rearrangements (the serum
+% calcium a product implies for a given phosphate, and the serum phosphate it implies for a given
+% calcium). As with every compute library, a consumer states NO arithmetic: it `import`s this
+% file, binds the measured labs from its own byte-provenance decomposition, and asks the engine to
+% APPLY the cited definition on the CPU. Zero math is performed by the model; the engine computes
+% each value EXACTLY (over exact rationals), carrying the definition's citation.
+%
+%     import "calcium-phosphate-product.adj"
+%     observe serum_calcium(9)      % "…serum calcium 9 mg/dL…"       (span cited by the model)
+%     observe serum_phosphate(4)    % "…serum phosphate 4 mg/dL…"     (span cited by the model)
+%     ? calcium_phosphate_product(serum_calcium, serum_phosphate)
+%                                   % engine → 36, carrying CPP = Ca × PO4
+%
+% All three formulas are EXACT over their parameters, so every value the engine returns is exact.
+% They COMPOSE and invert cleanly around the worked case serum calcium = 9 mg/dL, serum phosphate
+% = 4 mg/dL (CPP = 9 × 4 = 36): the `calcium_phosphate_product` a consumer computes from the two
+% minerals is exactly the value the `serum_calcium` formula divides by the phosphate to recover 9,
+% and exactly the value the `serum_phosphate` formula divides by the calcium to recover 4.
+%
+%   calcium_phosphate_product(serum_calcium, serum_phosphate)
+%       = serum_calcium * serum_phosphate                 % CPP = Ca × PO4  (definition)
+%   serum_calcium(calcium_phosphate_product, serum_phosphate)
+%       = calcium_phosphate_product / serum_phosphate      % Ca = CPP ÷ PO4  (solved for calcium)
+%   serum_phosphate(calcium_phosphate_product, serum_calcium)
+%       = calcium_phosphate_product / serum_calcium        % PO4 = CPP ÷ Ca  (solved for phosphate)
+%
+% NOTE ON UNITS: the serum calcium and serum phosphate are each in milligrams per decilitre; the
+% calcium phosphate product comes out in mg²/dL² (the units are conventionally dropped), and this
+% library computes the exact product over whatever consistent inputs it is given.
+%
+% All three formulas are defended by the SAME clause — "Calcium phosphate product (CPP) is
+% measured by multiplying the total serum calcium by total serum phosphorus concentration" —
+% because that one definition (the product IS the calcium-times-phosphate product) sanctions the
+% relation read every way. The quote is transcribed verbatim from a peer-reviewed review archived
+% on the NCBI PMC repository, so each `formula` carries the provenance envelope every shipped
+% grounded clause carries; the linter rejects an unsourced one. (See feedback_nothing_human_authored
+% — the clause is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable serum lab the definition ranges over, and each
+% result is a derived quantity. `serum_calcium`, `serum_phosphate` and `calcium_phosphate_product`
+% each appear BOTH as a derived result and as an input (of the other formulas), so each is a single
+% dictionary term used in both roles. The `surface` lists are the everyday names a decomposer maps
+% onto the canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary calcium_phosphate_product_vocab {
+    define serum_calcium              : finding  surface "serum calcium", "calcium", "Ca"                                   % milligrams per decilitre (mg/dL)
+    define serum_phosphate            : finding  surface "serum phosphate", "serum phosphorus", "phosphate", "phosphorus"   % milligrams per decilitre (mg/dL)
+    define calcium_phosphate_product  : finding  surface "calcium phosphate product", "calcium-phosphate product", "CPP"    % mg squared per dL squared (mg2/dL2)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the definitional clause from the cited review
+% on the NCBI PMC repository (a quote is required on a shipped formula). Each is an exact product or
+% ratio of measured labs, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook calcium_phosphate_product_laws {
+    use calcium_phosphate_product_vocab
+
+    % Calcium phosphate product — the serum calcium times the serum phosphate, i.e. CPP = Ca × PO4.
+    formula calcium_phosphate_product(serum_calcium, serum_phosphate) = serum_calcium * serum_phosphate
+        source "Calcium phosphate product (CPP) is measured by multiplying the total serum calcium by total serum phosphorus concentration"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC2989826/"
+        trust authoritative
+
+    % Serum calcium — the same definition solved for the calcium a product implies for a given
+    % phosphate (Ca = CPP ÷ PO4). Defended by the SAME clause.
+    formula serum_calcium(calcium_phosphate_product, serum_phosphate) = calcium_phosphate_product / serum_phosphate
+        source "Calcium phosphate product (CPP) is measured by multiplying the total serum calcium by total serum phosphorus concentration"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC2989826/"
+        trust authoritative
+
+    % Serum phosphate — the same definition solved for the phosphate (PO4 = CPP ÷ Ca): the calcium
+    % phosphate product divided by the serum calcium. The SAME clause, read the third way.
+    formula serum_phosphate(calcium_phosphate_product, serum_calcium) = calcium_phosphate_product / serum_calcium
+        source "Calcium phosphate product (CPP) is measured by multiplying the total serum calcium by total serum phosphorus concentration"
+        locator "https://pmc.ncbi.nlm.nih.gov/articles/PMC2989826/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/calcium-phosphate-product.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/calcium-phosphate-product.query.adj
@@ -1,0 +1,27 @@
+% ============================================================================
+% calcium-phosphate-product.query.adj — worked applications of the calcium-phosphate-product definition.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a renal/bone-mineral vignette into observed
+% serum labs: it `import`s the grounded formulabook, `observe`s the measured calcium and phosphate,
+% and asks the engine to APPLY the cited definition. No arithmetic is stated by the consumer; the
+% engine computes each value EXACTLY (over exact rationals) and carries the review's citation as its
+% proof, on the CPU, with zero model calls.
+%
+% Worked case (serum calcium = 9 mg/dL, serum phosphate = 4 mg/dL): CPP = 9 × 4 = 36. Each query
+% below fixes two of the three quantities and asks the engine to recover the third; every answer is
+% exact and the three COMPOSE (each inversion recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli calcium-phosphate-product.query.adj
+% ============================================================================
+
+import "calcium-phosphate-product.adj"
+
+% --- Forward: the calcium phosphate product the two labs imply (expect 36). -------------------
+observe serum_calcium(9)
+observe serum_phosphate(4)
+? calcium_phosphate_product(serum_calcium, serum_phosphate)   % expect 36
+
+% --- Inverse: the serum calcium a product of 36 implies at that phosphate (9). ----------------
+observe calcium_phosphate_product(36)
+? serum_calcium(calcium_phosphate_product, serum_phosphate)   % expect 9


### PR DESCRIPTION
## What

Ships the **calcium phosphate product** (CPP = serum calcium × serum phosphate) as an importable, byte-provenanced, parameterized `formula` in the **clinical** track of the ADJ formula standard library, with its two exact algebraic rearrangements.

All three formulas are defended by the **same verbatim clause**, transcribed from a peer-reviewed review archived on the NCBI PMC repository:

> "Calcium phosphate product (CPP) is measured by multiplying the total serum calcium by total serum phosphorus concentration"
> — https://pmc.ncbi.nlm.nih.gov/articles/PMC2989826/ · `trust authoritative`

## Why

The renal / bone-mineral (CKD-MBD, calciphylaxis-risk) product-cousin of the shipped `rate-pressure-product.adj` (RPP = HR × SBP): two serum minerals multiplied the same way. A consumer states **no arithmetic** — it imports the library, `observe`s the measured labs from its own byte-provenance decomposition, and the engine **applies** the cited relation on the CPU, computing each value **exactly over exact rationals** and carrying the citation + trust tier in the auditable `derived` section.

## The three readings

```
calcium_phosphate_product(serum_calcium, serum_phosphate) = serum_calcium * serum_phosphate   % CPP = Ca × PO4
serum_calcium(calcium_phosphate_product, serum_phosphate) = calcium_phosphate_product / serum_phosphate  % Ca = CPP ÷ PO4
serum_phosphate(calcium_phosphate_product, serum_calcium) = calcium_phosphate_product / serum_calcium     % PO4 = CPP ÷ Ca
```

They **compose** around the worked case Ca = 9 mg/dL, PO₄ = 4 mg/dL: 9 × 4 = 36, 36 ÷ 4 = 9, 36 ÷ 9 = 4. The three asserted values (36 / 9 / 4) are chosen so none is a colon-anchored prefix of another rendered value.

## Files

- `code/specs/data/adj-formula-stdlib/clinical/calcium-phosphate-product.adj` — dictionary + formulabook (3 cited formulas)
- `code/specs/data/adj-formula-stdlib/clinical/calcium-phosphate-product.query.adj` — worked applications
- `code/packages/rust/adj-lang-cli/tests/formula_calcium_phosphate_product_e2e.rs` — 3 e2e tests (own dedicated file, no shared anchor)

## Verification

- `cargo test -p adj-lang-cli --test formula_calcium_phosphate_product_e2e` — **3/3 green**
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — **clean**
- Render-probe of `.query.adj` against the built CLI: forward → 36 with the verbatim citation + `trust:authoritative`; inverse recovers `serum_calcium` = 9.
- Data + test only — no engine change, **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)