### PR TITLE
feat(adj-formula-stdlib): volume of distribution — first pharmacokinetics Vd=amount/Cp library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_volume_of_distribution_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_volume_of_distribution_e2e.rs
@@ -1,0 +1,141 @@
+//! End-to-end tests for the `clinical/volume-of-distribution.adj` library — the definition of the
+//! (apparent) volume of distribution (Vd = amount of drug in the body ÷ plasma concentration) and
+//! its two exact rearrangements — driven through the built CLI binary against the SHIPPED stdlib.
+//! The same invariant as every other formula library: a consumer states NO arithmetic; it imports
+//! the grounded library, binds the measured quantities with `observe`, and the engine applies the
+//! cited relation on the CPU, computing the EXACT value and rendering the relation's citation and
+//! trust tier in the `derived` section (the auditable answer). The three formulas INVERT around
+//! the worked case amount = 200 mg, Cp = 5 mg/L: 200 ÷ 5 = 40, 40 × 5 = 200, and 200 ÷ 40 = 5. The
+//! three asserted values (40, 200, 5) are chosen so none is a colon-anchored prefix of another
+//! rendered value. This is the first pharmacokinetics library, a dosing cousin of the shipped
+//! cockcroft_gault.adj — a ratio-DEFINED quantity (unlike the product-defined rate-pressure-product).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped volume-of-distribution library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_vd_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/volume-of-distribution.adj")
+        .canonicalize()
+        .expect("shipped volume-of-distribution.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_vd_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_vd_lib()).unwrap();
+    std::fs::write(dir.join("volume-of-distribution.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// volume_of_distribution — the definition: amount of drug divided by plasma concentration.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_volume_of_distribution_library_and_computes_it_with_citation() {
+    let dir = scratch("vd");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"volume-of-distribution.adj\"\n\
+         observe amount_of_drug_in_body(200)\n\
+         observe plasma_concentration(5)\n\
+         ? volume_of_distribution(amount_of_drug_in_body, plasma_concentration)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 200 ÷ 5 = 40.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"volume_of_distribution\"") && s.contains("\"value\":40"),
+        "volume_of_distribution(200, 5) = 40: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// amount_of_drug_in_body — the same relation solved for the amount: Vd × Cp.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_amount_from_vd_and_concentration_with_citation() {
+    let dir = scratch("amount");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"volume-of-distribution.adj\"\n\
+         observe volume_of_distribution(40)\n\
+         observe plasma_concentration(5)\n\
+         ? amount_of_drug_in_body(volume_of_distribution, plasma_concentration)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 40 × 5 = 200, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"amount_of_drug_in_body\"") && s.contains("\"value\":200"),
+        "amount_of_drug_in_body(40, 5) = 200: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "amount_of_drug_in_body carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// plasma_concentration — the same relation solved for the concentration: amount ÷ Vd, the third
+// reading of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_concentration_from_amount_and_vd_with_citation() {
+    let dir = scratch("cp");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"volume-of-distribution.adj\"\n\
+         observe amount_of_drug_in_body(200)\n\
+         observe volume_of_distribution(40)\n\
+         ? plasma_concentration(amount_of_drug_in_body, volume_of_distribution)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 200 ÷ 40 = 5, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"plasma_concentration\"") && s.contains("\"value\":5"),
+        "plasma_concentration(200, 40) = 5: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "plasma_concentration carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/volume-of-distribution.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/volume-of-distribution.adj
@@ -1,0 +1,98 @@
+% ============================================================================
+% volume-of-distribution.adj — the definition of the (apparent) volume of distribution
+% (Vd = amount of drug in the body ÷ plasma concentration) in the ADJ standard library.
+% ============================================================================
+% The volume-of-distribution entry of the *clinical* track — the first PHARMACOKINETICS library,
+% a bedside/dosing cousin of the shipped cockcroft_gault.adj (creatinine clearance). Where a
+% product library like rate-pressure-product MULTIPLIES two quantities, the volume of distribution
+% is DEFINED as a RATIO: THE VOLUME OF DISTRIBUTION IS THE AMOUNT OF DRUG IN THE BODY DIVIDED BY
+% THE PLASMA CONCENTRATION OF THE DRUG — a proportionality constant that relates the total amount
+% of drug in the body to the plasma concentration at a given time. It is "apparent" because it is
+% not a real anatomical volume: a drug that partitions heavily into tissue leaves little in plasma,
+% so the concentration is low and the computed volume can exceed total body water. It sets the
+% loading dose (a larger Vd needs more drug to reach a target concentration). It ships as an
+% importable, byte-provenanced, PARAMETERIZED `formula`, together with its two exact rearrangements
+% (the amount of drug a Vd implies for a given concentration, and the concentration it implies for
+% a given amount). As with every compute library, a consumer states NO arithmetic: it `import`s
+% this file, binds the measured quantities from its own byte-provenance decomposition, and asks the
+% engine to APPLY the cited definition on the CPU. Zero math is performed by the model; the engine
+% computes each value EXACTLY (over exact rationals), carrying the definition's citation.
+%
+%     import "volume-of-distribution.adj"
+%     observe amount_of_drug_in_body(200)   % "…200 mg in the body…"        (span cited by the model)
+%     observe plasma_concentration(5)        % "…plasma concentration 5 mg/L…" (span cited by the model)
+%     ? volume_of_distribution(amount_of_drug_in_body, plasma_concentration)
+%                                            % engine → 40, carrying Vd = amount ÷ Cp
+%
+% All three formulas are EXACT over their parameters, so every value the engine returns is exact.
+% They COMPOSE and invert cleanly around the worked case amount = 200 mg, plasma concentration =
+% 5 mg/L (Vd = 200 ÷ 5 = 40): the `volume_of_distribution` a consumer computes from the amount and
+% concentration is exactly the value the `amount_of_drug_in_body` formula multiplies by the
+% concentration to recover 200, and exactly the value the `plasma_concentration` formula divides
+% the amount by to recover 5.
+%
+%   volume_of_distribution(amount_of_drug_in_body, plasma_concentration)
+%       = amount_of_drug_in_body / plasma_concentration    % Vd = amount ÷ Cp   (definition)
+%   amount_of_drug_in_body(volume_of_distribution, plasma_concentration)
+%       = volume_of_distribution * plasma_concentration     % amount = Vd × Cp   (solved for amount)
+%   plasma_concentration(amount_of_drug_in_body, volume_of_distribution)
+%       = amount_of_drug_in_body / volume_of_distribution   % Cp = amount ÷ Vd   (solved for Cp)
+%
+% NOTE ON UNITS: the amount of drug in the body is in milligrams and the plasma concentration is in
+% milligrams per litre; the volume of distribution comes out in litres, and this library computes
+% the exact quotient over whatever consistent inputs it is given.
+%
+% All three formulas are defended by the SAME clause — "Vd=Amount of drug in the body/Plasma
+% concentration of the drug" — because that one definition (Vd IS the amount-over-concentration
+% ratio) sanctions the relation read every way. The quote is transcribed verbatim from a
+% peer-reviewed article archived on the NCBI Bookshelf, so each `formula` carries the provenance
+% envelope every shipped grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the clause is a verbatim span of the cited page, not asserted
+% from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable pharmacokinetic quantity the definition ranges over,
+% and each result is a derived quantity. `amount_of_drug_in_body`, `plasma_concentration` and
+% `volume_of_distribution` each appear BOTH as a derived result and as an input (of the other
+% formulas), so each is a single dictionary term used in both roles. The `surface` lists are the
+% everyday names a decomposer maps onto the canonical term; the trailing comment records the
+% intended unit.
+% ----------------------------------------------------------------------------
+dictionary volume_of_distribution_vocab {
+    define amount_of_drug_in_body  : finding  surface "amount of drug in the body", "amount of drug", "drug amount"        % milligrams (mg)
+    define plasma_concentration    : finding  surface "plasma concentration", "plasma drug concentration", "Cp"            % milligrams per litre (mg/L)
+    define volume_of_distribution  : finding  surface "volume of distribution", "apparent volume of distribution", "Vd"    % litres (L)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the definitional clause from the cited article
+% on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an exact quotient or
+% product of measured quantities, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook volume_of_distribution_laws {
+    use volume_of_distribution_vocab
+
+    % Volume of distribution — the amount of drug in the body divided by the plasma concentration,
+    % i.e. Vd = amount ÷ Cp.
+    formula volume_of_distribution(amount_of_drug_in_body, plasma_concentration) = amount_of_drug_in_body / plasma_concentration
+        source "Vd=Amount of drug in the body/Plasma concentration of the drug"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK545280/"
+        trust authoritative
+
+    % Amount of drug in the body — the same definition solved for the amount a Vd implies for a
+    % given concentration (amount = Vd × Cp). Defended by the SAME clause.
+    formula amount_of_drug_in_body(volume_of_distribution, plasma_concentration) = volume_of_distribution * plasma_concentration
+        source "Vd=Amount of drug in the body/Plasma concentration of the drug"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK545280/"
+        trust authoritative
+
+    % Plasma concentration — the same definition solved for the concentration (Cp = amount ÷ Vd):
+    % the amount of drug in the body divided by the volume of distribution. The SAME clause, read
+    % the third way.
+    formula plasma_concentration(amount_of_drug_in_body, volume_of_distribution) = amount_of_drug_in_body / volume_of_distribution
+        source "Vd=Amount of drug in the body/Plasma concentration of the drug"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK545280/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/volume-of-distribution.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/volume-of-distribution.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% volume-of-distribution.query.adj — worked applications of the volume-of-distribution definition.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a pharmacokinetics/dosing vignette into
+% observed quantities: it `import`s the grounded formulabook, `observe`s the measured amount of
+% drug and plasma concentration, and asks the engine to APPLY the cited definition. No arithmetic
+% is stated by the consumer; the engine computes each value EXACTLY (over exact rationals) and
+% carries the article's citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (amount of drug in the body = 200 mg, plasma concentration = 5 mg/L): Vd = 200 ÷ 5 =
+% 40 L. Each query below fixes two of the three quantities and asks the engine to recover the
+% third; every answer is exact and the three COMPOSE (each inversion recovers exactly the worked
+% value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli volume-of-distribution.query.adj
+% ============================================================================
+
+import "volume-of-distribution.adj"
+
+% --- Definition: the volume of distribution the amount and concentration imply (expect 40). ----
+observe amount_of_drug_in_body(200)
+observe plasma_concentration(5)
+? volume_of_distribution(amount_of_drug_in_body, plasma_concentration)   % expect 40
+
+% --- Inverse: the amount of drug a Vd of 40 implies at that concentration (200). ---------------
+observe volume_of_distribution(40)
+? amount_of_drug_in_body(volume_of_distribution, plasma_concentration)   % expect 200


### PR DESCRIPTION
## What

Ships the **(apparent) volume of distribution** (Vd = amount of drug in the body ÷ plasma concentration) as an importable, byte-provenanced, parameterized `formula` in the **clinical** track — the **first pharmacokinetics library** — with its two exact algebraic rearrangements.

All three formulas are defended by the **same verbatim clause**, transcribed from a peer-reviewed article on the NCBI Bookshelf:

> "Vd=Amount of drug in the body/Plasma concentration of the drug"
> — https://www.ncbi.nlm.nih.gov/books/NBK545280/ · `trust authoritative`

## Why

Opens pharmacokinetics in the clinical track (a dosing cousin of the shipped `cockcroft_gault.adj`). Unlike the product-defined `rate-pressure-product` / `calcium-phosphate-product`, **Vd is a ratio-defined quantity**, so here the *definition* formula is the division and one rearrangement is the multiplication — exercising the same three-way inverter shape from the other side. A consumer states **no arithmetic**: it imports the library, `observe`s the measured quantities from its own byte-provenance decomposition, and the engine **applies** the cited relation on the CPU, computing each value **exactly over exact rationals** and carrying the citation + trust tier in the auditable `derived` section.

## The three readings

```
volume_of_distribution(amount_of_drug_in_body, plasma_concentration) = amount_of_drug_in_body / plasma_concentration   % Vd = amount ÷ Cp
amount_of_drug_in_body(volume_of_distribution, plasma_concentration) = volume_of_distribution * plasma_concentration     % amount = Vd × Cp
plasma_concentration(amount_of_drug_in_body, volume_of_distribution) = amount_of_drug_in_body / volume_of_distribution   % Cp = amount ÷ Vd
```

They **compose** around the worked case amount = 200 mg, Cp = 5 mg/L: 200 ÷ 5 = 40, 40 × 5 = 200, 200 ÷ 40 = 5. The three asserted values (40 / 200 / 5) are chosen so none is a colon-anchored prefix of another rendered value.

## Files

- `code/specs/data/adj-formula-stdlib/clinical/volume-of-distribution.adj` — dictionary + formulabook (3 cited formulas)
- `code/specs/data/adj-formula-stdlib/clinical/volume-of-distribution.query.adj` — worked applications
- `code/packages/rust/adj-lang-cli/tests/formula_volume_of_distribution_e2e.rs` — 3 e2e tests (own dedicated file, no shared anchor)

## Verification

- `cargo test -p adj-lang-cli --test formula_volume_of_distribution_e2e` — **3/3 green**
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — **clean**
- Render-probe of `.query.adj` against the built CLI: forward → 40 with the verbatim citation + `trust:authoritative`; inverse recovers `amount_of_drug_in_body` = 200.
- Data + test only — no engine change, **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)