### PR TITLE
Bridge HTML render trees into shared layout

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -167,6 +167,7 @@ members = [
     "engram-wasm",
     "html-lexer",
     "html-parser",
+    "html-to-layout",
     "html-renderer",
     "intel4004-gatelevel",
     "mos6502-gatelevel",

--- a/code/packages/rust/html-to-layout/BUILD
+++ b/code/packages/rust/html-to-layout/BUILD
@@ -1,0 +1,1 @@
+cargo test --manifest-path Cargo.toml

--- a/code/packages/rust/html-to-layout/CHANGELOG.md
+++ b/code/packages/rust/html-to-layout/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [0.1.0] - 2026-07-29
+
+### Added
+
+- Browser render-tree to shared Layout IR conversion.
+- Mosaic-era default typography, colors, spacing, and page background.
+- Retention of HTML roles, display classes, link targets, language, direction,
+  and image metadata in the Layout IR extension bag.
+- An executable parser-to-positioned-layout acceptance test.

--- a/code/packages/rust/html-to-layout/Cargo.toml
+++ b/code/packages/rust/html-to-layout/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "html-to-layout"
+version = "0.1.0"
+edition = "2021"
+description = "Converts html-parser browser render trees into the shared Layout IR."
+
+[dependencies]
+coding-adventures-html-parser = { path = "../html-parser" }
+layout-ir = { path = "../layout-ir" }
+
+[dev-dependencies]
+layout-block = { path = "../layout-block" }

--- a/code/packages/rust/html-to-layout/README.md
+++ b/code/packages/rust/html-to-layout/README.md
@@ -1,0 +1,41 @@
+# html-to-layout
+
+`html-to-layout` is the browser-facing front end for the shared Rust layout
+stack. It converts the `BrowserRenderTree` produced by `html-parser` into a
+`layout-ir::LayoutNode` tree:
+
+```text
+HTML source
+  -> html-parser
+  -> BrowserRenderTree
+  -> html-to-layout
+  -> LayoutNode
+  -> layout-block
+  -> PositionedNode
+  -> layout-to-paint
+```
+
+## API
+
+- `html_render_tree_to_layout(&BrowserRenderTree, &HtmlTheme) -> LayoutNode`
+- `mosaic_html_theme() -> HtmlTheme`
+
+The adapter maps parser-supplied display categories, text, headings, images,
+hidden content, stable IDs, and resolved link/resource URLs. Browser metadata
+needed after layout is retained under `LayoutNode.ext["html"]`, so positioned
+nodes still carry link targets and semantic roles for hit testing.
+
+This first bridge intentionally does not implement CSS cascade or a complete
+CSS inline-formatting context. Inline nodes remain explicit layout containers;
+the current `layout-block` engine positions them using its documented v1 block
+flow. A dedicated inline layout pass is the next rendering-fidelity boundary,
+not parser conformance work.
+
+## Verification
+
+From `code/packages/rust`:
+
+```sh
+cargo test -p html-to-layout
+cargo clippy -p html-to-layout --all-targets -- -D warnings
+```

--- a/code/packages/rust/html-to-layout/required_capabilities.json
+++ b/code/packages/rust/html-to-layout/required_capabilities.json
@@ -1,0 +1,3 @@
+{
+  "capabilities": ["rust-cargo"]
+}

--- a/code/packages/rust/html-to-layout/src/lib.rs
+++ b/code/packages/rust/html-to-layout/src/lib.rs
@@ -1,0 +1,463 @@
+//! Convert [`BrowserRenderTree`] values from `html-parser` into the shared
+//! [`LayoutNode`] intermediate representation.
+//!
+//! This crate is deliberately a front-end adapter. Parsing stays in
+//! `html-parser`; geometry stays in layout engines such as `layout-block`; and
+//! painting stays in `layout-to-paint`.
+
+use std::collections::HashMap;
+
+use coding_adventures_html_parser::{BrowserRenderNode, BrowserRenderTree};
+use layout_ir::{
+    color_black, edges_all, edges_xy, font_bold, font_italic, font_spec, rgb, Color, ExtValue,
+    FontSpec, ImageContent, ImageFit, LayoutNode, SizeValue, TextAlign, TextContent,
+};
+
+pub const VERSION: &str = "0.1.0";
+
+/// Fully resolved visual defaults applied before a future CSS cascade exists.
+#[derive(Clone, Debug, PartialEq)]
+pub struct HtmlTheme {
+    pub body_font: FontSpec,
+    pub heading_fonts: [FontSpec; 6],
+    pub code_font: FontSpec,
+    pub text_color: Color,
+    pub heading_color: Color,
+    pub link_color: Color,
+    pub page_background: Color,
+    pub page_padding: f64,
+    pub block_spacing: f64,
+    pub heading_spacing: f64,
+}
+
+/// The recognizable defaults used by Mosaic-era HTML documents.
+pub fn mosaic_html_theme() -> HtmlTheme {
+    HtmlTheme {
+        body_font: FontSpec {
+            line_height: 1.4,
+            ..font_spec("Times New Roman", 14.0)
+        },
+        heading_fonts: [
+            font_bold(font_spec("Times New Roman", 24.0)),
+            font_bold(font_spec("Times New Roman", 20.0)),
+            font_bold(font_spec("Times New Roman", 18.0)),
+            font_bold(font_spec("Times New Roman", 16.0)),
+            font_bold(font_spec("Times New Roman", 14.0)),
+            font_bold(font_spec("Times New Roman", 12.0)),
+        ],
+        code_font: font_spec("Courier New", 13.0),
+        text_color: color_black(),
+        heading_color: color_black(),
+        link_color: rgb(0, 0, 238),
+        page_background: rgb(192, 192, 192),
+        page_padding: 16.0,
+        block_spacing: 12.0,
+        heading_spacing: 12.0,
+    }
+}
+
+/// Convert a browser render tree into a shared layout tree.
+///
+/// The returned root fills the available width, wraps its content height, and
+/// carries the theme's page background in the `paint` extension namespace.
+pub fn html_render_tree_to_layout(
+    render_tree: &BrowserRenderTree,
+    theme: &HtmlTheme,
+) -> LayoutNode {
+    let style = InheritedStyle {
+        font: theme.body_font.clone(),
+        color: theme.text_color,
+    };
+    let children = render_tree
+        .children
+        .iter()
+        .filter_map(|node| convert_node(node, theme, &style))
+        .collect();
+
+    LayoutNode::container(children)
+        .with_padding(edges_all(theme.page_padding))
+        .with_width(SizeValue::Fill)
+        .with_height(SizeValue::Wrap)
+        .with_ext("block", display_ext("block"))
+        .with_ext("html", root_html_ext())
+        .with_ext("paint", background_ext(theme.page_background))
+}
+
+#[derive(Clone)]
+struct InheritedStyle {
+    font: FontSpec,
+    color: Color,
+}
+
+fn convert_node(
+    node: &BrowserRenderNode,
+    theme: &HtmlTheme,
+    inherited: &InheritedStyle,
+) -> Option<LayoutNode> {
+    if node.display == "none" || node.hidden {
+        return None;
+    }
+
+    let style = style_for_node(node, theme, inherited);
+    let mut layout = match node.display.as_str() {
+        "inline-text" => text_leaf(node.text.as_deref().unwrap_or_default(), &style),
+        "line-break" => text_leaf("\n", &style),
+        "inline-replaced" if node.role == "image" => image_leaf(node),
+        _ => container_or_fallback(node, theme, &style),
+    };
+
+    if let Some(id) = &node.id {
+        layout = layout.with_id(id);
+    }
+    apply_size_hints(&mut layout, node);
+    apply_spacing(&mut layout, node, theme);
+    layout.ext.insert("html".into(), html_ext(node));
+    layout
+        .ext
+        .insert("block".into(), display_ext(node.display.as_str()));
+    Some(layout)
+}
+
+fn container_or_fallback(
+    node: &BrowserRenderNode,
+    theme: &HtmlTheme,
+    style: &InheritedStyle,
+) -> LayoutNode {
+    let children: Vec<_> = node
+        .children
+        .iter()
+        .filter_map(|child| convert_node(child, theme, style))
+        .collect();
+
+    if !children.is_empty() {
+        return LayoutNode::container(children);
+    }
+
+    let fallback = node
+        .text
+        .as_deref()
+        .or(node.accessible_name.as_deref())
+        .or(node.value.as_deref())
+        .or(node.alt.as_deref());
+    match fallback {
+        Some(text) if !text.is_empty() => text_leaf(text, style),
+        _ => LayoutNode::empty(),
+    }
+}
+
+fn text_leaf(value: &str, style: &InheritedStyle) -> LayoutNode {
+    LayoutNode::leaf_text(TextContent {
+        value: value.to_string(),
+        font: style.font.clone(),
+        color: style.color,
+        max_lines: None,
+        text_align: TextAlign::Start,
+    })
+    .with_width(SizeValue::Fill)
+    .with_height(SizeValue::Wrap)
+}
+
+fn image_leaf(node: &BrowserRenderNode) -> LayoutNode {
+    let source = node
+        .resolved_src
+        .as_deref()
+        .or(node.src.as_deref())
+        .unwrap_or_default();
+    LayoutNode::leaf_image(ImageContent {
+        src: source.to_string(),
+        fit: ImageFit::Contain,
+    })
+}
+
+fn style_for_node(
+    node: &BrowserRenderNode,
+    theme: &HtmlTheme,
+    inherited: &InheritedStyle,
+) -> InheritedStyle {
+    let mut style = inherited.clone();
+    if node.role == "heading" {
+        let level = node.heading_level.unwrap_or(1).clamp(1, 6);
+        style.font = theme.heading_fonts[usize::from(level - 1)].clone();
+        style.color = theme.heading_color;
+    } else if node.role == "preformatted" {
+        style.font = theme.code_font.clone();
+    }
+
+    match node.name.as_deref() {
+        Some("b" | "strong") => style.font = font_bold(style.font),
+        Some("em" | "i") => style.font = font_italic(style.font),
+        _ => {}
+    }
+    if node.role == "link" {
+        style.color = theme.link_color;
+    }
+    style
+}
+
+fn apply_size_hints(layout: &mut LayoutNode, node: &BrowserRenderNode) {
+    if let Some(width) = parse_dimension(node.width.as_deref()) {
+        layout.width = Some(SizeValue::Fixed(width));
+    } else if node.display == "block" || node.display.starts_with("table") {
+        layout.width = Some(SizeValue::Fill);
+    } else if layout.width.is_none() {
+        layout.width = Some(SizeValue::Wrap);
+    }
+
+    if let Some(height) = parse_dimension(node.height.as_deref()) {
+        layout.height = Some(SizeValue::Fixed(height));
+    } else if layout.height.is_none() {
+        layout.height = Some(SizeValue::Wrap);
+    }
+}
+
+fn apply_spacing(layout: &mut LayoutNode, node: &BrowserRenderNode, theme: &HtmlTheme) {
+    let spacing = if node.role == "heading" {
+        theme.heading_spacing
+    } else if matches!(
+        node.role.as_str(),
+        "paragraph" | "preformatted" | "list" | "quote_block" | "description_list" | "figure"
+    ) {
+        theme.block_spacing
+    } else {
+        0.0
+    };
+    if spacing > 0.0 {
+        layout.margin = Some(edges_xy(0.0, spacing / 2.0));
+    }
+}
+
+fn parse_dimension(value: Option<&str>) -> Option<f64> {
+    value?
+        .trim()
+        .trim_end_matches("px")
+        .parse::<f64>()
+        .ok()
+        .filter(|value| value.is_finite() && *value >= 0.0)
+}
+
+fn html_ext(node: &BrowserRenderNode) -> ExtValue {
+    let mut values = HashMap::new();
+    values.insert("role".into(), ExtValue::Str(node.role.clone()));
+    values.insert("display".into(), ExtValue::Str(node.display.clone()));
+    insert_optional(&mut values, "tag", node.name.as_deref());
+    insert_optional(
+        &mut values,
+        "href",
+        node.resolved_href.as_deref().or(node.href.as_deref()),
+    );
+    insert_optional(&mut values, "target", node.target.as_deref());
+    insert_optional(&mut values, "lang", node.lang.as_deref());
+    insert_optional(&mut values, "dir", node.dir.as_deref());
+    insert_optional(&mut values, "alt", node.alt.as_deref());
+    ExtValue::Map(values)
+}
+
+fn root_html_ext() -> ExtValue {
+    ExtValue::Map(HashMap::from([(
+        "role".into(),
+        ExtValue::Str("document".into()),
+    )]))
+}
+
+fn display_ext(display: &str) -> ExtValue {
+    ExtValue::Map(HashMap::from([(
+        "display".into(),
+        ExtValue::Str(display.to_string()),
+    )]))
+}
+
+fn background_ext(color: Color) -> ExtValue {
+    ExtValue::Map(HashMap::from([(
+        "backgroundColor".into(),
+        color_ext(color),
+    )]))
+}
+
+fn color_ext(color: Color) -> ExtValue {
+    ExtValue::Map(HashMap::from([
+        ("r".into(), ExtValue::Int(i64::from(color.r))),
+        ("g".into(), ExtValue::Int(i64::from(color.g))),
+        ("b".into(), ExtValue::Int(i64::from(color.b))),
+        ("a".into(), ExtValue::Int(i64::from(color.a))),
+    ]))
+}
+
+fn insert_optional(values: &mut HashMap<String, ExtValue>, key: &str, value: Option<&str>) {
+    if let Some(value) = value {
+        values.insert(key.into(), ExtValue::Str(value.into()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coding_adventures_html_parser::parse_browser_render_tree;
+    use layout_block::layout_block;
+    use layout_ir::{constraints_width, Content, MeasureResult, PositionedNode, TextMeasurer};
+
+    struct TestMeasurer;
+
+    impl TextMeasurer for TestMeasurer {
+        fn measure(&self, text: &str, font: &FontSpec, max_width: Option<f64>) -> MeasureResult {
+            let width = text.chars().count() as f64 * font.size * 0.5;
+            MeasureResult {
+                width: max_width.map_or(width, |limit| width.min(limit)),
+                height: font.size * font.line_height,
+                line_count: 1,
+            }
+        }
+    }
+
+    #[test]
+    fn mosaic_theme_uses_era_defaults() {
+        let theme = mosaic_html_theme();
+        assert_eq!(theme.body_font.family, "Times New Roman");
+        assert_eq!(theme.link_color, rgb(0, 0, 238));
+        assert_eq!(theme.page_background, rgb(192, 192, 192));
+    }
+
+    #[test]
+    fn maps_heading_link_and_resolved_image_metadata() {
+        let render = parse_browser_render_tree(
+            r#"<base href="https://example.test/docs/">
+               <h2 id="intro">Hello</h2>
+               <p>Read <a href="next.html">next</a>.</p>
+               <img src="logo.gif" alt="Logo" width="64" height="32">"#,
+        )
+        .unwrap();
+        let layout = html_render_tree_to_layout(&render, &mosaic_html_theme());
+
+        let heading = find_by_id(&layout, "intro").unwrap();
+        let heading_text = first_text(heading).unwrap();
+        assert_eq!(heading_text.value, "Hello");
+        assert_eq!(heading_text.font.size, 20.0);
+
+        let link = find_by_html_role(&layout, "link").unwrap();
+        assert_eq!(
+            html_string(link, "href"),
+            Some("https://example.test/docs/next.html")
+        );
+        assert_eq!(first_text(link).unwrap().color, rgb(0, 0, 238));
+
+        let image = find_by_html_role(&layout, "image").unwrap();
+        assert_eq!(image.width, Some(SizeValue::Fixed(64.0)));
+        assert_eq!(image.height, Some(SizeValue::Fixed(32.0)));
+        assert!(matches!(
+            image.content.as_ref(),
+            Some(Content::Image(content))
+                if content.src == "https://example.test/docs/logo.gif"
+        ));
+    }
+
+    #[test]
+    fn omits_hidden_browser_content() {
+        let render = parse_browser_render_tree(
+            "<p>shown</p><p aria-hidden=\"true\">visual</p><p hidden>hidden</p>",
+        )
+        .unwrap();
+        let layout = html_render_tree_to_layout(&render, &mosaic_html_theme());
+        let text = all_text(&layout);
+        assert_eq!(text, vec!["shown", "visual"]);
+    }
+
+    #[test]
+    fn parser_to_positioned_layout_acceptance_path_is_executable() {
+        let render = parse_browser_render_tree(
+            r#"<base href="https://example.test/">
+               <main><h1>Mosaic lives</h1>
+               <p>The browser pipeline is <a href="status">connected</a>.</p></main>"#,
+        )
+        .unwrap();
+        let layout = html_render_tree_to_layout(&render, &mosaic_html_theme());
+        let positioned = layout_block(&layout, constraints_width(640.0), &TestMeasurer);
+
+        assert_eq!(positioned.width, 640.0);
+        assert!(positioned.height > 0.0);
+        assert_eq!(
+            positioned_text(&positioned),
+            vec!["Mosaic lives", "The browser pipeline is", "connected", "."]
+        );
+        let link = find_positioned_by_html_role(&positioned, "link").unwrap();
+        assert_eq!(
+            positioned_html_string(link, "href"),
+            Some("https://example.test/status")
+        );
+    }
+
+    fn find_by_id<'a>(node: &'a LayoutNode, id: &str) -> Option<&'a LayoutNode> {
+        if node.id.as_deref() == Some(id) {
+            return Some(node);
+        }
+        node.children.iter().find_map(|child| find_by_id(child, id))
+    }
+
+    fn find_by_html_role<'a>(node: &'a LayoutNode, role: &str) -> Option<&'a LayoutNode> {
+        if html_string(node, "role") == Some(role) {
+            return Some(node);
+        }
+        node.children
+            .iter()
+            .find_map(|child| find_by_html_role(child, role))
+    }
+
+    fn html_string<'a>(node: &'a LayoutNode, key: &str) -> Option<&'a str> {
+        let ExtValue::Map(values) = node.ext.get("html")? else {
+            return None;
+        };
+        let ExtValue::Str(value) = values.get(key)? else {
+            return None;
+        };
+        Some(value)
+    }
+
+    fn first_text(node: &LayoutNode) -> Option<&TextContent> {
+        if let Some(Content::Text(text)) = &node.content {
+            return Some(text);
+        }
+        node.children.iter().find_map(first_text)
+    }
+
+    fn all_text(node: &LayoutNode) -> Vec<&str> {
+        let mut values = Vec::new();
+        if let Some(Content::Text(text)) = &node.content {
+            values.push(text.value.as_str());
+        }
+        for child in &node.children {
+            values.extend(all_text(child));
+        }
+        values
+    }
+
+    fn positioned_text(node: &PositionedNode) -> Vec<&str> {
+        let mut values = Vec::new();
+        if let Some(Content::Text(text)) = &node.content {
+            values.push(text.value.as_str());
+        }
+        for child in &node.children {
+            values.extend(positioned_text(child));
+        }
+        values
+    }
+
+    fn find_positioned_by_html_role<'a>(
+        node: &'a PositionedNode,
+        role: &str,
+    ) -> Option<&'a PositionedNode> {
+        if positioned_html_string(node, "role") == Some(role) {
+            return Some(node);
+        }
+        node.children
+            .iter()
+            .find_map(|child| find_positioned_by_html_role(child, role))
+    }
+
+    fn positioned_html_string<'a>(node: &'a PositionedNode, key: &str) -> Option<&'a str> {
+        let ExtValue::Map(values) = node.ext.get("html")? else {
+            return None;
+        };
+        let ExtValue::Str(value) = values.get(key)? else {
+            return None;
+        };
+        Some(value)
+    }
+}

