### PR TITLE
Honor MOS model nominal temperature

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Prefer a non-default Level-1 MOS model-card `TNOM` over the circuit nominal
+  temperature when applying Berkeley temperature preprocessing.
 - Scale Level-1 MOS zero-bias bottom-junction `CJ`, source/drain `CBS`/`CBD`,
   and sidewall `CJSW` capacitances with temperature using Berkeley MOS1
   `MJ`/`MJSW` grading paths.

--- a/code/packages/python/spice-engine/README.md
+++ b/code/packages/python/spice-engine/README.md
@@ -80,7 +80,8 @@ models before running an analysis.
 Level-1 MOS temperature preprocessing follows the Berkeley MOS1 silicon
 band-gap correction for `PHI`, polarity-aware `VT0`, and bulk-junction `PB`,
 and scales zero-bias `CJ`/`CBS`/`CBD` and `CJSW` through their respective
-`MJ` and `MJSW` grading paths.
+`MJ` and `MJSW` grading paths. A non-default model-card `TNOM` takes
+precedence over the circuit nominal temperature for these transforms.
 JFET model cards use `TCV` for threshold-voltage scaling and `BEX` for
 `BETA(T) = BETA * (T / TNOM)^BEX`. When explicitly present, `VTOTC` overrides
 `TCV` with `VTO(T) = VTO + VTOTC * (T - TNOM)`, while `BETATCE` overrides

