### PR TITLE
Preprocess MOS electrostatics across temperature

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Apply Berkeley MOS1 electrostatic temperature preprocessing to Level-1 MOS
+  `PHI` and polarity-aware `VT0` instead of a fixed threshold-voltage shift.
 - Scale Level-1 MOS bulk-junction `IS` and `JS` with temperature using the
   silicon energy-gap law already shared by semiconductor junction models.
 - Scale Level-1 MOS `U0` alongside `KP` by `(T / T_NOM)^-3/2` so temperature

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -77,6 +77,8 @@ print(result.diagnostics.solver)   # "dense_real" or "sparse_real"
 `mosfet_at_temperature()`, and `circuit_at_temperature()` provide
 operating-temperature footholds for diode, BJT, JFET, and Level-1 MOSFET
 models before running an analysis.
+Level-1 MOS temperature preprocessing follows the Berkeley MOS1 silicon
+band-gap correction for `PHI` and polarity-aware `VT0`.
 JFET model cards use `TCV` for threshold-voltage scaling and `BEX` for
 `BETA(T) = BETA * (T / TNOM)^BEX`. When explicitly present, `VTOTC` overrides
 `TCV` with `VTO(T) = VTO + VTOTC * (T - TNOM)`, while `BETATCE` overrides

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -392,7 +392,47 @@ def mosfet_at_temperature(
     if not isinstance(params, Level1Params):
         raise ValueError(f"{mosfet.name}: only Level-1 MOSFET parameters are supported")
     ratio = temperature_kelvin / nominal_temperature_kelvin
-    threshold_shift = -2.0e-3 * (temperature_kelvin - nominal_temperature_kelvin)
+    reference_temperature_kelvin = 300.15
+
+    def silicon_band_gap(temperature: float) -> float:
+        return 1.16 - 7.02e-4 * temperature**2 / (temperature + 1108.0)
+
+    def potential_correction(temperature: float) -> float:
+        thermal_voltage = _BOLTZMANN * temperature / _ELECTRON_CHARGE
+        argument = (
+            -silicon_band_gap(temperature)
+            * _ELECTRON_CHARGE
+            / (2.0 * _BOLTZMANN * temperature)
+            + 1.115_087_7
+            * _ELECTRON_CHARGE
+            / (2.0 * _BOLTZMANN * reference_temperature_kelvin)
+        )
+        return -2.0 * thermal_voltage * (
+            1.5 * math.log(temperature / reference_temperature_kelvin) + argument
+        )
+
+    nominal_factor = nominal_temperature_kelvin / reference_temperature_kelvin
+    temperature_factor = temperature_kelvin / reference_temperature_kelvin
+    nominal_phi = (
+        params.PHI - potential_correction(nominal_temperature_kelvin)
+    ) / nominal_factor
+    temperature_phi = (
+        temperature_factor * nominal_phi + potential_correction(temperature_kelvin)
+    )
+    polarity = 1.0 if model.type is MosfetType.NMOS else -1.0
+    temperature_vbi = (
+        params.VT0
+        - polarity * params.GAMMA * math.sqrt(params.PHI)
+        + 0.5
+        * (
+            silicon_band_gap(nominal_temperature_kelvin)
+            - silicon_band_gap(temperature_kelvin)
+        )
+        + polarity * 0.5 * (temperature_phi - params.PHI)
+    )
+    temperature_vt0 = (
+        temperature_vbi + polarity * params.GAMMA * math.sqrt(temperature_phi)
+    )
     saturation_exponent = (
         energy_gap_ev
         * _ELECTRON_CHARGE
@@ -404,7 +444,8 @@ def mosfet_at_temperature(
     )
     adjusted_params = replace(
         params,
-        VT0=params.VT0 + threshold_shift,
+        VT0=temperature_vt0,
+        PHI=temperature_phi,
         KP=params.KP * ratio**-1.5,
         U0=params.U0 * ratio**-1.5,
         IS=params.IS * saturation_scale,

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -4193,7 +4193,7 @@ def test_dc_rejects_invalid_bjt_depletion_parameters(kwargs, message):
 
 
 def test_mosfet_temperature_scaling_changes_common_source_bias():
-    """Hotter Level-1 NMOS lowers VT0 enough to pull the drain node down."""
+    """Berkeley MOS1 temperature preprocessing changes common-source bias."""
     nominal = Circuit()
     nominal.add(VoltageSource("Vdd", "vdd", "0", 1.8))
     nominal.add(VoltageSource("Vgate", "gate", "0", 1.1))
@@ -4226,8 +4226,8 @@ def test_mosfet_temperature_scaling_changes_common_source_bias():
     assert cold_result.converged
     assert nominal_result.converged
     assert hot_result.converged
-    assert cold_result.node_voltages["out"] > nominal_result.node_voltages["out"]
-    assert hot_result.node_voltages["out"] < nominal_result.node_voltages["out"]
+    assert cold_result.node_voltages["out"] < nominal_result.node_voltages["out"]
+    assert hot_result.node_voltages["out"] > nominal_result.node_voltages["out"]
 
 
 def test_mosfet_temperature_scaling_keeps_surface_mobility_and_kp_aligned():
@@ -4256,6 +4256,35 @@ def test_mosfet_temperature_scaling_keeps_surface_mobility_and_kp_aligned():
     assert pytest.approx(nominal_params.KP / nominal_params.U0) == (
         hot_params.KP / hot_params.U0
     )
+
+
+def test_mosfet_temperature_scaling_adjusts_phi_and_threshold_by_polarity():
+    nmos = Mosfet(
+        "Mn",
+        "d",
+        "g",
+        "s",
+        "b",
+        MOSFET(MosfetType.NMOS, Level1Model(Level1Params())),
+    )
+    pmos = Mosfet(
+        "Mp",
+        "d",
+        "g",
+        "s",
+        "b",
+        MOSFET(MosfetType.PMOS, Level1Model(Level1Params(VT0=-0.42))),
+    )
+
+    hot_nmos = mosfet_at_temperature(nmos, 350.0)
+    hot_pmos = mosfet_at_temperature(pmos, 350.0)
+    nmos_params = hot_nmos.model.model.params
+    pmos_params = hot_pmos.model.model.params
+
+    assert pytest.approx(0.766_340_574_915_624_6) == nmos_params.PHI
+    assert pytest.approx(nmos_params.PHI) == pmos_params.PHI
+    assert pytest.approx(0.379_106_188_982_781_14) == nmos_params.VT0
+    assert pytest.approx(-0.365_036_965_282_786_06) == pmos_params.VT0
 
 
 def test_mosfet_temperature_scaling_adjusts_bulk_junction_saturation_currents():

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Apply Berkeley MOS1 electrostatic temperature preprocessing to Level-1 MOS
+  `PHI` and polarity-aware `VT0` instead of a fixed threshold-voltage shift.
 - Scale Level-1 MOS bulk-junction `IS` and `JS` with temperature using the
   silicon energy-gap law already shared by semiconductor junction models.
 - Scale Level-1 MOS `U0` alongside `KP` by `(T / T_NOM)^-3/2` so temperature

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -118,6 +118,8 @@ let result = transient_adaptive(
 `mosfet_at_temperature`, and `circuit_at_temperature` provide
 operating-temperature footholds for diode, BJT, JFET, and Level-1 MOSFET
 models before running an analysis.
+Level-1 MOS temperature preprocessing follows the Berkeley MOS1 silicon
+band-gap correction for `PHI` and polarity-aware `VT0`.
 JFET model cards use `TCV` for threshold-voltage scaling and `BEX` for
 `BETA(T) = BETA * (T / TNOM)^BEX`. When explicitly present, `VTOTC` overrides
 `TCV` with `VTO(T) = VTO + VTOTC * (T - TNOM)`, while `BETATCE` overrides

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -2780,12 +2780,39 @@ pub fn mosfet_at_temperature(
         });
     }
     let ratio = temperature_kelvin / nominal_temperature_kelvin;
-    let threshold_shift = -2.0e-3 * (temperature_kelvin - nominal_temperature_kelvin);
+    let reference_temperature_kelvin = 300.15;
+    let silicon_band_gap =
+        |temperature: f64| 1.16 - 7.02e-4 * temperature * temperature / (temperature + 1108.0);
+    let potential_correction = |temperature: f64| {
+        let thermal_voltage = BOLTZMANN * temperature / ELECTRON_CHARGE;
+        let argument = -silicon_band_gap(temperature) * ELECTRON_CHARGE
+            / (2.0 * BOLTZMANN * temperature)
+            + 1.115_087_7 * ELECTRON_CHARGE / (2.0 * BOLTZMANN * reference_temperature_kelvin);
+        -2.0 * thermal_voltage
+            * (1.5 * (temperature / reference_temperature_kelvin).ln() + argument)
+    };
+    let nominal_factor = nominal_temperature_kelvin / reference_temperature_kelvin;
+    let temperature_factor = temperature_kelvin / reference_temperature_kelvin;
+    let nominal_potential_correction = potential_correction(nominal_temperature_kelvin);
+    let temperature_potential_correction = potential_correction(temperature_kelvin);
+    let nominal_phi = (mosfet.params.phi - nominal_potential_correction) / nominal_factor;
+    let temperature_phi = temperature_factor * nominal_phi + temperature_potential_correction;
+    let polarity = match mosfet.mosfet_type {
+        MosfetType::Nmos => 1.0,
+        MosfetType::Pmos => -1.0,
+    };
+    let temperature_vbi = mosfet.params.vt0
+        - polarity * mosfet.params.gamma * mosfet.params.phi.sqrt()
+        + 0.5
+            * (silicon_band_gap(nominal_temperature_kelvin) - silicon_band_gap(temperature_kelvin))
+        + polarity * 0.5 * (temperature_phi - mosfet.params.phi);
+    let temperature_vt0 = temperature_vbi + polarity * mosfet.params.gamma * temperature_phi.sqrt();
     let saturation_exponent = energy_gap_electron_volts * ELECTRON_CHARGE / BOLTZMANN
         * (1.0 / nominal_temperature_kelvin - 1.0 / temperature_kelvin);
     let saturation_scale = ratio.powi(3) * saturation_exponent.clamp(-100.0, 100.0).exp();
     let mut adjusted = mosfet.clone();
-    adjusted.params.vt0 += threshold_shift;
+    adjusted.params.vt0 = temperature_vt0;
+    adjusted.params.phi = temperature_phi;
     adjusted.params.kp *= ratio.powf(-1.5);
     adjusted.params.surface_mobility *= ratio.powf(-1.5);
     adjusted.params.saturation_current *= saturation_scale;

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -3502,8 +3502,8 @@ fn dc_mosfet_temperature_scaling_changes_common_source_bias() {
     let cold_result = dc_op(&cold).unwrap();
     let hot_result = dc_op(&hot).unwrap();
 
-    assert!(cold_result.voltage("out").unwrap() > nominal_result.voltage("out").unwrap());
-    assert!(hot_result.voltage("out").unwrap() < nominal_result.voltage("out").unwrap());
+    assert!(cold_result.voltage("out").unwrap() < nominal_result.voltage("out").unwrap());
+    assert!(hot_result.voltage("out").unwrap() > nominal_result.voltage("out").unwrap());
 }
 
 #[test]
@@ -3533,6 +3533,39 @@ fn mosfet_temperature_scaling_keeps_surface_mobility_and_kp_aligned() {
         hot.params.kp / hot.params.surface_mobility,
         nominal.params.kp / nominal.params.surface_mobility,
     );
+}
+
+#[test]
+fn mosfet_temperature_scaling_adjusts_phi_and_threshold_by_polarity() {
+    let nmos = Mosfet::with_model(
+        "Mn",
+        "d",
+        "g",
+        "s",
+        "b",
+        MosfetType::Nmos,
+        MosfetLevel1Params::default(),
+    );
+    let pmos = Mosfet::with_model(
+        "Mp",
+        "d",
+        "g",
+        "s",
+        "b",
+        MosfetType::Pmos,
+        MosfetLevel1Params {
+            vt0: -0.42,
+            ..MosfetLevel1Params::default()
+        },
+    );
+
+    let hot_nmos = mosfet_at_temperature(&nmos, 350.0, 300.15, 1.11).unwrap();
+    let hot_pmos = mosfet_at_temperature(&pmos, 350.0, 300.15, 1.11).unwrap();
+
+    assert_close(hot_nmos.params.phi, 0.766_340_574_915_624_6);
+    assert_close(hot_pmos.params.phi, hot_nmos.params.phi);
+    assert_close(hot_nmos.params.vt0, 0.379_106_188_982_781_14);
+    assert_close(hot_pmos.params.vt0, -0.365_036_965_282_786_06);
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Apply Berkeley MOS1 electrostatic temperature preprocessing to Level-1 MOS
+  `PHI` and polarity-aware `VT0` instead of a fixed threshold-voltage shift.
 - Scale Level-1 MOS bulk-junction `IS` and `JS` with temperature using the
   silicon energy-gap law already shared by semiconductor junction models.
 - Scale Level-1 MOS `U0` alongside `KP` by `(T / T_NOM)^-3/2` so temperature

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -69,6 +69,8 @@ steps were clipped, and the minimum damping factor; pass
 `mosfetAtTemperature`, and `circuitAtTemperature` provide
 operating-temperature footholds for diode, BJT, JFET, and Level-1 MOSFET
 models before running an analysis.
+Level-1 MOS temperature preprocessing follows the Berkeley MOS1 silicon
+band-gap correction for `PHI` and polarity-aware `VT0`.
 JFET model cards use `TCV` for threshold-voltage scaling and `BEX` for
 `BETA(T) = BETA * (T / TNOM)^BEX`. When explicitly present, `VTOTC` overrides
 `TCV` with `VTO(T) = VTO + VTOTC * (T - TNOM)`, while `BETATCE` overrides

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -7736,7 +7736,37 @@ export function mosfetAtTemperature(
     throw invalidElement(element.name, "energy gap must be finite and positive");
   }
   const ratio = temperatureKelvin / nominalTemperatureKelvin;
-  const thresholdShift = -2.0e-3 * (temperatureKelvin - nominalTemperatureKelvin);
+  const referenceTemperatureKelvin = 300.15;
+  const siliconBandGap = (temperature: number): number =>
+    1.16 - (7.02e-4 * temperature * temperature) / (temperature + 1108.0);
+  const potentialCorrection = (temperature: number): number => {
+    const thermalVoltage = (BOLTZMANN * temperature) / ELECTRON_CHARGE;
+    const argument =
+      (-siliconBandGap(temperature) * ELECTRON_CHARGE) /
+        (2.0 * BOLTZMANN * temperature) +
+      (1.115_087_7 * ELECTRON_CHARGE) /
+        (2.0 * BOLTZMANN * referenceTemperatureKelvin);
+    return (
+      -2.0 *
+      thermalVoltage *
+      (1.5 * Math.log(temperature / referenceTemperatureKelvin) + argument)
+    );
+  };
+  const nominalFactor = nominalTemperatureKelvin / referenceTemperatureKelvin;
+  const temperatureFactor = temperatureKelvin / referenceTemperatureKelvin;
+  const nominalPhi =
+    (element.params.PHI - potentialCorrection(nominalTemperatureKelvin)) / nominalFactor;
+  const temperaturePhi =
+    temperatureFactor * nominalPhi + potentialCorrection(temperatureKelvin);
+  const polarity = element.type === "NMOS" ? 1.0 : -1.0;
+  const temperatureVbi =
+    element.params.VT0 -
+    polarity * element.params.GAMMA * Math.sqrt(element.params.PHI) +
+    0.5 *
+      (siliconBandGap(nominalTemperatureKelvin) - siliconBandGap(temperatureKelvin)) +
+    polarity * 0.5 * (temperaturePhi - element.params.PHI);
+  const temperatureVt0 =
+    temperatureVbi + polarity * element.params.GAMMA * Math.sqrt(temperaturePhi);
   const saturationExponent =
     (energyGapElectronVolts * ELECTRON_CHARGE) /
     BOLTZMANN *
@@ -7747,7 +7777,8 @@ export function mosfetAtTemperature(
     ...element,
     params: {
       ...element.params,
-      VT0: element.params.VT0 + thresholdShift,
+      VT0: temperatureVt0,
+      PHI: temperaturePhi,
       KP: element.params.KP * ratio ** -1.5,
       U0: element.params.U0 * ratio ** -1.5,
       IS: element.params.IS * saturationScale,

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -2322,8 +2322,8 @@ describe("dcOp", () => {
     const coldResult = dcOp(cold);
     const hotResult = dcOp(hot);
 
-    expect(coldResult.voltage("out")).toBeGreaterThan(nominalResult.voltage("out")!);
-    expect(hotResult.voltage("out")).toBeLessThan(nominalResult.voltage("out")!);
+    expect(coldResult.voltage("out")).toBeLessThan(nominalResult.voltage("out")!);
+    expect(hotResult.voltage("out")).toBeGreaterThan(nominalResult.voltage("out")!);
   });
 
   it("keeps MOSFET surface mobility and KP aligned across temperature", () => {
@@ -2340,6 +2340,21 @@ describe("dcOp", () => {
       hot.params.KP / hot.params.U0,
       nominal.params.KP / nominal.params.U0,
     );
+  });
+
+  it("adjusts MOSFET PHI and threshold voltage by device polarity", () => {
+    const nmos = mosfet("Mn", "d", "g", "s", "b", "NMOS");
+    const pmos = mosfet("Mp", "d", "g", "s", "b", "PMOS", {
+      VT0: -0.42,
+    });
+
+    const hotNmos = mosfetAtTemperature(nmos, 350.0);
+    const hotPmos = mosfetAtTemperature(pmos, 350.0);
+
+    expectClose(hotNmos.params.PHI, 0.766_340_574_915_624_6);
+    expectClose(hotPmos.params.PHI, hotNmos.params.PHI);
+    expectClose(hotNmos.params.VT0, 0.379_106_188_982_781_14);
+    expectClose(hotPmos.params.VT0, -0.365_036_965_282_786_06);
   });
 
   it("scales MOSFET bulk-junction saturation currents with temperature", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,13 +33,13 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS bulk-junction leakage temperature scaling.
+1. Cross-language Level-1 MOS electrostatic temperature preprocessing.
    - Status: current PR completion candidate.
-   - Scale scalar `IS` and area-density `JS` through Level-1 MOS temperature
-     transforms using the shared silicon energy-gap saturation-current law.
-   - Preserve the nominal `JS / IS` relationship and route circuit-level
-     energy-gap configuration through MOS transforms.
-   - Keep Rust, Python, and TypeScript helper behavior, validation, tests, and
+   - Replace the fixed threshold-voltage shift with Berkeley MOS1 silicon
+     band-gap preprocessing for `PHI` and `VT0`.
+   - Preserve NMOS/PMOS polarity semantics through direct MOS temperature
+     helpers and circuit-level transforms.
+   - Keep Rust, Python, and TypeScript helper behavior, tests, docs, and
      changelogs aligned.
 
 ## Completed Slices
@@ -3574,6 +3574,13 @@ the Rust, Python, and TypeScript surfaces together.
      mobility law already applied to `KP`.
    - Direct MOS temperature helpers and circuit-level transforms preserve the
      nominal `KP / U0` relationship in Rust, Python, and TypeScript.
+
+285. Cross-language Level-1 MOS bulk-junction leakage temperature scaling.
+   - Status: completed in PR 9126.
+   - Scalar `IS` and area-density `JS` scale through Level-1 MOS temperature
+     transforms using the shared silicon energy-gap saturation-current law.
+   - The nominal `JS / IS` relationship is preserved, and circuit-level
+     energy-gap configuration reaches MOS transforms in all three languages.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- replace the fixed Level-1 MOS threshold shift with Berkeley MOS1 silicon band-gap preprocessing
- temperature-adjust `PHI` and polarity-aware `VT0` consistently in Rust, Python, and TypeScript
- reconcile PR #9126 in the SPICE completion plan and document the new behavior

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python `ruff check src tests`
- Python `pytest -q` (670 passed, 88.87% coverage)
- TypeScript `npm run build`
- TypeScript `npm test` (413 passed)