### PR TITLE
feat(adj-formula-stdlib): wave-number — NIST SP 811 B.9 kayser→reciprocal-metre factor (facts b30, NEW dimension)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -1344,6 +1344,48 @@ fn shipped_electric_current_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b30) The shipped NIST SP 811 B.9 wave-number → reciprocal-metre table resolves the exact kayser
+//       factor with its citation, and ABSTAINS on a wrong-dimension unit. This opens a NEW dimension
+//       — WAVE NUMBER (spatial frequency, wavelengths per unit length) — beyond the length/mass/…/
+//       electric family. The kayser (wave number) and the angstrom (length/wavelength) are RECIPROCAL
+//       quantities that convert to DIFFERENT SI units (m⁻¹ vs m), so the abstain guards the
+//       wavelength-versus-wavenumber confusion directly, not mere absence of a value: the kayser is
+//       one reciprocal centimetre = exactly 100 reciprocal metres.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_wave_number_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_wavenumber");
+    let src = stdlib().join("reference/wave-number-conversions.adj");
+    std::fs::copy(&src, dir.join("wave-number-conversions.adj"))
+        .expect("copy shipped wave-number-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"wave-number-conversions.adj\"\n\
+         ? wave_number_to_reciprocal_metre(kayser, $v)\n\
+         ? wave_number_to_reciprocal_metre(angstrom, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 exact factor resolves, character-for-character from the table
+    // (boldface = exact; the kayser is one reciprocal centimetre = exactly 1 E+02 reciprocal metres).
+    assert!(out.contains("\"v\":\"100\""), "kayser = 1 E+02 m^-1: {out}");
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `angstrom` is a LENGTH (wavelength) unit (it converts to the metre, a DIFFERENT quantity), so
+    // this wave-number table has no row for it — the engine abstains rather than mis-converting a
+    // length unit as if it were a wave-number unit (its reciprocal).
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a wrong-dimension unit abstains, never a cross-dimension fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/wave-number-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/wave-number-conversions.adj
@@ -1,0 +1,57 @@
+% ============================================================================
+% wave-number-conversions — wave-number-unit → reciprocal-metre factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of the NIST-cited conversion tables (length, mass, energy, the electric-EMU
+% family, and the rest): a native tabular relation ingested VERBATIM from a published NIST
+% conversion table. The row states the factor converting the traditional (CGS) unit of WAVE NUMBER
+% to the SI coherent derived unit, the reciprocal metre (m⁻¹):
+%
+%     ? wave_number_to_reciprocal_metre(kayser, $v)   % 100
+%
+% This opens a NEW dimension — WAVE NUMBER (the spatial frequency of a wave, the number of
+% wavelengths per unit length, used throughout spectroscopy) — alongside the already-tabulated
+% length/mass/area/volume/time/speed/energy/pressure/force/acceleration/dynamic-viscosity/
+% kinematic-viscosity/magnetic-flux-density/magnetic-flux/illuminance/luminance/radioactivity/
+% absorbed-dose/dose-equivalent/exposure/power and electric charge/potential/resistance/capacitance/
+% inductance/conductance/current tables. Wave number is the RECIPROCAL of wavelength: the kayser is
+% one reciprocal centimetre (1 cm⁻¹), so it equals exactly 100 reciprocal metres. Do NOT confuse
+% WAVE NUMBER (the kayser → the reciprocal metre) with LENGTH or WAVELENGTH (e.g. the angstrom → the
+% metre): those are RECIPROCAL quantities that convert to DIFFERENT SI units (m⁻¹ vs m). A quantity
+% given in kaysers must be put into SI first, then reasoned over (write-once-use-many). Why a
+% `table` and not a hand-written `relate` clause: this is exactly the shape reference data comes in —
+% a published table, not prose. The citable artifact IS the NIST conversion-factors table at the
+% `locator` below; the factor here is a CELL of NIST Special Publication 811, Appendix B.9, defended
+% by one provenance envelope. Each `row` lowers to a ground relation
+% `wave_number_to_reciprocal_metre(unit, v)`, so the exact lookup above is the ordinary SLD binding
+% query — the engine returns the factor WITH this table's citation as its proof, on the CPU, with
+% zero model calls.
+%
+% HONESTY NOTE (like every other NIST table, only the EXACT defined factor gets a row): NIST SP 811
+% B.9 prints the "kayser" wave-number factor in BOLDFACE, its convention for factors that are EXACT
+% by definition, transcribed here as the plain decimal number of reciprocal metres it names:
+%
+%     kayser (K)   1 E+02  →  100
+%
+% This is exact because the kayser is DEFINED as exactly one reciprocal centimetre = 1 E+02
+% reciprocal metres. It terminates; nothing here is a rounded measurement. This table is SPECIFIC to
+% wave number: a unit of a DIFFERENT quantity — e.g. the "angstrom", which NIST SP 811 B.9 lists
+% separately as a LENGTH unit converting to the metre, NOT the reciprocal metre — therefore gets no
+% row here, and a `? wave_number_to_reciprocal_metre(angstrom, $v)` ABSTAINS rather than
+% mis-converting a length (wavelength) unit as if it were a wave-number unit. Since wave number is
+% the reciprocal of wavelength, this abstain guards exactly the wavelength-versus-wavenumber
+% confusion. The only claim this table makes is "this is the exact factor NIST SP 811 B.9 prints for
+% the kayser's conversion to the reciprocal metre" — which is exactly what a byte-check against the
+% cited table verifies. `trust authoritative` — a primary, re-fetchable standards reference. (See
+% ADJ-TABLES.md; and feedback_nothing_human_authored — the factor is a verbatim cell of the cited
+% table, nothing asserted from memory.)
+% ============================================================================
+
+table wave_number_to_reciprocal_metre {
+    columns unit, reciprocal_metre
+
+    row (kayser, 100)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/wave-number-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/wave-number-conversions.query.adj
@@ -1,0 +1,25 @@
+% ============================================================================
+% wave-number-conversions.query.adj — worked lookups over the NIST wave-number → reciprocal-metre table.
+% ============================================================================
+% The shape a consumer produces to convert a wave number given in the traditional CGS unit into SI:
+% it `import`s the grounded table and asks the engine to bind the factor. No arithmetic and no factor
+% is stated by the consumer; the engine returns the cell WITH the table's NIST citation as its proof,
+% on the CPU.
+%
+%   ? wave_number_to_reciprocal_metre(kayser, $v)   % 100   (kayser = 1 E+02 m⁻¹, exact)
+%
+% And the dimension guard: a unit of a DIFFERENT quantity has no row, so the lookup ABSTAINS rather
+% than mis-converting across dimensions. The "angstrom" is a LENGTH (wavelength) unit (it converts to
+% the metre), NOT a wave-number unit — and since wave number is the reciprocal of wavelength, this
+% abstain guards the wavelength-versus-wavenumber confusion directly:
+%
+%   ? wave_number_to_reciprocal_metre(angstrom, $v)   % abstains (angstrom is length → metre)
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli wave-number-conversions.query.adj
+% ============================================================================
+
+import "wave-number-conversions.adj"
+
+? wave_number_to_reciprocal_metre(kayser, $v)     % expect 100      (exact NIST SP 811 B.9 factor)
+? wave_number_to_reciprocal_metre(angstrom, $v)   % expect abstain  (length unit, wrong dimension)


### PR DESCRIPTION
## What

Opens a **new NIST SP 811 Appendix B.9 dimension — WAVE NUMBER** (spatial frequency, wavelengths per unit length; the reciprocal of wavelength, ubiquitous in spectroscopy) — beyond the length/mass/energy/…/electric-EMU tables already shipped. Adds the wave-number conversion table (RS-5 `table`) to the **reference** track: the factor converting the traditional CGS unit of wave number, the **kayser**, to the SI coherent derived unit, the **reciprocal metre (m⁻¹)**.

```
? wave_number_to_reciprocal_metre(kayser, $v)   →  100   (kayser = 1 E+02 m⁻¹, exact)
```

Byte-verified against the cited NIST table (**boldface** = exact by definition; the kayser is one reciprocal centimetre = exactly 1 E+02 reciprocal metres).

## Why

The electromagnetic-EMU electrical family is complete (charge/potential/resistance/capacitance/inductance/conductance/current), and the remaining CGS-EMU magnetic units (gilbert, oersted) carry a 4π factor and are **not exact** — so this rotation opens a fresh **exact-factor** dimension instead.

## Dimension guard — the reciprocal distinction

The abstain probe uses the **angstrom** — a *length / wavelength* unit converting to the metre:

```
? wave_number_to_reciprocal_metre(angstrom, $v)   →  abstains   (wrong dimension)
```

Since wave number is the **reciprocal** of wavelength, this abstain guards the exact wavelength-versus-wavenumber confusion (m vs m⁻¹) — a dimension check, not mere absence of a value.

## Files

- `code/specs/data/adj-formula-stdlib/reference/wave-number-conversions.adj` — one-row `table` + honesty note
- `code/specs/data/adj-formula-stdlib/reference/wave-number-conversions.query.adj` — worked lookup + abstain
- `code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs` — `(b30)` block appended to the shared anchor

## Verification

- `cargo test -p adj-lang-cli --test rs5_table_e2e` — **35/35 green** (incl. the new b30)
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — **clean**
- Render-probe: `kayser` → `"v":"100"` carrying the NIST B.9 locator; `angstrom` → `"abstained":true`.
- Data + test only — no engine change, **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)