### PR TITLE
Derive MOS electrostatics from substrate doping

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Derive Level-1 MOS `PHI` and `GAMMA` from explicit model-card `NSUB` plus
+  `TOX`, preserving explicit electrostatic parameters and rejecting substrate
+  doping at or below the intrinsic carrier density.
 - Prefer a non-default Level-1 MOS model-card `TNOM` over the circuit nominal
   temperature when applying Berkeley temperature preprocessing.
 - Scale Level-1 MOS zero-bias bottom-junction `CJ`, source/drain `CBS`/`CBD`,

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -7,6 +7,7 @@ duplicating diode, BJT, JFET, and Level-1 MOS parameter mapping logic.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
 
@@ -29,6 +30,12 @@ from spice_engine.engine import (
     format_deck_table_csv,
     format_deck_table_json,
 )
+
+_BOLTZMANN = 1.380_649e-23
+_ELECTRON_CHARGE = 1.602_176_634e-19
+_SILICON_PERMITTIVITY = 11.70 * 8.854_214_871e-12
+_INTRINSIC_CARRIER_DENSITY_PER_CUBIC_METER = 1.45e16
+_CUBIC_CENTIMETERS_PER_CUBIC_METER = 1.0e6
 
 
 @dataclass(frozen=True, slots=True)
