### PR TITLE
feat(adj-formula-stdlib): osmolar gap — toxicology measured−calculated osmolality difference (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_osmolar_gap_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_osmolar_gap_e2e.rs
@@ -1,0 +1,140 @@
+//! End-to-end tests for the `clinical/osmolar-gap.adj` library — the definition of the osmol gap
+//! (measured osmolality − calculated osmolality) and its two exact rearrangements — driven through
+//! the built CLI binary against the SHIPPED stdlib. The same invariant as every other formula
+//! library: a consumer states NO arithmetic; it imports the grounded library, binds the measured
+//! osmolalities with `observe`, and the engine applies the cited relation on the CPU, computing the
+//! EXACT value and rendering the relation's citation and trust tier in the `derived` section (the
+//! auditable answer). The three formulas INVERT around the worked case measured = 290 mOsm/kg,
+//! calculated = 280 mOsm/kg: 290 − 280 = 10, 10 + 280 = 290, and 290 − 10 = 280. The three asserted
+//! values (10, 290, 280) are chosen so none is a colon-anchored prefix of another rendered value.
+//! This is the osmolality (difference-type) cousin of the shipped anion-gap.adj.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped osmolar-gap library, resolved from this crate's manifest dir so the
+/// test is location-independent.
+fn shipped_og_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/osmolar-gap.adj")
+        .canonicalize()
+        .expect("shipped osmolar-gap.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_og_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_og_lib()).unwrap();
+    std::fs::write(dir.join("osmolar-gap.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// osmol_gap — the definition: measured osmolality minus calculated osmolality.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_osmolar_gap_library_and_computes_it_with_citation() {
+    let dir = scratch("og");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"osmolar-gap.adj\"\n\
+         observe measured_osmolality(290)\n\
+         observe calculated_osmolality(280)\n\
+         ? osmol_gap(measured_osmolality, calculated_osmolality)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied relation's result: 290 − 280 = 10.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"osmol_gap\"") && s.contains("\"value\":10"),
+        "osmol_gap(290, 280) = 10: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// measured_osmolality — the same relation solved for the measured value: gap + calculated.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_measured_from_gap_and_calculated_with_citation() {
+    let dir = scratch("meas");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"osmolar-gap.adj\"\n\
+         observe osmol_gap(10)\n\
+         observe calculated_osmolality(280)\n\
+         ? measured_osmolality(osmol_gap, calculated_osmolality)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 10 + 280 = 290, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"measured_osmolality\"") && s.contains("\"value\":290"),
+        "measured_osmolality(10, 280) = 290: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "measured_osmolality carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// calculated_osmolality — the same relation solved for the calculated value: measured − gap, the
+// third reading of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_calculated_from_measured_and_gap_with_citation() {
+    let dir = scratch("calc");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"osmolar-gap.adj\"\n\
+         observe measured_osmolality(290)\n\
+         observe osmol_gap(10)\n\
+         ? calculated_osmolality(measured_osmolality, osmol_gap)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 290 − 10 = 280, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"calculated_osmolality\"") && s.contains("\"value\":280"),
+        "calculated_osmolality(290, 10) = 280: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "calculated_osmolality carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/osmolar-gap.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/osmolar-gap.adj
@@ -1,0 +1,97 @@
+% ============================================================================
+% osmolar-gap.adj — the definition of the osmol(ar) gap (measured osmolality − calculated
+% osmolality) in the ADJ standard library.
+% ============================================================================
+% The osmolar-gap entry of the *clinical* track — a toxicology/nephrology bedside index, the
+% osmolality sibling of the shipped anion-gap.adj. Where the anion gap is a difference among serum
+% cations and anions, the osmol gap is a difference between two osmolalities: THE OSMOL GAP IS THE
+% DIFFERENCE BETWEEN THE MEASURED SERUM OSMOLALITY AND THE CALCULATED SERUM OSMOLALITY — a screen
+% for unmeasured osmotically active particles. The calculated osmolality accounts only for the
+% commonly measured osmoles (sodium, glucose, urea, etc.); an elevated gap (> 10 mOsm/kg) means
+% something osmotically active is present that the calculation did not include, classically a toxic
+% alcohol (methanol, ethylene glycol, or isopropanol). It ships as an importable, byte-provenanced,
+% PARAMETERIZED `formula`, together with its two exact rearrangements (the measured osmolality a gap
+% implies for a given calculated value, and the calculated osmolality it implies for a given
+% measured value). As with every compute library, a consumer states NO arithmetic: it `import`s
+% this file, binds the two osmolalities from its own byte-provenance decomposition, and asks the
+% engine to APPLY the cited definition on the CPU. Zero math is performed by the model; the engine
+% computes each value EXACTLY (over exact rationals), carrying the definition's citation.
+%
+%     import "osmolar-gap.adj"
+%     observe measured_osmolality(290)     % "…measured osm 290 mOsm/kg…"    (span cited by the model)
+%     observe calculated_osmolality(280)    % "…calculated osm 280 mOsm/kg…"  (span cited by the model)
+%     ? osmol_gap(measured_osmolality, calculated_osmolality)
+%                                           % engine → 10, carrying the osmol-gap difference
+%
+% All three formulas are EXACT over their parameters, so every value the engine returns is exact.
+% They COMPOSE and invert cleanly around the worked case measured osmolality = 290 mOsm/kg,
+% calculated osmolality = 280 mOsm/kg (osmol gap = 290 − 280 = 10): the `osmol_gap` a consumer
+% computes is exactly the value the `measured_osmolality` formula adds back to the calculated value
+% to recover 290, and exactly the value the `calculated_osmolality` formula subtracts from the
+% measured value to recover 280.
+%
+%   osmol_gap(measured_osmolality, calculated_osmolality)
+%       = measured_osmolality - calculated_osmolality      % gap = measured − calculated  (definition)
+%   measured_osmolality(osmol_gap, calculated_osmolality)
+%       = osmol_gap + calculated_osmolality                % measured = gap + calculated  (solved for measured)
+%   calculated_osmolality(measured_osmolality, osmol_gap)
+%       = measured_osmolality - osmol_gap                  % calculated = measured − gap  (solved for calculated)
+%
+% NOTE ON UNITS AND SIGN: both osmolalities are in milliosmoles per kilogram, so the gap is in
+% mOsm/kg. The cited clause names the osmol gap as "the difference between the calculated and
+% measured osmolality"; this library uses the universal clinical sign convention gap = measured −
+% calculated, so an elevated (positive) gap flags unmeasured osmoles. The engine computes the exact
+% difference over whatever consistent inputs it is given.
+%
+% All three formulas are defended by the SAME clause — "The difference between the calculated and
+% measured osmolality is known as the osmol gap, also known as the osmolal or osmolar gap" —
+% because that one definition (the osmol gap IS the measured-minus-calculated osmolality difference)
+% sanctions the relation read every way. The quote is transcribed verbatim from a peer-reviewed
+% article archived on the NCBI Bookshelf, so each `formula` carries the provenance envelope every
+% shipped grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the clause is a verbatim span of the cited page, not asserted
+% from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable osmolality the definition ranges over, and each result
+% is a derived quantity. `measured_osmolality`, `calculated_osmolality` and `osmol_gap` each appear
+% BOTH as a derived result and as an input (of the other formulas), so each is a single dictionary
+% term used in both roles. The `surface` lists are the everyday names a decomposer maps onto the
+% canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary osmolar_gap_vocab {
+    define measured_osmolality   : finding  surface "measured osmolality", "measured serum osmolality"       % milliosmoles per kilogram (mOsm/kg)
+    define calculated_osmolality : finding  surface "calculated osmolality", "calculated serum osmolality"   % milliosmoles per kilogram (mOsm/kg)
+    define osmol_gap             : finding  surface "osmol gap", "osmolal gap", "osmolar gap"                 % milliosmoles per kilogram (mOsm/kg)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the definitional clause from the cited article
+% on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an exact sum or
+% difference of measured osmolalities, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook osmolar_gap_laws {
+    use osmolar_gap_vocab
+
+    % Osmol gap — the measured osmolality minus the calculated osmolality, i.e. gap = measured − calculated.
+    formula osmol_gap(measured_osmolality, calculated_osmolality) = measured_osmolality - calculated_osmolality
+        source "The difference between the calculated and measured osmolality is known as the osmol gap, also known as the osmolal or osmolar gap"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK589659/"
+        trust authoritative
+
+    % Measured osmolality — the same definition solved for the measured value a gap implies for a
+    % given calculated value (measured = gap + calculated). Defended by the SAME clause.
+    formula measured_osmolality(osmol_gap, calculated_osmolality) = osmol_gap + calculated_osmolality
+        source "The difference between the calculated and measured osmolality is known as the osmol gap, also known as the osmolal or osmolar gap"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK589659/"
+        trust authoritative
+
+    % Calculated osmolality — the same definition solved for the calculated value (calculated =
+    % measured − gap): the measured osmolality minus the osmol gap. The SAME clause, read the third way.
+    formula calculated_osmolality(measured_osmolality, osmol_gap) = measured_osmolality - osmol_gap
+        source "The difference between the calculated and measured osmolality is known as the osmol gap, also known as the osmolal or osmolar gap"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK589659/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/osmolar-gap.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/osmolar-gap.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% osmolar-gap.query.adj — worked applications of the osmol-gap definition.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a toxicology/metabolic vignette into observed
+% osmolalities: it `import`s the grounded formulabook, `observe`s the measured and calculated serum
+% osmolality, and asks the engine to APPLY the cited definition. No arithmetic is stated by the
+% consumer; the engine computes each value EXACTLY (over exact rationals) and carries the article's
+% citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (measured osmolality = 290 mOsm/kg, calculated osmolality = 280 mOsm/kg): osmol gap =
+% 290 − 280 = 10. Each query below fixes two of the three quantities and asks the engine to recover
+% the third; every answer is exact and the three COMPOSE (each inversion recovers exactly the worked
+% value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli osmolar-gap.query.adj
+% ============================================================================
+
+import "osmolar-gap.adj"
+
+% --- Definition: the osmol gap the two osmolalities imply (expect 10). -------------------------
+observe measured_osmolality(290)
+observe calculated_osmolality(280)
+? osmol_gap(measured_osmolality, calculated_osmolality)   % expect 10
+
+% --- Inverse: the measured osmolality a gap of 10 implies at that calculated value (290). ------
+observe osmol_gap(10)
+? measured_osmolality(osmol_gap, calculated_osmolality)   % expect 290


### PR DESCRIPTION
## What

Ships the **osmol(ar) gap** (measured osmolality − calculated osmolality) as an importable, byte-provenanced, parameterized `formula` in the **clinical** track — a toxicology/nephrology **difference** index, the osmolality sibling of the shipped `anion-gap.adj` — with its two exact algebraic rearrangements.

All three formulas are defended by the **same verbatim clause**, transcribed from a peer-reviewed article on the NCBI Bookshelf:

> "The difference between the calculated and measured osmolality is known as the osmol gap, also known as the osmolal or osmolar gap"
> — https://www.ncbi.nlm.nih.gov/books/NBK589659/ · `trust authoritative`

## Why

Diversifies the recent pharmacokinetics run (Vd, clearance, loading dose) back to a difference-type formula in a fresh domain. The osmol gap screens for **unmeasured osmotically active particles** — an elevated gap (> 10 mOsm/kg) classically flags a **toxic alcohol** (methanol, ethylene glycol, isopropanol). The library uses the universal clinical sign convention **gap = measured − calculated** (positive gap → unmeasured osmoles). A consumer states **no arithmetic**: it imports the library, `observe`s the two osmolalities from its own byte-provenance decomposition, and the engine **applies** the cited relation on the CPU, computing each value **exactly over exact rationals** and carrying the citation + trust tier in the auditable `derived` section.

## The three readings

```
osmol_gap(measured, calculated)        = measured - calculated   % gap = measured − calculated
measured_osmolality(gap, calculated)   = gap + calculated         % measured = gap + calculated
calculated_osmolality(measured, gap)   = measured - gap           % calculated = measured − gap
```

They **compose** around the worked case measured = 290 mOsm/kg, calculated = 280 mOsm/kg: 290 − 280 = 10, 10 + 280 = 290, 290 − 10 = 280. The three asserted values (10 / 290 / 280) are chosen so none is a colon-anchored prefix of another rendered value.

## Files

- `code/specs/data/adj-formula-stdlib/clinical/osmolar-gap.adj` — dictionary + formulabook (3 cited formulas)
- `code/specs/data/adj-formula-stdlib/clinical/osmolar-gap.query.adj` — worked applications
- `code/packages/rust/adj-lang-cli/tests/formula_osmolar_gap_e2e.rs` — 3 e2e tests (own dedicated file, no shared anchor)

## Verification

- `cargo test -p adj-lang-cli --test formula_osmolar_gap_e2e` — **3/3 green**
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — **clean**
- Render-probe of `.query.adj` against the built CLI: forward → 10 with the verbatim citation + `trust:authoritative`; inverse recovers `measured_osmolality` = 290.
- Data + test only — no engine change, **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)