### PR TITLE
feat(adj-formula-stdlib): electric-conductance — NIST SP 811 B.9 abmho→siemens EMU factor (facts b28)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -1260,6 +1260,48 @@ fn shipped_electric_inductance_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b28) The shipped NIST SP 811 B.9 electric-conductance → siemens table resolves the exact abmho
+//       factor with its citation, and ABSTAINS on a wrong-dimension unit. This EXTENDS the
+//       electromagnetic-EMU family (charge/potential/resistance/capacitance/inductance) with
+//       conductance. The abmho (conductance) and the abohm (resistance) are RECIPROCAL quantities
+//       that convert to DIFFERENT, reciprocal SI units (siemens vs ohm) with reciprocal factors
+//       (1.0 E+09 vs 1.0 E-09), so the abstain proves dimension safety even against the reciprocal
+//       quantity, not mere absence of a value: the siemens is one reciprocal ohm (an ampere per volt).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_electric_conductance_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_conductance");
+    let src = stdlib().join("reference/electric-conductance-conversions.adj");
+    std::fs::copy(&src, dir.join("electric-conductance-conversions.adj"))
+        .expect("copy shipped electric-conductance-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"electric-conductance-conversions.adj\"\n\
+         ? electric_conductance_to_siemens(abmho, $v)\n\
+         ? electric_conductance_to_siemens(abohm, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 exact factor resolves, character-for-character from the table
+    // (boldface = exact; the abmho is defined as exactly 1.0 E+09 siemens).
+    assert!(out.contains("\"v\":\"1000000000\""), "abmho = 1.0 E+09 S: {out}");
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `abohm` is a RESISTANCE unit (it converts to the ohm, the reciprocal quantity), so this
+    // conductance table has no row for it — the engine abstains rather than mis-converting a
+    // resistance unit as if it were a conductance unit.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a wrong-dimension unit abstains, never a cross-dimension fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/electric-conductance-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/electric-conductance-conversions.adj
@@ -1,0 +1,62 @@
+% ============================================================================
+% electric-conductance-conversions — electric-conductance-unit → siemens factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of electric-charge-conversions.adj, electric-potential-conversions.adj,
+% electric-resistance-conversions.adj, electric-capacitance-conversions.adj,
+% electric-inductance-conversions.adj and the other NIST-cited conversion tables: a native tabular
+% relation ingested VERBATIM from a published NIST conversion table. The row states the factor
+% converting the traditional (CGS-EMU) unit of ELECTRIC CONDUCTANCE to the SI coherent derived
+% unit, the siemens (S):
+%
+%     ? electric_conductance_to_siemens(abmho, $v)   % 1000000000
+%
+% This EXTENDS the electromagnetic-EMU family alongside electric-charge (the abcoulomb → the
+% coulomb), electric-potential (the abvolt → the volt), electric-resistance (the abohm → the ohm),
+% electric-capacitance (the abfarad → the farad) and electric-inductance (the abhenry → the
+% henry), and is a NEW dimension alongside the length/mass/area/volume/time/speed/energy/pressure/
+% force/acceleration/dynamic-viscosity/kinematic-viscosity/magnetic-flux-density/magnetic-flux/
+% illuminance/luminance/radioactivity/absorbed-dose/dose-equivalent/exposure/power tables.
+% Conductance is the RECIPROCAL of resistance: the siemens is one reciprocal ohm (one ampere per
+% volt), and the abmho is its traditional (EMU) unit — "mho" is "ohm" spelled backwards precisely
+% because a conductance is an inverse resistance. Do NOT confuse ELECTRIC CONDUCTANCE (the abmho →
+% the siemens) with ELECTRIC RESISTANCE (the abohm → the ohm): those are RECIPROCAL quantities that
+% convert to DIFFERENT, reciprocal SI units, and their EMU factors are reciprocals too — the abmho
+% is 1.0 E+09 siemens while the abohm is 1.0 E-09 ohm. Put a conductance given in abmhos into SI
+% first, then reason (write-once-use-many). Why a `table` and not a hand-written `relate` clause:
+% this is exactly the shape reference data comes in — a published table, not prose. The citable
+% artifact IS the NIST conversion-factors table at the `locator` below; the factor here is a CELL
+% of NIST Special Publication 811, Appendix B.9, defended by one provenance envelope. Each `row`
+% lowers to a ground relation `electric_conductance_to_siemens(unit, v)`, so the exact lookup above
+% is the ordinary SLD binding query — the engine returns the factor WITH this table's citation as
+% its proof, on the CPU, with zero model calls.
+%
+% HONESTY NOTE (like the electric-charge / electric-potential / electric-resistance /
+% electric-capacitance / electric-inductance / power tables, only the EXACT defined factor gets a
+% row): NIST SP 811 B.9 prints the "abmho" conductance factor in BOLDFACE, its convention for
+% factors that are EXACT by definition, transcribed here as the plain decimal number of siemens it
+% names:
+%
+%     abmho   1.0 E+09  →  1000000000
+%
+% This is exact because the abmho is DEFINED as exactly 1.0 E+09 siemens (the EMU of conductance).
+% It terminates; nothing here is a rounded measurement. This table is SPECIFIC to electric
+% conductance: a unit of a DIFFERENT quantity — e.g. the "abohm", which NIST SP 811 B.9 lists
+% separately as an electric-RESISTANCE unit converting to the ohm, NOT the siemens — therefore
+% gets no row here, and a `? electric_conductance_to_siemens(abohm, $v)` ABSTAINS rather than
+% mis-converting a resistance unit as if it were a conductance unit (even though resistance is
+% conductance's reciprocal). The only claim this table makes is "this is the exact factor NIST SP
+% 811 B.9 prints for the abmho's conversion to the siemens" — which is exactly what a byte-check
+% against the cited table verifies. `trust authoritative` — a primary, re-fetchable standards
+% reference. (See ADJ-TABLES.md; and feedback_nothing_human_authored — the factor is a verbatim
+% cell of the cited table, nothing asserted from memory.)
+% ============================================================================
+
+table electric_conductance_to_siemens {
+    columns unit, siemens
+
+    row (abmho, 1000000000)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/electric-conductance-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/electric-conductance-conversions.query.adj
@@ -1,0 +1,24 @@
+% ============================================================================
+% electric-conductance-conversions.query.adj — worked lookups over the NIST conductance → siemens table.
+% ============================================================================
+% The shape a consumer produces to convert a conductance given in a traditional CGS-EMU unit into
+% SI: it `import`s the grounded table and asks the engine to bind the factor. No arithmetic and
+% no factor is stated by the consumer; the engine returns the cell WITH the table's NIST citation
+% as its proof, on the CPU.
+%
+%   ? electric_conductance_to_siemens(abmho, $v)   % 1000000000   (abmho = 1.0 E+09 S, exact)
+%
+% And the dimension guard: a unit of a DIFFERENT quantity has no row, so the lookup ABSTAINS
+% rather than mis-converting across dimensions. The "abohm" is an electric-RESISTANCE unit (it
+% converts to the ohm, the reciprocal quantity), NOT a conductance unit:
+%
+%   ? electric_conductance_to_siemens(abohm, $v)   % abstains (abohm is resistance → ohm)
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli electric-conductance-conversions.query.adj
+% ============================================================================
+
+import "electric-conductance-conversions.adj"
+
+? electric_conductance_to_siemens(abmho, $v)   % expect 1000000000  (exact NIST SP 811 B.9 factor)
+? electric_conductance_to_siemens(abohm, $v)   % expect abstain      (resistance unit, wrong dimension)


### PR DESCRIPTION
## What

Adds the **electric-conductance** conversion table (RS-5 `table`) to the **reference** track: the NIST SP 811 Appendix B.9 factor converting the traditional CGS-EMU unit of electric conductance, the **abmho**, to the SI coherent derived unit, the **siemens (S)**.

```
? electric_conductance_to_siemens(abmho, $v)   →  1000000000   (abmho = 1.0 E+09 S, exact)
```

Byte-verified against the cited NIST table (the factor is printed in **boldface** = exact by definition, character-for-character `1.0 E+09`).

## Why

Extends the electromagnetic-EMU conversion family — charge (abcoulomb→coulomb), potential (abvolt→volt), resistance (abohm→ohm), capacitance (abfarad→farad), inductance (abhenry→henry) — with **conductance**. Conductance is the **reciprocal** of resistance: the siemens is one reciprocal ohm (an ampere per volt), and *"mho" is "ohm" spelled backwards* for exactly that reason.

## Dimension guard (abstain)

The abstain probe uses the **abohm** — a *resistance* unit converting to the ohm (factor 1.0 E-09), the reciprocal quantity:

```
? electric_conductance_to_siemens(abohm, $v)   →  abstains   (wrong dimension)
```

proving dimension safety **even against the reciprocal quantity** — never a cross-dimension fabricated factor.

## Files

- `code/specs/data/adj-formula-stdlib/reference/electric-conductance-conversions.adj` — one-row `table` + honesty note
- `code/specs/data/adj-formula-stdlib/reference/electric-conductance-conversions.query.adj` — worked lookup + abstain
- `code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs` — `(b28)` block appended to the shared anchor

## Verification

- `cargo test -p adj-lang-cli --test rs5_table_e2e` — **33/33 green** (incl. the new b28)
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — **clean**
- Render-probe: `abmho` → `"v":"1000000000"` carrying the NIST B.9 locator; `abohm` → `"abstained":true`.
- Data + test only — no engine change, **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)