### PR TITLE
feat(task-app): bring the app up to the design — shell, groups, status, cards

### DIFF
--- a/code/packages/rust/mosaic-emit-react/CHANGELOG.md
+++ b/code/packages/rust/mosaic-emit-react/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed - two styles that were silently discarded
+
+Both were found while polishing the task-app UI, and both had the same shape: the
+emitter accepted the author's input and then produced nothing, with no diagnostic.
+
+- **`align: center-vertical` emitted `align: "center-vertical"`** — which is not a CSS
+  property, so browsers dropped it. **Nothing using it was ever actually centred.** It
+  is now translated to `alignItems: "center"` (with `center-horizontal`, `center`,
+  `start`, `end`, `space-between` mapped alongside). An unrecognised value still falls
+  through to the escaped generic path rather than being dropped.
+- **`Text ( content : "literal" )` rendered `<span></span>`** — a literal `content:`
+  returned `None`, and the doc comment claimed the "standard Text walker" handled it
+  instead. There was no such path. It is now emitted as a JS string expression, so the
+  text appears *and* is escaped. This went unnoticed because no `.mll` in the repo used
+  a literal `content:` until the task-app rail needed a static wordmark and a section
+  heading — both of which came out blank.
+
+4 new tests (196 total).
+
+**Worth knowing:** nothing in the pipeline validates mosstyle property names, which is
+exactly how `align` survived. A sweep of all 109 `.msl` files (4 026 declarations, 44
+distinct property names) found `align` to be the *only* non-CSS name in the repo, so
+there is no second instance today — but a typo in any `.msl` still becomes a dead
+declaration with no warning. A validation pass in `mosaic-analyzer` is the durable fix
+for the class and is not attempted here.
+
+
 ### Added - UI36 data-driven sizing (`width` / `height` from a slot or expression)
 
 The size props `width`, `height`, `min-width`, `max-width`, `min-height` and