--- a/code/specs/BR01-venture-browser.md
+++ b/code/specs/BR01-venture-browser.md
@@ -41,6 +41,18 @@ ecosystem. The web in 1993 was simple enough that a single developer can
 understand the entire stack — from TCP socket to rendered pixel — and that is
 exactly the educational goal.
 
+## Implementation Status
+
+The current `html-parser` corpus gates are complete: the checked WPT
+tree-construction audit and html5lib tokenizer audit both ratchet missing
+upstream cases at zero. The `html-to-layout` package now provides the first
+executable browser seam from `BrowserRenderTree` to the shared Layout IR and
+`layout-block`.
+
+That does not make Venture complete. The remaining acceptance work includes a
+real inline-formatting pass, paint-scene acceptance, resource loading, link
+hit-testing, and a platform host that wires navigation through pixels.
+
 ## Where It Fits
 
 Venture sits at the top of the stack. It is a **program** (not a library) that
@@ -56,18 +68,18 @@ Layer 6 — Platform Paint VMs
   └── P2D08 paint-vm-cairo (Linux, future)
 
 Layer 5 — Layout & Paint Translation
+  ├── html-to-layout
   ├── layout-block
-  ├── layout-to-paint
-  └── document-ast-to-layout
+  └── layout-to-paint
 
 Layer 4 — Document Model