--- a/code/packages/python/spice-engine/src/spice_engine/engine.py
+++ b/code/packages/python/spice-engine/src/spice_engine/engine.py
@@ -391,8 +391,15 @@ def mosfet_at_temperature(
     params = model.model.params
     if not isinstance(params, Level1Params):
         raise ValueError(f"{mosfet.name}: only Level-1 MOSFET parameters are supported")
-    ratio = temperature_kelvin / nominal_temperature_kelvin
     reference_temperature_kelvin = 300.15
+    nominal_temperature = (
+        params.T_NOM
+        if reference_temperature_kelvin != params.T_NOM
+        else nominal_temperature_kelvin
+    )
+    if not math.isfinite(nominal_temperature) or nominal_temperature <= 0.0:
+        raise ValueError("nominal_temperature_kelvin must be finite and positive")
+    ratio = temperature_kelvin / nominal_temperature
 
     def silicon_band_gap(temperature: float) -> float:
         return 1.16 - 7.02e-4 * temperature**2 / (temperature + 1108.0)
@@ -411,16 +418,16 @@ def mosfet_at_temperature(
             1.5 * math.log(temperature / reference_temperature_kelvin) + argument
         )
 
-    nominal_factor = nominal_temperature_kelvin / reference_temperature_kelvin
+    nominal_factor = nominal_temperature / reference_temperature_kelvin
     temperature_factor = temperature_kelvin / reference_temperature_kelvin
     nominal_phi = (
-        params.PHI - potential_correction(nominal_temperature_kelvin)
+        params.PHI - potential_correction(nominal_temperature)
     ) / nominal_factor
     temperature_phi = (
         temperature_factor * nominal_phi + potential_correction(temperature_kelvin)
     )
     nominal_bulk_junction_potential = (
-        params.PB - potential_correction(nominal_temperature_kelvin)
+        params.PB - potential_correction(nominal_temperature)
     ) / nominal_factor
     temperature_bulk_junction_potential = (
         temperature_factor * nominal_bulk_junction_potential
@@ -439,7 +446,7 @@ def mosfet_at_temperature(
             + grading_coefficient
             * (
                 4.0e-4
-                * (nominal_temperature_kelvin - reference_temperature_kelvin)
+                * (nominal_temperature - reference_temperature_kelvin)
                 - nominal_bulk_potential_shift
             )
         )
@@ -457,7 +464,7 @@ def mosfet_at_temperature(
         - polarity * params.GAMMA * math.sqrt(params.PHI)
         + 0.5
         * (
-            silicon_band_gap(nominal_temperature_kelvin)
+            silicon_band_gap(nominal_temperature)
             - silicon_band_gap(temperature_kelvin)
         )
         + polarity * 0.5 * (temperature_phi - params.PHI)
@@ -469,7 +476,7 @@ def mosfet_at_temperature(
         energy_gap_ev
         * _ELECTRON_CHARGE
         / _BOLTZMANN
-        * (1.0 / nominal_temperature_kelvin - 1.0 / temperature_kelvin)
+        * (1.0 / nominal_temperature - 1.0 / temperature_kelvin)
     )
     saturation_scale = ratio**3 * math.exp(
         max(-100.0, min(100.0, saturation_exponent))

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -4373,6 +4373,58 @@ def test_mosfet_temperature_scaling_adjusts_bulk_junction_saturation_currents():
     assert silicon_params.IS > lower_gap_params.IS
 
 
+def test_mosfet_temperature_scaling_prefers_model_nominal_temperature():
+    nominal = Mosfet(
+        "M1",
+        "d",
+        "g",
+        "s",
+        "b",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(Level1Params(KP=200.0e-6, U0=500.0, T_NOM=325.0)),
+        ),
+    )
+    expected_scale = (350.0 / 325.0) ** -1.5
+    hot = mosfet_at_temperature(
+        nominal,
+        350.0,
+        nominal_temperature_kelvin=300.15,
+    )
+
+    assert pytest.approx(200.0e-6 * expected_scale) == hot.model.model.params.KP
+    assert pytest.approx(500.0 * expected_scale) == hot.model.model.params.U0
+
+    adjusted = circuit_at_temperature(
+        Circuit([nominal]),
+        350.0,
+        nominal_temperature_kelvin=300.15,
+    )
+    assert pytest.approx(200.0e-6 * expected_scale) == (
+        adjusted.elements[0].model.model.params.KP
+    )
+
+    fallback = Mosfet(
+        "M2",
+        "d",
+        "g",
+        "s",
+        "b",
+        MOSFET(
+            MosfetType.NMOS,
+            Level1Model(Level1Params(KP=200.0e-6)),
+        ),
+    )
+    fallback_hot = mosfet_at_temperature(
+        fallback,
+        350.0,
+        nominal_temperature_kelvin=325.0,
+    )
+    assert pytest.approx(200.0e-6 * expected_scale) == (
+        fallback_hot.model.model.params.KP
+    )
+
+
 # ---- DC: Capacitor (open in DC) ----
 
 

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Prefer a non-default Level-1 MOS model-card `TNOM` over the circuit nominal
+  temperature when applying Berkeley temperature preprocessing.
 - Scale Level-1 MOS zero-bias bottom-junction `CJ`, source/drain `CBS`/`CBD`,
   and sidewall `CJSW` capacitances with temperature using Berkeley MOS1
   `MJ`/`MJSW` grading paths.

--- a/code/packages/rust/spice-engine/README.md
+++ b/code/packages/rust/spice-engine/README.md
@@ -121,7 +121,8 @@ models before running an analysis.
 Level-1 MOS temperature preprocessing follows the Berkeley MOS1 silicon
 band-gap correction for `PHI`, polarity-aware `VT0`, and bulk-junction `PB`,
 and scales zero-bias `CJ`/`CBS`/`CBD` and `CJSW` through their respective
-`MJ` and `MJSW` grading paths.
+`MJ` and `MJSW` grading paths. A non-default model-card `TNOM` takes
+precedence over the circuit nominal temperature for these transforms.
 JFET model cards use `TCV` for threshold-voltage scaling and `BEX` for
 `BETA(T) = BETA * (T / TNOM)^BEX`. When explicitly present, `VTOTC` overrides
 `TCV` with `VTO(T) = VTO + VTOTC * (T - TNOM)`, while `BETATCE` overrides

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -2773,14 +2773,25 @@ pub fn mosfet_at_temperature(
             reason: "nominal temperature must be finite and positive".to_string(),
         });
     }
+    let reference_temperature_kelvin = 300.15;
+    let nominal_temperature = if mosfet.params.t_nom != reference_temperature_kelvin {
+        mosfet.params.t_nom
+    } else {
+        nominal_temperature_kelvin
+    };
+    if !nominal_temperature.is_finite() || nominal_temperature <= 0.0 {
+        return Err(SpiceError::InvalidElement {
+            name: mosfet.name.clone(),
+            reason: "nominal temperature must be finite and positive".to_string(),
+        });
+    }
     if !energy_gap_electron_volts.is_finite() || energy_gap_electron_volts <= 0.0 {
         return Err(SpiceError::InvalidElement {
             name: mosfet.name.clone(),
             reason: "energy gap must be finite and positive".to_string(),
         });
     }
-    let ratio = temperature_kelvin / nominal_temperature_kelvin;
-    let reference_temperature_kelvin = 300.15;
+    let ratio = temperature_kelvin / nominal_temperature;
     let silicon_band_gap =
         |temperature: f64| 1.16 - 7.02e-4 * temperature * temperature / (temperature + 1108.0);
     let potential_correction = |temperature: f64| {
@@ -2791,9 +2802,9 @@ pub fn mosfet_at_temperature(
         -2.0 * thermal_voltage
             * (1.5 * (temperature / reference_temperature_kelvin).ln() + argument)
     };
-    let nominal_factor = nominal_temperature_kelvin / reference_temperature_kelvin;
+    let nominal_factor = nominal_temperature / reference_temperature_kelvin;
     let temperature_factor = temperature_kelvin / reference_temperature_kelvin;
-    let nominal_potential_correction = potential_correction(nominal_temperature_kelvin);
+    let nominal_potential_correction = potential_correction(nominal_temperature);
     let temperature_potential_correction = potential_correction(temperature_kelvin);
     let nominal_phi = (mosfet.params.phi - nominal_potential_correction) / nominal_factor;
     let temperature_phi = temperature_factor * nominal_phi + temperature_potential_correction;
@@ -2811,7 +2822,7 @@ pub fn mosfet_at_temperature(
         let nominal_scale = 1.0
             / (1.0
                 + grading_coefficient
-                    * (4.0e-4 * (nominal_temperature_kelvin - reference_temperature_kelvin)
+                    * (4.0e-4 * (nominal_temperature - reference_temperature_kelvin)
                         - nominal_bulk_potential_shift));
         let temperature_scale = 1.0
             + grading_coefficient
@@ -2829,12 +2840,11 @@ pub fn mosfet_at_temperature(
     };
     let temperature_vbi = mosfet.params.vt0
         - polarity * mosfet.params.gamma * mosfet.params.phi.sqrt()
-        + 0.5
-            * (silicon_band_gap(nominal_temperature_kelvin) - silicon_band_gap(temperature_kelvin))
+        + 0.5 * (silicon_band_gap(nominal_temperature) - silicon_band_gap(temperature_kelvin))
         + polarity * 0.5 * (temperature_phi - mosfet.params.phi);
     let temperature_vt0 = temperature_vbi + polarity * mosfet.params.gamma * temperature_phi.sqrt();
     let saturation_exponent = energy_gap_electron_volts * ELECTRON_CHARGE / BOLTZMANN
-        * (1.0 / nominal_temperature_kelvin - 1.0 / temperature_kelvin);
+        * (1.0 / nominal_temperature - 1.0 / temperature_kelvin);
     let saturation_scale = ratio.powi(3) * saturation_exponent.clamp(-100.0, 100.0).exp();
     let mut adjusted = mosfet.clone();
     adjusted.params.vt0 = temperature_vt0;

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -3691,6 +3691,60 @@ fn mosfet_temperature_scaling_adjusts_bulk_junction_saturation_currents() {
 }
 
 #[test]
+fn mosfet_temperature_scaling_prefers_model_nominal_temperature() {
+    let nominal = Mosfet::with_model(
+        "M1",
+        "d",
+        "g",
+        "s",
+        "b",
+        MosfetType::Nmos,
+        MosfetLevel1Params {
+            kp: 200.0e-6,
+            surface_mobility: 500.0,
+            t_nom: 325.0,
+            ..MosfetLevel1Params::default()
+        },
+    );
+    let expected_scale = (350.0_f64 / 325.0).powf(-1.5);
+    let hot = mosfet_at_temperature(&nominal, 350.0, 300.15, 1.11).unwrap();
+
+    assert_close(hot.params.kp, nominal.params.kp * expected_scale);
+    assert_close(
+        hot.params.surface_mobility,
+        nominal.params.surface_mobility * expected_scale,
+    );
+
+    let mut circuit = Circuit::new();
+    circuit.add(Element::Mosfet(nominal));
+    let adjusted = circuit_at_temperature(&circuit, 350.0, 300.15, 1.11).unwrap();
+    let circuit_kp = adjusted
+        .elements()
+        .iter()
+        .find_map(|element| match element {
+            Element::Mosfet(mosfet) => Some(mosfet.params.kp),
+            _ => None,
+        })
+        .unwrap();
+    assert_close(circuit_kp, 200.0e-6 * expected_scale);
+
+    let fallback = Mosfet::with_model(
+        "M2",
+        "d",
+        "g",
+        "s",
+        "b",
+        MosfetType::Nmos,
+        MosfetLevel1Params {
+            kp: 200.0e-6,
+            ..MosfetLevel1Params::default()
+        },
+    );
+    let fallback_hot = mosfet_at_temperature(&fallback, 350.0, 325.0, 1.11).unwrap();
+    assert_close(fallback_hot.params.kp, 200.0e-6 * expected_scale);
+}
+
+#[test]
 fn dc_bjt_solves_npn_emitter_follower_operating_point() {
     let mut circuit = Circuit::new();
     circuit.add(Element::VoltageSource(VoltageSource::new(

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Prefer a non-default Level-1 MOS model-card `TNOM` over the circuit nominal
+  temperature when applying Berkeley temperature preprocessing.
 - Scale Level-1 MOS zero-bias bottom-junction `CJ`, source/drain `CBS`/`CBD`,
   and sidewall `CJSW` capacitances with temperature using Berkeley MOS1
   `MJ`/`MJSW` grading paths.

--- a/code/packages/typescript/spice-engine/README.md
+++ b/code/packages/typescript/spice-engine/README.md
@@ -72,7 +72,8 @@ models before running an analysis.
 Level-1 MOS temperature preprocessing follows the Berkeley MOS1 silicon
 band-gap correction for `PHI`, polarity-aware `VT0`, and bulk-junction `PB`,
 and scales zero-bias `CJ`/`CBS`/`CBD` and `CJSW` through their respective
-`MJ` and `MJSW` grading paths.
+`MJ` and `MJSW` grading paths. A non-default model-card `TNOM` takes
+precedence over the circuit nominal temperature for these transforms.
 JFET model cards use `TCV` for threshold-voltage scaling and `BEX` for
 `BETA(T) = BETA * (T / TNOM)^BEX`. When explicitly present, `VTOTC` overrides
 `TCV` with `VTO(T) = VTO + VTOTC * (T - TNOM)`, while `BETATCE` overrides

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -7735,8 +7735,15 @@ export function mosfetAtTemperature(
   if (!Number.isFinite(energyGapElectronVolts) || energyGapElectronVolts <= 0.0) {
     throw invalidElement(element.name, "energy gap must be finite and positive");
   }
-  const ratio = temperatureKelvin / nominalTemperatureKelvin;
   const referenceTemperatureKelvin = 300.15;
+  const nominalTemperature =
+    element.params.T_NOM !== referenceTemperatureKelvin
+      ? element.params.T_NOM
+      : nominalTemperatureKelvin;
+  if (!Number.isFinite(nominalTemperature) || nominalTemperature <= 0.0) {
+    throw invalidElement(element.name, "nominal temperature must be finite and positive");
+  }
+  const ratio = temperatureKelvin / nominalTemperature;
   const siliconBandGap = (temperature: number): number =>
     1.16 - (7.02e-4 * temperature * temperature) / (temperature + 1108.0);
   const potentialCorrection = (temperature: number): number => {
@@ -7752,14 +7759,14 @@ export function mosfetAtTemperature(
       (1.5 * Math.log(temperature / referenceTemperatureKelvin) + argument)
     );
   };
-  const nominalFactor = nominalTemperatureKelvin / referenceTemperatureKelvin;
+  const nominalFactor = nominalTemperature / referenceTemperatureKelvin;
   const temperatureFactor = temperatureKelvin / referenceTemperatureKelvin;
   const nominalPhi =
-    (element.params.PHI - potentialCorrection(nominalTemperatureKelvin)) / nominalFactor;
+    (element.params.PHI - potentialCorrection(nominalTemperature)) / nominalFactor;
   const temperaturePhi =
     temperatureFactor * nominalPhi + potentialCorrection(temperatureKelvin);
   const nominalBulkJunctionPotential =
-    (element.params.PB - potentialCorrection(nominalTemperatureKelvin)) / nominalFactor;
+    (element.params.PB - potentialCorrection(nominalTemperature)) / nominalFactor;
   const temperatureBulkJunctionPotential =
     temperatureFactor * nominalBulkJunctionPotential +
     potentialCorrection(temperatureKelvin);
@@ -7773,7 +7780,7 @@ export function mosfetAtTemperature(
       1.0 /
       (1.0 +
         gradingCoefficient *
-          (4.0e-4 * (nominalTemperatureKelvin - referenceTemperatureKelvin) -
+          (4.0e-4 * (nominalTemperature - referenceTemperatureKelvin) -
             nominalBulkPotentialShift));
     const temperatureScale =
       1.0 +
@@ -7789,14 +7796,14 @@ export function mosfetAtTemperature(
     element.params.VT0 -
     polarity * element.params.GAMMA * Math.sqrt(element.params.PHI) +
     0.5 *
-      (siliconBandGap(nominalTemperatureKelvin) - siliconBandGap(temperatureKelvin)) +
+      (siliconBandGap(nominalTemperature) - siliconBandGap(temperatureKelvin)) +
     polarity * 0.5 * (temperaturePhi - element.params.PHI);
   const temperatureVt0 =
     temperatureVbi + polarity * element.params.GAMMA * Math.sqrt(temperaturePhi);
   const saturationExponent =
     (energyGapElectronVolts * ELECTRON_CHARGE) /
     BOLTZMANN *
-    (1.0 / nominalTemperatureKelvin - 1.0 / temperatureKelvin);
+    (1.0 / nominalTemperature - 1.0 / temperatureKelvin);
   const saturationScale =
     ratio ** 3 * Math.exp(Math.max(-100.0, Math.min(100.0, saturationExponent)));
   return {

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -2422,6 +2422,33 @@ describe("dcOp", () => {
     expect(siliconMosfet!.params.IS).toBeGreaterThan(lowerGapMosfet!.params.IS);
   });
 
+  it("prefers the MOSFET model nominal temperature", () => {
+    const nominal = mosfet("M1", "d", "g", "s", "b", "NMOS", {
+      KP: 200.0e-6,
+      U0: 500.0,
+      T_NOM: 325.0,
+    });
+    const expectedScale = (350.0 / 325.0) ** -1.5;
+    const hot = mosfetAtTemperature(nominal, 350.0, 300.15);
+
+    expectClose(hot.params.KP, 200.0e-6 * expectedScale);
+    expectClose(hot.params.U0, 500.0 * expectedScale);
+
+    const circuit = new Circuit();
+    circuit.add(nominal);
+    const adjusted = circuitAtTemperature(circuit, 350.0, 300.15);
+    const adjustedMosfet = adjusted
+      .elements()
+      .find((element): element is Mosfet => element.kind === "mosfet");
+    expectClose(adjustedMosfet!.params.KP, 200.0e-6 * expectedScale);
+
+    const fallback = mosfet("M2", "d", "g", "s", "b", "NMOS", {
+      KP: 200.0e-6,
+    });
+    const fallbackHot = mosfetAtTemperature(fallback, 350.0, 325.0);
+    expectClose(fallbackHot.params.KP, 200.0e-6 * expectedScale);
+  });
+
   it("preserves subcircuits when applying temperature helpers", () => {
     const nominal = new Circuit();
     nominal.defineSubcircuit(

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS junction-capacitance temperature scaling.
+1. Cross-language Level-1 MOS model nominal-temperature precedence.
    - Status: current PR completion candidate.
-   - Scale zero-bias `CJ`, `CBS`, and `CBD` through the Berkeley MOS1 `MJ`
-     bottom-junction grading path.
-   - Scale zero-bias `CJSW` through the independent `MJSW` sidewall grading
-     path, reusing the temperature-adjusted bulk-junction potential.
+   - Make a non-default model-card `TNOM` authoritative for Berkeley MOS1
+     temperature preprocessing while preserving the circuit nominal
+     temperature as the default-model fallback.
    - Preserve direct MOS helper and circuit-level temperature-transform parity.
    - Keep Rust, Python, and TypeScript helper behavior, tests, docs, and
      changelogs aligned.
@@ -3596,6 +3595,13 @@ the Rust, Python, and TypeScript surfaces together.
      correction alongside the existing electrostatic transform.
    - Direct MOS helpers and circuit-level transforms preserve matching behavior
      in Rust, Python, and TypeScript.
+
+288. Cross-language Level-1 MOS junction-capacitance temperature scaling.
+   - Status: completed in PR 9148.
+   - Zero-bias `CJ`, `CBS`, and `CBD` scale through the Berkeley MOS1 `MJ`
+     bottom-junction grading path.
+   - Zero-bias `CJSW` scales independently through `MJSW`, reusing the
+     temperature-adjusted bulk-junction potential in all three languages.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- make non-default Level-1 MOS model-card `TNOM` authoritative for Berkeley temperature preprocessing
- retain circuit nominal-temperature fallback for models at the default `300.15 K` value
- cover direct and circuit transforms across Rust, Python, and TypeScript and reconcile the SPICE plan

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python `ruff check src tests`
- Python `pytest -q` (673 passed, 88.89% coverage)
- `npm run build`
- `npm test` (416 passed)