### PR TITLE
Add atomic inline flow for HTML layout

### DIFF
--- a/code/packages/rust/html-to-layout/CHANGELOG.md
+++ b/code/packages/rust/html-to-layout/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.2.0] - 2026-07-29
+
+### Changed
+
+- Inline text now uses content-wrapping width hints so `layout-block` can place
+  text, links, and trailing punctuation on the same line.
+- The parser-to-positioned-layout acceptance test now verifies horizontal link
+  geometry as well as retained navigation metadata.
+
 ## [0.1.0] - 2026-07-29
 
 ### Added

--- a/code/packages/rust/html-to-layout/Cargo.toml
+++ b/code/packages/rust/html-to-layout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "html-to-layout"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Converts html-parser browser render trees into the shared Layout IR."
 

--- a/code/packages/rust/html-to-layout/README.md
+++ b/code/packages/rust/html-to-layout/README.md
@@ -25,11 +25,12 @@ hidden content, stable IDs, and resolved link/resource URLs. Browser metadata
 needed after layout is retained under `LayoutNode.ext["html"]`, so positioned
 nodes still carry link targets and semantic roles for hit testing.
 
-This first bridge intentionally does not implement CSS cascade or a complete
-CSS inline-formatting context. Inline nodes remain explicit layout containers;
-the current `layout-block` engine positions them using its documented v1 block
-flow. A dedicated inline layout pass is the next rendering-fidelity boundary,
-not parser conformance work.
+This bridge intentionally does not implement CSS cascade or a complete CSS
+inline-formatting context. `layout-block` now places consecutive inline nodes
+on shared lines and wraps atomic boxes, which is sufficient to give links
+meaningful horizontal geometry. Word-boundary fragmentation, baseline
+alignment, and splitting a styled inline box across lines remain later
+rendering-fidelity work, not parser conformance work.
 
 ## Verification
 

--- a/code/packages/rust/html-to-layout/src/lib.rs
+++ b/code/packages/rust/html-to-layout/src/lib.rs
@@ -13,7 +13,7 @@ use layout_ir::{
     FontSpec, ImageContent, ImageFit, LayoutNode, SizeValue, TextAlign, TextContent,
 };
 
-pub const VERSION: &str = "0.1.0";
+pub const VERSION: &str = "0.2.0";
 
 /// Fully resolved visual defaults applied before a future CSS cascade exists.
 #[derive(Clone, Debug, PartialEq)]
@@ -153,7 +153,7 @@ fn text_leaf(value: &str, style: &InheritedStyle) -> LayoutNode {
         max_lines: None,
         text_align: TextAlign::Start,
     })
-    .with_width(SizeValue::Fill)
+    .with_width(SizeValue::Wrap)
     .with_height(SizeValue::Wrap)
 }
 
@@ -378,6 +378,12 @@ mod tests {
             vec!["Mosaic lives", "The browser pipeline is", "connected", "."]
         );
         let link = find_positioned_by_html_role(&positioned, "link").unwrap();
+        let leading_text = find_positioned_text(&positioned, "The browser pipeline is").unwrap();
+        let trailing_text = find_positioned_text(&positioned, ".").unwrap();
+        assert_eq!(link.y, leading_text.y);
+        assert_eq!(trailing_text.y, link.y);
+        assert!(link.x > leading_text.x);
+        assert!(trailing_text.x > link.x);
         assert_eq!(
             positioned_html_string(link, "href"),
             Some("https://example.test/status")
@@ -437,6 +443,18 @@ mod tests {
             values.extend(positioned_text(child));
         }
         values
+    }
+
+    fn find_positioned_text<'a>(
+        node: &'a PositionedNode,
+        value: &str,
+    ) -> Option<&'a PositionedNode> {
+        if matches!(&node.content, Some(Content::Text(text)) if text.value == value) {
+            return Some(node);
+        }
+        node.children
+            .iter()
+            .find_map(|child| find_positioned_text(child, value))
     }
 
     fn find_positioned_by_html_role<'a>(

