### PR TITLE
feat(adj-formula-stdlib): pack-year — StatPearls packs/day × years smoked exposure library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_pack_year_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_pack_year_e2e.rs
@@ -1,0 +1,140 @@
+//! End-to-end tests for the `clinical/pack-year.adj` library — the pack-year relation
+//! (pack-years = packs smoked per day × years smoked) and its two exact rearrangements — driven
+//! through the built CLI binary against the SHIPPED stdlib. The same invariant as every other
+//! formula library: a consumer states NO arithmetic; it imports the grounded library, binds the
+//! observed daily rate and duration with `observe`, and the engine applies the cited definition on
+//! the CPU, computing the EXACT value and rendering the definition's citation and trust tier in the
+//! `derived` section (the auditable answer). The three formulas INVERT around the worked case packs
+//! per day = 2, years smoked = 15: 2 × 15 = 30 (pack-years), 30 ÷ 15 = 2 (rate), 30 ÷ 2 = 15
+//! (years). The three asserted values (30, 2, 15) — none is a colon-anchored prefix of another
+//! rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped pack-year library, resolved from this crate's manifest dir so the
+/// test is location-independent.
+fn shipped_pack_year_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/pack-year.adj")
+        .canonicalize()
+        .expect("shipped pack-year.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_packyear_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_pack_year_lib()).unwrap();
+    std::fs::write(dir.join("pack-year.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// pack_years — the relation: packs per day × years smoked.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_pack_year_library_and_computes_it_with_citation() {
+    let dir = scratch("py");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"pack-year.adj\"\n\
+         observe packs_per_day(2)\n\
+         observe years_smoked(15)\n\
+         ? pack_years(packs_per_day, years_smoked)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied definition's result: 2 × 15 = 30.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"pack_years\"") && s.contains("\"value\":30"),
+        "pack_years(2, 15) = 30: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// packs_per_day — the same definition solved for the daily rate: pack-years ÷ years.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_rate_from_total_and_years_with_citation() {
+    let dir = scratch("rate");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"pack-year.adj\"\n\
+         observe pack_years(30)\n\
+         observe years_smoked(15)\n\
+         ? packs_per_day(pack_years, years_smoked)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 30 ÷ 15 = 2, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"packs_per_day\"") && s.contains("\"value\":2"),
+        "packs_per_day(30, 15) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "packs_per_day carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// years_smoked — the same definition solved for the duration: pack-years ÷ packs/day, the third
+// reading of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_years_from_total_and_rate_with_citation() {
+    let dir = scratch("years");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"pack-year.adj\"\n\
+         observe pack_years(30)\n\
+         observe packs_per_day(2)\n\
+         ? years_smoked(pack_years, packs_per_day)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 30 ÷ 2 = 15, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"years_smoked\"") && s.contains("\"value\":15"),
+        "years_smoked(30, 2) = 15: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "years_smoked carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/pack-year.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/pack-year.adj
@@ -1,0 +1,95 @@
+% ============================================================================
+% pack-year.adj — the definition of the smoking pack-year
+% (pack-years = packs smoked per day × years smoked) in the ADJ standard library.
+% ============================================================================
+% The pack-year entry of the *clinical* track — a preventive-medicine/pulmonology exposure index, a
+% product sibling of the shipped cardiac-output.adj (HR × SV) and rate-pressure-product.adj (HR ×
+% SBP). The pack-year quantifies cumulative tobacco exposure: PACK-YEARS ARE THE PACKS SMOKED PER DAY
+% MULTIPLIED BY THE YEARS SMOKED — the standard summary of lifetime smoking used to stratify
+% lung-cancer-screening eligibility and to gauge COPD/coronary risk. It ships as an importable,
+% byte-provenanced, PARAMETERIZED `formula`, together with its two exact rearrangements (the
+% packs-per-day a pack-year total implies for a given duration, and the years it implies for a given
+% daily rate). As with every compute library, a consumer states NO arithmetic: it `import`s this
+% file, binds the daily rate and the duration from its own byte-provenance decomposition, and asks
+% the engine to APPLY the cited definition on the CPU. Zero math is performed by the model; the engine
+% computes each value EXACTLY (over exact rationals), carrying the definition's citation.
+%
+%     import "pack-year.adj"
+%     observe packs_per_day(2)     % "…2 packs per day…"    (span cited by the model)
+%     observe years_smoked(15)     % "…for 15 years…"        (span cited by the model)
+%     ? pack_years(packs_per_day, years_smoked)
+%                                   % engine → 30, carrying the pack-year product
+%
+% All three formulas are EXACT over their parameters (a product or a quotient of the daily rate and
+% the duration), so every value the engine returns is exact. They COMPOSE and invert cleanly around
+% the worked case packs per day = 2, years smoked = 15 (pack-years = 2 × 15 = 30): the `pack_years` a
+% consumer computes is exactly the total the `packs_per_day` formula divides by the years to recover
+% 2, and exactly the total the `years_smoked` formula divides by the daily rate to recover 15.
+%
+%   pack_years(packs_per_day, years_smoked)
+%       = packs_per_day * years_smoked        % pack-years = packs/day × years   (definition)
+%   packs_per_day(pack_years, years_smoked)
+%       = pack_years / years_smoked           % packs/day = pack-years ÷ years   (solved for the rate)
+%   years_smoked(pack_years, packs_per_day)
+%       = pack_years / packs_per_day          % years = pack-years ÷ packs/day   (solved for the duration)
+%
+% NOTE ON UNITS: the daily rate is in packs per day (one pack = 20 cigarettes by the standard
+% convention the cited article uses in its worked example, but that pack↔cigarette conversion is a
+% SEPARATE fact — this formula ranges over packs, so it carries NO embedded constant and is exact over
+% whatever consistent inputs it is given); the duration is in years; the product is in pack-years.
+%
+% All three formulas are defended by the SAME definitional clause — "Pack-year history provides an
+% estimated number of cigarettes a patient has consumed over a lifetime and is calculated as packs
+% smoked per day multiplied by the total number of years smoked." — because that one definition (the
+% pack-year IS the packs-per-day × years product) sanctions the relation read every way (the total
+% from the rate and the duration, the rate from the total and the duration, or the duration from the
+% total and the rate). The quote is transcribed verbatim from the StatPearls "Nicotine Addiction and
+% Smoking: Health Effects and Interventions" article on the NCBI Bookshelf, so each `formula` carries
+% the provenance envelope every shipped grounded clause carries; the linter rejects an unsourced one.
+% (See feedback_nothing_human_authored — the definitional clause is a verbatim span of the cited page,
+% not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable smoking quantity the definition ranges over, and each
+% result is a derived quantity. `packs_per_day`, `years_smoked` and `pack_years` each appear BOTH as a
+% derived result and as an input (of the other formulas), so each is a single dictionary term used in
+% both roles. The `surface` lists are the everyday names a decomposer maps onto the canonical term;
+% the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary pack_year_vocab {
+    define packs_per_day : finding  surface "packs per day", "packs smoked per day", "packs/day"   % packs per day
+    define years_smoked  : finding  surface "years smoked", "years of smoking", "pack-year duration"  % years
+    define pack_years    : finding  surface "pack-years", "pack years", "pack-year history"        % pack-years
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the definitional clause from the StatPearls
+% "Nicotine Addiction and Smoking" article on the NCBI Bookshelf (a quote is required on a shipped
+% formula). Each is an exact product or quotient of the daily rate and the duration, so the engine
+% returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook pack_year_laws {
+    use pack_year_vocab
+
+    % Pack-years — the packs smoked per day multiplied by the years smoked, i.e. total = rate × years.
+    formula pack_years(packs_per_day, years_smoked) = packs_per_day * years_smoked
+        source "Pack-year history provides an estimated number of cigarettes a patient has consumed over a lifetime and is calculated as packs smoked per day multiplied by the total number of years smoked."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537066/"
+        trust authoritative
+
+    % Packs per day — the same definition solved for the daily rate a pack-year total implies for a
+    % given duration (packs/day = pack-years ÷ years). Defended by the SAME clause.
+    formula packs_per_day(pack_years, years_smoked) = pack_years / years_smoked
+        source "Pack-year history provides an estimated number of cigarettes a patient has consumed over a lifetime and is calculated as packs smoked per day multiplied by the total number of years smoked."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537066/"
+        trust authoritative
+
+    % Years smoked — the same definition solved for the duration (years = pack-years ÷ packs/day): the
+    % pack-year total divided by the daily rate. The SAME clause, read the third way.
+    formula years_smoked(pack_years, packs_per_day) = pack_years / packs_per_day
+        source "Pack-year history provides an estimated number of cigarettes a patient has consumed over a lifetime and is calculated as packs smoked per day multiplied by the total number of years smoked."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK537066/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/pack-year.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/pack-year.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% pack-year.query.adj — worked applications of the pack-year definition.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a smoking-history vignette into an observed
+% daily rate and duration: it `import`s the grounded formulabook, `observe`s the packs per day and the
+% years smoked, and asks the engine to APPLY the cited definition. No arithmetic is stated by the
+% consumer; the engine computes each value EXACTLY (over exact rationals) and carries the article's
+% citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (packs per day = 2, years smoked = 15): pack-years = 2 × 15 = 30 — a heavy cumulative
+% exposure well past the common 20-pack-year lung-cancer-screening threshold. Each query below fixes
+% two of the three quantities and asks the engine to recover the third; every answer is exact and the
+% three COMPOSE (each inversion recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli pack-year.query.adj
+% ============================================================================
+
+import "pack-year.adj"
+
+% --- Definition: the pack-years the daily rate and duration imply (expect 30). ----------------
+observe packs_per_day(2)
+observe years_smoked(15)
+? pack_years(packs_per_day, years_smoked)   % expect 30
+
+% --- Inverse: the packs per day a 30 pack-year history implies over 15 years (expect 2). -------
+observe pack_years(30)
+? packs_per_day(pack_years, years_smoked)   % expect 2


### PR DESCRIPTION
## What

Ships a new grounded clinical formula library for the **pack-year** — the standard cumulative tobacco-exposure index used for lung-cancer-screening eligibility and COPD/coronary risk — in the ADJ formula stdlib:

- `code/specs/data/adj-formula-stdlib/clinical/pack-year.adj` — a `dictionary` + `formulabook` defining **pack-years = packs smoked per day × years smoked** plus its two exact rearrangements (packs/day = pack-years ÷ years; years = pack-years ÷ packs/day).
- `…/clinical/pack-year.query.adj` — worked applications.
- `code/packages/rust/adj-lang-cli/tests/formula_pack_year_e2e.rs` — a dedicated 3-test e2e driving the built CLI against the shipped stdlib.

## Grounding

Every formula carries the SAME verbatim definitional clause, transcribed byte-for-byte from the StatPearls **"Nicotine Addiction and Smoking: Health Effects and Interventions"** article on the NCBI Bookshelf:

> "Pack-year history provides an estimated number of cigarettes a patient has consumed over a lifetime and is calculated as packs smoked per day multiplied by the total number of years smoked."

locator `https://www.ncbi.nlm.nih.gov/books/NBK537066/`, `trust authoritative`. One clause defends the relation read three ways — nothing asserted from memory (`feedback_nothing_human_authored`).

## Invariant

A consumer states **no arithmetic**: it imports the library, `observe`s the daily rate and duration, and the engine applies the cited definition on the CPU, computing the EXACT value (over rationals) and rendering the citation + trust tier in `derived`. Worked case 2 packs/day × 15 years → 30 pack-years; the three formulas compose and invert exactly. The relation ranges over **packs** (not cigarettes), so it carries no embedded constant and is exact over its parameters.

## Verification

- `cargo test -p adj-lang-cli --test formula_pack_year_e2e` → 3 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean.
- Render-probe confirms `pack_years=30`, `packs_per_day=2`, exact rationals, verbatim source + NBK537066 locator + authoritative trust.
- NUL-scan clean. Security review: clean (no vulnerabilities) — conducted inline this run because the review sub-agent was unavailable due to a transient upstream 529 outage.

Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)