### PR TITLE
feat(c-to-sir): E10 — faithful printf (float display) across all three legs

### DIFF
--- a/code/packages/rust/c-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/c-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## Unreleased
 
+### Milestone 10 — faithful `printf`
+
+`printf` now reproduces C's formatting exactly, so a program can print a
+`double` with `%f` and get byte-identical output across reference C, emitted
+Ruby, and emitted C (milestone 9's corpus had to cast to `(int)` to dodge float
+display — that dodge is gone).
+
+- The frontend parses the format string (`parse_printf_format`) into literal
+  chunks and typed conversions; a backend never receives a source-derived format
+  string (no format-string vulnerability). `printf("<fmt>", args…)` lowers to a
+  single `print(seg₀, seg₁, …)`.
+- **Literal chunks** → `StrLit` (C escapes decoded; `%%` → `%`), re-escaped by
+  each backend's string emitter. **`%d`/`%i`/`%u`** → the integer value passed
+  straight through (`print` renders it as decimal). **`%f`/`%F`/`%e`/`%E`/`%g`/
+  `%G`** (optional `.precision`, default 6) → a new `fmt_float(value, precision,
+  kind)` builtin both backends implement with C-compatible `sprintf`/`snprintf`.
+- `print` concatenates with no separator and no auto-newline, so a `\n` in the
+  format is emitted as literal text (the old lowering auto-added a newline and
+  discarded the format's literal content). A literal-only `printf("hi\n")` now
+  works (was an error).
+- **Refused** (positioned error, not mis-formatted): field width (`%5d`), flags
+  (`%-`/`%+`/`%0`/`%#`), and `%c`/`%s`/`%x`/`%p`/`%n`. Precision is capped
+  (`MAX_PRINTF_PRECISION = 512`) as a DoS guard.
+- `Feature::Strings` is declared only when a `printf` actually emits literal
+  text / `fmt_float`, so a program that never prints stays string-free.
+- Verified: 49 frontend unit tests (6 new printf) + three-way conformance (8 new
+  float-display cases, fixed `%f`/`%.Nf` notation) byte-identical across all
+  three legs; emitted C compiles clean on clang + gcc + MSVC. Exponent forms
+  `%e`/`%g` are supported but kept out of the byte-identical corpus (their
+  exponent digit count varies by platform: Windows libc `e+004` vs Ruby `e+04`).
+
 ### Milestone 9b — floating-point value track
 
 The lowering gains a **second value track** for floating point.  Each expression

--- a/code/packages/rust/c-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/c-to-semantic-ir/src/lib.rs
@@ -126,6 +126,87 @@ mod tests {
         );
     }
 
