### PR TITLE
feat(adj-formula-stdlib): drug clearance — second pharmacokinetics CL=rate/Cp library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_drug_clearance_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_drug_clearance_e2e.rs
@@ -1,0 +1,141 @@
+//! End-to-end tests for the `clinical/drug-clearance.adj` library — the definition of drug
+//! clearance (CL = rate of drug removal ÷ plasma concentration) and its two exact rearrangements —
+//! driven through the built CLI binary against the SHIPPED stdlib. The same invariant as every
+//! other formula library: a consumer states NO arithmetic; it imports the grounded library, binds
+//! the measured quantities with `observe`, and the engine applies the cited relation on the CPU,
+//! computing the EXACT value and rendering the relation's citation and trust tier in the `derived`
+//! section (the auditable answer). The three formulas INVERT around the worked case rate = 100
+//! mg/min, Cp = 5 mg/mL: 100 ÷ 5 = 20, 20 × 5 = 100, and 100 ÷ 20 = 5. The three asserted values
+//! (20, 100, 5) are chosen so none is a colon-anchored prefix of another rendered value. This is
+//! the second pharmacokinetics library, the companion of volume-of-distribution.adj (Vd and CL are
+//! the two independent primary PK parameters).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped drug-clearance library, resolved from this crate's manifest dir so
+/// the test is location-independent.
+fn shipped_cl_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/drug-clearance.adj")
+        .canonicalize()
+        .expect("shipped drug-clearance.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_cl_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_cl_lib()).unwrap();
+    std::fs::write(dir.join("drug-clearance.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// clearance — the definition: rate of drug removal divided by plasma concentration.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_drug_clearance_library_and_computes_it_with_citation() {
+    let dir = scratch("cl");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"drug-clearance.adj\"\n\
+         observe rate_of_drug_removal(100)\n\
+         observe plasma_concentration(5)\n\
+         ? clearance(rate_of_drug_removal, plasma_concentration)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 100 ÷ 5 = 20.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"clearance\"") && s.contains("\"value\":20"),
+        "clearance(100, 5) = 20: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// rate_of_drug_removal — the same relation solved for the rate: CL × Cp.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_rate_from_clearance_and_concentration_with_citation() {
+    let dir = scratch("rate");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"drug-clearance.adj\"\n\
+         observe clearance(20)\n\
+         observe plasma_concentration(5)\n\
+         ? rate_of_drug_removal(clearance, plasma_concentration)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 20 × 5 = 100, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"rate_of_drug_removal\"") && s.contains("\"value\":100"),
+        "rate_of_drug_removal(20, 5) = 100: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "rate_of_drug_removal carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// plasma_concentration — the same relation solved for the concentration: rate ÷ CL, the third
+// reading of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_concentration_from_rate_and_clearance_with_citation() {
+    let dir = scratch("cp");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"drug-clearance.adj\"\n\
+         observe rate_of_drug_removal(100)\n\
+         observe clearance(20)\n\
+         ? plasma_concentration(rate_of_drug_removal, clearance)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 100 ÷ 20 = 5, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"plasma_concentration\"") && s.contains("\"value\":5"),
+        "plasma_concentration(100, 20) = 5: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "plasma_concentration carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/drug-clearance.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/drug-clearance.adj
@@ -1,0 +1,96 @@
+% ============================================================================
+% drug-clearance.adj — the definition of drug clearance (CL = rate of drug removal ÷ plasma
+% concentration) in the ADJ standard library.
+% ============================================================================
+% The drug-clearance entry of the *clinical* track — the second PHARMACOKINETICS library, the
+% companion of volume-of-distribution.adj. Vd and clearance are THE two independent primary
+% pharmacokinetic parameters (the elimination half-life derives from both). Like the volume of
+% distribution, clearance is DEFINED as a RATIO: CLEARANCE IS THE RATE AT WHICH A DRUG IS REMOVED
+% FROM PLASMA DIVIDED BY THE CONCENTRATION OF THE DRUG IN THE PLASMA — the volume of plasma cleared
+% of drug per unit time (units of volume/time). It sets the maintenance dosing rate (at steady
+% state the rate in equals the rate out, so the dose rate needed to hold a target concentration
+% scales with clearance). It ships as an importable, byte-provenanced, PARAMETERIZED `formula`,
+% together with its two exact rearrangements (the elimination rate a clearance implies for a given
+% concentration, and the concentration it implies for a given rate). As with every compute
+% library, a consumer states NO arithmetic: it `import`s this file, binds the measured quantities
+% from its own byte-provenance decomposition, and asks the engine to APPLY the cited definition on
+% the CPU. Zero math is performed by the model; the engine computes each value EXACTLY (over exact
+% rationals), carrying the definition's citation.
+%
+%     import "drug-clearance.adj"
+%     observe rate_of_drug_removal(100)    % "…removed at 100 mg/min…"      (span cited by the model)
+%     observe plasma_concentration(5)       % "…plasma concentration 5 mg/mL…" (span cited by the model)
+%     ? clearance(rate_of_drug_removal, plasma_concentration)
+%                                           % engine → 20, carrying CL = rate ÷ Cp
+%
+% All three formulas are EXACT over their parameters, so every value the engine returns is exact.
+% They COMPOSE and invert cleanly around the worked case rate of removal = 100 mg/min, plasma
+% concentration = 5 mg/mL (CL = 100 ÷ 5 = 20 mL/min): the `clearance` a consumer computes from the
+% rate and concentration is exactly the value the `rate_of_drug_removal` formula multiplies by the
+% concentration to recover 100, and exactly the value the `plasma_concentration` formula divides
+% the rate by to recover 5.
+%
+%   clearance(rate_of_drug_removal, plasma_concentration)
+%       = rate_of_drug_removal / plasma_concentration     % CL = rate ÷ Cp   (definition)
+%   rate_of_drug_removal(clearance, plasma_concentration)
+%       = clearance * plasma_concentration                 % rate = CL × Cp   (solved for rate)
+%   plasma_concentration(rate_of_drug_removal, clearance)
+%       = rate_of_drug_removal / clearance                 % Cp = rate ÷ CL   (solved for Cp)
+%
+% NOTE ON UNITS: the cited source states the rate at which the drug is removed in milligrams per
+% minute and the plasma concentration in milligrams per millilitre; the clearance therefore comes
+% out in millilitres per minute (a volume-per-time), and this library computes the exact quotient
+% over whatever consistent inputs it is given.
+%
+% All three formulas are defended by the SAME clause — "Clearance is equal to the rate at which a
+% drug is removed from plasma(mg/min) divided by the concentration of that drug in the plasma
+% (mg/mL)" — because that one definition (clearance IS the rate-over-concentration ratio) sanctions
+% the relation read every way. The quote is transcribed verbatim from a peer-reviewed article
+% archived on the NCBI Bookshelf, so each `formula` carries the provenance envelope every shipped
+% grounded clause carries; the linter rejects an unsourced one. (See feedback_nothing_human_authored
+% — the clause is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable pharmacokinetic quantity the definition ranges over,
+% and each result is a derived quantity. `rate_of_drug_removal`, `plasma_concentration` and
+% `clearance` each appear BOTH as a derived result and as an input (of the other formulas), so each
+% is a single dictionary term used in both roles. The `surface` lists are the everyday names a
+% decomposer maps onto the canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary drug_clearance_vocab {
+    define rate_of_drug_removal  : finding  surface "rate at which a drug is removed from plasma", "rate of elimination", "elimination rate"   % milligrams per minute (mg/min)
+    define plasma_concentration  : finding  surface "plasma concentration", "concentration of the drug in the plasma", "Cp"                    % milligrams per millilitre (mg/mL)
+    define clearance             : finding  surface "clearance", "drug clearance", "CL"                                                        % millilitres per minute (mL/min)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the definitional clause from the cited article
+% on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an exact quotient or
+% product of measured quantities, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook drug_clearance_laws {
+    use drug_clearance_vocab
+
+    % Clearance — the rate at which the drug is removed from plasma divided by the plasma
+    % concentration, i.e. CL = rate ÷ Cp.
+    formula clearance(rate_of_drug_removal, plasma_concentration) = rate_of_drug_removal / plasma_concentration
+        source "Clearance is equal to the rate at which a drug is removed from plasma(mg/min) divided by the concentration of that drug in the plasma (mg/mL)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557758/"
+        trust authoritative
+
+    % Rate of drug removal — the same definition solved for the elimination rate a clearance implies
+    % for a given concentration (rate = CL × Cp). Defended by the SAME clause.
+    formula rate_of_drug_removal(clearance, plasma_concentration) = clearance * plasma_concentration
+        source "Clearance is equal to the rate at which a drug is removed from plasma(mg/min) divided by the concentration of that drug in the plasma (mg/mL)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557758/"
+        trust authoritative
+
+    % Plasma concentration — the same definition solved for the concentration (Cp = rate ÷ CL): the
+    % rate of drug removal divided by the clearance. The SAME clause, read the third way.
+    formula plasma_concentration(rate_of_drug_removal, clearance) = rate_of_drug_removal / clearance
+        source "Clearance is equal to the rate at which a drug is removed from plasma(mg/min) divided by the concentration of that drug in the plasma (mg/mL)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK557758/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/drug-clearance.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/drug-clearance.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% drug-clearance.query.adj — worked applications of the drug-clearance definition.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a pharmacokinetics/dosing vignette into
+% observed quantities: it `import`s the grounded formulabook, `observe`s the elimination rate and
+% plasma concentration, and asks the engine to APPLY the cited definition. No arithmetic is stated
+% by the consumer; the engine computes each value EXACTLY (over exact rationals) and carries the
+% article's citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (rate of drug removal = 100 mg/min, plasma concentration = 5 mg/mL): CL = 100 ÷ 5 =
+% 20 mL/min. Each query below fixes two of the three quantities and asks the engine to recover the
+% third; every answer is exact and the three COMPOSE (each inversion recovers exactly the worked
+% value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli drug-clearance.query.adj
+% ============================================================================
+
+import "drug-clearance.adj"
+
+% --- Definition: the clearance the rate and concentration imply (expect 20). -------------------
+observe rate_of_drug_removal(100)
+observe plasma_concentration(5)
+? clearance(rate_of_drug_removal, plasma_concentration)   % expect 20
+
+% --- Inverse: the elimination rate a clearance of 20 implies at that concentration (100). ------
+observe clearance(20)
+? rate_of_drug_removal(clearance, plasma_concentration)   % expect 100


### PR DESCRIPTION
## What

Ships **drug clearance** (CL = rate of drug removal ÷ plasma concentration) as an importable, byte-provenanced, parameterized `formula` in the **clinical** track — the **second pharmacokinetics library**, the companion of `volume-of-distribution.adj` — with its two exact algebraic rearrangements.

All three formulas are defended by the **same verbatim clause**, transcribed exactly (including the source's own spacing around the units) from a peer-reviewed article on the NCBI Bookshelf:

> "Clearance is equal to the rate at which a drug is removed from plasma(mg/min) divided by the concentration of that drug in the plasma (mg/mL)"
> — https://www.ncbi.nlm.nih.gov/books/NBK557758/ · `trust authoritative`

## Why

Vd and CL are **the two independent primary pharmacokinetic parameters** (the elimination half-life derives from both); this lands CL right after Vd to complete that pair. Like Vd, clearance is **ratio-defined**, so the *definition* formula is the division and one rearrangement is the multiplication. A consumer states **no arithmetic**: it imports the library, `observe`s the measured quantities from its own byte-provenance decomposition, and the engine **applies** the cited relation on the CPU, computing each value **exactly over exact rationals** and carrying the citation + trust tier in the auditable `derived` section.

## The three readings

```
clearance(rate_of_drug_removal, plasma_concentration) = rate_of_drug_removal / plasma_concentration   % CL = rate ÷ Cp
rate_of_drug_removal(clearance, plasma_concentration) = clearance * plasma_concentration                % rate = CL × Cp
plasma_concentration(rate_of_drug_removal, clearance) = rate_of_drug_removal / clearance                % Cp = rate ÷ CL
```

They **compose** around the worked case rate = 100 mg/min, Cp = 5 mg/mL: 100 ÷ 5 = 20, 20 × 5 = 100, 100 ÷ 20 = 5. The three asserted values (20 / 100 / 5) are chosen so none is a colon-anchored prefix of another rendered value.

## Files

- `code/specs/data/adj-formula-stdlib/clinical/drug-clearance.adj` — dictionary + formulabook (3 cited formulas)
- `code/specs/data/adj-formula-stdlib/clinical/drug-clearance.query.adj` — worked applications
- `code/packages/rust/adj-lang-cli/tests/formula_drug_clearance_e2e.rs` — 3 e2e tests (own dedicated file, no shared anchor)

## Verification

- `cargo test -p adj-lang-cli --test formula_drug_clearance_e2e` — **3/3 green**
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — **clean**
- Render-probe of `.query.adj` against the built CLI: forward → 20 with the verbatim citation + `trust:authoritative`; inverse recovers `rate_of_drug_removal` = 100.
- Data + test only — no engine change, **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)