### PR TITLE
feat(http-core): add Haskell semantic model and parity plan

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,15 +8,20 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": null,
+  "active_pr": {
+    "number": 9144,
+    "url": "https://github.com/adhithyan15/coding-adventures/pull/9144",
+    "branch": "codex/haskell-http-core-parity",
+    "status": "open"
+  },
   "items": [
     {
       "id": "haskell-http-core",
       "title": "Haskell http-core plus Haskell scaffold and resolver integrity",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": [],
       "branch": "codex/haskell-http-core-parity",
-      "pr_number": null,
+      "pr_number": 9144,
       "notes": "Current slice. Locally validated with GHC 9.4.8, 19 Hspec examples, 96% expression coverage, and 95% alternative coverage."
     },
     {

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -1,0 +1,185 @@
+{
+  "job": "full-language-and-build-tool-parity",
+  "automation_id": "package-parity-pr-loop",
+  "started": "2026-07-29",
+  "policy": {
+    "maximum_active_parity_prs": 1,
+    "merge_authority": "user",
+    "reprioritize_after_every_merge": true,
+    "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
+  },
+  "active_pr": null,
+  "items": [
+    {
+      "id": "haskell-http-core",
+      "title": "Haskell http-core plus Haskell scaffold and resolver integrity",
+      "status": "in-progress",
+      "depends_on": [],
+      "branch": "codex/haskell-http-core-parity",
+      "pr_number": null,
+      "notes": "Current slice. Locally validated with GHC 9.4.8, 19 Hspec examples, 96% expression coverage, and 95% alternative coverage."
+    },
+    {
+      "id": "build-tool-contract",
+      "title": "Language-neutral build-tool contract and shared fixture schema",
+      "status": "pending",
+      "depends_on": ["haskell-http-core"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Reconcile specs 12, 15, build-plan-v1, sharding, and B05; define canonical machine-readable behavior."
+    },
+    {
+      "id": "build-tool-fixtures",
+      "title": "Cross-implementation build-tool fixture runner and inventory gate",
+      "status": "pending",
+      "depends_on": ["build-tool-contract"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Cover discovery, resolution, graph order, diff, hashing, Starlark, plan interchange, sharding, execution, validation, and toolchain detection."
+    },
+    {
+      "id": "build-tool-go-oracle",
+      "title": "Bring the Go build tool to the canonical contract",
+      "status": "pending",
+      "depends_on": ["build-tool-fixtures"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Wire structured Starlark context/commands and complete the B05 Windows executor contract."
+    },
+    {
+      "id": "build-tool-existing-remediation",
+      "title": "Remediate all 12 existing build-tool front doors against shared fixtures",
+      "status": "pending",
+      "depends_on": ["build-tool-go-oracle"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Deliver one independent engine per PR; explicitly review the shared C#/F# engine exception."
+    },
+    {
+      "id": "build-tool-jvm",
+      "title": "Add language-native Java and Kotlin build tools",
+      "status": "pending",
+      "depends_on": ["build-tool-fixtures"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Use shared JVM fixture infrastructure but separate idiomatic engines."
+    },
+    {
+      "id": "build-tool-dart",
+      "title": "Add the Dart build tool",
+      "status": "pending",
+      "depends_on": ["build-tool-fixtures"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Must pass the same plan, resolver, execution, and platform fixtures as the reference."
+    },
+    {
+      "id": "ocaml-lane-contract",
+      "title": "Define OCaml emerging-lane and denominator-safe reporter contracts",
+      "status": "pending",
+      "depends_on": ["build-tool-contract"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "OCaml remains outside the established denominator until all promotion gates pass."
+    },
+    {
+      "id": "ocaml-infrastructure",
+      "title": "Add OCaml scaffolding, build integration, CI, capabilities, and logic-gates",
+      "status": "pending",
+      "depends_on": ["ocaml-lane-contract", "build-tool-go-oracle"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Use OCaml 5.2.1, opam 2.5.x, Dune 3.16.x, Alcotest, bisect_ppx, and ocamlformat."
+    },
+    {
+      "id": "ocaml-representative-core",
+      "title": "Port graph, directed-graph, and state-machine to OCaml",
+      "status": "pending",
+      "depends_on": ["ocaml-infrastructure"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "This dependency chain validates opam metadata, resolver edges, BUILD order, and affected-node expansion."
+    },
+    {
+      "id": "ocaml-build-tool-and-promotion",
+      "title": "Implement the OCaml build tool and review 16-lane promotion",
+      "status": "pending",
+      "depends_on": ["ocaml-representative-core", "build-tool-fixtures"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Require conformance, two-way Go plan interchange, three-OS CI, capability enforcement, and explicit backlog acceptance."
+    },
+    {
+      "id": "dart-current-14-of-15",
+      "title": "Close the 13-package Dart-only 14-of-15 frontier",
+      "status": "pending",
+      "depends_on": ["haskell-http-core"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Deliver small dependency-shaped PRs: ML, trig/wave, data structures, ciphers, document-ast, and uuid."
+    },
+    {
+      "id": "haskell-http1",
+      "title": "Port http1 to Haskell on the new http-core",
+      "status": "pending",
+      "depends_on": ["haskell-http-core"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Next protocol dependency node; validate the repaired Cabal dependency graph."
+    },
+    {
+      "id": "haskell-high-consensus-tail",
+      "title": "Close Haskell event-loop and brotli",
+      "status": "pending",
+      "depends_on": ["haskell-http1"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Keep the event loop generic and portable; use byte-exact Brotli conformance vectors."
+    },
+    {
+      "id": "java-kotlin-high-consensus",
+      "title": "Close paired Java/Kotlin high-consensus families",
+      "status": "pending",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Start with lz78/deflate, zstd, and state-machine, then move through shared dependency chains."
+    },
+    {
+      "id": "swift-dart-high-consensus",
+      "title": "Close Swift/Dart data-structure, storage, parser, WASM, ML, and protocol families",
+      "status": "pending",
+      "depends_on": ["dart-current-14-of-15"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Use generated grammars and dependency-first storage/compiler sequences."
+    },
+    {
+      "id": "portable-core-expansion",
+      "title": "Expand through 9-language and then 5-8-language portable packages",
+      "status": "pending",
+      "depends_on": ["haskell-high-consensus-tail", "java-kotlin-high-consensus", "swift-dart-high-consensus"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Recompute and reprioritize after every merged wave."
+    },
+    {
+      "id": "singleton-classification",
+      "title": "Classify all singleton families and enforce declared parity work",
+      "status": "pending",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Current singleton leaders are Rust 538, Python 86, and TypeScript 84; do not port blindly."
+    },
+    {
+      "id": "c-cpp-graduation",
+      "title": "Review C/C++ graduation and native build-tool requirements",
+      "status": "pending",
+      "depends_on": ["build-tool-fixtures"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Keep both emerging until package/scaffold/build-tool maturity and applicability are explicit."
+    }
+  ]
+}

--- a/code/packages/haskell/http-core/BUILD
+++ b/code/packages/haskell/http-core/BUILD
@@ -1,0 +1,1 @@
+cabal test

--- a/code/packages/haskell/http-core/BUILD_windows
+++ b/code/packages/haskell/http-core/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/http-core/CHANGELOG.md
+++ b/code/packages/haskell/http-core/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-07-29
+
+### Added
+
+- Add ordered HTTP headers with ASCII case-insensitive first-value lookup.
+- Add bounded HTTP versions, body framing hints, and semantic request/response
+  head records with content helpers.
+- Add raw request-target and query helpers that preserve percent-encoded text,
+  duplicate parameters, flags, and fragments.
+- Add small path-only route patterns with ordered named captures.
+- Add a 19-example Hspec suite covering valid, malformed, boundary, delegation,
+  query, path, and routing behavior.

--- a/code/packages/haskell/http-core/CHANGELOG.md
+++ b/code/packages/haskell/http-core/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this package will be documented in this file.
 - Add ordered HTTP headers with ASCII case-insensitive first-value lookup.
 - Add bounded HTTP versions, body framing hints, and semantic request/response
   head records with content helpers.
+- Reject oversized decimal version and content-length values with a bounded
+  fold that does not allocate attacker-sized arbitrary-precision integers.
 - Add raw request-target and query helpers that preserve percent-encoded text,
   duplicate parameters, flags, and fragments.
 - Add small path-only route patterns with ordered named captures.

--- a/code/packages/haskell/http-core/README.md
+++ b/code/packages/haskell/http-core/README.md
@@ -1,0 +1,67 @@
+# http-core (Haskell)
+
+Pure Haskell shared HTTP message types and semantic helpers.
+
+HTTP/1.x, HTTP/2, and HTTP/3 use different bytes on the wire, but application
+code still consumes the same conceptual message head:
+
+```text
+version-specific parser
+        |
+        v
+Header / HttpVersion / BodyKind
+        |
+        v
+RequestHead or ResponseHead
+```
+
+This package is that shared middle layer. It performs no socket I/O, HTTP wire
+parsing, percent decoding, or body decoding.
+
+## API
+
+- `Header` preserves arrival order, duplicate fields, values, and original name
+  spelling. `findHeader` performs ASCII case-insensitive first-value lookup.
+- `HttpVersion`, `parseHttpVersion`, and `renderHttpVersion` provide bounded,
+  round-trippable `HTTP/x.y` markers.
+- `BodyKind` describes no body, a fixed content length, EOF framing, or chunked
+  framing.
+- `RequestHead` and `ResponseHead` carry the semantic head fields and expose
+  delegating header, content-length, and content-type helpers.
+- `RequestTarget` splits a raw path, query, and fragment without decoding.
+  `queryPairs` preserves duplicate keys and `queryValue` returns the first.
+- `RoutePattern` matches literal and `:name` path segments. `matchTarget`
+  ignores query strings and fragments.
+
+## Example
+
+```haskell
+import CodingAdventures.HttpCore
+
+request :: RequestHead
+request =
+  RequestHead
+    { requestMethod = "GET"
+    , requestTarget = "/devices/light-1?verbose=true"
+    , requestVersion = HttpVersion 1 1
+    , requestHeaders = [Header "Accept" "application/json"]
+    }
+
+route :: Maybe [(String, String)]
+route = matchTarget (parseRoutePattern "/devices/:id") (requestTarget request)
+-- Just [("id", "light-1")]
+```
+
+Content length accepts non-negative ASCII decimal values that fit in `Int`.
+Content type parsing extracts a trimmed media type and the first
+case-insensitive `charset` parameter.
+
+## Development
+
+```sh
+cabal check
+cabal test
+cabal test --enable-coverage
+```
+
+The package depends only on `base`; Hspec is a test-only dependency.

--- a/code/packages/haskell/http-core/cabal.project
+++ b/code/packages/haskell/http-core/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/http-core/http-core.cabal
+++ b/code/packages/haskell/http-core/http-core.cabal
@@ -1,0 +1,33 @@
+cabal-version: 3.0
+name:          http-core
+version:       0.1.0
+synopsis:      Pure Haskell shared HTTP message types and semantic helpers
+description:   Defines ordered headers, bounded HTTP versions, request and
+               response heads, body framing hints, request-target helpers,
+               and path-only route matching without wire parsing or I/O.
+category:      Network
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  CodingAdventures.HttpCore
+    build-depends:    base >=4.14 && <5
+    hs-source-dirs:   src
+    ghc-options:      -Wall
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    HttpCoreSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , http-core
+                    , hspec ==2.*
+    ghc-options:      -Wall
+    default-language: Haskell2010

--- a/code/packages/haskell/http-core/required_capabilities.json
+++ b/code/packages/haskell/http-core/required_capabilities.json
@@ -1,0 +1,1 @@
+{"capabilities": []}

--- a/code/packages/haskell/http-core/src/CodingAdventures/HttpCore.hs
+++ b/code/packages/haskell/http-core/src/CodingAdventures/HttpCore.hs
@@ -1,0 +1,333 @@
+-- | Shared, version-neutral HTTP message types.
+--
+-- HTTP has two layers:
+--
+-- @
+-- bytes on a connection -> version-specific parser -> semantic message head
+-- @
+--
+-- HTTP/1.x, HTTP/2, and HTTP/3 disagree about bytes on the wire, but callers
+-- still need the same ordered headers, version, status, and body-framing hint.
+-- This module models that common semantic layer. It deliberately performs no
+-- socket I/O and no wire parsing.
+module CodingAdventures.HttpCore
+  ( Header (..)
+  , HttpVersion (..)
+  , BodyKind (..)
+  , RequestHead (..)
+  , ResponseHead (..)
+  , RequestTarget (..)
+  , RouteSegment (..)
+  , RoutePattern (..)
+  , version
+  , parseHttpVersion
+  , renderHttpVersion
+  , findHeader
+  , parseContentLength
+  , parseContentType
+  , requestHeader
+  , requestContentLength
+  , requestContentType
+  , responseHeader
+  , responseContentLength
+  , responseContentType
+  , parseRequestTarget
+  , queryPairs
+  , queryValue
+  , requestTargetParts
+  , requestPath
+  , requestQueryValue
+  , splitPathSegments
+  , parseRoutePattern
+  , matchPath
+  , matchTarget
+  ) where
+
+import Data.Char (isSpace)
+import Data.List (dropWhileEnd, find)
+import Data.Word (Word16)
+import Text.Read (readMaybe)
+
+-- | Package version shared across implementation languages.
+version :: String
+version = "0.1.0"
+
+-- | One HTTP header line.
+--
+-- A list is intentional here: a map would erase duplicate fields such as
+-- @Set-Cookie@ and would lose arrival order and original name spelling.
+data Header = Header
+  { headerName :: String
+  , headerValue :: String
+  } deriving (Eq, Show)
+
+-- | A future-friendly HTTP version represented as bounded components.
+data HttpVersion = HttpVersion
+  { versionMajor :: Word16
+  , versionMinor :: Word16
+  } deriving (Eq, Show)
+
+-- | Parse the exact textual form @HTTP/x.y@.
+--
+-- Parsing through 'Integer' first makes overflow explicit instead of letting a
+-- bounded numeric conversion wrap. Only ASCII decimal digits are accepted.
+parseHttpVersion :: String -> Either String HttpVersion
+parseHttpVersion input =
+  case stripPrefix "HTTP/" input of
+    Nothing -> invalid
+    Just rest ->
+      case splitOnce '.' rest of
+        (majorText, Just minorText) ->
+          case (parseWord16 majorText, parseWord16 minorText) of
+            (Just major, Just minor) ->
+              Right HttpVersion
+                { versionMajor = major
+                , versionMinor = minor
+                }
+            _ -> invalid
+        _ -> invalid
+  where
+    invalid = Left ("invalid HTTP version: " ++ input)
+
+-- | Render a semantic version back to the stable HTTP marker.
+renderHttpVersion :: HttpVersion -> String
+renderHttpVersion httpVersion =
+  "HTTP/"
+    ++ show (versionMajor httpVersion)
+    ++ "."
+    ++ show (versionMinor httpVersion)
+
+-- | Tell the caller how to consume the payload after parsing the head.
+data BodyKind
+  = NoBody
+  | ContentLength Int
+  | UntilEof
+  | Chunked
+  deriving (Eq, Show)
+
+-- | The semantic fields known after parsing a request head.
+data RequestHead = RequestHead
+  { requestMethod :: String
+  , requestTarget :: String
+  , requestVersion :: HttpVersion
+  , requestHeaders :: [Header]
+  } deriving (Eq, Show)
+
+-- | The semantic fields known after parsing a response head.
+data ResponseHead = ResponseHead
+  { responseVersion :: HttpVersion
+  , responseStatus :: Word16
+  , responseReason :: String
+  , responseHeaders :: [Header]
+  } deriving (Eq, Show)
+
+-- | Return the first matching value using ASCII case-insensitive comparison.
+--
+-- HTTP field names are ASCII. Restricting the fold to @A-Z@ avoids quietly
+-- applying locale or Unicode case rules to a protocol token.
+findHeader :: [Header] -> String -> Maybe String
+findHeader headers name =
+  headerValue <$> find matches headers
+  where
+    matches header =
+      asciiCaseFold (headerName header) == asciiCaseFold name
+
+-- | Parse a non-negative decimal Content-Length that fits in 'Int'.
+parseContentLength :: [Header] -> Maybe Int
+parseContentLength headers = do
+  value <- findHeader headers "Content-Length"
+  if null value || not (all isAsciiDigit value)
+    then Nothing
+    else do
+      parsed <- readMaybe value :: Maybe Integer
+      if parsed > toInteger (maxBound :: Int)
+        then Nothing
+        else Just (fromInteger parsed)
+
+-- | Split Content-Type into media type and optional charset.
+--
+-- Unknown parameters remain intentionally ignored. Charset matching is ASCII
+-- case-insensitive, surrounding whitespace is trimmed, and one pair of
+-- surrounding double quotes is removed from the charset value.
+parseContentType :: [Header] -> Maybe (String, Maybe String)
+parseContentType headers = do
+  value <- findHeader headers "Content-Type"
+  case map trim (splitOn ';' value) of
+    [] -> Nothing
+    mediaType : parameters
+      | null mediaType -> Nothing
+      | otherwise -> Just (mediaType, firstCharset parameters)
+
+-- | Request-specific convenience wrappers keep application code declarative.
+requestHeader :: RequestHead -> String -> Maybe String
+requestHeader request name = findHeader (requestHeaders request) name
+
+requestContentLength :: RequestHead -> Maybe Int
+requestContentLength = parseContentLength . requestHeaders
+
+requestContentType :: RequestHead -> Maybe (String, Maybe String)
+requestContentType = parseContentType . requestHeaders
+
+-- | Response-specific counterparts to the request helpers.
+responseHeader :: ResponseHead -> String -> Maybe String
+responseHeader response name = findHeader (responseHeaders response) name
+
+responseContentLength :: ResponseHead -> Maybe Int
+responseContentLength = parseContentLength . responseHeaders
+
+responseContentType :: ResponseHead -> Maybe (String, Maybe String)
+responseContentType = parseContentType . responseHeaders
+
+-- | A non-decoding view of an origin-form request target.
+--
+-- Query strings stay raw. A caller can therefore apply its own percent-decoder
+-- and duplicate-key policy instead of receiving an irreversible interpretation.
+data RequestTarget = RequestTarget
+  { targetPath :: String
+  , targetQuery :: Maybe String
+  , targetFragment :: Maybe String
+  } deriving (Eq, Show)
+
+-- | Split a request target at its first fragment marker and first query marker.
+-- An omitted path normalizes to @/@, matching browser and server expectations.
+parseRequestTarget :: String -> RequestTarget
+parseRequestTarget input =
+  RequestTarget
+    { targetPath = if null path then "/" else path
+    , targetQuery = query
+    , targetFragment = fragment
+    }
+  where
+    (beforeFragment, fragment) = splitOnce '#' input
+    (path, query) = splitOnce '?' beforeFragment
+
+-- | Interpret the raw query as ordered @name=value@ pairs.
+--
+-- Empty ampersand-delimited pieces are skipped. A flag such as @verbose@ has
+-- an empty value, and only the first equals sign separates name from value.
+queryPairs :: RequestTarget -> [(String, String)]
+queryPairs target =
+  map toPair nonEmptyPieces
+  where
+    pieces = maybe [] (splitOn '&') (targetQuery target)
+    nonEmptyPieces = filter (not . null) pieces
+    toPair piece =
+      case splitOnce '=' piece of
+        (name, Just value) -> (name, value)
+        (name, Nothing) -> (name, "")
+
+-- | Return the first raw query value with the requested name.
+queryValue :: RequestTarget -> String -> Maybe String
+queryValue target name =
+  snd <$> find ((== name) . fst) (queryPairs target)
+
+requestTargetParts :: RequestHead -> RequestTarget
+requestTargetParts = parseRequestTarget . requestTarget
+
+requestPath :: RequestHead -> String
+requestPath = targetPath . requestTargetParts
+
+requestQueryValue :: RequestHead -> String -> Maybe String
+requestQueryValue request = queryValue (requestTargetParts request)
+
+-- | Split a path into its non-empty slash-delimited pieces.
+--
+-- Leading, trailing, and repeated slashes do not create phantom route
+-- segments. Consequently the root path is represented by the empty list.
+splitPathSegments :: String -> [String]
+splitPathSegments = filter (not . null) . splitOn '/'
+
+-- | A literal route component or a named capture introduced by @:@.
+data RouteSegment
+  = Literal String
+  | Param String
+  deriving (Eq, Show)
+
+-- | A parsed path pattern such as @/devices/:id@.
+newtype RoutePattern = RoutePattern
+  { routeSegments :: [RouteSegment]
+  } deriving (Eq, Show)
+
+parseRoutePattern :: String -> RoutePattern
+parseRoutePattern patternText =
+  RoutePattern (map parseSegment (splitPathSegments patternText))
+  where
+    parseSegment (':' : name) = Param name
+    parseSegment literal = Literal literal
+
+-- | Match a path and return named captures in pattern order.
+matchPath :: RoutePattern -> String -> Maybe [(String, String)]
+matchPath patternValue path =
+  matchSegments (routeSegments patternValue) (splitPathSegments path)
+  where
+    matchSegments [] [] = Just []
+    matchSegments (Literal expected : rest) (actual : actualRest)
+      | expected == actual = matchSegments rest actualRest
+      | otherwise = Nothing
+    matchSegments (Param name : rest) (actual : actualRest) =
+      ((name, actual) :) <$> matchSegments rest actualRest
+    matchSegments _ _ = Nothing
+
+-- | Match only the path portion of a full request target.
+matchTarget :: RoutePattern -> String -> Maybe [(String, String)]
+matchTarget patternValue =
+  matchPath patternValue . targetPath . parseRequestTarget
+
+-- Private helpers -----------------------------------------------------------
+
+parseWord16 :: String -> Maybe Word16
+parseWord16 text
+  | null text || not (all isAsciiDigit text) = Nothing
+  | otherwise = do
+      parsed <- readMaybe text :: Maybe Integer
+      if parsed > toInteger (maxBound :: Word16)
+        then Nothing
+        else Just (fromInteger parsed)
+
+isAsciiDigit :: Char -> Bool
+isAsciiDigit character = character >= '0' && character <= '9'
+
+asciiCaseFold :: String -> String
+asciiCaseFold = map lowerAscii
+  where
+    lowerAscii character
+      | character >= 'A' && character <= 'Z' =
+          toEnum (fromEnum character + fromEnum 'a' - fromEnum 'A')
+      | otherwise = character
+
+firstCharset :: [String] -> Maybe String
+firstCharset [] = Nothing
+firstCharset (parameter : rest) =
+  case splitOnce '=' parameter of
+    (name, Just value)
+      | asciiCaseFold (trim name) == "charset" ->
+          Just (stripSurroundingQuotes (trim value))
+    _ -> firstCharset rest
+
+stripSurroundingQuotes :: String -> String
+stripSurroundingQuotes text
+  | length text >= 2 && head text == '"' && last text == '"' =
+      init (tail text)
+  | otherwise = text
+
+trim :: String -> String
+trim = dropWhileEnd isSpace . dropWhile isSpace
+
+stripPrefix :: String -> String -> Maybe String
+stripPrefix [] input = Just input
+stripPrefix _ [] = Nothing
+stripPrefix (expected : expectedRest) (actual : actualRest)
+  | expected == actual = stripPrefix expectedRest actualRest
+  | otherwise = Nothing
+
+splitOnce :: Char -> String -> (String, Maybe String)
+splitOnce delimiter input =
+  case break (== delimiter) input of
+    (before, []) -> (before, Nothing)
+    (before, _ : after) -> (before, Just after)
+
+splitOn :: Char -> String -> [String]
+splitOn delimiter input =
+  case splitOnce delimiter input of
+    (piece, Nothing) -> [piece]
+    (piece, Just rest) -> piece : splitOn delimiter rest

--- a/code/packages/haskell/http-core/src/CodingAdventures/HttpCore.hs
+++ b/code/packages/haskell/http-core/src/CodingAdventures/HttpCore.hs
@@ -46,7 +46,6 @@ module CodingAdventures.HttpCore
 import Data.Char (isSpace)
 import Data.List (dropWhileEnd, find)
 import Data.Word (Word16)
-import Text.Read (readMaybe)
 
 -- | Package version shared across implementation languages.
 version :: String
@@ -69,8 +68,9 @@ data HttpVersion = HttpVersion
 
 -- | Parse the exact textual form @HTTP/x.y@.
 --
--- Parsing through 'Integer' first makes overflow explicit instead of letting a
--- bounded numeric conversion wrap. Only ASCII decimal digits are accepted.
+-- Parsing uses a bounded decimal fold so oversized network input is rejected
+-- before it can allocate an attacker-sized arbitrary-precision integer. Only
+-- ASCII decimal digits are accepted.
 parseHttpVersion :: String -> Either String HttpVersion
 parseHttpVersion input =
   case stripPrefix "HTTP/" input of
@@ -136,13 +136,7 @@ findHeader headers name =
 parseContentLength :: [Header] -> Maybe Int
 parseContentLength headers = do
   value <- findHeader headers "Content-Length"
-  if null value || not (all isAsciiDigit value)
-    then Nothing
-    else do
-      parsed <- readMaybe value :: Maybe Integer
-      if parsed > toInteger (maxBound :: Int)
-        then Nothing
-        else Just (fromInteger parsed)
+  parseBoundedDecimal maxBound value
 
 -- | Split Content-Type into media type and optional charset.
 --
@@ -276,13 +270,20 @@ matchTarget patternValue =
 -- Private helpers -----------------------------------------------------------
 
 parseWord16 :: String -> Maybe Word16
-parseWord16 text
-  | null text || not (all isAsciiDigit text) = Nothing
-  | otherwise = do
-      parsed <- readMaybe text :: Maybe Integer
-      if parsed > toInteger (maxBound :: Word16)
-        then Nothing
-        else Just (fromInteger parsed)
+parseWord16 = parseBoundedDecimal maxBound
+
+parseBoundedDecimal :: Integral value => value -> String -> Maybe value
+parseBoundedDecimal limit text
+  | null text = Nothing
+  | otherwise = go 0 text
+  where
+    go accumulator [] = Just accumulator
+    go accumulator (character : rest)
+      | not (isAsciiDigit character) = Nothing
+      | accumulator > (limit - digit) `div` 10 = Nothing
+      | otherwise = go (accumulator * 10 + digit) rest
+      where
+        digit = fromIntegral (fromEnum character - fromEnum '0')
 
 isAsciiDigit :: Char -> Bool
 isAsciiDigit character = character >= '0' && character <= '9'

--- a/code/packages/haskell/http-core/test/HttpCoreSpec.hs
+++ b/code/packages/haskell/http-core/test/HttpCoreSpec.hs
@@ -1,0 +1,162 @@
+module HttpCoreSpec (spec) where
+
+import CodingAdventures.HttpCore
+import Data.Either (isLeft)
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "package metadata and HTTP versions" $ do
+    it "reports version 0.1.0" $
+      version `shouldBe` "0.1.0"
+
+    it "parses and renders bounded HTTP versions" $ do
+      let expected = HttpVersion {versionMajor = 1, versionMinor = 1}
+      parseHttpVersion "HTTP/1.1" `shouldBe` Right expected
+      renderHttpVersion expected `shouldBe` "HTTP/1.1"
+
+    it "rejects malformed and overflowing HTTP versions" $ do
+      mapM_
+        (\input -> parseHttpVersion input `shouldSatisfy` isLeft)
+        [ "http/1.1"
+        , "HTTP/1"
+        , "HTTP/.1"
+        , "HTTP/1."
+        , "HTTP/a.1"
+        , "HTTP/1.2.3"
+        , "HTTP/65536.1"
+        ]
+
+  describe "ordered HTTP headers" $ do
+    let headers =
+          [ Header "Set-Cookie" "session=abc"
+          , Header "set-cookie" "theme=dark"
+          , Header "Content-Type" "text/plain"
+          ]
+
+    it "looks up names with ASCII case-insensitive comparison" $ do
+      findHeader headers "CONTENT-TYPE" `shouldBe` Just "text/plain"
+      findHeader headers "missing" `shouldBe` Nothing
+      findHeader [Header "Ä-Test" "value"] "ä-test" `shouldBe` Nothing
+
+    it "preserves duplicates and returns the first matching value" $ do
+      map headerValue headers
+        `shouldBe` ["session=abc", "theme=dark", "text/plain"]
+      findHeader headers "set-cookie" `shouldBe` Just "session=abc"
+
+  describe "semantic header helpers" $ do
+    it "parses zero and positive content lengths" $ do
+      parseContentLength [Header "Content-Length" "0"] `shouldBe` Just 0
+      parseContentLength [Header "content-length" "42"] `shouldBe` Just 42
+
+    it "rejects malformed, signed, padded, and overflowing lengths" $ do
+      let overflow = show (toInteger (maxBound :: Int) + 1)
+      mapM_
+        (\value ->
+          parseContentLength [Header "Content-Length" value]
+            `shouldBe` Nothing)
+        ["", "-1", "+1", " 1", "1 ", "forty-two", overflow]
+
+    it "parses media types with and without charsets" $ do
+      parseContentType [Header "Content-Type" "application/json"]
+        `shouldBe` Just ("application/json", Nothing)
+      parseContentType
+        [Header "Content-Type" "text/html; level=1; CHARSET=\"utf-8\"; q=1"]
+        `shouldBe` Just ("text/html", Just "utf-8")
+
+    it "uses the first charset and rejects an empty media type" $ do
+      parseContentType
+        [Header "Content-Type" "text/plain; charset=ascii; charset=utf-8"]
+        `shouldBe` Just ("text/plain", Just "ascii")
+      parseContentType [Header "Content-Type" " ; charset=utf-8"]
+        `shouldBe` Nothing
+      parseContentType [] `shouldBe` Nothing
+
+  describe "body framing and message heads" $ do
+    it "compares all body framing constructors by value" $ do
+      NoBody `shouldBe` NoBody
+      ContentLength 7 `shouldBe` ContentLength 7
+      UntilEof `shouldBe` UntilEof
+      Chunked `shouldBe` Chunked
+
+    it "delegates request helpers to the ordered header list" $ do
+      let request =
+            RequestHead
+              { requestMethod = "POST"
+              , requestTarget = "/submit?mode=fast"
+              , requestVersion = HttpVersion 1 1
+              , requestHeaders =
+                  [ Header "Content-Length" "5"
+                  , Header "Content-Type" "text/plain; charset=utf-8"
+                  ]
+              }
+      requestHeader request "content-length" `shouldBe` Just "5"
+      requestContentLength request `shouldBe` Just 5
+      requestContentType request
+        `shouldBe` Just ("text/plain", Just "utf-8")
+      requestPath request `shouldBe` "/submit"
+      requestQueryValue request "mode" `shouldBe` Just "fast"
+
+    it "delegates response helpers to the ordered header list" $ do
+      let response =
+            ResponseHead
+              { responseVersion = HttpVersion 1 0
+              , responseStatus = 200
+              , responseReason = "OK"
+              , responseHeaders = [Header "Content-Type" "application/json"]
+              }
+      responseHeader response "content-type" `shouldBe` Just "application/json"
+      responseContentLength response `shouldBe` Nothing
+      responseContentType response
+        `shouldBe` Just ("application/json", Nothing)
+
+  describe "request targets and raw query strings" $ do
+    it "splits path, query, and fragment without percent-decoding" $ do
+      let target =
+            parseRequestTarget
+              "/clip/v2/resource?id=abc%20123&limit=10#ignored"
+      targetPath target `shouldBe` "/clip/v2/resource"
+      targetQuery target `shouldBe` Just "id=abc%20123&limit=10"
+      targetFragment target `shouldBe` Just "ignored"
+      queryValue target "id" `shouldBe` Just "abc%20123"
+
+    it "normalizes an empty path while preserving empty suffixes" $ do
+      parseRequestTarget "?flag#"
+        `shouldBe` RequestTarget "/" (Just "flag") (Just "")
+      parseRequestTarget ""
+        `shouldBe` RequestTarget "/" Nothing Nothing
+
+    it "splits on the first equals, skips empty pieces, and keeps duplicates" $ do
+      let target = parseRequestTarget "/?&&flag&name=first=rest&name=second"
+      queryPairs target
+        `shouldBe`
+          [ ("flag", "")
+          , ("name", "first=rest")
+          , ("name", "second")
+          ]
+      queryValue target "name" `shouldBe` Just "first=rest"
+      queryValue target "missing" `shouldBe` Nothing
+
+    it "splits paths consistently across repeated and trailing slashes" $ do
+      splitPathSegments "/" `shouldBe` []
+      splitPathSegments "/api//devices/" `shouldBe` ["api", "devices"]
+      splitPathSegments "api/devices" `shouldBe` ["api", "devices"]
+
+  describe "path-only route matching" $ do
+    it "matches literals and returns ordered named captures" $ do
+      let pattern = parseRoutePattern "/clip/:kind/:id"
+      matchPath pattern "/clip/light/abc"
+        `shouldBe` Just [("kind", "light"), ("id", "abc")]
+
+    it "matches roots and rejects literal or arity mismatches" $ do
+      matchPath (parseRoutePattern "/") "/" `shouldBe` Just []
+      matchPath (parseRoutePattern "/hello/:name") "/goodbye/Ada"
+        `shouldBe` Nothing
+      matchPath (parseRoutePattern "/hello/:name") "/hello"
+        `shouldBe` Nothing
+
+    it "ignores query strings and fragments when matching a target" $ do
+      matchTarget
+        (parseRoutePattern "/devices/:id")
+        "/devices/abc?verbose=true#client"
+        `shouldBe` Just [("id", "abc")]

--- a/code/packages/haskell/http-core/test/HttpCoreSpec.hs
+++ b/code/packages/haskell/http-core/test/HttpCoreSpec.hs
@@ -25,6 +25,7 @@ spec = do
         , "HTTP/a.1"
         , "HTTP/1.2.3"
         , "HTTP/65536.1"
+        , "HTTP/" ++ replicate 100000 '9' ++ ".0"
         ]
 
   describe "ordered HTTP headers" $ do
@@ -55,7 +56,15 @@ spec = do
         (\value ->
           parseContentLength [Header "Content-Length" value]
             `shouldBe` Nothing)
-        ["", "-1", "+1", " 1", "1 ", "forty-two", overflow]
+        [ ""
+        , "-1"
+        , "+1"
+        , " 1"
+        , "1 "
+        , "forty-two"
+        , overflow
+        , replicate 100000 '9'
+        ]
 
     it "parses media types with and without charsets" $ do
       parseContentType [Header "Content-Type" "application/json"]

--- a/code/packages/haskell/http-core/test/Spec.hs
+++ b/code/packages/haskell/http-core/test/Spec.hs
@@ -1,0 +1,5 @@
+import HttpCoreSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/programs/go/build-tool/CHANGELOG.md
+++ b/code/programs/go/build-tool/CHANGELOG.md
@@ -21,6 +21,14 @@ All notable changes to the Go build tool will be documented in this file.
   MSVC on Windows so the pure-ISO multi-compiler check sees all three across the
   matrix.
 
+### Fixed
+
+- Haskell dependency resolution now recognizes the plain Cabal names used by
+  current packages as well as legacy `coding-adventures-*` names. The resolver
+  registers directory and manifest aliases, parses every `build-depends`
+  stanza, removes duplicates and self-references, and therefore exposes local
+  dependency edges to diff-based affected-package analysis.
+
 ## [0.3.1] - 2026-03-30
 
 ### Fixed

--- a/code/programs/go/build-tool/CHANGELOG.md
+++ b/code/programs/go/build-tool/CHANGELOG.md
@@ -28,6 +28,8 @@ All notable changes to the Go build tool will be documented in this file.
   registers directory and manifest aliases, parses every `build-depends`
   stanza, removes duplicates and self-references, and therefore exposes local
   dependency edges to diff-based affected-package analysis.
+- Haskell package discovery now rejects directories with multiple ambiguous
+  Cabal manifests instead of selecting one based on enumeration order.
 
 ## [0.3.1] - 2026-03-30
 

--- a/code/programs/go/build-tool/internal/resolver/resolver.go
+++ b/code/programs/go/build-tool/internal/resolver/resolver.go
@@ -1120,20 +1120,24 @@ func readCargoPackageName(pkgPath string) string {
 	return strings.ToLower(strings.TrimSpace(string(match[1])))
 }
 
-// findCabalFile returns the first Cabal manifest in a package directory.
-// Package directories contain at most one manifest, while the filename itself
-// may use either the modern plain name or the legacy prefixed name.
+// findCabalFile returns the sole Cabal manifest in a package directory.
+// Multiple manifests are ambiguous, so reject them instead of allowing
+// directory enumeration order to change package identity or dependencies.
 func findCabalFile(pkgPath string) string {
 	entries, err := os.ReadDir(pkgPath)
 	if err != nil {
 		return ""
 	}
+	var cabalFile string
 	for _, entry := range entries {
 		if !entry.IsDir() && strings.HasSuffix(strings.ToLower(entry.Name()), ".cabal") {
-			return filepath.Join(pkgPath, entry.Name())
+			if cabalFile != "" {
+				return ""
+			}
+			cabalFile = filepath.Join(pkgPath, entry.Name())
 		}
 	}
-	return ""
+	return cabalFile
 }
 
 func readCabalPackageName(pkgPath string) string {

--- a/code/programs/go/build-tool/internal/resolver/resolver.go
+++ b/code/programs/go/build-tool/internal/resolver/resolver.go
@@ -685,28 +685,15 @@ func parseSwiftDeps(pkg discovery.Package, knownNames map[string]string) []strin
 // We scan settings.gradle.kts for includeBuild("../...") entries, which is
 // the primary mechanism for monorepo-local dependencies. The directory name
 // inside the "../" reference maps directly to our internal package names.
-// parseHaskellDeps extracts internal dependencies from a Haskell .cabal file.
+// parseHaskellDeps extracts internal dependencies from every build-depends
+// field in a Haskell .cabal file.
 //
-// A Cabal file lists dependencies in a build-depends block:
-//
-//	build-depends: base >= 4.7 && < 5,
-//	               coding-adventures-logic-gates
-//
-// We scan the file for package names starting with the "coding-adventures-" prefix
-// and map them to internal package names.
+// Most repository Cabal packages use plain names, while a few older packages
+// retain the coding-adventures-* prefix. Both aliases are registered in
+// buildKnownNamesForLanguage, so this parser maps only names belonging to
+// discovered Haskell packages.
 func parseHaskellDeps(pkg discovery.Package, knownNames map[string]string) []string {
-	entries, err := os.ReadDir(pkg.Path)
-	if err != nil {
-		return nil
-	}
-
-	var cabalFile string
-	for _, entry := range entries {
-		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".cabal") {
-			cabalFile = filepath.Join(pkg.Path, entry.Name())
-			break
-		}
-	}
+	cabalFile := findCabalFile(pkg.Path)
 	if cabalFile == "" {
 		return nil
 	}
@@ -716,12 +703,35 @@ func parseHaskellDeps(pkg discovery.Package, knownNames map[string]string) []str
 		return nil
 	}
 
+	nameRe := regexp.MustCompile(`^([a-zA-Z0-9][a-zA-Z0-9-]*)`)
+	fieldRe := regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-]*\s*:`)
+	seen := make(map[string]bool)
 	var internalDeps []string
-	re := regexp.MustCompile(`coding-adventures-([a-z0-9-]+)`)
-	for _, match := range re.FindAllStringSubmatch(string(data), -1) {
-		if len(match) >= 2 {
-			depName := "coding-adventures-" + strings.ToLower(match[1])
-			if pkgName, ok := knownNames[depName]; ok && pkgName != pkg.Name {
+	inBuildDepends := false
+	for _, rawLine := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(strings.SplitN(rawLine, "--", 2)[0])
+		lowerLine := strings.ToLower(line)
+		if strings.HasPrefix(lowerLine, "build-depends:") {
+			inBuildDepends = true
+			line = strings.TrimSpace(line[len("build-depends:"):])
+		} else if inBuildDepends &&
+			(line == "" || fieldRe.MatchString(line) ||
+				(len(rawLine) > 0 && rawLine[0] != ' ' && rawLine[0] != '\t')) {
+			inBuildDepends = false
+		}
+		if !inBuildDepends {
+			continue
+		}
+
+		for _, piece := range strings.Split(line, ",") {
+			match := nameRe.FindStringSubmatch(strings.TrimSpace(piece))
+			if len(match) != 2 {
+				continue
+			}
+			depName := strings.ToLower(match[1])
+			if pkgName, ok := knownNames[depName]; ok &&
+				pkgName != pkg.Name && !seen[pkgName] {
+				seen[pkgName] = true
 				internalDeps = append(internalDeps, pkgName)
 			}
 		}
@@ -1066,9 +1076,14 @@ func buildKnownNamesForLanguage(packages []discovery.Package, language string) m
 			setKnown(dirBase, pkg.Name, pkg.Path, pkg.Language)
 
 		case "haskell":
-			// Haskell Cabal package names use hyphens: "logic-gates" → "coding-adventures-logic-gates"
-			cabalName := "coding-adventures-" + strings.ToLower(filepath.Base(pkg.Path))
-			setKnown(cabalName, pkg.Name, pkg.Path, pkg.Language)
+			// Modern repository Cabal packages use the plain directory name.
+			// Keep the legacy prefix and the manifest's declared name as aliases.
+			dirBase := strings.ToLower(filepath.Base(pkg.Path))
+			setKnown(dirBase, pkg.Name, pkg.Path, pkg.Language)
+			setKnown("coding-adventures-"+dirBase, pkg.Name, pkg.Path, pkg.Language)
+			if cabalName := readCabalPackageName(pkg.Path); cabalName != "" {
+				setKnown(cabalName, pkg.Name, pkg.Path, pkg.Language)
+			}
 
 		case "java", "kotlin":
 			// Java and Kotlin packages use Gradle composite builds. Dependencies
@@ -1102,6 +1117,39 @@ func readCargoPackageName(pkgPath string) string {
 		return ""
 	}
 
+	return strings.ToLower(strings.TrimSpace(string(match[1])))
+}
+
+// findCabalFile returns the first Cabal manifest in a package directory.
+// Package directories contain at most one manifest, while the filename itself
+// may use either the modern plain name or the legacy prefixed name.
+func findCabalFile(pkgPath string) string {
+	entries, err := os.ReadDir(pkgPath)
+	if err != nil {
+		return ""
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(strings.ToLower(entry.Name()), ".cabal") {
+			return filepath.Join(pkgPath, entry.Name())
+		}
+	}
+	return ""
+}
+
+func readCabalPackageName(pkgPath string) string {
+	cabalFile := findCabalFile(pkgPath)
+	if cabalFile == "" {
+		return ""
+	}
+	data, err := os.ReadFile(cabalFile)
+	if err != nil {
+		return ""
+	}
+	re := regexp.MustCompile(`(?m)^\s*name\s*:\s*([a-zA-Z0-9][a-zA-Z0-9-]*)\s*$`)
+	match := re.FindSubmatch(data)
+	if len(match) != 2 {
+		return ""
+	}
 	return strings.ToLower(strings.TrimSpace(string(match[1])))
 }
 

--- a/code/programs/go/build-tool/internal/resolver/resolver_test.go
+++ b/code/programs/go/build-tool/internal/resolver/resolver_test.go
@@ -383,36 +383,42 @@ func TestResolveDependenciesDotnetPrefersSameLanguageOnSharedBasename(t *testing
 	}
 }
 
-func TestParseHaskellDepsSkipsSelfReference(t *testing.T) {
+func TestParseHaskellDepsSupportsPlainAndPrefixedNames(t *testing.T) {
 	root := makeFixture(t, map[string]string{
-		"build-tool/coding-adventures-build-tool.cabal": `cabal-version: 3.0
-name:          coding-adventures-build-tool
+		"build-tool/build-tool.cabal": `cabal-version: 3.0
+name:          build-tool
 version:       0.1.0
 
 library
     exposed-modules:  BuildTool
     build-depends:    base >=4.14
+                    , logic-gates >=0.1 && <0.2
+                    , coding-adventures-bitset
 
 test-suite spec
     type:             exitcode-stdio-1.0
     main-is:          Spec.hs
     build-depends:    base >=4.14
-                    , coding-adventures-build-tool
+                    , build-tool
                     , coding-adventures-logic-gates
 `,
-		"logic-gates/coding-adventures-logic-gates.cabal": `name: coding-adventures-logic-gates`,
+		"logic-gates/logic-gates.cabal":         `name: logic-gates`,
+		"bitset/coding-adventures-bitset.cabal": `name: coding-adventures-bitset`,
 	})
 
 	packages := []discovery.Package{
 		{Name: "haskell/programs/build-tool", Path: filepath.Join(root, "build-tool"), Language: "haskell"},
 		{Name: "haskell/logic-gates", Path: filepath.Join(root, "logic-gates"), Language: "haskell"},
+		{Name: "haskell/bitset", Path: filepath.Join(root, "bitset"), Language: "haskell"},
 	}
 
 	known := BuildKnownNames(packages)
 	deps := parseHaskellDeps(packages[0], known)
 
-	if len(deps) != 1 || deps[0] != "haskell/logic-gates" {
-		t.Fatalf("expected only haskell/logic-gates dependency, got %v", deps)
+	if len(deps) != 2 ||
+		deps[0] != "haskell/logic-gates" ||
+		deps[1] != "haskell/bitset" {
+		t.Fatalf("expected plain and prefixed Haskell dependencies without self-reference, got %v", deps)
 	}
 }
 

--- a/code/programs/go/build-tool/internal/resolver/resolver_test.go
+++ b/code/programs/go/build-tool/internal/resolver/resolver_test.go
@@ -422,6 +422,17 @@ test-suite spec
 	}
 }
 
+func TestFindCabalFileRejectsMultipleManifests(t *testing.T) {
+	root := makeFixture(t, map[string]string{
+		"pkg/first.cabal":  "name: first\n",
+		"pkg/second.cabal": "name: second\n",
+	})
+
+	if got := findCabalFile(filepath.Join(root, "pkg")); got != "" {
+		t.Fatalf("findCabalFile() = %q, want ambiguous manifests rejected", got)
+	}
+}
+
 func TestDependencyScopeMapsSharedToolchainFamilies(t *testing.T) {
 	tests := map[string]string{
 		"python": "python",

--- a/code/programs/go/scaffold-generator/CHANGELOG.md
+++ b/code/programs/go/scaffold-generator/CHANGELOG.md
@@ -17,6 +17,16 @@ All notable changes to this program will be documented in this file.
   set (deps go in the BUILD comment). See
   `code/specs/CCPP01-c-cpp-iso-multicompiler-lane.md`.
 
+### Fixed
+
+- Haskell scaffolds now follow the repository's current plain Cabal package
+  naming, `CodingAdventures.*` module layout, Hspec wiring, `-Wall`, explicit
+  Windows skip, empty capability metadata, and plain `cabal test` convention.
+- Haskell dependency discovery now reads the transitive sibling paths from
+  `cabal.project` and retains a Cabal-manifest fallback for older packages.
+- Cabal manifests now distinguish the short synopsis from a publishable
+  description and include a category, README, and changelog metadata.
+
 ## [1.1.0] - 2026-03-25
 
 ### Added

--- a/code/programs/go/scaffold-generator/CHANGELOG.md
+++ b/code/programs/go/scaffold-generator/CHANGELOG.md
@@ -23,9 +23,13 @@ All notable changes to this program will be documented in this file.
   naming, `CodingAdventures.*` module layout, Hspec wiring, `-Wall`, explicit
   Windows skip, empty capability metadata, and plain `cabal test` convention.
 - Haskell dependency discovery now reads the transitive sibling paths from
-  `cabal.project` and retains a Cabal-manifest fallback for older packages.
+  the `packages` field in `cabal.project`, ignores comments and unrelated
+  fields, validates sibling directories, and retains a Cabal-manifest fallback
+  for older packages.
 - Cabal manifests now distinguish the short synopsis from a publishable
   description and include a category, README, and changelog metadata.
+- Cabal generation now treats descriptions containing percent signs as plain
+  text instead of accidentally reusing generated content as a format string.
 
 ## [1.1.0] - 2026-03-25
 

--- a/code/programs/go/scaffold-generator/README.md
+++ b/code/programs/go/scaffold-generator/README.md
@@ -1,7 +1,8 @@
 # scaffold-generator
 
 A CLI tool that generates CI-ready package scaffolding for the coding-adventures
-monorepo across all six languages: Python, Go, Ruby, TypeScript, Rust, and Elixir.
+monorepo across 14 languages: Python, Go, Ruby, TypeScript, Rust, Elixir, Perl,
+Lua, Swift, Haskell, Java, Kotlin, C, and C++.
 
 ## Why
 
@@ -15,7 +16,7 @@ producing correct-by-construction packages.
 # Scaffold a Python library with dependencies
 scaffold-generator my-package --language python --depends-on arithmetic,logic-gates --description "My new package"
 
-# Scaffold across all 6 languages
+# Scaffold across all supported languages
 scaffold-generator my-package --language all --description "My new package"
 
 # Preview without creating files

--- a/code/programs/go/scaffold-generator/main.go
+++ b/code/programs/go/scaffold-generator/main.go
@@ -444,12 +444,35 @@ func readHaskellDeps(pkgDir string) ([]string, error) {
 		re := regexp.MustCompile(`\.\.[/\\]([a-zA-Z0-9-]+)`)
 		seen := make(map[string]bool)
 		var deps []string
-		for _, match := range re.FindAllStringSubmatch(string(data), -1) {
-			if len(match) != 2 || seen[match[1]] {
+		inPackages := false
+		for _, rawLine := range strings.Split(string(data), "\n") {
+			line := strings.TrimSpace(strings.SplitN(rawLine, "--", 2)[0])
+			lowerLine := strings.ToLower(line)
+			if strings.HasPrefix(lowerLine, "packages:") {
+				inPackages = true
+				line = strings.TrimSpace(line[len("packages:"):])
+			} else if inPackages &&
+				line != "" &&
+				len(rawLine) > 0 &&
+				rawLine[0] != ' ' &&
+				rawLine[0] != '\t' {
+				inPackages = false
+			}
+			if !inPackages {
 				continue
 			}
-			seen[match[1]] = true
-			deps = append(deps, match[1])
+
+			for _, match := range re.FindAllStringSubmatch(line, -1) {
+				if len(match) != 2 || seen[match[1]] {
+					continue
+				}
+				siblingPath := filepath.Join(filepath.Dir(pkgDir), match[1])
+				if info, statErr := os.Stat(siblingPath); statErr != nil || !info.IsDir() {
+					continue
+				}
+				seen[match[1]] = true
+				deps = append(deps, match[1])
+			}
 		}
 		return deps, nil
 	}
@@ -1779,7 +1802,7 @@ library
 	for _, dep := range directDeps {
 		cabal += fmt.Sprintf("                    , %s >=0.1 && <0.2\n", dep)
 	}
-	cabal += `    hs-source-dirs:   src
+	cabal += fmt.Sprintf(`    hs-source-dirs:   src
     ghc-options:      -Wall
     default-language: Haskell2010
 
@@ -1793,8 +1816,7 @@ test-suite spec
                     , hspec ==2.*
     ghc-options:      -Wall
     default-language: Haskell2010
-`
-	cabal = fmt.Sprintf(cabal, moduleName, pkgName)
+`, moduleName, pkgName)
 
 	libHs := fmt.Sprintf(`-- | %s
 --

--- a/code/programs/go/scaffold-generator/main.go
+++ b/code/programs/go/scaffold-generator/main.go
@@ -432,24 +432,78 @@ func readSwiftDeps(pkgDir string) ([]string, error) {
 	return deps, nil
 }
 
-// readHaskellDeps reads cabal file for build-depends entries targeting coding-adventures-* packages.
+// readHaskellDeps reads the local package paths from cabal.project. Modern
+// Haskell packages in this repository use plain Cabal names, and cabal.project
+// is the authoritative list of sibling packages needed to build them.
+//
+// The Cabal-file fallback keeps older prefixed packages discoverable when they
+// predate the cabal.project convention.
 func readHaskellDeps(pkgDir string) ([]string, error) {
-	cabalPath := filepath.Join(pkgDir, "coding-adventures-"+filepath.Base(pkgDir)+".cabal")
-	data, err := os.ReadFile(cabalPath)
-	if err != nil {
-		return nil, nil // no cabal file = no deps
-	}
-	re := regexp.MustCompile(`coding-adventures-([a-zA-Z0-9-]+)`)
-	selfName := filepath.Base(pkgDir)
-	var deps []string
-	for _, line := range strings.Split(string(data), "\n") {
-		m := re.FindStringSubmatch(line)
-		if len(m) == 2 {
-			// Ignore metadata lines and the package's own test-suite self-reference.
-			if strings.Contains(line, "name:") || strings.Contains(line, "executable") || strings.Contains(line, "library") || m[1] == selfName {
+	projectPath := filepath.Join(pkgDir, "cabal.project")
+	if data, err := os.ReadFile(projectPath); err == nil {
+		re := regexp.MustCompile(`\.\.[/\\]([a-zA-Z0-9-]+)`)
+		seen := make(map[string]bool)
+		var deps []string
+		for _, match := range re.FindAllStringSubmatch(string(data), -1) {
+			if len(match) != 2 || seen[match[1]] {
 				continue
 			}
-			deps = append(deps, m[1])
+			seen[match[1]] = true
+			deps = append(deps, match[1])
+		}
+		return deps, nil
+	}
+
+	cabalFiles, err := filepath.Glob(filepath.Join(pkgDir, "*.cabal"))
+	if err != nil || len(cabalFiles) == 0 {
+		return nil, nil
+	}
+	data, err := os.ReadFile(cabalFiles[0])
+	if err != nil {
+		return nil, nil
+	}
+
+	selfName := filepath.Base(pkgDir)
+	siblingEntries, _ := os.ReadDir(filepath.Dir(pkgDir))
+	knownSiblings := make(map[string]bool)
+	for _, entry := range siblingEntries {
+		if entry.IsDir() {
+			knownSiblings[strings.ToLower(entry.Name())] = true
+		}
+	}
+
+	nameRe := regexp.MustCompile(`^([a-zA-Z0-9][a-zA-Z0-9-]*)`)
+	fieldRe := regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-]*\s*:`)
+	seen := make(map[string]bool)
+	var deps []string
+	inBuildDepends := false
+	for _, rawLine := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(strings.SplitN(rawLine, "--", 2)[0])
+		lowerLine := strings.ToLower(line)
+		if strings.HasPrefix(lowerLine, "build-depends:") {
+			inBuildDepends = true
+			line = strings.TrimSpace(line[len("build-depends:"):])
+		} else if inBuildDepends &&
+			(line == "" || fieldRe.MatchString(line) ||
+				(len(rawLine) > 0 && rawLine[0] != ' ' && rawLine[0] != '\t')) {
+			inBuildDepends = false
+		}
+		if !inBuildDepends {
+			continue
+		}
+
+		for _, piece := range strings.Split(line, ",") {
+			match := nameRe.FindStringSubmatch(strings.TrimSpace(piece))
+			if len(match) != 2 {
+				continue
+			}
+			name := strings.ToLower(match[1])
+			name = strings.TrimPrefix(name, "coding-adventures-")
+			if name == selfName || !knownSiblings[name] || seen[name] {
+				continue
+			}
+			seen[name] = true
+			deps = append(deps, name)
 		}
 	}
 	return deps, nil
@@ -1700,57 +1754,78 @@ final class %sTests: XCTestCase {
 // =========================================================================
 
 func generateHaskell(targetDir, pkgName, description, layerCtx string, directDeps, orderedDeps []string) error {
-	pkgNameHaskell := "coding-adventures-" + pkgName
 	moduleName := toCamelCase(pkgName)
+	qualifiedModuleName := "CodingAdventures." + moduleName
 
 	cabal := fmt.Sprintf(`cabal-version: 3.0
 name:          %s
 version:       0.1.0
 synopsis:      %s
+description:   %s. This package is generated as a publishable library in the coding-adventures monorepo.
+category:      Development
 license:       MIT
 author:        Adhithya Rajasekaran
 maintainer:    Adhithya Rajasekaran
 build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
 
 library
     exposed-modules:  %s
-    build-depends:    base >=4.14
-`, pkgNameHaskell, description, moduleName)
+    build-depends:    base >=4.14 && <5
+`, pkgName, description, description, qualifiedModuleName)
 
-	for _, dep := range orderedDeps {
-		cabal += fmt.Sprintf("                      , coding-adventures-%s\n", dep)
+	for _, dep := range directDeps {
+		cabal += fmt.Sprintf("                    , %s >=0.1 && <0.2\n", dep)
 	}
 	cabal += `    hs-source-dirs:   src
+    ghc-options:      -Wall
     default-language: Haskell2010
 
 test-suite spec
     type:             exitcode-stdio-1.0
     main-is:          Spec.hs
-    build-depends:    base >=4.14
+    other-modules:    %sSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
                     , %s
-`
-	for _, dep := range orderedDeps {
-		cabal += fmt.Sprintf("                    , coding-adventures-%s\n", dep)
-	}
-	cabal = fmt.Sprintf(cabal, pkgNameHaskell, pkgNameHaskell)
-	cabal += `    hs-source-dirs:   test
+                    , hspec ==2.*
+    ghc-options:      -Wall
     default-language: Haskell2010
 `
+	cabal = fmt.Sprintf(cabal, moduleName, pkgName)
 
-	libHs := fmt.Sprintf(`module %s where
-
--- | %s
+	libHs := fmt.Sprintf(`-- | %s
+--
 -- %s
-someFunc :: IO ()
-someFunc = putStrLn "someFunc"
-`, moduleName, description, layerCtx)
+module %s
+  ( version
+  ) where
 
-	specHs := fmt.Sprintf(`import %s
+-- | Package version shared across implementation languages.
+version :: String
+version = "0.1.0"
+`, description, layerCtx, qualifiedModuleName)
+
+	specHs := fmt.Sprintf(`import %sSpec (spec)
+import Test.Hspec (hspec)
 
 main :: IO ()
-main = do
-    putStrLn "Test suite not yet implemented."
+main = hspec spec
 `, moduleName)
+
+	packageSpecHs := fmt.Sprintf(`module %sSpec (spec) where
+
+import %s (version)
+import Test.Hspec
+
+spec :: Spec
+spec =
+  describe "package metadata" $
+    it "reports version 0.1.0" $
+      shouldBe version "0.1.0"
+`, moduleName, qualifiedModuleName)
 
 	cabalProject := "packages: ."
 	for _, dep := range orderedDeps {
@@ -1758,15 +1833,15 @@ main = do
 	}
 	cabalProject += "\n"
 
-	// BUILD
-	build := "cabal test all\n"
-
 	files := map[string]string{
-		fmt.Sprintf("%s.cabal", pkgNameHaskell): cabal,
-		"cabal.project":                         cabalProject,
-		"src/" + moduleName + ".hs":             libHs,
-		"test/Spec.hs":                          specHs,
-		"BUILD":                                 build,
+		fmt.Sprintf("%s.cabal", pkgName):             cabal,
+		"cabal.project":                              cabalProject,
+		"src/CodingAdventures/" + moduleName + ".hs": libHs,
+		"test/Spec.hs":                               specHs,
+		"test/" + moduleName + "Spec.hs":             packageSpecHs,
+		"BUILD":                                      "cabal test\n",
+		"BUILD_windows":                              "echo \"haskell support not enabled in windows CI yet -- skipping\"\n",
+		"required_capabilities.json":                 "{\"capabilities\": []}\n",
 	}
 
 	for path, content := range files {
@@ -2189,7 +2264,7 @@ int main() {
 		"BUILD":                                    build,
 		"BUILD_windows":                            buildWin,
 		filepath.Join("tools", "run.sh"):           runSh,
-		filepath.Join("tools", "run.ps1"):          runPs1,
+		filepath.Join("tools", "run.ps1"):           runPs1,
 		".gitignore":                               "_build/\n",
 	})
 }

--- a/code/programs/go/scaffold-generator/main_test.go
+++ b/code/programs/go/scaffold-generator/main_test.go
@@ -780,19 +780,97 @@ func TestGeneratePerlNoDeps(t *testing.T) {
 	}
 }
 
-func TestGenerateHaskellUsesShortTestSuiteName(t *testing.T) {
+func TestGenerateHaskellUsesRepositoryConventions(t *testing.T) {
 	tmpDir := t.TempDir()
-	if err := generateHaskell(tmpDir, "my-pkg", "My package", "", nil, nil); err != nil {
+	if err := generateHaskell(
+		tmpDir,
+		"my-pkg",
+		"My package",
+		"Layer context",
+		[]string{"graph"},
+		[]string{"bitset", "graph"},
+	); err != nil {
 		t.Fatalf("generateHaskell: %v", err)
 	}
 
-	cabal, err := os.ReadFile(filepath.Join(tmpDir, "coding-adventures-my-pkg.cabal"))
+	cabal, err := os.ReadFile(filepath.Join(tmpDir, "my-pkg.cabal"))
 	if err != nil {
 		t.Fatalf("cannot read cabal file: %v", err)
 	}
 
-	if !strings.Contains(string(cabal), "test-suite spec") {
-		t.Fatal("cabal file should use a short test-suite name")
+	cabalText := string(cabal)
+	for _, want := range []string{
+		"name:          my-pkg",
+		"category:      Development",
+		"exposed-modules:  CodingAdventures.MyPkg",
+		", graph >=0.1 && <0.2",
+		"other-modules:    MyPkgSpec",
+		", hspec ==2.*",
+		"ghc-options:      -Wall",
+	} {
+		if !strings.Contains(cabalText, want) {
+			t.Errorf("cabal file missing %q", want)
+		}
+	}
+	if strings.Contains(cabalText, "coding-adventures-") {
+		t.Error("cabal file should use the repository's plain package names")
+	}
+	if strings.Contains(cabalText, ", bitset") {
+		t.Error("cabal build-depends should contain direct dependencies only")
+	}
+
+	project, err := os.ReadFile(filepath.Join(tmpDir, "cabal.project"))
+	if err != nil {
+		t.Fatalf("cannot read cabal.project: %v", err)
+	}
+	projectText := string(project)
+	if !strings.Contains(projectText, "../bitset") || !strings.Contains(projectText, "../graph") {
+		t.Errorf("cabal.project should contain the transitive local closure, got %q", projectText)
+	}
+
+	for _, path := range []string{
+		"BUILD",
+		"BUILD_windows",
+		"required_capabilities.json",
+		filepath.Join("src", "CodingAdventures", "MyPkg.hs"),
+		filepath.Join("test", "MyPkgSpec.hs"),
+		filepath.Join("test", "Spec.hs"),
+	} {
+		if _, err := os.Stat(filepath.Join(tmpDir, path)); err != nil {
+			t.Errorf("generated Haskell file %s missing: %v", path, err)
+		}
+	}
+
+	build, err := os.ReadFile(filepath.Join(tmpDir, "BUILD"))
+	if err != nil {
+		t.Fatalf("cannot read BUILD: %v", err)
+	}
+	if string(build) != "cabal test\n" {
+		t.Errorf("BUILD = %q, want plain cabal test", build)
+	}
+}
+
+func TestReadHaskellDepsUsesCabalProjectSiblingPaths(t *testing.T) {
+	root := t.TempDir()
+	pkgDir := filepath.Join(root, "http1")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	project := "packages: . ../http-core ../parser\n"
+	if err := os.WriteFile(
+		filepath.Join(pkgDir, "cabal.project"),
+		[]byte(project),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, err := readHaskellDeps(pkgDir)
+	if err != nil {
+		t.Fatalf("readHaskellDeps: %v", err)
+	}
+	if strings.Join(deps, ",") != "http-core,parser" {
+		t.Fatalf("readHaskellDeps = %v, want [http-core parser]", deps)
 	}
 }
 

--- a/code/programs/go/scaffold-generator/main_test.go
+++ b/code/programs/go/scaffold-generator/main_test.go
@@ -785,7 +785,7 @@ func TestGenerateHaskellUsesRepositoryConventions(t *testing.T) {
 	if err := generateHaskell(
 		tmpDir,
 		"my-pkg",
-		"My package",
+		"100% compatible package",
 		"Layer context",
 		[]string{"graph"},
 		[]string{"bitset", "graph"},
@@ -801,6 +801,8 @@ func TestGenerateHaskellUsesRepositoryConventions(t *testing.T) {
 	cabalText := string(cabal)
 	for _, want := range []string{
 		"name:          my-pkg",
+		"synopsis:      100% compatible package",
+		"description:   100% compatible package.",
 		"category:      Development",
 		"exposed-modules:  CodingAdventures.MyPkg",
 		", graph >=0.1 && <0.2",
@@ -856,7 +858,17 @@ func TestReadHaskellDepsUsesCabalProjectSiblingPaths(t *testing.T) {
 	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	project := "packages: . ../http-core ../parser\n"
+	for _, sibling := range []string{"http-core", "parser"} {
+		if err := os.MkdirAll(filepath.Join(root, sibling), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	project := `packages: . ../http-core
+          ../parser
+          ../missing
+          -- ../commented-out
+repository: ../not-a-package
+`
 	if err := os.WriteFile(
 		filepath.Join(pkgDir, "cabal.project"),
 		[]byte(project),

--- a/code/specs/NET03-http-core.md
+++ b/code/specs/NET03-http-core.md
@@ -26,6 +26,8 @@ At that layer, the application needs the same concepts:
 - `BodyKind`
 - `RequestHead`
 - `ResponseHead`
+- `RequestTarget`
+- `RoutePattern`
 
 That is the job of `http-core`.
 
@@ -119,6 +121,34 @@ into:
 
 This is a semantic helper, not a wire parser.
 
+### Raw Request Targets
+
+Routing and API clients need the path and query portions of a request target,
+but `http-core` must not choose an application-level decoding policy. The raw
+target helper therefore splits:
+
+```text
+/devices/light%201?limit=10&verbose#client
+```
+
+into a path, optional query, and optional fragment while preserving
+percent-encoded text. Query pairs split only on the first equals sign, flag
+parameters receive an empty value, empty ampersand-delimited pieces are
+ignored, and duplicate keys stay ordered.
+
+### Path-Only Route Matching
+
+Small HTTP servers repeatedly need the same deterministic operation: match a
+pattern such as `/devices/:kind/:id` against a request target and return named
+captures. `RoutePattern` provides that operation without becoming a server
+framework. Matching:
+
+- ignores query strings and fragments
+- treats `:name` segments as ordered captures
+- compares literal segments exactly
+- ignores empty path pieces introduced by repeated or trailing slashes
+- requires the pattern and path to have the same number of segments
+
 ## Public API
 
 ```rust
@@ -153,12 +183,39 @@ pub struct ResponseHead {
     pub headers: Vec<Header>,
 }
 
+pub struct RequestTarget<'a> {
+    pub path: &'a str,
+    pub query: Option<&'a str>,
+    pub fragment: Option<&'a str>,
+}
+
+pub enum RouteSegment {
+    Literal(String),
+    Param(String),
+}
+
+pub struct RoutePattern {
+    pub segments: Vec<RouteSegment>,
+}
+
 pub fn find_header<'a>(headers: &'a [Header], name: &str) -> Option<&'a str>;
 pub fn parse_content_length(headers: &[Header]) -> Option<usize>;
 pub fn parse_content_type(headers: &[Header]) -> Option<(String, Option<String>)>;
+pub fn parse_request_target(target: &str) -> RequestTarget<'_>;
+pub fn split_path_segments(path: &str) -> Vec<&str>;
 ```
 
-Equivalent APIs should exist in all supported languages.
+`RequestTarget` must expose ordered raw query pairs and first-value lookup.
+`RequestHead` and `ResponseHead` should delegate to the header helpers, and
+`RequestHead` should also delegate to the target/path/query helpers.
+`RoutePattern` must parse patterns, match paths, and match full request targets
+using only their path portion.
+
+Equivalent APIs should exist in all supported languages, using native naming
+and sum/product types. The expanded request-target and routing surface is
+normative for new ports. Rolling it through established implementations that
+currently expose only the original basic surface is tracked as follow-up
+conformance work.
 
 ## Design Decisions
 
@@ -179,6 +236,18 @@ every language.
 It is useful for logging and debugging, even though applications should make
 decisions primarily on the numeric status code.
 
+**Why preserve raw query text instead of percent-decoding it?**
+
+Decoding is an application policy. Keeping the core helper raw avoids double
+decoding and lets callers decide how to handle invalid escapes, plus signs,
+duplicate fields, and character encodings.
+
+**Why place simple route matching in the core?**
+
+The operation depends only on the semantic request target, is useful across
+HTTP versions, and gives small clients and servers one shared deterministic
+contract without importing a framework.
+
 ## Testing Strategy
 
 1. Header lookup is ASCII case-insensitive.
@@ -189,6 +258,14 @@ decisions primarily on the numeric status code.
 6. `Content-Type` parsing tolerates extra parameters beyond charset.
 7. `HttpVersion` string rendering stays stable.
 8. `BodyKind` constructors or tagged values compare correctly.
+9. Request-target splitting preserves raw query and fragment text.
+10. Empty paths normalize to `/`.
+11. Query pairs preserve order, duplicate names, flags, and equals signs in
+    values.
+12. Path splitting handles root, leading, trailing, and repeated slashes.
+13. Route patterns return ordered captures and reject literal or arity
+    mismatches.
+14. Full-target matching ignores query strings and fragments.
 
 ## Scope
 
@@ -199,6 +276,8 @@ decisions primarily on the numeric status code.
 - content length helper
 - content type helper
 - body framing kind representation
+- raw request-target splitting and query lookup
+- path segmentation and small path-only route patterns
 
 **Out of scope:**
 
@@ -208,17 +287,25 @@ decisions primarily on the numeric status code.
 - HTTP/2 frame parsing
 - body decoding
 - HTML parsing
+- percent decoding
+- middleware, handler dispatch, or server lifecycle management
 
 ## Implementation Languages
 
-This package will be implemented in:
-
-- Python
-- Go
-- Ruby
-- TypeScript
-- Rust
+- C#
 - Elixir
-- Perl
+- F#
+- Go
+- Haskell
 - Lua
+- Perl
+- Python
+- Ruby
+- Rust
 - Swift
+- TypeScript
+
+C and C++ also have emerging native implementations, but those lanes are
+classified separately from the 15 established implementation languages in the
+parity reporter. Directory presence does not by itself prove conformance; the
+expanded target/routing surface still needs shared fixtures across older ports.

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -119,6 +119,30 @@ Rust-only package families:
 The loop must not start by attempting 10,262 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
+The July 29 lane audit is:
+
+| Established lane | Packages present | High-consensus gaps | Rust/Python-core coverage |
+|---|---:|---:|---:|
+| C# | 196 | 0 | 47.5% |
+| Dart | 73 | 107 | 17.1% |
+| Elixir | 276 | 0 | 69.3% |
+| F# | 195 | 0 | 47.5% |
+| Go | 292 | 0 | 72.4% |
+| Haskell | 202 | 3 | 48.6% |
+| Java | 126 | 58 | 31.0% |
+| Kotlin | 125 | 58 | 31.0% |
+| Lua | 251 | 0 | 63.3% |
+| Perl | 251 | 0 | 63.3% |
+| Python | 496 | 1 | 100% |
+| Ruby | 294 | 0 | 70.3% |
+| Rust | 948 | 0 | 100% |
+| Swift | 160 | 51 | 37.8% |
+| TypeScript | 439 | 0 | 82.2% |
+
+These are structural counts, not conformance claims. The full review queue must
+cover all 15 rows even when a lane has zero gaps in the current
+high-consensus subset.
+
 ## Priority 0: Inventory And Identity Integrity
 
 Completed. The reporter now inventories Git-visible files, emits Markdown,
@@ -127,6 +151,16 @@ covered by CI unit tests. The conflicting `ruby/b_tree` and
 `ruby/b_plus_tree` shadow packages were removed in favor of the authoritative
 DT11/DT12 `ruby/b-tree` and `ruby/b-plus-tree` implementations. CI now rejects
 new canonical identity collisions with `--fail-on-collisions`.
+
+Remaining inventory/build-integrity work discovered in the July 29 audit:
+
+- reconcile stale `BUILD_windows` prerequisite declarations reported by the
+  build-tool validator across Python, Perl, TypeScript, Swift, Dart, Kotlin, and
+  related packages in dependency-shaped waves;
+- remove environment-specific Starlark grammar lookup so build discovery works
+  from arbitrary clean worktrees;
+- add explicit applicability and maturity data before either C/C++ or OCaml
+  enters the all-language completion denominator.
 
 ## Priority 1: Complete The 14-Of-15 Set
 
@@ -151,6 +185,22 @@ Completed in the Haskell lane: `activation-functions`, `caesar-cipher`,
 Completed in the Swift lane: `wasm-simulator`, `cli-builder`,
 `sql-execution-engine`.
 
+### Current 14-of-15 frontier: reopened
+
+The historical Priority 1 cohort is complete, but later Haskell work promoted
+13 packages into a new 14-of-15 frontier. Every current gap is Dart-only:
+
+- dependency-shaped ML: `matrix`, then `loss-functions` and
+  `feature-normalization`;
+- numeric family: `trig`, then `wave`;
+- deterministic data structures: `binary-search-tree`, `fenwick-tree`, and
+  `trie`;
+- leaf ciphers: `atbash-cipher`, `scytale-cipher`, and `vigenere-cipher`;
+- shared model and utility leaves: `document-ast` and `uuid`.
+
+Close these as small coherent PRs after the cross-language build-tool contract
+foundation is stable.
+
 Port dependency families together when doing so avoids temporary broken package
 graphs. Grammar-generated lexer/parser pairs should be generated from the shared
 grammar sources rather than independently handwritten.
@@ -162,20 +212,24 @@ ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
 |---|---:|---|
-| Python | 1 | Classify the remaining self-hosted `python-parser` carefully |
-| Elixir | 0 | Complete; `python-parser` uses the shared grammar-driven frontend |
-| Lua | 0 | Complete; paired data-structure/storage wave |
-| Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
+| Dart | 107 | Close the reopened 14-of-15 set, then dependencies before consumers |
+| Elixir | 0 | Complete; retain as a reference lane and run conformance fixtures |
 | F# | 0 | Complete; paired native package wave |
+| Go | 0 | Complete; primary build-tool and portable-core reference lane |
 | Haskell | 3 | Finish `http1`, then the generic `event-loop` and pure `brotli` gaps |
-| Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
-| Dart | 107 | Algorithms, data structures, codecs, grammar frontends, documents, and paint transforms first |
+| Lua | 0 | Complete; retain as a reference lane and remediate build-tool drift |
+| Perl | 0 | Complete; retain as a reference lane and remediate build-tool drift |
+| Python | 1 | Classify the remaining self-hosted `python-parser` carefully |
+| Ruby | 0 | Complete; retain as a reference lane and run conformance fixtures |
+| Rust | 0 | Complete; reference lane for broad and singleton families |
+| Swift | 51 | Data structures and generated frontends before native app surfaces |
+| TypeScript | 0 | Complete; reference lane for web-capable portable contracts |
 
-Go, Ruby, Rust, and TypeScript currently have no gaps within the 10-language
-consensus set. They remain reference/template lanes for these waves.
+Zero-gap lanes remain active reference and conformance lanes; they are not
+exempt from semantic review or build-tool parity.
 
 The first seventeen paired Lua/Perl slices are complete: `fenwick-tree`,
 `binary-tree`, `binary-search-tree`, `in-memory-data-store-protocol`,
@@ -706,14 +760,14 @@ The thirty-first Haskell high-consensus slice is complete: `http-core` now
 provides the dependency-free NET03 semantic model with ordered duplicate
 headers, bounded versions and status codes, body-framing hints, request and
 response heads, content helpers, raw request-target/query handling, and
-path-only route patterns. Its package-native suite exercises 19 examples across
-valid and malformed versions, ASCII-only header matching, length overflow,
-content parameters, message delegates, raw queries, repeated slashes, captures,
-and route mismatches. The port also repairs Haskell scaffold naming/test
-conventions and build-graph dependency discovery so the follow-on `http1` edge
-is visible to incremental CI. The package now spans 12 established lanes,
-reduces the high-consensus backlog to 278 slots, and leaves 3 gaps in the
-Haskell lane.
+path-only route patterns. Its package-native suite exercises 19 examples with
+96% expression and 95% alternative coverage across valid and malformed
+versions, ASCII-only header matching, length overflow, content parameters,
+message delegates, raw queries, repeated slashes, captures, and route
+mismatches. The port also repairs Haskell scaffold naming/test conventions and
+build-graph dependency discovery so the follow-on `http1` edge is visible to
+incremental CI. The package now spans 12 established lanes, reduces the
+high-consensus backlog to 278 slots, and leaves 3 gaps in the Haskell lane.
 
 Recommended family order:
 
@@ -817,6 +871,89 @@ the first port PR.
 7. Track package maturity separately from structural presence: manifest,
    source, tests, BUILD, README, CHANGELOG, conformance status, and last verified
    revision.
+
+## Cross-Cutting Stream A: Build-Tool Parity
+
+The build tool is itself a cross-language program and must follow the same
+rules as portable packages: directory presence is not behavioral parity.
+
+Executable front doors currently exist in 12 of the 15 established lanes:
+
+- C# and F# under `code/programs/dotnet/`
+- Elixir, Go, Haskell, Lua, Perl, Python, Ruby, Rust, Swift, and TypeScript
+  under their respective `code/programs/<language>/build-tool` directories
+
+Dart, Java, and Kotlin have no implementation. The F# entry point is currently
+a thin facade over the C# engine rather than an independent native engine.
+C and C++ are emerging lanes without build tools; OCaml must receive one before
+it can graduate from emerging status. WASM is an execution target, Mosaic and
+Twig are domain languages, and Starlark is a build language, so none enters this
+program-level requirement without a separate applicability decision.
+
+The existing implementations have materially drifted. The Go program is the
+broadest reference, but even it has unfinished OS-aware structured command and
+Windows execution work. Other ports differ on package discovery, ecosystem
+resolvers, diff selection, hashing, Starlark, plan read/write, sharding,
+toolchain detection, parallelism, and failure propagation. Specifications 12,
+`build-plan-v1`, `build-plan-sharding`, 15, and B05 must be reconciled with
+current code before more directory-only ports are added.
+
+Delivery order:
+
+1. Define `build-tool-conformance.md`, a versioned fixture schema, and stable
+   machine-readable results for discovery, resolution, graph order, diff
+   selection, hashing/cache, Starlark, plan interchange, sharding, execution,
+   validation, platform BUILD selection, and toolchain detection.
+2. Add a cross-implementation runner. The runner may orchestrate processes in
+   Python, but the fixtures and canonical JSON are the behavior oracle.
+3. Make the Go reference pass the contract, including structured Starlark
+   context/commands and the B05 Windows executor contract.
+4. Remediate existing ports in fixture-failure order: C#/F#, Python, Ruby,
+   Swift, TypeScript, Elixir, Rust, Perl, Haskell, and Lua. Each independent
+   engine is its own PR; a reviewed shared-engine exception must be explicit.
+5. Add language-native Java and Kotlin implementations using shared JVM fixture
+   infrastructure but separate engines, then add Dart.
+6. Add the OCaml implementation after the lane foundation is stable.
+7. Decide and document whether C and C++ require native build tools before
+   either emerging lane graduates.
+8. Gate completion in CI: every supported implementation runs the same
+   conformance corpus on its applicable operating systems.
+
+## Cross-Cutting Stream B: Introduce OCaml Safely
+
+OCaml begins as an `emerging_implementation` lane. It must not silently change
+the current 15-language denominator until its package, build, security, and CI
+substrate is real. Use OCaml 5.2.1, opam 2.5.x, Dune 3.16.x, Alcotest,
+`bisect_ppx`, and `ocamlformat`.
+
+Bootstrap order:
+
+1. Add an OCaml lane contract. Make the reporter's hard-coded `10-15`
+   completion band denominator-safe, classify OCaml as emerging, and test that
+   OCaml packages create neither unknown buckets nor 15-lane missing slots.
+2. Add complete Go and TypeScript scaffold templates plus golden tests,
+   repository ignores, capability metadata/schema support, and the
+   `code/packages/ocaml/` lane README.
+3. Add OCaml discovery, opam/Dune dependency resolution, source hashing,
+   opam-switch serialization, language detection, validator support, shard
+   cost, and CI workflow markers to the canonical Go build tool.
+4. Exercise the full path with a real dependency chain:
+   `logic-gates`, then `graph -> directed-graph -> state-machine`. Every package
+   needs native tests, formatting, measured coverage, README, changelog,
+   capability metadata, opam/Dune manifests, and BUILD/BUILD_windows.
+5. Add an OCaml capability analyzer over compiler-libs ASTs, covering process
+   execution, dynamic loading, unsafe marshaling, and `Obj.magic` under the
+   repository's explicit capability/exception policy.
+6. Implement the OCaml build tool on `directed-graph` and require two-way
+   build-plan interchange plus the shared conformance corpus.
+7. Promote OCaml into the implementation denominator only when Ubuntu, macOS,
+   and Windows run real tests without a skip path, the representative chain and
+   build tool are green, capability enforcement is active, and the generated
+   16-lane backlog has been explicitly reviewed.
+
+After promotion, start the OCaml portable-core queue with `http-core -> http1`,
+then recompute dependency-shaped high-consensus work alongside the existing
+Dart, Java/Kotlin, Swift, and Haskell lanes.
 
 ## Autonomous Loop Protocol
 

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -104,34 +104,19 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 
 ## Work Inventory
 
-The missing matrix is heavily concentrated in singleton packages. Regenerated
-on July 20, 2026 after the paired Lua/Perl `fenwick-tree`, `binary-tree`,
-`binary-search-tree`, `in-memory-data-store-protocol`, `avl-tree`, `tree-set`,
-`skip-list`, `hyperloglog`, `trie`, `radix-tree`, and `resp-protocol` ports,
-the paired `hash-functions` prerequisite, the paired `bloom-filter`, `hash-map`,
-and `hash-set` ports, the paired `in-memory-data-store-engine` and
-`in-memory-data-store` ports, and the paired C#/F# `wasm-module-encoder`,
-`x25519`, `brainfuck-wasm-compiler`, `argon2i`, `argon2d`, and `argon2id`
-ports, and the paired C#/F# `chacha20-poly1305`, `xml-lexer`, `block-ram`,
-`nib-wasm-compiler`, `dartmouth-basic-lexer`, and `dartmouth-basic-parser`
-ports, followed by the paired `ed25519`, `font-parser`, `asciidoc-parser`, and
-`fpga` ports, the paired C#/F# `zstd` ports, and the Haskell `atbash-cipher`,
-`scytale-cipher`, `feature-normalization`, `loss-functions`, `trig`, `wave`,
-`matrix`, `vigenere-cipher`, `uuid`, `document-ast`, `lz78`, `deflate`,
-`point2d`, `affine2d`, `bezier2d`, and `arc2d`
-ports, followed by the Haskell `gradient-descent`, `perceptron`, and
-`type-checker-protocol` ports, and the Haskell `paint-vm-ascii`,
-`barcode-layout-1d`, `itf`, `code39`, `codabar`, `code128`, `upc-a`, `ean-13`,
-`sql-csv-source`, and `zstd` ports:
+The missing matrix is heavily concentrated in singleton packages. The current
+inventory was regenerated on July 29, 2026 after the Haskell `barcode-1d` and
+`http-core` ports, the Go/Rust `multi-directed-graph` slice, and a new wave of
+Rust-only package families:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 172 | 280 |
+| Present in 10-15 languages | 172 | 278 |
 | Present in 5-9 languages | 121 | 911 |
-| Present in 2-4 languages | 157 | 1,972 |
-| Present in one language | 715 | 10,010 |
+| Present in 2-4 languages | 157 | 1,970 |
+| Present in one language | 733 | 10,262 |
 
-The loop must not start by attempting 10,010 singleton ports. It should finish
+The loop must not start by attempting 10,262 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 ## Priority 0: Inventory And Identity Integrity
@@ -172,7 +157,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 172 packages present in at least ten implementation languages need 280
+The 172 packages present in at least ten implementation languages need 278
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -183,7 +168,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 0 | Complete; paired data-structure/storage wave |
 | C# | 0 | Complete; paired native package wave |
 | F# | 0 | Complete; paired native package wave |
-| Haskell | 4 | Leaf algorithms before dependency-shaped compression, graphics, ML, and protocol waves |
+| Haskell | 3 | Finish `http1`, then the generic `event-loop` and pure `brotli` gaps |
 | Swift | 51 | Data structures and generated frontends before native app surfaces |
 | Java | 58 | Move with Kotlin |
 | Kotlin | 58 | Move with Java |
@@ -717,6 +702,19 @@ guards, typed failures, and ASCII backend errors. The package now spans 12
 implementation lanes, reduces the high-consensus backlog to 279 slots, and
 leaves 4 gaps in the Haskell lane.
 
+The thirty-first Haskell high-consensus slice is complete: `http-core` now
+provides the dependency-free NET03 semantic model with ordered duplicate
+headers, bounded versions and status codes, body-framing hints, request and
+response heads, content helpers, raw request-target/query handling, and
+path-only route patterns. Its package-native suite exercises 19 examples across
+valid and malformed versions, ASCII-only header matching, length overflow,
+content parameters, message delegates, raw queries, repeated slashes, captures,
+and route mismatches. The port also repairs Haskell scaffold naming/test
+conventions and build-graph dependency discovery so the follow-on `http1` edge
+is visible to incremental CI. The package now spans 12 established lanes,
+reduces the high-consensus backlog to 278 slots, and leaves 3 gaps in the
+Haskell lane.
+
 Recommended family order:
 
 1. Leaf algorithms and data structures.
@@ -752,7 +750,7 @@ language ports stay eligible for later dependency-shaped waves.
 
 ## Priority 4: Classify Sparse And Singleton Families
 
-The singleton inventory is led by 520 Rust, 86 Python, and 84 TypeScript
+The singleton inventory is led by 538 Rust, 86 Python, and 84 TypeScript
 packages. Classify families before opening implementation PRs.
 
 ### Likely portable Rust-led families
@@ -765,6 +763,14 @@ packages. Classify families before opening implementation PRs.
 - language runtimes and frontends such as `r-*` and `twig-*`, when their
   dependency stacks are ready
 - deterministic portions of `vault-*`, `adjudication-*`, and `smart-home-*`
+- the new Axiom, IDL, and Q frontend/runtime stacks in dependency order
+- deterministic SIR lowerings such as `idl-to-semantic-ir`,
+  `q-to-semantic-ir`, and `scilab-to-semantic-ir`
+- `html-to-layout`, after its document and layout dependencies are classified
+
+`sir-bench` remains a likely tool/harness exception, while
+`chief-of-staff-vault-runtime` needs an explicit domain/native applicability
+review before any port is selected.
 
 ### Likely native, wrapper, or target-specific Rust-led families
 
@@ -799,6 +805,9 @@ the first port PR.
 1. Give each portable family a language-neutral fixture corpus or oracle.
 2. Add package-level conformance runners where directory presence currently
    masks API or semantic drift.
+   Start with NET03 `http-core`: align raw request-target, query, and route
+   behavior across the established ports that currently expose only the basic
+   header/head surface.
 3. Extend the parity reporter with explicit applicability data rather than
    hard-coding exceptions in reporting logic.
 4. Fail CI on unclassified new package buckets.


### PR DESCRIPTION
## Summary

- add a dependency-free Haskell `http-core` semantic model with ordered headers, bounded HTTP versions and content lengths, message heads, raw request-target/query helpers, and path-only route matching
- add 19 package-native Hspec examples, including adversarial oversized decimal inputs
- align Haskell scaffold generation with the repository's Cabal/module/test conventions and make Cabal-project dependency discovery precise
- teach the Go build tool to resolve modern plain and legacy-prefixed Haskell Cabal dependencies while rejecting ambiguous multiple manifests
- document the measured 15-lane backlog, the build-tool parity stream, and the gated OCaml first-class-lane plan in durable loop state

This is the dependency-shaped prerequisite for a Haskell `http1` port. It reduces the Haskell high-consensus gap to `http1`, `event-loop`, and `brotli`.

## Validation

- `cabal check`
- `cabal test --enable-coverage` with GHC 9.4.8: 19 examples, 0 failures
- HPC: 96% expressions, 95% alternatives, 100% local declarations
- `go test ./...` and `go vet ./...` in `code/programs/go/scaffold-generator`
- `go test ./...`, `go vet ./...`, and `go build ./...` in `code/programs/go/build-tool`
- freshly built Go build tool dry-run against `origin/main`: 204 Haskell packages discovered; only `haskell/http-core` selected
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions`: schema 2, 1,183 implementation identities, 4,324 implementation slots, 0 canonical collisions, 0 unknown language buckets
- `git diff --check`
- focused security review completed; oversized numeric parsing, percent-sign Cabal formatting, Cabal-project field parsing, and multiple-manifest ambiguity were hardened before publication

## Follow-up

The loop state keeps one active parity PR at a time. After this merges, the next item will be reprioritized from the live inventory; current leading candidates are the shared build-tool conformance contract and Haskell `http1`.