@@ -1076,13 +1083,48 @@ def mosfet_from_model_card(
         transconductance = (
             surface_mobility * 1.0e-4 * OXIDE_PERMITTIVITY / p["TOX"]
         )
+    surface_potential = p.get("PHI", defaults.PHI)
+    body_effect_coefficient = p.get("GAMMA", defaults.GAMMA)
+    if "N_SUB" in p and "TOX" in p:
+        substrate_doping_per_cubic_meter = (
+            p["N_SUB"] * _CUBIC_CENTIMETERS_PER_CUBIC_METER
+        )
+        if (
+            substrate_doping_per_cubic_meter
+            <= _INTRINSIC_CARRIER_DENSITY_PER_CUBIC_METER
+        ):
+            raise ValueError(
+                f"{name}: MOSFET NSUB must exceed the intrinsic carrier density"
+            )
+        if p["TOX"] > 0.0:
+            if "PHI" not in p:
+                thermal_voltage = (
+                    _BOLTZMANN * p.get("T_NOM", defaults.T_NOM) / _ELECTRON_CHARGE
+                )
+                surface_potential = max(
+                    0.1,
+                    2.0
+                    * thermal_voltage
+                    * math.log(
+                        substrate_doping_per_cubic_meter
+                        / _INTRINSIC_CARRIER_DENSITY_PER_CUBIC_METER
+                    ),
+                )
+            if "GAMMA" not in p:
+                oxide_capacitance = OXIDE_PERMITTIVITY / p["TOX"]
+                body_effect_coefficient = math.sqrt(
+                    2.0
+                    * _SILICON_PERMITTIVITY
+                    * _ELECTRON_CHARGE
+                    * substrate_doping_per_cubic_meter
+                ) / oxide_capacitance
     params = replace(
         defaults,
         VT0=p.get("VT0", defaults.VT0),
         KP=transconductance,
         LAMBDA=p.get("LAMBDA", defaults.LAMBDA),
-        GAMMA=p.get("GAMMA", defaults.GAMMA),
-        PHI=p.get("PHI", defaults.PHI),
+        GAMMA=body_effect_coefficient,
+        PHI=surface_potential,
         W=p.get("W", defaults.W),
         L=p.get("L", defaults.L),
         LD=p.get("LD", defaults.LD),

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -744,7 +744,7 @@ def test_model_card_aliases_build_device_instances() -> None:
             "LEVEL": 1.0,
             "VTO": 0.55,
             "LAM": 0.04,
-            "NSUB": 1.6,
+            "NSUB": 1.6e16,
             "CJD": 3.0e-13,
             "PB": 0.9,
             "MJ": 0.45,
@@ -768,7 +768,7 @@ def test_model_card_aliases_build_device_instances() -> None:
         "LEVEL": 1.0,
         "VT0": 0.55,
         "LAMBDA": 0.04,
-        "N_SUB": 1.6,
+        "N_SUB": 1.6e16,
         "CBD": 3.0e-13,
         "PB": 0.9,
         "MJ": 0.45,
@@ -791,7 +791,7 @@ def test_model_card_aliases_build_device_instances() -> None:
     assert isinstance(mos_model.model.model, Level1Model)
     assert pytest.approx(0.55) == mos_model.model.model.params.VT0
     assert pytest.approx(0.04) == mos_model.model.model.params.LAMBDA
-    assert pytest.approx(1.6) == mos_model.model.model.params.N_SUB
+    assert pytest.approx(1.6e16) == mos_model.model.model.params.N_SUB
     assert pytest.approx(3.0e-13) == mos_model.model.model.params.CBD
     assert pytest.approx(0.9) == mos_model.model.model.params.PB
     assert pytest.approx(0.45) == mos_model.model.model.params.MJ
@@ -843,6 +843,63 @@ def test_mos_model_card_surface_mobility_derives_kp_with_explicit_precedence() -
     )
     assert pytest.approx(500.0) == explicit.model.model.params.U0
     assert pytest.approx(250.0e-6) == explicit.model.model.params.KP
+
+
+def test_mos_model_card_substrate_doping_derives_electrostatics_with_precedence() -> None:
+    derived = mosfet_from_model_card(
+        "M1",
+        "d",
+        "g",
+        "s",
+        "b",
+        normalize_model_card(
+            "Mderived", "nmos", {"NSUB": 4.0e15, "TOX": 100.0e-9}
+        ),
+    )
+    thermal_voltage = 1.380_649e-23 * 300.15 / 1.602_176_634e-19
+    expected_phi = max(
+        0.1, 2.0 * thermal_voltage * math.log(4.0e21 / 1.45e16)
+    )
+    expected_gamma = math.sqrt(
+        2.0 * (11.70 * 8.854_214_871e-12) * 1.602_176_634e-19 * 4.0e21
+    ) / (3.453133e-11 / 100.0e-9)
+    assert pytest.approx(expected_phi) == derived.model.model.params.PHI
+    assert pytest.approx(expected_gamma) == derived.model.model.params.GAMMA
+
+    explicit = mosfet_from_model_card(
+        "M2",
+        "d",
+        "g",
+        "s",
+        "b",
+        normalize_model_card(
+            "Mexplicit",
+            "nmos",
+            {
+                "NSUB": 4.0e15,
+                "TOX": 100.0e-9,
+                "PHI": 0.72,
+                "GAMMA": 0.41,
+            },
+        ),
+    )
+    assert pytest.approx(0.72) == explicit.model.model.params.PHI
+    assert pytest.approx(0.41) == explicit.model.model.params.GAMMA
+
+    with pytest.raises(
+        ValueError,
+        match="MOSFET NSUB must exceed the intrinsic carrier density",
+    ):
+        mosfet_from_model_card(
+            "M3",
+            "d",
+            "g",
+            "s",
+            "b",
+            normalize_model_card(
+                "Minvalid", "nmos", {"NSUB": 1.0e10, "TOX": 1.0e-7}
+            ),
+        )
 
 
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Derive Level-1 MOS `PHI` and `GAMMA` from explicit model-card `NSUB` plus
+  `TOX`, preserving explicit electrostatic parameters and rejecting substrate
+  doping at or below the intrinsic carrier density.
 - Prefer a non-default Level-1 MOS model-card `TNOM` over the circuit nominal
   temperature when applying Berkeley temperature preprocessing.
 - Scale Level-1 MOS zero-bias bottom-junction `CJ`, source/drain `CBS`/`CBD`,

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -20,6 +20,9 @@ const ELECTRON_CHARGE: f64 = 1.602_176_634e-19;
 const MOSFET_CHANNEL_NOISE_GAMMA: f64 = 2.0 / 3.0;
 const DIGITAL_BRIDGE_TIME_EPSILON: f64 = 1.0e-18;
 const OXIDE_PERMITTIVITY: f64 = 3.453_133e-11;
+const SILICON_PERMITTIVITY: f64 = 11.70 * 8.854_214_871e-12;
+const INTRINSIC_CARRIER_DENSITY_PER_CUBIC_METER: f64 = 1.45e16;
+const CUBIC_CENTIMETERS_PER_CUBIC_METER: f64 = 1.0e6;
 
 fn real_solver_kind(matrix_size: usize) -> &'static str {
     if matrix_size == 0 {
@@ -5050,6 +5053,37 @@ pub fn mosfet_from_model_card(
     }
     if let Some(value) = model.parameters.get("T_NOM") {
         params.t_nom = *value;
+    }
+    if let (Some(substrate_doping), Some(oxide_thickness)) =
+        (model.parameters.get("N_SUB"), model.parameters.get("TOX"))
+    {
+        let substrate_doping_per_cubic_meter = substrate_doping * CUBIC_CENTIMETERS_PER_CUBIC_METER;
+        if substrate_doping_per_cubic_meter <= INTRINSIC_CARRIER_DENSITY_PER_CUBIC_METER {
+            return Err(SpiceError::InvalidElement {
+                name: name.clone(),
+                reason: "MOSFET NSUB must exceed the intrinsic carrier density".to_string(),
+            });
+        }
+        if *oxide_thickness > 0.0 {
+            if !model.parameters.contains_key("PHI") {
+                let thermal_voltage = BOLTZMANN * params.t_nom / ELECTRON_CHARGE;
+                params.phi = (2.0
+                    * thermal_voltage
+                    * (substrate_doping_per_cubic_meter
+                        / INTRINSIC_CARRIER_DENSITY_PER_CUBIC_METER)
+                        .ln())
+                .max(0.1);
+            }
+            if !model.parameters.contains_key("GAMMA") {
+                let oxide_capacitance = OXIDE_PERMITTIVITY / oxide_thickness;
+                params.gamma = (2.0
+                    * SILICON_PERMITTIVITY
+                    * ELECTRON_CHARGE
+                    * substrate_doping_per_cubic_meter)
+                    .sqrt()
+                    / oxide_capacitance;
+            }
+        }
     }
     if let Some(value) = model.parameters.get("CGSO") {
         params.gate_source_overlap_capacitance = *value;

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -589,7 +589,7 @@ fn model_card_aliases_build_device_instances() {
             ("LEVEL", 1.0),
             ("VTO", 0.55),
             ("LAM", 0.04),
-            ("NSUB", 1.6),
+            ("NSUB", 1.6e16),
             ("CJD", 3.0e-13),
             ("PB", 0.9),
             ("MJ", 0.45),
@@ -612,7 +612,7 @@ fn model_card_aliases_build_device_instances() {
     let mos_model = mosfet_from_model_card("M1", "d", "g", "s", "b", &mos_card).unwrap();
     assert_close(*mos_card.parameters.get("VT0").unwrap(), 0.55);
     assert_close(*mos_card.parameters.get("LAMBDA").unwrap(), 0.04);
-    assert_close(*mos_card.parameters.get("N_SUB").unwrap(), 1.6);
+    assert_close(*mos_card.parameters.get("N_SUB").unwrap(), 1.6e16);
     assert_close(*mos_card.parameters.get("CBD").unwrap(), 3.0e-13);
     assert_close(*mos_card.parameters.get("PB").unwrap(), 0.9);
     assert_close(*mos_card.parameters.get("MJ").unwrap(), 0.45);
@@ -632,7 +632,7 @@ fn model_card_aliases_build_device_instances() {
     assert_eq!(mos_model.mosfet_type, MosfetType::Nmos);
     assert_close(mos_model.params.vt0, 0.55);
     assert_close(mos_model.params.lambda, 0.04);
-    assert_close(mos_model.params.n_sub, 1.6);
+    assert_close(mos_model.params.n_sub, 1.6e16);
     assert_close(mos_model.params.drain_bulk_capacitance, 3.0e-13);
     assert_close(mos_model.params.bulk_junction_potential, 0.9);
     assert_close(mos_model.params.bulk_junction_grading_coefficient, 0.45);
@@ -673,6 +673,43 @@ fn mos_model_card_surface_mobility_derives_kp_with_explicit_precedence() {
     let explicit = mosfet_from_model_card("M2", "d", "g", "s", "b", &explicit).unwrap();
     assert_close(explicit.params.surface_mobility, 500.0);
     assert_close(explicit.params.kp, 250.0e-6);
+}
+
+#[test]
+fn mos_model_card_substrate_doping_derives_electrostatics_with_explicit_precedence() {
+    let derived_card =
+        normalize_model_card("Mderived", "nmos", &[("NSUB", 4.0e15), ("TOX", 100.0e-9)]).unwrap();
+    let derived = mosfet_from_model_card("M1", "d", "g", "s", "b", &derived_card).unwrap();
+    let thermal_voltage = 1.380_649e-23 * 300.15 / 1.602_176_634e-19;
+    let expected_phi = (2.0 * thermal_voltage * (4.0e21_f64 / 1.45e16).ln()).max(0.1);
+    let expected_gamma = (2.0_f64 * (11.70 * 8.854_214_871e-12) * 1.602_176_634e-19 * 4.0e21)
+        .sqrt()
+        / (3.453_133e-11 / 100.0e-9);
+    assert_close(derived.params.phi, expected_phi);
+    assert_close(derived.params.gamma, expected_gamma);
+
+    let explicit_card = normalize_model_card(
+        "Mexplicit",
+        "nmos",
+        &[
+            ("NSUB", 4.0e15),
+            ("TOX", 100.0e-9),
+            ("PHI", 0.72),
+            ("GAMMA", 0.41),
+        ],
+    )
+    .unwrap();
+    let explicit = mosfet_from_model_card("M2", "d", "g", "s", "b", &explicit_card).unwrap();
+    assert_close(explicit.params.phi, 0.72);
+    assert_close(explicit.params.gamma, 0.41);
+
+    let invalid_card =
+        normalize_model_card("Minvalid", "nmos", &[("NSUB", 1.0e10), ("TOX", 1.0e-7)]).unwrap();
+    assert!(matches!(
+        mosfet_from_model_card("M3", "d", "g", "s", "b", &invalid_card),
+        Err(SpiceError::InvalidElement { reason, .. })
+            if reason == "MOSFET NSUB must exceed the intrinsic carrier density"
+    ));
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Derive Level-1 MOS `PHI` and `GAMMA` from explicit model-card `NSUB` plus
+  `TOX`, preserving explicit electrostatic parameters and rejecting substrate
+  doping at or below the intrinsic carrier density.
 - Prefer a non-default Level-1 MOS model-card `TNOM` over the circuit nominal
   temperature when applying Berkeley temperature preprocessing.
 - Scale Level-1 MOS zero-bias bottom-junction `CJ`, source/drain `CBS`/`CBD`,

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -7,6 +7,9 @@ const ELECTRON_CHARGE = 1.602_176_634e-19;
 const MOSFET_CHANNEL_NOISE_GAMMA = 2.0 / 3.0;
 const DIGITAL_BRIDGE_TIME_EPSILON = 1.0e-18;
 const OXIDE_PERMITTIVITY = 3.453133e-11;
+const SILICON_PERMITTIVITY = 11.70 * 8.854_214_871e-12;
+const INTRINSIC_CARRIER_DENSITY_PER_CUBIC_METER = 1.45e16;
+const CUBIC_CENTIMETERS_PER_CUBIC_METER = 1.0e6;
 const SPICE_SUFFIX_FACTORS: Readonly<Record<string, number>> = Object.freeze({
   t: 1.0e12,
   g: 1.0e9,
@@ -8917,12 +8920,46 @@ export function mosfetFromModelCard(
     (p.TOX !== undefined && p.TOX > 0.0
       ? surfaceMobility * 1.0e-4 * OXIDE_PERMITTIVITY / p.TOX
       : undefined);
+  let surfacePotential = p.PHI;
+  let bodyEffectCoefficient = p.GAMMA;
+  if (p.N_SUB !== undefined && p.TOX !== undefined) {
+    const substrateDopingPerCubicMeter =
+      p.N_SUB * CUBIC_CENTIMETERS_PER_CUBIC_METER;
+    if (substrateDopingPerCubicMeter <= INTRINSIC_CARRIER_DENSITY_PER_CUBIC_METER) {
+      throw invalidElement(name, "MOSFET NSUB must exceed the intrinsic carrier density");
+    }
+    if (p.TOX > 0.0) {
+      if (surfacePotential === undefined) {
+        const nominalTemperature = p.T_NOM ?? 300.15;
+        const thermalVoltage = BOLTZMANN * nominalTemperature / ELECTRON_CHARGE;
+        surfacePotential = Math.max(
+          0.1,
+          2.0 *
+            thermalVoltage *
+            Math.log(
+              substrateDopingPerCubicMeter /
+                INTRINSIC_CARRIER_DENSITY_PER_CUBIC_METER,
+            ),
+        );
+      }
+      if (bodyEffectCoefficient === undefined) {
+        const oxideCapacitance = OXIDE_PERMITTIVITY / p.TOX;
+        bodyEffectCoefficient =
+          Math.sqrt(
+            2.0 *
+              SILICON_PERMITTIVITY *
+              ELECTRON_CHARGE *
+              substrateDopingPerCubicMeter,
+          ) / oxideCapacitance;
+      }
+    }
+  }
   const params: Partial<MosfetLevel1Params> = {
     ...(p.VT0 !== undefined ? { VT0: p.VT0 } : {}),
     ...(transconductance !== undefined ? { KP: transconductance } : {}),
     ...(p.LAMBDA !== undefined ? { LAMBDA: p.LAMBDA } : {}),
-    ...(p.GAMMA !== undefined ? { GAMMA: p.GAMMA } : {}),
-    ...(p.PHI !== undefined ? { PHI: p.PHI } : {}),
+    ...(bodyEffectCoefficient !== undefined ? { GAMMA: bodyEffectCoefficient } : {}),
+    ...(surfacePotential !== undefined ? { PHI: surfacePotential } : {}),
     ...(p.W !== undefined ? { W: p.W } : {}),
     ...(p.L !== undefined ? { L: p.L } : {}),
     ...(p.LD !== undefined ? { LD: p.LD } : {}),

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -414,7 +414,7 @@ describe("dcOp", () => {
       LEVEL: 1.0,
       VTO: 0.55,
       LAM: 0.04,
-      NSUB: 1.6,
+      NSUB: 1.6e16,
       CJD: 3.0e-13,
       PB: 0.9,
       MJ: 0.45,
@@ -437,7 +437,7 @@ describe("dcOp", () => {
       LEVEL: 1.0,
       VT0: 0.55,
       LAMBDA: 0.04,
-      N_SUB: 1.6,
+      N_SUB: 1.6e16,
       CBD: 3.0e-13,
       PB: 0.9,
       MJ: 0.45,
@@ -458,7 +458,7 @@ describe("dcOp", () => {
     expect(mosModel.type).toBe("NMOS");
     expectClose(mosModel.params.VT0, 0.55);
     expectClose(mosModel.params.LAMBDA, 0.04);
-    expectClose(mosModel.params.N_SUB, 1.6);
+    expectClose(mosModel.params.N_SUB, 1.6e16);
     expectClose(mosModel.params.CBD, 3.0e-13);
     expectClose(mosModel.params.PB, 0.9);
     expectClose(mosModel.params.MJ, 0.45);
@@ -506,6 +506,62 @@ describe("dcOp", () => {
     );
     expectClose(explicit.params.U0, 500.0);
     expectClose(explicit.params.KP, 250.0e-6);
+  });
+
+  it("derives MOS electrostatics from substrate doping with explicit precedence", () => {
+    const derived = mosfetFromModelCard(
+      "M1",
+      "d",
+      "g",
+      "s",
+      "b",
+      normalizeModelCard("Mderived", "nmos", {
+        NSUB: 4.0e15,
+        TOX: 100.0e-9,
+      }),
+    );
+    const thermalVoltage = 1.380_649e-23 * 300.15 / 1.602_176_634e-19;
+    const expectedPhi = Math.max(
+      0.1,
+      2.0 * thermalVoltage * Math.log(4.0e21 / 1.45e16),
+    );
+    const expectedGamma =
+      Math.sqrt(
+        2.0 * (11.70 * 8.854_214_871e-12) * 1.602_176_634e-19 * 4.0e21,
+      ) /
+      (3.453133e-11 / 100.0e-9);
+    expectClose(derived.params.PHI, expectedPhi);
+    expectClose(derived.params.GAMMA, expectedGamma);
+
+    const explicit = mosfetFromModelCard(
+      "M2",
+      "d",
+      "g",
+      "s",
+      "b",
+      normalizeModelCard("Mexplicit", "nmos", {
+        NSUB: 4.0e15,
+        TOX: 100.0e-9,
+        PHI: 0.72,
+        GAMMA: 0.41,
+      }),
+    );
+    expectClose(explicit.params.PHI, 0.72);
+    expectClose(explicit.params.GAMMA, 0.41);
+
+    expect(() =>
+      mosfetFromModelCard(
+        "M3",
+        "d",
+        "g",
+        "s",
+        "b",
+        normalizeModelCard("Minvalid", "nmos", {
+          NSUB: 1.0e10,
+          TOX: 1.0e-7,
+        }),
+      ),
+    ).toThrow("MOSFET NSUB must exceed the intrinsic carrier density");
   });
 
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,14 +33,13 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS model nominal-temperature precedence.
+1. Cross-language Level-1 MOS substrate-doping electrostatic derivation.
    - Status: current PR completion candidate.
-   - Make a non-default model-card `TNOM` authoritative for Berkeley MOS1
-     temperature preprocessing while preserving the circuit nominal
-     temperature as the default-model fallback.
-   - Preserve direct MOS helper and circuit-level temperature-transform parity.
-   - Keep Rust, Python, and TypeScript helper behavior, tests, docs, and
-     changelogs aligned.
+   - Derive `PHI` and `GAMMA` from model-card `NSUB` plus `TOX` using the
+     Berkeley MOS1 process-parameter equations.
+   - Preserve explicit `PHI` / `GAMMA` precedence and reject substrate doping
+     at or below the intrinsic carrier density.
+   - Keep Rust, Python, and TypeScript model lowering, tests, and docs aligned.
 
 ## Completed Slices
 
@@ -3602,6 +3601,14 @@ the Rust, Python, and TypeScript surfaces together.
      bottom-junction grading path.
    - Zero-bias `CJSW` scales independently through `MJSW`, reusing the
      temperature-adjusted bulk-junction potential in all three languages.
+
+289. Cross-language Level-1 MOS model nominal-temperature precedence.
+   - Status: completed in PR 9153.
+   - Non-default model-card `TNOM` is authoritative for Berkeley MOS1
+     temperature preprocessing while the default model value preserves the
+     circuit nominal temperature as the fallback.
+   - Direct MOS helpers and circuit-level temperature transforms preserve
+     matching behavior in Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- derive Level-1 MOS `PHI` and `GAMMA` from explicit model-card `NSUB` plus `TOX` using Berkeley MOS1 process equations
- preserve explicit electrostatic parameter precedence and reject doping at or below intrinsic carrier density
- keep Rust, Python, and TypeScript lowering, tests, changelogs, and the SPICE implementation plan aligned

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- `python3.12 -m ruff check src/spice_engine/model_cards.py tests/test_engine.py`
- `PYTHONPATH=$(printf "%s:" ../*/src) python3.12 -m pytest -q` (674 passed, 88.90% coverage)
- `npm test` (417 passed)
- `npm run build`