### PR TITLE
Scale MOS junction capacitance with temperature

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Scale Level-1 MOS zero-bias bottom-junction `CJ`, source/drain `CBS`/`CBD`,
+  and sidewall `CJSW` capacitances with temperature using Berkeley MOS1
+  `MJ`/`MJSW` grading paths.
 - Apply Berkeley MOS1 temperature preprocessing to the Level-1 MOS
   bulk-junction potential `PB`.
 - Apply Berkeley MOS1 electrostatic temperature preprocessing to Level-1 MOS

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -78,7 +78,9 @@ print(result.diagnostics.solver)   # "dense_real" or "sparse_real"
 operating-temperature footholds for diode, BJT, JFET, and Level-1 MOSFET
 models before running an analysis.
 Level-1 MOS temperature preprocessing follows the Berkeley MOS1 silicon
-band-gap correction for `PHI`, polarity-aware `VT0`, and bulk-junction `PB`.
+band-gap correction for `PHI`, polarity-aware `VT0`, and bulk-junction `PB`,
+and scales zero-bias `CJ`/`CBS`/`CBD` and `CJSW` through their respective
+`MJ` and `MJSW` grading paths.
 JFET model cards use `TCV` for threshold-voltage scaling and `BEX` for
 `BETA(T) = BETA * (T / TNOM)^BEX`. When explicitly present, `VTOTC` overrides
 `TCV` with `VTO(T) = VTO + VTOTC * (T - TNOM)`, while `BETATCE` overrides

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -426,6 +426,31 @@ def mosfet_at_temperature(
         temperature_factor * nominal_bulk_junction_potential
         + potential_correction(temperature_kelvin)
     )
