### PR TITLE
feat(adj-formula-stdlib): linear mass density — NIST SP 811 B.9 tex→kg/m table (b31, RS-5, new dimension)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -1386,6 +1386,49 @@ fn shipped_wave_number_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b31) The shipped NIST SP 811 B.9 linear-mass-density → kilogram-per-metre table resolves the exact
+//       tex factor with its citation, and ABSTAINS on a wrong-dimension unit. This opens a NEW
+//       dimension — LINEAR MASS DENSITY (mass per unit length, the titre of a fibre/yarn) — beyond
+//       the length/mass/…/wave-number and electric families. The tex (linear mass density → kg/m) and
+//       the pound (plain mass → kg) are DIFFERENT quantities that convert to DIFFERENT SI units
+//       (kg/m vs kg), so the abstain guards the mass-versus-mass-per-length confusion (dropping the
+//       "per metre") directly, not mere absence of a value: the tex is one gram per kilometre =
+//       exactly 1 E-06 kilogram per metre.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_linear_mass_density_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_lineardensity");
+    let src = stdlib().join("reference/linear-mass-density-conversions.adj");
+    std::fs::copy(&src, dir.join("linear-mass-density-conversions.adj"))
+        .expect("copy shipped linear-mass-density-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"linear-mass-density-conversions.adj\"\n\
+         ? linear_mass_density_to_kilogram_per_metre(tex, $v)\n\
+         ? linear_mass_density_to_kilogram_per_metre(pound, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 exact factor resolves, character-for-character from the table
+    // (boldface = exact; the tex is one gram per kilometre = exactly 1 E-06 kilogram per metre).
+    assert!(out.contains("\"v\":\"0.000001\""), "tex = 1 E-06 kg/m: {out}");
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `pound` is a MASS unit (it converts to the kilogram, a DIFFERENT quantity), so this
+    // linear-mass-density table has no row for it — the engine abstains rather than mis-converting a
+    // mass unit as if it were a mass-per-length unit.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a wrong-dimension unit abstains, never a cross-dimension fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/linear-mass-density-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/linear-mass-density-conversions.adj
@@ -1,0 +1,60 @@
+% ============================================================================
+% linear-mass-density-conversions — linear-mass-density-unit → kilogram-per-metre factors
+% (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of the NIST-cited conversion tables (length, mass, area, volume, energy, the
+% electric-EMU family, wave number, and the rest): a native tabular relation ingested VERBATIM from a
+% published NIST conversion table. The row states the factor converting the traditional textile unit
+% of LINEAR MASS DENSITY (mass per unit length) to the SI coherent unit, the kilogram per metre
+% (kg/m):
+%
+%     ? linear_mass_density_to_kilogram_per_metre(tex, $v)   % 0.000001
+%
+% This opens a NEW dimension — LINEAR MASS DENSITY (a.k.a. linear density or titre: the mass per unit
+% length of a fibre or yarn, the workhorse quantity of textile engineering) — alongside the already-
+% tabulated length/mass/area/volume/time/speed/energy/pressure/force/acceleration/dynamic-viscosity/
+% kinematic-viscosity/magnetic-flux-density/magnetic-flux/illuminance/luminance/radioactivity/
+% absorbed-dose/dose-equivalent/exposure/power/wave-number tables and the electric charge/potential/
+% resistance/capacitance/inductance/conductance/current tables. The tex is DEFINED as one gram per
+% thousand metres (1 g / 1000 m), so it equals exactly 1 E-06 kilogram per metre. Do NOT confuse
+% LINEAR MASS DENSITY (the tex → the kilogram per metre, kg/m) with plain MASS (e.g. the pound → the
+% kilogram, kg): those are DIFFERENT quantities that convert to DIFFERENT SI units (kg/m vs kg) —
+% dropping the "per metre" is exactly the mistake this table's abstain guards against. A quantity
+% given in tex must be put into SI first, then reasoned over (write-once-use-many). Why a `table` and
+% not a hand-written `relate` clause: this is exactly the shape reference data comes in — a published
+% table, not prose. The citable artifact IS the NIST conversion-factors table at the `locator` below;
+% the factor here is a CELL of NIST Special Publication 811, Appendix B.9, defended by one provenance
+% envelope. Each `row` lowers to a ground relation
+% `linear_mass_density_to_kilogram_per_metre(unit, v)`, so the exact lookup above is the ordinary SLD
+% binding query — the engine returns the factor WITH this table's citation as its proof, on the CPU,
+% with zero model calls.
+%
+% HONESTY NOTE (like every other NIST table, only the EXACT defined factor gets a row): NIST SP 811
+% B.9 prints the "tex" linear-mass-density factor in BOLDFACE, its convention for factors that are
+% EXACT by definition, transcribed here as the plain decimal number of kilograms per metre it names:
+%
+%     tex   1.0 E-06  →  0.000001
+%
+% This is exact because the tex is DEFINED as exactly one gram per kilometre = 1 E-06 kilogram per
+% metre. It terminates; nothing here is a rounded measurement. (Its textile sibling the "denier" is
+% one gram per 9000 metres = 1/9 E-06 kg/m, which does NOT terminate, so — like every non-exact
+% factor — it gets no row.) This table is SPECIFIC to linear mass density: a unit of a DIFFERENT
+% quantity — e.g. the "pound", which NIST SP 811 B.9 lists separately as a MASS unit converting to
+% the kilogram, NOT the kilogram per metre — therefore gets no row here, and a
+% `? linear_mass_density_to_kilogram_per_metre(pound, $v)` ABSTAINS rather than mis-converting a mass
+% unit as if it were a mass-per-length unit. The only claim this table makes is "this is the exact
+% factor NIST SP 811 B.9 prints for the tex's conversion to the kilogram per metre" — which is
+% exactly what a byte-check against the cited table verifies. `trust authoritative` — a primary,
+% re-fetchable standards reference. (See ADJ-TABLES.md; and feedback_nothing_human_authored — the
+% factor is a verbatim cell of the cited table, nothing asserted from memory.)
+% ============================================================================
+
+table linear_mass_density_to_kilogram_per_metre {
+    columns unit, kilogram_per_metre
+
+    row (tex, 0.000001)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/linear-mass-density-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/linear-mass-density-conversions.query.adj
@@ -1,0 +1,26 @@
+% ============================================================================
+% linear-mass-density-conversions.query.adj — worked lookups over the NIST linear-mass-density →
+% kilogram-per-metre table.
+% ============================================================================
+% The shape a consumer produces to convert a linear mass density given in the traditional textile
+% unit into SI: it `import`s the grounded table and asks the engine to bind the factor. No arithmetic
+% and no factor is stated by the consumer; the engine returns the cell WITH the table's NIST citation
+% as its proof, on the CPU.
+%
+%   ? linear_mass_density_to_kilogram_per_metre(tex, $v)   % 0.000001   (tex = 1 E-06 kg/m, exact)
+%
+% And the dimension guard: a unit of a DIFFERENT quantity has no row, so the lookup ABSTAINS rather
+% than mis-converting across dimensions. The "pound" is a MASS unit (it converts to the kilogram),
+% NOT a linear-mass-density unit — so dropping the "per metre" that separates mass from mass-per-
+% length is caught rather than silently mis-converted:
+%
+%   ? linear_mass_density_to_kilogram_per_metre(pound, $v)   % abstains (pound is mass → kilogram)
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli linear-mass-density-conversions.query.adj
+% ============================================================================
+
+import "linear-mass-density-conversions.adj"
+
+? linear_mass_density_to_kilogram_per_metre(tex, $v)     % expect 0.000001  (exact NIST SP 811 B.9 factor)
+? linear_mass_density_to_kilogram_per_metre(pound, $v)   % expect abstain   (mass unit, wrong dimension)


### PR DESCRIPTION
## What

Ships a new grounded NIST SP 811 B.9 conversion table opening a **NEW dimension — LINEAR MASS DENSITY** (mass per unit length, the textile "titre") in the ADJ formula stdlib:

- `code/specs/data/adj-formula-stdlib/reference/linear-mass-density-conversions.adj` — a native RS-5 `table` with the exact row **tex → kilogram per metre = 0.000001** (1.0 E-06).
- `…/reference/linear-mass-density-conversions.query.adj` — a worked exact-lookup + a dimension-guard abstain.
- `code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs` — appends the **b31** e2e block (35 → 36 tests).

## Grounding

The factor is a verbatim BOLDFACE (= exact) cell of NIST Special Publication 811, Appendix B.9:

> tex   1.0 E-06

locator `https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9`, `trust authoritative`. The tex is DEFINED as one gram per kilometre = exactly 1 E-06 kg/m — it terminates; nothing is a rounded measurement. (Its sibling the denier = 1/9 E-06 kg/m does NOT terminate, so — like every non-exact factor — it gets no row.)

## Dimension safety

`? linear_mass_density_to_kilogram_per_metre(tex, $v)` binds `0.000001` with the NIST citation as proof. A wrong-dimension probe — the **pound**, a MASS unit (→ kilogram, a DIFFERENT quantity) — **abstains** (`"abstained":true`) rather than mis-converting a mass as a mass-per-length: the abstain guards exactly the mistake of dropping the "per metre".

## Verification

- `cargo test -p adj-lang-cli --test rs5_table_e2e` → 36 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean.
- Render-probe confirms `"v":"0.000001"` for tex + `"abstained":true` for pound + the NIST locator.
- NUL-scan clean; `/security-review` PASSED.

Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)