### PR TITLE
Scale MOS bulk potential across temperature

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Apply Berkeley MOS1 temperature preprocessing to the Level-1 MOS
+  bulk-junction potential `PB`.
 - Apply Berkeley MOS1 electrostatic temperature preprocessing to Level-1 MOS
   `PHI` and polarity-aware `VT0` instead of a fixed threshold-voltage shift.
 - Scale Level-1 MOS bulk-junction `IS` and `JS` with temperature using the

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -78,7 +78,7 @@ print(result.diagnostics.solver)   # "dense_real" or "sparse_real"
 operating-temperature footholds for diode, BJT, JFET, and Level-1 MOSFET
 models before running an analysis.
 Level-1 MOS temperature preprocessing follows the Berkeley MOS1 silicon
-band-gap correction for `PHI` and polarity-aware `VT0`.
+band-gap correction for `PHI`, polarity-aware `VT0`, and bulk-junction `PB`.
 JFET model cards use `TCV` for threshold-voltage scaling and `BEX` for
 `BETA(T) = BETA * (T / TNOM)^BEX`. When explicitly present, `VTOTC` overrides
 `TCV` with `VTO(T) = VTO + VTOTC * (T - TNOM)`, while `BETATCE` overrides

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -419,6 +419,13 @@ def mosfet_at_temperature(
     temperature_phi = (
         temperature_factor * nominal_phi + potential_correction(temperature_kelvin)
     )
+    nominal_bulk_junction_potential = (
+        params.PB - potential_correction(nominal_temperature_kelvin)
+    ) / nominal_factor
+    temperature_bulk_junction_potential = (
+        temperature_factor * nominal_bulk_junction_potential
+        + potential_correction(temperature_kelvin)
+    )
     polarity = 1.0 if model.type is MosfetType.NMOS else -1.0
     temperature_vbi = (
         params.VT0
@@ -446,6 +453,7 @@ def mosfet_at_temperature(
         params,
         VT0=temperature_vt0,
         PHI=temperature_phi,
+        PB=temperature_bulk_junction_potential,
         KP=params.KP * ratio**-1.5,
         U0=params.U0 * ratio**-1.5,
         IS=params.IS * saturation_scale,

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -4287,6 +4287,23 @@ def test_mosfet_temperature_scaling_adjusts_phi_and_threshold_by_polarity():
     assert pytest.approx(-0.365_036_965_282_786_06) == pmos_params.VT0
 
 
+def test_mosfet_temperature_scaling_adjusts_bulk_junction_potential():
+    nominal = Mosfet(
+        "M1",
+        "d",
+        "g",
+        "s",
+        "b",
+        MOSFET(MosfetType.NMOS, Level1Model(Level1Params())),
+    )
+
+    cold = mosfet_at_temperature(nominal, 275.0)
+    hot = mosfet_at_temperature(nominal, 350.0)
+
+    assert pytest.approx(0.839_148_690_629_946_5) == cold.model.model.params.PB
+    assert pytest.approx(0.719_697_229_921_455) == hot.model.model.params.PB
+
+
 def test_mosfet_temperature_scaling_adjusts_bulk_junction_saturation_currents():
     nominal = Mosfet(
         "M1",

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Apply Berkeley MOS1 temperature preprocessing to the Level-1 MOS
+  bulk-junction potential `PB`.
 - Apply Berkeley MOS1 electrostatic temperature preprocessing to Level-1 MOS
   `PHI` and polarity-aware `VT0` instead of a fixed threshold-voltage shift.
 - Scale Level-1 MOS bulk-junction `IS` and `JS` with temperature using the

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -119,7 +119,7 @@ let result = transient_adaptive(
 operating-temperature footholds for diode, BJT, JFET, and Level-1 MOSFET
 models before running an analysis.
 Level-1 MOS temperature preprocessing follows the Berkeley MOS1 silicon
-band-gap correction for `PHI` and polarity-aware `VT0`.
+band-gap correction for `PHI`, polarity-aware `VT0`, and bulk-junction `PB`.
 JFET model cards use `TCV` for threshold-voltage scaling and `BEX` for
 `BETA(T) = BETA * (T / TNOM)^BEX`. When explicitly present, `VTOTC` overrides
 `TCV` with `VTO(T) = VTO + VTOTC * (T - TNOM)`, while `BETATCE` overrides

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -2797,6 +2797,10 @@ pub fn mosfet_at_temperature(
     let temperature_potential_correction = potential_correction(temperature_kelvin);
     let nominal_phi = (mosfet.params.phi - nominal_potential_correction) / nominal_factor;
     let temperature_phi = temperature_factor * nominal_phi + temperature_potential_correction;
+    let nominal_bulk_junction_potential =
+        (mosfet.params.bulk_junction_potential - nominal_potential_correction) / nominal_factor;
+    let temperature_bulk_junction_potential =
+        temperature_factor * nominal_bulk_junction_potential + temperature_potential_correction;
     let polarity = match mosfet.mosfet_type {
         MosfetType::Nmos => 1.0,
         MosfetType::Pmos => -1.0,
@@ -2813,6 +2817,7 @@ pub fn mosfet_at_temperature(
     let mut adjusted = mosfet.clone();
     adjusted.params.vt0 = temperature_vt0;
     adjusted.params.phi = temperature_phi;
+    adjusted.params.bulk_junction_potential = temperature_bulk_junction_potential;
     adjusted.params.kp *= ratio.powf(-1.5);
     adjusted.params.surface_mobility *= ratio.powf(-1.5);
     adjusted.params.saturation_current *= saturation_scale;

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -3569,6 +3569,25 @@ fn mosfet_temperature_scaling_adjusts_phi_and_threshold_by_polarity() {
 }
 
 #[test]
+fn mosfet_temperature_scaling_adjusts_bulk_junction_potential() {
+    let nominal = Mosfet::with_model(
+        "M1",
+        "d",
+        "g",
+        "s",
+        "b",
+        MosfetType::Nmos,
+        MosfetLevel1Params::default(),
+    );
+
+    let cold = mosfet_at_temperature(&nominal, 275.0, 300.15, 1.11).unwrap();
+    let hot = mosfet_at_temperature(&nominal, 350.0, 300.15, 1.11).unwrap();
+
+    assert_close(cold.params.bulk_junction_potential, 0.839_148_690_629_946_5);
+    assert_close(hot.params.bulk_junction_potential, 0.719_697_229_921_455);
+}
+
+#[test]
 fn mosfet_temperature_scaling_adjusts_bulk_junction_saturation_currents() {
     let nominal = Mosfet::with_model(
         "M1",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Apply Berkeley MOS1 temperature preprocessing to the Level-1 MOS
+  bulk-junction potential `PB`.
 - Apply Berkeley MOS1 electrostatic temperature preprocessing to Level-1 MOS
   `PHI` and polarity-aware `VT0` instead of a fixed threshold-voltage shift.
 - Scale Level-1 MOS bulk-junction `IS` and `JS` with temperature using the

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -70,7 +70,7 @@ steps were clipped, and the minimum damping factor; pass
 operating-temperature footholds for diode, BJT, JFET, and Level-1 MOSFET
 models before running an analysis.
 Level-1 MOS temperature preprocessing follows the Berkeley MOS1 silicon
-band-gap correction for `PHI` and polarity-aware `VT0`.
+band-gap correction for `PHI`, polarity-aware `VT0`, and bulk-junction `PB`.
 JFET model cards use `TCV` for threshold-voltage scaling and `BEX` for
 `BETA(T) = BETA * (T / TNOM)^BEX`. When explicitly present, `VTOTC` overrides
 `TCV` with `VTO(T) = VTO + VTOTC * (T - TNOM)`, while `BETATCE` overrides

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -7758,6 +7758,11 @@ export function mosfetAtTemperature(
     (element.params.PHI - potentialCorrection(nominalTemperatureKelvin)) / nominalFactor;
   const temperaturePhi =
     temperatureFactor * nominalPhi + potentialCorrection(temperatureKelvin);
+  const nominalBulkJunctionPotential =
+    (element.params.PB - potentialCorrection(nominalTemperatureKelvin)) / nominalFactor;
+  const temperatureBulkJunctionPotential =
+    temperatureFactor * nominalBulkJunctionPotential +
+    potentialCorrection(temperatureKelvin);
   const polarity = element.type === "NMOS" ? 1.0 : -1.0;
   const temperatureVbi =
     element.params.VT0 -
@@ -7779,6 +7784,7 @@ export function mosfetAtTemperature(
       ...element.params,
       VT0: temperatureVt0,
       PHI: temperaturePhi,
+      PB: temperatureBulkJunctionPotential,
       KP: element.params.KP * ratio ** -1.5,
       U0: element.params.U0 * ratio ** -1.5,
       IS: element.params.IS * saturationScale,

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -2357,6 +2357,16 @@ describe("dcOp", () => {
     expectClose(hotPmos.params.VT0, -0.365_036_965_282_786_06);
   });
 
+  it("adjusts the MOSFET bulk-junction potential across temperature", () => {
+    const nominal = mosfet("M1", "d", "g", "s", "b", "NMOS");
+
+    const cold = mosfetAtTemperature(nominal, 275.0);
+    const hot = mosfetAtTemperature(nominal, 350.0);
+
+    expectClose(cold.params.PB, 0.839_148_690_629_946_5);
+    expectClose(hot.params.PB, 0.719_697_229_921_455);
+  });
+
   it("scales MOSFET bulk-junction saturation currents with temperature", () => {
     const nominal = mosfet("M1", "d", "g", "s", "b", "NMOS", {
       IS: 2.0e-15,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS electrostatic temperature preprocessing.
+1. Cross-language Level-1 MOS bulk-junction potential temperature preprocessing.
    - Status: current PR completion candidate.
-   - Replace the fixed threshold-voltage shift with Berkeley MOS1 silicon
-     band-gap preprocessing for `PHI` and `VT0`.
-   - Preserve NMOS/PMOS polarity semantics through direct MOS temperature
-     helpers and circuit-level transforms.
+   - Apply the Berkeley MOS1 silicon potential correction to bulk-junction
+     potential `PB` alongside the existing electrostatic transform.
+   - Preserve direct MOS helper and circuit-level temperature-transform parity.
    - Keep Rust, Python, and TypeScript helper behavior, tests, docs, and
      changelogs aligned.
 
@@ -3581,6 +3580,13 @@ the Rust, Python, and TypeScript surfaces together.
      transforms using the shared silicon energy-gap saturation-current law.
    - The nominal `JS / IS` relationship is preserved, and circuit-level
      energy-gap configuration reaches MOS transforms in all three languages.
+
+286. Cross-language Level-1 MOS electrostatic temperature preprocessing.
+   - Status: completed in PR 9135.
+   - Berkeley MOS1 silicon band-gap preprocessing replaces the fixed threshold
+     shift for `PHI` and polarity-aware `VT0`.
+   - Direct MOS helpers and circuit-level transforms preserve matching
+     NMOS/PMOS behavior in Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- apply Berkeley MOS1 silicon potential preprocessing to Level-1 MOS `PB`
- keep Rust, Python, and TypeScript temperature helpers aligned with cold/hot reference coverage
- reconcile PR #9135 in the SPICE completion plan and document the expanded transform

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python `ruff check src tests`
- Python `pytest -q` (671 passed, 88.88% coverage)
- TypeScript `npm run build`
- TypeScript `npm test` (414 passed)