### PR TITLE
feat(adj-formula-stdlib): Mentzer index — StatPearls MCV÷RBC ratio library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_mentzer_index_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_mentzer_index_e2e.rs
@@ -1,0 +1,139 @@
+//! End-to-end tests for the `clinical/mentzer-index.adj` library — the Mentzer-index relation
+//! (Mentzer index = mean corpuscular volume ÷ red cell count) and its two exact rearrangements —
+//! driven through the built CLI binary against the SHIPPED stdlib. The same invariant as every other
+//! formula library: a consumer states NO arithmetic; it imports the grounded library, binds the
+//! measured red-cell indices with `observe`, and the engine applies the cited definition on the CPU,
+//! computing the EXACT value and rendering the definition's citation and trust tier in the `derived`
+//! section (the auditable answer). The three formulas INVERT around the worked case MCV = 80 fL, red
+//! cell count = 4 (million/µL): 80 ÷ 4 = 20 (index), 20 × 4 = 80 (MCV), 80 ÷ 20 = 4 (count). The
+//! three asserted values (20, 80, 4) — none is a colon-anchored prefix of another rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped Mentzer-index library, resolved from this crate's manifest dir so the
+/// test is location-independent.
+fn shipped_mentzer_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/mentzer-index.adj")
+        .canonicalize()
+        .expect("shipped mentzer-index.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_mentzer_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_mentzer_lib()).unwrap();
+    std::fs::write(dir.join("mentzer-index.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// mentzer_index — the relation: mean corpuscular volume ÷ red cell count.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_mentzer_library_and_computes_it_with_citation() {
+    let dir = scratch("idx");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"mentzer-index.adj\"\n\
+         observe mean_corpuscular_volume(80)\n\
+         observe red_cell_count(4)\n\
+         ? mentzer_index(mean_corpuscular_volume, red_cell_count)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied definition's result: 80 ÷ 4 = 20.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"mentzer_index\"") && s.contains("\"value\":20"),
+        "mentzer_index(80, 4) = 20: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// mean_corpuscular_volume — the same definition solved for the MCV: index × red cell count.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_mcv_from_index_and_count_with_citation() {
+    let dir = scratch("mcv");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"mentzer-index.adj\"\n\
+         observe mentzer_index(20)\n\
+         observe red_cell_count(4)\n\
+         ? mean_corpuscular_volume(mentzer_index, red_cell_count)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 20 × 4 = 80, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"mean_corpuscular_volume\"") && s.contains("\"value\":80"),
+        "mean_corpuscular_volume(20, 4) = 80: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "mean_corpuscular_volume carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// red_cell_count — the same definition solved for the count: MCV ÷ index, the third reading of the
+// one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_count_from_mcv_and_index_with_citation() {
+    let dir = scratch("rbc");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"mentzer-index.adj\"\n\
+         observe mean_corpuscular_volume(80)\n\
+         observe mentzer_index(20)\n\
+         ? red_cell_count(mean_corpuscular_volume, mentzer_index)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 80 ÷ 20 = 4, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"red_cell_count\"") && s.contains("\"value\":4"),
+        "red_cell_count(80, 20) = 4: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "red_cell_count carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/mentzer-index.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/mentzer-index.adj
@@ -1,0 +1,96 @@
+% ============================================================================
+% mentzer-index.adj — the definition of the Mentzer index
+% (Mentzer index = mean corpuscular volume ÷ red cell count) in the ADJ standard library.
+% ============================================================================
+% The Mentzer-index entry of the *clinical* track — a hematology bedside discriminant, a ratio
+% sibling of the shipped anion-gap.adj / osmolar-gap.adj (which are differences) and of the
+% cardiac-index / ejection-fraction ratios. Where those are gaps, the Mentzer index is a RATIO of two
+% red-cell indices: THE MENTZER INDEX IS THE MEAN CORPUSCULAR VOLUME DIVIDED BY THE RED CELL COUNT —
+% a one-number screen that helps distinguish the two commonest causes of a microcytic anaemia. A LOW
+% index (< 13) suggests thalassemia trait (many small cells: high RBC count, low MCV); a HIGH index
+% (> 13) suggests iron-deficiency anaemia (fewer, small cells: low RBC count). It ships as an
+% importable, byte-provenanced, PARAMETERIZED `formula`, together with its two exact rearrangements
+% (the MCV an index implies for a given red cell count, and the red cell count it implies for a given
+% MCV). As with every compute library, a consumer states NO arithmetic: it `import`s this file, binds
+% the two red-cell indices from its own byte-provenance decomposition, and asks the engine to APPLY
+% the cited definition on the CPU. Zero math is performed by the model; the engine computes each value
+% EXACTLY (over exact rationals), carrying the definition's citation.
+%
+%     import "mentzer-index.adj"
+%     observe mean_corpuscular_volume(80)   % "…MCV 80 fL…"                (span cited by the model)
+%     observe red_cell_count(4)             % "…RBC 4 million/µL…"          (span cited by the model)
+%     ? mentzer_index(mean_corpuscular_volume, red_cell_count)
+%                                            % engine → 20, carrying the Mentzer-index ratio
+%
+% All three formulas are EXACT over their parameters, so every value the engine returns is exact.
+% They COMPOSE and invert cleanly around the worked case MCV = 80 fL, red cell count = 4 (million/µL):
+% Mentzer index = 80 ÷ 4 = 20 (a HIGH index, > 13, pointing to iron deficiency). The `mentzer_index` a
+% consumer computes is exactly the value the `mean_corpuscular_volume` formula multiplies back by the
+% red cell count to recover 80, and exactly the value the `red_cell_count` formula divides the MCV by
+% to recover 4.
+%
+%   mentzer_index(mean_corpuscular_volume, red_cell_count)
+%       = mean_corpuscular_volume / red_cell_count      % index = MCV ÷ RBC        (definition)
+%   mean_corpuscular_volume(mentzer_index, red_cell_count)
+%       = mentzer_index * red_cell_count                % MCV = index × RBC         (solved for MCV)
+%   red_cell_count(mean_corpuscular_volume, mentzer_index)
+%       = mean_corpuscular_volume / mentzer_index       % RBC = MCV ÷ index         (solved for RBC)
+%
+% NOTE ON UNITS: by clinical convention the MCV is in femtolitres (fL) and the red cell count in
+% millions per microlitre (equivalently 10¹² per litre); the Mentzer index is the pure number that
+% results, compared against the dimensionless cut-off of 13. The engine computes the exact ratio over
+% whatever consistent inputs it is given.
+%
+% All three formulas are defended by the SAME definitional clause — "The calculation of the Mentzer
+% index (mean corpuscular volume divided by red cell count) is useful. A Mentzer index below 13
+% suggests thalassemia, whereas an index above 13 suggests anemia due to iron deficiency." — because
+% that one definition (the Mentzer index IS the MCV-over-RBC ratio) sanctions the relation read every
+% way (the index from the two indices, the MCV from the index and the count, or the count from the MCV
+% and the index). The quote is transcribed verbatim from the StatPearls "Thalassemia" article on the
+% NCBI Bookshelf, so each `formula` carries the provenance envelope every shipped grounded clause
+% carries; the linter rejects an unsourced one. (See feedback_nothing_human_authored — the
+% definitional clause is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable red-cell index the definition ranges over, and each
+% result is a derived quantity. `mean_corpuscular_volume`, `red_cell_count` and `mentzer_index` each
+% appear BOTH as a derived result and as an input (of the other formulas), so each is a single
+% dictionary term used in both roles. The `surface` lists are the everyday names a decomposer maps
+% onto the canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary mentzer_index_vocab {
+    define mean_corpuscular_volume : finding  surface "MCV", "mean corpuscular volume"                       % femtolitres (fL)
+    define red_cell_count          : finding  surface "RBC count", "red cell count", "red blood cell count"  % millions per microlitre (10^12/L)
+    define mentzer_index           : finding  surface "Mentzer index"                                        % dimensionless (cut-off 13)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the definitional clause from the StatPearls
+% "Thalassemia" article on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an
+% exact quotient or product of two red-cell indices, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook mentzer_index_laws {
+    use mentzer_index_vocab
+
+    % Mentzer index — the mean corpuscular volume divided by the red cell count, i.e. index = MCV ÷ RBC.
+    formula mentzer_index(mean_corpuscular_volume, red_cell_count) = mean_corpuscular_volume / red_cell_count
+        source "The calculation of the Mentzer index (mean corpuscular volume divided by red cell count) is useful. A Mentzer index below 13 suggests thalassemia, whereas an index above 13 suggests anemia due to iron deficiency."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK545151/"
+        trust authoritative
+
+    % Mean corpuscular volume — the same definition solved for the MCV an index implies for a given red
+    % cell count (MCV = index × RBC). Defended by the SAME clause.
+    formula mean_corpuscular_volume(mentzer_index, red_cell_count) = mentzer_index * red_cell_count
+        source "The calculation of the Mentzer index (mean corpuscular volume divided by red cell count) is useful. A Mentzer index below 13 suggests thalassemia, whereas an index above 13 suggests anemia due to iron deficiency."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK545151/"
+        trust authoritative
+
+    % Red cell count — the same definition solved for the count (RBC = MCV ÷ index): the mean
+    % corpuscular volume divided by the index. The SAME clause, read the third way.
+    formula red_cell_count(mean_corpuscular_volume, mentzer_index) = mean_corpuscular_volume / mentzer_index
+        source "The calculation of the Mentzer index (mean corpuscular volume divided by red cell count) is useful. A Mentzer index below 13 suggests thalassemia, whereas an index above 13 suggests anemia due to iron deficiency."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK545151/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/mentzer-index.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/mentzer-index.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% mentzer-index.query.adj — worked applications of the Mentzer-index definition.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a microcytic-anaemia vignette into observed
+% red-cell indices: it `import`s the grounded formulabook, `observe`s the mean corpuscular volume and
+% the red cell count, and asks the engine to APPLY the cited definition. No arithmetic is stated by
+% the consumer; the engine computes each value EXACTLY (over exact rationals) and carries the
+% article's citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (MCV = 80 fL, red cell count = 4 million/µL): Mentzer index = 80 ÷ 4 = 20 — a HIGH index
+% (> 13), pointing to iron-deficiency anaemia. Each query below fixes two of the three quantities and
+% asks the engine to recover the third; every answer is exact and the three COMPOSE (each inversion
+% recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli mentzer-index.query.adj
+% ============================================================================
+
+import "mentzer-index.adj"
+
+% --- Definition: the Mentzer index the two red-cell indices imply (expect 20). ----------------
+observe mean_corpuscular_volume(80)
+observe red_cell_count(4)
+? mentzer_index(mean_corpuscular_volume, red_cell_count)   % expect 20
+
+% --- Inverse: the MCV a Mentzer index of 20 implies at that red cell count (expect 80). --------
+observe mentzer_index(20)
+? mean_corpuscular_volume(mentzer_index, red_cell_count)   % expect 80


### PR DESCRIPTION
## What

Ships a new grounded clinical formula library for the **Mentzer index** — a hematology bedside discriminant that helps distinguish the two commonest microcytic anaemias — in the ADJ formula stdlib:

- `code/specs/data/adj-formula-stdlib/clinical/mentzer-index.adj` — a `dictionary` + `formulabook` defining **Mentzer index = mean corpuscular volume ÷ red cell count** plus its two exact rearrangements (MCV = index × RBC; RBC = MCV ÷ index).
- `…/clinical/mentzer-index.query.adj` — worked applications.
- `code/packages/rust/adj-lang-cli/tests/formula_mentzer_index_e2e.rs` — a dedicated 3-test e2e driving the built CLI against the shipped stdlib.

## Grounding

Every formula carries the SAME verbatim definitional clause, transcribed byte-for-byte from the StatPearls **"Thalassemia"** article on the NCBI Bookshelf:

> "The calculation of the Mentzer index (mean corpuscular volume divided by red cell count) is useful. A Mentzer index below 13 suggests thalassemia, whereas an index above 13 suggests anemia due to iron deficiency."

locator `https://www.ncbi.nlm.nih.gov/books/NBK545151/`, `trust authoritative`. One clause defends the relation read three ways — nothing asserted from memory (`feedback_nothing_human_authored`).

## Invariant

A consumer states **no arithmetic**: it imports the library, `observe`s MCV and the red cell count, and the engine applies the cited definition on the CPU, computing the EXACT value (over rationals) and rendering the citation + trust tier in `derived`. Worked case MCV 80 fL, RBC 4 → index 20 (a HIGH index, > 13, → iron deficiency); the three formulas compose and invert exactly.

## Verification

- `cargo test -p adj-lang-cli --test formula_mentzer_index_e2e` → 3 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean.
- Render-probe confirms `mentzer_index=20`, `mean_corpuscular_volume=80`, exact rationals, verbatim source + NBK545151 locator + authoritative trust.
- NUL-scan clean. Security review: clean (no vulnerabilities) — conducted inline this run because the review sub-agent was unavailable due to a transient upstream 529 outage.

Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)