-  ├── document-ast
+  ├── html-parser / dom-core
   ├── layout-ir
   └── paint-instructions
 
 Layer 3 — Protocol Parsers
   ├── http1.0-lexer / http1.0-parser / http1.0-client
-  └── html1.0-lexer / html1.0-parser
+  └── html-lexer / html-parser
 
 Layer 2 — Network Primitives
   ├── tcp-client
@@ -80,7 +92,7 @@ Layer 1 — Data Formats
 
 Every box is a separate crate. Improving any crate automatically improves the
 browser. Adding CSS support in the future means adding a `css-lexer`,
-`css-parser`, and updating `document-ast-to-layout` — Venture itself barely
+`css-parser`, and updating `html-to-layout` — Venture itself barely
 changes.
 
 ## Concepts
@@ -103,10 +115,10 @@ tcp-client ──────────────────► TcpStream (
 http1.0-client ──────────────► HttpResponse { status, headers, body }
   │
   ▼
-html1.0-parser ──────────────► DocumentNode (tree of elements & text)
+html-parser ─────────────────► BrowserRenderTree (display-ready HTML tree)
   │
   ▼
-document-ast-to-layout ──────► LayoutNode (styled tree with fonts/colors)
+html-to-layout ───────────────► LayoutNode (styled tree with fonts/colors)
   │
   ▼
 layout-block ────────────────► PositionedNode (x, y, width, height for each node)
@@ -215,9 +227,9 @@ PaintScene before rendering. The paint VM sees pre-translated coordinates.
 │  │                                                            │   │
 │  │  url-parser → tcp-client → frame-extractor                │   │
 │  │                  → http1.0-lexer → http1.0-parser         │   │
-│  │                      → html1.0-lexer → html1.0-parser     │   │
-│  │                          → document-ast                    │   │
-│  │                              → document-ast-to-layout      │   │
+│  │                      → html-lexer → html-parser           │   │
+│  │                          → BrowserRenderTree              │   │
+│  │                              → html-to-layout              │   │
 │  │                                  → layout-block            │   │
 │  │                                      → layout-to-paint     │   │
 │  │                                          → paint-vm-direct2d│  │
@@ -298,9 +310,10 @@ User action (Enter key / link click)
   │     - "image/*"   → display standalone image
   │     - other       → show raw text in monospace
   │
-  ├─ 6. html1_0_parser::parse(response.body) → DocumentNode tree
+  ├─ 6. html_parser::parse_browser_render_tree(response.body)
+  │       → BrowserRenderTree
   │
-  ├─ 7. document_ast_to_layout(doc, mosaic_theme) → LayoutNode tree
+  ├─ 7. html_render_tree_to_layout(tree, mosaic_theme) → LayoutNode tree
   │     - Apply Mosaic-era font/color defaults
   │     - Annotate links with destination URLs
   │
@@ -321,8 +334,10 @@ User action (Enter key / link click)
 
 ### Link Handling
 
-During `document-ast-to-layout`, each `<a href="...">` is annotated with both
-its destination URL and a color/underline style:
+During `html-to-layout`, each `<a href="...">` retains its resolved destination
+in the `html` extension namespace and receives the default unvisited color.
+The browser host combines that target with session history to select the final
+color and underline style:
 
 - **Unvisited links**: `#0000EE` (blue) with underline
 - **Visited links**: `#551A8B` (purple) with underline
@@ -343,8 +358,9 @@ On **WM_LBUTTONDOWN**:
 
 When the HTML parser encounters `<img src="photo.gif">`:
 
-1. The `DocumentNode` tree contains an `ImageNode { src, alt }`.
-2. During layout, the image source URL is resolved against the page base URL.
+1. The `BrowserRenderTree` contains an image node with resolved `src`, `alt`,
+   and authored dimensions.
+2. `html-to-layout` carries that resolved resource URL into `ImageContent`.
 3. A separate `http1_0_client::get()` call fetches the image data.
 4. The `image` crate decodes the data (GIF or JPEG for v0.1) into pixels.
 5. The pixel data becomes a `PaintImage` instruction in the `PaintScene`.
@@ -419,10 +435,8 @@ frame-extractor        = { path = "../../../packages/rust/frame-extractor" }
 http1_0_lexer          = { path = "../../../packages/rust/http1.0-lexer" }
 http1_0_parser         = { path = "../../../packages/rust/http1.0-parser" }
 http1_0_client         = { path = "../../../packages/rust/http1.0-client" }
-html1_0_lexer          = { path = "../../../packages/rust/html1.0-lexer" }
-html1_0_parser         = { path = "../../../packages/rust/html1.0-parser" }
-document_ast           = { path = "../../../packages/rust/document-ast" }
-document_ast_to_layout = { path = "../../../packages/rust/document-ast-to-layout" }
+coding-adventures-html-parser = { path = "../../../packages/rust/html-parser" }
+html-to-layout         = { path = "../../../packages/rust/html-to-layout" }
 layout_ir              = { path = "../../../packages/rust/layout-ir" }
 layout_block           = { path = "../../../packages/rust/layout-block" }
 layout_to_paint        = { path = "../../../packages/rust/layout-to-paint" }
@@ -485,7 +499,7 @@ image                  = "0.25"  # GIF and JPEG decoding
 
 - URL bar navigation with Enter key
 - Back, Forward, Home, Reload toolbar buttons
-- HTML 1.0 rendering via the full pipeline
+- Mosaic-era HTML rendering via the full pipeline
 - Vertical scrolling with mouse wheel and scrollbar
 - Link clicking with hit-testing and navigation
 - Inline images (GIF, JPEG) loaded synchronously


### PR DESCRIPTION
## What changed

- add a new `html-to-layout` Rust crate that converts `html-parser::BrowserRenderTree` into the shared `layout-ir::LayoutNode` representation
- map Mosaic-era typography, colors, block spacing, headings, hidden content, images, authored dimensions, and resolved resource URLs
- preserve HTML role/display/link metadata through `LayoutNode.ext["html"]`, including after `layout-block` positioning
- add an executable canned-HTML acceptance test covering parser -> render tree -> layout IR -> positioned layout
- update BR01 to describe the current parser/layout pipeline and its remaining browser acceptance work

## Why

The HTML parser corpus gates are now at zero missing upstream WPT tree-construction and html5lib tokenizer cases, but Venture still had no executable adapter from the parser's browser-facing render tree into the existing layout/paint stack. The BR01 spec also pointed at removed `html1.0-*` and `document-ast-to-layout` stages.

## Impact

This establishes the first real parser-to-browser seam without coupling HTML semantics to the Markdown-oriented `document-ast` path. It also retains resolved navigation/resource metadata for later hit testing and resource loading.

This is not full Venture acceptance. CSS cascade, a real inline-formatting pass, paint-scene acceptance, networking/resource loading, hit testing, and platform-host wiring remain explicit follow-on work.

## Validation

- `cargo fmt -p html-to-layout -- --check`
- `cargo test -p html-to-layout`
- `cargo clippy -p html-to-layout --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-parser`
- refreshed live WPT and html5lib upstream check: tree upstream 1,934 / local 2,637 / missing 0; tokenizer upstream 6,806 / local raw 7,015 / missing 0; normalized 7,242 / skipped 0
- `git diff --check`