--- a/code/packages/rust/mosaic-emit-react/src/pipeline.rs
+++ b/code/packages/rust/mosaic-emit-react/src/pipeline.rs
@@ -4614,10 +4614,38 @@ fn build_part_style_map(style: &StyleDef) -> HashMap<String, String> {
 fn build_inline_style_fragment(props: &[StyleProp]) -> String {
     let mut parts: Vec<String> = Vec::with_capacity(props.len());
     for p in props {
+        if let Some(translated) = translate_layout_alias(&p.name, p.value.trim()) {
+            parts.push(translated);
+            continue;
+        }
         let key = css_property_to_camel(&p.name);
         parts.push(format!("{key}: {}", react_style_value_literal(&p.value)));
     }
     parts.join(", ")
+}
+
+/// Translate a mosstyle **layout intent** into real CSS.
+///
+/// Most mosstyle properties are CSS property names and pass straight through. A few
+/// describe intent in mosstyle's own vocabulary and have no CSS property of that name —
+/// they must be translated, or they emit a declaration the browser silently discards.
+///
+/// `align: center-vertical` was the live example: it emitted `align: "center-vertical"`,
+/// which is not a CSS property at all, so **nothing using it was ever actually centred**
+/// on any Mosaic web app. It means "centre on the cross axis", which in a `Row` (the
+/// only place it is used) is the vertical one — i.e. `alignItems: center`.
+///
+/// Returns `None` for anything that isn't an alias, so ordinary CSS is untouched.
+fn translate_layout_alias(name: &str, value: &str) -> Option<String> {
+    match (name, value) {
+        ("align", "center-vertical") => Some("alignItems: \"center\"".to_string()),
+        ("align", "center-horizontal") => Some("justifyContent: \"center\"".to_string()),
+        ("align", "center") => Some("alignItems: \"center\", justifyContent: \"center\"".to_string()),
+        ("align", "start") => Some("alignItems: \"flex-start\"".to_string()),
+        ("align", "end") => Some("alignItems: \"flex-end\"".to_string()),
+        ("align", "space-between") => Some("justifyContent: \"space-between\"".to_string()),
+        _ => None,
+    }
 }
 
 /// Render a mosstyle value as a React inline-style literal.
@@ -4682,12 +4710,16 @@ fn merge_styles(builtin: &str, author: &str) -> String {
 ///     `For (as: row) { … }` the JS engine
 ///     resolves it just like any other
 ///     closure variable).
-///   - `content: "string"`       → None (a literal string is rendered
-///     by the standard Text walker as its
-///     own `<span>literal</span>`; this
-///     helper only surfaces the JSX-
-///     expression form so the cell flatten
-///     path can inline it).
+///   - `content: "string"`       → `{"literal"}` (a JS string literal, so the
+///     text is escaped rather than pasted
+///     into JSX as markup).
+///
+/// A literal used to return `None` here, and the doc claimed the "standard Text
+/// walker" rendered it instead. There is no such path: `emit_jsx_tree` took the
+/// no-content branch and emitted `<span></span>`, so `Text ( content : "Projects" )`
+/// silently rendered NOTHING. It went unnoticed because no `.mll` in the repo used a
+/// literal `content:` until the task-app rail needed a static wordmark and a section
+/// heading — both of which came out blank.
 ///
 /// The Keyword arm is the L10 wiring that lets HostTable composers
 /// write `For (as: row) { Text (content: row) }` and have the row
@@ -4705,6 +4737,9 @@ fn jsx_text_content(node: &LayoutNode) -> Option<String> {
                 LayoutPropValue::SlotRef(slot) => {
                     Some(format!("{{{}}}", to_camel_case_first_lower(slot)))
                 }
+                // A static label. Emitted as a JS string expression rather than raw
+                // JSX text so `{`, `}` and `<` in the literal stay literal.
+                LayoutPropValue::String(text) => Some(jsx_string_expr(text)),
                 LayoutPropValue::Keyword(name) => {
                     let camel = to_camel_case_first_lower(name);
                     if is_safe_js_identifier(&camel) {
@@ -7535,6 +7570,105 @@ mod tests {
         let out = from_pipeline(&m, &l, &empty_style("X")).unwrap().output;
         assert!(!out.contains("mosaic$grab"), "controller leaked:\n{out}");
         assert!(!out.contains("useState"), "useState leaked:\n{out}");
+    }
+
+    // ===================================================================
+    // Layout aliases + literal text
+    // ===================================================================
+
+    fn text_layout(prop: LayoutProp) -> LayoutDef {
+        LayoutDef {
+            component_name: "T".to_string(),
+            root: LayoutNode {
+                tag: "Text".to_string(),
+                part_name: None,
+                props: vec![prop],
+                children: vec![],
+            },
+        }
+    }
+
+    /// A static label must render. It used to emit `<span></span>` — the text simply
+    /// vanished — because a literal `content:` returned None and nothing else handled
+    /// it. Two blank labels in the task-app rail are what surfaced this.
+    #[test]
+    fn literal_text_content_actually_renders() {
+        let out = from_pipeline(
+            &component("T", vec![], vec![]),
+            &text_layout(LayoutProp {
+                name: "content".to_string(),
+                value: LayoutPropValue::String("Projects".to_string()),
+            }),
+            &empty_style("T"),
+        )
+        .unwrap()
+        .output;
+        assert!(out.contains("Projects"), "literal label missing:
+{out}");
+        assert!(!out.contains("<span></span>"), "rendered an empty span:
+{out}");
+    }
+
+    /// ...and it is escaped, not pasted into JSX as markup.
+    #[test]
+    fn literal_text_content_is_escaped() {
+        let out = from_pipeline(
+            &component("T", vec![], vec![]),
+            &text_layout(LayoutProp {
+                name: "content".to_string(),
+                value: LayoutPropValue::String("a{b}<c>".to_string()),
+            }),
+            &empty_style("T"),
+        )
+        .unwrap()
+        .output;
+        // A JS string expression, so the braces are data rather than a JSX hole.
+        assert!(out.contains("{\"a{b}<c>\"}"), "not emitted as a string:
+{out}");
+    }
+
+    fn aligned(value: &str) -> String {
+        let style = StyleDef {
+            component_name: "A".to_string(),
+            parts: vec![PartStyle {
+                name: "r".to_string(),
+                base: vec![StyleProp {
+                    name: "align".to_string(),
+                    value: value.to_string(),
+                }],
+                states: vec![],
+            }],
+        };
+        let layout = LayoutDef {
+            component_name: "A".to_string(),
+            root: LayoutNode {
+                tag: "Row".to_string(),
+                part_name: Some("r".to_string()),
+                props: vec![],
+                children: vec![],
+            },
+        };
+        from_pipeline(&component("A", vec![], vec![]), &layout, &style)
+            .unwrap()
+            .output
+    }
+
+    /// `align` is NOT a CSS property, so it was emitted verbatim and browsers threw it
+    /// away — nothing using it was ever actually centred.
+    #[test]
+    fn align_center_vertical_becomes_align_items() {
+        let out = aligned("center-vertical");
+        assert!(out.contains("alignItems: \"center\""), "{out}");
+        assert!(!out.contains("align: \"center-vertical\""), "alias leaked:
+{out}");
+    }
+
+    /// An unrecognised value must still fall through to the escaped generic path
+    /// rather than being silently dropped.
+    #[test]
+    fn an_unknown_align_value_falls_through_unchanged() {
+        let out = aligned("sideways");
+        assert!(out.contains("align: \"sideways\""), "{out}");
     }
 
     // ===================================================================

--- a/code/programs/mosaic/task-app/CHANGELOG.md
+++ b/code/programs/mosaic/task-app/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to the `task-app` web program are documented here.
 
 ## [0.1.0] - Unreleased
 
+### Changed - the app now looks like the design
+
+A polish pass bringing the real app up to `design/ui-prototype.html`, which it had
+drifted well behind.
+
+- **Two-column shell.** A quiet left rail holds the workspace's projects (active one
+  honey-filled, nested ones indented) with the new-project composer at its foot; the
+  main column holds a topbar and the content.
+- **Topbar** — title, the summary line, and the engine's verdict as a **status pill**
+  (sage "On track", red "N overdue"), with a proper **segmented view switch**. The
+  switch uses two explicit events rather than one toggle, so clicking the view you are
+  already on is a no-op instead of switching away from it.
+- **The list reads as sections** — In progress / Up next / Done, with the heading
+  riding on the row that opens each group.
+- **Card treatment throughout** — the composer and every task are warm-white cards with
+  the design's radii and warm-tinted shadows; chips, the round completion toggle, and
+  the disclosure panel all match the prototype.
+- Both themes stay in lockstep: 57 parts with identical name *and* property sets, since
+  the dark theme is generated from the light one by token substitution.
+- `index.html` gained the host's only CSS — a margin reset so the shell reaches the
+  viewport edge (it had been floating 8px off every side), plus a pre-hydration
+  background so the first paint isn't white. The *real* ground is set by the app from
+  the resolved theme, because an explicit theme choice outranks the OS and the static
+  guess can therefore be wrong.
+
+Depends on two emitter fixes in the same change — see `mosaic-emit-react`'s changelog.
+Without them nothing in this layout would have been vertically centred, and the rail's
+"Planner" and "Projects" labels would have rendered as empty spans.
+
+
 ### Added - progressive disclosure on task rows
 
 - **Click a task's name to reveal its scheduling detail** — when it's scheduled for,

--- a/code/programs/mosaic/task-app/host/web/index.html
+++ b/code/programs/mosaic/task-app/host/web/index.html
@@ -8,6 +8,35 @@
       name="description"
       content="A to-do app with automatic critical-path scheduling, built on the shared task-core engine. Tasks persist locally via IndexedDB."
     />
+    <style>
+      /*
+        The only CSS the host owns. Everything else is emitted from mosstyle — this
+        just clears the browser's own defaults so the app can reach the viewport edge.
+        Without the margin reset the shell floats 8px off every side, which reads as a
+        rendering bug rather than a design choice.
+
+        The background here is ONLY a pre-hydration hint, so the first paint isn't a
+        white flash before React mounts. It follows the OS because that is all this
+        file can know; once the app boots it sets the real ground from the resolved
+        theme (which may be an explicit choice that outranks the OS) — see theme.ts.
+
+        Deliberately NOT a place to style the app: a rule here would be invisible to
+        every other Mosaic host and would silently diverge from the .msl.
+      */
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      html {
+        background: #f0ebe3;
+      }
+      @media (prefers-color-scheme: dark) {
+        html {
+          background: #1a1714;
+        }
+      }
+    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/code/programs/mosaic/task-app/host/web/src/main.tsx
+++ b/code/programs/mosaic/task-app/host/web/src/main.tsx
@@ -11,7 +11,13 @@ import { createRoot } from "react-dom/client";
 // scripts/build-web; the event type is identical, so either can be used interchangeably.
 import { TaskApp as TaskAppLight, type TaskAppEvent } from "./TaskApp.light";
 import { TaskApp as TaskAppDark } from "./TaskApp.dark";
-import { resolveTheme, storeTheme, watchSystemTheme, type Theme } from "./theme";
+import {
+  applyThemeGround,
+  resolveTheme,
+  storeTheme,
+  watchSystemTheme,
+  type Theme,
+} from "./theme";
 import { buildTimeline, type GanttBar } from "./timeline";
 import { createTaskEngine } from "./task-engine.mjs";
 import {
@@ -182,6 +188,19 @@ function makeController(engine: any, init: ControllerInit = {}) {
   };
   const visible = (): string[] => rows().ids;
 
+  // The list is drawn in GROUP order, so a click index refers to that order — not to
+  // creation order. Both the rows and every index lookup must go through this, or a
+  // click lands on the wrong task the moment the two disagree.
+  const displayIds = (): string[] => {
+    const { byTask, ids } = rows();
+    const groupRank = (id: string) => {
+      const c = byTask.get(id)!;
+      if (c.value[DONE]?.value === true) return 2;
+      return c.display[START] ? 0 : 1;
+    };
+    return [...ids].sort((a, b) => groupRank(a) - groupRank(b));
+  };
+
   return {
     getProps() {
       // Ask the ENGINE for render-ready cells. The host no longer formats dates,
@@ -219,13 +238,30 @@ function makeController(engine: any, init: ControllerInit = {}) {
         ];
       };
 
-      const taskRows: string[][] = ids.map((id) => {
+      // Group the list the way the design does: what's underway, what's next, and
+      // what's finished. The heading rides on the row that OPENS each group, so the
+      // layout can print it without knowing anything about grouping.
+      const groupOf = (id: string): string => {
+        const c = byTask.get(id)!;
+        if (c.value[DONE]?.value === true) return "Done";
+        return c.display[START] ? "In progress" : "Up next";
+      };
+      let lastGroup = "";
+
+      // displayIds() is the ONE ordering: the rows are drawn from it and every click
+      // index is resolved through it. Deriving them separately is how this app got a
+      // row-index desync before — a click landed on whatever task happened to sit at
+      // that position in the *other* ordering.
+      const taskRows: string[][] = displayIds().map((id) => {
         const c = byTask.get(id)!;
         const due = c.display[DEADLINE] ? `due ${c.display[DEADLINE]}` : "";
         const window = c.display[START] ? `${c.display[START]} → ${c.display[FINISH]}` : "";
         const late = c.value[OVERDUE]?.value === true ? "⚠ overdue" : "";
         const isOpen = id === expanded;
         const [d1, d2, d3] = isOpen ? detailFor(id) : ["", "", ""];
+        const group = groupOf(id);
+        const heading = group === lastGroup ? "" : group;
+        lastGroup = group;
         return [
           c.display[DONE],
           c.display[NAME],
@@ -236,6 +272,7 @@ function makeController(engine: any, init: ControllerInit = {}) {
           d1,
           d2,
           d3,
+          heading,
         ];
       });
       const doneCount = ids.filter((id) => byTask.get(id)!.value[DONE]?.value === true).length;
@@ -251,12 +288,18 @@ function makeController(engine: any, init: ControllerInit = {}) {
         p.depths[i] > 0 ? `${" ".repeat((p.depths[i] - 1) * 2)}↳` : "",
       ]);
       const tl = showTimeline ? timeline() : { scale: "", rows: [] };
+      // The engine's verdict on the plan. Overdue work is the one thing worth
+      // colouring red in the header; everything else reads as on track.
+      const overdue = ids.filter(
+        (id) => byTask.get(id)!.value[OVERDUE]?.value === true,
+      ).length;
       return {
         appTitle: "Tasks — auto-scheduled",
+        statusLabel: overdue > 0 ? `${overdue} overdue` : "On track",
+        statusWarn: overdue > 0 ? "warn" : "",
         timelineMode: showTimeline ? "timeline" : "",
         timelineScale: tl.scale,
         timelineRows: tl.rows,
-        viewToggleLabel: showTimeline ? "List" : "Timeline",
         newTaskName: newName,
         newTaskDue: newDue,
         newProjectName: newProject,
@@ -279,12 +322,15 @@ function makeController(engine: any, init: ControllerInit = {}) {
         case "expandTask": {
           // Resolve through the same ordered id list the rows were drawn from, so the
           // clicked index can't drift onto a different task.
-          const id = rows().ids[event.index];
+          const id = displayIds()[event.index];
           if (id) expanded = expanded === id ? null : id;
           break;
         }
-        case "toggleView":
-          showTimeline = !showTimeline;
+        case "showList":
+          showTimeline = false;
+          break;
+        case "showTimeline":
+          showTimeline = true;
           break;
         case "newProjectNameChange":
           newProject = event.value;
@@ -355,8 +401,8 @@ function makeController(engine: any, init: ControllerInit = {}) {
         case "toggleTask": {
           // Resolve the row AND its current state from the same selection the UI drew,
           // so the index and the completed flag can never disagree.
-          const { byTask, ids } = rows();
-          const id = ids[event.index];
+          const { byTask } = rows();
+          const id = displayIds()[event.index];
           if (id) {
             const done = byTask.get(id)?.value[DONE]?.value === true;
             engine.setCompleted({ id, completed: !done });
@@ -365,7 +411,7 @@ function makeController(engine: any, init: ControllerInit = {}) {
           break;
         }
         case "deleteTask": {
-          const id = visible()[event.index];
+          const id = displayIds()[event.index];
           if (id) {
             engine.deleteTask({ id });
             if (expanded === id) expanded = null;
@@ -464,6 +510,10 @@ async function boot() {
     // Follow the OS while the user hasn't overridden it — so a machine that flips to
     // dark at sunset takes the app with it, without a reload.
     useEffect(() => watchSystemTheme(changeTheme), [changeTheme]);
+
+    // Repaint the page ground. index.html guesses from the OS before React mounts;
+    // an explicit choice outranks the OS, so the guess can be wrong.
+    useEffect(() => applyThemeGround(theme), [theme]);
 
     const toggle = useCallback(() => {
       // Compute off the rendered value, not inside the updater: React double-invokes

--- a/code/programs/mosaic/task-app/host/web/src/theme.ts
+++ b/code/programs/mosaic/task-app/host/web/src/theme.ts
@@ -90,3 +90,24 @@ export function watchSystemTheme(onChange: (theme: Theme) => void): () => void {
   query.addListener(listener);
   return () => query.removeListener(listener);
 }
+
+/**
+ * The page ground for a theme. `index.html` paints an OS-derived guess before React
+ * mounts; once the real theme is resolved the app must repaint it, or an explicit
+ * choice that disagrees with the OS leaves the wrong colour showing in the overscroll
+ * area and behind the app.
+ *
+ * These two values are the `app-shell` background from TaskApp.{light,dark}.msl. They
+ * are duplicated here because the emitted component inlines its styles and exposes no
+ * token to read back — if the .msl ground changes, change it here too.
+ */
+const GROUND: Record<Theme, string> = {
+  light: "#f0ebe3",
+  dark: "#1a1714",
+};
+
+/** Paint the page ground to match the resolved theme. */
+export function applyThemeGround(theme: Theme): void {
+  const root = globalThis.document?.documentElement;
+  if (root) root.style.background = GROUND[theme];
+}

--- a/code/programs/mosaic/task-app/src/TaskApp.dark.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.dark.msl
@@ -1,151 +1,414 @@
 // TaskApp — styling (mosstyle), dark theme. Parts match the [ part-name ] labels
 // in TaskApp.mll, and mirror TaskApp.light.msl part-for-part.
 //
-// The dark half of the "warm & approachable" identity (code/specs/task-app-ui-design.md):
-// a warm near-black ground (#1a1714, not a cold #000), warm-ivory ink, and the same
-// honey accent — lifted to #eaa63f so it stays legible on the dark ground. Both themes
-// are authored, not inverted. Resolved by `mosaic-compile --theme dark`.
+// The "warm & approachable" identity from code/specs/task-app-ui-design.md: a warm
+// paper ground, crisp warm-white cards, warm-charcoal ink, and a single honey accent
+// (#eaa63f) spent only on *now* — the active project, the primary action, focus.
+// Semantic colour is a separate axis: sage for on-track, red for critical/overdue.
+// Shadows carry a brown tint rather than neutral black, so they sit in the same warm
+// world instead of greying the page.
 
 style TaskApp {
+  // ── shell ───────────────────────────────────────────────────────────────
   part app-shell {
     background : "#1a1714" ;
     color : "#f1ebe1" ;
     font-family : "-apple-system, Segoe UI, system-ui, sans-serif" ;
-    padding : 28 ;
-    gap : 16 ;
+    min-height : "100vh" ;
   }
-  part project-bar {
-    gap : 8 ;
+  part rail {
+    width : 236 ;
+    flex-shrink : 0 ;
+    padding : 20 ;
+    gap : 18 ;
+    border-right-width : 1 ;
+    border-right-color : "#352e25" ;
+    border-right-style : "solid" ;
+  }
+  part main {
+    flex-grow : 1 ;
+    min-width : 0 ;
+    padding : 20 ;
+    gap : 14 ;
+  }
+  part content {
+    gap : 14 ;
+  }
+
+  // ── brand ───────────────────────────────────────────────────────────────
+  part brand {
+    gap : 10 ;
     align : center-vertical ;
+    padding : 4 ;
   }
-  // The project you are looking at: honey fill, so "where am I" is answerable at a
-  // glance. The others stay quiet surfaces.
-  part project-on {
+  part brand-mark {
+    width : 28 ;
+    height : 28 ;
+    border-radius : 8 ;
     background : "#eaa63f" ;
-    color : "#1a1714" ;
-    font-size : 13 ;
+    box-shadow : "0 1px 2px rgba(0,0,0,.35), 0 4px 14px rgba(0,0,0,.35)" ;
+  }
+  part brand-name {
+    font-size : 15 ;
     font-weight : bold ;
-    padding : 8 ;
-    border-radius : 20 ;
-  }
-  part project-off {
-    background : "#252019" ;
-    color : "#b3a99c" ;
-    font-size : 13 ;
-    padding : 8 ;
-    border-width : 1 ;
-    border-color : "#352e25" ;
-    border-radius : 20 ;
-    state hover {
-      border-color : "#eaa63f" ;
-      color : "#f1ebe1" ;
-    }
-  }
-  part project-input {
-    background : "#252019" ;
     color : "#f1ebe1" ;
-    font-size : 13 ;
-    padding : 8 ;
-    border-width : 1 ;
-    border-color : "#352e25" ;
-    border-radius : 9 ;
-    state focused {
-      border-color : "#eaa63f" ;
-    }
   }
-  part project-add {
-    background : "#2d271f" ;
-    color : "#eaa63f" ;
-    font-size : 13 ;
+
+  // ── rail: projects ──────────────────────────────────────────────────────
+  part rail-label {
+    font-size : 10 ;
     font-weight : bold ;
-    padding : 8 ;
-    border-radius : 9 ;
-    state hover {
-      background : "#3a2c17" ;
-    }
+    color : "#867c70" ;
+    letter-spacing : "0.08em" ;
+    text-transform : "uppercase" ;
+    padding : 4 ;
+  }
+  part rail-projects {
+    gap : 2 ;
+  }
+  part rail-row {
+    gap : 4 ;
+    align : center-vertical ;
   }
   part project-indent {
     color : "#867c70" ;
     font-size : 13 ;
   }
-  part project-sub {
-    background : "#2d271f" ;
+  // The project you are looking at. Honey fill, so "where am I" is answerable at a
+  // glance; the rest stay quiet until hovered.
+  part project-on {
+    width : 100% ;
+    background : "#eaa63f" ;
+    color : "#1a1714" ;
+    font-size : 13 ;
+    font-weight : bold ;
+    text-align : "left" ;
+    padding : 8 ;
+    border-radius : 8 ;
+    border-width : 0 ;
+    box-shadow : "0 1px 2px rgba(0,0,0,.35)" ;
+  }
+  part project-off {
+    width : 100% ;
+    background : "transparent" ;
     color : "#b3a99c" ;
     font-size : 13 ;
+    text-align : "left" ;
     padding : 8 ;
-    border-radius : 9 ;
+    border-radius : 8 ;
+    border-width : 0 ;
+    state hover {
+      background : "#332c23" ;
+      color : "#f1ebe1" ;
+    }
+  }
+  part rail-composer {
+    gap : 6 ;
+    align : center-vertical ;
+  }
+  part project-input {
+    width : 100% ;
+    background : "#252019" ;
+    color : "#f1ebe1" ;
+    font-size : 12 ;
+    padding : 7 ;
+    border-width : 1 ;
+    border-color : "#352e25" ;
+    border-radius : 8 ;
+    state focused {
+      border-color : "#eaa63f" ;
+    }
+  }
+  part project-add {
+    background : "#252019" ;
+    color : "#eaa63f" ;
+    font-size : 15 ;
+    font-weight : bold ;
+    padding : 6 ;
+    border-width : 1 ;
+    border-color : "#352e25" ;
+    border-radius : 8 ;
     state hover {
       background : "#3a2c17" ;
+      border-color : "#eaa63f" ;
+    }
+  }
+  part project-sub {
+    background : "transparent" ;
+    color : "#867c70" ;
+    font-size : 12 ;
+    text-align : "left" ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 8 ;
+    state hover {
       color : "#eaa63f" ;
     }
+  }
+
+  // ── topbar ──────────────────────────────────────────────────────────────
+  part topbar {
+    gap : 16 ;
+    align : center-vertical ;
+    padding : 4 ;
+  }
+  part title-block {
+    width : 100% ;
+    gap : 3 ;
   }
   part title {
     font-size : 22 ;
     font-weight : bold ;
     color : "#f1ebe1" ;
+    letter-spacing : "-0.02em" ;
   }
-  part add-row {
+  part subline {
     gap : 8 ;
     align : center-vertical ;
-  }
-  part name-input {
-    background : "#252019" ;
-    color : "#f1ebe1" ;
-    font-size : 14 ;
-    padding : 10 ;
-    border-width : 1 ;
-    border-color : "#352e25" ;
-    border-radius : 9 ;
-    state focused {
-      border-color : "#eaa63f" ;
-    }
-  }
-  part due-input {
-    background : "#252019" ;
-    color : "#f1ebe1" ;
-    font-size : 14 ;
-    padding : 10 ;
-    border-width : 1 ;
-    border-color : "#352e25" ;
-    border-radius : 9 ;
-    state focused {
-      border-color : "#eaa63f" ;
-    }
-  }
-  part add-btn {
-    background : "#eaa63f" ;
-    color : "#1a1714" ;
-    font-weight : bold ;
-    padding : 10 ;
-    border-radius : 9 ;
-    state hover {
-      background : "#d4922f" ;
-    }
   }
   part summary {
     color : "#b3a99c" ;
     font-size : 13 ;
   }
-  part summary-row {
-    gap : 10 ;
-    align : center-vertical ;
-  }
-  part view-toggle {
-    background : "#252019" ;
-    color : "#b3a99c" ;
+  // The engine's verdict. Semantic colour, deliberately not the honey accent.
+  part pill-ok {
+    background : "#22301f" ;
+    color : "#6fb489" ;
     font-size : 12 ;
-    padding : 6 ;
+    font-weight : bold ;
+    padding : 3 ;
+    border-radius : 20 ;
+  }
+  part pill-warn {
+    background : "#3a221c" ;
+    color : "#e26a52" ;
+    font-size : 12 ;
+    font-weight : bold ;
+    padding : 3 ;
+    border-radius : 20 ;
+  }
+
+  // ── segmented view switch ───────────────────────────────────────────────
+  part seg {
+    gap : 2 ;
+    align : center-vertical ;
+    background : "#2d271f" ;
+    padding : 3 ;
     border-width : 1 ;
     border-color : "#352e25" ;
+    border-radius : 10 ;
+  }
+  part seg-list-on {
+    background : "#252019" ;
+    color : "#f1ebe1" ;
+    font-size : 13 ;
+    font-weight : bold ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    box-shadow : "0 1px 2px rgba(0,0,0,.4)" ;
+  }
+  part seg-tl-on {
+    background : "#252019" ;
+    color : "#f1ebe1" ;
+    font-size : 13 ;
+    font-weight : bold ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    box-shadow : "0 1px 2px rgba(0,0,0,.4)" ;
+  }
+  part seg-list-off {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+  part seg-tl-off {
+    background : "transparent" ;
+    color : "#b3a99c" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#f1ebe1" ;
+    }
+  }
+
+  // ── list ────────────────────────────────────────────────────────────────
+  part list-wrap {
+    max-width : 760 ;
+    gap : 16 ;
+  }
+  part composer {
+    gap : 8 ;
+    align : center-vertical ;
+    background : "#252019" ;
+    padding : 8 ;
+    border-width : 1 ;
+    border-color : "#352e25" ;
+    border-radius : 13 ;
+    box-shadow : "0 1px 2px rgba(0,0,0,.35), 0 4px 14px rgba(0,0,0,.35)" ;
+  }
+  part name-input {
+    width : 100% ;
+    background : "transparent" ;
+    color : "#f1ebe1" ;
+    font-size : 14 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 8 ;
+  }
+  part due-input {
+    width : 150 ;
+    flex-shrink : 0 ;
+    background : "transparent" ;
+    color : "#f1ebe1" ;
+    font-size : 14 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-left-width : 1 ;
+    border-left-color : "#2c2620" ;
+    border-left-style : "solid" ;
+  }
+  part add-btn {
+    background : "#eaa63f" ;
+    color : "#1a1714" ;
+    font-size : 13 ;
+    font-weight : bold ;
+    padding : 8 ;
+    border-width : 0 ;
+    border-radius : 8 ;
+    state hover {
+      background : "#d4922f" ;
+    }
+  }
+
+  part task-list {
+    gap : 7 ;
+  }
+  // Section heading between groups — the engine decides the grouping.
+  part group-head {
+    font-size : 11 ;
+    font-weight : bold ;
+    color : "#867c70" ;
+    letter-spacing : "0.07em" ;
+    text-transform : "uppercase" ;
+    padding : 10 ;
+  }
+  part task-card {
+    background : "#252019" ;
+    border-width : 1 ;
+    border-color : "#352e25" ;
+    border-radius : 13 ;
+    box-shadow : "0 1px 2px rgba(0,0,0,.35), 0 4px 14px rgba(0,0,0,.35)" ;
+  }
+  part task-row {
+    gap : 10 ;
+    align : center-vertical ;
+    padding : 12 ;
+  }
+  // The completion toggle — a round control whose label is the engine's glyph.
+  part toggle {
+    background : "transparent" ;
+    color : "#6fb489" ;
+    font-size : 14 ;
+    padding : 3 ;
+    border-width : 2 ;
+    border-color : "#4a4136" ;
     border-radius : 20 ;
     state hover {
       border-color : "#eaa63f" ;
+    }
+  }
+  part task-name {
+    width : 100% ;
+    background : "transparent" ;
+    color : "#f1ebe1" ;
+    font-size : 14 ;
+    text-align : "left" ;
+    padding : 4 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
       color : "#eaa63f" ;
     }
   }
-  // ── Timeline (Gantt) ──────────────────────────────────────────────────
-  part timeline {
-    gap : 6 ;
+  // Meta chips: due is honey (time), schedule a quiet surface, overdue the one place
+  // semantic red appears in a row.
+  part chip-due {
+    background : "#3a2c17" ;
+    color : "#eaa63f" ;
+    font-size : 11 ;
+    font-weight : bold ;
+    padding : 4 ;
+    border-radius : 20 ;
+  }
+  part chip-sched {
+    background : "#2d271f" ;
+    color : "#b3a99c" ;
+    font-size : 11 ;
+    padding : 4 ;
+    border-radius : 20 ;
+  }
+  part chip-over {
+    background : "#3a221c" ;
+    color : "#e26a52" ;
+    font-size : 11 ;
+    font-weight : bold ;
+    padding : 4 ;
+    border-radius : 20 ;
+  }
+  part del-btn {
+    background : "transparent" ;
+    color : "#867c70" ;
+    font-size : 12 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 8 ;
+    state hover {
+      background : "#3a221c" ;
+      color : "#e26a52" ;
+    }
+  }
+
+  // ── progressive disclosure ──────────────────────────────────────────────
+  part task-detail {
+    background : "#2d271f" ;
+    border-top-width : 1 ;
+    border-top-color : "#2c2620" ;
+    border-top-style : "solid" ;
+    padding : 14 ;
+    gap : 5 ;
+  }
+  part detail-sched {
+    color : "#b3a99c" ;
+    font-size : 12 ;
+  }
+  part detail-slack {
+    color : "#b3a99c" ;
+    font-size : 12 ;
+  }
+  part detail-free {
+    color : "#867c70" ;
+    font-size : 12 ;
+  }
+
+  // ── timeline ────────────────────────────────────────────────────────────
+  part timeline-card {
+    background : "#252019" ;
+    padding : 16 ;
+    gap : 8 ;
+    border-width : 1 ;
+    border-color : "#352e25" ;
+    border-radius : 13 ;
+    box-shadow : "0 1px 2px rgba(0,0,0,.35), 0 4px 14px rgba(0,0,0,.35)" ;
   }
   part tl-scale {
     color : "#867c70" ;
@@ -159,11 +422,12 @@ style TaskApp {
     color : "#f1ebe1" ;
     font-size : 13 ;
     width : 150 ;
+    flex-shrink : 0 ;
   }
   // The shared track every bar is measured against. Bars are positioned by a
-  // percentage pad, so the track must be a fixed, common width.
+  // percentage pad, so the track is one common width for every row.
   part tl-track {
-    width : 420 ;
+    width : 100% ;
     background : "#2d271f" ;
     border-radius : 6 ;
   }
@@ -183,89 +447,7 @@ style TaskApp {
   part tl-window {
     color : "#b3a99c" ;
     font-size : 11 ;
-  }
-  part task-list {
-    gap : 8 ;
-  }
-  part task-row {
-    gap : 10 ;
-    align : center-vertical ;
-  }
-  // The completion toggle — a round button whose label is the engine's done glyph.
-  part toggle {
-    background : "#252019" ;
-    color : "#6fb489" ;
-    font-size : 15 ;
-    padding : 6 ;
-    border-width : 2 ;
-    border-color : "#4a4136" ;
-    border-radius : 20 ;
-    state hover {
-      border-color : "#eaa63f" ;
-    }
-  }
-  part task-name {
-    background : "#252019" ;
-    color : "#f1ebe1" ;
-    font-size : 14 ;
-    padding : 4 ;
-    border-radius : 7 ;
-    state hover {
-      background : "#3a2c17" ;
-      color : "#eaa63f" ;
-    }
-  }
-  // Meta chips. Due is honey (time), schedule is a quiet surface, overdue is the
-  // one place semantic red appears in a row.
-  part chip-due {
-    background : "#3a2c17" ;
-    color : "#eaa63f" ;
-    font-size : 12 ;
-    padding : 5 ;
-    border-radius : 20 ;
-  }
-  part chip-sched {
-    background : "#2d271f" ;
-    color : "#b3a99c" ;
-    font-size : 12 ;
-    padding : 5 ;
-    border-radius : 20 ;
-  }
-  part chip-over {
-    background : "#3a221c" ;
-    color : "#e26a52" ;
-    font-size : 12 ;
-    font-weight : bold ;
-    padding : 5 ;
-    border-radius : 20 ;
-  }
-  // Progressive disclosure: the scheduling detail, inset under its row.
-  part task-detail {
-    background : "#2d271f" ;
-    border-radius : 11 ;
-    padding : 12 ;
-    gap : 4 ;
-  }
-  part detail-sched {
-    color : "#b3a99c" ;
-    font-size : 12 ;
-  }
-  part detail-slack {
-    color : "#b3a99c" ;
-    font-size : 12 ;
-  }
-  part detail-free {
-    color : "#b3a99c" ;
-    font-size : 12 ;
-  }
-  part del-btn {
-    background : "#3a221c" ;
-    color : "#e26a52" ;
-    font-weight : bold ;
-    padding : 10 ;
-    border-radius : 9 ;
-    state hover {
-      background : "#4a2a22" ;
-    }
+    width : 190 ;
+    flex-shrink : 0 ;
   }
 }

--- a/code/programs/mosaic/task-app/src/TaskApp.light.msl
+++ b/code/programs/mosaic/task-app/src/TaskApp.light.msl
@@ -1,151 +1,414 @@
 // TaskApp — styling (mosstyle), light theme. Parts match the [ part-name ] labels
-// in TaskApp.mll.
+// in TaskApp.mll, and TaskApp.dark.msl mirrors this file part-for-part.
 //
-// The "warm & approachable" identity from code/specs/task-app-ui-design.md: warm
-// paper ground, crisp warm-white surfaces, warm-charcoal ink, and a single honey
-// accent (#e0942a) spent only on the primary action and active affordances.
-// Semantic red (#cf4b34) is a separate axis, used only for the destructive Delete.
+// The "warm & approachable" identity from code/specs/task-app-ui-design.md: a warm
+// paper ground, crisp warm-white cards, warm-charcoal ink, and a single honey accent
+// (#e0942a) spent only on *now* — the active project, the primary action, focus.
+// Semantic colour is a separate axis: sage for on-track, red for critical/overdue.
+// Shadows carry a brown tint rather than neutral black, so they sit in the same warm
+// world instead of greying the page.
 
 style TaskApp {
+  // ── shell ───────────────────────────────────────────────────────────────
   part app-shell {
     background : "#f0ebe3" ;
     color : "#2b2723" ;
     font-family : "-apple-system, Segoe UI, system-ui, sans-serif" ;
-    padding : 28 ;
-    gap : 16 ;
+    min-height : "100vh" ;
   }
-  part project-bar {
-    gap : 8 ;
+  part rail {
+    width : 236 ;
+    flex-shrink : 0 ;
+    padding : 20 ;
+    gap : 18 ;
+    border-right-width : 1 ;
+    border-right-color : "#e6ded3" ;
+    border-right-style : "solid" ;
+  }
+  part main {
+    flex-grow : 1 ;
+    min-width : 0 ;
+    padding : 20 ;
+    gap : 14 ;
+  }
+  part content {
+    gap : 14 ;
+  }
+
+  // ── brand ───────────────────────────────────────────────────────────────
+  part brand {
+    gap : 10 ;
     align : center-vertical ;
+    padding : 4 ;
   }
-  // The project you are looking at: honey fill, so "where am I" is answerable at a
-  // glance. The others stay quiet surfaces.
-  part project-on {
+  part brand-mark {
+    width : 28 ;
+    height : 28 ;
+    border-radius : 8 ;
     background : "#e0942a" ;
-    color : "#ffffff" ;
-    font-size : 13 ;
+    box-shadow : "0 1px 2px rgba(60,45,25,.06), 0 4px 14px rgba(60,45,25,.06)" ;
+  }
+  part brand-name {
+    font-size : 15 ;
     font-weight : bold ;
-    padding : 8 ;
-    border-radius : 20 ;
-  }
-  part project-off {
-    background : "#fffdfa" ;
-    color : "#6a625a" ;
-    font-size : 13 ;
-    padding : 8 ;
-    border-width : 1 ;
-    border-color : "#e6ded3" ;
-    border-radius : 20 ;
-    state hover {
-      border-color : "#e0942a" ;
-      color : "#2b2723" ;
-    }
-  }
-  part project-input {
-    background : "#fffdfa" ;
     color : "#2b2723" ;
-    font-size : 13 ;
-    padding : 8 ;
-    border-width : 1 ;
-    border-color : "#e6ded3" ;
-    border-radius : 9 ;
-    state focused {
-      border-color : "#e0942a" ;
-    }
   }
-  part project-add {
-    background : "#f7f2ea" ;
-    color : "#b6741a" ;
-    font-size : 13 ;
+
+  // ── rail: projects ──────────────────────────────────────────────────────
+  part rail-label {
+    font-size : 10 ;
     font-weight : bold ;
-    padding : 8 ;
-    border-radius : 9 ;
-    state hover {
-      background : "#faedd6" ;
-    }
+    color : "#9b9289" ;
+    letter-spacing : "0.08em" ;
+    text-transform : "uppercase" ;
+    padding : 4 ;
+  }
+  part rail-projects {
+    gap : 2 ;
+  }
+  part rail-row {
+    gap : 4 ;
+    align : center-vertical ;
   }
   part project-indent {
     color : "#9b9289" ;
     font-size : 13 ;
   }
-  part project-sub {
-    background : "#f7f2ea" ;
+  // The project you are looking at. Honey fill, so "where am I" is answerable at a
+  // glance; the rest stay quiet until hovered.
+  part project-on {
+    width : 100% ;
+    background : "#e0942a" ;
+    color : "#ffffff" ;
+    font-size : 13 ;
+    font-weight : bold ;
+    text-align : "left" ;
+    padding : 8 ;
+    border-radius : 8 ;
+    border-width : 0 ;
+    box-shadow : "0 1px 2px rgba(60,45,25,.06)" ;
+  }
+  part project-off {
+    width : 100% ;
+    background : "transparent" ;
     color : "#6a625a" ;
     font-size : 13 ;
+    text-align : "left" ;
     padding : 8 ;
-    border-radius : 9 ;
+    border-radius : 8 ;
+    border-width : 0 ;
+    state hover {
+      background : "#e8e0d4" ;
+      color : "#2b2723" ;
+    }
+  }
+  part rail-composer {
+    gap : 6 ;
+    align : center-vertical ;
+  }
+  part project-input {
+    width : 100% ;
+    background : "#fffdfa" ;
+    color : "#2b2723" ;
+    font-size : 12 ;
+    padding : 7 ;
+    border-width : 1 ;
+    border-color : "#e6ded3" ;
+    border-radius : 8 ;
+    state focused {
+      border-color : "#e0942a" ;
+    }
+  }
+  part project-add {
+    background : "#fffdfa" ;
+    color : "#b6741a" ;
+    font-size : 15 ;
+    font-weight : bold ;
+    padding : 6 ;
+    border-width : 1 ;
+    border-color : "#e6ded3" ;
+    border-radius : 8 ;
     state hover {
       background : "#faedd6" ;
+      border-color : "#e0942a" ;
+    }
+  }
+  part project-sub {
+    background : "transparent" ;
+    color : "#9b9289" ;
+    font-size : 12 ;
+    text-align : "left" ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 8 ;
+    state hover {
       color : "#b6741a" ;
     }
+  }
+
+  // ── topbar ──────────────────────────────────────────────────────────────
+  part topbar {
+    gap : 16 ;
+    align : center-vertical ;
+    padding : 4 ;
+  }
+  part title-block {
+    width : 100% ;
+    gap : 3 ;
   }
   part title {
     font-size : 22 ;
     font-weight : bold ;
     color : "#2b2723" ;
+    letter-spacing : "-0.02em" ;
   }
-  part add-row {
+  part subline {
     gap : 8 ;
     align : center-vertical ;
-  }
-  part name-input {
-    background : "#fffdfa" ;
-    color : "#2b2723" ;
-    font-size : 14 ;
-    padding : 10 ;
-    border-width : 1 ;
-    border-color : "#e6ded3" ;
-    border-radius : 9 ;
-    state focused {
-      border-color : "#e0942a" ;
-    }
-  }
-  part due-input {
-    background : "#fffdfa" ;
-    color : "#2b2723" ;
-    font-size : 14 ;
-    padding : 10 ;
-    border-width : 1 ;
-    border-color : "#e6ded3" ;
-    border-radius : 9 ;
-    state focused {
-      border-color : "#e0942a" ;
-    }
-  }
-  part add-btn {
-    background : "#e0942a" ;
-    color : "#ffffff" ;
-    font-weight : bold ;
-    padding : 10 ;
-    border-radius : 9 ;
-    state hover {
-      background : "#c67f1e" ;
-    }
   }
   part summary {
     color : "#6a625a" ;
     font-size : 13 ;
   }
-  part summary-row {
-    gap : 10 ;
-    align : center-vertical ;
-  }
-  part view-toggle {
-    background : "#fffdfa" ;
-    color : "#6a625a" ;
+  // The engine's verdict. Semantic colour, deliberately not the honey accent.
+  part pill-ok {
+    background : "#e4efe7" ;
+    color : "#4f8e6a" ;
     font-size : 12 ;
-    padding : 6 ;
+    font-weight : bold ;
+    padding : 3 ;
+    border-radius : 20 ;
+  }
+  part pill-warn {
+    background : "#f8e4df" ;
+    color : "#cf4b34" ;
+    font-size : 12 ;
+    font-weight : bold ;
+    padding : 3 ;
+    border-radius : 20 ;
+  }
+
+  // ── segmented view switch ───────────────────────────────────────────────
+  part seg {
+    gap : 2 ;
+    align : center-vertical ;
+    background : "#f7f2ea" ;
+    padding : 3 ;
     border-width : 1 ;
     border-color : "#e6ded3" ;
+    border-radius : 10 ;
+  }
+  part seg-list-on {
+    background : "#fffdfa" ;
+    color : "#2b2723" ;
+    font-size : 13 ;
+    font-weight : bold ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    box-shadow : "0 1px 2px rgba(60,45,25,.07)" ;
+  }
+  part seg-tl-on {
+    background : "#fffdfa" ;
+    color : "#2b2723" ;
+    font-size : 13 ;
+    font-weight : bold ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    box-shadow : "0 1px 2px rgba(60,45,25,.07)" ;
+  }
+  part seg-list-off {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+  part seg-tl-off {
+    background : "transparent" ;
+    color : "#6a625a" ;
+    font-size : 13 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
+      color : "#2b2723" ;
+    }
+  }
+
+  // ── list ────────────────────────────────────────────────────────────────
+  part list-wrap {
+    max-width : 760 ;
+    gap : 16 ;
+  }
+  part composer {
+    gap : 8 ;
+    align : center-vertical ;
+    background : "#fffdfa" ;
+    padding : 8 ;
+    border-width : 1 ;
+    border-color : "#e6ded3" ;
+    border-radius : 13 ;
+    box-shadow : "0 1px 2px rgba(60,45,25,.05), 0 4px 14px rgba(60,45,25,.05)" ;
+  }
+  part name-input {
+    width : 100% ;
+    background : "transparent" ;
+    color : "#2b2723" ;
+    font-size : 14 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 8 ;
+  }
+  part due-input {
+    width : 150 ;
+    flex-shrink : 0 ;
+    background : "transparent" ;
+    color : "#2b2723" ;
+    font-size : 14 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-left-width : 1 ;
+    border-left-color : "#efe8dd" ;
+    border-left-style : "solid" ;
+  }
+  part add-btn {
+    background : "#e0942a" ;
+    color : "#ffffff" ;
+    font-size : 13 ;
+    font-weight : bold ;
+    padding : 8 ;
+    border-width : 0 ;
+    border-radius : 8 ;
+    state hover {
+      background : "#c67f1e" ;
+    }
+  }
+
+  part task-list {
+    gap : 7 ;
+  }
+  // Section heading between groups — the engine decides the grouping.
+  part group-head {
+    font-size : 11 ;
+    font-weight : bold ;
+    color : "#9b9289" ;
+    letter-spacing : "0.07em" ;
+    text-transform : "uppercase" ;
+    padding : 10 ;
+  }
+  part task-card {
+    background : "#fffdfa" ;
+    border-width : 1 ;
+    border-color : "#e6ded3" ;
+    border-radius : 13 ;
+    box-shadow : "0 1px 2px rgba(60,45,25,.05), 0 4px 14px rgba(60,45,25,.05)" ;
+  }
+  part task-row {
+    gap : 10 ;
+    align : center-vertical ;
+    padding : 12 ;
+  }
+  // The completion toggle — a round control whose label is the engine's glyph.
+  part toggle {
+    background : "transparent" ;
+    color : "#4f8e6a" ;
+    font-size : 14 ;
+    padding : 3 ;
+    border-width : 2 ;
+    border-color : "#c7bfb4" ;
     border-radius : 20 ;
     state hover {
       border-color : "#e0942a" ;
+    }
+  }
+  part task-name {
+    width : 100% ;
+    background : "transparent" ;
+    color : "#2b2723" ;
+    font-size : 14 ;
+    text-align : "left" ;
+    padding : 4 ;
+    border-width : 0 ;
+    border-radius : 7 ;
+    state hover {
       color : "#b6741a" ;
     }
   }
-  // ── Timeline (Gantt) ──────────────────────────────────────────────────
-  part timeline {
-    gap : 6 ;
+  // Meta chips: due is honey (time), schedule a quiet surface, overdue the one place
+  // semantic red appears in a row.
+  part chip-due {
+    background : "#faedd6" ;
+    color : "#b6741a" ;
+    font-size : 11 ;
+    font-weight : bold ;
+    padding : 4 ;
+    border-radius : 20 ;
+  }
+  part chip-sched {
+    background : "#f7f2ea" ;
+    color : "#6a625a" ;
+    font-size : 11 ;
+    padding : 4 ;
+    border-radius : 20 ;
+  }
+  part chip-over {
+    background : "#f8e4df" ;
+    color : "#cf4b34" ;
+    font-size : 11 ;
+    font-weight : bold ;
+    padding : 4 ;
+    border-radius : 20 ;
+  }
+  part del-btn {
+    background : "transparent" ;
+    color : "#9b9289" ;
+    font-size : 12 ;
+    padding : 6 ;
+    border-width : 0 ;
+    border-radius : 8 ;
+    state hover {
+      background : "#f8e4df" ;
+      color : "#cf4b34" ;
+    }
+  }
+
+  // ── progressive disclosure ──────────────────────────────────────────────
+  part task-detail {
+    background : "#f7f2ea" ;
+    border-top-width : 1 ;
+    border-top-color : "#efe8dd" ;
+    border-top-style : "solid" ;
+    padding : 14 ;
+    gap : 5 ;
+  }
+  part detail-sched {
+    color : "#6a625a" ;
+    font-size : 12 ;
+  }
+  part detail-slack {
+    color : "#6a625a" ;
+    font-size : 12 ;
+  }
+  part detail-free {
+    color : "#9b9289" ;
+    font-size : 12 ;
+  }
+
+  // ── timeline ────────────────────────────────────────────────────────────
+  part timeline-card {
+    background : "#fffdfa" ;
+    padding : 16 ;
+    gap : 8 ;
+    border-width : 1 ;
+    border-color : "#e6ded3" ;
+    border-radius : 13 ;
+    box-shadow : "0 1px 2px rgba(60,45,25,.05), 0 4px 14px rgba(60,45,25,.05)" ;
   }
   part tl-scale {
     color : "#9b9289" ;
@@ -159,11 +422,12 @@ style TaskApp {
     color : "#2b2723" ;
     font-size : 13 ;
     width : 150 ;
+    flex-shrink : 0 ;
   }
   // The shared track every bar is measured against. Bars are positioned by a
-  // percentage pad, so the track must be a fixed, common width.
+  // percentage pad, so the track is one common width for every row.
   part tl-track {
-    width : 420 ;
+    width : 100% ;
     background : "#f7f2ea" ;
     border-radius : 6 ;
   }
@@ -183,89 +447,7 @@ style TaskApp {
   part tl-window {
     color : "#6a625a" ;
     font-size : 11 ;
-  }
-  part task-list {
-    gap : 8 ;
-  }
-  part task-row {
-    gap : 10 ;
-    align : center-vertical ;
-  }
-  // The completion toggle — a round button whose label is the engine's done glyph.
-  part toggle {
-    background : "#fffdfa" ;
-    color : "#4f8e6a" ;
-    font-size : 15 ;
-    padding : 6 ;
-    border-width : 2 ;
-    border-color : "#c7bfb4" ;
-    border-radius : 20 ;
-    state hover {
-      border-color : "#e0942a" ;
-    }
-  }
-  part task-name {
-    background : "#fffdfa" ;
-    color : "#2b2723" ;
-    font-size : 14 ;
-    padding : 4 ;
-    border-radius : 7 ;
-    state hover {
-      background : "#faedd6" ;
-      color : "#b6741a" ;
-    }
-  }
-  // Meta chips. Due is honey (time), schedule is a quiet surface, overdue is the
-  // one place semantic red appears in a row.
-  part chip-due {
-    background : "#faedd6" ;
-    color : "#b6741a" ;
-    font-size : 12 ;
-    padding : 5 ;
-    border-radius : 20 ;
-  }
-  part chip-sched {
-    background : "#f7f2ea" ;
-    color : "#6a625a" ;
-    font-size : 12 ;
-    padding : 5 ;
-    border-radius : 20 ;
-  }
-  part chip-over {
-    background : "#f8e4df" ;
-    color : "#cf4b34" ;
-    font-size : 12 ;
-    font-weight : bold ;
-    padding : 5 ;
-    border-radius : 20 ;
-  }
-  // Progressive disclosure: the scheduling detail, inset under its row.
-  part task-detail {
-    background : "#f7f2ea" ;
-    border-radius : 11 ;
-    padding : 12 ;
-    gap : 4 ;
-  }
-  part detail-sched {
-    color : "#6a625a" ;
-    font-size : 12 ;
-  }
-  part detail-slack {
-    color : "#6a625a" ;
-    font-size : 12 ;
-  }
-  part detail-free {
-    color : "#6a625a" ;
-    font-size : 12 ;
-  }
-  part del-btn {
-    background : "#f8e4df" ;
-    color : "#cf4b34" ;
-    font-weight : bold ;
-    padding : 10 ;
-    border-radius : 9 ;
-    state hover {
-      background : "#f1cabf" ;
-    }
+    width : 190 ;
+    flex-shrink : 0 ;
   }
 }

--- a/code/programs/mosaic/task-app/src/TaskApp.mil
+++ b/code/programs/mosaic/task-app/src/TaskApp.mil
@@ -23,8 +23,12 @@ component TaskApp {
   slot project-rows     : list<list<text>> ;
   slot new-project-name : text ;
 
-  // A one-line summary (counts, project finish).
-  slot summary : text ;
+  // A one-line summary (counts, project finish), plus the engine's verdict on the
+  // plan rendered as a pill. `status-warn` is non-empty when that verdict is bad
+  // news, which is the layout's cue to colour it as a warning rather than as OK.
+  slot summary      : text ;
+  slot status-label : text ;
+  slot status-warn  : text ;
 
   // Timeline (Gantt). `timeline-mode` is non-empty when the timeline is showing instead
   // of the task list, and `view-toggle-label` names the view you'd switch TO.
@@ -37,7 +41,6 @@ component TaskApp {
   slot timeline-mode     : text ;
   slot timeline-scale    : text ;
   slot timeline-rows     : list<list<text>> ;
-  slot view-toggle-label : text ;
 
   // One row per task, in schedule order. Each row is a list of pre-formatted cells:
   //
@@ -45,7 +48,8 @@ component TaskApp {
   //   [ 1 ] name            [ 6 ] detail: scheduled / earliest / latest
   //   [ 2 ] due             [ 7 ] detail: slack, or "on the critical path"
   //   [ 3 ] schedule        [ 8 ] detail: free slack (only when it differs)
-  //   [ 4 ] overdue
+  //   [ 4 ] overdue         [ 9 ] group heading — present ONLY on the row that
+  //                               opens a group, so the list reads as sections
   //
   // Every cell is optional: an empty one (no due date, not overdue, nothing to add)
   // is the empty string and the layout hides it. Cells 6-8 are the
@@ -65,8 +69,10 @@ component TaskApp {
   emit onAddSubproject ;
   emit onSelectProject ( index : number ) ;
 
-  // Switch between the task list and the timeline.
-  emit onToggleView ;
+  // Choose a view. Two explicit events rather than one toggle, so clicking the view
+  // you are already on is a no-op instead of switching away from it.
+  emit onShowList ;
+  emit onShowTimeline ;
 
   // Expand (or collapse) a task row to reveal its scheduling detail.
   emit onExpandTask ( index : number ) ;

--- a/code/programs/mosaic/task-app/src/TaskApp.mll
+++ b/code/programs/mosaic/task-app/src/TaskApp.mll
@@ -1,128 +1,171 @@
 // TaskApp — layout (moslayout).
 //
-// One screen: a header, an add-row (name + optional due date + Add), a summary line,
-// and the auto-scheduled task list. Clicking a row toggles done; Delete removes it.
+// The shell follows code/specs/task-app-ui-design.md: a quiet left RAIL holding the
+// workspace's projects, and a MAIN column with a topbar (title, summary, status,
+// view switch) over the content. Exactly one view shows at a time.
+//
+// Everything here is a renderer. Grouping, ordering, formatting, scheduling and the
+// status verdict all arrive already decided by the engine; the layout only places them.
 
 layout TaskApp {
-  Column [ app-shell ] {
-    // Projects. One button per project — the active one styled as selected via the
-    // row's marker cell — plus an inline composer for creating another. Selecting is
-    // by row index, matching how task rows report which row was acted on.
-    Row [ project-bar ] {
-      For ( each: slot: project-rows , as: p , index: pi ) {
-        // A nested project gets a leading glyph; a top-level one has an empty indent
-        // cell and so renders nothing, keeping the row flush left.
-        If ( when: ( p[2] ) ) {
-          Text [ project-indent ] ( content : ( p[2] ) )
+  Row [ app-shell ] {
+
+    // ── RAIL ────────────────────────────────────────────────────────────────
+    Column [ rail ] {
+      Row [ brand ] {
+        Box [ brand-mark ] { }
+        Text [ brand-name ] ( content : "Planner" )
+      }
+
+      Text [ rail-label ] ( content : "Projects" )
+      Column [ rail-projects ] {
+        For ( each: slot: project-rows , as: p , index: pi ) {
+          Row [ rail-row ] {
+            // A nested project gets a leading glyph; a top-level one has an empty
+            // indent cell and renders nothing, keeping the row flush left.
+            If ( when: ( p[2] ) ) {
+              Text [ project-indent ] ( content : ( p[2] ) )
+            }
+            If ( when: ( p[1] ) ) {
+              HostButton [ project-on ] ( label : ( p[0] ) , onClick : emit: onSelectProject )
+            }
+            Else {
+              HostButton [ project-off ] ( label : ( p[0] ) , onClick : emit: onSelectProject )
+            }
+          }
         }
-        If ( when: ( p[1] ) ) {
-          HostButton [ project-on ] ( label : ( p[0] ) , onClick : emit: onSelectProject )
+      }
+
+      Row [ rail-composer ] {
+        HostInput [ project-input ] (
+          value : slot: new-project-name ,
+          placeholder : "New project" ,
+          onChange : emit: onNewProjectNameChange
+        )
+        HostButton [ project-add ] ( label : "+" , onClick : emit: onAddProject )
+      }
+      HostButton [ project-sub ] ( label : "+ Sub-project" , onClick : emit: onAddSubproject )
+    }
+
+    // ── MAIN ────────────────────────────────────────────────────────────────
+    Column [ main ] {
+      Row [ topbar ] {
+        Column [ title-block ] {
+          Text [ title ] ( content : slot: app-title , a11y-role : heading )
+          Row [ subline ] {
+            Text [ summary ] ( content : slot: summary )
+            // The engine's own verdict, coloured by tone: a warning reads red.
+            If ( when: slot: status-warn ) {
+              Text [ pill-warn ] ( content : slot: status-label )
+            }
+            Else {
+              Text [ pill-ok ] ( content : slot: status-label )
+            }
+          }
+        }
+
+        // Segmented view switch. Two explicit emits rather than one toggle, so
+        // clicking the view you are already on is a no-op instead of a swap.
+        Row [ seg ] {
+          // Part names are unique layout-wide, even across mutually-exclusive
+          // branches, so each of the four states gets its own name.
+          If ( when: slot: timeline-mode ) {
+            HostButton [ seg-list-off ] ( label : "List" , onClick : emit: onShowList )
+            HostButton [ seg-tl-on ] ( label : "Timeline" , onClick : emit: onShowTimeline )
+          }
+          Else {
+            HostButton [ seg-list-on ] ( label : "List" , onClick : emit: onShowList )
+            HostButton [ seg-tl-off ] ( label : "Timeline" , onClick : emit: onShowTimeline )
+          }
+        }
+      }
+
+      Column [ content ] {
+        If ( when: slot: timeline-mode ) {
+          Column [ timeline-card ] {
+            Text [ tl-scale ] ( content : slot: timeline-scale )
+            For ( each: slot: timeline-rows , as: t , index: ti ) {
+              Row [ timeline-row ] {
+                Text [ tl-name ] ( content : ( t[0] ) )
+                // A real proportional bar: the leading pad and the bar take their
+                // widths from the row's data (UI36 data-driven sizing), both as
+                // percentages of the shared track, so every bar sits on one date
+                // scale. A critical bar differs only in colour — geometry is equal.
+                Row [ tl-track ] {
+                  Box [ tl-pad ] ( width : ( t[1] ) )
+                  If ( when: ( t[4] ) ) {
+                    Box [ tl-bar-crit ] ( width : ( t[2] ) )
+                  }
+                  Else {
+                    Box [ tl-bar ] ( width : ( t[2] ) )
+                  }
+                }
+                Text [ tl-window ] ( content : ( t[3] ) )
+              }
+            }
+          }
         }
         Else {
-          HostButton [ project-off ] ( label : ( p[0] ) , onClick : emit: onSelectProject )
-        }
-      }
-      HostInput [ project-input ] (
-        value : slot: new-project-name ,
-        placeholder : "New project" ,
-        onChange : emit: onNewProjectNameChange
-      )
-      HostButton [ project-add ] ( label : "+ Project" , onClick : emit: onAddProject )
-      HostButton [ project-sub ] ( label : "+ Sub" , onClick : emit: onAddSubproject )
-    }
+          Column [ list-wrap ] {
+            Row [ composer ] {
+              HostInput [ name-input ] (
+                value : slot: new-task-name ,
+                placeholder : "What needs doing?" ,
+                onChange : emit: onNewTaskNameChange
+              )
+              HostInput [ due-input ] (
+                value : slot: new-task-due ,
+                placeholder : "Due (optional)" ,
+                onChange : emit: onNewTaskDueChange
+              )
+              HostButton [ add-btn ] ( label : "Add task" , onClick : emit: onAddTask )
+            }
 
-    Text [ title ] ( content : slot: app-title , a11y-role : heading )
-
-    Row [ add-row ] {
-      HostInput [ name-input ] (
-        value : slot: new-task-name ,
-        placeholder : "What needs doing?" ,
-        onChange : emit: onNewTaskNameChange
-      )
-      HostInput [ due-input ] (
-        value : slot: new-task-due ,
-        placeholder : "Due YYYY-MM-DD (optional)" ,
-        onChange : emit: onNewTaskDueChange
-      )
-      HostButton [ add-btn ] ( label : "Add" , onClick : emit: onAddTask )
-    }
-
-    Row [ summary-row ] {
-      Text [ summary ] ( content : slot: summary )
-      HostButton [ view-toggle ] (
-        label : slot: view-toggle-label ,
-        onClick : emit: onToggleView
-      )
-    }
-
-    // The timeline and the task list are the two views of the same project; exactly one
-    // shows at a time, chosen by the non-empty `timeline-mode` marker.
-    If ( when: slot: timeline-mode ) {
-      Column [ timeline ] {
-        Text [ tl-scale ] ( content : slot: timeline-scale )
-        For ( each: slot: timeline-rows , as: t , index: ti ) {
-          Row [ timeline-row ] {
-            Text [ tl-name ] ( content : ( t[0] ) )
-            // A real proportional bar: the leading pad and the bar itself take their
-            // widths from the row's data (UI36 data-driven sizing), both as percentages
-            // of the shared track, so every bar lines up on one date scale. A critical
-            // bar differs from a normal one only in colour — the geometry is identical.
-            Row [ tl-track ] {
-              Box [ tl-pad ] ( width : ( t[1] ) )
-              If ( when: ( t[4] ) ) {
-                Box [ tl-bar-crit ] ( width : ( t[2] ) )
+            Column [ task-list ] {
+              For ( each: slot: task-rows , as: row , index: i ) {
+                // A group heading, present only on the row that opens a group — the
+                // engine decides the grouping, so the layout just prints the label
+                // where it is handed one.
+                If ( when: ( row[9] ) ) {
+                  Text [ group-head ] ( content : ( row[9] ) )
+                }
+                Column [ task-card ] {
+                  Row [ task-row ] {
+                    HostButton [ toggle ] ( label : ( row[0] ) , onClick : emit: onToggleTask )
+                    // The name is the disclosure control: it opens this row's detail.
+                    HostButton [ task-name ] ( label : ( row[1] ) , onClick : emit: onExpandTask )
+                    If ( when: ( row[2] ) ) {
+                      Text [ chip-due ] ( content : ( row[2] ) )
+                    }
+                    If ( when: ( row[3] ) ) {
+                      Text [ chip-sched ] ( content : ( row[3] ) )
+                    }
+                    If ( when: ( row[4] ) ) {
+                      Text [ chip-over ] ( content : ( row[4] ) )
+                    }
+                    HostButton [ del-btn ] ( label : "Delete" , onClick : emit: onDeleteTask )
+                  }
+                  // Progressive disclosure: the scheduling detail exists for every
+                  // task but is rendered only for the open row.
+                  If ( when: ( row[5] ) ) {
+                    Column [ task-detail ] {
+                      If ( when: ( row[6] ) ) {
+                        Text [ detail-sched ] ( content : ( row[6] ) )
+                      }
+                      If ( when: ( row[7] ) ) {
+                        Text [ detail-slack ] ( content : ( row[7] ) )
+                      }
+                      If ( when: ( row[8] ) ) {
+                        Text [ detail-free ] ( content : ( row[8] ) )
+                      }
+                    }
+                  }
+                }
               }
-              Else {
-                Box [ tl-bar ] ( width : ( t[2] ) )
-              }
-            }
-            Text [ tl-window ] ( content : ( t[3] ) )
-          }
-        }
-      }
-    }
-    Else {
-
-    Column [ task-list ] {
-      // Each row is a list of cells. The toggle and Delete buttons sit directly in
-      // the For body so their `number` payload carries the outer row index `i`; the
-      // name and the meta chips read individual cells by `( row[n] )`. Each chip is
-      // wrapped in an `If` on its own cell so an empty cell renders nothing at all.
-      For ( each: slot: task-rows , as: row , index: i ) {
-        Row [ task-row ] {
-          HostButton [ toggle ] ( label : ( row[0] ) , onClick : emit: onToggleTask )
-          // The name is the disclosure control: clicking it opens this row's detail.
-          HostButton [ task-name ] ( label : ( row[1] ) , onClick : emit: onExpandTask )
-          If ( when: ( row[2] ) ) {
-            Text [ chip-due ] ( content : ( row[2] ) )
-          }
-          If ( when: ( row[3] ) ) {
-            Text [ chip-sched ] ( content : ( row[3] ) )
-          }
-          If ( when: ( row[4] ) ) {
-            Text [ chip-over ] ( content : ( row[4] ) )
-          }
-          HostButton [ del-btn ] ( label : "Delete" , onClick : emit: onDeleteTask )
-        }
-        // Progressive disclosure: the scheduling detail exists for every task but is
-        // only rendered for the open row, so the default list stays a plain to-do list.
-        If ( when: ( row[5] ) ) {
-          Column [ task-detail ] {
-            // Every line is guarded on its own cell, so an unscheduled task shows one
-            // explanatory line rather than a panel padded with blanks.
-            If ( when: ( row[6] ) ) {
-              Text [ detail-sched ] ( content : ( row[6] ) )
-            }
-            If ( when: ( row[7] ) ) {
-              Text [ detail-slack ] ( content : ( row[7] ) )
-            }
-            If ( when: ( row[8] ) ) {
-              Text [ detail-free ] ( content : ( row[8] ) )
             }
           }
         }
       }
-    }
     }
   }
 }


### PR DESCRIPTION
> *"I want the real app to be closer to the design prototype. The current app is not polished."*

The app had drifted well behind `design/ui-prototype.html`. This closes most of that gap — and fixes two emitter bugs that were quietly preventing it.

## The app

- **Two-column shell.** A quiet left rail holds the workspace's projects (active one honey-filled, nested ones indented) with the new-project composer at its foot; a main column holds the topbar and content.
- **Topbar** — title, summary, and the engine's verdict as a **status pill** (sage "On track", red "N overdue"), plus a real **segmented view switch**. It uses two explicit events rather than one toggle, so clicking the view you're already on is a no-op instead of switching away from it.
- **The list reads as sections** — In progress / Up next / Done — with the heading riding on the row that opens each group.
- **Card treatment throughout** — composer and task cards in warm white with the design's radii and warm-tinted shadows; chips, the round completion toggle, and the disclosure panel all match the prototype.
- Both themes stay in lockstep: **57 parts with identical name *and* property sets**, because the dark theme is generated from the light one by token substitution.
- `index.html` gained the host's only CSS — a margin reset (the shell had been floating 8px off every side) and a pre-hydration background so the first paint isn't white.

## Two styles that were being silently discarded (`mosaic-emit-react`)

Same shape both times: the emitter accepted the author's input and produced nothing, with no diagnostic.

- **`align: center-vertical` emitted `align: "center-vertical"`** — not a CSS property, so browsers dropped it. **Nothing using it was ever actually centred**, on any Mosaic web app. Now translated to `alignItems` (with the other five values mapped alongside); an unknown value still falls through to the escaped generic path.
- **`Text ( content : "literal" )` rendered `<span></span>`.** A literal `content:` returned `None`, and the doc comment claimed the "standard Text walker" handled it — there is no such path. Now emitted as an escaped JS string. It went unnoticed because no `.mll` used a literal `content:` until this rail needed a static wordmark and a section heading — **both came out blank.**

## Caught in security review before pushing

The literal-text bug (I'd otherwise have shipped an app whose brand and section labels were invisible), and that the page ground ignored an explicit theme choice — an OS-dark + user-picked-light combination left the wrong colour behind the app. The app now paints the ground from the resolved theme.

I also re-verified the row-index question hardest, since this app has had a desync before: the list now renders in **group order**, and `getProps` plus toggle/delete/expand all resolve through one `displayIds()` helper whose ranking agrees with the one `getProps` groups by. The sort is stable and runs on a copy, so within-group order stays creation order.

## Verification

196 emitter tests, 28 host tests, clippy clean, both themes compile and emit. Driven in a real browser at 1280px: rail 236px, main 948px, group headings and status pill present, **zero empty spans**, no console errors.

## Known gap

No narrow-viewport handling yet — mosstyle has no media queries, so the rail can't collapse the way the prototype's does below 780px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)