### PR TITLE
docs(build-tool): define cross-language conformance contract

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,17 +8,23 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": {
-    "number": 9144,
-    "url": "https://github.com/adhithyan15/coding-adventures/pull/9144",
-    "branch": "codex/haskell-http-core-parity",
-    "status": "open"
+  "active_pr": null,
+  "last_inventory": {
+    "revision": "326de7c72c24605cc935006d11b24d50dfbd9c65",
+    "schema_version": 2,
+    "established_languages": 15,
+    "implementation_identities": 1183,
+    "implementation_package_slots": 4324,
+    "high_consensus_packages": 172,
+    "high_consensus_missing_slots": 278,
+    "canonical_collisions": 0,
+    "unknown_language_buckets": 0
   },
   "items": [
     {
       "id": "haskell-http-core",
       "title": "Haskell http-core plus Haskell scaffold and resolver integrity",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": [],
       "branch": "codex/haskell-http-core-parity",
       "pr_number": 9144,
@@ -27,11 +33,11 @@
     {
       "id": "build-tool-contract",
       "title": "Language-neutral build-tool contract and shared fixture schema",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["haskell-http-core"],
-      "branch": null,
+      "branch": "codex/build-tool-conformance-contract",
       "pr_number": null,
-      "notes": "Reconcile specs 12, 15, build-plan-v1, sharding, and B05; define canonical machine-readable behavior."
+      "notes": "Selected after the 2026-07-29 post-merge reprioritization because it unlocks every existing build-tool remediation lane, missing Java/Kotlin/Dart implementations, and the future OCaml build tool. Reconcile specs 12, 15, build-plan-v1, sharding, and B05; define canonical machine-readable behavior."
     },
     {
       "id": "build-tool-fixtures",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,7 +8,12 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": null,
+  "active_pr": {
+    "number": 9151,
+    "url": "https://github.com/adhithyan15/coding-adventures/pull/9151",
+    "branch": "codex/build-tool-conformance-contract",
+    "status": "open"
+  },
   "last_inventory": {
     "revision": "326de7c72c24605cc935006d11b24d50dfbd9c65",
     "schema_version": 2,
@@ -33,11 +38,11 @@
     {
       "id": "build-tool-contract",
       "title": "Language-neutral build-tool contract and shared fixture schema",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["haskell-http-core"],
       "branch": "codex/build-tool-conformance-contract",
-      "pr_number": null,
-      "notes": "Selected after the 2026-07-29 post-merge reprioritization because it unlocks every existing build-tool remediation lane, missing Java/Kotlin/Dart implementations, and the future OCaml build tool. Reconcile specs 12, 15, build-plan-v1, sharding, and B05; define canonical machine-readable behavior."
+      "pr_number": 9151,
+      "notes": "PR #9151 defines the reconciled v1 conformance contract, strict fixture schema, representative Windows override case, CI schema tests, and security boundary. It unlocks every existing build-tool remediation lane, missing Java/Kotlin/Dart implementations, and the future OCaml build tool."
     },
     {
       "id": "build-tool-fixtures",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,11 @@ jobs:
         with:
           go-version: '1.23'
 
-      - name: Test package parity reporter
+      - name: Test parity metadata contracts
         run: |
+          python3 -m pip install --disable-pip-version-check --quiet jsonschema==4.26.0
           python3 -m unittest discover -s code/scripts/tests -p 'test_package_parity_report.py'
+          python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_schema.py'
           python3 code/scripts/package_parity_report.py --format json --fail-on-collisions > /tmp/package-parity-report.json
 
       - name: Determine diff base

--- a/code/scripts/tests/test_build_tool_conformance_schema.py
+++ b/code/scripts/tests/test_build_tool_conformance_schema.py
@@ -1,0 +1,447 @@
+from __future__ import annotations
+
+import base64
+import copy
+import json
+import re
+import unicodedata
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[3]
+FIXTURE_ROOT = ROOT / "code" / "specs" / "fixtures" / "build-tool-v1"
+SCHEMA_PATH = FIXTURE_ROOT / "schema.json"
+EXAMPLE_ROOT = FIXTURE_ROOT / "examples"
+MAX_SAFE_INTEGER = 9_007_199_254_740_991
+RESERVED_ADAPTER_FLAGS = ("--conformance", "--workspace-root", "--output")
+DOMAIN_CAPABILITIES = {
+    "discovery": {"discovery"},
+    "resolution": {"resolution"},
+    "graph": {"graph"},
+    "diff_selection": {"diff_selection"},
+    "hashing_cache": {"hashing_cache"},
+    "starlark": {"starlark"},
+    "plan": {"plan_v1_read", "plan_v1_write"},
+    "sharding": {"sharding"},
+    "execution": {"execution", "trusted_execution"},
+    "validation": {"validation"},
+    "toolchain_detection": {"toolchain_detection"},
+    "cli": {"cli"},
+}
+WINDOWS_RESERVED_BASENAMES = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    *(f"COM{index}" for index in range(1, 10)),
+    *(f"LPT{index}" for index in range(1, 10)),
+}
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _reject_non_finite(value: str) -> None:
+    raise ValueError(f"non-finite JSON number: {value}")
+
+
+def _validate_json_value(value: Any, depth: int = 0) -> None:
+    if depth > 64:
+        raise ValueError("JSON nesting exceeds 64 levels")
+    if isinstance(value, str):
+        if any(0xD800 <= ord(character) <= 0xDFFF for character in value):
+            raise ValueError("unpaired Unicode surrogate")
+        return
+    if value is None or isinstance(value, bool):
+        return
+    if isinstance(value, int):
+        if not -MAX_SAFE_INTEGER <= value <= MAX_SAFE_INTEGER:
+            raise ValueError("integer outside interoperable range")
+        return
+    if isinstance(value, float):
+        raise ValueError("floating-point JSON values are forbidden")
+    if isinstance(value, list):
+        for item in value:
+            _validate_json_value(item, depth + 1)
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            _validate_json_value(key, depth + 1)
+            _validate_json_value(item, depth + 1)
+        return
+    raise ValueError(f"unsupported JSON value: {type(value).__name__}")
+
+
+def strict_loads(raw: bytes, max_bytes: int = 2_000_000) -> dict[str, Any]:
+    if len(raw) > max_bytes:
+        raise ValueError("JSON input exceeds byte limit")
+    if raw.startswith(b"\xef\xbb\xbf"):
+        raise ValueError("UTF-8 BOM is forbidden")
+    text = raw.decode("utf-8", errors="strict")
+    value = json.loads(
+        text,
+        object_pairs_hook=_reject_duplicate_pairs,
+        parse_constant=_reject_non_finite,
+    )
+    _validate_json_value(value)
+    if not isinstance(value, dict):
+        raise ValueError("top-level JSON value must be an object")
+    return value
+
+
+def portable_path_error(path: str) -> str | None:
+    if (
+        not path
+        or path.startswith("/")
+        or (len(path) >= 2 and path[0].isalpha() and path[1] == ":")
+        or "\\" in path
+        or "//" in path
+        or any(ord(character) < 32 or character in '<>:"|?*' for character in path)
+    ):
+        return "path is not a portable relative path"
+    for segment in path.split("/"):
+        if segment in {".", ".."}:
+            return "path contains a dot segment"
+        if segment.endswith((" ", ".")):
+            return "path segment has a trailing dot or space"
+        basename = segment.split(".", 1)[0].upper()
+        if basename in WINDOWS_RESERVED_BASENAMES:
+            return "path segment uses a Windows reserved basename"
+    return None
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return strict_loads(path.read_bytes())
+
+
+def semantic_errors(case: dict[str, Any]) -> list[str]:
+    """Check cross-field and filesystem invariants JSON Schema cannot express."""
+
+    errors: list[str] = []
+    case_id = case.get("id")
+    domain = case.get("domain")
+    operation = case.get("input", {}).get("operation")
+    expected = case.get("expected", {})
+
+    if domain != operation:
+        errors.append("domain must equal input.operation")
+    if case_id != expected.get("case_id"):
+        errors.append("id must equal expected.case_id")
+    if domain != expected.get("domain"):
+        errors.append("domain must equal expected.domain")
+
+    capabilities = case.get("capabilities", [])
+    required_capabilities = DOMAIN_CAPABILITIES.get(domain, set())
+    if domain == "plan":
+        if not required_capabilities.intersection(capabilities):
+            errors.append("plan cases require a plan_v1_read or plan_v1_write capability")
+    elif not required_capabilities.issubset(capabilities):
+        errors.append(f"{domain} case is missing its domain capability")
+
+    trusted_execution = "trusted_execution" in capabilities
+    if (domain == "execution") != trusted_execution:
+        errors.append("trusted_execution is required only for execution cases")
+
+    normalized_paths: set[str] = set()
+    workspace_bytes = 0
+    for file_entry in case.get("workspace", {}).get("files", []):
+        path = file_entry.get("path", "")
+        if path_error := portable_path_error(path):
+            errors.append(f"unsafe portable path {path}: {path_error}")
+        normalized = unicodedata.normalize("NFC", path).casefold()
+        if normalized in normalized_paths:
+            errors.append(f"duplicate normalized path: {path}")
+        if any(
+            normalized.startswith(f"{existing}/")
+            or existing.startswith(f"{normalized}/")
+            for existing in normalized_paths
+        ):
+            errors.append(f"file/directory path conflict: {path}")
+        normalized_paths.add(normalized)
+
+        if "content_base64" in file_entry:
+            try:
+                decoded = base64.b64decode(file_entry["content_base64"], validate=True)
+                canonical = base64.b64encode(decoded).decode("ascii")
+                if canonical != file_entry["content_base64"]:
+                    errors.append(f"non-canonical base64 content: {path}")
+                workspace_bytes += len(decoded)
+            except (ValueError, TypeError):
+                errors.append(f"invalid base64 content: {path}")
+        elif "content_utf8" in file_entry:
+            workspace_bytes += len(file_entry["content_utf8"].encode("utf-8"))
+
+    workspace_limit = case.get("limits", {}).get("workspace_bytes")
+    if isinstance(workspace_limit, int) and workspace_bytes > workspace_limit:
+        errors.append("decoded workspace exceeds requested workspace_bytes")
+
+    normalized_changed_paths: set[str] = set()
+    for path in case.get("input", {}).get("changed_paths", []):
+        if path_error := portable_path_error(path):
+            errors.append(f"unsafe portable path {path}: {path_error}")
+        normalized = unicodedata.normalize("NFC", path).casefold()
+        if normalized in normalized_changed_paths:
+            errors.append(f"duplicate normalized changed path: {path}")
+        normalized_changed_paths.add(normalized)
+
+    for key, value in case.get("input", {}).get("options", {}).items():
+        if (
+            isinstance(value, str)
+            and key.endswith(("_path", "_root", "_file"))
+            and (path_error := portable_path_error(value))
+        ):
+            errors.append(f"unsafe portable path {value}: {path_error}")
+
+    for argument in case.get("input", {}).get("arguments", []):
+        if any(
+            argument == flag or argument.startswith(f"{flag}=")
+            for flag in RESERVED_ADAPTER_FLAGS
+        ):
+            errors.append(f"reserved adapter flag in input.arguments: {argument}")
+
+    outcome = expected.get("outcome")
+    if outcome in {"unsupported", "skipped"} and not expected.get("diagnostics"):
+        errors.append(f"{outcome} outcome requires a diagnostic")
+
+    return errors
+
+
+class BuildToolConformanceSchemaTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.schema = load_json(SCHEMA_PATH)
+        cls.examples = [load_json(path) for path in sorted(EXAMPLE_ROOT.glob("*.json"))]
+
+    def test_schema_is_draft_2020_12_and_closed_at_the_boundary(self) -> None:
+        self.assertEqual(
+            self.schema["$schema"],
+            "https://json-schema.org/draft/2020-12/schema",
+        )
+        self.assertFalse(self.schema["additionalProperties"])
+        self.assertEqual(self.schema["properties"]["schema_version"], {"const": 1})
+        self.assertEqual(
+            set(self.schema["required"]),
+            {
+                "schema_version",
+                "id",
+                "domain",
+                "summary",
+                "platforms",
+                "capabilities",
+                "workspace",
+                "input",
+                "expected",
+                "limits",
+            },
+        )
+
+    def test_checked_in_examples_are_formally_valid(self) -> None:
+        import jsonschema
+
+        jsonschema.Draft202012Validator.check_schema(self.schema)
+        validator = jsonschema.Draft202012Validator(self.schema)
+        for example in self.examples:
+            errors = sorted(validator.iter_errors(example), key=lambda error: list(error.path))
+            self.assertEqual(
+                errors,
+                [],
+                "\n".join(error.message for error in errors),
+            )
+
+    def test_checked_in_examples_satisfy_semantic_invariants(self) -> None:
+        self.assertGreater(len(self.examples), 0)
+        for example in self.examples:
+            self.assertEqual(semantic_errors(example), [])
+
+    def test_safe_path_pattern_rejects_portable_escape_shapes(self) -> None:
+        pattern = re.compile(self.schema["$defs"]["safe_path"]["pattern"])
+        for valid in (
+            "code/packages/python/demo/BUILD",
+            "fixtures/space and & metacharacters.txt",
+            "a/.hidden",
+        ):
+            self.assertIsNotNone(pattern.fullmatch(valid), valid)
+
+        for invalid in (
+            "",
+            "/absolute",
+            "C:/drive-relative",
+            r"\\server\share",
+            r"code\package\BUILD",
+            "../escape",
+            "code/../escape",
+            "code/./package",
+            "code//package",
+            "file:stream",
+            "nul\u0000byte",
+        ):
+            self.assertIsNone(pattern.fullmatch(invalid), invalid)
+
+    def test_fixture_environment_is_data_with_a_narrow_key_namespace(self) -> None:
+        environment_pattern = re.compile(
+            self.schema["$defs"]["input"]["properties"]["environment"][
+                "propertyNames"
+            ]["pattern"]
+        )
+        self.assertIsNotNone(environment_pattern.fullmatch("CONFORMANCE_MODE"))
+        for dangerous in (
+            "LD_PRELOAD",
+            "DYLD_INSERT_LIBRARIES",
+            "NODE_OPTIONS",
+            "PYTHONPATH",
+            "RUBYOPT",
+            "PERL5OPT",
+            "JAVA_TOOL_OPTIONS",
+            "DOTNET_STARTUP_HOOKS",
+            "BASH_ENV",
+        ):
+            self.assertIsNone(environment_pattern.fullmatch(dangerous), dangerous)
+
+    def test_domain_operation_and_expected_identity_mismatches_are_rejected(
+        self,
+    ) -> None:
+        base = self.examples[0]
+
+        mismatch = copy.deepcopy(base)
+        mismatch["input"]["operation"] = "execution"
+        self.assertIn("domain must equal input.operation", semantic_errors(mismatch))
+
+        mismatch = copy.deepcopy(base)
+        mismatch["expected"]["case_id"] = "discovery/not-the-case"
+        self.assertIn("id must equal expected.case_id", semantic_errors(mismatch))
+
+        mismatch = copy.deepcopy(base)
+        mismatch["expected"]["domain"] = "resolution"
+        self.assertIn("domain must equal expected.domain", semantic_errors(mismatch))
+
+        mismatch = copy.deepcopy(base)
+        mismatch["input"]["arguments"] = ["--workspace-root=../../outside"]
+        self.assertTrue(
+            any(
+                error.startswith("reserved adapter flag in input.arguments:")
+                for error in semantic_errors(mismatch)
+            )
+        )
+
+        for unsafe in (
+            "../../outside",
+            "/absolute",
+            r"C:\outside",
+            "//server/share",
+        ):
+            mismatch = copy.deepcopy(base)
+            mismatch["input"]["options"]["code_root"] = unsafe
+            self.assertTrue(
+                any(error.startswith("unsafe portable path") for error in semantic_errors(mismatch)),
+                unsafe,
+            )
+
+    def test_normalized_duplicate_paths_and_invalid_base64_are_rejected(self) -> None:
+        duplicate = copy.deepcopy(self.examples[0])
+        duplicate["workspace"]["files"].append(
+            {
+                "path": "CODE/PACKAGES/PYTHON/DEMO/build",
+                "content_utf8": "duplicate on a case-insensitive filesystem\n",
+            }
+        )
+        self.assertTrue(
+            any(error.startswith("duplicate normalized path:") for error in semantic_errors(duplicate))
+        )
+
+        prefix_conflict = copy.deepcopy(self.examples[0])
+        prefix_conflict["workspace"]["files"] = [
+            {"path": "fixtures/data", "content_utf8": "file\n"},
+            {"path": "FIXTURES/DATA/child", "content_utf8": "child\n"},
+        ]
+        self.assertTrue(
+            any(
+                error.startswith("file/directory path conflict:")
+                for error in semantic_errors(prefix_conflict)
+            )
+        )
+
+        changed_duplicate = copy.deepcopy(self.examples[0])
+        changed_duplicate["input"]["changed_paths"] = ["Code/X", "code/x"]
+        self.assertTrue(
+            any(
+                error.startswith("duplicate normalized changed path:")
+                for error in semantic_errors(changed_duplicate)
+            )
+        )
+
+        invalid_base64 = copy.deepcopy(self.examples[0])
+        invalid_base64["workspace"]["files"][0].pop("content_utf8")
+        invalid_base64["workspace"]["files"][0]["content_base64"] = "not base64!"
+        self.assertTrue(
+            any(error.startswith("invalid base64 content:") for error in semantic_errors(invalid_base64))
+        )
+
+        noncanonical_base64 = copy.deepcopy(self.examples[0])
+        noncanonical_base64["workspace"]["files"][0].pop("content_utf8")
+        noncanonical_base64["workspace"]["files"][0]["content_base64"] = "AB=="
+        self.assertTrue(
+            any(
+                error.startswith("non-canonical base64 content:")
+                for error in semantic_errors(noncanonical_base64)
+            )
+        )
+
+    def test_windows_reserved_and_trailing_names_are_semantically_rejected(self) -> None:
+        for unsafe in ("fixtures/NUL.txt", "fixtures/name.", "fixtures/name "):
+            invalid = copy.deepcopy(self.examples[0])
+            invalid["workspace"]["files"][0]["path"] = unsafe
+            self.assertTrue(
+                any(error.startswith("unsafe portable path") for error in semantic_errors(invalid)),
+                unsafe,
+            )
+
+    def test_resource_requests_cover_the_adapter_process_and_cpu(self) -> None:
+        required = set(self.schema["$defs"]["limits"]["required"])
+        self.assertIn("cpu_time_ms", required)
+        self.assertGreaterEqual(
+            self.schema["$defs"]["limits"]["properties"]["process_count"]["minimum"],
+            1,
+        )
+
+    def test_strict_parser_rejects_ambiguous_or_nonportable_json(self) -> None:
+        invalid_documents = (
+            b'{"domain":"discovery","domain":"execution"}',
+            b'{"input":{"operation":"discovery","operation":"execution"}}',
+            b'{"limits":{"wall_time_ms":1,"wall_time_ms":2}}',
+            b'{"value":NaN}',
+            b'{"value":1.5}',
+            b'{"value":9007199254740992}',
+            b'{"value":"\\ud800"}',
+            b"\xef\xbb\xbf{}",
+        )
+        for raw in invalid_documents:
+            with self.subTest(raw=raw):
+                with self.assertRaises((UnicodeDecodeError, ValueError)):
+                    strict_loads(raw)
+
+        too_deep = b'{"value":' + (b"[" * 66) + b"0" + (b"]" * 66) + b"}"
+        with self.assertRaises(ValueError):
+            strict_loads(too_deep)
+        with self.assertRaises(ValueError):
+            strict_loads(b'{"value":"oversized"}', max_bytes=8)
+
+    def test_schema_forbids_floats_and_out_of_range_integers(self) -> None:
+        json_value = self.schema["$defs"]["json_value"]["oneOf"]
+        integer_schema = next(
+            entry for entry in json_value if entry.get("type") == "integer"
+        )
+        self.assertEqual(integer_schema["minimum"], -MAX_SAFE_INTEGER)
+        self.assertEqual(integer_schema["maximum"], MAX_SAFE_INTEGER)
+        self.assertNotIn("number", {entry.get("type") for entry in json_value})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/specs/12-build-system.md
+++ b/code/specs/12-build-system.md
@@ -2,7 +2,20 @@
 
 ## Overview
 
-The build system discovers, resolves, and builds packages across a multi-language monorepo. It is implemented in four languages (Go, Python, Ruby, Rust) with a shared architecture, but the Go implementation is the most up to date and is the primary build tool used in CI.
+The build system discovers, resolves, and builds packages across a
+multi-language monorepo. The Go implementation is the primary tool used in CI
+and is currently the broadest operational reference.
+
+Executable front doors also exist in C#, Elixir, F#, Haskell, Lua, Perl,
+Python, Ruby, Rust, Swift, and TypeScript. Dart, Java, and Kotlin are established
+package lanes that still need build-tool implementations. F# currently delegates
+to the C# engine. C and C++ are emerging lanes, and OCaml is planned as an
+emerging lane.
+
+These implementations are not yet feature-identical. Observable portable
+behavior is defined by [the build-tool conformance
+contract](build-tool-conformance.md), not by directory presence or this
+architecture overview.
 
 The build system is not part of the computing stack — it is the infrastructure that builds and tests the stack.
 
@@ -10,7 +23,8 @@ The build system is not part of the computing stack — it is the infrastructure
 
 1. **Incremental**: Only rebuild packages that changed (via git diff or hash comparison).
 2. **Parallel**: Independent packages build concurrently.
-3. **Multi-language**: The primary tool builds Python, Ruby, Go, Rust, and TypeScript packages.
+3. **Multi-language**: The primary tool discovers every established
+   implementation lane and the explicitly supported emerging lanes.
 4. **Zero configuration**: Packages are discovered automatically from the directory tree.
 5. **Deterministic**: Same inputs always produce the same build plan.
 
@@ -81,25 +95,21 @@ cargo test -p logic-gates -- --nocapture
 
 ### Platform-Specific BUILD Files
 
-On macOS, if `BUILD_mac` exists in a directory, it takes precedence over `BUILD`. On Linux, `BUILD_linux` takes precedence. This allows platform-specific build commands (e.g., different compiler flags).
-
-Priority:
-1. `BUILD_mac` (on macOS/Darwin only)
-2. `BUILD_linux` (on Linux only)
-3. `BUILD` (cross-platform fallback)
+Platform-specific shell files take precedence over shared Unix, Starlark, and
+generic fallbacks. The canonical order is specified and tested in
+`build-tool-conformance.md`. In particular, a Windows `BUILD_windows` override
+must win over a Starlark plan; current implementations that do otherwise are
+non-conforming.
 
 ### Language Inference
 
 The package's language is inferred from its directory path. The build system scans path components for known language names:
 
-| Path component | Language |
-|---------------|----------|
-| `python`      | python     |
-| `ruby`        | ruby       |
-| `go`          | go         |
-| `rust`        | rust       |
-| `typescript`  | typescript |
-| `elixir`      | elixir     |
+| Classification | Path components |
+|---|---|
+| Established implementation | `csharp`, `dart`, `elixir`, `fsharp`, `go`, `haskell`, `java`, `kotlin`, `lua`, `perl`, `python`, `ruby`, `rust`, `swift`, `typescript` |
+| Emerging implementation | `c`, `cpp`; later `ocaml` |
+| Shared execution/build buckets | `dotnet`, `wasm`, `starlark` |
 
 For example, `code/packages/python/logic-gates` yields language `python`. If no known language component is found, the language is `unknown`.
 
@@ -182,12 +192,14 @@ Flags:
 
 ## Implementations
 
-| Language | Location                              | Parallelism      | Notes                    |
-|----------|---------------------------------------|-------------------|--------------------------|
-| Go       | `code/programs/go/build-tool/`        | goroutines        | Primary CI tool, broadest language support |
-| Python   | `code/programs/python/build-tool/`    | ThreadPoolExecutor| Reference implementation |
-| Ruby     | `code/programs/ruby/build-tool/`      | Threads           | Educational              |
-| Rust     | `code/programs/rust/build-tool/`      | rayon             | Native performance       |
+| Status | Languages | Notes |
+|---|---|---|
+| Operational front doors | C#, Elixir, F#, Go, Haskell, Lua, Perl, Python, Ruby, Rust, Swift, TypeScript | Behavior and maturity vary; Go is the CI reference. |
+| Missing established front doors | Dart, Java, Kotlin | Required for final parity. |
+| Emerging/future | C, C++, OCaml | Graduation requires an explicit applicability decision and conformance. |
+
+The exact implementation inventory and remediation order live in
+`package-parity-roadmap.md`.
 
 ## Migration Note
 

--- a/code/specs/15-os-aware-build-rules.md
+++ b/code/specs/15-os-aware-build-rules.md
@@ -1,4 +1,13 @@
 # OS-Aware Starlark BUILD Rules
+
+## Status
+
+Target behavior; not yet implemented consistently by the build-tool ports. The
+Go reference has partial Starlark evaluation and a structured-command renderer,
+but `_ctx` propagation and production structured-command use remain work.
+Conformance is defined by
+[`build-tool-conformance.md`](build-tool-conformance.md).
+
 ## Specification
 
 ### Problem
@@ -26,7 +35,9 @@ BUILD file authors write a single Starlark BUILD file. No BUILD_windows, no BUIL
 
 - Changing how shell BUILD files work (full backward compatibility).
 - Adding OS detection to the Starlark VM itself (the VM is language-agnostic).
-- Rewriting the executor's shell dispatch (it already handles `sh -c` vs `cmd /C`).
+- Rewriting the executor's shell dispatch. The current `cmd /C` Windows path is
+  a known gap governed by `B05-build-windows-executor.md`; it is not accepted as
+  portable behavior.
 
 ---
 
@@ -210,3 +221,8 @@ def py_library(name, srcs=[], deps=[], test_runner="pytest"):
 3. **Delete**: Remove all BUILD_windows files.
 
 After migration, a package that previously needed two files (BUILD + BUILD_windows) has one Starlark BUILD file that works everywhere.
+
+Until that migration is complete, platform-specific shell overrides take
+precedence over Starlark according to the conformance contract. Structured
+command support must not cause an existing `BUILD_windows`, `BUILD_mac`, or
+`BUILD_linux` escape hatch to be ignored.

--- a/code/specs/B05-build-windows-executor.md
+++ b/code/specs/B05-build-windows-executor.md
@@ -25,6 +25,12 @@ This spec defines the target behavior and the migration plan. The
 implementation lives in `code/programs/go/build-tool/internal/executor/`
 and `code/programs/go/build-tool/main.go`.
 
+The observable precedence, quoting, failure, timeout, and process-tree behavior
+is tested by the language-neutral fixtures defined in
+[`build-tool-conformance.md`](build-tool-conformance.md). Until those fixtures
+pass, `cmd /C` and Starlark-first plan loading remain known gaps rather than
+reference semantics for other ports.
+
 ---
 
 ## §1 Problem 1 — `cmd.exe` argument mangling

--- a/code/specs/B05-build-windows-executor.md
+++ b/code/specs/B05-build-windows-executor.md
@@ -31,6 +31,11 @@ is tested by the language-neutral fixtures defined in
 pass, `cmd /C` and Starlark-first plan loading remain known gaps rather than
 reference semantics for other ports.
 
+Repository reality note: the current Go tool detects Starlark syntax in the
+canonical `BUILD` file. References below to `BUILD.lark` preserve the older
+migration design; `BUILD.lark` is not a recognized package marker in
+conformance v1.
+
 ---
 
 ## §1 Problem 1 — `cmd.exe` argument mangling

--- a/code/specs/build-plan-sharding.md
+++ b/code/specs/build-plan-sharding.md
@@ -7,6 +7,11 @@ packages without requiring one CI runner to hold every build artifact at once.
 A single monorepo build plan is still the source of truth, but that plan can be
 split into multiple independently executable shards.
 
+This document defines target behavior. Sharding is currently implemented most
+completely by the Go build tool; final cross-language requirements and
+deterministic fixtures are defined by
+[`build-tool-conformance.md`](build-tool-conformance.md).
+
 ## Model
 
 The detect job computes the normal build plan:
@@ -107,3 +112,10 @@ Each sharded main job downloads the same `build-plan.json` and passes
   fix.
 - Future versions can use historical durations and artifact exchange to reduce
   duplicate prerequisite work.
+
+## Conformance
+
+The shared fixtures require deterministic assignment, exactly one direct
+assignment per scheduled package, prerequisite closure, shard-local toolchain
+calculation, stable indexes, and explicit invalid-count/index errors. A port
+that can read a plan but ignores its `shards` field is not conforming.

--- a/code/specs/build-plan-v1.md
+++ b/code/specs/build-plan-v1.md
@@ -9,6 +9,10 @@ cross-job communication in CI: the `detect` job computes the plan once, and all
 
 ## Motivation
 
+This is the interchange schema, not a claim that every build-tool front door
+already implements it. Cross-language behavior and fixtures are governed by
+[`build-tool-conformance.md`](build-tool-conformance.md).
+
 The CI pipeline has two jobs:
 
 1. **detect** — compiles the build tool, discovers packages, resolves
@@ -25,7 +29,7 @@ the build job skips straight to step 6 (hashing), saving time on each of the
 
 ```json
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Build Plan v1",
   "description": "Serialized build plan for cross-job/cross-platform build orchestration.",
   "type": "object",
@@ -97,7 +101,7 @@ the build job skips straight to step 6 (hashing), saving time on each of the
         },
         "language": {
           "type": "string",
-          "enum": ["python", "ruby", "go", "typescript", "rust", "elixir", "starlark", "unknown"],
+          "enum": ["c", "cpp", "csharp", "dart", "dotnet", "elixir", "fsharp", "go", "haskell", "java", "kotlin", "lua", "ocaml", "perl", "python", "ruby", "rust", "starlark", "swift", "typescript", "wasm", "unknown"],
           "description": "The package's programming language, inferred from its path."
         },
         "build_commands": {
@@ -269,6 +273,15 @@ normal flow.
 
 ## Cross-Language Compatibility
 
-All 6 build tool implementations (Go, Python, Ruby, TypeScript, Rust, Elixir)
-read and write the same JSON schema. A plan emitted by the Go build tool can
-be consumed by the Python build tool, and vice versa.
+Cross-language compatibility is a target that must be demonstrated, not
+inferred from similarly named structs. Implementations currently differ in
+whether they write plans, read plans, preserve `null` versus `[]`, support
+shards, validate paths, and honor platform BUILD overrides.
+
+The shared conformance corpus proves compatibility through a writer/reader
+cross-product:
+
+- every supported implementation must consume a Go-emitted plan; and
+- Go must consume a plan emitted by every supported implementation.
+
+No implementation is described as plan-compatible until those fixtures pass.

--- a/code/specs/build-plan-v1.md
+++ b/code/specs/build-plan-v1.md
@@ -101,8 +101,8 @@ the build job skips straight to step 6 (hashing), saving time on each of the
         },
         "language": {
           "type": "string",
-          "enum": ["c", "cpp", "csharp", "dart", "dotnet", "elixir", "fsharp", "go", "haskell", "java", "kotlin", "lua", "ocaml", "perl", "python", "ruby", "rust", "starlark", "swift", "typescript", "wasm", "unknown"],
-          "description": "The package's programming language, inferred from its path."
+          "pattern": "^[a-z][a-z0-9-]*$",
+          "description": "Open language identifier inferred from the package path. The registry is maintained by the conformance contract; additive language identifiers do not require a plan schema bump."
         },
         "build_commands": {
           "type": "array",

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -1,0 +1,457 @@
+# Build-Tool Conformance Contract
+
+## Status and authority
+
+This document defines the language-neutral behavior required of every supported
+implementation of the coding-adventures build tool.
+
+The older build-system specifications describe important pieces of the target,
+but they were written at different stages of the build tool's evolution. Where
+those documents disagree about observable behavior, this contract is the
+conformance authority:
+
+- `12-build-system.md` describes the overall architecture;
+- `build-plan-v1.md` defines the build-plan interchange format;
+- `build-plan-sharding.md` defines prerequisite-closed CI shards;
+- `15-os-aware-build-rules.md` defines structured, OS-aware Starlark commands;
+- `B05-build-windows-executor.md` defines the planned Windows executor and
+  platform-override corrections.
+
+Implementation-specific internals are not normative. The Go implementation is
+the current operational reference used by CI, but a behavior does not become
+portable merely because Go implements it. Portable behavior is established by
+this contract and the shared fixtures.
+
+## Purpose
+
+Directory presence is not parity. A conforming build tool must make the same
+decisions from the same repository-shaped input:
+
+1. discover the same packages;
+2. resolve the same local dependency edges;
+3. select the same changed, affected, and prerequisite package sets;
+4. produce compatible hashes, plans, shards, diagnostics, and status values;
+5. apply the same platform BUILD precedence and Starlark semantics;
+6. execute or simulate work with the same failure-propagation rules; and
+7. expose those decisions as deterministic machine-readable output.
+
+The shared fixture corpus is the behavioral oracle. A Python runner may
+orchestrate implementations, but no implementation language is the oracle.
+
+## Implementation scope
+
+The established package-parity denominator currently contains 15
+implementation languages:
+
+`csharp`, `dart`, `elixir`, `fsharp`, `go`, `haskell`, `java`, `kotlin`, `lua`,
+`perl`, `python`, `ruby`, `rust`, `swift`, and `typescript`.
+
+Build-tool front doors currently exist for C#, Elixir, F#, Go, Haskell, Lua,
+Perl, Python, Ruby, Rust, Swift, and TypeScript. Dart, Java, and Kotlin still
+need implementations. The F# front door currently delegates to the C# engine;
+that is a shared-engine exception candidate, not proof of an independent F#
+implementation.
+
+C and C++ remain emerging implementation lanes. OCaml also begins as emerging
+and must implement this contract before promotion. WASM is an execution target,
+Mosaic and Twig are domain languages, and Starlark is a build language; none is
+automatically required to provide a build-tool program.
+
+Final parity requires every established implementation language to have either:
+
+- a native build-tool engine that passes all required fixtures; or
+- a narrow, reviewed shared-engine exception recorded in the parity roadmap,
+  with a language-native front door and the same fixture results.
+
+## Normative language
+
+The terms **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** are
+normative.
+
+- **Required** fixture domains are completion gates for every supported
+  build-tool implementation.
+- **Capability-gated** cases apply only when their declared capability is
+  implemented, but every established implementation must eventually implement
+  all capabilities marked `required_for_final_parity`.
+- **Platform-gated** cases run only on listed operating systems.
+- **Deferred** behavior is planned and tested by fixtures that may initially be
+  expected failures. Deferred cases must not be reported as passing or omitted
+  silently.
+
+## Conformance adapter
+
+Every implementation MUST eventually expose this test-only interface:
+
+```text
+build-tool --conformance CASE.json --workspace-root ROOT --output RESULT.json
+```
+
+The adapter MUST:
+
+1. read one fixture conforming to
+   `code/specs/fixtures/build-tool-v1/schema.json`;
+2. operate only on the runner-created, already validated `ROOT`;
+3. run exactly one requested domain operation;
+4. write one canonical result object;
+5. write no timestamps, durations, absolute host paths, random identifiers, or
+   locale-dependent text into the result;
+6. exit `0` only when the adapter itself completed and wrote a result;
+7. represent an expected build-tool error inside the result rather than using
+   the adapter process exit code; and
+8. exit nonzero for malformed fixtures, unsupported schema versions, unsafe
+   materialization, adapter crashes, or failure to write the result.
+
+The runner, not the adapter, materializes the fixture into `ROOT`. It then
+launches the adapter inside an outer sandbox whose only writable mount is the
+runner-owned scratch tree. This keeps containment policy bound to a root chosen
+before untrusted implementation code starts. The runner compares the adapter
+result with the fixture's `expected` object. Human-readable stdout and stderr
+are diagnostic only and are not conformance inputs.
+
+## Fixture manifest
+
+Each fixture is a single JSON document. Inline files make a case atomic and
+portable across Git checkouts and operating systems.
+
+Required top-level fields:
+
+| Field | Meaning |
+|---|---|
+| `schema_version` | Integer fixture schema version; v1 is `1`. |
+| `id` | Stable lowercase identifier, unique across the corpus. |
+| `domain` | One conformance domain from the registry below. |
+| `summary` | Short explanation of the behavior under test. |
+| `platforms` | Normalized OS names on which the case applies. |
+| `capabilities` | Capabilities required to run the case. |
+| `workspace.files` | Inline UTF-8 or base64 files materialized under a fresh root. |
+| `input` | Domain-specific operation parameters. |
+| `expected` | Canonical result expected from every conforming implementation. |
+| `limits` | Requested timeout and output-size limits, always capped by runner policy. |
+
+The schema rejects obvious absolute paths, backslashes, empty path components,
+and `..` components. The runner MUST additionally perform semantic containment
+checks after platform-native normalization. JSON Schema alone cannot detect
+drive-relative paths, UNC/device names, Unicode or case-folding collisions,
+symlink/reparse escapes, or filesystem-specific aliases. Base64 content is
+strictly decoded, and every path must remain unique after platform-native case
+folding and Unicode normalization. The fixture `id` is data and is never used
+as a filesystem path.
+
+## Canonical result
+
+The `expected` object and adapter output share this shape:
+
+```json
+{
+  "schema_version": 1,
+  "case_id": "discovery/platform-precedence",
+  "status": "pass",
+  "result": {},
+  "diagnostics": []
+}
+```
+
+Rules:
+
+- object keys are serialized in lexicographic order;
+- package names, paths, dependency edges, levels, diagnostics, commands, and
+  language lists use deterministic ordering defined by the domain;
+- repository-relative paths use `/` on every platform;
+- no path may escape the materialized repository root;
+- absent optional values are omitted unless the domain assigns meaning to
+  `null`;
+- `null` and `[]` remain distinct;
+- diagnostics use stable codes and severities; prose may be present but is not
+  used as the sole assertion;
+- duplicate set-like values are invalid rather than silently deduplicated;
+- status is one of `pass`, `error`, `unsupported`, or `skipped`;
+- `unsupported` and `skipped` require a stable diagnostic code and never count
+  as conformance success.
+
+## Domain registry
+
+### 1. Discovery
+
+Required behavior:
+
+- walk the configured code root recursively;
+- match BUILD filenames exactly and stop recursion at a package root;
+- skip the canonical generated/dependency directories;
+- infer language only from exact path components;
+- distinguish packages and programs with the same basename;
+- return packages sorted by qualified name;
+- reject duplicate qualified names; and
+- select platform files in this order:
+  - Windows: `BUILD_windows`, then Starlark, then `BUILD`;
+  - macOS: `BUILD_mac`, then `BUILD_mac_and_linux`, then Starlark, then `BUILD`;
+  - Linux: `BUILD_linux`, then `BUILD_mac_and_linux`, then Starlark, then
+    `BUILD`.
+
+During the Starlark migration, fixtures declare whether the Starlark source is
+`BUILD.lark` or a Starlark-formatted `BUILD`. Implementations must not infer the
+format from arbitrary executable text after a platform-specific shell override
+has already won precedence.
+
+### 2. Dependency resolution
+
+Resolvers MUST cover every established implementation language and any emerging
+language the implementation advertises. Fixtures use real minimal manifests,
+not invented dependency summaries.
+
+The canonical graph edge `[from, to]` means "`to` depends on `from`". Resolution
+MUST:
+
+- ignore external dependencies;
+- recognize repository-supported legacy and current package-name aliases;
+- keep dependency scope within the implementation ecosystem unless metadata
+  explicitly names another qualified package;
+- reject self-edges, ambiguous manifests, ambiguous aliases, and duplicate
+  package identities;
+- emit sorted, unique internal edges; and
+- report malformed metadata with stable diagnostics instead of silently
+  inventing a partial graph.
+
+### 3. Graph and scheduling
+
+Required cases cover isolated nodes, chains, diamonds, multiple components,
+cycles, affected dependents, prerequisite closure, independent levels, and
+failure propagation.
+
+Topological ordering is deterministic: packages inside a level are sorted by
+qualified name. A cycle is a build-plan error. If package `A` fails, every
+transitive dependent of `A` is `dep-skipped`; unrelated packages may continue.
+
+### 4. Diff selection
+
+Git-diff fixtures provide changed repository-relative paths rather than invoking
+the host Git binary. Implementations MUST map:
+
+- package-local changes to that package;
+- shared workflow/toolchain changes to the declared toolchain set;
+- strict Starlark `srcs` globs only to matching packages;
+- package changes to all transitive dependents; and
+- changes outside known packages according to explicit fixture policy.
+
+The adapter must not read the caller's real checkout, Git config, hooks, or
+credentials.
+
+### 5. Hashing and cache
+
+Required behavior:
+
+- sort normalized relative paths before hashing;
+- exclude generated, dependency, VCS, cache, and temporary directories;
+- include applicable BUILD and manifest files;
+- preserve file boundaries unambiguously;
+- combine dependency hashes in deterministic graph order;
+- invalidate dependents when a prerequisite hash changes; and
+- recover from a missing or corrupt cache with a stable diagnostic.
+
+Fixtures provide file bytes. Implementations MUST NOT include host metadata,
+absolute paths, mtimes, ownership, locale, or directory enumeration order.
+
+### 6. Starlark
+
+Final parity requires:
+
+- deterministic BUILD evaluation with repository-contained `load()` paths;
+- `_ctx` propagation through nested loads using the v1 context schema;
+- normalized `os`, `arch`, `cpu_count`, `ci`, and `repo_root` fields;
+- filtering of platform-inapplicable `None` commands;
+- structured command objects with separate `program` and `args`;
+- platform-correct rendering without executing text during evaluation; and
+- a declared fallback for legacy targets that do not yet expose structured
+  commands.
+
+Starlark evaluation MUST NOT read undeclared host files, environment variables,
+network resources, clocks, random sources, or process APIs.
+
+### 7. Build-plan v1
+
+`build-plan-v1.md` remains the interchange schema. Fixtures require:
+
+- stable round-trip serialization;
+- forward-slash relative paths;
+- preservation of `affected_packages: null` versus `[]`;
+- rejection and fallback for unsupported future versions;
+- tolerance of unknown optional fields;
+- sorted packages and edges;
+- validation that every edge and affected name references a declared package;
+- rejection of paths outside the repository root; and
+- no execution of `build_commands` during plan parsing.
+
+Cross-language compatibility is proven only when one implementation's emitted
+plan is consumed by another implementation under the fixture matrix.
+
+### 8. Sharding
+
+Final parity requires the behavior in `build-plan-sharding.md`:
+
+- deterministic balancing for a fixed input and shard count;
+- stable zero-based shard indexes and names;
+- exactly one direct assignment for every scheduled package;
+- prerequisite-closed `package_names`;
+- toolchains computed from each closed shard;
+- no unknown packages or cross-shard artifact assumptions; and
+- explicit errors for invalid shard counts or indexes.
+
+Duplicate prerequisites across shards are permitted.
+
+### 9. Execution
+
+Execution fixtures are separate from pure planning fixtures and are
+`trusted_execution` capability cases. They use only commands supplied by the
+repository-owned corpus and run inside an isolated temporary root.
+
+Required behavior:
+
+- each legacy BUILD line is a separate shell invocation in package order;
+- independent packages respect the job limit;
+- dependent packages never start before prerequisites finish;
+- first command failure stops that package;
+- failed prerequisites produce `dep-skipped` dependents;
+- dry-run executes no commands;
+- declared shared-resource locks serialize conflicting package operations;
+- cancellation, timeout, and output limits terminate the full child process
+  tree; and
+- platform shell selection follows the resolved Windows-executor contract.
+
+The current Go `cmd /C` behavior and lack of process limits are known gaps, not
+portable semantics.
+
+### 10. Validation
+
+Validation fixtures report stable diagnostic codes for:
+
+- missing or empty BUILD files;
+- missing platform coverage;
+- undeclared local dependency references;
+- metadata dependencies missing from standalone BUILD prerequisites;
+- invalid Starlark source/dependency declarations;
+- ambiguous identities or manifests;
+- unsupported languages/toolchains; and
+- unsafe paths or commands in plans and fixtures.
+
+Diagnostics are sorted by `(code, path, package, detail_key)`. Human prose is
+informational.
+
+### 11. Toolchain detection
+
+Toolchain detection operates on the scheduled package set after affected and
+shard filtering. It MUST:
+
+- use normalized implementation-language keys;
+- collapse only explicitly shared toolchains, such as C#/F# to `dotnet` and
+  C/C++ to `cpp`;
+- include forced CI toolchains from workflow changes;
+- distinguish `null` all-package selection from an empty selection; and
+- return a complete, sorted boolean map for the supported registry.
+
+OCaml enters this registry before its build-tool implementation is promoted.
+
+### 12. CLI and reporting
+
+Required stable process semantics:
+
+| Condition | Exit code |
+|---|---:|
+| successful build, validation, dry-run, or plan emission | `0` |
+| invalid CLI usage or unsafe/malformed input | `2` |
+| package build or validation failure | `1` |
+| internal adapter failure | nonzero, with no forged result |
+
+Machine output is JSON. Human progress output may vary and is not compared by
+the conformance runner.
+
+## Security and trust boundary
+
+A fixture is data supplied to a program that can execute commands. Therefore:
+
+1. The runner MUST treat every fixture and adapter binary as untrusted by
+   default. A fixture cannot
+   grant itself trust with `trusted_execution`. Execution trust comes only from
+   out-of-band runner policy: an explicit operator/CI flag plus a reviewed,
+   immutable corpus digest. Pull-request changes are untrusted until reviewed
+   and merged into that policy.
+2. Every adapter run, including a pure domain, MUST be enclosed by the outer
+   runner sandbox. Pure domains MUST NOT execute fixture commands, spawn child
+   processes, use the network, or consult the host checkout.
+3. Execution fixtures MUST run with a minimal allowlisted environment, no
+   inherited secrets, filesystem containment, and network disabled. If the
+   runner cannot enforce both filesystem and network containment on the current
+   platform, it MUST fail closed or report a non-passing `skipped` result; it
+   MUST NOT execute the adapter or commands.
+4. Materialization MUST reject absolute, parent, drive-relative, UNC, device,
+   alternate-data-stream, NUL-containing, reserved-name, case-folding, Unicode
+   normalization, symlink, and reparse-point escapes.
+5. The runner MUST create files without following links and re-check canonical
+   containment immediately before every read, write, copy, and execution.
+6. Fixture-controlled output paths MUST remain below a runner-owned temporary
+   directory and use atomic replacement.
+7. Plan `rel_path`, declared sources, load paths, and build commands are
+   untrusted inputs. Parsing a plan MUST NOT execute commands.
+8. Fixture limits are requests, not authority. The effective limit is the
+   smaller of the fixture request and a runner-controlled hard ceiling. Hard
+   ceilings cover input JSON bytes/depth, decoded file bytes/count, process
+   count, CPU, memory, wall time, output bytes, and workspace size for the
+   adapter and its entire process tree. Limit exhaustion produces a stable
+   diagnostic.
+9. Results MUST redact the temporary root and MUST NOT contain environment
+   values, credentials, usernames, or host-specific absolute paths.
+10. Schema validation is necessary but not sufficient; semantic safety checks
+    are mandatory in the runner and every adapter.
+11. The runner resolves each trusted adapter executable before applying the
+    fixture environment and invokes it directly with an argument vector, never
+    through a fixture-controlled shell command.
+12. Domain/capability consistency is semantic: only execution-domain cases may
+    request `trusted_execution`, every execution case must request it, and the
+    capability request never confers trust by itself.
+
+## Capability registry
+
+V1 capabilities are:
+
+| Capability | Final parity |
+|---|---:|
+| `discovery` | required |
+| `resolution` | required |
+| `graph` | required |
+| `diff_selection` | required |
+| `hashing_cache` | required |
+| `starlark` | required |
+| `plan_v1_read` | required |
+| `plan_v1_write` | required |
+| `sharding` | required |
+| `execution` | required |
+| `validation` | required |
+| `toolchain_detection` | required |
+| `trusted_execution` | required, platform-gated |
+
+An implementation manifest added by the fixture-runner work records supported
+capabilities and reviewed temporary expected failures. A missing capability
+never becomes an implicit pass.
+
+## Delivery and completion gates
+
+The conformance program proceeds in dependency order:
+
+1. land this contract, the v1 fixture schema, and schema self-tests;
+2. add the cross-implementation runner and representative fixtures;
+3. make the Go operational reference pass, including structured Starlark and
+   B05 behavior;
+4. remediate existing implementations in fixture-failure order;
+5. add Java, Kotlin, and Dart build tools;
+6. add the OCaml build tool after the OCaml lane substrate is stable;
+7. decide the C/C++ graduation and native build-tool requirement; and
+8. run every supported implementation against the same corpus in CI.
+
+The project is not at build-tool parity until:
+
+- every required domain has positive and adversarial cases;
+- all established implementations pass all applicable required cases or have a
+  reviewed shared-engine exception;
+- Go-emitted plans are consumed by every implementation and every
+  implementation emits plans consumed by Go;
+- Linux, macOS, and Windows execution cases pass where applicable;
+- zero unreviewed expected failures remain; and
+- the parity roadmap records the conformance revision for every front door.

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -145,7 +145,8 @@ The `expected` object and adapter output share this shape:
 {
   "schema_version": 1,
   "case_id": "discovery/platform-precedence",
-  "status": "pass",
+  "domain": "discovery",
+  "outcome": "ok",
   "result": {},
   "diagnostics": []
 }
@@ -153,20 +154,32 @@ The `expected` object and adapter output share this shape:
 
 Rules:
 
-- object keys are serialized in lexicographic order;
-- package names, paths, dependency edges, levels, diagnostics, commands, and
-  language lists use deterministic ordering defined by the domain;
+- adapters may emit ordinary valid JSON; the runner parses, schema-validates,
+  normalizes, and serializes object keys lexicographically before comparison;
+- package names, paths, dependency edges, diagnostics, language lists, and
+  other set-like arrays are sorted as defined by the domain;
+- command order, dependency-level order, and other sequence-semantic arrays are
+  preserved; packages inside a dependency level are sorted;
 - repository-relative paths use `/` on every platform;
 - no path may escape the materialized repository root;
 - absent optional values are omitted unless the domain assigns meaning to
   `null`;
 - `null` and `[]` remain distinct;
+- numeric values are signed integers in the interoperable
+  `[-9007199254740991, 9007199254740991]` range; floating-point values,
+  non-finite values, and negative zero are forbidden, and domain decimals use
+  canonical strings;
 - diagnostics use stable codes and severities; prose may be present but is not
   used as the sole assertion;
 - duplicate set-like values are invalid rather than silently deduplicated;
-- status is one of `pass`, `error`, `unsupported`, or `skipped`;
+- outcome is one of `ok`, `error`, `unsupported`, or `skipped`;
 - `unsupported` and `skipped` require a stable diagnostic code and never count
   as conformance success.
+
+The adapter reports the operation outcome. Only the outer runner decides
+whether a case passes after comparing the normalized output with `expected`.
+The result envelope echoes both `case_id` and `domain`; semantic validation
+requires them to equal the fixture's `id` and `domain`, respectively.
 
 ## Domain registry
 
@@ -175,22 +188,24 @@ Rules:
 Required behavior:
 
 - walk the configured code root recursively;
-- match BUILD filenames exactly and stop recursion at a package root;
+- require a canonical `BUILD` file to establish package membership, match
+  filenames exactly, and stop recursion at a package root;
 - skip the canonical generated/dependency directories;
 - infer language only from exact path components;
 - distinguish packages and programs with the same basename;
 - return packages sorted by qualified name;
 - reject duplicate qualified names; and
 - select platform files in this order:
-  - Windows: `BUILD_windows`, then Starlark, then `BUILD`;
-  - macOS: `BUILD_mac`, then `BUILD_mac_and_linux`, then Starlark, then `BUILD`;
-  - Linux: `BUILD_linux`, then `BUILD_mac_and_linux`, then Starlark, then
-    `BUILD`.
+  - Windows: `BUILD_windows`, then canonical `BUILD`;
+  - macOS: `BUILD_mac`, then `BUILD_mac_and_linux`, then canonical `BUILD`;
+  - Linux: `BUILD_linux`, then `BUILD_mac_and_linux`, then canonical `BUILD`.
 
-During the Starlark migration, fixtures declare whether the Starlark source is
-`BUILD.lark` or a Starlark-formatted `BUILD`. Implementations must not infer the
-format from arbitrary executable text after a platform-specific shell override
-has already won precedence.
+The selected canonical `BUILD` may contain legacy shell lines or Starlark.
+Conformance v1 does not recognize `BUILD.lark` as a package marker; that name in
+older migration documents is aspirational. Implementations must not infer
+Starlark from arbitrary executable text after a platform-specific shell
+override has already won precedence. Platform variants override recipes; they
+do not create a host-specific package universe.
 
 ### 2. Dependency resolution
 
@@ -279,6 +294,19 @@ network resources, clocks, random sources, or process APIs.
 - validation that every edge and affected name references a declared package;
 - rejection of paths outside the repository root; and
 - no execution of `build_commands` during plan parsing.
+
+Only Go, Python, Ruby, and Swift currently expose an end-to-end v1 plan
+consumption path. Other front doors emit divergent plans, expose library-only
+readers, parse and discard the plan, or have no plan support. Those are tracked
+gaps, not alternate valid formats.
+
+The logical package set, dependency graph, and change selection are
+platform-independent. A v1 plan's concrete `build_commands` are a
+producer-platform recipe. Before execution, a consumer on another platform
+MUST re-resolve the selected platform override or re-evaluate the canonical
+Starlark BUILD with the target context. It MUST NOT execute producer commands
+blindly. A future plan version should separate the portable logical plan from
+platform recipes explicitly.
 
 Cross-language compatibility is proven only when one implementation's emitted
 plan is consumed by another implementation under the fixture matrix.
@@ -376,16 +404,23 @@ A fixture is data supplied to a program that can execute commands. Therefore:
 2. Every adapter run, including a pure domain, MUST be enclosed by the outer
    runner sandbox. Pure domains MUST NOT execute fixture commands, spawn child
    processes, use the network, or consult the host checkout.
-3. Execution fixtures MUST run with a minimal allowlisted environment, no
-   inherited secrets, filesystem containment, and network disabled. If the
+3. Every adapter receives a fixed runner-owned sanitized environment. Fixture
+   environment values remain inert JSON input and are never applied to the
+   adapter process. A trusted execution adapter may pass only explicitly
+   allowlisted `CONFORMANCE_*` keys to its sandboxed children. Execution
+   fixtures MUST run with no inherited secrets, filesystem containment, and
+   network disabled. If the
    runner cannot enforce both filesystem and network containment on the current
    platform, it MUST fail closed or report a non-passing `skipped` result; it
    MUST NOT execute the adapter or commands.
 4. Materialization MUST reject absolute, parent, drive-relative, UNC, device,
    alternate-data-stream, NUL-containing, reserved-name, case-folding, Unicode
    normalization, symlink, and reparse-point escapes.
-5. The runner MUST create files without following links and re-check canonical
-   containment immediately before every read, write, copy, and execution.
+5. The runner MUST reject non-regular files and use handle-relative, no-follow
+   operations (or an equivalent atomic "beneath root" primitive) for every
+   materialization, read, write, copy, and output operation. A separate
+   check-then-use containment check is insufficient because a link or reparse
+   point can be swapped between the check and operation.
 6. Fixture-controlled output paths MUST remain below a runner-owned temporary
    directory and use atomic replacement.
 7. Plan `rel_path`, declared sources, load paths, and build commands are
@@ -393,19 +428,39 @@ A fixture is data supplied to a program that can execute commands. Therefore:
 8. Fixture limits are requests, not authority. The effective limit is the
    smaller of the fixture request and a runner-controlled hard ceiling. Hard
    ceilings cover input JSON bytes/depth, decoded file bytes/count, process
-   count, CPU, memory, wall time, output bytes, and workspace size for the
-   adapter and its entire process tree. Limit exhaustion produces a stable
-   diagnostic.
+   count, CPU time, memory, wall time, combined stdout/stderr/result bytes, and
+   workspace size for the adapter and its entire process tree. Output limits are
+   enforced while streaming, not after capture. Limit exhaustion produces a
+   stable diagnostic.
 9. Results MUST redact the temporary root and MUST NOT contain environment
    values, credentials, usernames, or host-specific absolute paths.
 10. Schema validation is necessary but not sufficient; semantic safety checks
     are mandatory in the runner and every adapter.
-11. The runner resolves each trusted adapter executable before applying the
-    fixture environment and invokes it directly with an argument vector, never
-    through a fixture-controlled shell command.
+11. The runner resolves each trusted adapter executable and launches it with
+    the fixed sanitized runner environment and a direct argument vector, never
+    through a fixture-controlled shell command. The executable, case,
+    workspace-root, and result paths are separate arguments even when they
+    contain shell metacharacters.
 12. Domain/capability consistency is semantic: only execution-domain cases may
     request `trusted_execution`, every execution case must request it, and the
-    capability request never confers trust by itself.
+    capability request never confers trust by itself. The runner also requires
+    exact equality between top-level `domain` and `input.operation`.
+13. Security invariants are runner-enforced and non-oracular. Fixture-controlled
+    `expected`, `platforms`, `capabilities`, and `limits` values can never
+    authorize host or network access, weaken hard ceilings, or turn a sandbox
+    escape into a passing result.
+14. The runner requires exact equality between fixture `id` and
+    `expected.case_id`, and between fixture `domain` and `expected.domain`.
+15. `input.arguments` remains inert JSON data. It MUST NOT be appended to the
+    adapter invocation or alter the runner-owned case, workspace-root, or output
+    arguments. Per-domain adapters interpret only registered options, and every
+    path-valued option receives the same atomic beneath-root validation.
+16. Before schema validation, the runner performs bounded strict UTF-8 RFC 8259
+    parsing. It rejects a BOM, duplicate object keys at any depth, non-finite
+    numbers, floating-point values, integers outside the interoperable range,
+    invalid or unpaired Unicode, excessive nesting, and oversized raw input.
+    Different language runtimes MUST NOT apply first-key/last-key or permissive
+    numeric behavior to security decisions.
 
 ## Capability registry
 
@@ -425,6 +480,7 @@ V1 capabilities are:
 | `execution` | required |
 | `validation` | required |
 | `toolchain_detection` | required |
+| `cli` | required |
 | `trusted_execution` | required, platform-gated |
 
 An implementation manifest added by the fixture-runner work records supported

--- a/code/specs/fixtures/build-tool-v1/README.md
+++ b/code/specs/fixtures/build-tool-v1/README.md
@@ -1,0 +1,45 @@
+# Build-Tool Conformance Fixtures v1
+
+This directory contains the versioned, language-neutral fixture format defined
+by `code/specs/build-tool-conformance.md`.
+
+## Layout
+
+```text
+build-tool-v1/
+  schema.json
+  README.md
+  examples/
+    discovery-windows-override.json
+```
+
+The contract PR includes the schema and a non-executing example. The next
+fixture-runner work item will add the case corpus, adapter manifests, and runner.
+
+Every case is one JSON document with:
+
+- an inline repository-shaped workspace;
+- one conformance domain operation;
+- one canonical expected result; and
+- requested resource limits that can only be tightened by runner policy.
+
+UTF-8 files use `content_utf8`. Binary files use strict padded
+`content_base64`. Fixtures cannot declare symlinks, directories, or special
+files.
+
+## Validation
+
+The repository self-test performs structural, formal Draft 2020-12, and
+adversarial checks. CI installs the pinned `jsonschema` validator before
+running it:
+
+```text
+python -m unittest discover \
+  -s code/scripts/tests \
+  -p "test_build_tool_conformance_schema.py"
+```
+
+Schema validation does not make a fixture safe to execute. The future runner
+must enforce the sandbox, trust, containment, normalization, and hard-limit
+requirements in the conformance contract. In particular, a fixture's
+`trusted_execution` capability is a request and never authorizes execution.

--- a/code/specs/fixtures/build-tool-v1/examples/discovery-windows-override.json
+++ b/code/specs/fixtures/build-tool-v1/examples/discovery-windows-override.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "id": "discovery/windows-override",
+  "domain": "discovery",
+  "summary": "A Windows shell override wins over generic and Starlark BUILD content.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "discovery"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/python/demo/BUILD",
+        "content_utf8": "load(\"//rules:python.star\", \"python_library\")\npython_library(name = \"demo\")\n"
+      },
+      {
+        "path": "code/packages/python/demo/BUILD_windows",
+        "content_utf8": "python -m unittest discover tests\n"
+      }
+    ]
+  },
+  "input": {
+    "operation": "discovery",
+    "options": {
+      "platform": "windows",
+      "code_root": "code"
+    },
+    "arguments": [],
+    "environment": {},
+    "changed_paths": []
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "discovery/windows-override",
+    "domain": "discovery",
+    "outcome": "ok",
+    "result": {
+      "packages": [
+        {
+          "build_file": "code/packages/python/demo/BUILD_windows",
+          "is_starlark": false,
+          "language": "python",
+          "name": "python/demo",
+          "rel_path": "code/packages/python/demo"
+        }
+      ]
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 5000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 256,
+    "cpu_time_ms": 5000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/schema.json
+++ b/code/specs/fixtures/build-tool-v1/schema.json
@@ -1,0 +1,425 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/build-tool-conformance-case-v1.json",
+  "title": "Build-tool conformance case v1",
+  "description": "A portable, inline repository fixture and its canonical expected result.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "domain",
+    "summary",
+    "platforms",
+    "capabilities",
+    "workspace",
+    "input",
+    "expected",
+    "limits"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "id": {
+      "$ref": "#/$defs/case_id"
+    },
+    "domain": {
+      "$ref": "#/$defs/domain"
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 240
+    },
+    "platforms": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "darwin",
+          "linux",
+          "windows"
+        ]
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/capability"
+      }
+    },
+    "workspace": {
+      "$ref": "#/$defs/workspace"
+    },
+    "input": {
+      "$ref": "#/$defs/input"
+    },
+    "expected": {
+      "$ref": "#/$defs/result"
+    },
+    "limits": {
+      "$ref": "#/$defs/limits"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "domain": {
+            "const": "execution"
+          }
+        },
+        "required": [
+          "domain"
+        ]
+      },
+      "then": {
+        "properties": {
+          "capabilities": {
+            "contains": {
+              "const": "trusted_execution"
+            }
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "capabilities": {
+            "not": {
+              "contains": {
+                "const": "trusted_execution"
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "case_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*(/[a-z0-9][a-z0-9._-]*)+$",
+      "maxLength": 160
+    },
+    "domain": {
+      "enum": [
+        "discovery",
+        "resolution",
+        "graph",
+        "diff_selection",
+        "hashing_cache",
+        "starlark",
+        "plan",
+        "sharding",
+        "execution",
+        "validation",
+        "toolchain_detection",
+        "cli"
+      ]
+    },
+    "capability": {
+      "enum": [
+        "discovery",
+        "resolution",
+        "graph",
+        "diff_selection",
+        "hashing_cache",
+        "starlark",
+        "plan_v1_read",
+        "plan_v1_write",
+        "sharding",
+        "execution",
+        "validation",
+        "toolchain_detection",
+        "cli",
+        "trusted_execution"
+      ]
+    },
+    "safe_path": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^(?!/)(?![A-Za-z]:)(?!.*\\\\)(?!.*(?:^|/)\\.\\.?(?:/|$))(?!.*//)[^<>:\"|?*\\u0000-\\u001F/]+(?:/[^<>:\"|?*\\u0000-\\u001F/]+)*$"
+    },
+    "file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/safe_path"
+        },
+        "content_utf8": {
+          "type": "string",
+          "maxLength": 1048576
+        },
+        "content_base64": {
+          "type": "string",
+          "contentEncoding": "base64",
+          "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+          "maxLength": 1398104
+        },
+        "executable": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "content_utf8"
+          ],
+          "not": {
+            "required": [
+              "content_base64"
+            ]
+          }
+        },
+        {
+          "required": [
+            "content_base64"
+          ],
+          "not": {
+            "required": [
+              "content_utf8"
+            ]
+          }
+        }
+      ]
+    },
+    "workspace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "files"
+      ],
+      "properties": {
+        "files": {
+          "type": "array",
+          "maxItems": 4096,
+          "items": {
+            "$ref": "#/$defs/file"
+          }
+        }
+      }
+    },
+    "input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operation"
+      ],
+      "properties": {
+        "operation": {
+          "$ref": "#/$defs/domain"
+        },
+        "options": {
+          "type": "object",
+          "default": {},
+          "maxProperties": 256,
+          "additionalProperties": {
+            "$ref": "#/$defs/json_value"
+          }
+        },
+        "arguments": {
+          "type": "array",
+          "default": [],
+          "maxItems": 128,
+          "items": {
+            "type": "string",
+            "maxLength": 4096
+          }
+        },
+        "environment": {
+          "type": "object",
+          "default": {},
+          "propertyNames": {
+            "pattern": "^CONFORMANCE_[A-Z0-9_]+$"
+          },
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 4096
+          }
+        },
+        "changed_paths": {
+          "type": "array",
+          "default": [],
+          "uniqueItems": true,
+          "maxItems": 4096,
+          "items": {
+            "$ref": "#/$defs/safe_path"
+          }
+        }
+      }
+    },
+    "diagnostic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "severity"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^[A-Z][A-Z0-9_]*$",
+          "maxLength": 96
+        },
+        "severity": {
+          "enum": [
+            "info",
+            "warning",
+            "error"
+          ]
+        },
+        "path": {
+          "$ref": "#/$defs/safe_path"
+        },
+        "package": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._/-]*$",
+          "maxLength": 240
+        },
+        "message": {
+          "type": "string",
+          "maxLength": 4096
+        },
+        "details": {
+          "type": "object",
+          "maxProperties": 256,
+          "additionalProperties": {
+            "$ref": "#/$defs/json_value"
+          }
+        }
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "case_id",
+        "domain",
+        "outcome",
+        "result",
+        "diagnostics"
+      ],
+      "properties": {
+        "schema_version": {
+          "const": 1
+        },
+        "case_id": {
+          "$ref": "#/$defs/case_id"
+        },
+        "domain": {
+          "$ref": "#/$defs/domain"
+        },
+        "outcome": {
+          "enum": [
+            "ok",
+            "error",
+            "unsupported",
+            "skipped"
+          ]
+        },
+        "result": {
+          "type": "object",
+          "maxProperties": 1024,
+          "additionalProperties": {
+            "$ref": "#/$defs/json_value"
+          }
+        },
+        "diagnostics": {
+          "type": "array",
+          "maxItems": 4096,
+          "items": {
+            "$ref": "#/$defs/diagnostic"
+          }
+        }
+      }
+    },
+    "json_value": {
+      "oneOf": [
+        {
+          "type": "string",
+          "maxLength": 1048576
+        },
+        {
+          "type": "integer",
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        },
+        {
+          "type": "array",
+          "maxItems": 4096,
+          "items": {
+            "$ref": "#/$defs/json_value"
+          }
+        },
+        {
+          "type": "object",
+          "maxProperties": 1024,
+          "additionalProperties": {
+            "$ref": "#/$defs/json_value"
+          }
+        }
+      ]
+    },
+    "limits": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "wall_time_ms",
+        "output_bytes",
+        "workspace_bytes",
+        "process_count",
+        "memory_mib",
+        "cpu_time_ms"
+      ],
+      "properties": {
+        "wall_time_ms": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 600000
+        },
+        "output_bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 16777216
+        },
+        "workspace_bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 268435456
+        },
+        "process_count": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 64
+        },
+        "memory_mib": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 2048
+        },
+        "cpu_time_ms": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 600000
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- define the first versioned, language-neutral build-tool conformance contract across discovery, resolution, graph ordering, diff selection, hashing, Starlark, plan interchange, sharding, execution, validation, toolchain detection, and CLI behavior
- reconcile the existing build-system, OS-aware rules, Windows executor, build-plan, and sharding specs with the behavior that implementations can actually share
- add a strict Draft 2020-12 fixture schema, a representative Windows override case, and CI-backed schema/semantic tests
- record the current implementation inventory and security boundary so follow-up ports can be measured consistently

## Current implementation inventory

The repository currently has 12 build-tool front doors (C#, F#, Elixir, Go, Haskell, Lua, Perl, Python, Ruby, Rust, Swift, and TypeScript). Dart, Java, and Kotlin are established package lanes without build-tool implementations yet. OCaml remains an emerging lane until its promotion gates pass.

Only Go, Python, Ruby, and Swift currently consume `build-plan-v1` end to end. The contract records that gap without claiming the other implementations already conform.

## Security

- adapters run inside an outer sandbox selected by the trusted runner
- fixture-provided environment values and arguments remain inert data
- workspace paths are normalized, bounded, duplicate-checked, and restricted to regular inline files
- JSON parsing rejects duplicate keys, BOMs, floats/non-finite values, unsafe integers, unpaired surrogates, excessive depth, and oversized documents
- execution fixtures require an explicit trusted-execution capability and remain excluded from untrusted pull-request fixture contributions

## Validation

- `python -m unittest discover -s code/scripts/tests -p "test_build_tool_conformance_schema.py"` — 11 tests passed
- `python -m unittest discover -s code/scripts/tests -p "test_package_parity_report.py"` — 6 tests passed
- `ruff check code/scripts/tests/test_build_tool_conformance_schema.py`
- JSON syntax checks for the schema and example
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` — zero canonical collisions
- `go test ./...` and `go vet ./...` in `code/programs/go/build-tool`
- fresh Go build-tool binary and repository dry run — 44 Starlark BUILD files evaluated, 4,721 packages discovered, no package-scoped work selected
- `git diff --check origin/main...HEAD`

## Follow-up

The next dependency-shaped item is the sandboxed fixture runner and broader behavior corpus. Once that lands, the Go implementation becomes the first measured oracle, followed by serial remediation or implementation of every remaining language front door.