--- a/code/packages/rust/layout-block/CHANGELOG.md
+++ b/code/packages/rust/layout-block/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.2.0] — atomic inline flow
+
+### Added
+- Consecutive `inline`, `inline-text`, and `inline-replaced` children now share
+  a line box and wrap atomically when the next child does not fit.
+- Explicit `line-break` display nodes advance to the next line while remaining
+  in the positioned tree.
+- Inline `Wrap` containers shrink to their occupied content width, preserving
+  useful geometry for links and other semantic inline wrappers.
+
+### Compatibility
+- Nodes without block display metadata remain block-level, preserving the
+  original document-layout behavior.
+- Full text-run fragmentation and baseline alignment remain explicit follow-up
+  work.
+
 ## [0.1.0] — initial release
 
 ### Added

--- a/code/packages/rust/layout-block/Cargo.toml
+++ b/code/packages/rust/layout-block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "layout-block"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "UI07 block-and-inline flow layout. Takes a LayoutNode tree + Constraints + TextMeasurer and produces a PositionedNode tree. The layout model underlying Markdown / rich-text document rendering."
 

--- a/code/packages/rust/layout-block/README.md
+++ b/code/packages/rust/layout-block/README.md
@@ -14,6 +14,9 @@ Spec: [code/specs/UI07-layout-block.md](../../../specs/UI07-layout-block.md).
 Handles:
 - Block containers — stack children vertically with margin collapsing
   between adjacent siblings.
+- Atomic inline flow — consecutive `inline`, `inline-text`, and
+  `inline-replaced` children share line boxes, wrap as units, and honor
+  explicit `line-break` nodes.
 - Nested containers with padding on both outer and inner sides.
 - Text leaves — width/height resolved by the supplied measurer with
   wrap-at-max-width semantics.
@@ -22,18 +25,21 @@ Handles:
   / `min_height` / `max_height` clamping.
 
 Out of scope for v1 (per UI07):
-- Mixed block + inline children with anonymous-block promotion.
+- Text-run fragmentation at word boundaries and splitting one inline box
+  across multiple line boxes.
+- Baseline and `vertical-align` alignment within line boxes.
 - `float` / `clear` / absolute positioning.
 - RTL / bidirectional text.
 - CSS columns.
 - Parent-child margin collapse.
 
-The upstream `document-ast-to-layout` converter produces strictly
-block-or-leaf trees, so the missing inline-flow path is not a blocker
-for Markdown rendering.
+Nodes without `ext["block"]["display"]` remain block-level by default, so
+existing `document-ast-to-layout` output preserves its original geometry.
+`html-to-layout` supplies explicit display metadata for browser content.
 
 ## Tests
 
-14 unit tests cover single leaves, block stacking, margin collapsing,
+18 unit tests cover single leaves, block stacking, atomic inline placement and
+wrapping, margin collapsing,
 nested containers, size hints, min/max clamping, content passthrough,
 empty containers, and a realistic document shape.

--- a/code/packages/rust/layout-block/src/lib.rs
+++ b/code/packages/rust/layout-block/src/lib.rs
@@ -44,21 +44,21 @@
 //! ### Explicit non-goals (v1)
 //!
 //! - `float` / `clear` / absolute positioning
-//! - Mixed block + inline children with anonymous-block promotion. The
-//!   primary upstream producer (`document-ast-to-layout`) already emits
-//!   strictly block-or-leaf trees, so the missing inline-flow path is
-//!   not a blocker for Markdown.
+//! - Full CSS inline formatting: text-run fragmentation, baseline alignment,
+//!   justification, and splitting one inline box across multiple line boxes.
+//!   The bounded inline path implemented here treats each child as an atomic
+//!   inline box and wraps it as a unit.
 //! - RTL / bidi
 //! - CSS columns
 //!
 //! Each exclusion matches the spec's documented non-goals.
 
 use layout_ir::{
-    Constraints, Content, Edges, LayoutNode, MeasureResult, PositionedNode, SizeValue,
+    Constraints, Content, Edges, ExtValue, LayoutNode, MeasureResult, PositionedNode, SizeValue,
     TextContent, TextMeasurer,
 };
 