+    // ── milestone 10: faithful printf ───────────────────────────────────────
+
+    #[test]
+    fn printf_float_lowers_to_fmt_float_with_precision_and_kind() {
+        // `printf("%.2f\n", x)` → print(fmt_float(x, 2, "f"), "\n").
+        let m = lower("int main(void) { double x = 3.14; printf(\"%.2f\\n\", x); return 0; }");
+        let text = semantic_ir::print_module(&m);
+        assert!(text.contains("fmt_float"), "no fmt_float:\n{text}");
+        assert!(text.contains("(int 2)"), "precision not 2:\n{text}");
+        assert!(text.contains("(builtin-call print"), "not a print:\n{text}");
+        // The trailing newline is emitted as literal text, not an auto-newline.
+        assert!(text.contains("(str \"\\n\")"), "no literal newline:\n{text}");
+        // Using a string makes the module declare Strings.
+        assert!(m.manifest.contains(semantic_ir::Feature::Strings));
+    }
+
+    #[test]
+    fn printf_default_float_precision_is_six() {
+        let m = lower("int main(void) { printf(\"%f\", 1.5); return 0; }");
+        let text = semantic_ir::print_module(&m);
+        assert!(text.contains("fmt_float"), "no fmt_float:\n{text}");
+        assert!(text.contains("(int 6)"), "default precision not 6:\n{text}");
+    }
+
+    #[test]
+    fn printf_integer_conversion_passes_the_value_through() {
+        // `%d` needs no formatting builtin — the int prints as decimal directly.
+        let m = lower("int main(void) { int n = 5; printf(\"n=%d\\n\", n); return 0; }");
+        let text = semantic_ir::print_module(&m);
+        assert!(!text.contains("fmt_float"), "int used fmt_float:\n{text}");
+        assert!(text.contains("(str \"n=\")"), "no literal prefix:\n{text}");
+        assert!(text.contains("(builtin-call print"), "not a print:\n{text}");
+    }
+
+    #[test]
+    fn printf_literal_only_format_needs_no_arguments() {
+        // Previously an error ("printf without a value argument"); now it prints
+        // the (escape-decoded) literal, and `%%` becomes a single `%`.
+        let m = lower("int main(void) { printf(\"100%% done\\n\"); return 0; }");
+        let text = semantic_ir::print_module(&m);
+        assert!(text.contains("(str \"100% done\\n\")"), "bad literal:\n{text}");
+    }
+
+    #[test]
+    fn printf_unsupported_conversion_is_rejected() {
+        for (fmt, needle) in [
+            ("\"%s\\n\", 0", "%s"),
+            ("\"%x\\n\", 0", "%x"),
+            ("\"%5d\\n\", 0", "width"),
+            ("\"%-d\\n\", 0", "flag"),
+        ] {
+            let src = format!("int main(void) {{ printf({fmt}); return 0; }}");
+            let err = compile_source(&src, "test").unwrap_err();
+            assert!(
+                err.message.contains(needle),
+                "for {fmt}: wrong error: {}",
+                err.message
+            );
+        }
+    }
+
+    #[test]
+    fn printf_argument_count_mismatch_is_rejected() {
+        let err =
+            compile_source("int main(void) { printf(\"%d %d\\n\", 1); return 0; }", "test")
+                .unwrap_err();
+        assert!(
+            err.message.contains("more conversions than arguments"),
+            "wrong error: {}",
+            err.message
+        );
+        let err =
+            compile_source("int main(void) { printf(\"%d\\n\", 1, 2); return 0; }", "test")
+                .unwrap_err();
+        assert!(
+            err.message.contains("more arguments than conversions"),
+            "wrong error: {}",
+            err.message
+        );
+    }
+
     #[test]
     fn bitwise_operator_on_double_is_rejected() {
         // `%`, `&`, `<<`, `~` etc. are not defined on `double` in C — lowering

--- a/code/packages/rust/c-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/c-to-semantic-ir/src/lower.rs
@@ -292,6 +292,10 @@ fn int_lit(v: i64) -> Expr {
     }
 }
 
