### PR TITLE
feat(adj-formula-stdlib): electric-current — NIST SP 811 B.9 abampere→ampere EMU factor (facts b29)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -1302,6 +1302,48 @@ fn shipped_electric_conductance_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b29) The shipped NIST SP 811 B.9 electric-current → ampere table resolves the exact abampere
+//       factor with its citation, and ABSTAINS on a wrong-dimension unit. This EXTENDS the
+//       electromagnetic-EMU family (charge/potential/resistance/capacitance/inductance/conductance)
+//       with current — the abampere is the BASE EMU electrical unit. The abampere (current) and the
+//       abcoulomb (charge) are DIFFERENT quantities that convert to DIFFERENT SI units (ampere vs
+//       coulomb) yet NIST prints the SAME numeric factor 1.0 E+01 for both, so the abstain is a
+//       genuine dimension check rather than a value coincidence, not mere absence of a value.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_electric_current_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_current");
+    let src = stdlib().join("reference/electric-current-conversions.adj");
+    std::fs::copy(&src, dir.join("electric-current-conversions.adj"))
+        .expect("copy shipped electric-current-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"electric-current-conversions.adj\"\n\
+         ? electric_current_to_ampere(abampere, $v)\n\
+         ? electric_current_to_ampere(abcoulomb, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 exact factor resolves, character-for-character from the table
+    // (boldface = exact; the abampere is defined as exactly 1.0 E+01 ampere, the base EMU unit).
+    assert!(out.contains("\"v\":\"10\""), "abampere = 1.0 E+01 A: {out}");
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `abcoulomb` is a CHARGE unit (it converts to the coulomb, a DIFFERENT quantity), so this
+    // current table has no row for it — the engine abstains rather than mis-converting a charge
+    // unit as if it were a current unit, even though NIST prints the same 1.0 E+01 factor for it.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a wrong-dimension unit abstains, never a cross-dimension fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/electric-current-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/electric-current-conversions.adj
@@ -1,0 +1,63 @@
+% ============================================================================
+% electric-current-conversions — electric-current-unit → ampere factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of electric-charge-conversions.adj, electric-potential-conversions.adj,
+% electric-resistance-conversions.adj, electric-capacitance-conversions.adj,
+% electric-inductance-conversions.adj, electric-conductance-conversions.adj and the other
+% NIST-cited conversion tables: a native tabular relation ingested VERBATIM from a published NIST
+% conversion table. The row states the factor converting the traditional (CGS-EMU) unit of
+% ELECTRIC CURRENT to the SI base unit, the ampere (A):
+%
+%     ? electric_current_to_ampere(abampere, $v)   % 10
+%
+% This EXTENDS the electromagnetic-EMU family alongside electric-charge (the abcoulomb → the
+% coulomb), electric-potential (the abvolt → the volt), electric-resistance (the abohm → the ohm),
+% electric-capacitance (the abfarad → the farad), electric-inductance (the abhenry → the henry) and
+% electric-conductance (the abmho → the siemens). The abampere is the BASE unit of the EMU
+% electromagnetic system — the other EMU electrical units are derived from it — and it is a NEW
+% dimension alongside the length/mass/area/volume/time/speed/energy/pressure/force/acceleration/
+% dynamic-viscosity/kinematic-viscosity/magnetic-flux-density/magnetic-flux/illuminance/luminance/
+% radioactivity/absorbed-dose/dose-equivalent/exposure/power tables. Do NOT confuse ELECTRIC
+% CURRENT (the abampere → the ampere) with ELECTRIC CHARGE (the abcoulomb → the coulomb): those are
+% DIFFERENT quantities (charge is current integrated over time) that convert to DIFFERENT SI units
+% (ampere vs coulomb) — and here they even share the SAME numeric factor 1.0 E+01, which makes the
+% dimension guard below all the more important. Put a current given in abamperes into SI first,
+% then reason (write-once-use-many). Why a `table` and not a hand-written `relate` clause: this is
+% exactly the shape reference data comes in — a published table, not prose. The citable artifact IS
+% the NIST conversion-factors table at the `locator` below; the factor here is a CELL of NIST
+% Special Publication 811, Appendix B.9, defended by one provenance envelope. Each `row` lowers to
+% a ground relation `electric_current_to_ampere(unit, v)`, so the exact lookup above is the ordinary
+% SLD binding query — the engine returns the factor WITH this table's citation as its proof, on the
+% CPU, with zero model calls.
+%
+% HONESTY NOTE (like the electric-charge / electric-potential / electric-resistance /
+% electric-capacitance / electric-inductance / electric-conductance / power tables, only the EXACT
+% defined factor gets a row): NIST SP 811 B.9 prints the "abampere" current factor in BOLDFACE, its
+% convention for factors that are EXACT by definition, transcribed here as the plain decimal number
+% of amperes it names:
+%
+%     abampere   1.0 E+01  →  10
+%
+% This is exact because the abampere is DEFINED as exactly 1.0 E+01 ampere (the base EMU unit of
+% current). It terminates; nothing here is a rounded measurement. This table is SPECIFIC to electric
+% current: a unit of a DIFFERENT quantity — e.g. the "abcoulomb", which NIST SP 811 B.9 lists
+% separately as an electric-CHARGE unit converting to the coulomb, NOT the ampere (even though NIST
+% prints the SAME factor 1.0 E+01 for it) — therefore gets no row here, and a
+% `? electric_current_to_ampere(abcoulomb, $v)` ABSTAINS rather than mis-converting a charge unit as
+% if it were a current unit. That the numeric factor would coincide makes the abstain a real
+% dimension check, not an accident of value. The only claim this table makes is "this is the exact
+% factor NIST SP 811 B.9 prints for the abampere's conversion to the ampere" — which is exactly what
+% a byte-check against the cited table verifies. `trust authoritative` — a primary, re-fetchable
+% standards reference. (See ADJ-TABLES.md; and feedback_nothing_human_authored — the factor is a
+% verbatim cell of the cited table, nothing asserted from memory.)
+% ============================================================================
+
+table electric_current_to_ampere {
+    columns unit, ampere
+
+    row (abampere, 10)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/electric-current-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/electric-current-conversions.query.adj
@@ -1,0 +1,25 @@
+% ============================================================================
+% electric-current-conversions.query.adj — worked lookups over the NIST current → ampere table.
+% ============================================================================
+% The shape a consumer produces to convert a current given in a traditional CGS-EMU unit into SI:
+% it `import`s the grounded table and asks the engine to bind the factor. No arithmetic and no
+% factor is stated by the consumer; the engine returns the cell WITH the table's NIST citation as
+% its proof, on the CPU.
+%
+%   ? electric_current_to_ampere(abampere, $v)   % 10   (abampere = 1.0 E+01 A, exact)
+%
+% And the dimension guard: a unit of a DIFFERENT quantity has no row, so the lookup ABSTAINS rather
+% than mis-converting across dimensions. The "abcoulomb" is an electric-CHARGE unit (it converts to
+% the coulomb), NOT a current unit — and NIST prints the SAME numeric factor 1.0 E+01 for it, so the
+% abstain is a genuine dimension check, not a value coincidence:
+%
+%   ? electric_current_to_ampere(abcoulomb, $v)   % abstains (abcoulomb is charge → coulomb)
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli electric-current-conversions.query.adj
+% ============================================================================
+
+import "electric-current-conversions.adj"
+
+? electric_current_to_ampere(abampere, $v)    % expect 10       (exact NIST SP 811 B.9 factor)
+? electric_current_to_ampere(abcoulomb, $v)   % expect abstain  (charge unit, wrong dimension)


### PR DESCRIPTION
## What

Adds the **electric-current** conversion table (RS-5 `table`) to the **reference** track: the NIST SP 811 Appendix B.9 factor converting the traditional CGS-EMU unit of electric current, the **abampere**, to the SI base unit, the **ampere (A)**.

```
? electric_current_to_ampere(abampere, $v)   →  10   (abampere = 1.0 E+01 A, exact)
```

Byte-verified against the cited NIST table (boldface = exact by definition, character-for-character `1.0 E+01`).

## Why

Extends the electromagnetic-EMU conversion family — charge, potential, resistance, capacitance, inductance, conductance — with **current**. The abampere is the **base unit** of the EMU electromagnetic system (the other EMU electrical units derive from it).

## Dimension guard — strongest form (abstain despite identical factor)

The abstain probe uses the **abcoulomb** — a *charge* unit converting to the coulomb — for which **NIST prints the SAME numeric factor 1.0 E+01**:

```
? electric_current_to_ampere(abcoulomb, $v)   →  abstains   (wrong dimension)
```

Because the number would coincide, the abstain is a genuine **dimension check** (current/ampere vs charge/coulomb are different quantities), not a value coincidence — the strongest demonstration of the cross-dimension guard in the family so far.

## Files

- `code/specs/data/adj-formula-stdlib/reference/electric-current-conversions.adj` — one-row `table` + honesty note
- `code/specs/data/adj-formula-stdlib/reference/electric-current-conversions.query.adj` — worked lookup + abstain
- `code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs` — `(b29)` block appended to the shared anchor

## Verification

- `cargo test -p adj-lang-cli --test rs5_table_e2e` — **34/34 green** (incl. the new b29)
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — **clean**
- Render-probe: `abampere` → `"v":"10"` carrying the NIST B.9 locator; `abcoulomb` → `"abstained":true`.
- Data + test only — no engine change, **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)