### PR TITLE
feat(build-tool): add safe conformance corpus runner

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -118,7 +118,7 @@
       "depends_on": ["ocaml-lane-contract", "build-tool-go-oracle"],
       "branch": null,
       "pr_number": null,
-      "notes": "Use OCaml 5.2.1, opam 2.5.x, Dune 3.17.2 (the nearest available compatible release; 3.16.1 is absent from opam), Alcotest, bisect_ppx, and ocamlformat."
+      "notes": "Use OCaml 5.2.1, opam 2.5.x, Dune 3.16.x, Alcotest, bisect_ppx, and ocamlformat."
     },
     {
       "id": "ocaml-representative-core",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,18 +8,13 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": {
-    "number": 9151,
-    "url": "https://github.com/adhithyan15/coding-adventures/pull/9151",
-    "branch": "codex/build-tool-conformance-contract",
-    "status": "open"
-  },
+  "active_pr": null,
   "last_inventory": {
-    "revision": "326de7c72c24605cc935006d11b24d50dfbd9c65",
+    "revision": "edddc9b46af7662ce08799c1b5d9cd4d373025aa",
     "schema_version": 2,
     "established_languages": 15,
-    "implementation_identities": 1183,
-    "implementation_package_slots": 4324,
+    "implementation_identities": 1184,
+    "implementation_package_slots": 4325,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 278,
     "canonical_collisions": 0,
@@ -38,7 +33,7 @@
     {
       "id": "build-tool-contract",
       "title": "Language-neutral build-tool contract and shared fixture schema",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["haskell-http-core"],
       "branch": "codex/build-tool-conformance-contract",
       "pr_number": 9151,
@@ -47,11 +42,20 @@
     {
       "id": "build-tool-fixtures",
       "title": "Cross-implementation build-tool fixture runner and inventory gate",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-contract"],
+      "branch": "codex/build-tool-conformance-runner",
+      "pr_number": null,
+      "notes": "Selected after PR #9151 merged because one safe non-execution runner, adapter manifest, domain result schemas, and representative corpus unlock the Go oracle, every existing front-door remediation, Java/Kotlin/Dart implementations, and OCaml promotion."
+    },
+    {
+      "id": "build-tool-execution-sandbox",
+      "title": "Add the trusted execution sandbox and adversarial execution corpus",
+      "status": "pending",
+      "depends_on": ["build-tool-fixtures"],
       "branch": null,
       "pr_number": null,
-      "notes": "Cover discovery, resolution, graph order, diff, hashing, Starlark, plan interchange, sharding, execution, validation, and toolchain detection."
+      "notes": "Newly separated after the contract security review. Require fail-closed filesystem and network isolation, no-follow materialization/output, direct argv, sanitized environments, and process-tree wall/CPU/memory/output/workspace/process-count limits before any execution fixture can run."
     },
     {
       "id": "build-tool-go-oracle",
@@ -105,7 +109,7 @@
       "depends_on": ["ocaml-lane-contract", "build-tool-go-oracle"],
       "branch": null,
       "pr_number": null,
-      "notes": "Use OCaml 5.2.1, opam 2.5.x, Dune 3.16.x, Alcotest, bisect_ppx, and ocamlformat."
+      "notes": "Use OCaml 5.2.1, opam 2.5.x, Dune 3.17.2 (the nearest available compatible release; 3.16.1 is absent from opam), Alcotest, bisect_ppx, and ocamlformat."
     },
     {
       "id": "ocaml-representative-core",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -58,10 +58,19 @@
       "notes": "Newly separated after the contract security review. Require fail-closed filesystem and network isolation, no-follow materialization/output, direct argv, sanitized environments, and process-tree wall/CPU/memory/output/workspace/process-count limits before any execution fixture can run."
     },
     {
+      "id": "build-tool-pure-domain-corpus",
+      "title": "Close the remaining non-execution build-tool domain schemas and fixtures",
+      "status": "pending",
+      "depends_on": ["build-tool-fixtures"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Newly explicit after the bootstrap schema audit. Add closed inputs/results and positive plus adversarial cases for diff selection, hashing/cache, Starlark, sharding, validation, toolchain detection, and CLI before those domains can report success."
+    },
+    {
       "id": "build-tool-go-oracle",
       "title": "Bring the Go build tool to the canonical contract",
       "status": "pending",
-      "depends_on": ["build-tool-fixtures"],
+      "depends_on": ["build-tool-pure-domain-corpus", "build-tool-execution-sandbox"],
       "branch": null,
       "pr_number": null,
       "notes": "Wire structured Starlark context/commands and complete the B05 Windows executor contract."
@@ -79,7 +88,7 @@
       "id": "build-tool-jvm",
       "title": "Add language-native Java and Kotlin build tools",
       "status": "pending",
-      "depends_on": ["build-tool-fixtures"],
+      "depends_on": ["build-tool-pure-domain-corpus", "build-tool-execution-sandbox"],
       "branch": null,
       "pr_number": null,
       "notes": "Use shared JVM fixture infrastructure but separate idiomatic engines."
@@ -88,7 +97,7 @@
       "id": "build-tool-dart",
       "title": "Add the Dart build tool",
       "status": "pending",
-      "depends_on": ["build-tool-fixtures"],
+      "depends_on": ["build-tool-pure-domain-corpus", "build-tool-execution-sandbox"],
       "branch": null,
       "pr_number": null,
       "notes": "Must pass the same plan, resolver, execution, and platform fixtures as the reference."
@@ -124,7 +133,7 @@
       "id": "ocaml-build-tool-and-promotion",
       "title": "Implement the OCaml build tool and review 16-lane promotion",
       "status": "pending",
-      "depends_on": ["ocaml-representative-core", "build-tool-fixtures"],
+      "depends_on": ["ocaml-representative-core", "build-tool-pure-domain-corpus", "build-tool-execution-sandbox"],
       "branch": null,
       "pr_number": null,
       "notes": "Require conformance, two-way Go plan interchange, three-OS CI, capability enforcement, and explicit backlog acceptance."
@@ -196,7 +205,7 @@
       "id": "c-cpp-graduation",
       "title": "Review C/C++ graduation and native build-tool requirements",
       "status": "pending",
-      "depends_on": ["build-tool-fixtures"],
+      "depends_on": ["build-tool-pure-domain-corpus", "build-tool-execution-sandbox"],
       "branch": null,
       "pr_number": null,
       "notes": "Keep both emerging until package/scaffold/build-tool maturity and applicability are explicit."

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,7 +8,12 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": null,
+  "active_pr": {
+    "number": 9157,
+    "url": "https://github.com/adhithyan15/coding-adventures/pull/9157",
+    "branch": "codex/build-tool-conformance-runner",
+    "status": "open"
+  },
   "last_inventory": {
     "revision": "edddc9b46af7662ce08799c1b5d9cd4d373025aa",
     "schema_version": 2,
@@ -42,10 +47,10 @@
     {
       "id": "build-tool-fixtures",
       "title": "Cross-implementation build-tool fixture runner and inventory gate",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-contract"],
       "branch": "codex/build-tool-conformance-runner",
-      "pr_number": null,
+      "pr_number": 9157,
       "notes": "Selected after PR #9151 merged because one safe non-execution runner, adapter manifest, domain result schemas, and representative corpus unlock the Go oracle, every existing front-door remediation, Java/Kotlin/Dart implementations, and OCaml promotion."
     },
     {

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -67,6 +67,15 @@
       "notes": "Newly explicit after the bootstrap schema audit. Add closed inputs/results and positive plus adversarial cases for diff selection, hashing/cache, Starlark, sharding, validation, toolchain detection, and CLI before those domains can report success."
     },
     {
+      "id": "build-file-standalone-integrity",
+      "title": "Repair stale BUILD_windows standalone prerequisite declarations",
+      "status": "pending",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": null,
+      "notes": "The rebased Go oracle full dry-run currently reports 73 pre-existing validation gaps: 12 Python, 3 Swift, and 58 TypeScript. Deliver dependency-shaped waves and preserve the broader July 29 audit queue for Perl, Dart, Kotlin, and related packages."
+    },
+    {
       "id": "build-tool-go-oracle",
       "title": "Bring the Go build tool to the canonical contract",
       "status": "pending",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
           python3 -m pip install --disable-pip-version-check --quiet jsonschema==4.26.0
           python3 -m unittest discover -s code/scripts/tests -p 'test_package_parity_report.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_schema.py'
+          python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_runner.py'
+          python3 code/scripts/build_tool_conformance.py validate-corpus
           python3 code/scripts/package_parity_report.py --format json --fail-on-collisions > /tmp/package-parity-report.json
 
       - name: Determine diff base

--- a/code/scripts/build_tool_conformance.py
+++ b/code/scripts/build_tool_conformance.py
@@ -37,6 +37,7 @@ MAX_WORKSPACE_FILES = 4096
 MAX_WORKSPACE_BYTES = 268_435_456
 RESERVED_ADAPTER_FLAGS = ("--conformance", "--workspace-root", "--output")
 EXECUTION_CAPABILITIES = {"execution", "trusted_execution"}
+BOOTSTRAP_DOMAINS = {"discovery", "graph", "plan", "resolution"}
 ESTABLISHED_LANGUAGES = (
     "csharp",
     "dart",
@@ -309,6 +310,15 @@ def reject_execution_intent(case: dict[str, Any]) -> None:
         raise ConformanceError(
             "EXECUTION_DISABLED",
             "the bootstrap runner never accepts execution intent",
+        )
+
+
+def reject_unmodeled_domain(case: dict[str, Any]) -> None:
+    domain = case.get("domain")
+    if domain not in BOOTSTRAP_DOMAINS:
+        raise ConformanceError(
+            "CASE_DOMAIN_UNMODELED",
+            f"bootstrap runner has no closed schema for domain: {domain}",
         )
 
 
@@ -715,6 +725,7 @@ def assert_result_matches(
     plan_schema: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reject_execution_intent(case)
+    reject_unmodeled_domain(case)
     result_schema = result_schema or load_document(
         DEFAULT_FIXTURE_ROOT / "result.schema.json"
     )
@@ -747,6 +758,7 @@ def validate_case_document(
 ) -> list[WorkspaceFile]:
     reject_execution_intent(case)
     _validate_schema(case, case_schema, "CASE_SCHEMA_INVALID")
+    reject_unmodeled_domain(case)
     _validate_case_identity(case)
     _validate_input_paths(case)
     staged_files = preflight_workspace(case)

--- a/code/scripts/build_tool_conformance.py
+++ b/code/scripts/build_tool_conformance.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Validate the language-neutral build-tool conformance corpus and results.
 
-This bootstrap runner is intentionally process-free. It validates and
-materializes data-only, non-execution cases, and it compares externally
-produced results with the shared fixture oracle. Adapter orchestration belongs
-to the later trusted-sandbox tranche.
+This bootstrap runner is intentionally process-free. It validates data-only,
+non-execution cases entirely in memory, and it compares externally produced
+results with the shared fixture oracle. Adapter orchestration belongs to the
+later trusted-sandbox tranche.
 """
 
 from __future__ import annotations
@@ -17,12 +17,10 @@ import os
 import re
 import stat
 import sys
-import tempfile
 import unicodedata
-from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterator, Sequence
+from typing import Any, Sequence
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -79,6 +77,8 @@ WINDOWS_RESERVED_BASENAMES = {
     "CLOCK$",
     *(f"COM{index}" for index in range(1, 10)),
     *(f"LPT{index}" for index in range(1, 10)),
+    *(f"COM{index}" for index in "¹²³"),
+    *(f"LPT{index}" for index in "¹²³"),
 }
 
 
@@ -250,18 +250,118 @@ def strict_load_bytes(
     return value
 
 
+def _open_windows_regular_no_follow(path: Path) -> Any:
+    import ctypes
+    import msvcrt
+    from ctypes import wintypes
+
+    path_text = str(path)
+    if path_text.startswith("\\\\"):
+        raise ConformanceError(
+            "DOCUMENT_PATH_UNSAFE",
+            "Windows UNC, device, and extended paths are forbidden",
+        )
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = (
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    )
+    create_file.restype = wintypes.HANDLE
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = (wintypes.HANDLE,)
+    close_handle.restype = wintypes.BOOL
+
+    handle = create_file(
+        path_text,
+        0x80000000,
+        0x00000001,
+        None,
+        3,
+        0x00200000 | 0x08000000,
+        None,
+    )
+    invalid_handle = ctypes.c_void_p(-1).value
+    if handle == invalid_handle:
+        raise OSError(ctypes.get_last_error(), "CreateFileW failed")
+
+    class FileAttributeTagInfo(ctypes.Structure):
+        _fields_ = [
+            ("file_attributes", wintypes.DWORD),
+            ("reparse_tag", wintypes.DWORD),
+        ]
+
+    info = FileAttributeTagInfo()
+    get_info = kernel32.GetFileInformationByHandleEx
+    get_info.argtypes = (
+        wintypes.HANDLE,
+        ctypes.c_int,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+    )
+    get_info.restype = wintypes.BOOL
+    if not get_info(handle, 9, ctypes.byref(info), ctypes.sizeof(info)):
+        error_code = ctypes.get_last_error()
+        close_handle(handle)
+        raise OSError(error_code, "GetFileInformationByHandleEx failed")
+    if info.file_attributes & 0x00000400:
+        close_handle(handle)
+        raise ConformanceError(
+            "DOCUMENT_TYPE_INVALID",
+            "symbolic links and reparse points are forbidden",
+        )
+    try:
+        descriptor = msvcrt.open_osfhandle(
+            handle,
+            os.O_RDONLY | os.O_BINARY,
+        )
+    except OSError:
+        close_handle(handle)
+        raise
+    return os.fdopen(descriptor, "rb")
+
+
+def _open_regular_no_follow(path: Path) -> Any:
+    if os.name == "nt":
+        return _open_windows_regular_no_follow(path)
+    flags = os.O_RDONLY
+    for option in ("O_CLOEXEC", "O_NOFOLLOW", "O_NONBLOCK"):
+        flags |= getattr(os, option, 0)
+    descriptor = os.open(path, flags)
+    return os.fdopen(descriptor, "rb")
+
+
 def load_document(
     path: Path,
     *,
     max_bytes: int = MAX_DOCUMENT_BYTES,
 ) -> dict[str, Any]:
     try:
-        raw = path.read_bytes()
-    except OSError as error:
+        with _open_regular_no_follow(path) as source:
+            if not stat.S_ISREG(os.fstat(source.fileno()).st_mode):
+                raise ConformanceError(
+                    "DOCUMENT_TYPE_INVALID",
+                    f"document is not a regular file: {path}",
+                )
+            raw = source.read(max_bytes + 1)
+    except ConformanceError:
+        raise
+    except (OSError, ValueError) as error:
         raise ConformanceError(
             "DOCUMENT_READ_FAILED",
             f"could not read {path}",
         ) from error
+    if len(raw) > max_bytes:
+        raise ConformanceError(
+            "JSON_INPUT_TOO_LARGE",
+            f"JSON input exceeds {max_bytes} bytes",
+        )
     return strict_load_bytes(raw, max_bytes=max_bytes)
 
 
@@ -301,11 +401,15 @@ def reject_execution_intent(case: dict[str, Any]) -> None:
         input_value.get("operation") if isinstance(input_value, dict) else None
     )
     capabilities = case.get("capabilities")
-    capability_set = set(capabilities) if isinstance(capabilities, list) else set()
+    capability_values = capabilities if isinstance(capabilities, list) else []
     if (
         domain == "execution"
         or operation == "execution"
-        or capability_set.intersection(EXECUTION_CAPABILITIES)
+        or any(
+            isinstance(capability, str)
+            and capability in EXECUTION_CAPABILITIES
+            for capability in capability_values
+        )
     ):
         raise ConformanceError(
             "EXECUTION_DISABLED",
@@ -422,53 +526,6 @@ def preflight_workspace(case: dict[str, Any]) -> list[WorkspaceFile]:
     return sorted(staged_files, key=lambda entry: entry.path.casefold())
 
 
-def _ensure_beneath(root: Path, destination: Path) -> None:
-    try:
-        destination.relative_to(root)
-    except ValueError as error:
-        raise ConformanceError(
-            "WORKSPACE_PATH_ESCAPE",
-            "workspace destination escapes the temporary root",
-        ) from error
-
-
-@contextmanager
-def materialized_workspace(case: dict[str, Any]) -> Iterator[Path]:
-    """Materialize a preflighted pure case in a private temporary directory."""
-
-    staged_files = preflight_workspace(case)
-    with tempfile.TemporaryDirectory(prefix="build-tool-conformance-") as directory:
-        root = Path(directory).resolve(strict=True)
-        for entry in staged_files:
-            destination = root.joinpath(*entry.path.split("/"))
-            _ensure_beneath(root, destination)
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            _ensure_beneath(root, destination.parent.resolve(strict=True))
-            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
-            if hasattr(os, "O_BINARY"):
-                flags |= os.O_BINARY
-            if hasattr(os, "O_NOFOLLOW"):
-                flags |= os.O_NOFOLLOW
-            mode = 0o700 if entry.executable else 0o600
-            try:
-                descriptor = os.open(destination, flags, mode)
-                with os.fdopen(descriptor, "wb") as output:
-                    output.write(entry.content)
-                if entry.executable:
-                    os.chmod(destination, 0o700)
-            except OSError as error:
-                raise ConformanceError(
-                    "WORKSPACE_WRITE_FAILED",
-                    f"could not materialize {entry.path}",
-                ) from error
-            if not stat.S_ISREG(destination.stat(follow_symlinks=False).st_mode):
-                raise ConformanceError(
-                    "WORKSPACE_FILE_TYPE_INVALID",
-                    f"materialized path is not a regular file: {entry.path}",
-                )
-        yield root
-
-
 def _schema_errors(
     instance: dict[str, Any],
     schema: dict[str, Any],
@@ -481,12 +538,36 @@ def _schema_errors(
             "install jsonschema==4.26.0 to validate conformance documents",
         ) from error
 
-    jsonschema.Draft202012Validator.check_schema(schema)
-    validator = jsonschema.Draft202012Validator(schema)
-    errors = sorted(
-        validator.iter_errors(instance),
-        key=lambda error: [str(part) for part in error.absolute_path],
-    )
+    def reject_external_refs(value: Any) -> None:
+        if isinstance(value, dict):
+            for keyword in ("$ref", "$dynamicRef"):
+                reference = value.get(keyword)
+                if isinstance(reference, str) and not reference.startswith("#"):
+                    raise ConformanceError(
+                        "SCHEMA_REFERENCE_FORBIDDEN",
+                        f"external schema reference is forbidden: {reference}",
+                    )
+            for item in value.values():
+                reject_external_refs(item)
+        elif isinstance(value, list):
+            for item in value:
+                reject_external_refs(item)
+
+    reject_external_refs(schema)
+    try:
+        jsonschema.Draft202012Validator.check_schema(schema)
+        validator = jsonschema.Draft202012Validator(schema)
+        errors = sorted(
+            validator.iter_errors(instance),
+            key=lambda error: [str(part) for part in error.absolute_path],
+        )
+    except ConformanceError:
+        raise
+    except Exception as error:
+        raise ConformanceError(
+            "SCHEMA_VALIDATION_FAILED",
+            "schema validation could not be completed safely",
+        ) from error
     formatted: list[str] = []
     for error in errors:
         path = "/".join(str(part) for part in error.absolute_path) or "<root>"
@@ -877,10 +958,10 @@ def validate_corpus(
     fixture_root: Path = DEFAULT_FIXTURE_ROOT,
 ) -> dict[str, Any]:
     fixture_root = fixture_root.resolve()
-    case_schema = load_document(fixture_root / "schema.json")
-    result_schema = load_document(fixture_root / "result.schema.json")
+    case_schema = load_document(DEFAULT_FIXTURE_ROOT / "schema.json")
+    result_schema = load_document(DEFAULT_FIXTURE_ROOT / "result.schema.json")
     manifest_schema = load_document(
-        fixture_root / "implementations.schema.json"
+        DEFAULT_FIXTURE_ROOT / "implementations.schema.json"
     )
     manifest = load_document(fixture_root / "implementations.json")
     plan_schema = load_document(
@@ -896,7 +977,7 @@ def validate_corpus(
         )
     case_ids: set[str] = set()
     domains: set[str] = set()
-    materialized_files = 0
+    validated_files = 0
     for case_path in case_paths:
         case = load_document(case_path)
         if case.get("id") in case_ids:
@@ -910,11 +991,9 @@ def validate_corpus(
             result_schema=result_schema,
             plan_schema=plan_schema,
         )
-        with materialized_workspace(case):
-            pass
         case_ids.add(case["id"])
         domains.add(case["domain"])
-        materialized_files += len(staged_files)
+        validated_files += len(staged_files)
 
     return {
         "schema_version": 1,
@@ -926,7 +1005,7 @@ def validate_corpus(
         "conformance_run_count": 0,
         "conformance_status": "not-run",
         "execution_case_count": 0,
-        "materialized_file_count": materialized_files,
+        "validated_file_count": validated_files,
         "domains": sorted(domains),
         "status": "valid",
     }
@@ -935,7 +1014,6 @@ def validate_corpus(
 def validate_result_files(case_path: Path, result_path: Path) -> dict[str, Any]:
     case = load_document(case_path)
     reject_execution_intent(case)
-    result = load_document(result_path, max_bytes=MAX_RESULT_BYTES)
     case_schema = load_document(DEFAULT_FIXTURE_ROOT / "schema.json")
     result_schema = load_document(DEFAULT_FIXTURE_ROOT / "result.schema.json")
     plan_schema = load_document(
@@ -947,6 +1025,8 @@ def validate_result_files(case_path: Path, result_path: Path) -> dict[str, Any]:
         result_schema=result_schema,
         plan_schema=plan_schema,
     )
+    output_limit = min(case["limits"]["output_bytes"], MAX_RESULT_BYTES)
+    result = load_document(result_path, max_bytes=output_limit)
     return assert_result_matches(
         case,
         result,
@@ -963,7 +1043,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     corpus_parser = subparsers.add_parser(
         "validate-corpus",
-        help="Validate and safely materialize the non-execution corpus.",
+        help="Validate the non-execution corpus without filesystem staging.",
     )
     corpus_parser.add_argument(
         "--fixture-root",
@@ -986,6 +1066,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         arguments = parser.parse_args(argv)
     except SystemExit as error:
         return int(error.code)
+    exit_code = 0
     try:
         if arguments.command == "validate-corpus":
             output = validate_corpus(arguments.fixture_root)
@@ -997,8 +1078,16 @@ def main(argv: Sequence[str] | None = None) -> int:
             output = {
                 "case_id": canonical["case_id"],
                 "domain": canonical["domain"],
-                "status": "pass",
+                "outcome": canonical["outcome"],
+                "status": "matched",
+                "conformance_status": (
+                    "non-passing"
+                    if canonical["outcome"] in {"unsupported", "skipped"}
+                    else "pass"
+                ),
             }
+            if output["conformance_status"] == "non-passing":
+                exit_code = 1
     except ConformanceError as error:
         print(
             json.dumps(
@@ -1014,7 +1103,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 1 if error.code == "RESULT_MISMATCH" else 2
 
     print(json.dumps(output, sort_keys=True))
-    return 0
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/code/scripts/build_tool_conformance.py
+++ b/code/scripts/build_tool_conformance.py
@@ -1,0 +1,1009 @@
+#!/usr/bin/env python3
+"""Validate the language-neutral build-tool conformance corpus and results.
+
+This bootstrap runner is intentionally process-free. It validates and
+materializes data-only, non-execution cases, and it compares externally
+produced results with the shared fixture oracle. Adapter orchestration belongs
+to the later trusted-sandbox tranche.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import json
+import os
+import re
+import stat
+import sys
+import tempfile
+import unicodedata
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_FIXTURE_ROOT = (
+    REPO_ROOT / "code" / "specs" / "fixtures" / "build-tool-v1"
+)
+MAX_SAFE_INTEGER = 9_007_199_254_740_991
+MAX_DOCUMENT_BYTES = 2_000_000
+MAX_RESULT_BYTES = 16_777_216
+MAX_JSON_DEPTH = 64
+MAX_WORKSPACE_FILES = 4096
+MAX_WORKSPACE_BYTES = 268_435_456
+RESERVED_ADAPTER_FLAGS = ("--conformance", "--workspace-root", "--output")
+EXECUTION_CAPABILITIES = {"execution", "trusted_execution"}
+ESTABLISHED_LANGUAGES = (
+    "csharp",
+    "dart",
+    "elixir",
+    "fsharp",
+    "go",
+    "haskell",
+    "java",
+    "kotlin",
+    "lua",
+    "perl",
+    "python",
+    "ruby",
+    "rust",
+    "swift",
+    "typescript",
+)
+DOMAIN_CAPABILITIES = {
+    "discovery": {"discovery"},
+    "resolution": {"resolution"},
+    "graph": {"graph"},
+    "diff_selection": {"diff_selection"},
+    "hashing_cache": {"hashing_cache"},
+    "starlark": {"starlark"},
+    "plan": {"plan_v1_read", "plan_v1_write"},
+    "sharding": {"sharding"},
+    "execution": {"execution", "trusted_execution"},
+    "validation": {"validation"},
+    "toolchain_detection": {"toolchain_detection"},
+    "cli": {"cli"},
+}
+WINDOWS_RESERVED_BASENAMES = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    "CONIN$",
+    "CONOUT$",
+    "CLOCK$",
+    *(f"COM{index}" for index in range(1, 10)),
+    *(f"LPT{index}" for index in range(1, 10)),
+}
+
+
+class ConformanceError(ValueError):
+    """A stable machine-readable conformance runner failure."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True)
+class WorkspaceFile:
+    path: str
+    content: bytes
+    executable: bool
+
+
+def _raise_duplicate_key(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ConformanceError(
+                "JSON_DUPLICATE_KEY",
+                f"duplicate JSON key: {key}",
+            )
+        result[key] = value
+    return result
+
+
+def _raise_non_finite(value: str) -> None:
+    raise ConformanceError(
+        "JSON_NON_FINITE",
+        f"non-finite JSON number: {value}",
+    )
+
+
+def _raise_float(value: str) -> None:
+    raise ConformanceError(
+        "JSON_FLOAT_FORBIDDEN",
+        f"floating-point JSON value is forbidden: {value}",
+    )
+
+
+def _scan_json_depth(text: str, max_depth: int) -> None:
+    depth = 0
+    in_string = False
+    escaped = False
+    for character in text:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            continue
+        if character == '"':
+            in_string = True
+        elif character in "[{":
+            depth += 1
+            if depth > max_depth:
+                raise ConformanceError(
+                    "JSON_DEPTH_EXCEEDED",
+                    f"JSON nesting exceeds {max_depth} levels",
+                )
+        elif character in "]}":
+            depth -= 1
+            if depth < 0:
+                raise ConformanceError(
+                    "JSON_SYNTAX_INVALID",
+                    "JSON has an unmatched closing delimiter",
+                )
+
+
+def _validate_json_value(value: Any, depth: int = 0) -> None:
+    if depth > MAX_JSON_DEPTH:
+        raise ConformanceError(
+            "JSON_DEPTH_EXCEEDED",
+            f"JSON nesting exceeds {MAX_JSON_DEPTH} levels",
+        )
+    if isinstance(value, str):
+        if any(0xD800 <= ord(character) <= 0xDFFF for character in value):
+            raise ConformanceError(
+                "JSON_UNICODE_SURROGATE",
+                "unpaired Unicode surrogate",
+            )
+        return
+    if value is None or isinstance(value, bool):
+        return
+    if isinstance(value, int):
+        if not -MAX_SAFE_INTEGER <= value <= MAX_SAFE_INTEGER:
+            raise ConformanceError(
+                "JSON_INTEGER_RANGE",
+                "integer is outside the interoperable range",
+            )
+        return
+    if isinstance(value, float):
+        raise ConformanceError(
+            "JSON_FLOAT_FORBIDDEN",
+            "floating-point JSON values are forbidden",
+        )
+    if isinstance(value, list):
+        for item in value:
+            _validate_json_value(item, depth + 1)
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            _validate_json_value(key, depth + 1)
+            _validate_json_value(item, depth + 1)
+        return
+    raise ConformanceError(
+        "JSON_VALUE_INVALID",
+        f"unsupported JSON value: {type(value).__name__}",
+    )
+
+
+def strict_load_bytes(
+    raw: bytes,
+    *,
+    max_bytes: int = MAX_DOCUMENT_BYTES,
+    max_depth: int = MAX_JSON_DEPTH,
+) -> dict[str, Any]:
+    """Parse a bounded, strict UTF-8 RFC 8259 object."""
+
+    if len(raw) > max_bytes:
+        raise ConformanceError(
+            "JSON_INPUT_TOO_LARGE",
+            f"JSON input exceeds {max_bytes} bytes",
+        )
+    if raw.startswith(b"\xef\xbb\xbf"):
+        raise ConformanceError("JSON_BOM_FORBIDDEN", "UTF-8 BOM is forbidden")
+    try:
+        text = raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as error:
+        raise ConformanceError(
+            "JSON_UTF8_INVALID",
+            "JSON input is not strict UTF-8",
+        ) from error
+
+    _scan_json_depth(text, max_depth)
+    try:
+        value = json.loads(
+            text,
+            object_pairs_hook=_raise_duplicate_key,
+            parse_constant=_raise_non_finite,
+            parse_float=_raise_float,
+        )
+    except ConformanceError:
+        raise
+    except RecursionError as error:
+        raise ConformanceError(
+            "JSON_DEPTH_EXCEEDED",
+            f"JSON nesting exceeds {max_depth} levels",
+        ) from error
+    except json.JSONDecodeError as error:
+        raise ConformanceError(
+            "JSON_SYNTAX_INVALID",
+            f"invalid JSON at line {error.lineno}, column {error.colno}",
+        ) from error
+
+    _validate_json_value(value)
+    if not isinstance(value, dict):
+        raise ConformanceError(
+            "JSON_TOP_LEVEL_INVALID",
+            "top-level JSON value must be an object",
+        )
+    return value
+
+
+def load_document(
+    path: Path,
+    *,
+    max_bytes: int = MAX_DOCUMENT_BYTES,
+) -> dict[str, Any]:
+    try:
+        raw = path.read_bytes()
+    except OSError as error:
+        raise ConformanceError(
+            "DOCUMENT_READ_FAILED",
+            f"could not read {path}",
+        ) from error
+    return strict_load_bytes(raw, max_bytes=max_bytes)
+
+
+def portable_path_error(path: Any) -> str | None:
+    if not isinstance(path, str) or not path:
+        return "path is empty or not a string"
+    if len(path) > 512:
+        return "path exceeds 512 characters"
+    if path != unicodedata.normalize("NFC", path):
+        return "path is not NFC-normalized"
+    if (
+        path.startswith("/")
+        or re.match(r"^[A-Za-z]:", path)
+        or "\\" in path
+        or "//" in path
+        or any(
+            ord(character) < 32 or character in '<>:"|?*'
+            for character in path
+        )
+    ):
+        return "path is not a portable relative path"
+    for segment in path.split("/"):
+        if segment in {".", ".."}:
+            return "path contains a dot segment"
+        if segment.endswith((" ", ".")):
+            return "path segment has a trailing dot or space"
+        basename = segment.split(".", 1)[0].upper()
+        if basename in WINDOWS_RESERVED_BASENAMES:
+            return "path segment uses a Windows reserved basename"
+    return None
+
+
+def reject_execution_intent(case: dict[str, Any]) -> None:
+    domain = case.get("domain")
+    input_value = case.get("input")
+    operation = (
+        input_value.get("operation") if isinstance(input_value, dict) else None
+    )
+    capabilities = case.get("capabilities")
+    capability_set = set(capabilities) if isinstance(capabilities, list) else set()
+    if (
+        domain == "execution"
+        or operation == "execution"
+        or capability_set.intersection(EXECUTION_CAPABILITIES)
+    ):
+        raise ConformanceError(
+            "EXECUTION_DISABLED",
+            "the bootstrap runner never accepts execution intent",
+        )
+
+
+def _decode_workspace_file(entry: dict[str, Any]) -> bytes:
+    if "content_utf8" in entry:
+        value = entry["content_utf8"]
+        if not isinstance(value, str):
+            raise ConformanceError(
+                "WORKSPACE_UTF8_INVALID",
+                "content_utf8 must be a string",
+            )
+        return value.encode("utf-8")
+    value = entry.get("content_base64")
+    if not isinstance(value, str):
+        raise ConformanceError(
+            "WORKSPACE_CONTENT_MISSING",
+            "workspace file must contain UTF-8 or base64 content",
+        )
+    try:
+        decoded = base64.b64decode(value, validate=True)
+    except (binascii.Error, ValueError) as error:
+        raise ConformanceError(
+            "WORKSPACE_BASE64_INVALID",
+            "workspace file contains invalid base64",
+        ) from error
+    if base64.b64encode(decoded).decode("ascii") != value:
+        raise ConformanceError(
+            "WORKSPACE_BASE64_NONCANONICAL",
+            "workspace file contains non-canonical base64",
+        )
+    return decoded
+
+
+def preflight_workspace(case: dict[str, Any]) -> list[WorkspaceFile]:
+    """Validate and decode a workspace completely before creating a root."""
+
+    reject_execution_intent(case)
+    workspace = case.get("workspace")
+    files_value = workspace.get("files") if isinstance(workspace, dict) else None
+    if not isinstance(files_value, list):
+        raise ConformanceError(
+            "WORKSPACE_FILES_INVALID",
+            "workspace.files must be an array",
+        )
+    if len(files_value) > MAX_WORKSPACE_FILES:
+        raise ConformanceError(
+            "WORKSPACE_FILE_LIMIT",
+            f"workspace contains more than {MAX_WORKSPACE_FILES} files",
+        )
+
+    normalized_paths: dict[str, str] = {}
+    staged_files: list[WorkspaceFile] = []
+    total_bytes = 0
+    for entry in files_value:
+        if not isinstance(entry, dict):
+            raise ConformanceError(
+                "WORKSPACE_FILE_INVALID",
+                "workspace file entry must be an object",
+            )
+        path = entry.get("path")
+        if error := portable_path_error(path):
+            raise ConformanceError(
+                "WORKSPACE_PATH_UNSAFE",
+                f"unsafe workspace path {path!r}: {error}",
+            )
+        normalized = unicodedata.normalize("NFC", path).casefold()
+        if normalized in normalized_paths:
+            raise ConformanceError(
+                "WORKSPACE_PATH_COLLISION",
+                f"workspace path collides with {normalized_paths[normalized]}",
+            )
+        for existing, original in normalized_paths.items():
+            if (
+                normalized.startswith(f"{existing}/")
+                or existing.startswith(f"{normalized}/")
+            ):
+                raise ConformanceError(
+                    "WORKSPACE_PATH_PREFIX_CONFLICT",
+                    f"workspace paths conflict: {original} and {path}",
+                )
+        normalized_paths[normalized] = path
+        content = _decode_workspace_file(entry)
+        total_bytes += len(content)
+        staged_files.append(
+            WorkspaceFile(
+                path=path,
+                content=content,
+                executable=bool(entry.get("executable", False)),
+            )
+        )
+
+    requested_limit = case.get("limits", {}).get("workspace_bytes")
+    if not isinstance(requested_limit, int):
+        requested_limit = MAX_WORKSPACE_BYTES
+    effective_limit = min(requested_limit, MAX_WORKSPACE_BYTES)
+    if total_bytes > effective_limit:
+        raise ConformanceError(
+            "WORKSPACE_BYTE_LIMIT",
+            f"decoded workspace exceeds {effective_limit} bytes",
+        )
+    return sorted(staged_files, key=lambda entry: entry.path.casefold())
+
+
+def _ensure_beneath(root: Path, destination: Path) -> None:
+    try:
+        destination.relative_to(root)
+    except ValueError as error:
+        raise ConformanceError(
+            "WORKSPACE_PATH_ESCAPE",
+            "workspace destination escapes the temporary root",
+        ) from error
+
+
+@contextmanager
+def materialized_workspace(case: dict[str, Any]) -> Iterator[Path]:
+    """Materialize a preflighted pure case in a private temporary directory."""
+
+    staged_files = preflight_workspace(case)
+    with tempfile.TemporaryDirectory(prefix="build-tool-conformance-") as directory:
+        root = Path(directory).resolve(strict=True)
+        for entry in staged_files:
+            destination = root.joinpath(*entry.path.split("/"))
+            _ensure_beneath(root, destination)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            _ensure_beneath(root, destination.parent.resolve(strict=True))
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+            if hasattr(os, "O_BINARY"):
+                flags |= os.O_BINARY
+            if hasattr(os, "O_NOFOLLOW"):
+                flags |= os.O_NOFOLLOW
+            mode = 0o700 if entry.executable else 0o600
+            try:
+                descriptor = os.open(destination, flags, mode)
+                with os.fdopen(descriptor, "wb") as output:
+                    output.write(entry.content)
+                if entry.executable:
+                    os.chmod(destination, 0o700)
+            except OSError as error:
+                raise ConformanceError(
+                    "WORKSPACE_WRITE_FAILED",
+                    f"could not materialize {entry.path}",
+                ) from error
+            if not stat.S_ISREG(destination.stat(follow_symlinks=False).st_mode):
+                raise ConformanceError(
+                    "WORKSPACE_FILE_TYPE_INVALID",
+                    f"materialized path is not a regular file: {entry.path}",
+                )
+        yield root
+
+
+def _schema_errors(
+    instance: dict[str, Any],
+    schema: dict[str, Any],
+) -> list[str]:
+    try:
+        import jsonschema
+    except ImportError as error:
+        raise ConformanceError(
+            "JSONSCHEMA_UNAVAILABLE",
+            "install jsonschema==4.26.0 to validate conformance documents",
+        ) from error
+
+    jsonschema.Draft202012Validator.check_schema(schema)
+    validator = jsonschema.Draft202012Validator(schema)
+    errors = sorted(
+        validator.iter_errors(instance),
+        key=lambda error: [str(part) for part in error.absolute_path],
+    )
+    formatted: list[str] = []
+    for error in errors:
+        path = "/".join(str(part) for part in error.absolute_path) or "<root>"
+        formatted.append(f"{path}: {error.message}")
+    return formatted
+
+
+def _validate_schema(
+    instance: dict[str, Any],
+    schema: dict[str, Any],
+    code: str,
+) -> None:
+    if errors := _schema_errors(instance, schema):
+        raise ConformanceError(code, errors[0])
+
+
+def _validate_input_paths(case: dict[str, Any]) -> None:
+    input_value = case.get("input", {})
+    changed_paths = input_value.get("changed_paths", [])
+    normalized_changed: set[str] = set()
+    for path in changed_paths:
+        if error := portable_path_error(path):
+            raise ConformanceError(
+                "CASE_CHANGED_PATH_UNSAFE",
+                f"unsafe changed path {path!r}: {error}",
+            )
+        normalized = unicodedata.normalize("NFC", path).casefold()
+        if normalized in normalized_changed:
+            raise ConformanceError(
+                "CASE_CHANGED_PATH_COLLISION",
+                f"changed path collides after normalization: {path}",
+            )
+        normalized_changed.add(normalized)
+
+    for key, value in input_value.get("options", {}).items():
+        if (
+            isinstance(value, str)
+            and key.endswith(("_path", "_root", "_file"))
+            and (error := portable_path_error(value))
+        ):
+            raise ConformanceError(
+                "CASE_OPTION_PATH_UNSAFE",
+                f"unsafe path option {key}: {error}",
+            )
+
+    for argument in input_value.get("arguments", []):
+        if any(
+            argument == flag or argument.startswith(f"{flag}=")
+            for flag in RESERVED_ADAPTER_FLAGS
+        ):
+            raise ConformanceError(
+                "CASE_RESERVED_ARGUMENT",
+                f"input.arguments contains reserved flag: {argument}",
+            )
+
+
+def _validate_case_identity(case: dict[str, Any]) -> None:
+    domain = case["domain"]
+    if domain != case["input"]["operation"]:
+        raise ConformanceError(
+            "CASE_DOMAIN_OPERATION_MISMATCH",
+            "domain must equal input.operation",
+        )
+    if case["id"] != case["expected"]["case_id"]:
+        raise ConformanceError(
+            "CASE_EXPECTED_ID_MISMATCH",
+            "id must equal expected.case_id",
+        )
+    if domain != case["expected"]["domain"]:
+        raise ConformanceError(
+            "CASE_EXPECTED_DOMAIN_MISMATCH",
+            "domain must equal expected.domain",
+        )
+
+    capabilities = set(case["capabilities"])
+    required = DOMAIN_CAPABILITIES[domain]
+    if domain == "plan":
+        if not required.intersection(capabilities):
+            raise ConformanceError(
+                "CASE_CAPABILITY_MISSING",
+                "plan case requires plan_v1_read or plan_v1_write",
+            )
+    elif not required.issubset(capabilities):
+        raise ConformanceError(
+            "CASE_CAPABILITY_MISSING",
+            f"{domain} case is missing its domain capability",
+        )
+
+
+def _validate_plan_semantics(plan: dict[str, Any]) -> None:
+    packages = plan.get("packages", [])
+    package_names: set[str] = set()
+    for package in packages:
+        name = package["name"]
+        if name in package_names:
+            raise ConformanceError(
+                "RESULT_PLAN_PACKAGE_DUPLICATE",
+                f"duplicate plan package: {name}",
+            )
+        package_names.add(name)
+        if error := portable_path_error(package["rel_path"]):
+            raise ConformanceError(
+                "RESULT_PLAN_PATH_UNSAFE",
+                f"unsafe plan rel_path for {name}: {error}",
+            )
+    for edge in plan.get("dependency_edges", []):
+        if edge[0] not in package_names or edge[1] not in package_names:
+            raise ConformanceError(
+                "RESULT_PLAN_EDGE_UNKNOWN",
+                f"plan edge references an unknown package: {edge}",
+            )
+    affected = plan.get("affected_packages")
+    if isinstance(affected, list):
+        for name in affected:
+            if name not in package_names:
+                raise ConformanceError(
+                    "RESULT_PLAN_AFFECTED_UNKNOWN",
+                    f"affected package is not declared: {name}",
+                )
+
+
+def _sort_json_objects(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _sort_json_objects(value[key])
+            for key in sorted(value)
+        }
+    if isinstance(value, list):
+        return [_sort_json_objects(item) for item in value]
+    return value
+
+
+def canonicalize_result(result: dict[str, Any]) -> dict[str, Any]:
+    canonical = json.loads(json.dumps(result))
+    domain = canonical.get("domain")
+    payload = canonical.get("result", {})
+
+    diagnostics = canonical.get("diagnostics", [])
+    diagnostics.sort(
+        key=lambda item: (
+            item.get("code", ""),
+            item.get("path", ""),
+            item.get("package", ""),
+            json.dumps(item.get("details", {}), sort_keys=True),
+        )
+    )
+
+    if domain == "discovery" and "packages" in payload:
+        payload["packages"].sort(key=lambda package: package["name"])
+    elif domain == "resolution" and "edges" in payload:
+        payload["edges"].sort(key=lambda edge: (edge[0], edge[1]))
+    elif domain == "graph":
+        if "edges" in payload:
+            payload["edges"].sort(key=lambda edge: (edge[0], edge[1]))
+        if "levels" in payload:
+            payload["levels"] = [sorted(level) for level in payload["levels"]]
+    elif domain == "plan" and "plan" in payload:
+        plan = payload["plan"]
+        plan["packages"].sort(key=lambda package: package["name"])
+        plan["dependency_edges"].sort(key=lambda edge: (edge[0], edge[1]))
+        if isinstance(plan.get("affected_packages"), list):
+            plan["affected_packages"].sort()
+        if "shards" in plan:
+            plan["shards"].sort(key=lambda shard: shard["index"])
+            for shard in plan["shards"]:
+                shard["assigned_packages"].sort()
+                shard["package_names"].sort()
+
+    return _sort_json_objects(canonical)
+
+
+def _validate_result_shape(
+    case: dict[str, Any],
+    result: dict[str, Any],
+    *,
+    result_schema: dict[str, Any],
+    plan_schema: dict[str, Any],
+    code: str,
+) -> None:
+    _validate_schema(result, result_schema, code)
+    if result["case_id"] != case["id"]:
+        raise ConformanceError(
+            "RESULT_CASE_ID_MISMATCH",
+            "result case_id does not match the fixture",
+        )
+    if result["domain"] != case["domain"]:
+        raise ConformanceError(
+            "RESULT_DOMAIN_MISMATCH",
+            "result domain does not match the fixture",
+        )
+    payload = result["result"]
+    if result["outcome"] == "ok" and result["domain"] == "discovery":
+        names = [package["name"] for package in payload["packages"]]
+        if len(names) != len(set(names)):
+            raise ConformanceError(
+                "RESULT_PACKAGE_NAME_DUPLICATE",
+                "discovery result contains a duplicate package name",
+            )
+    if result["outcome"] == "ok" and result["domain"] == "graph":
+        flattened = [
+            package
+            for level in payload["levels"]
+            for package in level
+        ]
+        if len(flattened) != len(set(flattened)):
+            raise ConformanceError(
+                "RESULT_GRAPH_LEVEL_DUPLICATE",
+                "a graph package appears in more than one level",
+            )
+        level_packages = set(flattened)
+        edge_packages = {
+            package
+            for edge in payload["edges"]
+            for package in edge
+        }
+        if not edge_packages.issubset(level_packages):
+            raise ConformanceError(
+                "RESULT_GRAPH_LEVEL_MISSING",
+                "a graph edge endpoint is absent from the dependency levels",
+            )
+    if (
+        result["domain"] == "plan"
+        and result["outcome"] == "ok"
+        and "plan" in result["result"]
+    ):
+        plan = result["result"]["plan"]
+        _validate_schema(plan, plan_schema, "RESULT_PLAN_SCHEMA_INVALID")
+        _validate_plan_semantics(plan)
+
+
+def assert_result_matches(
+    case: dict[str, Any],
+    actual: dict[str, Any],
+    *,
+    result_schema: dict[str, Any] | None = None,
+    plan_schema: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    reject_execution_intent(case)
+    result_schema = result_schema or load_document(
+        DEFAULT_FIXTURE_ROOT / "result.schema.json"
+    )
+    plan_schema = plan_schema or load_document(
+        REPO_ROOT / "code" / "specs" / "schemas" / "build-plan-v1.schema.json"
+    )
+    _validate_result_shape(
+        case,
+        actual,
+        result_schema=result_schema,
+        plan_schema=plan_schema,
+        code="RESULT_SCHEMA_INVALID",
+    )
+    canonical_actual = canonicalize_result(actual)
+    canonical_expected = canonicalize_result(case["expected"])
+    if canonical_actual != canonical_expected:
+        raise ConformanceError(
+            "RESULT_MISMATCH",
+            "canonical adapter result does not match the fixture oracle",
+        )
+    return canonical_actual
+
+
+def validate_case_document(
+    case: dict[str, Any],
+    *,
+    case_schema: dict[str, Any],
+    result_schema: dict[str, Any],
+    plan_schema: dict[str, Any],
+) -> list[WorkspaceFile]:
+    reject_execution_intent(case)
+    _validate_schema(case, case_schema, "CASE_SCHEMA_INVALID")
+    _validate_case_identity(case)
+    _validate_input_paths(case)
+    staged_files = preflight_workspace(case)
+    _validate_result_shape(
+        case,
+        case["expected"],
+        result_schema=result_schema,
+        plan_schema=plan_schema,
+        code="EXPECTED_SCHEMA_INVALID",
+    )
+    expected = case["expected"]
+    if expected["outcome"] in {"unsupported", "skipped"}:
+        if not expected["diagnostics"]:
+            raise ConformanceError(
+                "EXPECTED_DIAGNOSTIC_MISSING",
+                f"{expected['outcome']} requires a diagnostic",
+            )
+    if expected != canonicalize_result(expected):
+        raise ConformanceError(
+            "EXPECTED_NOT_CANONICAL",
+            "checked-in expected result is not canonically ordered",
+        )
+    return staged_files
+
+
+def _validate_manifest(
+    manifest: dict[str, Any],
+    schema: dict[str, Any],
+) -> dict[str, int]:
+    _validate_schema(manifest, schema, "MANIFEST_SCHEMA_INVALID")
+    implementations = manifest["implementations"]
+    languages = [item["language"] for item in implementations]
+    if languages != sorted(languages):
+        raise ConformanceError(
+            "MANIFEST_NOT_CANONICAL",
+            "implementations must be sorted by language",
+        )
+    if len(languages) != len(set(languages)):
+        raise ConformanceError(
+            "MANIFEST_LANGUAGE_DUPLICATE",
+            "implementation languages must be unique",
+        )
+    established = {
+        item["language"]
+        for item in implementations
+        if item["lane_status"] == "established"
+    }
+    if established != set(ESTABLISHED_LANGUAGES):
+        raise ConformanceError(
+            "MANIFEST_ESTABLISHED_SET",
+            "manifest must contain exactly the established language registry",
+        )
+    by_language = {item["language"]: item for item in implementations}
+    for item in implementations:
+        status_value = item["implementation_status"]
+        front_door = item["front_door"]
+        capabilities = item["capabilities"]
+        if capabilities != sorted(capabilities):
+            raise ConformanceError(
+                "MANIFEST_CAPABILITIES_NOT_CANONICAL",
+                f"capabilities are not sorted for {item['language']}",
+            )
+        if status_value == "missing":
+            if front_door is not None or capabilities:
+                raise ConformanceError(
+                    "MANIFEST_MISSING_HAS_IMPLEMENTATION",
+                    f"missing implementation has a front door: {item['language']}",
+                )
+        else:
+            if not isinstance(front_door, str):
+                raise ConformanceError(
+                    "MANIFEST_FRONT_DOOR_MISSING",
+                    f"implementation has no front door: {item['language']}",
+                )
+            if error := portable_path_error(front_door):
+                raise ConformanceError(
+                    "MANIFEST_FRONT_DOOR_UNSAFE",
+                    f"unsafe front door for {item['language']}: {error}",
+                )
+            if not (REPO_ROOT / front_door).is_dir():
+                raise ConformanceError(
+                    "MANIFEST_FRONT_DOOR_ABSENT",
+                    f"front door does not exist: {front_door}",
+                )
+        if status_value == "shared_engine":
+            shared_engine = item["shared_engine"]
+            if (
+                not isinstance(shared_engine, str)
+                or shared_engine not in by_language
+                or shared_engine == item["language"]
+            ):
+                raise ConformanceError(
+                    "MANIFEST_SHARED_ENGINE_INVALID",
+                    f"invalid shared engine for {item['language']}",
+                )
+        elif item["shared_engine"] is not None:
+            raise ConformanceError(
+                "MANIFEST_SHARED_ENGINE_UNEXPECTED",
+                f"unexpected shared engine for {item['language']}",
+            )
+    return {
+        "implementation_count": len(implementations),
+        "established_languages": len(established),
+        "front_door_count": sum(
+            item["implementation_status"] in {"present", "shared_engine"}
+            for item in implementations
+        ),
+        "adapter_ready_count": sum(
+            item["adapter_status"] == "ready"
+            for item in implementations
+        ),
+    }
+
+
+def validate_corpus(
+    fixture_root: Path = DEFAULT_FIXTURE_ROOT,
+) -> dict[str, Any]:
+    fixture_root = fixture_root.resolve()
+    case_schema = load_document(fixture_root / "schema.json")
+    result_schema = load_document(fixture_root / "result.schema.json")
+    manifest_schema = load_document(
+        fixture_root / "implementations.schema.json"
+    )
+    manifest = load_document(fixture_root / "implementations.json")
+    plan_schema = load_document(
+        REPO_ROOT / "code" / "specs" / "schemas" / "build-plan-v1.schema.json"
+    )
+    manifest_summary = _validate_manifest(manifest, manifest_schema)
+
+    case_paths = sorted((fixture_root / "cases").glob("*.json"))
+    if not case_paths:
+        raise ConformanceError(
+            "CORPUS_EMPTY",
+            "the conformance corpus contains no cases",
+        )
+    case_ids: set[str] = set()
+    domains: set[str] = set()
+    materialized_files = 0
+    for case_path in case_paths:
+        case = load_document(case_path)
+        if case.get("id") in case_ids:
+            raise ConformanceError(
+                "CORPUS_CASE_ID_DUPLICATE",
+                f"duplicate corpus case id: {case.get('id')}",
+            )
+        staged_files = validate_case_document(
+            case,
+            case_schema=case_schema,
+            result_schema=result_schema,
+            plan_schema=plan_schema,
+        )
+        with materialized_workspace(case):
+            pass
+        case_ids.add(case["id"])
+        domains.add(case["domain"])
+        materialized_files += len(staged_files)
+
+    return {
+        "schema_version": 1,
+        "case_count": len(case_paths),
+        "implementation_count": manifest_summary["implementation_count"],
+        "established_languages": manifest_summary["established_languages"],
+        "front_door_count": manifest_summary["front_door_count"],
+        "adapter_ready_count": manifest_summary["adapter_ready_count"],
+        "conformance_run_count": 0,
+        "conformance_status": "not-run",
+        "execution_case_count": 0,
+        "materialized_file_count": materialized_files,
+        "domains": sorted(domains),
+        "status": "valid",
+    }
+
+
+def validate_result_files(case_path: Path, result_path: Path) -> dict[str, Any]:
+    case = load_document(case_path)
+    reject_execution_intent(case)
+    result = load_document(result_path, max_bytes=MAX_RESULT_BYTES)
+    case_schema = load_document(DEFAULT_FIXTURE_ROOT / "schema.json")
+    result_schema = load_document(DEFAULT_FIXTURE_ROOT / "result.schema.json")
+    plan_schema = load_document(
+        REPO_ROOT / "code" / "specs" / "schemas" / "build-plan-v1.schema.json"
+    )
+    validate_case_document(
+        case,
+        case_schema=case_schema,
+        result_schema=result_schema,
+        plan_schema=plan_schema,
+    )
+    return assert_result_matches(
+        case,
+        result,
+        result_schema=result_schema,
+        plan_schema=plan_schema,
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate build-tool conformance fixtures and results."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    corpus_parser = subparsers.add_parser(
+        "validate-corpus",
+        help="Validate and safely materialize the non-execution corpus.",
+    )
+    corpus_parser.add_argument(
+        "--fixture-root",
+        type=Path,
+        default=DEFAULT_FIXTURE_ROOT,
+    )
+
+    result_parser = subparsers.add_parser(
+        "validate-result",
+        help="Compare an externally produced result with one fixture.",
+    )
+    result_parser.add_argument("--case", type=Path, required=True)
+    result_parser.add_argument("--result", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    try:
+        arguments = parser.parse_args(argv)
+    except SystemExit as error:
+        return int(error.code)
+    try:
+        if arguments.command == "validate-corpus":
+            output = validate_corpus(arguments.fixture_root)
+        else:
+            canonical = validate_result_files(
+                arguments.case,
+                arguments.result,
+            )
+            output = {
+                "case_id": canonical["case_id"],
+                "domain": canonical["domain"],
+                "status": "pass",
+            }
+    except ConformanceError as error:
+        print(
+            json.dumps(
+                {
+                    "code": error.code,
+                    "message": error.message,
+                    "status": "error",
+                },
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 1 if error.code == "RESULT_MISMATCH" else 2
+
+    print(json.dumps(output, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/tests/test_build_tool_conformance_runner.py
+++ b/code/scripts/tests/test_build_tool_conformance_runner.py
@@ -45,6 +45,19 @@ class StrictJsonTests(unittest.TestCase):
             with self.subTest(code=code):
                 self.assert_parse_error(raw, code)
 
+    def test_rejects_invalid_utf8_syntax_delimiters_and_top_level_values(
+        self,
+    ) -> None:
+        cases = {
+            b'{"value":"\xff"}': "JSON_UTF8_INVALID",
+            b"}": "JSON_SYNTAX_INVALID",
+            b'{"value":': "JSON_SYNTAX_INVALID",
+            b"[]": "JSON_TOP_LEVEL_INVALID",
+        }
+        for raw, code in cases.items():
+            with self.subTest(code=code):
+                self.assert_parse_error(raw, code)
+
     def test_rejects_moderate_and_extreme_depth_with_the_same_code(self) -> None:
         for depth in (65, 1100):
             raw = b'{"value":' + (b"[" * depth) + b"0" + (b"]" * depth) + b"}"
@@ -56,6 +69,18 @@ class StrictJsonTests(unittest.TestCase):
             runner.strict_load_bytes(b'{"value":"oversized"}', max_bytes=8)
         self.assertEqual(raised.exception.code, "JSON_INPUT_TOO_LARGE")
 
+    def test_load_document_reports_missing_files(self) -> None:
+        with self.assertRaises(runner.ConformanceError) as raised:
+            runner.load_document(Path("definitely-not-present.json"))
+        self.assertEqual(raised.exception.code, "DOCUMENT_READ_FAILED")
+
+    def test_portable_path_validation_covers_canonical_edge_cases(self) -> None:
+        self.assertIsNotNone(runner.portable_path_error(None))
+        self.assertIsNotNone(runner.portable_path_error("a" * 513))
+        self.assertIsNotNone(runner.portable_path_error("fixtures/e\u0301.txt"))
+        self.assertIsNotNone(runner.portable_path_error("fixtures/name."))
+        self.assertIsNone(runner.portable_path_error("fixtures/.hidden"))
+
 
 class CorpusTests(unittest.TestCase):
     def test_checked_in_corpus_and_manifest_validate(self) -> None:
@@ -66,6 +91,10 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(summary["implementation_count"], 16)
         self.assertEqual(summary["established_languages"], 15)
         self.assertEqual(summary["execution_case_count"], 0)
+        self.assertEqual(summary["front_door_count"], 12)
+        self.assertEqual(summary["adapter_ready_count"], 0)
+        self.assertEqual(summary["conformance_run_count"], 0)
+        self.assertEqual(summary["conformance_status"], "not-run")
         self.assertEqual(
             summary["domains"],
             ["discovery", "graph", "plan", "resolution"],
@@ -160,6 +189,19 @@ class ExecutionDenialTests(unittest.TestCase):
         trusted_capability["capabilities"].append("trusted_execution")
         self.assert_denied_before_side_effects(trusted_capability)
 
+    def test_validate_result_rejects_execution_before_reading_the_result(
+        self,
+    ) -> None:
+        case = load_case("discovery-windows-override.json")
+        case["domain"] = "execution"
+        with tempfile.TemporaryDirectory() as directory:
+            case_path = Path(directory) / "case.json"
+            case_path.write_text(json.dumps(case), encoding="utf-8")
+            missing_result = Path(directory) / "missing-result.json"
+            with self.assertRaises(runner.ConformanceError) as raised:
+                runner.validate_result_files(case_path, missing_result)
+        self.assertEqual(raised.exception.code, "EXECUTION_DISABLED")
+
 
 class MaterializationTests(unittest.TestCase):
     def test_materializes_exact_regular_files_and_cleans_up(self) -> None:
@@ -198,7 +240,8 @@ class MaterializationTests(unittest.TestCase):
             mock.patch.object(runner.tempfile, "TemporaryDirectory") as temporary,
             self.assertRaises(runner.ConformanceError) as raised,
         ):
-            runner.materialized_workspace(invalid)
+            with runner.materialized_workspace(invalid):
+                pass
         self.assertEqual(raised.exception.code, "WORKSPACE_BASE64_NONCANONICAL")
         temporary.assert_not_called()
 
@@ -208,9 +251,36 @@ class MaterializationTests(unittest.TestCase):
             mock.patch.object(runner.tempfile, "TemporaryDirectory") as temporary,
             self.assertRaises(runner.ConformanceError) as raised,
         ):
-            runner.materialized_workspace(oversized)
+            with runner.materialized_workspace(oversized):
+                pass
         self.assertEqual(raised.exception.code, "WORKSPACE_BYTE_LIMIT")
         temporary.assert_not_called()
+
+        malformed = load_case("discovery-simple.json")
+        malformed["workspace"]["files"][0] = {
+            "path": "code/packages/python/demo/BUILD",
+            "content_base64": "not base64!",
+        }
+        with self.assertRaises(runner.ConformanceError) as raised:
+            runner.preflight_workspace(malformed)
+        self.assertEqual(raised.exception.code, "WORKSPACE_BASE64_INVALID")
+
+    def test_malformed_workspace_shapes_are_rejected(self) -> None:
+        base = load_case("discovery-simple.json")
+        for workspace, code in (
+            ({}, "WORKSPACE_FILES_INVALID"),
+            ({"files": ["not-an-object"]}, "WORKSPACE_FILE_INVALID"),
+            (
+                {"files": [{"path": "fixtures/no-content"}]},
+                "WORKSPACE_CONTENT_MISSING",
+            ),
+        ):
+            case = copy.deepcopy(base)
+            case["workspace"] = workspace
+            with self.subTest(code=code):
+                with self.assertRaises(runner.ConformanceError) as raised:
+                    runner.preflight_workspace(case)
+                self.assertEqual(raised.exception.code, code)
 
     def test_path_aliases_collisions_and_prefix_conflicts_fail_preflight(self) -> None:
         base = load_case("discovery-simple.json")
@@ -234,7 +304,8 @@ class MaterializationTests(unittest.TestCase):
                     ) as temporary,
                     self.assertRaises(runner.ConformanceError) as raised,
                 ):
-                    runner.materialized_workspace(case)
+                    with runner.materialized_workspace(case):
+                        pass
                 self.assertEqual(raised.exception.code, "WORKSPACE_PATH_UNSAFE")
                 temporary.assert_not_called()
 
@@ -289,7 +360,10 @@ class ResultValidationTests(unittest.TestCase):
     def test_result_mismatch_and_identity_mismatch_are_distinct(self) -> None:
         case = load_case("graph-diamond.json")
         mismatch = copy.deepcopy(case["expected"])
-        mismatch["result"]["levels"] = [["python/a"]]
+        mismatch["result"]["edges"][0] = [
+            "python/pkg-a",
+            "python/pkg-b",
+        ]
         with self.assertRaises(runner.ConformanceError) as raised:
             runner.assert_result_matches(case, mismatch)
         self.assertEqual(raised.exception.code, "RESULT_MISMATCH")
@@ -299,6 +373,37 @@ class ResultValidationTests(unittest.TestCase):
         with self.assertRaises(runner.ConformanceError) as raised:
             runner.assert_result_matches(case, wrong_identity)
         self.assertEqual(raised.exception.code, "RESULT_CASE_ID_MISMATCH")
+
+    def test_plan_semantics_reject_unknown_references_and_duplicate_names(
+        self,
+    ) -> None:
+        case = load_case("plan-affected-empty.json")
+
+        duplicate = copy.deepcopy(case["expected"])
+        duplicate_package = copy.deepcopy(
+            duplicate["result"]["plan"]["packages"][0]
+        )
+        duplicate_package["build_commands"] = ["different"]
+        duplicate["result"]["plan"]["packages"].append(duplicate_package)
+        with self.assertRaises(runner.ConformanceError) as raised:
+            runner.assert_result_matches(case, duplicate)
+        self.assertEqual(raised.exception.code, "RESULT_PLAN_PACKAGE_DUPLICATE")
+
+        unknown_edge = copy.deepcopy(case["expected"])
+        unknown_edge["result"]["plan"]["dependency_edges"] = [
+            ["python/missing", "python/pkg-a"]
+        ]
+        with self.assertRaises(runner.ConformanceError) as raised:
+            runner.assert_result_matches(case, unknown_edge)
+        self.assertEqual(raised.exception.code, "RESULT_PLAN_EDGE_UNKNOWN")
+
+        unknown_affected = copy.deepcopy(case["expected"])
+        unknown_affected["result"]["plan"]["affected_packages"] = [
+            "python/missing"
+        ]
+        with self.assertRaises(runner.ConformanceError) as raised:
+            runner.assert_result_matches(case, unknown_affected)
+        self.assertEqual(raised.exception.code, "RESULT_PLAN_AFFECTED_UNKNOWN")
 
     def test_validate_result_uses_the_bounded_parser_for_result_bytes(self) -> None:
         case_path = CASES_ROOT / "graph-diamond.json"
@@ -356,6 +461,31 @@ class CommandLineTests(unittest.TestCase):
         with redirect_stderr(stderr):
             exit_code = runner.main(["validate-corpus", "--allow-execution"])
         self.assertEqual(exit_code, 2)
+
+    def test_result_mismatch_is_a_conformance_exit_not_an_input_exit(self) -> None:
+        case_path = CASES_ROOT / "graph-diamond.json"
+        case = load_case(case_path.name)
+        mismatch = copy.deepcopy(case["expected"])
+        mismatch["result"]["edges"][0] = [
+            "python/pkg-a",
+            "python/pkg-b",
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            result_path = Path(directory) / "result.json"
+            result_path.write_text(json.dumps(mismatch), encoding="utf-8")
+            stderr = io.StringIO()
+            with redirect_stderr(stderr):
+                exit_code = runner.main(
+                    [
+                        "validate-result",
+                        "--case",
+                        str(case_path),
+                        "--result",
+                        str(result_path),
+                    ]
+                )
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(json.loads(stderr.getvalue())["code"], "RESULT_MISMATCH")
 
 
 if __name__ == "__main__":

--- a/code/scripts/tests/test_build_tool_conformance_runner.py
+++ b/code/scripts/tests/test_build_tool_conformance_runner.py
@@ -260,6 +260,22 @@ class MaterializationTests(unittest.TestCase):
 
 
 class ResultValidationTests(unittest.TestCase):
+    def test_domain_result_schema_rejects_field_name_drift(self) -> None:
+        discovery = load_case("discovery-simple.json")
+        typo = copy.deepcopy(discovery["expected"])
+        package = typo["result"]["packages"][0]
+        package["buildfile"] = package.pop("build_file")
+        with self.assertRaises(runner.ConformanceError) as raised:
+            runner.assert_result_matches(discovery, typo)
+        self.assertEqual(raised.exception.code, "RESULT_SCHEMA_INVALID")
+
+        graph = load_case("graph-diamond.json")
+        extra = copy.deepcopy(graph["expected"])
+        extra["result"]["unexpected"] = []
+        with self.assertRaises(runner.ConformanceError) as raised:
+            runner.assert_result_matches(graph, extra)
+        self.assertEqual(raised.exception.code, "RESULT_SCHEMA_INVALID")
+
     def test_domain_aware_canonicalization_accepts_set_order_variation(self) -> None:
         case = load_case("graph-diamond.json")
         actual = copy.deepcopy(case["expected"])

--- a/code/scripts/tests/test_build_tool_conformance_runner.py
+++ b/code/scripts/tests/test_build_tool_conformance_runner.py
@@ -152,6 +152,34 @@ class CorpusTests(unittest.TestCase):
                 case_path.name,
             )
 
+    def test_unmodeled_domains_cannot_claim_bootstrap_success(self) -> None:
+        case = load_case("discovery-simple.json")
+        case["id"] = "diff-selection/unmodeled"
+        case["domain"] = "diff_selection"
+        case["capabilities"] = ["diff_selection"]
+        case["input"]["operation"] = "diff_selection"
+        case["expected"] = {
+            "schema_version": 1,
+            "case_id": "diff-selection/unmodeled",
+            "domain": "diff_selection",
+            "outcome": "ok",
+            "result": {"affected_packges": []},
+            "diagnostics": [],
+        }
+        with self.assertRaises(runner.ConformanceError) as raised:
+            runner.validate_case_document(
+                case,
+                case_schema=runner.load_document(FIXTURE_ROOT / "schema.json"),
+                result_schema=runner.load_document(
+                    FIXTURE_ROOT / "result.schema.json"
+                ),
+                plan_schema=runner.load_document(
+                    runner.REPO_ROOT
+                    / "code/specs/schemas/build-plan-v1.schema.json"
+                ),
+            )
+        self.assertEqual(raised.exception.code, "CASE_DOMAIN_UNMODELED")
+
 
 class ExecutionDenialTests(unittest.TestCase):
     def assert_denied_before_side_effects(self, case: dict[str, object]) -> None:

--- a/code/scripts/tests/test_build_tool_conformance_runner.py
+++ b/code/scripts/tests/test_build_tool_conformance_runner.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import copy
+import io
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import build_tool_conformance as runner  # noqa: E402
+
+
+FIXTURE_ROOT = runner.DEFAULT_FIXTURE_ROOT
+CASES_ROOT = FIXTURE_ROOT / "cases"
+
+
+def load_case(name: str) -> dict[str, object]:
+    return runner.load_document(CASES_ROOT / name)
+
+
+class StrictJsonTests(unittest.TestCase):
+    def assert_parse_error(self, raw: bytes, code: str) -> None:
+        with self.assertRaises(runner.ConformanceError) as raised:
+            runner.strict_load_bytes(raw)
+        self.assertEqual(raised.exception.code, code)
+
+    def test_rejects_ambiguous_and_nonportable_json(self) -> None:
+        cases = {
+            b'{"domain":"discovery","domain":"execution"}': "JSON_DUPLICATE_KEY",
+            b'{"value":NaN}': "JSON_NON_FINITE",
+            b'{"value":1.5}': "JSON_FLOAT_FORBIDDEN",
+            b'{"value":9007199254740992}': "JSON_INTEGER_RANGE",
+            b'{"value":"\\ud800"}': "JSON_UNICODE_SURROGATE",
+            b"\xef\xbb\xbf{}": "JSON_BOM_FORBIDDEN",
+        }
+        for raw, code in cases.items():
+            with self.subTest(code=code):
+                self.assert_parse_error(raw, code)
+
+    def test_rejects_moderate_and_extreme_depth_with_the_same_code(self) -> None:
+        for depth in (65, 1100):
+            raw = b'{"value":' + (b"[" * depth) + b"0" + (b"]" * depth) + b"}"
+            with self.subTest(depth=depth):
+                self.assert_parse_error(raw, "JSON_DEPTH_EXCEEDED")
+
+    def test_rejects_oversized_input_before_decoding(self) -> None:
+        with self.assertRaises(runner.ConformanceError) as raised:
+            runner.strict_load_bytes(b'{"value":"oversized"}', max_bytes=8)
+        self.assertEqual(raised.exception.code, "JSON_INPUT_TOO_LARGE")
+
+
+class CorpusTests(unittest.TestCase):
+    def test_checked_in_corpus_and_manifest_validate(self) -> None:
+        summary = runner.validate_corpus(FIXTURE_ROOT)
+
+        self.assertEqual(summary["schema_version"], 1)
+        self.assertEqual(summary["case_count"], 7)
+        self.assertEqual(summary["implementation_count"], 16)
+        self.assertEqual(summary["established_languages"], 15)
+        self.assertEqual(summary["execution_case_count"], 0)
+        self.assertEqual(
+            summary["domains"],
+            ["discovery", "graph", "plan", "resolution"],
+        )
+
+    def test_manifest_classifies_every_established_front_door(self) -> None:
+        manifest = runner.load_document(FIXTURE_ROOT / "implementations.json")
+        implementations = {
+            item["language"]: item for item in manifest["implementations"]
+        }
+        established = {
+            language
+            for language, item in implementations.items()
+            if item["lane_status"] == "established"
+        }
+        present = {
+            language
+            for language, item in implementations.items()
+            if item["implementation_status"] in {"present", "shared_engine"}
+        }
+        missing = {
+            language
+            for language, item in implementations.items()
+            if item["implementation_status"] == "missing"
+        }
+
+        self.assertEqual(established, set(runner.ESTABLISHED_LANGUAGES))
+        self.assertEqual(
+            present,
+            {
+                "csharp",
+                "elixir",
+                "fsharp",
+                "go",
+                "haskell",
+                "lua",
+                "perl",
+                "python",
+                "ruby",
+                "rust",
+                "swift",
+                "typescript",
+            },
+        )
+        self.assertEqual(missing, {"dart", "java", "kotlin", "ocaml"})
+        self.assertEqual(implementations["fsharp"]["shared_engine"], "csharp")
+        self.assertEqual(implementations["ocaml"]["lane_status"], "emerging")
+
+    def test_expected_results_are_checked_in_canonical_order(self) -> None:
+        for case_path in sorted(CASES_ROOT.glob("*.json")):
+            case = runner.load_document(case_path)
+            self.assertEqual(
+                case["expected"],
+                runner.canonicalize_result(case["expected"]),
+                case_path.name,
+            )
+
+
+class ExecutionDenialTests(unittest.TestCase):
+    def assert_denied_before_side_effects(self, case: dict[str, object]) -> None:
+        with (
+            mock.patch.object(runner.tempfile, "TemporaryDirectory") as temporary,
+            mock.patch.object(runner.base64, "b64decode") as decode,
+            mock.patch.object(runner.os, "chmod") as chmod,
+            mock.patch.object(subprocess, "run") as process,
+            self.assertRaises(runner.ConformanceError) as raised,
+        ):
+            runner.preflight_workspace(case)
+
+        self.assertEqual(raised.exception.code, "EXECUTION_DISABLED")
+        temporary.assert_not_called()
+        decode.assert_not_called()
+        chmod.assert_not_called()
+        process.assert_not_called()
+
+    def test_execution_intent_is_denied_in_every_routing_field(self) -> None:
+        base = load_case("discovery-windows-override.json")
+
+        domain = copy.deepcopy(base)
+        domain["domain"] = "execution"
+        self.assert_denied_before_side_effects(domain)
+
+        operation = copy.deepcopy(base)
+        operation["input"]["operation"] = "execution"
+        self.assert_denied_before_side_effects(operation)
+
+        execution_capability = copy.deepcopy(base)
+        execution_capability["capabilities"].append("execution")
+        self.assert_denied_before_side_effects(execution_capability)
+
+        trusted_capability = copy.deepcopy(base)
+        trusted_capability["capabilities"].append("trusted_execution")
+        self.assert_denied_before_side_effects(trusted_capability)
+
+
+class MaterializationTests(unittest.TestCase):
+    def test_materializes_exact_regular_files_and_cleans_up(self) -> None:
+        case = load_case("discovery-simple.json")
+        case["workspace"]["files"].append(
+            {
+                "path": "fixtures/space and & metacharacters.bin",
+                "content_base64": "AAEC/w==",
+            }
+        )
+
+        with runner.materialized_workspace(case) as root:
+            retained_root = root
+            self.assertEqual(
+                (root / "code/packages/python/demo/BUILD").read_bytes(),
+                b"python -m unittest discover tests\n",
+            )
+            self.assertEqual(
+                (root / "fixtures/space and & metacharacters.bin").read_bytes(),
+                b"\x00\x01\x02\xff",
+            )
+            for path in root.rglob("*"):
+                self.assertFalse(path.is_symlink())
+                if path.is_file():
+                    self.assertTrue(path.stat().st_mode & 0o100000)
+
+        self.assertFalse(retained_root.exists())
+
+    def test_invalid_base64_and_workspace_limit_fail_before_root_creation(self) -> None:
+        invalid = load_case("discovery-simple.json")
+        invalid["workspace"]["files"][0] = {
+            "path": "code/packages/python/demo/BUILD",
+            "content_base64": "AB==",
+        }
+        with (
+            mock.patch.object(runner.tempfile, "TemporaryDirectory") as temporary,
+            self.assertRaises(runner.ConformanceError) as raised,
+        ):
+            runner.materialized_workspace(invalid)
+        self.assertEqual(raised.exception.code, "WORKSPACE_BASE64_NONCANONICAL")
+        temporary.assert_not_called()
+
+        oversized = load_case("discovery-simple.json")
+        oversized["limits"]["workspace_bytes"] = 1
+        with (
+            mock.patch.object(runner.tempfile, "TemporaryDirectory") as temporary,
+            self.assertRaises(runner.ConformanceError) as raised,
+        ):
+            runner.materialized_workspace(oversized)
+        self.assertEqual(raised.exception.code, "WORKSPACE_BYTE_LIMIT")
+        temporary.assert_not_called()
+
+    def test_path_aliases_collisions_and_prefix_conflicts_fail_preflight(self) -> None:
+        base = load_case("discovery-simple.json")
+        unsafe_paths = (
+            "/absolute",
+            "C:/drive",
+            "//server/share",
+            "../escape",
+            "fixtures/CONIN$.txt",
+            "fixtures/CONOUT$.txt",
+            "fixtures/CLOCK$.txt",
+        )
+        for unsafe_path in unsafe_paths:
+            case = copy.deepcopy(base)
+            case["workspace"]["files"][0]["path"] = unsafe_path
+            with self.subTest(path=unsafe_path):
+                with (
+                    mock.patch.object(
+                        runner.tempfile,
+                        "TemporaryDirectory",
+                    ) as temporary,
+                    self.assertRaises(runner.ConformanceError) as raised,
+                ):
+                    runner.materialized_workspace(case)
+                self.assertEqual(raised.exception.code, "WORKSPACE_PATH_UNSAFE")
+                temporary.assert_not_called()
+
+        collision = copy.deepcopy(base)
+        collision["workspace"]["files"].append(
+            {
+                "path": "CODE/PACKAGES/PYTHON/DEMO/build",
+                "content_utf8": "collision\n",
+            }
+        )
+        with self.assertRaises(runner.ConformanceError) as raised:
+            runner.preflight_workspace(collision)
+        self.assertEqual(raised.exception.code, "WORKSPACE_PATH_COLLISION")
+
+        prefix = copy.deepcopy(base)
+        prefix["workspace"]["files"] = [
+            {"path": "fixtures/data", "content_utf8": "file\n"},
+            {"path": "fixtures/data/child", "content_utf8": "child\n"},
+        ]
+        with self.assertRaises(runner.ConformanceError) as raised:
+            runner.preflight_workspace(prefix)
+        self.assertEqual(raised.exception.code, "WORKSPACE_PATH_PREFIX_CONFLICT")
+
+
+class ResultValidationTests(unittest.TestCase):
+    def test_domain_aware_canonicalization_accepts_set_order_variation(self) -> None:
+        case = load_case("graph-diamond.json")
+        actual = copy.deepcopy(case["expected"])
+        actual["result"]["edges"].reverse()
+        actual["result"]["levels"][1].reverse()
+
+        canonical = runner.assert_result_matches(case, actual)
+
+        self.assertEqual(canonical, case["expected"])
+
+    def test_result_mismatch_and_identity_mismatch_are_distinct(self) -> None:
+        case = load_case("graph-diamond.json")
+        mismatch = copy.deepcopy(case["expected"])
+        mismatch["result"]["levels"] = [["python/a"]]
+        with self.assertRaises(runner.ConformanceError) as raised:
+            runner.assert_result_matches(case, mismatch)
+        self.assertEqual(raised.exception.code, "RESULT_MISMATCH")
+
+        wrong_identity = copy.deepcopy(case["expected"])
+        wrong_identity["case_id"] = "graph/not-this-case"
+        with self.assertRaises(runner.ConformanceError) as raised:
+            runner.assert_result_matches(case, wrong_identity)
+        self.assertEqual(raised.exception.code, "RESULT_CASE_ID_MISMATCH")
+
+    def test_validate_result_uses_the_bounded_parser_for_result_bytes(self) -> None:
+        case_path = CASES_ROOT / "graph-diamond.json"
+        with tempfile.TemporaryDirectory() as directory:
+            result_path = Path(directory) / "result.json"
+            result_path.write_bytes(
+                b'{"schema_version":1,"case_id":"graph/diamond",'
+                b'"domain":"graph","outcome":"ok","result":'
+                + (b"[" * 1100)
+                + b"0"
+                + (b"]" * 1100)
+                + b',"diagnostics":[]}'
+            )
+            with self.assertRaises(runner.ConformanceError) as raised:
+                runner.validate_result_files(case_path, result_path)
+        self.assertEqual(raised.exception.code, "JSON_DEPTH_EXCEEDED")
+
+
+class CommandLineTests(unittest.TestCase):
+    def test_validate_corpus_prints_a_machine_readable_summary(self) -> None:
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            exit_code = runner.main(
+                ["validate-corpus", "--fixture-root", str(FIXTURE_ROOT)]
+            )
+
+        self.assertEqual(exit_code, 0)
+        summary = json.loads(stdout.getvalue())
+        self.assertEqual(summary["case_count"], 7)
+
+    def test_validate_result_reports_match_and_rejects_execution_override(self) -> None:
+        case_path = CASES_ROOT / "graph-diamond.json"
+        case = load_case(case_path.name)
+        with tempfile.TemporaryDirectory() as directory:
+            result_path = Path(directory) / "result.json"
+            result_path.write_text(
+                json.dumps(case["expected"]),
+                encoding="utf-8",
+            )
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                exit_code = runner.main(
+                    [
+                        "validate-result",
+                        "--case",
+                        str(case_path),
+                        "--result",
+                        str(result_path),
+                    ]
+                )
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(json.loads(stdout.getvalue())["status"], "pass")
+
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            exit_code = runner.main(["validate-corpus", "--allow-execution"])
+        self.assertEqual(exit_code, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/scripts/tests/test_build_tool_conformance_runner.py
+++ b/code/scripts/tests/test_build_tool_conformance_runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import io
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -74,12 +75,52 @@ class StrictJsonTests(unittest.TestCase):
             runner.load_document(Path("definitely-not-present.json"))
         self.assertEqual(raised.exception.code, "DOCUMENT_READ_FAILED")
 
+    def test_load_document_bounds_the_file_read_and_rejects_links(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            oversized = root / "oversized.json"
+            oversized.write_bytes(b'{"value":"' + (b"x" * 100) + b'"}')
+            with self.assertRaises(runner.ConformanceError) as raised:
+                runner.load_document(oversized, max_bytes=16)
+            self.assertEqual(raised.exception.code, "JSON_INPUT_TOO_LARGE")
+
+            target = root / "target.json"
+            target.write_text("{}", encoding="utf-8")
+            link = root / "link.json"
+            try:
+                link.symlink_to(target)
+            except OSError:
+                return
+            with self.assertRaises(runner.ConformanceError) as raised:
+                runner.load_document(link)
+            self.assertIn(
+                raised.exception.code,
+                {"DOCUMENT_READ_FAILED", "DOCUMENT_TYPE_INVALID"},
+            )
+
     def test_portable_path_validation_covers_canonical_edge_cases(self) -> None:
         self.assertIsNotNone(runner.portable_path_error(None))
         self.assertIsNotNone(runner.portable_path_error("a" * 513))
         self.assertIsNotNone(runner.portable_path_error("fixtures/e\u0301.txt"))
         self.assertIsNotNone(runner.portable_path_error("fixtures/name."))
+        self.assertIsNotNone(runner.portable_path_error("fixtures/COM¹.txt"))
+        self.assertIsNotNone(runner.portable_path_error("fixtures/LPT².txt"))
         self.assertIsNone(runner.portable_path_error("fixtures/.hidden"))
+
+    def test_schema_validation_never_retrieves_external_references(self) -> None:
+        for keyword in ("$ref", "$dynamicRef"):
+            schema = {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                keyword: "http://127.0.0.1:9/schema.json",
+            }
+            with (
+                self.subTest(keyword=keyword),
+                mock.patch("urllib.request.urlopen") as retrieve,
+                self.assertRaises(runner.ConformanceError) as raised,
+            ):
+                runner._schema_errors({}, schema)
+            self.assertEqual(raised.exception.code, "SCHEMA_REFERENCE_FORBIDDEN")
+            retrieve.assert_not_called()
 
 
 class CorpusTests(unittest.TestCase):
@@ -180,13 +221,30 @@ class CorpusTests(unittest.TestCase):
             )
         self.assertEqual(raised.exception.code, "CASE_DOMAIN_UNMODELED")
 
+    def test_malformed_capabilities_fail_schema_validation_not_routing(self) -> None:
+        case = load_case("discovery-simple.json")
+        case["capabilities"] = [{"execution": False}]
+        with self.assertRaises(runner.ConformanceError) as raised:
+            runner.validate_case_document(
+                case,
+                case_schema=runner.load_document(FIXTURE_ROOT / "schema.json"),
+                result_schema=runner.load_document(
+                    FIXTURE_ROOT / "result.schema.json"
+                ),
+                plan_schema=runner.load_document(
+                    runner.REPO_ROOT
+                    / "code/specs/schemas/build-plan-v1.schema.json"
+                ),
+            )
+        self.assertEqual(raised.exception.code, "CASE_SCHEMA_INVALID")
+
 
 class ExecutionDenialTests(unittest.TestCase):
     def assert_denied_before_side_effects(self, case: dict[str, object]) -> None:
         with (
-            mock.patch.object(runner.tempfile, "TemporaryDirectory") as temporary,
+            mock.patch.object(tempfile, "TemporaryDirectory") as temporary,
             mock.patch.object(runner.base64, "b64decode") as decode,
-            mock.patch.object(runner.os, "chmod") as chmod,
+            mock.patch.object(os, "chmod") as chmod,
             mock.patch.object(subprocess, "run") as process,
             self.assertRaises(runner.ConformanceError) as raised,
         ):
@@ -231,8 +289,8 @@ class ExecutionDenialTests(unittest.TestCase):
         self.assertEqual(raised.exception.code, "EXECUTION_DISABLED")
 
 
-class MaterializationTests(unittest.TestCase):
-    def test_materializes_exact_regular_files_and_cleans_up(self) -> None:
+class WorkspacePreflightTests(unittest.TestCase):
+    def test_decodes_exact_files_without_creating_a_workspace(self) -> None:
         case = load_case("discovery-simple.json")
         case["workspace"]["files"].append(
             {
@@ -241,22 +299,24 @@ class MaterializationTests(unittest.TestCase):
             }
         )
 
-        with runner.materialized_workspace(case) as root:
-            retained_root = root
-            self.assertEqual(
-                (root / "code/packages/python/demo/BUILD").read_bytes(),
-                b"python -m unittest discover tests\n",
-            )
-            self.assertEqual(
-                (root / "fixtures/space and & metacharacters.bin").read_bytes(),
-                b"\x00\x01\x02\xff",
-            )
-            for path in root.rglob("*"):
-                self.assertFalse(path.is_symlink())
-                if path.is_file():
-                    self.assertTrue(path.stat().st_mode & 0o100000)
+        with mock.patch.object(
+            tempfile,
+            "TemporaryDirectory",
+        ) as temporary:
+            staged = {
+                entry.path: entry.content
+                for entry in runner.preflight_workspace(case)
+            }
 
-        self.assertFalse(retained_root.exists())
+        temporary.assert_not_called()
+        self.assertEqual(
+            staged["code/packages/python/demo/BUILD"],
+            b"python -m unittest discover tests\n",
+        )
+        self.assertEqual(
+            staged["fixtures/space and & metacharacters.bin"],
+            b"\x00\x01\x02\xff",
+        )
 
     def test_invalid_base64_and_workspace_limit_fail_before_root_creation(self) -> None:
         invalid = load_case("discovery-simple.json")
@@ -265,22 +325,20 @@ class MaterializationTests(unittest.TestCase):
             "content_base64": "AB==",
         }
         with (
-            mock.patch.object(runner.tempfile, "TemporaryDirectory") as temporary,
+            mock.patch.object(tempfile, "TemporaryDirectory") as temporary,
             self.assertRaises(runner.ConformanceError) as raised,
         ):
-            with runner.materialized_workspace(invalid):
-                pass
+            runner.preflight_workspace(invalid)
         self.assertEqual(raised.exception.code, "WORKSPACE_BASE64_NONCANONICAL")
         temporary.assert_not_called()
 
         oversized = load_case("discovery-simple.json")
         oversized["limits"]["workspace_bytes"] = 1
         with (
-            mock.patch.object(runner.tempfile, "TemporaryDirectory") as temporary,
+            mock.patch.object(tempfile, "TemporaryDirectory") as temporary,
             self.assertRaises(runner.ConformanceError) as raised,
         ):
-            with runner.materialized_workspace(oversized):
-                pass
+            runner.preflight_workspace(oversized)
         self.assertEqual(raised.exception.code, "WORKSPACE_BYTE_LIMIT")
         temporary.assert_not_called()
 
@@ -327,13 +385,12 @@ class MaterializationTests(unittest.TestCase):
             with self.subTest(path=unsafe_path):
                 with (
                     mock.patch.object(
-                        runner.tempfile,
+                        tempfile,
                         "TemporaryDirectory",
                     ) as temporary,
                     self.assertRaises(runner.ConformanceError) as raised,
                 ):
-                    with runner.materialized_workspace(case):
-                        pass
+                    runner.preflight_workspace(case)
                 self.assertEqual(raised.exception.code, "WORKSPACE_PATH_UNSAFE")
                 temporary.assert_not_called()
 
@@ -449,6 +506,19 @@ class ResultValidationTests(unittest.TestCase):
                 runner.validate_result_files(case_path, result_path)
         self.assertEqual(raised.exception.code, "JSON_DEPTH_EXCEEDED")
 
+    def test_validate_result_enforces_the_case_output_limit(self) -> None:
+        case_path = CASES_ROOT / "graph-diamond.json"
+        case = load_case(case_path.name)
+        payload = json.dumps(case["expected"]).encode("utf-8")
+        output_limit = case["limits"]["output_bytes"]
+        oversized = (b" " * (output_limit + 1 - len(payload))) + payload
+        with tempfile.TemporaryDirectory() as directory:
+            result_path = Path(directory) / "result.json"
+            result_path.write_bytes(oversized)
+            with self.assertRaises(runner.ConformanceError) as raised:
+                runner.validate_result_files(case_path, result_path)
+        self.assertEqual(raised.exception.code, "JSON_INPUT_TOO_LARGE")
+
 
 class CommandLineTests(unittest.TestCase):
     def test_validate_corpus_prints_a_machine_readable_summary(self) -> None:
@@ -483,7 +553,9 @@ class CommandLineTests(unittest.TestCase):
                     ]
                 )
             self.assertEqual(exit_code, 0)
-            self.assertEqual(json.loads(stdout.getvalue())["status"], "pass")
+            result = json.loads(stdout.getvalue())
+            self.assertEqual(result["status"], "matched")
+            self.assertEqual(result["conformance_status"], "pass")
 
         stderr = io.StringIO()
         with redirect_stderr(stderr):
@@ -514,6 +586,47 @@ class CommandLineTests(unittest.TestCase):
                 )
         self.assertEqual(exit_code, 1)
         self.assertEqual(json.loads(stderr.getvalue())["code"], "RESULT_MISMATCH")
+
+    def test_matching_unsupported_result_is_never_reported_as_passing(self) -> None:
+        case = load_case("discovery-simple.json")
+        case["id"] = "discovery/unsupported"
+        case["expected"] = {
+            "schema_version": 1,
+            "case_id": "discovery/unsupported",
+            "domain": "discovery",
+            "outcome": "unsupported",
+            "result": {},
+            "diagnostics": [
+                {
+                    "code": "DISCOVERY_UNSUPPORTED",
+                    "severity": "error",
+                }
+            ],
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            case_path = Path(directory) / "case.json"
+            result_path = Path(directory) / "result.json"
+            case_path.write_text(json.dumps(case), encoding="utf-8")
+            result_path.write_text(
+                json.dumps(case["expected"]),
+                encoding="utf-8",
+            )
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                exit_code = runner.main(
+                    [
+                        "validate-result",
+                        "--case",
+                        str(case_path),
+                        "--result",
+                        str(result_path),
+                    ]
+                )
+        result = json.loads(stdout.getvalue())
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(result["status"], "matched")
+        self.assertEqual(result["conformance_status"], "non-passing")
+        self.assertEqual(result["outcome"], "unsupported")
 
 
 if __name__ == "__main__":

--- a/code/scripts/tests/test_build_tool_conformance_schema.py
+++ b/code/scripts/tests/test_build_tool_conformance_schema.py
@@ -13,7 +13,7 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[3]
 FIXTURE_ROOT = ROOT / "code" / "specs" / "fixtures" / "build-tool-v1"
 SCHEMA_PATH = FIXTURE_ROOT / "schema.json"
-EXAMPLE_ROOT = FIXTURE_ROOT / "examples"
+EXAMPLE_ROOT = FIXTURE_ROOT / "cases"
 MAX_SAFE_INTEGER = 9_007_199_254_740_991
 RESERVED_ADAPTER_FLAGS = ("--conformance", "--workspace-root", "--output")
 DOMAIN_CAPABILITIES = {

--- a/code/specs/build-plan-v1.md
+++ b/code/specs/build-plan-v1.md
@@ -27,6 +27,11 @@ the build job skips straight to step 6 (hashing), saving time on each of the
 
 ## JSON Schema
 
+The machine-readable schema is checked in at
+[`schemas/build-plan-v1.schema.json`](schemas/build-plan-v1.schema.json). The
+embedded copy below remains explanatory; conformance runners validate against
+the checked-in schema.
+
 ```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -121,8 +121,8 @@ python code/scripts/build_tool_conformance.py validate-result \
 
 `validate-corpus` strictly parses and validates the implementation manifest,
 every case, every expected result, path semantics, corpus-wide identity
-uniqueness, canonical ordering, and bounded materialization of non-execution
-workspaces into runner-owned temporary directories.
+uniqueness, canonical ordering, and bounded in-memory decoding of non-execution
+workspaces. The bootstrap runner never stages fixture files on disk.
 
 `validate-result` strictly parses one case and one externally produced result,
 validates both against their schemas, verifies the echoed case identity and
@@ -133,8 +133,9 @@ tests before sandboxed process orchestration is enabled.
 Neither mode launches an adapter, invokes a shell, reads an executable command
 from a manifest, or runs fixture content. The bootstrap runner MUST reject any
 case whose domain, operation, or capabilities request execution before it
-creates a temporary directory, decodes file content, changes permissions, or
-uses a process API. There is no command-line flag that can weaken this rule.
+decodes file content or uses a process API. It MUST NOT create a temporary
+workspace or change filesystem permissions. There is no command-line flag that
+can weaken this rule.
 Trusted execution becomes a separate delivery gate only after the runner can
 enforce the complete filesystem, network, environment, and process-tree
 boundary in this contract.

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -108,6 +108,43 @@ before untrusted implementation code starts. The runner compares the adapter
 result with the fixture's `expected` object. Human-readable stdout and stderr
 are diagnostic only and are not conformance inputs.
 
+### Bootstrap runner modes
+
+The first runner tranche is deliberately non-executing. It provides two
+language-neutral validation modes:
+
+```text
+python code/scripts/build_tool_conformance.py validate-corpus
+python code/scripts/build_tool_conformance.py validate-result \
+  --case CASE.json --result RESULT.json
+```
+
+`validate-corpus` strictly parses and validates the implementation manifest,
+every case, every expected result, path semantics, corpus-wide identity
+uniqueness, canonical ordering, and bounded materialization of non-execution
+workspaces into runner-owned temporary directories.
+
+`validate-result` strictly parses one case and one externally produced result,
+validates both against their schemas, verifies the echoed case identity and
+domain, applies domain-aware canonicalization, and compares the result with the
+fixture oracle. This lets each language wire its adapter in its own package
+tests before sandboxed process orchestration is enabled.
+
+Neither mode launches an adapter, invokes a shell, reads an executable command
+from a manifest, or runs fixture content. The bootstrap runner MUST reject any
+case whose domain, operation, or capabilities request execution before it
+creates a temporary directory, decodes file content, changes permissions, or
+uses a process API. There is no command-line flag that can weaken this rule.
+Trusted execution becomes a separate delivery gate only after the runner can
+enforce the complete filesystem, network, environment, and process-tree
+boundary in this contract.
+
+The bootstrap implementation manifest is metadata, not an executable registry.
+It records every established language, emerging lanes under active review,
+front-door presence, shared-engine relationships, advertised capabilities, and
+reviewed expected failures. It MUST NOT contain adapter commands, environment
+assignments, or arbitrary argument vectors.
+
 ## Fixture manifest
 
 Each fixture is a single JSON document. Inline files make a case atomic and

--- a/code/specs/fixtures/build-tool-v1/CHANGELOG.md
+++ b/code/specs/fixtures/build-tool-v1/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 2026-07-29
+
+- Added the process-free bootstrap conformance runner.
+- Added standalone result, implementation-inventory, and build-plan schemas.
+- Added the 16-lane implementation inventory with 12 present front doors,
+  three missing established implementations, and emerging OCaml.
+- Added seven representative discovery, resolution, graph, and plan cases.
+- Added bounded parsing, two-phase pure workspace materialization,
+  domain-aware canonical comparison, and fail-closed execution rejection.

--- a/code/specs/fixtures/build-tool-v1/CHANGELOG.md
+++ b/code/specs/fixtures/build-tool-v1/CHANGELOG.md
@@ -7,5 +7,5 @@
 - Added the 16-lane implementation inventory with 12 present front doors,
   three missing established implementations, and emerging OCaml.
 - Added seven representative discovery, resolution, graph, and plan cases.
-- Added bounded parsing, two-phase pure workspace materialization,
+- Added bounded parsing, two-phase in-memory workspace preflight,
   domain-aware canonical comparison, and fail-closed execution rejection.

--- a/code/specs/fixtures/build-tool-v1/README.md
+++ b/code/specs/fixtures/build-tool-v1/README.md
@@ -1,45 +1,95 @@
 # Build-Tool Conformance Fixtures v1
 
-This directory contains the versioned, language-neutral fixture format defined
-by `code/specs/build-tool-conformance.md`.
+This directory is the versioned, language-neutral build-tool behavior oracle
+defined by `code/specs/build-tool-conformance.md`.
 
 ## Layout
 
 ```text
 build-tool-v1/
   schema.json
-  README.md
-  examples/
+  result.schema.json
+  implementations.schema.json
+  implementations.json
+  CHANGELOG.md
+  cases/
+    discovery-simple.json
     discovery-windows-override.json
+    graph-diamond.json
+    plan-affected-empty.json
+    plan-affected-null.json
+    plan-future-version.json
+    resolution-python-diamond.json
 ```
 
-The contract PR includes the schema and a non-executing example. The next
-fixture-runner work item will add the case corpus, adapter manifests, and runner.
+`implementations.json` inventories all 15 established language lanes plus the
+emerging OCaml lane. It records front-door and shared-engine state but contains
+no executable commands. Every adapter is currently marked missing, so a valid
+inventory is not reported as conformance success.
 
-Every case is one JSON document with:
+The bootstrap corpus covers:
 
-- an inline repository-shaped workspace;
-- one conformance domain operation;
-- one canonical expected result; and
-- requested resource limits that can only be tightened by runner policy.
+- canonical and Windows-override discovery;
+- the shared Python dependency diamond;
+- deterministic diamond graph levels;
+- the build-plan distinction between `affected_packages: null` and `[]`; and
+- fail-closed rejection of a future plan version.
 
-UTF-8 files use `content_utf8`. Binary files use strict padded
-`content_base64`. Fixtures cannot declare symlinks, directories, or special
-files.
+The build-plan payload is validated against
+`code/specs/schemas/build-plan-v1.schema.json`.
+
+## Runner
+
+Validate the complete corpus and inventory:
+
+```text
+python code/scripts/build_tool_conformance.py validate-corpus
+```
+
+Compare one externally produced adapter result with its fixture:
+
+```text
+python code/scripts/build_tool_conformance.py validate-result \
+  --case code/specs/fixtures/build-tool-v1/cases/graph-diamond.json \
+  --result path/to/result.json
+```
+
+Both commands use bounded strict JSON parsing, formal Draft 2020-12 validation,
+semantic path and identity checks, domain-aware result canonicalization, and
+stable error codes. `validate-corpus` also performs two-phase validation and
+temporary materialization of pure fixture workspaces so invalid base64, path
+aliases, collisions, prefix conflicts, and aggregate size violations fail
+before any root is created.
+
+## Security boundary
+
+This tranche is intentionally process-free:
+
+- it never launches an adapter or shell;
+- it never applies fixture environment data;
+- it never interprets manifest content as a command;
+- it rejects `execution` or `trusted_execution` intent before decoding files,
+  creating a temporary directory, changing permissions, or using a process
+  API; and
+- it has no flag that can enable execution.
+
+The temporary materializer is only a data-validation stage in a private
+runner-owned directory. Its output must not be handed to untrusted code.
+Adapter orchestration and execution fixtures remain blocked until the separate
+trusted-sandbox item implements atomic no-follow filesystem access, network
+isolation, a sanitized environment, direct argument vectors, and complete
+process-tree resource limits.
 
 ## Validation
-
-The repository self-test performs structural, formal Draft 2020-12, and
-adversarial checks. CI installs the pinned `jsonschema` validator before
-running it:
 
 ```text
 python -m unittest discover \
   -s code/scripts/tests \
   -p "test_build_tool_conformance_schema.py"
+python -m unittest discover \
+  -s code/scripts/tests \
+  -p "test_build_tool_conformance_runner.py"
 ```
 
-Schema validation does not make a fixture safe to execute. The future runner
-must enforce the sandbox, trust, containment, normalization, and hard-limit
-requirements in the conformance contract. In particular, a fixture's
-`trusted_execution` capability is a request and never authorizes execution.
+CI installs the pinned `jsonschema==4.26.0` validator before running both suites
+and the corpus validator.

--- a/code/specs/fixtures/build-tool-v1/README.md
+++ b/code/specs/fixtures/build-tool-v1/README.md
@@ -57,9 +57,9 @@ python code/scripts/build_tool_conformance.py validate-result \
 Both commands use bounded strict JSON parsing, formal Draft 2020-12 validation,
 semantic path and identity checks, domain-aware result canonicalization, and
 stable error codes. `validate-corpus` also performs two-phase validation and
-temporary materialization of pure fixture workspaces so invalid base64, path
+bounded in-memory decoding of pure fixture workspaces so invalid base64, path
 aliases, collisions, prefix conflicts, and aggregate size violations fail
-before any root is created.
+without creating a filesystem root.
 
 ## Security boundary
 
@@ -69,13 +69,11 @@ This tranche is intentionally process-free:
 - it never applies fixture environment data;
 - it never interprets manifest content as a command;
 - it rejects `execution` or `trusted_execution` intent before decoding files,
-  creating a temporary directory, changing permissions, or using a process
-  API; and
+  changing permissions, or using a process API; and
 - it has no flag that can enable execution.
 
-The temporary materializer is only a data-validation stage in a private
-runner-owned directory. Its output must not be handed to untrusted code.
-Adapter orchestration and execution fixtures remain blocked until the separate
+The bootstrap runner performs no workspace materialization. Adapter
+orchestration and execution fixtures remain blocked until the separate
 trusted-sandbox item implements atomic no-follow filesystem access, network
 isolation, a sanitized environment, direct argument vectors, and complete
 process-tree resource limits.

--- a/code/specs/fixtures/build-tool-v1/cases/discovery-simple.json
+++ b/code/specs/fixtures/build-tool-v1/cases/discovery-simple.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
-  "id": "discovery/windows-override",
+  "id": "discovery/simple",
   "domain": "discovery",
-  "summary": "A Windows shell override wins over generic and Starlark BUILD content.",
+  "summary": "A canonical BUILD file establishes one Python package.",
   "platforms": [
     "darwin",
     "linux",
@@ -15,19 +15,19 @@
     "files": [
       {
         "path": "code/packages/python/demo/BUILD",
-        "content_utf8": "load(\"//rules:python.star\", \"python_library\")\npython_library(name = \"demo\")\n"
+        "content_utf8": "python -m unittest discover tests\n"
       },
       {
-        "path": "code/packages/python/demo/BUILD_windows",
-        "content_utf8": "python -m unittest discover tests\n"
+        "path": "code/packages/python/demo/pyproject.toml",
+        "content_utf8": "[project]\nname = \"demo\"\nversion = \"0.1.0\"\ndependencies = []\n"
       }
     ]
   },
   "input": {
     "operation": "discovery",
     "options": {
-      "platform": "windows",
-      "code_root": "code"
+      "code_root": "code",
+      "platform": "linux"
     },
     "arguments": [],
     "environment": {},
@@ -35,13 +35,13 @@
   },
   "expected": {
     "schema_version": 1,
-    "case_id": "discovery/windows-override",
+    "case_id": "discovery/simple",
     "domain": "discovery",
     "outcome": "ok",
     "result": {
       "packages": [
         {
-          "build_file": "code/packages/python/demo/BUILD_windows",
+          "build_file": "code/packages/python/demo/BUILD",
           "is_starlark": false,
           "language": "python",
           "name": "python/demo",

--- a/code/specs/fixtures/build-tool-v1/cases/discovery-windows-override.json
+++ b/code/specs/fixtures/build-tool-v1/cases/discovery-windows-override.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "id": "discovery/windows-override",
+  "domain": "discovery",
+  "summary": "A Windows shell override wins over generic and Starlark BUILD content.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "discovery"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/python/demo/BUILD",
+        "content_utf8": "load(\"//rules:python.star\", \"python_library\")\npython_library(name = \"demo\")\n"
+      },
+      {
+        "path": "code/packages/python/demo/BUILD_windows",
+        "content_utf8": "python -m unittest discover tests\n"
+      }
+    ]
+  },
+  "input": {
+    "operation": "discovery",
+    "options": {
+      "code_root": "code",
+      "platform": "windows"
+    },
+    "arguments": [],
+    "environment": {},
+    "changed_paths": []
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "discovery/windows-override",
+    "domain": "discovery",
+    "outcome": "ok",
+    "result": {
+      "packages": [
+        {
+          "build_file": "code/packages/python/demo/BUILD_windows",
+          "is_starlark": false,
+          "language": "python",
+          "name": "python/demo",
+          "rel_path": "code/packages/python/demo"
+        }
+      ]
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 5000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 256,
+    "cpu_time_ms": 5000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/graph-diamond.json
+++ b/code/specs/fixtures/build-tool-v1/cases/graph-diamond.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": 1,
+  "id": "graph/diamond",
+  "domain": "graph",
+  "summary": "The canonical diamond produces deterministic dependency levels.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "graph"
+  ],
+  "workspace": {
+    "files": []
+  },
+  "input": {
+    "operation": "graph",
+    "options": {
+      "packages": [
+        "python/pkg-a",
+        "python/pkg-b",
+        "python/pkg-c",
+        "python/pkg-d"
+      ],
+      "edges": [
+        [
+          "python/pkg-b",
+          "python/pkg-a"
+        ],
+        [
+          "python/pkg-c",
+          "python/pkg-a"
+        ],
+        [
+          "python/pkg-d",
+          "python/pkg-b"
+        ],
+        [
+          "python/pkg-d",
+          "python/pkg-c"
+        ]
+      ]
+    },
+    "arguments": [],
+    "environment": {},
+    "changed_paths": []
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "graph/diamond",
+    "domain": "graph",
+    "outcome": "ok",
+    "result": {
+      "edges": [
+        [
+          "python/pkg-b",
+          "python/pkg-a"
+        ],
+        [
+          "python/pkg-c",
+          "python/pkg-a"
+        ],
+        [
+          "python/pkg-d",
+          "python/pkg-b"
+        ],
+        [
+          "python/pkg-d",
+          "python/pkg-c"
+        ]
+      ],
+      "levels": [
+        [
+          "python/pkg-d"
+        ],
+        [
+          "python/pkg-b",
+          "python/pkg-c"
+        ],
+        [
+          "python/pkg-a"
+        ]
+      ]
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 5000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 256,
+    "cpu_time_ms": 5000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/plan-affected-empty.json
+++ b/code/specs/fixtures/build-tool-v1/cases/plan-affected-empty.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": 1,
+  "id": "plan/affected-empty",
+  "domain": "plan",
+  "summary": "An empty affected package set remains distinct from null.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "plan_v1_read"
+  ],
+  "workspace": {
+    "files": []
+  },
+  "input": {
+    "operation": "plan",
+    "options": {
+      "mode": "read",
+      "plan": {
+        "schema_version": 1,
+        "diff_base": "origin/main",
+        "force": false,
+        "affected_packages": [],
+        "packages": [
+          {
+            "name": "python/pkg-a",
+            "rel_path": "code/packages/python/pkg-a",
+            "language": "python",
+            "build_commands": [
+              "echo should-not-run"
+            ],
+            "is_starlark": false
+          }
+        ],
+        "dependency_edges": [],
+        "languages_needed": {
+          "python": true
+        }
+      }
+    },
+    "arguments": [],
+    "environment": {},
+    "changed_paths": []
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "plan/affected-empty",
+    "domain": "plan",
+    "outcome": "ok",
+    "result": {
+      "plan": {
+        "schema_version": 1,
+        "diff_base": "origin/main",
+        "force": false,
+        "affected_packages": [],
+        "packages": [
+          {
+            "name": "python/pkg-a",
+            "rel_path": "code/packages/python/pkg-a",
+            "language": "python",
+            "build_commands": [
+              "echo should-not-run"
+            ],
+            "is_starlark": false
+          }
+        ],
+        "dependency_edges": [],
+        "languages_needed": {
+          "python": true
+        }
+      }
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 5000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 256,
+    "cpu_time_ms": 5000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/plan-affected-null.json
+++ b/code/specs/fixtures/build-tool-v1/cases/plan-affected-null.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": 1,
+  "id": "plan/affected-null",
+  "domain": "plan",
+  "summary": "A null affected package set remains distinct from an empty set.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "plan_v1_read"
+  ],
+  "workspace": {
+    "files": []
+  },
+  "input": {
+    "operation": "plan",
+    "options": {
+      "mode": "read",
+      "plan": {
+        "schema_version": 1,
+        "diff_base": "origin/main",
+        "force": true,
+        "affected_packages": null,
+        "packages": [
+          {
+            "name": "python/pkg-a",
+            "rel_path": "code/packages/python/pkg-a",
+            "language": "python",
+            "build_commands": [
+              "echo should-not-run"
+            ],
+            "is_starlark": false
+          }
+        ],
+        "dependency_edges": [],
+        "languages_needed": {
+          "python": true
+        }
+      }
+    },
+    "arguments": [],
+    "environment": {},
+    "changed_paths": []
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "plan/affected-null",
+    "domain": "plan",
+    "outcome": "ok",
+    "result": {
+      "plan": {
+        "schema_version": 1,
+        "diff_base": "origin/main",
+        "force": true,
+        "affected_packages": null,
+        "packages": [
+          {
+            "name": "python/pkg-a",
+            "rel_path": "code/packages/python/pkg-a",
+            "language": "python",
+            "build_commands": [
+              "echo should-not-run"
+            ],
+            "is_starlark": false
+          }
+        ],
+        "dependency_edges": [],
+        "languages_needed": {
+          "python": true
+        }
+      }
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 5000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 256,
+    "cpu_time_ms": 5000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/plan-future-version.json
+++ b/code/specs/fixtures/build-tool-v1/cases/plan-future-version.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": 1,
+  "id": "plan/future-version",
+  "domain": "plan",
+  "summary": "A future build-plan schema version is rejected without execution.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "plan_v1_read"
+  ],
+  "workspace": {
+    "files": []
+  },
+  "input": {
+    "operation": "plan",
+    "options": {
+      "mode": "read",
+      "plan": {
+        "schema_version": 2,
+        "packages": [],
+        "dependency_edges": [],
+        "languages_needed": {}
+      }
+    },
+    "arguments": [],
+    "environment": {},
+    "changed_paths": []
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "plan/future-version",
+    "domain": "plan",
+    "outcome": "error",
+    "result": {},
+    "diagnostics": [
+      {
+        "code": "PLAN_UNSUPPORTED_SCHEMA_VERSION",
+        "severity": "error"
+      }
+    ]
+  },
+  "limits": {
+    "wall_time_ms": 5000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 256,
+    "cpu_time_ms": 5000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/resolution-python-diamond.json
+++ b/code/specs/fixtures/build-tool-v1/cases/resolution-python-diamond.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": 1,
+  "id": "resolution/python-diamond",
+  "domain": "resolution",
+  "summary": "Python project metadata resolves the canonical four-node diamond.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "resolution"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/python/pkg-a/BUILD",
+        "content_utf8": "echo \"building pkg-a\"\n"
+      },
+      {
+        "path": "code/packages/python/pkg-a/pyproject.toml",
+        "content_utf8": "[project]\nname = \"coding-adventures-pkg-a\"\nversion = \"0.1.0\"\ndependencies = [\"coding-adventures-pkg-b\", \"coding-adventures-pkg-c\"]\n"
+      },
+      {
+        "path": "code/packages/python/pkg-b/BUILD",
+        "content_utf8": "echo \"building pkg-b\"\n"
+      },
+      {
+        "path": "code/packages/python/pkg-b/pyproject.toml",
+        "content_utf8": "[project]\nname = \"coding-adventures-pkg-b\"\nversion = \"0.1.0\"\ndependencies = [\"coding-adventures-pkg-d\"]\n"
+      },
+      {
+        "path": "code/packages/python/pkg-c/BUILD",
+        "content_utf8": "echo \"building pkg-c\"\n"
+      },
+      {
+        "path": "code/packages/python/pkg-c/pyproject.toml",
+        "content_utf8": "[project]\nname = \"coding-adventures-pkg-c\"\nversion = \"0.1.0\"\ndependencies = [\"coding-adventures-pkg-d\"]\n"
+      },
+      {
+        "path": "code/packages/python/pkg-d/BUILD",
+        "content_utf8": "echo \"building pkg-d\"\n"
+      },
+      {
+        "path": "code/packages/python/pkg-d/pyproject.toml",
+        "content_utf8": "[project]\nname = \"coding-adventures-pkg-d\"\nversion = \"0.1.0\"\ndependencies = []\n"
+      }
+    ]
+  },
+  "input": {
+    "operation": "resolution",
+    "options": {
+      "code_root": "code",
+      "language": "python"
+    },
+    "arguments": [],
+    "environment": {},
+    "changed_paths": []
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "resolution/python-diamond",
+    "domain": "resolution",
+    "outcome": "ok",
+    "result": {
+      "edges": [
+        [
+          "python/pkg-b",
+          "python/pkg-a"
+        ],
+        [
+          "python/pkg-c",
+          "python/pkg-a"
+        ],
+        [
+          "python/pkg-d",
+          "python/pkg-b"
+        ],
+        [
+          "python/pkg-d",
+          "python/pkg-c"
+        ]
+      ]
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 5000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 256,
+    "cpu_time_ms": 5000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/implementations.json
+++ b/code/specs/fixtures/build-tool-v1/implementations.json
@@ -1,0 +1,166 @@
+{
+  "schema_version": 1,
+  "conformance_revision": "build-tool-v1",
+  "implementations": [
+    {
+      "language": "csharp",
+      "lane_status": "established",
+      "implementation_status": "present",
+      "front_door": "code/programs/dotnet/build-tool-csharp",
+      "shared_engine": null,
+      "adapter_status": "missing",
+      "capabilities": [],
+      "expected_failures": []
+    },
+    {
+      "language": "dart",
+      "lane_status": "established",
+      "implementation_status": "missing",
+      "front_door": null,
+      "shared_engine": null,
+      "adapter_status": "missing",
+      "capabilities": [],
+      "expected_failures": []
+    },
+    {
+      "language": "elixir",
+      "lane_status": "established",
+      "implementation_status": "present",
+      "front_door": "code/programs/elixir/build-tool",
+      "shared_engine": null,
+      "adapter_status": "missing",
+      "capabilities": [],
+      "expected_failures": []
+    },
+    {
+      "language": "fsharp",
+      "lane_status": "established",
+      "implementation_status": "shared_engine",
+      "front_door": "code/programs/dotnet/build-tool-fsharp",
+      "shared_engine": "csharp",
+      "adapter_status": "missing",
+      "capabilities": [],
+      "expected_failures": []
+    },
+    {
+      "language": "go",
+      "lane_status": "established",
+      "implementation_status": "present",
+      "front_door": "code/programs/go/build-tool",
+      "shared_engine": null,
+      "adapter_status": "missing",
+      "capabilities": [],
+      "expected_failures": []
+    },
+    {
+      "language": "haskell",
+      "lane_status": "established",
+      "implementation_status": "present",
+      "front_door": "code/programs/haskell/build-tool",
+      "shared_engine": null,
+      "adapter_status": "missing",
+      "capabilities": [],
+      "expected_failures": []
+    },
+    {
+      "language": "java",
+      "lane_status": "established",
+      "implementation_status": "missing",
+      "front_door": null,
+      "shared_engine": null,
+      "adapter_status": "missing",
+      "capabilities": [],
+      "expected_failures": []
+    },
+    {
+      "language": "kotlin",
+      "lane_status": "established",
+      "implementation_status": "missing",
+      "front_door": null,
+      "shared_engine": null,
+      "adapter_status": "missing",
+      "capabilities": [],
+      "expected_failures": []
+    },
+    {
+      "language": "lua",
+      "lane_status": "established",
+      "implementation_status": "present",
+      "front_door": "code/programs/lua/build-tool",
+      "shared_engine": null,
+      "adapter_status": "missing",
+      "capabilities": [],
+      "expected_failures": []
+    },
+    {
+      "language": "ocaml",
+      "lane_status": "emerging",
+      "implementation_status": "missing",
+      "front_door": null,
+      "shared_engine": null,
+      "adapter_status": "missing",
+      "capabilities": [],
+      "expected_failures": []
+    },
+    {
+      "language": "perl",
+      "lane_status": "established",
+      "implementation_status": "present",
+      "front_door": "code/programs/perl/build-tool",
+      "shared_engine": null,
+      "adapter_status": "missing",
+      "capabilities": [],
+      "expected_failures": []
+    },
+    {
+      "language": "python",
+      "lane_status": "established",
+      "implementation_status": "present",
+      "front_door": "code/programs/python/build-tool",
+      "shared_engine": null,
+      "adapter_status": "missing",
+      "capabilities": [],
+      "expected_failures": []
+    },
+    {
+      "language": "ruby",
+      "lane_status": "established",
+      "implementation_status": "present",
+      "front_door": "code/programs/ruby/build-tool",
+      "shared_engine": null,
+      "adapter_status": "missing",
+      "capabilities": [],
+      "expected_failures": []
+    },
+    {
+      "language": "rust",
+      "lane_status": "established",
+      "implementation_status": "present",
+      "front_door": "code/programs/rust/build-tool",
+      "shared_engine": null,
+      "adapter_status": "missing",
+      "capabilities": [],
+      "expected_failures": []
+    },
+    {
+      "language": "swift",
+      "lane_status": "established",
+      "implementation_status": "present",
+      "front_door": "code/programs/swift/build-tool",
+      "shared_engine": null,
+      "adapter_status": "missing",
+      "capabilities": [],
+      "expected_failures": []
+    },
+    {
+      "language": "typescript",
+      "lane_status": "established",
+      "implementation_status": "present",
+      "front_door": "code/programs/typescript/build-tool",
+      "shared_engine": null,
+      "adapter_status": "missing",
+      "capabilities": [],
+      "expected_failures": []
+    }
+  ]
+}

--- a/code/specs/fixtures/build-tool-v1/implementations.schema.json
+++ b/code/specs/fixtures/build-tool-v1/implementations.schema.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/build-tool-conformance-implementations-v1.json",
+  "title": "Build-tool implementation inventory v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "conformance_revision",
+    "implementations"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "conformance_revision": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*$",
+      "maxLength": 80
+    },
+    "implementations": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/implementation"
+      }
+    }
+  },
+  "$defs": {
+    "language": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "maxLength": 64
+    },
+    "safe_path": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^(?!/)(?![A-Za-z]:)(?!.*\\\\)(?!.*(?:^|/)\\.\\.?(?:/|$))(?!.*//)[^<>:\"|?*\\u0000-\\u001F/]+(?:/[^<>:\"|?*\\u0000-\\u001F/]+)*$"
+    },
+    "capability": {
+      "enum": [
+        "discovery",
+        "resolution",
+        "graph",
+        "diff_selection",
+        "hashing_cache",
+        "starlark",
+        "plan_v1_read",
+        "plan_v1_write",
+        "sharding",
+        "execution",
+        "validation",
+        "toolchain_detection",
+        "cli",
+        "trusted_execution"
+      ]
+    },
+    "expected_failure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "case_id",
+        "reason"
+      ],
+      "properties": {
+        "case_id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9._-]*(/[a-z0-9][a-z0-9._-]*)+$",
+          "maxLength": 160
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 400
+        },
+        "tracking": {
+          "type": "string",
+          "pattern": "^(?:#[0-9]+|[A-Z][A-Z0-9_-]+)$",
+          "maxLength": 80
+        }
+      }
+    },
+    "implementation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "language",
+        "lane_status",
+        "implementation_status",
+        "front_door",
+        "shared_engine",
+        "adapter_status",
+        "capabilities",
+        "expected_failures"
+      ],
+      "properties": {
+        "language": {
+          "$ref": "#/$defs/language"
+        },
+        "lane_status": {
+          "enum": [
+            "established",
+            "emerging"
+          ]
+        },
+        "implementation_status": {
+          "enum": [
+            "present",
+            "shared_engine",
+            "missing"
+          ]
+        },
+        "front_door": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/safe_path"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "shared_engine": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/language"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "adapter_status": {
+          "enum": [
+            "missing",
+            "partial",
+            "ready"
+          ]
+        },
+        "capabilities": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/capability"
+          }
+        },
+        "expected_failures": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/expected_failure"
+          }
+        }
+      }
+    }
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/result.schema.json
+++ b/code/specs/fixtures/build-tool-v1/result.schema.json
@@ -153,18 +153,6 @@
         "properties": {
           "result": {
             "$ref": "#/$defs/empty_result"
-          },
-          "diagnostics": {
-            "contains": {
-              "properties": {
-                "code": {
-                  "const": "PLAN_UNSUPPORTED_SCHEMA_VERSION"
-                }
-              },
-              "required": [
-                "code"
-              ]
-            }
           }
         }
       }

--- a/code/specs/fixtures/build-tool-v1/result.schema.json
+++ b/code/specs/fixtures/build-tool-v1/result.schema.json
@@ -1,0 +1,431 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/build-tool-conformance-result-v1.json",
+  "title": "Build-tool conformance result v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "case_id",
+    "domain",
+    "outcome",
+    "result",
+    "diagnostics"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "case_id": {
+      "$ref": "#/$defs/case_id"
+    },
+    "domain": {
+      "$ref": "#/$defs/domain"
+    },
+    "outcome": {
+      "enum": [
+        "ok",
+        "error",
+        "unsupported",
+        "skipped"
+      ]
+    },
+    "result": {
+      "$ref": "#/$defs/generic_result"
+    },
+    "diagnostics": {
+      "type": "array",
+      "maxItems": 4096,
+      "items": {
+        "$ref": "#/$defs/diagnostic"
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "domain": {
+            "const": "discovery"
+          },
+          "outcome": {
+            "const": "ok"
+          }
+        },
+        "required": [
+          "domain",
+          "outcome"
+        ]
+      },
+      "then": {
+        "properties": {
+          "result": {
+            "$ref": "#/$defs/discovery_result"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "domain": {
+            "const": "resolution"
+          },
+          "outcome": {
+            "const": "ok"
+          }
+        },
+        "required": [
+          "domain",
+          "outcome"
+        ]
+      },
+      "then": {
+        "properties": {
+          "result": {
+            "$ref": "#/$defs/resolution_result"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "domain": {
+            "const": "graph"
+          },
+          "outcome": {
+            "const": "ok"
+          }
+        },
+        "required": [
+          "domain",
+          "outcome"
+        ]
+      },
+      "then": {
+        "properties": {
+          "result": {
+            "$ref": "#/$defs/graph_result"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "domain": {
+            "const": "plan"
+          },
+          "outcome": {
+            "const": "ok"
+          }
+        },
+        "required": [
+          "domain",
+          "outcome"
+        ]
+      },
+      "then": {
+        "properties": {
+          "result": {
+            "$ref": "#/$defs/plan_result"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "domain": {
+            "const": "plan"
+          },
+          "outcome": {
+            "const": "error"
+          }
+        },
+        "required": [
+          "domain",
+          "outcome"
+        ]
+      },
+      "then": {
+        "properties": {
+          "result": {
+            "$ref": "#/$defs/empty_result"
+          },
+          "diagnostics": {
+            "contains": {
+              "properties": {
+                "code": {
+                  "const": "PLAN_UNSUPPORTED_SCHEMA_VERSION"
+                }
+              },
+              "required": [
+                "code"
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "outcome": {
+            "enum": [
+              "unsupported",
+              "skipped"
+            ]
+          }
+        },
+        "required": [
+          "outcome"
+        ]
+      },
+      "then": {
+        "properties": {
+          "result": {
+            "$ref": "#/$defs/empty_result"
+          },
+          "diagnostics": {
+            "minItems": 1
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "case_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*(/[a-z0-9][a-z0-9._-]*)+$",
+      "maxLength": 160
+    },
+    "domain": {
+      "enum": [
+        "discovery",
+        "resolution",
+        "graph",
+        "diff_selection",
+        "hashing_cache",
+        "starlark",
+        "plan",
+        "sharding",
+        "execution",
+        "validation",
+        "toolchain_detection",
+        "cli"
+      ]
+    },
+    "safe_path": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^(?!/)(?![A-Za-z]:)(?!.*\\\\)(?!.*(?:^|/)\\.\\.?(?:/|$))(?!.*//)[^<>:\"|?*\\u0000-\\u001F/]+(?:/[^<>:\"|?*\\u0000-\\u001F/]+)*$"
+    },
+    "package_name": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._/-]*$",
+      "maxLength": 240
+    },
+    "edge": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "$ref": "#/$defs/package_name"
+        },
+        {
+          "$ref": "#/$defs/package_name"
+        }
+      ],
+      "items": false,
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "package": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "rel_path",
+        "language",
+        "build_file",
+        "is_starlark"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/package_name"
+        },
+        "rel_path": {
+          "$ref": "#/$defs/safe_path"
+        },
+        "language": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$",
+          "maxLength": 64
+        },
+        "build_file": {
+          "$ref": "#/$defs/safe_path"
+        },
+        "is_starlark": {
+          "type": "boolean"
+        }
+      }
+    },
+    "discovery_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "packages"
+      ],
+      "properties": {
+        "packages": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/package"
+          }
+        }
+      }
+    },
+    "resolution_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "edges"
+      ],
+      "properties": {
+        "edges": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/edge"
+          }
+        }
+      }
+    },
+    "graph_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "edges",
+        "levels"
+      ],
+      "properties": {
+        "edges": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/edge"
+          }
+        },
+        "levels": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "$ref": "#/$defs/package_name"
+            }
+          }
+        }
+      }
+    },
+    "plan_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "plan"
+      ],
+      "properties": {
+        "plan": {
+          "type": "object"
+        }
+      }
+    },
+    "diagnostic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "severity"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^[A-Z][A-Z0-9_]*$",
+          "maxLength": 96
+        },
+        "severity": {
+          "enum": [
+            "info",
+            "warning",
+            "error"
+          ]
+        },
+        "path": {
+          "$ref": "#/$defs/safe_path"
+        },
+        "package": {
+          "$ref": "#/$defs/package_name"
+        },
+        "message": {
+          "type": "string",
+          "maxLength": 4096
+        },
+        "details": {
+          "type": "object",
+          "maxProperties": 256,
+          "additionalProperties": {
+            "$ref": "#/$defs/json_value"
+          }
+        }
+      }
+    },
+    "generic_result": {
+      "type": "object",
+      "maxProperties": 1024,
+      "additionalProperties": {
+        "$ref": "#/$defs/json_value"
+      }
+    },
+    "empty_result": {
+      "type": "object",
+      "maxProperties": 0,
+      "additionalProperties": false
+    },
+    "json_value": {
+      "oneOf": [
+        {
+          "type": "string",
+          "maxLength": 1048576
+        },
+        {
+          "type": "integer",
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        },
+        {
+          "type": "array",
+          "maxItems": 4096,
+          "items": {
+            "$ref": "#/$defs/json_value"
+          }
+        },
+        {
+          "type": "object",
+          "maxProperties": 1024,
+          "additionalProperties": {
+            "$ref": "#/$defs/json_value"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/schema.json
+++ b/code/specs/fixtures/build-tool-v1/schema.json
@@ -256,6 +256,189 @@
             "$ref": "#/$defs/safe_path"
           }
         }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "operation": {
+                "const": "discovery"
+              }
+            },
+            "required": [
+              "operation"
+            ]
+          },
+          "then": {
+            "properties": {
+              "options": {
+                "$ref": "#/$defs/discovery_options"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "operation": {
+                "const": "resolution"
+              }
+            },
+            "required": [
+              "operation"
+            ]
+          },
+          "then": {
+            "properties": {
+              "options": {
+                "$ref": "#/$defs/resolution_options"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "operation": {
+                "const": "graph"
+              }
+            },
+            "required": [
+              "operation"
+            ]
+          },
+          "then": {
+            "properties": {
+              "options": {
+                "$ref": "#/$defs/graph_options"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "operation": {
+                "const": "plan"
+              }
+            },
+            "required": [
+              "operation"
+            ]
+          },
+          "then": {
+            "properties": {
+              "options": {
+                "$ref": "#/$defs/plan_options"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "package_name": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._/-]*$",
+      "maxLength": 240
+    },
+    "edge": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "$ref": "#/$defs/package_name"
+        },
+        {
+          "$ref": "#/$defs/package_name"
+        }
+      ],
+      "items": false,
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "discovery_options": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code_root",
+        "platform"
+      ],
+      "properties": {
+        "code_root": {
+          "$ref": "#/$defs/safe_path"
+        },
+        "platform": {
+          "enum": [
+            "darwin",
+            "linux",
+            "windows"
+          ]
+        }
+      }
+    },
+    "resolution_options": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code_root",
+        "language"
+      ],
+      "properties": {
+        "code_root": {
+          "$ref": "#/$defs/safe_path"
+        },
+        "language": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$",
+          "maxLength": 64
+        }
+      }
+    },
+    "graph_options": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "packages",
+        "edges"
+      ],
+      "properties": {
+        "packages": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/package_name"
+          }
+        },
+        "edges": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/edge"
+          }
+        }
+      }
+    },
+    "plan_options": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "plan"
+      ],
+      "properties": {
+        "mode": {
+          "enum": [
+            "read",
+            "write",
+            "round_trip"
+          ]
+        },
+        "plan": {
+          "type": "object",
+          "maxProperties": 1024,
+          "additionalProperties": {
+            "$ref": "#/$defs/json_value"
+          }
+        }
       }
     },
     "diagnostic": {
@@ -282,9 +465,7 @@
           "$ref": "#/$defs/safe_path"
         },
         "package": {
-          "type": "string",
-          "pattern": "^[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._/-]*$",
-          "maxLength": 240
+          "$ref": "#/$defs/package_name"
         },
         "message": {
           "type": "string",

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -908,21 +908,25 @@ Delivery order:
 2. Add a cross-implementation runner. The runner may orchestrate processes in
    Python, but the fixtures and canonical JSON are the behavior oracle. Start
    with non-execution domains and fail closed on every execution case.
-3. Add the trusted-execution sandbox and adversarial execution corpus. No
+3. Expand the bootstrap's closed input/result schemas and positive plus
+   adversarial corpus from discovery, resolution, graph, and plan into the
+   remaining non-execution domains: diff selection, hashing/cache, Starlark,
+   sharding, validation, toolchain detection, and CLI.
+4. Add the trusted-execution sandbox and adversarial execution corpus. No
    repository command may run until filesystem and network isolation,
    no-follow path handling, sanitized environments, direct argv, and hard
    process-tree limits are enforced.
-4. Make the Go reference pass the contract, including structured Starlark
+5. Make the Go reference pass the contract, including structured Starlark
    context/commands and the B05 Windows executor contract.
-5. Remediate existing ports in fixture-failure order: C#/F#, Python, Ruby,
+6. Remediate existing ports in fixture-failure order: C#/F#, Python, Ruby,
    Swift, TypeScript, Elixir, Rust, Perl, Haskell, and Lua. Each independent
    engine is its own PR; a reviewed shared-engine exception must be explicit.
-6. Add language-native Java and Kotlin implementations using shared JVM fixture
+7. Add language-native Java and Kotlin implementations using shared JVM fixture
    infrastructure but separate engines, then add Dart.
-7. Add the OCaml implementation after the lane foundation is stable.
-8. Decide and document whether C and C++ require native build tools before
+8. Add the OCaml implementation after the lane foundation is stable.
+9. Decide and document whether C and C++ require native build tools before
    either emerging lane graduates.
-9. Gate completion in CI: every supported implementation runs the same
+10. Gate completion in CI: every supported implementation runs the same
    conformance corpus on its applicable operating systems.
 
 ## Cross-Cutting Stream B: Introduce OCaml Safely

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -903,28 +903,35 @@ Delivery order:
 1. Define `build-tool-conformance.md`, a versioned fixture schema, and stable
    machine-readable results for discovery, resolution, graph order, diff
    selection, hashing/cache, Starlark, plan interchange, sharding, execution,
-   validation, platform BUILD selection, and toolchain detection.
+   validation, platform BUILD selection, and toolchain detection. Completed by
+   PR #9151.
 2. Add a cross-implementation runner. The runner may orchestrate processes in
-   Python, but the fixtures and canonical JSON are the behavior oracle.
-3. Make the Go reference pass the contract, including structured Starlark
+   Python, but the fixtures and canonical JSON are the behavior oracle. Start
+   with non-execution domains and fail closed on every execution case.
+3. Add the trusted-execution sandbox and adversarial execution corpus. No
+   repository command may run until filesystem and network isolation,
+   no-follow path handling, sanitized environments, direct argv, and hard
+   process-tree limits are enforced.
+4. Make the Go reference pass the contract, including structured Starlark
    context/commands and the B05 Windows executor contract.
-4. Remediate existing ports in fixture-failure order: C#/F#, Python, Ruby,
+5. Remediate existing ports in fixture-failure order: C#/F#, Python, Ruby,
    Swift, TypeScript, Elixir, Rust, Perl, Haskell, and Lua. Each independent
    engine is its own PR; a reviewed shared-engine exception must be explicit.
-5. Add language-native Java and Kotlin implementations using shared JVM fixture
+6. Add language-native Java and Kotlin implementations using shared JVM fixture
    infrastructure but separate engines, then add Dart.
-6. Add the OCaml implementation after the lane foundation is stable.
-7. Decide and document whether C and C++ require native build tools before
+7. Add the OCaml implementation after the lane foundation is stable.
+8. Decide and document whether C and C++ require native build tools before
    either emerging lane graduates.
-8. Gate completion in CI: every supported implementation runs the same
+9. Gate completion in CI: every supported implementation runs the same
    conformance corpus on its applicable operating systems.
 
 ## Cross-Cutting Stream B: Introduce OCaml Safely
 
 OCaml begins as an `emerging_implementation` lane. It must not silently change
 the current 15-language denominator until its package, build, security, and CI
-substrate is real. Use OCaml 5.2.1, opam 2.5.x, Dune 3.16.x, Alcotest,
-`bisect_ppx`, and `ocamlformat`.
+substrate is real. Use OCaml 5.2.1, opam 2.5.x, Dune 3.17.2, Alcotest,
+`bisect_ppx`, and `ocamlformat`. Dune 3.16.1 is not published in the current
+opam repository; 3.17.2 is the nearest available compatible release.
 
 Bootstrap order:
 

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -933,9 +933,8 @@ Delivery order:
 
 OCaml begins as an `emerging_implementation` lane. It must not silently change
 the current 15-language denominator until its package, build, security, and CI
-substrate is real. Use OCaml 5.2.1, opam 2.5.x, Dune 3.17.2, Alcotest,
-`bisect_ppx`, and `ocamlformat`. Dune 3.16.1 is not published in the current
-opam repository; 3.17.2 is the nearest available compatible release.
+substrate is real. Use OCaml 5.2.1, opam 2.5.x, Dune 3.16.x, Alcotest,
+`bisect_ppx`, and `ocamlformat`.
 
 Bootstrap order:
 

--- a/code/specs/schemas/build-plan-v1.schema.json
+++ b/code/specs/schemas/build-plan-v1.schema.json
@@ -1,0 +1,192 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/build-plan-v1.json",
+  "title": "Build Plan v1",
+  "description": "Serialized build plan for cross-job and cross-language build orchestration.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "packages",
+    "dependency_edges",
+    "languages_needed"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "diff_base": {
+      "type": "string"
+    },
+    "force": {
+      "type": "boolean",
+      "default": false
+    },
+    "affected_packages": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/$defs/package_name"
+      },
+      "uniqueItems": true
+    },
+    "packages": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/package_entry"
+      }
+    },
+    "dependency_edges": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/edge"
+      },
+      "uniqueItems": true
+    },
+    "languages_needed": {
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/language"
+      },
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "shards": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/shard_entry"
+      }
+    }
+  },
+  "$defs": {
+    "language": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "maxLength": 64
+    },
+    "package_name": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._/-]*$",
+      "maxLength": 240
+    },
+    "safe_path": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^(?!/)(?![A-Za-z]:)(?!.*\\\\)(?!.*(?:^|/)\\.\\.?(?:/|$))(?!.*//)[^<>:\"|?*\\u0000-\\u001F/]+(?:/[^<>:\"|?*\\u0000-\\u001F/]+)*$"
+    },
+    "edge": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "$ref": "#/$defs/package_name"
+        },
+        {
+          "$ref": "#/$defs/package_name"
+        }
+      ],
+      "items": false,
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "package_entry": {
+      "type": "object",
+      "required": [
+        "name",
+        "rel_path",
+        "language",
+        "build_commands"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/package_name"
+        },
+        "rel_path": {
+          "$ref": "#/$defs/safe_path"
+        },
+        "language": {
+          "$ref": "#/$defs/language"
+        },
+        "build_commands": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "maxLength": 65536
+          }
+        },
+        "is_starlark": {
+          "type": "boolean",
+          "default": false
+        },
+        "declared_srcs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "maxLength": 4096
+          },
+          "default": []
+        },
+        "declared_deps": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/package_name"
+          },
+          "uniqueItems": true,
+          "default": []
+        }
+      }
+    },
+    "shard_entry": {
+      "type": "object",
+      "required": [
+        "index",
+        "name",
+        "assigned_packages",
+        "package_names"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "index": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 160
+        },
+        "assigned_packages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/package_name"
+          },
+          "uniqueItems": true
+        },
+        "package_names": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/package_name"
+          },
+          "uniqueItems": true
+        },
+        "languages_needed": {
+          "type": "object",
+          "propertyNames": {
+            "$ref": "#/$defs/language"
+          },
+          "additionalProperties": {
+            "type": "boolean"
+          }
+        },
+        "estimated_cost": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add a process-free, language-neutral conformance runner for strict corpus and externally produced result validation
- add closed schemas and seven representative cases for discovery, resolution, graph, and build-plan behavior
- inventory all 15 established implementation lanes plus emerging OCaml without claiming any adapter is ready
- enforce bounded strict JSON, portable workspace preflight, trusted bundled schemas, no external references, no-follow regular-file reads, case output limits, and fail-closed execution intent
- wire the safe corpus validation into CI and track the next pure-domain, execution-sandbox, adapter, OCaml, and standalone BUILD-integrity work items

## Why

PR #9151 defined the shared build-tool contract. This is the dependency-shaped bootstrap needed before language adapters can be implemented or remediated: it gives every lane the same schemas, fixtures, canonical result oracle, and inventory while deliberately running no adapter and creating no workspace.

`unsupported` and `skipped` oracle matches remain non-passing. Domains without closed bootstrap schemas are rejected instead of being represented as conforming.

## Validation

- `ruff check ...` — passed
- runner unit/security tests — 29 passed
- schema tests — 11 passed
- package parity reporter tests — 6 passed
- runner branch coverage — 84% (80% gate)
- `validate-corpus` — 7 cases, 4 closed domains, 16 inventory entries, 12 front doors, 0 adapter-ready, 0 conformance runs, status `not-run`
- `package_parity_report.py --format json --fail-on-collisions` — schema v2, 15 established lanes, 1,184 identities, 278 high-consensus missing slots, 0 collisions, 0 unknown buckets
- Go build-tool `go test ./...`, `go vet ./...`, and fresh `go build` — passed
- Bandit scan of the new runner — passed
- JSON validation and `git diff --check` — passed
- independent contract and security re-reviews — approved with no publication blockers

A forced full-repo Go build-tool dry run reached 44 Starlark files and 4,722 packages, then correctly failed on 73 pre-existing `BUILD_windows` prerequisite declaration gaps (12 Python, 3 Swift, 58 TypeScript). Those unrelated repairs are recorded as a separate pending parity item rather than being mixed into this PR.