-pub const VERSION: &str = "0.1.0";
+pub const VERSION: &str = "0.2.0";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Entry point
@@ -123,7 +123,15 @@ fn lay_out_any<M: TextMeasurer>(
     if is_leaf_text {
         if let Some(Content::Text(tc)) = &node.content {
             return lay_out_text_leaf(
-                node, tc, constraints, measurer, x, y, margin, padding, outer_max_width,
+                node,
+                tc,
+                constraints,
+                measurer,
+                x,
+                y,
+                margin,
+                padding,
+                outer_max_width,
                 padding_horizontal,
             );
         }
@@ -149,7 +157,7 @@ fn lay_out_any<M: TextMeasurer>(
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Container layout — stack block children vertically
+// Container layout — block stacking plus bounded atomic inline flow
 // ═══════════════════════════════════════════════════════════════════════════
 
 #[allow(clippy::too_many_arguments)]
@@ -164,27 +172,93 @@ fn lay_out_container<M: TextMeasurer>(
     outer_max_width: f64,
     padding_horizontal: f64,
 ) -> PositionedNode {
-    // Resolve the container's outer width.
+    // Use the full available width while placing children. Inline containers
+    // with `Wrap` width shrink to their occupied line width after placement.
     let outer_width = resolve_container_width(node, outer_max_width);
     let inner_max_width = (outer_width - padding_horizontal).max(0.0);
 
-    // Lay out children in source order, stacking vertically.
+    // Lay out children in source order. Nodes without display metadata retain
+    // the original block-stacking behavior. Consecutive inline-level nodes
+    // share an atomic line box and wrap as units when the next box does not fit.
     let mut children_positioned: Vec<PositionedNode> = Vec::with_capacity(node.children.len());
     let mut cursor_y = padding.top;
+    let mut inline_cursor_x = padding.left;
+    let mut inline_line_height: f64 = 0.0;
+    let mut max_inline_right = padding.left;
     let mut prev_margin_bottom: f64 = 0.0;
-    let mut have_placed_a_child = false;
+    let mut have_placed_block = false;
+    let mut inline_line_open = false;
 
     for child in &node.children {
         let child_margin = child.margin.unwrap_or_default();
+        let child_display = display_value(child);
+
+        if is_inline_level(child_display) || child_display == Some("line-break") {
+            if child_display == Some("line-break") {
+                let mut positioned = lay_out_any(
+                    child,
+                    unconstrained_height(inner_max_width),
+                    measurer,
+                    inline_cursor_x,
+                    cursor_y,
+                );
+                positioned.width = 0.0;
+                positioned.x = inline_cursor_x;
+                positioned.y = cursor_y;
+                let break_height = positioned.height + child_margin.top + child_margin.bottom;
+                children_positioned.push(positioned);
+                cursor_y += inline_line_height.max(break_height);
+                inline_cursor_x = padding.left;
+                inline_line_height = 0.0;
+                inline_line_open = false;
+                have_placed_block = false;
+                prev_margin_bottom = 0.0;
+                continue;
+            }
+
+            let mut positioned = lay_out_any(
+                child,
+                unconstrained_height(inner_max_width),
+                measurer,
+                0.0,
+                0.0,
+            );
+            let item_width = child_margin.left + positioned.width + child_margin.right;
+            let remaining = padding.left + inner_max_width - inline_cursor_x;
+            if inline_line_open && item_width > remaining {
+                cursor_y += inline_line_height;
+                inline_cursor_x = padding.left;
+                inline_line_height = 0.0;
+            }
+
+            positioned.x = inline_cursor_x + child_margin.left;
+            positioned.y = cursor_y + child_margin.top;
+            inline_cursor_x += item_width;
+            inline_line_height =
+                inline_line_height.max(child_margin.top + positioned.height + child_margin.bottom);
+            max_inline_right = max_inline_right.max(inline_cursor_x);
+            inline_line_open = true;
+            have_placed_block = false;
+            prev_margin_bottom = 0.0;
+            children_positioned.push(positioned);
+            continue;
+        }
+
+        if inline_line_open {
+            cursor_y += inline_line_height;
+            inline_cursor_x = padding.left;
+            inline_line_height = 0.0;
+            inline_line_open = false;
+        }
 
         // Margin collapse between adjacent block siblings.
-        let collapsed_top = if have_placed_a_child {
+        let collapsed_top = if have_placed_block {
             collapse_margin(prev_margin_bottom, child_margin.top)
         } else {
             child_margin.top
         };
 
-        if have_placed_a_child {
+        if have_placed_block {
             // Subtract the previously-added margin.bottom because we
             // are replacing it with the collapsed value.
             cursor_y -= prev_margin_bottom;
@@ -196,12 +270,7 @@ fn lay_out_container<M: TextMeasurer>(
         // Child constraints: width-limited by the container's inner
         // content area; height is unconstrained here — the parent
         // accumulates it from children.
-        let child_constraints = Constraints {
-            min_width: 0.0,
-            max_width: inner_max_width,
-            min_height: 0.0,
-            max_height: f64::MAX,
-        };
+        let child_constraints = unconstrained_height(inner_max_width);
 
         // Pass parent-relative x/y to the child. Coordinates are
         // relative to the parent's content-area origin (per UI02
@@ -214,14 +283,25 @@ fn lay_out_container<M: TextMeasurer>(
         cursor_y += positioned.height + child_margin.bottom;
 
         prev_margin_bottom = child_margin.bottom;
-        have_placed_a_child = true;
+        have_placed_block = true;
         children_positioned.push(positioned);
     }
 
+    if inline_line_open {
+        cursor_y += inline_line_height;
+    }
     let content_height = cursor_y + padding.bottom;
 
     // Resolve outer height: explicit hint overrides content height.
     let outer_height = resolve_container_height(node, content_height);
+    let occupied_inline_width = max_inline_right + padding.right;
+    let outer_width = if is_inline_level(display_value(node))
+        && matches!(node.width, Some(SizeValue::Wrap) | None)
+    {
+        clamp_with_min_max(occupied_inline_width, node.min_width, node.max_width).min(outer_width)
+    } else {
+        outer_width
+    };
 
     PositionedNode {
         x,
@@ -233,6 +313,29 @@ fn lay_out_container<M: TextMeasurer>(
         children: children_positioned,
         ext: node.ext.clone(),
     }
+}
+
+fn unconstrained_height(max_width: f64) -> Constraints {
+    Constraints {
+        min_width: 0.0,
+        max_width,
+        min_height: 0.0,
+        max_height: f64::MAX,
+    }
+}
+
+fn display_value(node: &LayoutNode) -> Option<&str> {
+    let ExtValue::Map(values) = node.ext.get("block")? else {
+        return None;
+    };
+    let ExtValue::Str(display) = values.get("display")? else {
+        return None;
+    };
+    Some(display)
+}
+
+fn is_inline_level(display: Option<&str>) -> bool {
+    matches!(display, Some("inline" | "inline-text" | "inline-replaced"))
 }
 
 fn resolve_container_width(node: &LayoutNode, outer_max_width: f64) -> f64 {
@@ -285,13 +388,7 @@ fn lay_out_text_leaf<M: TextMeasurer>(
     let inner_max_width = (outer_max_width - padding_horizontal).max(0.0);
 
     // Ask the measurer to wrap within the inner max width.
-    let max_wrap_width = if node.width == Some(SizeValue::Wrap) {
-        None
-    } else {
-        Some(inner_max_width)
-    };
-
-    let measured: MeasureResult = measurer.measure(&tc.value, &tc.font, max_wrap_width);
+    let measured: MeasureResult = measurer.measure(&tc.value, &tc.font, Some(inner_max_width));
 
     // The node's outer width: for Fill / None, use the full outer_max_width.
     // For Wrap or Fixed, base on the measurement (or the hint).
@@ -300,8 +397,8 @@ fn lay_out_text_leaf<M: TextMeasurer>(
         Some(SizeValue::Wrap) => (measured.width + padding_horizontal).min(outer_max_width),
         Some(SizeValue::Fill) | None => outer_max_width,
     };
-    let outer_width = clamp_with_min_max(outer_width, node.min_width, node.max_width)
-        .min(outer_max_width);
+    let outer_width =
+        clamp_with_min_max(outer_width, node.min_width, node.max_width).min(outer_max_width);
 
     let content_height = measured.height;
     let outer_height_raw = content_height + padding.top + padding.bottom;
@@ -346,8 +443,8 @@ fn lay_out_image_leaf(
         Some(SizeValue::Fixed(v)) => v,
         _ => outer_max_width,
     };
-    let outer_width = clamp_with_min_max(outer_width, node.min_width, node.max_width)
-        .min(outer_max_width);
+    let outer_width =
+        clamp_with_min_max(outer_width, node.min_width, node.max_width).min(outer_max_width);
 
     let outer_height = match node.height {
         Some(SizeValue::Fixed(v)) => v,
@@ -388,17 +485,14 @@ mod tests {
 
     impl MonoMeasurer {
         fn new() -> Self {
-            Self { char_width_factor: 0.5 }
+            Self {
+                char_width_factor: 0.5,
+            }
         }
     }
 
     impl TextMeasurer for MonoMeasurer {
-        fn measure(
-            &self,
-            text: &str,
-            font: &FontSpec,
-            max_width: Option<f64>,
-        ) -> MeasureResult {
+        fn measure(&self, text: &str, font: &FontSpec, max_width: Option<f64>) -> MeasureResult {
             let chars = text.chars().count() as f64;
             let full_width = chars * self.char_width_factor * font.size;
             let line_h = font.size * font.line_height;
@@ -430,7 +524,12 @@ mod tests {
         TextContent {
             value: value.into(),
             font: font_spec("Test", size),
-            color: Color { r: 0, g: 0, b: 0, a: 255 },
+            color: Color {
+                r: 0,
+                g: 0,
+                b: 0,
+                a: 255,
+            },
             max_lines: None,
             text_align: TextAlign::Start,
         }
@@ -458,6 +557,58 @@ mod tests {
         let p = layout_block(&node, constraints_fixed(500.0, 500.0), &MonoMeasurer::new());
         // "Hi" = 2 × 0.5 × 10 = 10 wide
         assert_eq!(p.width, 10.0);
+    }
+
+    #[test]
+    fn inline_children_share_a_line() {
+        let node = LayoutNode::container(vec![
+            inline_text("ab", 10.0),
+            inline_container(vec![inline_text("cd", 10.0)]),
+            inline_text("ef", 10.0),
+        ]);
+        let p = layout_block(&node, constraints_fixed(100.0, 500.0), &MonoMeasurer::new());
+
+        assert_eq!(p.children[0].x, 0.0);
+        assert_eq!(p.children[1].x, 10.0);
+        assert_eq!(p.children[1].width, 10.0);
+        assert_eq!(p.children[2].x, 20.0);
+        assert_eq!(p.children[0].y, p.children[1].y);
+        assert_eq!(p.children[1].y, p.children[2].y);
+        assert_eq!(p.height, 12.0);
+    }
+
+    #[test]
+    fn atomic_inline_children_wrap_to_the_next_line() {
+        let node =
+            LayoutNode::container(vec![inline_text("abcd", 10.0), inline_text("efgh", 10.0)]);
+        let p = layout_block(&node, constraints_fixed(30.0, 500.0), &MonoMeasurer::new());
+
+        assert_eq!(p.children[0].x, 0.0);
+        assert_eq!(p.children[0].y, 0.0);
+        assert_eq!(p.children[1].x, 0.0);
+        assert_eq!(p.children[1].y, 12.0);
+        assert_eq!(p.height, 24.0);
+    }
+
+    #[test]
+    fn explicit_line_break_starts_a_new_inline_line() {
+        let line_break = LayoutNode::leaf_text(text("\n", 10.0))
+            .with_width(size_wrap())
+            .with_ext("block", display("line-break"));
+        let node = LayoutNode::container(vec![
+            inline_text("ab", 10.0),
+            line_break,
+            inline_text("cd", 10.0),
+        ]);
+        let p = layout_block(&node, constraints_fixed(100.0, 500.0), &MonoMeasurer::new());
+
+        assert_eq!(p.children[0].x, 0.0);
+        assert_eq!(p.children[0].y, 0.0);
+        assert_eq!(p.children[1].x, 10.0);
+        assert_eq!(p.children[1].width, 0.0);
+        assert_eq!(p.children[2].x, 0.0);
+        assert_eq!(p.children[2].y, 12.0);
+        assert_eq!(p.height, 24.0);
     }
 
     #[test]
@@ -514,10 +665,19 @@ mod tests {
         // Collapsed gap = max(10, 6) = 10.
         let node = LayoutNode::container(vec![
             LayoutNode::leaf_text(text("a", 10.0))
-                .with_margin(edges_xy(0.0, 5.0))  // top:5 bottom:5... but edges_xy sets y on top & bottom
-                .with_margin(Edges { top: 0.0, right: 0.0, bottom: 10.0, left: 0.0 }),
-            LayoutNode::leaf_text(text("b", 10.0))
-                .with_margin(Edges { top: 6.0, right: 0.0, bottom: 0.0, left: 0.0 }),
+                .with_margin(edges_xy(0.0, 5.0)) // top:5 bottom:5... but edges_xy sets y on top & bottom
+                .with_margin(Edges {
+                    top: 0.0,
+                    right: 0.0,
+                    bottom: 10.0,
+                    left: 0.0,
+                }),
+            LayoutNode::leaf_text(text("b", 10.0)).with_margin(Edges {
+                top: 6.0,
+                right: 0.0,
+                bottom: 0.0,
+                left: 0.0,
+            }),
         ]);
         let p = layout_block(&node, constraints_fixed(300.0, 300.0), &MonoMeasurer::new());
         // child0 y = 0, height = 12. With child0.bottom=10 and child1.top=6 collapsed to 10,
@@ -534,7 +694,11 @@ mod tests {
         let inner = LayoutNode::container(vec![LayoutNode::leaf_text(text("hi", 10.0))])
             .with_padding(edges_all(3.0));
         let outer = LayoutNode::container(vec![inner]).with_padding(edges_all(5.0));
-        let p = layout_block(&outer, constraints_fixed(300.0, 300.0), &MonoMeasurer::new());
+        let p = layout_block(
+            &outer,
+            constraints_fixed(300.0, 300.0),
+            &MonoMeasurer::new(),
+        );
         assert_eq!(p.children.len(), 1);
         let inner_p = &p.children[0];
         assert_eq!(inner_p.x, 5.0);
@@ -564,11 +728,14 @@ mod tests {
 
     #[test]
     fn min_max_width_clamping() {
-        let node = LayoutNode::leaf_text(text("Hello", 10.0))
-            .with_width(size_fixed(200.0));
+        let node = LayoutNode::leaf_text(text("Hello", 10.0)).with_width(size_fixed(200.0));
         let mut constrained = node.clone();
         constrained.max_width = Some(100.0);
-        let p = layout_block(&constrained, constraints_fixed(500.0, 500.0), &MonoMeasurer::new());
+        let p = layout_block(
+            &constrained,
+            constraints_fixed(500.0, 500.0),
+            &MonoMeasurer::new(),
+        );
         assert!(p.width <= 100.0);
     }
 
@@ -621,10 +788,18 @@ mod tests {
     fn realistic_document_lays_out_sensibly() {
         // h1 "Hello" + paragraph "World lorem ipsum"
         let _ = rgb(0, 0, 0); // silence unused-import on builds that don't need it
-        let h1 = LayoutNode::leaf_text(text("Hello", 24.0))
-            .with_margin(Edges { top: 0.0, right: 0.0, bottom: 12.0, left: 0.0 });
-        let p1 = LayoutNode::leaf_text(text("World lorem ipsum", 16.0))
-            .with_margin(Edges { top: 8.0, right: 0.0, bottom: 8.0, left: 0.0 });
+        let h1 = LayoutNode::leaf_text(text("Hello", 24.0)).with_margin(Edges {
+            top: 0.0,
+            right: 0.0,
+            bottom: 12.0,
+            left: 0.0,
+        });
+        let p1 = LayoutNode::leaf_text(text("World lorem ipsum", 16.0)).with_margin(Edges {
+            top: 8.0,
+            right: 0.0,
+            bottom: 8.0,
+            left: 0.0,
+        });
         let doc = LayoutNode::container(vec![h1, p1]).with_padding(edges_all(24.0));
         let out = layout_block(&doc, constraints_fixed(800.0, 1000.0), &MonoMeasurer::new());
         // Document starts at 0, 0. Inner children offset by padding 24 on both axes.
@@ -636,5 +811,24 @@ mod tests {
         // h1 height = 24 × 1.2 = 28.8. Collapsed margin between children = max(12, 8) = 12
         // p1 y = 24 + 28.8 + 12 = 64.8
         assert!((out.children[1].y - 64.8).abs() < 1e-6);
+    }
+
+    fn inline_text(value: &str, size: f64) -> LayoutNode {
+        LayoutNode::leaf_text(text(value, size))
+            .with_width(size_wrap())
+            .with_ext("block", display("inline-text"))
+    }
+
+    fn inline_container(children: Vec<LayoutNode>) -> LayoutNode {
+        LayoutNode::container(children)
+            .with_width(size_wrap())
+            .with_ext("block", display("inline"))
+    }
+
+    fn display(value: &str) -> ExtValue {
+        ExtValue::Map(std::collections::HashMap::from([(
+            "display".into(),
+            ExtValue::Str(value.into()),
+        )]))
     }
 }

--- a/code/specs/BR01-venture-browser.md
+++ b/code/specs/BR01-venture-browser.md
@@ -49,9 +49,10 @@ upstream cases at zero. The `html-to-layout` package now provides the first
 executable browser seam from `BrowserRenderTree` to the shared Layout IR and
 `layout-block`.
 
-That does not make Venture complete. The remaining acceptance work includes a
-real inline-formatting pass, paint-scene acceptance, resource loading, link
-hit-testing, and a platform host that wires navigation through pixels.
+That does not make Venture complete. The current layout path places atomic
+inline boxes on shared lines; text-run fragmentation and baseline alignment
+remain. Paint-scene acceptance, resource loading, link hit-testing, and a
+platform host must still wire navigation through pixels.
 
 ## Where It Fits
 

--- a/code/specs/UI07-layout-block.md
+++ b/code/specs/UI07-layout-block.md
@@ -35,7 +35,8 @@ Block/inline properties live in `ext["block"]`:
 
 ```
 BlockExt {
-  display:     "block" | "inline"    // default: "block"
+  display:     "block" | "inline" | "inline-text"
+             | "inline-replaced" | "line-break" // default: "block"
   // Block-specific
   float:       "none" | "left" | "right"   // default: "none" (future)
   clear:       "none" | "left" | "right" | "both"  // default: "none" (future)
@@ -74,7 +75,9 @@ All direct children of a block container are classified as either block-level
 or inline-level based on `ext["block"]["display"]`:
 
 - `"block"` → block-level: stacks vertically, full available width
-- `"inline"` → inline-level: flows horizontally, wraps
+- `"inline"` / `"inline-text"` / `"inline-replaced"` → inline-level: flows
+  horizontally and wraps
+- `"line-break"` → terminates the current line box
 
 When a block container has a **mix** of block and inline children, inline
 children are wrapped in an anonymous block container (inline formatting
@@ -96,6 +99,11 @@ For each block-level child in source order:
    own `margin.bottom`
 
 ### Inline formatting context
+
+The current executable slice implements the line-box cursor and atomic child
+placement described below. Each child is kept intact and moves to the next
+line when it does not fit. Text splitting at word boundaries, one inline box
+spanning multiple lines, and baseline alignment remain planned refinements.
 
 When laying out a sequence of inline children:
 


### PR DESCRIPTION
## What changed

- teach `layout-block` to place adjacent `inline`, `inline-text`, and `inline-replaced` children on shared lines
- wrap inline children atomically when the next box does not fit and honor explicit `line-break` nodes
- keep nodes without block display metadata on the existing block-stacking path for compatibility
- make HTML text leaves wrap-sized so links and surrounding text receive meaningful horizontal geometry
- strengthen parser-to-positioned-layout acceptance coverage and document the remaining browser/layout boundary

## Why

The HTML parser and browser adapter already preserve inline semantics, but `layout-block` previously stacked every sibling vertically. That made ordinary text such as `text <a>link</a>.` produce unusable geometry and prevented meaningful link bounds in the Mosaic/Venture pipeline.

## Impact

HTML render trees now reach shared layout with a bounded first inline-flow implementation. Text, links, replaced elements, and explicit breaks can participate in line geometry while existing non-HTML layout producers retain their previous default block behavior.

This is intentionally not full CSS inline formatting. Word-level text fragmentation, splitting one styled inline wrapper across multiple line boxes, and baseline alignment remain explicit follow-up work, as do paint/resource/hit-test/host acceptance gates.

## Validation

- `cargo fmt -p layout-block -p html-to-layout -- --check`
- `cargo test -p layout-block -p html-to-layout`
- `cargo clippy -p layout-block -p html-to-layout --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-parser`
- live upstream conformance audit: WPT tree construction 1,934 upstream / 2,637 local / 0 missing; html5lib tokenizer 6,806 upstream / 7,015 local raw / 0 missing; 7,242 normalized / 0 skipped
