### PR TITLE
feat(adj-formula-stdlib): serum-ascites albumin gradient — StatPearls SAAG definition library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_serum_ascites_albumin_gradient_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_serum_ascites_albumin_gradient_e2e.rs
@@ -1,0 +1,140 @@
+//! End-to-end tests for the `clinical/serum-ascites-albumin-gradient.adj` library — the SAAG
+//! relation (SAAG = serum albumin − ascitic albumin) and its two exact rearrangements — driven
+//! through the built CLI binary against the SHIPPED stdlib. The same invariant as every other
+//! formula library: a consumer states NO arithmetic; it imports the grounded library, binds the
+//! measured albumin concentrations with `observe`, and the engine applies the cited definition on
+//! the CPU, computing the EXACT value and rendering the definition's citation and trust tier in the
+//! `derived` section (the auditable answer). The three formulas INVERT around the worked case serum
+//! albumin = 4 g/dL, ascitic albumin = 1 g/dL: 4 − 1 = 3 (SAAG), 3 + 1 = 4 (serum), 4 − 3 = 1
+//! (ascitic). The three asserted values (3, 4, 1) are distinct single digits, none a colon-anchored
+//! prefix of another rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped SAAG library, resolved from this crate's manifest dir so the test is
+/// location-independent.
+fn shipped_saag_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/serum-ascites-albumin-gradient.adj")
+        .canonicalize()
+        .expect("shipped serum-ascites-albumin-gradient.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_saag_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_saag_lib()).unwrap();
+    std::fs::write(dir.join("serum-ascites-albumin-gradient.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// saag — the relation: serum albumin − ascitic albumin.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_saag_library_and_computes_it_with_citation() {
+    let dir = scratch("gap");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"serum-ascites-albumin-gradient.adj\"\n\
+         observe serum_albumin(4)\n\
+         observe ascites_albumin(1)\n\
+         ? saag(serum_albumin, ascites_albumin)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied definition's result: 4 − 1 = 3.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"saag\"") && s.contains("\"value\":3"),
+        "saag(4, 1) = 3: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// serum_albumin — the same definition solved for the serum value: SAAG + ascitic.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_serum_albumin_from_gradient_and_ascitic_with_citation() {
+    let dir = scratch("serum");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"serum-ascites-albumin-gradient.adj\"\n\
+         observe saag(3)\n\
+         observe ascites_albumin(1)\n\
+         ? serum_albumin(saag, ascites_albumin)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 3 + 1 = 4, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"serum_albumin\"") && s.contains("\"value\":4"),
+        "serum_albumin(3, 1) = 4: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "serum_albumin carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ascites_albumin — the same definition solved for the ascitic value: serum − SAAG, the third
+// reading of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_ascites_albumin_from_serum_and_gradient_with_citation() {
+    let dir = scratch("ascites");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"serum-ascites-albumin-gradient.adj\"\n\
+         observe serum_albumin(4)\n\
+         observe saag(3)\n\
+         ? ascites_albumin(serum_albumin, saag)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 4 − 3 = 1, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"ascites_albumin\"") && s.contains("\"value\":1"),
+        "ascites_albumin(4, 3) = 1: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "ascites_albumin carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/serum-ascites-albumin-gradient.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/serum-ascites-albumin-gradient.adj
@@ -1,0 +1,97 @@
+% ============================================================================
+% serum-ascites-albumin-gradient.adj — the definition of the serum–ascites albumin gradient
+% (SAAG = serum albumin − ascitic albumin) in the ADJ standard library.
+% ============================================================================
+% The serum–ascites albumin gradient (SAAG) entry of the *clinical* track — a hepatology/GI bedside
+% index, the ascitic-fluid sibling of the shipped osmolar-gap.adj and anion-gap.adj. Where the osmol
+% gap is a difference between two osmolalities and the anion gap a difference among serum electrolytes,
+% the SAAG is a difference between two albumin concentrations: THE SAAG IS THE SERUM ALBUMIN LEVEL
+% MINUS THE ASCITIC (ASCITES-FLUID) ALBUMIN LEVEL — the single most useful test for classifying the
+% cause of ascites. A high gradient (≥ 1.1 g/dL) predicts portal hypertension (cirrhosis, alcoholic
+% hepatitis, heart failure, Budd–Chiari, etc.) with high accuracy; a low gradient (< 1.1 g/dL) points
+% away from portal hypertension (peritoneal carcinomatosis, tuberculous peritonitis, pancreatitis,
+% nephrotic syndrome, serositis). It ships as an importable, byte-provenanced, PARAMETERIZED
+% `formula`, together with its two exact rearrangements (the serum albumin a gradient implies for a
+% given ascitic value, and the ascitic albumin it implies for a given serum value). As with every
+% compute library, a consumer states NO arithmetic: it `import`s this file, binds the two albumin
+% concentrations from its own byte-provenance decomposition, and asks the engine to APPLY the cited
+% definition on the CPU. Zero math is performed by the model; the engine computes each value EXACTLY
+% (over exact rationals), carrying the definition's citation.
+%
+%     import "serum-ascites-albumin-gradient.adj"
+%     observe serum_albumin(4)      % "…serum albumin 4.0 g/dL…"     (span cited by the model)
+%     observe ascites_albumin(1)    % "…ascitic albumin 1.0 g/dL…"   (span cited by the model)
+%     ? saag(serum_albumin, ascites_albumin)
+%                                    % engine → 3, carrying the SAAG difference
+%
+% All three formulas are EXACT over their parameters (a sum or a difference of two albumin
+% concentrations), so every value the engine returns is exact. They COMPOSE and invert cleanly around
+% the worked case serum albumin = 4 g/dL, ascitic albumin = 1 g/dL (SAAG = 4 − 1 = 3 g/dL, a HIGH
+% gradient): the `saag` a consumer computes is exactly the value the `serum_albumin` formula adds back
+% to the ascitic value to recover 4, and exactly the value the `ascites_albumin` formula subtracts
+% from the serum value to recover 1.
+%
+%   saag(serum_albumin, ascites_albumin)
+%       = serum_albumin - ascites_albumin      % SAAG = serum − ascitic   (definition)
+%   serum_albumin(saag, ascites_albumin)
+%       = saag + ascites_albumin               % serum = SAAG + ascitic   (solved for serum)
+%   ascites_albumin(serum_albumin, saag)
+%       = serum_albumin - saag                 % ascitic = serum − SAAG   (solved for ascitic)
+%
+% NOTE ON UNITS: both albumin concentrations are in grams per decilitre, so the gradient is in g/dL
+% (the same unit the cited clause names). The two samples must be obtained on the same day for the
+% gradient to be valid, but that is a collection caveat, not an arithmetic one; the engine computes
+% the exact difference over whatever consistent inputs it is given.
+%
+% All three formulas are defended by the SAME definitional clause — "SAAG equals the serum albumin
+% level minus the ascitic albumin level (g/dL)" — because that one definition (the SAAG IS the
+% serum-minus-ascitic albumin difference) sanctions the relation read every way (the gradient from the
+% two albumins, the serum albumin from the gradient and the ascitic value, or the ascitic albumin from
+% the serum value and the gradient). The quote is transcribed verbatim from the StatPearls "Ascites"
+% article on the NCBI Bookshelf, so each `formula` carries the provenance envelope every shipped
+% grounded clause carries; the linter rejects an unsourced one. (See feedback_nothing_human_authored —
+% the definitional clause is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable albumin concentration the definition ranges over, and
+% each result is a derived quantity. `serum_albumin`, `ascites_albumin` and `saag` each appear BOTH as
+% a derived result and as an input (of the other formulas), so each is a single dictionary term used
+% in both roles. The `surface` lists are the everyday names a decomposer maps onto the canonical term;
+% the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary serum_ascites_albumin_gradient_vocab {
+    define serum_albumin   : finding  surface "serum albumin", "serum albumin level"                      % grams per decilitre (g/dL)
+    define ascites_albumin : finding  surface "ascites albumin", "ascitic albumin", "ascitic albumin level"  % grams per decilitre (g/dL)
+    define saag            : finding  surface "SAAG", "serum-ascites albumin gradient", "serum ascites albumin gradient"  % grams per decilitre (g/dL)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the definitional clause from the StatPearls
+% "Ascites" article on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an exact
+% sum or difference of two albumin concentrations, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook serum_ascites_albumin_gradient_laws {
+    use serum_ascites_albumin_gradient_vocab
+
+    % SAAG — the serum albumin minus the ascitic albumin, i.e. gradient = serum − ascitic.
+    formula saag(serum_albumin, ascites_albumin) = serum_albumin - ascites_albumin
+        source "SAAG equals the serum albumin level minus the ascitic albumin level (g/dL)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470482/"
+        trust authoritative
+
+    % Serum albumin — the same definition solved for the serum value a gradient implies for a given
+    % ascitic value (serum = SAAG + ascitic). Defended by the SAME clause.
+    formula serum_albumin(saag, ascites_albumin) = saag + ascites_albumin
+        source "SAAG equals the serum albumin level minus the ascitic albumin level (g/dL)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470482/"
+        trust authoritative
+
+    % Ascitic albumin — the same definition solved for the ascitic value (ascitic = serum − SAAG): the
+    % serum albumin minus the gradient. The SAME clause, read the third way.
+    formula ascites_albumin(serum_albumin, saag) = serum_albumin - saag
+        source "SAAG equals the serum albumin level minus the ascitic albumin level (g/dL)"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470482/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/serum-ascites-albumin-gradient.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/serum-ascites-albumin-gradient.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% serum-ascites-albumin-gradient.query.adj — worked applications of the SAAG definition.
+% ============================================================================
+% The shape a consumer produces once it has decomposed an ascites vignette into observed albumin
+% concentrations: it `import`s the grounded formulabook, `observe`s the serum and ascitic albumin,
+% and asks the engine to APPLY the cited definition. No arithmetic is stated by the consumer; the
+% engine computes each value EXACTLY (over exact rationals) and carries the article's citation as its
+% proof, on the CPU, with zero model calls.
+%
+% Worked case (serum albumin = 4 g/dL, ascitic albumin = 1 g/dL): SAAG = 4 − 1 = 3 g/dL — a HIGH
+% gradient (≥ 1.1 g/dL), predicting portal hypertension. Each query below fixes two of the three
+% quantities and asks the engine to recover the third; every answer is exact and the three COMPOSE
+% (each inversion recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli serum-ascites-albumin-gradient.query.adj
+% ============================================================================
+
+import "serum-ascites-albumin-gradient.adj"
+
+% --- Definition: the SAAG the two albumins imply (expect 3). ----------------------------------
+observe serum_albumin(4)
+observe ascites_albumin(1)
+? saag(serum_albumin, ascites_albumin)   % expect 3
+
+% --- Inverse: the serum albumin a gradient of 3 implies at that ascitic value (expect 4). ------
+observe saag(3)
+? serum_albumin(saag, ascites_albumin)   % expect 4


### PR DESCRIPTION
## What

Ships a new grounded clinical formula library for the **serum–ascites albumin gradient (SAAG)** — a high-yield hepatology/GI bedside index — in the ADJ formula stdlib:

- `code/specs/data/adj-formula-stdlib/clinical/serum-ascites-albumin-gradient.adj` — a `dictionary` + `formulabook` defining **SAAG = serum albumin − ascitic albumin** plus its two exact rearrangements (serum = SAAG + ascitic; ascitic = serum − SAAG).
- `…/clinical/serum-ascites-albumin-gradient.query.adj` — worked applications.
- `code/packages/rust/adj-lang-cli/tests/formula_serum_ascites_albumin_gradient_e2e.rs` — a dedicated 3-test e2e driving the built CLI against the shipped stdlib.

## Grounding

Every formula carries the SAME verbatim definitional clause, transcribed byte-for-byte from the StatPearls **"Ascites"** article on the NCBI Bookshelf:

> "SAAG equals the serum albumin level minus the ascitic albumin level (g/dL)"

locator `https://www.ncbi.nlm.nih.gov/books/NBK470482/`, `trust authoritative`. One clause defends the relation read three ways — nothing is asserted from memory (`feedback_nothing_human_authored`).

## Invariant

A consumer states **no arithmetic**: it imports the library, `observe`s the two albumin concentrations, and the engine applies the cited definition on the CPU, computing the EXACT value (over rationals) and rendering the citation + trust tier in `derived`. Worked case serum 4, ascitic 1 g/dL → SAAG 3 (a HIGH gradient); the three formulas compose and invert exactly.

## Verification

- `cargo test -p adj-lang-cli --test formula_serum_ascites_albumin_gradient_e2e` → 3 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean.
- Render-probe of the `.query.adj` confirms `saag=3`, `serum_albumin=4`, exact rationals, verbatim source + NBK470482 locator + authoritative trust.
- NUL-scan clean; `/security-review` PASSED.

Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)