### PR TITLE
Add HTML Cairo raster acceptance

### DIFF
--- a/code/packages/rust/html-to-paint/CHANGELOG.md
+++ b/code/packages/rust/html-to-paint/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.2.1
+
+- Added a cross-platform Cairo acceptance test proving canned text-only HTML
+  traverses parsing, shared layout, paint-scene emission, and rasterization
+  into a non-uniform RGBA pixel buffer.
+- Kept URI image decoding outside the raster test so resource loading remains
+  an explicit follow-up gate rather than a hidden backend responsibility.
+
 ## 0.2.0
 
 - Added `LinkRegion` values in logical document-content coordinates.

--- a/code/packages/rust/html-to-paint/Cargo.toml
+++ b/code/packages/rust/html-to-paint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "html-to-paint"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Composes HTML render-tree adaptation, block layout, and shared paint-scene emission."
 
@@ -12,3 +12,6 @@ layout-ir = { path = "../layout-ir" }
 layout-to-paint = { path = "../layout-to-paint" }
 paint-instructions = { path = "../paint-instructions" }
 text-interfaces = { path = "../text-interfaces" }
+
+[dev-dependencies]
+paint-vm-cairo = { path = "../paint-vm-cairo" }

--- a/code/packages/rust/html-to-paint/README.md
+++ b/code/packages/rust/html-to-paint/README.md
@@ -48,9 +48,10 @@ let target = hit_test_link(&output.links, mouse_x, mouse_y, scroll_y)
 - HTML source parsing remains in `html-parser`.
 - Resource fetching and image decoding are not performed here.
 - Host navigation and visited-link policy remain follow-up work.
-- Paint backends consume the returned `PaintScene`; this package does not
-  rasterize it.
+- Paint backends consume the returned `PaintScene`; Cairo acceptance proves
+  text-only HTML reaches RGBA pixels, while host backend selection remains
+  outside this package.
 
-Four tests cover viewport normalization, end-to-end canned HTML paint output,
+Five tests cover viewport normalization, end-to-end canned HTML paint output,
 absolute link-region extraction, empty-box filtering, scroll-aware hit testing,
-and half-open boundary behavior.
+half-open boundary behavior, and real Cairo rasterization into RGBA pixels.

--- a/code/packages/rust/html-to-paint/src/lib.rs
+++ b/code/packages/rust/html-to-paint/src/lib.rs
@@ -9,7 +9,7 @@ use layout_to_paint::{layout_to_paint, LayoutToPaintOptions};
 use paint_instructions::PaintScene;
 use text_interfaces::{FontMetrics, FontResolver, TextShaper};
 
-pub const VERSION: &str = "0.2.0";
+pub const VERSION: &str = "0.2.1";
 
 /// Viewport and device scale used by the composed HTML paint pipeline.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -444,6 +444,36 @@ mod tests {
             hit_test_link(std::slice::from_ref(&region), f64::NAN, 20.0, 60.0),
             None
         );
+    }
+
+    #[test]
+    fn canned_html_rasterizes_to_rgba_pixels_with_cairo() {
+        let render = parse_browser_render_tree(
+            "<h1>Mosaic</h1><p>Hello <a href='https://example.test/'>world</a>.</p>",
+        )
+        .unwrap();
+        let output = html_render_tree_to_paint(
+            &render,
+            &mosaic_html_theme(),
+            HtmlPaintViewport::new(200.0, 96.0, 1.0),
+            &MonoMeasurer,
+            &FakeShaper,
+            &FakeMetrics,
+            &FakeResolver,
+        );
+
+        let pixels = paint_vm_cairo::render(&output.scene)
+            .expect("canned HTML paint scene should rasterize");
+        assert_eq!(pixels.width, 200);
+        assert_eq!(pixels.height, output.scene.height.ceil() as u32);
+        assert_eq!(
+            pixels.data.len(),
+            pixels.width as usize * pixels.height as usize * 4
+        );
+        assert!(pixels
+            .data
+            .chunks_exact(4)
+            .any(|pixel| pixel != [192, 192, 192, 255]));
     }
 
     fn color_css(color: Color) -> String {

--- a/code/specs/BR01-venture-browser.md
+++ b/code/specs/BR01-venture-browser.md
@@ -52,9 +52,10 @@ executable browser seam from `BrowserRenderTree` to the shared Layout IR and
 That does not make Venture complete. The current layout path places atomic
 inline boxes on shared lines; text-run fragmentation and baseline alignment
 remain. The `html-to-paint` composition package now carries canned HTML
-through shared layout into a backend-neutral `PaintScene`. Resource loading,
-link hit-testing, raster acceptance, and a platform host must still wire
-navigation through pixels.
+through shared layout into a backend-neutral `PaintScene`, extracts clickable
+link regions, and proves text-only scenes rasterize to RGBA pixels with Cairo.
+Resource loading and decoding plus a platform host must still wire navigation
+through pixels.
 
 ## Where It Fits
 


### PR DESCRIPTION
## What

- add a canned text-only HTML acceptance test that runs the complete parser → DOM → layout → PaintScene → Cairo raster path
- assert the resulting RGBA buffer has the expected dimensions and contains painted pixels beyond Mosaic's gray background
- keep `paint-vm-cairo` as a dev-dependency so this acceptance gate does not choose a production backend
- bump `html-to-paint` to 0.2.1 and update package/status documentation

## Why

#9145 established HTML-to-PaintScene composition and #9149 added link hit regions. The next browser acceptance gap was proving that a real HTML document reaches actual pixels through a cross-platform raster backend.

## Impact

This proves text-only HTML scenes rasterize through Cairo's native Unix path or software fallback. It does not claim full browser completion: URI image fetching/decoding and the platform window/event-loop host remain explicit follow-up gates.

## Checks

- `cargo fmt -p html-to-paint -- --check`
- `cargo test -p html-to-paint` (5 passed)
- `cargo clippy -p html-to-paint --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-parser`
- refreshed live upstream parser audit: WPT tree 1,934 upstream / 2,637 local / 0 missing; tokenizer 6,806 upstream / 7,015 local raw / 0 missing; 7,242 normalized / 0 skipped
- `git diff --check`