+fn str_lit(value: String) -> Expr {
+    Expr::StrLit { value, span: sp() }
+}
+
 fn convert(e: Expr, to: IntSpec) -> Expr {
     Expr::Convert {
         value: Box::new(e),
@@ -415,6 +419,10 @@ struct Lowerer {
     /// floating point (an integer-only program stays float-free, and backends
     /// that gate on the feature are not forced to support it needlessly).
     uses_floats: bool,
+    /// Set once any `Expr::StrLit` or string-producing builtin (the `printf`
+    /// format literals / `fmt_float`) is emitted, so the module declares
+    /// [`Feature::Strings`] only when it actually uses strings.
+    uses_strings: bool,
 }
 
 pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, CLowerError> {
@@ -426,6 +434,7 @@ pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, CLowe
         expr_depth: 0,
         stmt_depth: 0,
         uses_floats: false,
+        uses_strings: false,
     };
 
     // Pre-pass: collect function signatures.
@@ -466,6 +475,13 @@ pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, CLowe
     // modules stay float-free.
     if lo.uses_floats {
         features.push(Feature::Floats);
+    }
+    // Strings: the `printf` lowering emits `StrLit` format chunks and the
+    // `fmt_float` builtin produces a string, so a program that calls `printf`
+    // with any literal text uses strings.  Declared conditionally so a program
+    // that never prints stays string-free.
+    if lo.uses_strings {
+        features.push(Feature::Strings);
     }
     let manifest = FeatureManifest::from_features(&features);
 
@@ -1725,25 +1741,98 @@ impl Lowerer {
         self.lower_call(&name, &arg_exprs, call)
     }
 
+    /// Lower `printf("<fmt>", args…)` faithfully.
+    ///
+    /// The format string is parsed (in the frontend, so no source text ever
+    /// reaches a backend's `printf`) into a sequence of literal chunks and
+    /// typed conversions.  The result is a single `print(seg₀, seg₁, …)`:
+    ///
+    /// - a **literal chunk** becomes a `StrLit` (C escapes already decoded, so
+    ///   the backend re-escapes correctly);
+    /// - `%d`/`%i`/`%u` pass the (already width-correct) integer value straight
+    ///   through — `print` renders an int as decimal, which is what `%d` wants;
+    /// - `%f`/`%e`/`%g` (with optional `.precision`) become a `fmt_float`
+    ///   builtin that formats the `double` exactly as C's `printf` does.
+    ///
+    /// `print` concatenates its arguments with no separator and adds no trailing
+    /// newline, so a `\n` in the format is emitted as literal text — matching C.
+    fn lower_printf(
+        &mut self,
+        args: &[&GrammarASTNode],
+        call: &GrammarASTNode,
+    ) -> Result<(Expr, CType), CLowerError> {
+        let err_here = |msg: String| CLowerError {
+            message: msg,
+            line: call.start_line.unwrap_or(0),
+            column: call.start_column.unwrap_or(0),
+        };
+        let raw_fmt = call_string_literal(call).ok_or_else(|| {
+            err_here("printf's first argument must be a string-literal format".into())
+        })?;
+        let fmt = decode_c_string(&raw_fmt);
+        let segs = parse_printf_format(&fmt).map_err(err_here)?;
+        // The value arguments follow the format string (`args[0]`).
+        let value_args = args.get(1..).unwrap_or(&[]);
+        let mut parts: Vec<Expr> = Vec::new();
+        let mut argi = 0usize;
+        for seg in segs {
+            match seg {
+                PrintfSeg::Lit(text) => {
+                    if !text.is_empty() {
+                        self.uses_strings = true;
+                        parts.push(str_lit(text));
+                    }
+                }
+                PrintfSeg::Conv { kind, precision } => {
+                    let a = value_args.get(argi).ok_or_else(|| {
+                        err_here("printf has more conversions than arguments".into())
+                    })?;
+                    argi += 1;
+                    let (e, t) = self.lower_expr(a)?;
+                    match kind {
+                        PrintfConv::Int => {
+                            if t.is_double() {
+                                return Err(err_here(
+                                    "printf `%d`/`%i`/`%u` expects an integer argument, got a double"
+                                        .into(),
+                                ));
+                            }
+                            parts.push(e);
+                        }
+                        PrintfConv::Float(c) => {
+                            // C promotes a `float` argument to `double` (default
+                            // argument promotions); an integer arg to `%f` is UB
+                            // in C, so we require a numeric operand and widen it.
+                            let d = convert_ct(e, t, CType::Double);
+                            self.uses_strings = true;
+                            parts.push(builtin(
+                                "fmt_float",
+                                vec![d, int_lit(precision as i64), str_lit(c.to_string())],
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        if argi != value_args.len() {
+            return Err(err_here(
+                "printf has more arguments than conversions".into(),
+            ));
+        }
+        Ok((builtin("print", parts), i32_ct()))
+    }
+
     fn lower_call(
         &mut self,
         name: &str,
         args: &[&GrammarASTNode],
         call: &GrammarASTNode,
     ) -> Result<(Expr, CType), CLowerError> {
-        // printf("<fmt>", e) → puts(e) when <fmt> ends in \n, else print(e).
+        // printf("<fmt>", args…) → a faithful format: the format string is
+        // parsed into literal chunks and conversions, each conversion formatted
+        // per C's rules, then concatenated and printed (see `lower_printf`).
         if name == "printf" {
-            let fmt = call_string_literal(call);
-            let newline = fmt.map(|s| s.ends_with("\\n")).unwrap_or(false);
-            // The value argument (skip the format string) — the last expr.
-            let val = args.last().ok_or_else(|| CLowerError {
-                message: "printf without a value argument".into(),
-                line: call.start_line.unwrap_or(0),
-                column: call.start_column.unwrap_or(0),
-            })?;
-            let (e, _t) = self.lower_expr(val)?;
-            let helper = if newline { "puts" } else { "print" };
-            return Ok((builtin(helper, vec![e]), i32_ct()));
+            return self.lower_printf(args, call);
         }
         // Ordinary function call: convert each argument to its parameter type.
         let (ptypes, ret) = self.fns.get(name).cloned().ok_or_else(|| CLowerError {
@@ -1942,6 +2031,160 @@ fn call_string_literal(call: &GrammarASTNode) -> Option<String> {
         }
     }
     None
+}
+
+// ── printf format parsing (milestone 10) ────────────────────────────────────
+//
+// The C frontend owns all format-string parsing: a backend never receives a
+// source-derived format string (which would be a classic format-string
+// vulnerability), only a fixed sequence of typed pieces.
+
+/// One piece of a parsed `printf` format string.
+enum PrintfSeg {
+    /// Literal text between conversions (C escapes already decoded).
+    Lit(String),
+    /// A `%…` conversion.
+    Conv { kind: PrintfConv, precision: u32 },
+}
+
+/// The kinds of `printf` conversion the subset supports.
+enum PrintfConv {
+    /// `%d` / `%i` / `%u` — printed as a decimal integer (the stored value is
+    /// already width-correct and, for `%u`, masked non-negative).
+    Int,
+    /// `%f` / `%F` / `%e` / `%E` / `%g` / `%G` — the exact conversion character
+    /// is carried through so the backend uses the matching format.
+    Float(char),
+}
+
+/// The largest floating-point precision accepted — a DoS guard so a source
+/// program cannot bake in `%.99999999f` and make the emitted program allocate
+/// an enormous formatting buffer.
+const MAX_PRINTF_PRECISION: u32 = 512;
+
+/// Decode C string-literal escape sequences (`\n`, `\t`, `\\`, `\"`, …) into the
+/// characters they denote, so the resulting `String` holds real bytes.  Each
+/// backend's own string emitter then re-escapes them for its target language.
+fn decode_c_string(raw: &str) -> String {
+    let mut out = String::new();
+    let mut chars = raw.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('n') => out.push('\n'),
+            Some('t') => out.push('\t'),
+            Some('r') => out.push('\r'),
+            Some('0') => out.push('\0'),
+            Some('\\') => out.push('\\'),
+            Some('"') => out.push('"'),
+            Some('\'') => out.push('\''),
+            Some('a') => out.push('\u{07}'),
+            Some('b') => out.push('\u{08}'),
+            Some('f') => out.push('\u{0C}'),
+            Some('v') => out.push('\u{0B}'),
+            Some(other) => out.push(other), // unknown escape → the char itself
+            None => out.push('\\'),
+        }
+    }
+    out
+}
+
+/// Parse a (already escape-decoded) `printf` format string into segments.  The
+/// subset supports `%d`/`%i`/`%u` and `%f`/`%F`/`%e`/`%E`/`%g`/`%G` with an
+/// optional `.precision`, plus `%%`.  Flags, field width, and other conversions
+/// (`%c`, `%s`, `%x`, `%p`, `%n`, …) are refused with a clear message rather
+/// than mis-formatted.
+fn parse_printf_format(fmt: &str) -> Result<Vec<PrintfSeg>, String> {
+    let chars: Vec<char> = fmt.chars().collect();
+    let mut segs: Vec<PrintfSeg> = Vec::new();
+    let mut lit = String::new();
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] != '%' {
+            lit.push(chars[i]);
+            i += 1;
+            continue;
+        }
+        i += 1; // consume '%'
+        if i >= chars.len() {
+            return Err("printf format ends with a lone `%`".into());
+        }
+        if chars[i] == '%' {
+            lit.push('%');
+            i += 1;
+            continue;
+        }
+        // A real conversion begins: flush any pending literal text.
+        if !lit.is_empty() {
+            segs.push(PrintfSeg::Lit(std::mem::take(&mut lit)));
+        }
+        if matches!(chars[i], '-' | '+' | ' ' | '#' | '0') {
+            return Err(format!(
+                "printf flag `{}` is not supported (only plain conversions)",
+                chars[i]
+            ));
+        }
+        if chars[i].is_ascii_digit() {
+            return Err("printf field width is not supported".into());
+        }
+        // Optional `.precision`.
+        let mut precision: Option<u32> = None;
+        if chars[i] == '.' {
+            i += 1;
+            let mut p: u32 = 0;
+            while i < chars.len() && chars[i].is_ascii_digit() {
+                p = p
+                    .saturating_mul(10)
+                    .saturating_add(chars[i].to_digit(10).unwrap());
+                i += 1;
+            }
+            precision = Some(p); // `.` with no digits means precision 0
+        }
+        // Length modifiers (`l`, `ll`, `h`, `z`, …) don't change our formatting
+        // — everything is stored as int64 / double — so accept and skip them.
+        while i < chars.len() && matches!(chars[i], 'l' | 'h' | 'z' | 'j' | 't' | 'L') {
+            i += 1;
+        }
+        if i >= chars.len() {
+            return Err("printf conversion is missing its type character".into());
+        }
+        let conv = chars[i];
+        i += 1;
+        let seg = match conv {
+            'd' | 'i' | 'u' => {
+                if precision.is_some() {
+                    return Err(format!(
+                        "printf precision on the integer conversion `%.{conv}` is not supported"
+                    ));
+                }
+                PrintfSeg::Conv {
+                    kind: PrintfConv::Int,
+                    precision: 0,
+                }
+            }
+            'f' | 'F' | 'e' | 'E' | 'g' | 'G' => {
+                let prec = precision.unwrap_or(6); // C's default precision
+                if prec > MAX_PRINTF_PRECISION {
+                    return Err(format!(
+                        "printf precision larger than {MAX_PRINTF_PRECISION} is not supported"
+                    ));
+                }
+                PrintfSeg::Conv {
+                    kind: PrintfConv::Float(conv),
+                    precision: prec,
+                }
+            }
+            other => return Err(format!("printf conversion `%{other}` is not supported")),
+        };
+        segs.push(seg);
+    }
+    if !lit.is_empty() {
+        segs.push(PrintfSeg::Lit(lit));
+    }
+    Ok(segs)
 }
 
 /// Parse a C integer literal (hex/decimal + u/l suffix) → (value, type).

--- a/code/packages/rust/c-to-semantic-ir/tests/three_way_conformance.rs
+++ b/code/packages/rust/c-to-semantic-ir/tests/three_way_conformance.rs
@@ -629,6 +629,56 @@ fn corpus() -> Vec<Case> {
                    int main(void) { int x = 5; double r = x / 2.0 * 4.0; \
                    printf(\"%d\\n\", (int)r); return 0; }",
         },
+        // ── milestone 10: faithful printf (float DISPLAY, no (int) cast) ──────
+        // These print doubles *directly* with `%f`/`%.Nf` and assert the emitted
+        // text is byte-identical to reference C's printf — the payoff of the
+        // faithful format lowering.  Restricted to FIXED notation (`%f`): the
+        // exponent forms `%e`/`%g` format their exponent with a platform-varying
+        // digit count (Windows libc `e+004` vs Ruby/UCRT `e+04`), so those are
+        // supported by the lowering but deliberately kept out of the byte-
+        // identical corpus.  Values avoid exact-half precision boundaries so C
+        // and Ruby rounding never disagree.
+        Case {
+            label: "printf %f default precision 3.14 → 3.140000",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int main(void) { double x = 3.14; printf(\"%f\\n\", x); return 0; }",
+        },
+        Case {
+            label: "printf %.2f rounds 3.14159 → 3.14",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int main(void) { printf(\"%.2f\\n\", 3.14159); return 0; }",
+        },
+        Case {
+            label: "printf %.4f rounds up 3.14159 → 3.1416 with literal text",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int main(void) { printf(\"pi is about %.4f today\\n\", 3.14159); return 0; }",
+        },
+        Case {
+            label: "printf %.1f of a computed double 7.0/2.0 → 3.5",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int main(void) { printf(\"%.1f\\n\", 7.0 / 2.0); return 0; }",
+        },
+        Case {
+            label: "printf negative double %.2f -1.5 → -1.50",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int main(void) { printf(\"%.2f\\n\", -1.5); return 0; }",
+        },
+        Case {
+            label: "printf mixed %d and %.2f in one call → n=3 avg=2.50",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int main(void) { printf(\"n=%d avg=%.2f\\n\", 3, 2.5); return 0; }",
+        },
+        Case {
+            label: "printf %.2f of a double param/return area(3.0) → 12.00",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   double area(double r) { return r * r + r; }\n\
+                   int main(void) { printf(\"%.2f\\n\", area(3.0)); return 0; }",
+        },
+        Case {
+            label: "printf literal-only format (no conversions) passes through",
+            src: "#include <stdio.h>\n#include <stdint.h>\n\
+                   int main(void) { printf(\"no args, 100%% literal\\n\"); return 0; }",
+        },
     ]
 }
 

--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.18.0 — `fmt_float`: C-printf-faithful float formatting
+
+One builtin, mirroring the Ruby backend, for the C frontend's faithful `printf`
+(SIR27 milestone 10).
+
+- `fmt_float(value, precision, kind)` → `_sir_fmt_float_c`, which renders a
+  `double` with `snprintf` for the conversion `kind` (`'f'`/`'F'`/`'e'`/`'E'`/
+  `'g'`/`'G'`) and precision. The format string is chosen by a `switch` over the
+  fixed `kind` character — never built from source text, so there is no
+  format-string vulnerability. The output is measured first (`snprintf(NULL, 0,
+  …)`) then arena-allocated to the exact size, so any precision fits.
+
+Compiles clean on clang + gcc + MSVC; matches reference C and emitted Ruby
+byte-for-byte on the faithful-`printf` corpus.
+
 ## 0.17.1 — fix: `raise ClassName, "msg"` constructs the exception
 
 Fixes a cross-backend conformance failure (`exception_reflection` / `puts(e)`): a

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.17.1"
+version = "0.18.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -2026,6 +2026,9 @@ fn fixed_helper(name: &str) -> Option<(&'static str, usize)> {
         // (double → int, truncating toward zero, matching C's `(int)double`).
         "to_f" => ("_sir_to_f", 1),
         "to_i" => ("_sir_to_i", 1),
+        // Milestone 10 faithful printf: `fmt_float(value, precision, kind)`
+        // renders a double exactly as C's printf `%f`/`%e`/`%g` (+ uppercase).
+        "fmt_float" => ("_sir_fmt_float_c", 3),
         "cons" => ("_sir_cons", 2),
         "car" => ("_sir_car", 1),
         "cdr" => ("_sir_cdr", 1),

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -250,6 +250,37 @@ int64_t _sir_as_int(SirValue v) {
 SirValue _sir_to_f(SirValue v) { return _sir_float(_sir_as_num(v)); }
 SirValue _sir_to_i(SirValue v) { return _sir_int(_sir_as_int(v)); }
 
+/* SIR27 milestone 10 — faithful printf float formatting (the `fmt_float`
+ * builtin).  Render `v` as C's printf would for conversion `kind`
+ * ('f'/'F'/'e'/'E'/'g'/'G') and `prec` digits of precision.  The format string
+ * is chosen by a switch over the fixed `kind` character — it is NEVER built
+ * from source text — so there is no format-string vulnerability.  The output
+ * is measured first (snprintf with a NULL buffer), then arena-allocated to the
+ * exact size, so any precision fits without truncation. */
+SirValue _sir_fmt_float_c(SirValue v, SirValue prec, SirValue kind) {
+    double  x = _sir_as_num(v);
+    int     p = (int)_sir_as_int(prec);
+    char    k = (kind.tag == SIR_STR && kind.as.s[0]) ? kind.as.s[0] : 'f';
+    const char *fmt;
+    int need;
+    char *buf;
+    if (p < 0) p = 0;
+    switch (k) {
+        case 'F': fmt = "%.*F"; break;
+        case 'e': fmt = "%.*e"; break;
+        case 'E': fmt = "%.*E"; break;
+        case 'g': fmt = "%.*g"; break;
+        case 'G': fmt = "%.*G"; break;
+        case 'f':
+        default:  fmt = "%.*f"; break;
+    }
+    need = snprintf(NULL, 0, fmt, p, x);
+    if (need < 0) return _sir_str("");
+    buf = (char *)_sir_alloc((size_t)need + 1);
+    snprintf(buf, (size_t)need + 1, fmt, p, x);
+    return _sir_str(buf);
+}
+
 const char *_sir_str_of(SirValue v) {
     return (v.tag == SIR_STR || v.tag == SIR_SYM) ? v.as.s : "";
 }

--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.19.0 — `fmt_float`: C-printf-faithful float formatting
+
+One builtin, for the C frontend's faithful `printf` (SIR27 milestone 10).
+
+- `fmt_float(value, precision, kind)` → `sir_fmt_float_c`, which renders a
+  `double` exactly as C's `printf` would for the conversion `kind`
+  (`'f'`/`'F'`/`'e'`/`'E'`/`'g'`/`'G'`) and precision. Ruby's `sprintf` is
+  C-compatible, and the runtime switches on the fixed `kind` character (never
+  interpolating a source-derived format string), so `printf("%.2f", 3.14159)`
+  and the emitted C both produce `"3.14"`.
+
+This leaves the backend's *default* float display (`sir_fmt_float`, `3.14`)
+untouched — `fmt_float` is only reached through an explicit C `printf`.
+
 ## 0.18.1 — fix: `Foo.new` runs the `initialize` constructor
 
 Fixes a cross-backend conformance failure (`counter_state`): a `def initialize`

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.18.1"
+version = "0.19.0"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -53,6 +53,10 @@ const SUPPORTED_BUILTINS: &[&str] = &[
     // (the frontend then masks it to the target width with a `Convert`).
     "to_f",
     "to_i",
+    // Faithful `printf` float formatting (SIR27 milestone 10): `fmt_float(value,
+    // precision, kind)` renders a `double` exactly as C's `printf` `%f`/`%e`/`%g`
+    // (and their uppercase forms) would.
+    "fmt_float",
     "=",
     "==",
     "!=",
@@ -1466,6 +1470,15 @@ fn emit_builtin(name: &str, args: &[Expr]) -> String {
         // `Float#to_i` (truncates toward zero, matching C's `(int)double` cast).
         "to_f" => format!("({}).to_f", arg(&a, 0)),
         "to_i" => format!("({}).to_i", arg(&a, 0)),
+        // `fmt_float(value, precision, kind)` → the runtime C-printf-faithful
+        // formatter (Ruby's `sprintf` is C-compatible; the runtime switches on
+        // the fixed `kind` character so no format string is source-derived).
+        "fmt_float" => format!(
+            "sir_fmt_float_c({}, {}, {})",
+            arg(&a, 0),
+            arg(&a, 1),
+            arg(&a, 2)
+        ),
         "not" => format!("(!sir_truthy({}))", arg(&a, 0)),
         "<" => format!("({} < {})", arg(&a, 0), arg(&a, 1)),
         ">" => format!("({} > {})", arg(&a, 0), arg(&a, 1)),

--- a/code/packages/rust/semantic-ir-to-ruby/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/runtime.rs
@@ -188,6 +188,26 @@ def sir_fmt_float(f)
   f.to_s
 end
 
+# C-printf-faithful float formatting for the `fmt_float` builtin (SIR27
+# milestone 10): render `value` as C's `printf` would for the given conversion
+# `kind` ('f'/'F'/'e'/'E'/'g'/'G') and `precision`.  Ruby's `sprintf` is
+# C-compatible, and we switch on the fixed kind character (never interpolating
+# a source-derived format string), so `printf("%.2f", 3.14159)` and the emitted
+# C produce byte-identical "3.14".
+def sir_fmt_float_c(value, precision, kind)
+  v = value.to_f
+  p = precision.to_i
+  case kind
+  when "f" then sprintf("%.*f", p, v)
+  when "F" then sprintf("%.*F", p, v)
+  when "e" then sprintf("%.*e", p, v)
+  when "E" then sprintf("%.*E", p, v)
+  when "g" then sprintf("%.*g", p, v)
+  when "G" then sprintf("%.*G", p, v)
+  else sprintf("%.*f", p, v)
+  end
+end
+
 def sir_puts(*xs)
   if xs.empty?
     STDOUT.write("\n")

--- a/code/specs/SIR27-c-to-semantic-ir.md
+++ b/code/specs/SIR27-c-to-semantic-ir.md
@@ -47,9 +47,10 @@ Deliberately small and honest, focused on the type/wrap/truncate story:
   `u`/`l`/`ll` suffix, parenthesised expression).
 - **Statements:** expression statement, `if`/`else`, `while`, `for`, `return`,
   compound `{ … }`.
-- **Output:** a restricted `printf` — `printf("<fmt>", e)` where `<fmt>` is a
-  single integer conversion (`%d`/`%u`/`%ld`/`%lld`/…) optionally followed by
-  `\n` — lowers to the SIR `print`/`puts` builtin; and `putchar(e)`.
+- **Output:** a faithful `printf` (see the milestone-10 section) — the format
+  string is parsed into literal chunks and `%d`/`%i`/`%u` and `%f`/`%e`/`%g`
+  conversions (with optional `.precision`), each formatted per C's rules; and
+  `putchar(e)`.
 - **Preprocessor:** only `#include <stdint.h>` / `#include <stdio.h>` (ignored).
   No `#define`, no macros, no other directives.
 
@@ -419,6 +420,48 @@ and what is actually proven is the floating-point *computation* — mixed
 promotion, true division, loop accumulation, and float→int truncation — is
 identical across reference C, emitted Ruby, and emitted C.
 
+## Faithful `printf` (milestone 10)
+
+Milestone 9's conformance dodged float *display* by casting to `(int)`.
+Milestone 10 removes the dodge: a C program can print a `double` with `%f` and
+get byte-identical output across all three legs.
+
+**The format string never reaches a backend.**  The frontend owns all
+format-string parsing (`parse_printf_format`) — a backend receiving a
+source-derived format string would be a classic format-string vulnerability.
+`printf("<fmt>", args…)` lowers to a single **`print(seg₀, seg₁, …)`** whose
+segments are a *fixed* sequence of typed pieces:
+
+- a **literal chunk** (the text between conversions, with C escapes like `\n`
+  already decoded) → a `StrLit`.  The backend's own string emitter re-escapes it,
+  so no source text is emitted raw.  `%%` becomes a literal `%`.
+- `%d` / `%i` / `%u` → the matched integer value **passed straight through**.
+  `print` renders an integer as decimal, which is exactly `%d`; and because a
+  `%u` value has already been masked non-negative by its `Convert`, its decimal
+  is the unsigned value.  No new builtin is needed.
+- `%f` / `%F` / `%e` / `%E` / `%g` / `%G` (with an optional `.precision`,
+  default 6) → a **`fmt_float(value, precision, kind)`** builtin.  Both backends
+  implement it with their C-compatible `sprintf`/`snprintf`, switching on the
+  *fixed* `kind` character to choose a literal format (`"%.*f"`, `"%.*e"`, …) —
+  so the precision is a runtime `*` argument but the format itself is never
+  built from source text.
+
+`print` concatenates its arguments with no separator and adds **no** trailing
+newline, so a `\n` in the format is emitted as literal text — unlike the old
+lowering, which auto-added a newline and discarded the format's literal content.
+
+**Honest boundaries.**  Field width (`%5d`), flags (`%-`, `%+`, `%0`, `%#`), and
+the conversions `%c`/`%s`/`%x`/`%p`/`%n` are **refused** with a positioned error
+rather than mis-formatted — each is a future slice.  Precision is capped
+(`MAX_PRINTF_PRECISION`) as a DoS guard against a source baking in `%.99999999f`.
+
+**Conformance.**  The corpus now prints doubles *directly* with `%f`/`%.Nf` and
+asserts byte-identical text.  It is restricted to **fixed notation**: `%e`/`%g`
+format their exponent with a platform-varying digit count (Windows libc `e+004`
+vs Ruby/UCRT `e+04`), so those conversions are supported by the lowering but kept
+out of the byte-identical corpus, and the corpus values avoid exact-half
+precision boundaries so C and Ruby rounding never disagree.
+
 ## Pipeline
 
 ```text
@@ -472,4 +515,6 @@ pub struct CLowerError { pub message: String, pub line: usize, pub column: usize
 - The full preprocessor (`#define`, macros, conditional compilation).
 - Multiple translation units / real headers (only `#include <stdint.h|stdio.h>`
   is recognised and ignored).
-- Full `printf` format-string semantics (only a single integer conversion).
+- Full `printf` format-string semantics: `%d`/`%i`/`%u` and `%f`/`%e`/`%g`
+  (with `.precision`) are supported (milestone 10), but field width, flags, and
+  `%c`/`%s`/`%x`/`%p`/`%n` are not yet.


### PR DESCRIPTION
## Milestone 10 — faithful `printf` (float display)

`printf` now reproduces C's formatting exactly, so a C program can print a `double` with `%f` and get **byte-identical** output across reference C, emitted Ruby, and emitted C. Milestone 9's corpus had to cast every double to `(int)` to dodge float display — that dodge is gone.

### Design — the frontend owns format parsing
`printf("<fmt>", args…)` lowers to a single `print(seg₀, seg₁, …)`. A backend **never** receives a source-derived format string (which would be a format-string vulnerability) — only a fixed sequence of typed pieces:

- **Literal chunks** (text between conversions, C escapes decoded, `%%`→`%`) → `StrLit`, re-escaped by each backend's own string emitter.
- **`%d`/`%i`/`%u`** → the integer value passed straight through (`print` renders an int as decimal — exactly `%d`).
- **`%f`/`%F`/`%e`/`%E`/`%g`/`%G`** (optional `.precision`, default 6) → a new `fmt_float(value, precision, kind)` builtin. Both backends implement it with their C-compatible `sprintf`/`snprintf`, choosing a **fixed** format via a `switch` on the `kind` char.

`print` concatenates with no separator and no auto-newline, so a `\n` in the format is emitted as literal text (the old lowering auto-added a newline and discarded literal content). A literal-only `printf("hi\n")` now works.

### Boundaries & safety
- **Refused** (positioned error, not mis-formatted): field width (`%5d`), flags (`%-`/`%+`/`%0`/`%#`), and `%c`/`%s`/`%x`/`%p`/`%n` — each a future slice.
- Precision capped (`MAX_PRINTF_PRECISION = 512`) as a DoS guard.
- `Feature::Strings` declared only when a `printf` actually emits literal text.

### Backends
- `semantic-ir-to-ruby` 0.19.0 — `sir_fmt_float_c`.
- `semantic-ir-to-c` 0.18.0 — `_sir_fmt_float_c` (snprintf into an arena buffer sized by a measuring `snprintf(NULL, 0, …)`).

### Verification
- 49 frontend unit tests (6 new printf) + three-way conformance (8 new float-display cases, fixed `%f`/`%.Nf`) byte-identical across all three legs.
- Emitted C compiles clean on **clang + gcc + MSVC**.
- `%e`/`%g` are supported by the lowering but kept out of the byte-identical corpus (exponent digit count varies by platform: Windows libc `e+004` vs Ruby/UCRT `e+04`).
- Security review passed (no source text reaches a backend's `printf`; format chosen by a fixed switch; parser is panic-free with a precision cap).

Builds on the merged double-arithmetic milestone (#9123).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
