### PR TITLE
feat(adj-formula-stdlib): loading dose — first 4-quantity clinical formulabook, LD=(Cp×Vd)/F

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_loading_dose_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_loading_dose_e2e.rs
@@ -1,0 +1,176 @@
+//! End-to-end tests for the `clinical/loading-dose.adj` library — the loading-dose relation
+//! (Loading dose = (Cp × Vd) / F) and its three exact rearrangements — driven through the built CLI
+//! binary against the SHIPPED stdlib. The same invariant as every other formula library: a consumer
+//! states NO arithmetic; it imports the grounded library, binds the measured/target quantities with
+//! `observe`, and the engine applies the cited relation on the CPU, computing the EXACT value and
+//! rendering the relation's citation and trust tier in the `derived` section (the auditable answer).
+//! This is the FIRST four-quantity formulabook in the clinical track — the dosing payoff of
+//! volume-of-distribution.adj. The four formulas INVERT around the worked case Cp = 5 mg/L, Vd =
+//! 40 L, F = 1: (5 × 40) / 1 = 200, (200 × 1) / 40 = 5, (200 × 1) / 5 = 40, and (5 × 40) / 200 = 1.
+//! The four asserted values (200, 5, 40, 1) are chosen so none is a colon-anchored prefix of another
+//! rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped loading-dose library, resolved from this crate's manifest dir so the
+/// test is location-independent.
+fn shipped_ld_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/loading-dose.adj")
+        .canonicalize()
+        .expect("shipped loading-dose.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_ld_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_ld_lib()).unwrap();
+    std::fs::write(dir.join("loading-dose.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// loading_dose — the relation: (concentration × volume of distribution) / bioavailability.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_loading_dose_library_and_computes_it_with_citation() {
+    let dir = scratch("ld");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"loading-dose.adj\"\n\
+         observe desired_plasma_concentration(5)\n\
+         observe volume_of_distribution(40)\n\
+         observe bioavailability(1)\n\
+         ? loading_dose(desired_plasma_concentration, volume_of_distribution, bioavailability)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: (5 × 40) / 1 = 200.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"loading_dose\"") && s.contains("\"value\":200"),
+        "loading_dose(5, 40, 1) = 200: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// desired_plasma_concentration — the same relation solved for Cp: (LD × F) / Vd.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_concentration_from_dose_volume_and_bioavailability_with_citation() {
+    let dir = scratch("cp");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"loading-dose.adj\"\n\
+         observe loading_dose(200)\n\
+         observe volume_of_distribution(40)\n\
+         observe bioavailability(1)\n\
+         ? desired_plasma_concentration(loading_dose, volume_of_distribution, bioavailability)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (200 × 1) / 40 = 5, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"desired_plasma_concentration\"") && s.contains("\"value\":5"),
+        "desired_plasma_concentration(200, 40, 1) = 5: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "desired_plasma_concentration carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// volume_of_distribution — the same relation solved for Vd: (LD × F) / Cp.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_volume_from_dose_concentration_and_bioavailability_with_citation() {
+    let dir = scratch("vd");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"loading-dose.adj\"\n\
+         observe loading_dose(200)\n\
+         observe desired_plasma_concentration(5)\n\
+         observe bioavailability(1)\n\
+         ? volume_of_distribution(loading_dose, desired_plasma_concentration, bioavailability)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (200 × 1) / 5 = 40, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"volume_of_distribution\"") && s.contains("\"value\":40"),
+        "volume_of_distribution(200, 5, 1) = 40: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "volume_of_distribution carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// bioavailability — the same relation solved for F: (Cp × Vd) / LD, the fourth reading of the one
+// relation.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_bioavailability_from_concentration_volume_and_dose_with_citation() {
+    let dir = scratch("f");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"loading-dose.adj\"\n\
+         observe desired_plasma_concentration(5)\n\
+         observe volume_of_distribution(40)\n\
+         observe loading_dose(200)\n\
+         ? bioavailability(loading_dose, desired_plasma_concentration, volume_of_distribution)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (5 × 40) / 200 = 1, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"bioavailability\"") && s.contains("\"value\":1"),
+        "bioavailability(200, 5, 40) = 1: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "bioavailability carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/loading-dose.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/loading-dose.adj
@@ -1,0 +1,107 @@
+% ============================================================================
+% loading-dose.adj — the loading-dose relation (Loading dose = (Cp × Vd) / F) in the ADJ standard
+% library.
+% ============================================================================
+% The loading-dose entry of the *clinical* track — the third PHARMACOKINETICS library and the
+% dosing PAYOFF of volume-of-distribution.adj: "the single most important utility of Vd is the
+% calculation of the loading dose of a drug." Where Vd and clearance are single ratios, the loading
+% dose COMPOSES three quantities — THE LOADING DOSE IS THE DESIRED PLASMA CONCENTRATION TIMES THE
+% VOLUME OF DISTRIBUTION, DIVIDED BY THE BIOAVAILABILITY — the up-front dose that fills the apparent
+% distribution volume to the target concentration at once (for an intravenous drug the
+% bioavailability F = 1, so it reduces to Cp × Vd). This is the FIRST four-quantity formulabook in
+% the clinical track: it ships as an importable, byte-provenanced, PARAMETERIZED `formula` together
+% with its three exact rearrangements (solving for the concentration, the volume of distribution,
+% and the bioavailability). As with every compute library, a consumer states NO arithmetic: it
+% `import`s this file, binds the measured/target quantities from its own byte-provenance
+% decomposition, and asks the engine to APPLY the cited relation on the CPU. Zero math is performed
+% by the model; the engine computes each value EXACTLY (over exact rationals), carrying the
+% relation's citation.
+%
+%     import "loading-dose.adj"
+%     observe desired_plasma_concentration(5)   % "…target Cp 5 mg/L…"      (span cited by the model)
+%     observe volume_of_distribution(40)         % "…Vd 40 L…"               (span cited by the model)
+%     observe bioavailability(1)                 % "…IV, F = 1…"             (span cited by the model)
+%     ? loading_dose(desired_plasma_concentration, volume_of_distribution, bioavailability)
+%                                                % engine → 200, carrying LD = (Cp × Vd) / F
+%
+% All four formulas are EXACT over their parameters, so every value the engine returns is exact.
+% They COMPOSE and invert cleanly around the worked case desired plasma concentration = 5 mg/L,
+% volume of distribution = 40 L, bioavailability = 1 (LD = (5 × 40) / 1 = 200 mg): the
+% `loading_dose` a consumer computes is exactly the value each rearrangement re-uses to recover its
+% own quantity — the concentration (200 × 1 ÷ 40 = 5), the volume of distribution (200 × 1 ÷ 5 =
+% 40), and the bioavailability (5 × 40 ÷ 200 = 1).
+%
+%   loading_dose(desired_plasma_concentration, volume_of_distribution, bioavailability)
+%       = desired_plasma_concentration * volume_of_distribution / bioavailability   % LD = (Cp × Vd) / F
+%   desired_plasma_concentration(loading_dose, volume_of_distribution, bioavailability)
+%       = loading_dose * bioavailability / volume_of_distribution                    % Cp = (LD × F) / Vd
+%   volume_of_distribution(loading_dose, desired_plasma_concentration, bioavailability)
+%       = loading_dose * bioavailability / desired_plasma_concentration              % Vd = (LD × F) / Cp
+%   bioavailability(loading_dose, desired_plasma_concentration, volume_of_distribution)
+%       = desired_plasma_concentration * volume_of_distribution / loading_dose       % F = (Cp × Vd) / LD
+%
+% NOTE ON UNITS: the desired plasma concentration is in milligrams per litre and the volume of
+% distribution is in litres, so their product is in milligrams; the bioavailability is a
+% dimensionless fraction (1 for an intravenous drug), so the loading dose comes out in milligrams,
+% and this library computes the exact value over whatever consistent inputs it is given.
+%
+% All four formulas are defended by the SAME clause — "Loading dose=(Cp×Vd)/F" — because that one
+% relation (the loading dose IS the concentration-times-volume over bioavailability) sanctions it
+% read every way. The quote is transcribed verbatim from a peer-reviewed article archived on the
+% NCBI Bookshelf, so each `formula` carries the provenance envelope every shipped grounded clause
+% carries; the linter rejects an unsourced one. (See feedback_nothing_human_authored — the clause is
+% a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable/target pharmacokinetic quantity the relation ranges
+% over, and each result is a derived quantity. `desired_plasma_concentration`,
+% `volume_of_distribution`, `bioavailability` and `loading_dose` each appear BOTH as a derived
+% result and as an input (of the other formulas), so each is a single dictionary term used in both
+% roles. The `surface` lists are the everyday names a decomposer maps onto the canonical term; the
+% trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary loading_dose_vocab {
+    define desired_plasma_concentration : finding  surface "desired plasma concentration", "target plasma concentration", "Cp"   % milligrams per litre (mg/L)
+    define volume_of_distribution       : finding  surface "volume of distribution", "Vd"                                        % litres (L)
+    define bioavailability              : finding  surface "bioavailability", "F"                                                % dimensionless fraction (1 for IV)
+    define loading_dose                 : finding  surface "loading dose", "LD"                                                  % milligrams (mg)
+}
+
+% ----------------------------------------------------------------------------
+% The relation, all four ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the loading-dose clause from the cited article
+% on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an exact product/quotient
+% of measured/target quantities, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook loading_dose_laws {
+    use loading_dose_vocab
+
+    % Loading dose — the desired plasma concentration times the volume of distribution, divided by
+    % the bioavailability, i.e. LD = (Cp × Vd) / F.
+    formula loading_dose(desired_plasma_concentration, volume_of_distribution, bioavailability) = desired_plasma_concentration * volume_of_distribution / bioavailability
+        source "Loading dose=(Cp×Vd)/F"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK545280/"
+        trust authoritative
+
+    % Desired plasma concentration — the same relation solved for the concentration a loading dose
+    % achieves (Cp = (LD × F) / Vd). Defended by the SAME clause.
+    formula desired_plasma_concentration(loading_dose, volume_of_distribution, bioavailability) = loading_dose * bioavailability / volume_of_distribution
+        source "Loading dose=(Cp×Vd)/F"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK545280/"
+        trust authoritative
+
+    % Volume of distribution — the same relation solved for the volume a loading dose implies
+    % (Vd = (LD × F) / Cp). Defended by the SAME clause.
+    formula volume_of_distribution(loading_dose, desired_plasma_concentration, bioavailability) = loading_dose * bioavailability / desired_plasma_concentration
+        source "Loading dose=(Cp×Vd)/F"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK545280/"
+        trust authoritative
+
+    % Bioavailability — the same relation solved for the fraction absorbed (F = (Cp × Vd) / LD): the
+    % concentration-times-volume divided by the loading dose. The SAME clause, read the fourth way.
+    formula bioavailability(loading_dose, desired_plasma_concentration, volume_of_distribution) = desired_plasma_concentration * volume_of_distribution / loading_dose
+        source "Loading dose=(Cp×Vd)/F"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK545280/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/loading-dose.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/loading-dose.query.adj
@@ -1,0 +1,29 @@
+% ============================================================================
+% loading-dose.query.adj — worked applications of the loading-dose relation.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a dosing vignette into observed/target
+% quantities: it `import`s the grounded formulabook, `observe`s the target concentration, the volume
+% of distribution and the bioavailability, and asks the engine to APPLY the cited relation. No
+% arithmetic is stated by the consumer; the engine computes each value EXACTLY (over exact rationals)
+% and carries the article's citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (desired plasma concentration = 5 mg/L, volume of distribution = 40 L, bioavailability
+% = 1 — an intravenous drug): LD = (5 × 40) / 1 = 200 mg. Each query below fixes three of the four
+% quantities and asks the engine to recover the fourth; every answer is exact and the four COMPOSE
+% (each inversion recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli loading-dose.query.adj
+% ============================================================================
+
+import "loading-dose.adj"
+
+% --- Forward: the loading dose the target, volume and bioavailability imply (expect 200). ------
+observe desired_plasma_concentration(5)
+observe volume_of_distribution(40)
+observe bioavailability(1)
+? loading_dose(desired_plasma_concentration, volume_of_distribution, bioavailability)   % expect 200
+
+% --- Inverse: the concentration a loading dose of 200 achieves at that volume/F (expect 5). ----
+observe loading_dose(200)
+? desired_plasma_concentration(loading_dose, volume_of_distribution, bioavailability)   % expect 5


### PR DESCRIPTION
## What

Ships the **loading-dose** relation (Loading dose = (Cp × Vd) / F) as an importable, byte-provenanced, parameterized `formula` in the **clinical** track — the **third pharmacokinetics library** and the dosing **payoff** of `volume-of-distribution.adj`. This is the **first four-quantity formulabook** in the clinical track: it composes three quantities and ships **all four** exact rearrangements.

All four formulas are defended by the **same verbatim clause**, transcribed from a peer-reviewed article on the NCBI Bookshelf:

> "Loading dose=(Cp×Vd)/F"
> — https://www.ncbi.nlm.nih.gov/books/NBK545280/ · `trust authoritative`

## Why

*"The single most important utility of Vd is the calculation of the loading dose of a drug."* Where Vd and clearance are single ratios, the loading dose composes the target concentration, the volume of distribution, and the bioavailability into the up-front dose that fills the apparent volume to the target at once (for IV, F = 1). A consumer states **no arithmetic**: it imports the library, `observe`s the quantities from its own byte-provenance decomposition, and the engine **applies** the cited relation on the CPU, computing each value **exactly over exact rationals** and carrying the citation + trust tier in the auditable `derived` section.

## The four readings

```
loading_dose(Cp, Vd, F)          = Cp * Vd / F     % LD = (Cp × Vd) / F
desired_plasma_concentration(...) = LD * F / Vd     % Cp = (LD × F) / Vd
volume_of_distribution(...)       = LD * F / Cp     % Vd = (LD × F) / Cp
bioavailability(...)              = Cp * Vd / LD    % F  = (Cp × Vd) / LD
```

They **compose** around the worked case Cp = 5 mg/L, Vd = 40 L, F = 1 (intravenous): (5 × 40) / 1 = 200, (200 × 1) / 40 = 5, (200 × 1) / 5 = 40, (5 × 40) / 200 = 1. The four asserted values (200 / 5 / 40 / 1) are chosen so none is a colon-anchored prefix of another rendered value.

## Files

- `code/specs/data/adj-formula-stdlib/clinical/loading-dose.adj` — dictionary + 4-formula formulabook
- `code/specs/data/adj-formula-stdlib/clinical/loading-dose.query.adj` — worked applications
- `code/packages/rust/adj-lang-cli/tests/formula_loading_dose_e2e.rs` — 4 e2e tests (own dedicated file, no shared anchor)

## Verification

- `cargo test -p adj-lang-cli --test formula_loading_dose_e2e` — **4/4 green**
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — **clean**
- Render-probe of `.query.adj` against the built CLI: forward → 200 (confirming `a*b/c` = (a×b)/c precedence) with the verbatim citation + `trust:authoritative`; inverse recovers `desired_plasma_concentration` = 5.
- Data + test only — no engine change, **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)