+    nominal_bulk_potential_shift = (
+        params.PB - nominal_bulk_junction_potential
+    ) / nominal_bulk_junction_potential
+    temperature_bulk_potential_shift = (
+        temperature_bulk_junction_potential - nominal_bulk_junction_potential
+    ) / nominal_bulk_junction_potential
+
+    def capacitance_scale(grading_coefficient: float) -> float:
+        nominal_scale = 1.0 / (
+            1.0
+            + grading_coefficient
+            * (
+                4.0e-4
+                * (nominal_temperature_kelvin - reference_temperature_kelvin)
+                - nominal_bulk_potential_shift
+            )
+        )
+        temperature_scale = 1.0 + grading_coefficient * (
+            4.0e-4 * (temperature_kelvin - reference_temperature_kelvin)
+            - temperature_bulk_potential_shift
+        )
+        return nominal_scale * temperature_scale
+
+    bottom_capacitance_scale = capacitance_scale(params.MJ)
+    sidewall_capacitance_scale = capacitance_scale(params.MJSW)
     polarity = 1.0 if model.type is MosfetType.NMOS else -1.0
     temperature_vbi = (
         params.VT0
@@ -454,6 +479,10 @@ def mosfet_at_temperature(
         VT0=temperature_vt0,
         PHI=temperature_phi,
         PB=temperature_bulk_junction_potential,
+        CJ=params.CJ * bottom_capacitance_scale,
+        CBS=params.CBS * bottom_capacitance_scale,
+        CBD=params.CBD * bottom_capacitance_scale,
+        CJSW=params.CJSW * sidewall_capacitance_scale,
         KP=params.KP * ratio**-1.5,
         U0=params.U0 * ratio**-1.5,
         IS=params.IS * saturation_scale,

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -4304,6 +4304,40 @@ def test_mosfet_temperature_scaling_adjusts_bulk_junction_potential():
     assert pytest.approx(0.719_697_229_921_455) == hot.model.model.params.PB
 
 
+def test_mosfet_temperature_scaling_adjusts_zero_bias_junction_capacitances():
+    nominal = Mosfet(
+        "M1",
+        "d",
+        "g",
+        "s",
+        "b",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(
+                Level1Params(CJ=2.0e-12, CBS=3.0e-12, CBD=4.0e-12, CJSW=5.0e-12)
+            ),
+        ),
+    )
+
+    cold = mosfet_at_temperature(nominal, 275.0)
+    hot = mosfet_at_temperature(nominal, 350.0)
+    cold_params = cold.model.model.params
+    hot_params = hot.model.model.params
+    cold_bottom_scale = 0.970_502_066_286_684_6
+    cold_sidewall_scale = 0.980_531_363_923_873_3
+    hot_bottom_scale = 1.060_159_235_535_130_4
+    hot_sidewall_scale = 1.039_705_095_096_974_2
+
+    assert pytest.approx(2.0e-12 * cold_bottom_scale) == cold_params.CJ
+    assert pytest.approx(3.0e-12 * cold_bottom_scale) == cold_params.CBS
+    assert pytest.approx(4.0e-12 * cold_bottom_scale) == cold_params.CBD
+    assert pytest.approx(5.0e-12 * cold_sidewall_scale) == cold_params.CJSW
+    assert pytest.approx(2.0e-12 * hot_bottom_scale) == hot_params.CJ
+    assert pytest.approx(3.0e-12 * hot_bottom_scale) == hot_params.CBS
+    assert pytest.approx(4.0e-12 * hot_bottom_scale) == hot_params.CBD
+    assert pytest.approx(5.0e-12 * hot_sidewall_scale) == hot_params.CJSW
+
+
 def test_mosfet_temperature_scaling_adjusts_bulk_junction_saturation_currents():
     nominal = Mosfet(
         "M1",

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Scale Level-1 MOS zero-bias bottom-junction `CJ`, source/drain `CBS`/`CBD`,
+  and sidewall `CJSW` capacitances with temperature using Berkeley MOS1
+  `MJ`/`MJSW` grading paths.
 - Apply Berkeley MOS1 temperature preprocessing to the Level-1 MOS
   bulk-junction potential `PB`.
 - Apply Berkeley MOS1 electrostatic temperature preprocessing to Level-1 MOS

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -119,7 +119,9 @@ let result = transient_adaptive(
 operating-temperature footholds for diode, BJT, JFET, and Level-1 MOSFET
 models before running an analysis.
 Level-1 MOS temperature preprocessing follows the Berkeley MOS1 silicon
-band-gap correction for `PHI`, polarity-aware `VT0`, and bulk-junction `PB`.
+band-gap correction for `PHI`, polarity-aware `VT0`, and bulk-junction `PB`,
+and scales zero-bias `CJ`/`CBS`/`CBD` and `CJSW` through their respective
+`MJ` and `MJSW` grading paths.
 JFET model cards use `TCV` for threshold-voltage scaling and `BEX` for
 `BETA(T) = BETA * (T / TNOM)^BEX`. When explicitly present, `VTOTC` overrides
 `TCV` with `VTO(T) = VTO + VTOTC * (T - TNOM)`, while `BETATCE` overrides

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -2801,6 +2801,28 @@ pub fn mosfet_at_temperature(
         (mosfet.params.bulk_junction_potential - nominal_potential_correction) / nominal_factor;
     let temperature_bulk_junction_potential =
         temperature_factor * nominal_bulk_junction_potential + temperature_potential_correction;
+    let nominal_bulk_potential_shift = (mosfet.params.bulk_junction_potential
+        - nominal_bulk_junction_potential)
+        / nominal_bulk_junction_potential;
+    let temperature_bulk_potential_shift = (temperature_bulk_junction_potential
+        - nominal_bulk_junction_potential)
+        / nominal_bulk_junction_potential;
+    let capacitance_scale = |grading_coefficient: f64| {
+        let nominal_scale = 1.0
+            / (1.0
+                + grading_coefficient
+                    * (4.0e-4 * (nominal_temperature_kelvin - reference_temperature_kelvin)
+                        - nominal_bulk_potential_shift));
+        let temperature_scale = 1.0
+            + grading_coefficient
+                * (4.0e-4 * (temperature_kelvin - reference_temperature_kelvin)
+                    - temperature_bulk_potential_shift);
+        nominal_scale * temperature_scale
+    };
+    let bottom_capacitance_scale =
+        capacitance_scale(mosfet.params.bulk_junction_grading_coefficient);
+    let sidewall_capacitance_scale =
+        capacitance_scale(mosfet.params.sidewall_junction_grading_coefficient);
     let polarity = match mosfet.mosfet_type {
         MosfetType::Nmos => 1.0,
         MosfetType::Pmos => -1.0,
@@ -2818,6 +2840,10 @@ pub fn mosfet_at_temperature(
     adjusted.params.vt0 = temperature_vt0;
     adjusted.params.phi = temperature_phi;
     adjusted.params.bulk_junction_potential = temperature_bulk_junction_potential;
+    adjusted.params.bottom_junction_capacitance *= bottom_capacitance_scale;
+    adjusted.params.source_bulk_capacitance *= bottom_capacitance_scale;
+    adjusted.params.drain_bulk_capacitance *= bottom_capacitance_scale;
+    adjusted.params.sidewall_junction_capacitance *= sidewall_capacitance_scale;
     adjusted.params.kp *= ratio.powf(-1.5);
     adjusted.params.surface_mobility *= ratio.powf(-1.5);
     adjusted.params.saturation_current *= saturation_scale;

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -3588,6 +3588,65 @@ fn mosfet_temperature_scaling_adjusts_bulk_junction_potential() {
 }
 
 #[test]
+fn mosfet_temperature_scaling_adjusts_zero_bias_junction_capacitances() {
+    let nominal = Mosfet::with_model(
+        "M1",
+        "d",
+        "g",
+        "s",
+        "b",
+        MosfetType::Nmos,
+        MosfetLevel1Params {
+            bottom_junction_capacitance: 2.0e-12,
+            source_bulk_capacitance: 3.0e-12,
+            drain_bulk_capacitance: 4.0e-12,
+            sidewall_junction_capacitance: 5.0e-12,
+            ..MosfetLevel1Params::default()
+        },
+    );
+
+    let cold = mosfet_at_temperature(&nominal, 275.0, 300.15, 1.11).unwrap();
+    let hot = mosfet_at_temperature(&nominal, 350.0, 300.15, 1.11).unwrap();
+    let cold_bottom_scale = 0.970_502_066_286_684_6;
+    let cold_sidewall_scale = 0.980_531_363_923_873_3;
+    let hot_bottom_scale = 1.060_159_235_535_130_4;
+    let hot_sidewall_scale = 1.039_705_095_096_974_2;
+
+    assert_close(
+        cold.params.bottom_junction_capacitance,
+        2.0e-12 * cold_bottom_scale,
+    );
+    assert_close(
+        cold.params.source_bulk_capacitance,
+        3.0e-12 * cold_bottom_scale,
+    );
+    assert_close(
+        cold.params.drain_bulk_capacitance,
+        4.0e-12 * cold_bottom_scale,
+    );
+    assert_close(
+        cold.params.sidewall_junction_capacitance,
+        5.0e-12 * cold_sidewall_scale,
+    );
+    assert_close(
+        hot.params.bottom_junction_capacitance,
+        2.0e-12 * hot_bottom_scale,
+    );
+    assert_close(
+        hot.params.source_bulk_capacitance,
+        3.0e-12 * hot_bottom_scale,
+    );
+    assert_close(
+        hot.params.drain_bulk_capacitance,
+        4.0e-12 * hot_bottom_scale,
+    );
+    assert_close(
+        hot.params.sidewall_junction_capacitance,
+        5.0e-12 * hot_sidewall_scale,
+    );
+}
+
+#[test]
 fn mosfet_temperature_scaling_adjusts_bulk_junction_saturation_currents() {
     let nominal = Mosfet::with_model(
         "M1",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Scale Level-1 MOS zero-bias bottom-junction `CJ`, source/drain `CBS`/`CBD`,
+  and sidewall `CJSW` capacitances with temperature using Berkeley MOS1
+  `MJ`/`MJSW` grading paths.
 - Apply Berkeley MOS1 temperature preprocessing to the Level-1 MOS
   bulk-junction potential `PB`.
 - Apply Berkeley MOS1 electrostatic temperature preprocessing to Level-1 MOS

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -70,7 +70,9 @@ steps were clipped, and the minimum damping factor; pass
 operating-temperature footholds for diode, BJT, JFET, and Level-1 MOSFET
 models before running an analysis.
 Level-1 MOS temperature preprocessing follows the Berkeley MOS1 silicon
-band-gap correction for `PHI`, polarity-aware `VT0`, and bulk-junction `PB`.
+band-gap correction for `PHI`, polarity-aware `VT0`, and bulk-junction `PB`,
+and scales zero-bias `CJ`/`CBS`/`CBD` and `CJSW` through their respective
+`MJ` and `MJSW` grading paths.
 JFET model cards use `TCV` for threshold-voltage scaling and `BEX` for
 `BETA(T) = BETA * (T / TNOM)^BEX`. When explicitly present, `VTOTC` overrides
 `TCV` with `VTO(T) = VTO + VTOTC * (T - TNOM)`, while `BETATCE` overrides

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -7763,6 +7763,27 @@ export function mosfetAtTemperature(
   const temperatureBulkJunctionPotential =
     temperatureFactor * nominalBulkJunctionPotential +
     potentialCorrection(temperatureKelvin);
+  const nominalBulkPotentialShift =
+    (element.params.PB - nominalBulkJunctionPotential) / nominalBulkJunctionPotential;
+  const temperatureBulkPotentialShift =
+    (temperatureBulkJunctionPotential - nominalBulkJunctionPotential) /
+    nominalBulkJunctionPotential;
+  const capacitanceScale = (gradingCoefficient: number): number => {
+    const nominalScale =
+      1.0 /
+      (1.0 +
+        gradingCoefficient *
+          (4.0e-4 * (nominalTemperatureKelvin - referenceTemperatureKelvin) -
+            nominalBulkPotentialShift));
+    const temperatureScale =
+      1.0 +
+      gradingCoefficient *
+        (4.0e-4 * (temperatureKelvin - referenceTemperatureKelvin) -
+          temperatureBulkPotentialShift);
+    return nominalScale * temperatureScale;
+  };
+  const bottomCapacitanceScale = capacitanceScale(element.params.MJ);
+  const sidewallCapacitanceScale = capacitanceScale(element.params.MJSW);
   const polarity = element.type === "NMOS" ? 1.0 : -1.0;
   const temperatureVbi =
     element.params.VT0 -
@@ -7785,6 +7806,10 @@ export function mosfetAtTemperature(
       VT0: temperatureVt0,
       PHI: temperaturePhi,
       PB: temperatureBulkJunctionPotential,
+      CJ: element.params.CJ * bottomCapacitanceScale,
+      CBS: element.params.CBS * bottomCapacitanceScale,
+      CBD: element.params.CBD * bottomCapacitanceScale,
+      CJSW: element.params.CJSW * sidewallCapacitanceScale,
       KP: element.params.KP * ratio ** -1.5,
       U0: element.params.U0 * ratio ** -1.5,
       IS: element.params.IS * saturationScale,

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -2367,6 +2367,31 @@ describe("dcOp", () => {
     expectClose(hot.params.PB, 0.719_697_229_921_455);
   });
 
+  it("scales MOSFET zero-bias junction capacitances with temperature", () => {
+    const nominal = mosfet("M1", "d", "g", "s", "b", "NMOS", {
+      CJ: 2.0e-12,
+      CBS: 3.0e-12,
+      CBD: 4.0e-12,
+      CJSW: 5.0e-12,
+    });
+
+    const cold = mosfetAtTemperature(nominal, 275.0);
+    const hot = mosfetAtTemperature(nominal, 350.0);
+    const coldBottomScale = 0.970_502_066_286_684_6;
+    const coldSidewallScale = 0.980_531_363_923_873_3;
+    const hotBottomScale = 1.060_159_235_535_130_4;
+    const hotSidewallScale = 1.039_705_095_096_974_2;
+
+    expectClose(cold.params.CJ, 2.0e-12 * coldBottomScale);
+    expectClose(cold.params.CBS, 3.0e-12 * coldBottomScale);
+    expectClose(cold.params.CBD, 4.0e-12 * coldBottomScale);
+    expectClose(cold.params.CJSW, 5.0e-12 * coldSidewallScale);
+    expectClose(hot.params.CJ, 2.0e-12 * hotBottomScale);
+    expectClose(hot.params.CBS, 3.0e-12 * hotBottomScale);
+    expectClose(hot.params.CBD, 4.0e-12 * hotBottomScale);
+    expectClose(hot.params.CJSW, 5.0e-12 * hotSidewallScale);
+  });
+
   it("scales MOSFET bulk-junction saturation currents with temperature", () => {
     const nominal = mosfet("M1", "d", "g", "s", "b", "NMOS", {
       IS: 2.0e-15,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,10 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS bulk-junction potential temperature preprocessing.
+1. Cross-language Level-1 MOS junction-capacitance temperature scaling.
    - Status: current PR completion candidate.
-   - Apply the Berkeley MOS1 silicon potential correction to bulk-junction
-     potential `PB` alongside the existing electrostatic transform.
+   - Scale zero-bias `CJ`, `CBS`, and `CBD` through the Berkeley MOS1 `MJ`
+     bottom-junction grading path.
+   - Scale zero-bias `CJSW` through the independent `MJSW` sidewall grading
+     path, reusing the temperature-adjusted bulk-junction potential.
    - Preserve direct MOS helper and circuit-level temperature-transform parity.
    - Keep Rust, Python, and TypeScript helper behavior, tests, docs, and
      changelogs aligned.
@@ -3587,6 +3589,13 @@ the Rust, Python, and TypeScript surfaces together.
      shift for `PHI` and polarity-aware `VT0`.
    - Direct MOS helpers and circuit-level transforms preserve matching
      NMOS/PMOS behavior in Rust, Python, and TypeScript.
+
+287. Cross-language Level-1 MOS bulk-junction potential temperature preprocessing.
+   - Status: completed in PR 9142.
+   - Bulk-junction potential `PB` follows the Berkeley MOS1 silicon potential
+     correction alongside the existing electrostatic transform.
+   - Direct MOS helpers and circuit-level transforms preserve matching behavior
+     in Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- scale Level-1 MOS `CJ`, `CBS`, and `CBD` through the Berkeley MOS1 `MJ` temperature path
- scale `CJSW` independently through `MJSW` using the temperature-adjusted bulk-junction potential
- keep Rust, Python, and TypeScript tests, docs, changelogs, and the SPICE completion plan aligned

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python `ruff check src tests`
- Python `pytest -q` (672 passed, 88.89% coverage)
- `npm run build`
- `npm test` (415 passed)