### PR TITLE
feat(spice): derive MOS threshold from process parameters

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Derive Level-1 MOS `VT0` from explicit model-card `NSUB` plus `TOX` using
+  Berkeley MOS1 default gate-work-function and surface-state assumptions,
+  preserving explicit `VTO` / `VT0` precedence for NMOS and PMOS.
 - Derive Level-1 MOS `PHI` and `GAMMA` from explicit model-card `NSUB` plus
   `TOX`, preserving explicit electrostatic parameters and rejecting substrate
   doping at or below the intrinsic carrier density.

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -38,6 +38,10 @@ _INTRINSIC_CARRIER_DENSITY_PER_CUBIC_METER = 1.45e16
 _CUBIC_CENTIMETERS_PER_CUBIC_METER = 1.0e6
 
 
+def _silicon_band_gap_electron_volts(temperature_kelvin: float) -> float:
+    return 1.16 - 7.02e-4 * temperature_kelvin**2 / (temperature_kelvin + 1108.0)
+
+
 @dataclass(frozen=True, slots=True)
 class NormalizedModelCard:
     """A normalized SPICE `.model` card with stable cross-language keys."""
@@ -1118,9 +1122,21 @@ def mosfet_from_model_card(
                     * _ELECTRON_CHARGE
                     * substrate_doping_per_cubic_meter
                 ) / oxide_capacitance
+    threshold_voltage = p.get("VT0", defaults.VT0)
+    if "VT0" not in p and "N_SUB" in p and "TOX" in p and p["TOX"] > 0.0:
+        polarity = 1.0 if model.kind == "NMOS" else -1.0
+        nominal_temperature = p.get("T_NOM", defaults.T_NOM)
+        threshold_voltage = polarity * (
+            body_effect_coefficient * math.sqrt(surface_potential)
+            + 0.5
+            * (
+                surface_potential
+                - _silicon_band_gap_electron_volts(nominal_temperature)
+            )
+        )
     params = replace(
         defaults,
-        VT0=p.get("VT0", defaults.VT0),
+        VT0=threshold_voltage,
         KP=transconductance,
         LAMBDA=p.get("LAMBDA", defaults.LAMBDA),
         GAMMA=body_effect_coefficient,

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -863,11 +863,28 @@ def test_mos_model_card_substrate_doping_derives_electrostatics_with_precedence(
     expected_gamma = math.sqrt(
         2.0 * (11.70 * 8.854_214_871e-12) * 1.602_176_634e-19 * 4.0e21
     ) / (3.453133e-11 / 100.0e-9)
+    expected_band_gap = 1.16 - 7.02e-4 * 300.15**2 / (300.15 + 1108.0)
+    expected_vt0 = expected_gamma * math.sqrt(expected_phi) + 0.5 * (
+        expected_phi - expected_band_gap
+    )
     assert pytest.approx(expected_phi) == derived.model.model.params.PHI
     assert pytest.approx(expected_gamma) == derived.model.model.params.GAMMA
+    assert pytest.approx(expected_vt0) == derived.model.model.params.VT0
+
+    pmos = mosfet_from_model_card(
+        "M2",
+        "d",
+        "g",
+        "s",
+        "b",
+        normalize_model_card(
+            "Mp", "pmos", {"NSUB": 4.0e15, "TOX": 100.0e-9}
+        ),
+    )
+    assert pytest.approx(-expected_vt0) == pmos.model.model.params.VT0
 
     explicit = mosfet_from_model_card(
-        "M2",
+        "M3",
         "d",
         "g",
         "s",
@@ -880,18 +897,20 @@ def test_mos_model_card_substrate_doping_derives_electrostatics_with_precedence(
                 "TOX": 100.0e-9,
                 "PHI": 0.72,
                 "GAMMA": 0.41,
+                "VTO": 0.63,
             },
         ),
     )
     assert pytest.approx(0.72) == explicit.model.model.params.PHI
     assert pytest.approx(0.41) == explicit.model.model.params.GAMMA
+    assert pytest.approx(0.63) == explicit.model.model.params.VT0
 
     with pytest.raises(
         ValueError,
         match="MOSFET NSUB must exceed the intrinsic carrier density",
     ):
         mosfet_from_model_card(
-            "M3",
+            "M4",
             "d",
             "g",
             "s",

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Derive Level-1 MOS `VT0` from explicit model-card `NSUB` plus `TOX` using
+  Berkeley MOS1 default gate-work-function and surface-state assumptions,
+  preserving explicit `VTO` / `VT0` precedence for NMOS and PMOS.
 - Derive Level-1 MOS `PHI` and `GAMMA` from explicit model-card `NSUB` plus
   `TOX`, preserving explicit electrostatic parameters and rejecting substrate
   doping at or below the intrinsic carrier density.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -24,6 +24,10 @@ const SILICON_PERMITTIVITY: f64 = 11.70 * 8.854_214_871e-12;
 const INTRINSIC_CARRIER_DENSITY_PER_CUBIC_METER: f64 = 1.45e16;
 const CUBIC_CENTIMETERS_PER_CUBIC_METER: f64 = 1.0e6;
 
+fn silicon_band_gap_electron_volts(temperature_kelvin: f64) -> f64 {
+    1.16 - 7.02e-4 * temperature_kelvin * temperature_kelvin / (temperature_kelvin + 1108.0)
+}
+
 fn real_solver_kind(matrix_size: usize) -> &'static str {
     if matrix_size == 0 {
         "none"
@@ -2795,11 +2799,9 @@ pub fn mosfet_at_temperature(
         });
     }
     let ratio = temperature_kelvin / nominal_temperature;
-    let silicon_band_gap =
-        |temperature: f64| 1.16 - 7.02e-4 * temperature * temperature / (temperature + 1108.0);
     let potential_correction = |temperature: f64| {
         let thermal_voltage = BOLTZMANN * temperature / ELECTRON_CHARGE;
-        let argument = -silicon_band_gap(temperature) * ELECTRON_CHARGE
+        let argument = -silicon_band_gap_electron_volts(temperature) * ELECTRON_CHARGE
             / (2.0 * BOLTZMANN * temperature)
             + 1.115_087_7 * ELECTRON_CHARGE / (2.0 * BOLTZMANN * reference_temperature_kelvin);
         -2.0 * thermal_voltage
@@ -2843,7 +2845,9 @@ pub fn mosfet_at_temperature(
     };
     let temperature_vbi = mosfet.params.vt0
         - polarity * mosfet.params.gamma * mosfet.params.phi.sqrt()
-        + 0.5 * (silicon_band_gap(nominal_temperature) - silicon_band_gap(temperature_kelvin))
+        + 0.5
+            * (silicon_band_gap_electron_volts(nominal_temperature)
+                - silicon_band_gap_electron_volts(temperature_kelvin))
         + polarity * 0.5 * (temperature_phi - mosfet.params.phi);
     let temperature_vt0 = temperature_vbi + polarity * mosfet.params.gamma * temperature_phi.sqrt();
     let saturation_exponent = energy_gap_electron_volts * ELECTRON_CHARGE / BOLTZMANN
@@ -5082,6 +5086,15 @@ pub fn mosfet_from_model_card(
                     * substrate_doping_per_cubic_meter)
                     .sqrt()
                     / oxide_capacitance;
+            }
+            if !model.parameters.contains_key("VT0") {
+                let polarity = match mosfet_type {
+                    MosfetType::Nmos => 1.0,
+                    MosfetType::Pmos => -1.0,
+                };
+                params.vt0 = polarity
+                    * (params.gamma * params.phi.sqrt()
+                        + 0.5 * (params.phi - silicon_band_gap_electron_volts(params.t_nom)));
             }
         }
     }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -685,8 +685,17 @@ fn mos_model_card_substrate_doping_derives_electrostatics_with_explicit_preceden
     let expected_gamma = (2.0_f64 * (11.70 * 8.854_214_871e-12) * 1.602_176_634e-19 * 4.0e21)
         .sqrt()
         / (3.453_133e-11 / 100.0e-9);
+    let expected_band_gap = 1.16 - 7.02e-4 * 300.15 * 300.15 / (300.15 + 1108.0);
+    let expected_vt0 =
+        expected_gamma * expected_phi.sqrt() + 0.5 * (expected_phi - expected_band_gap);
     assert_close(derived.params.phi, expected_phi);
     assert_close(derived.params.gamma, expected_gamma);
+    assert_close(derived.params.vt0, expected_vt0);
+
+    let pmos_card =
+        normalize_model_card("Mp", "pmos", &[("NSUB", 4.0e15), ("TOX", 100.0e-9)]).unwrap();
+    let pmos = mosfet_from_model_card("M2", "d", "g", "s", "b", &pmos_card).unwrap();
+    assert_close(pmos.params.vt0, -expected_vt0);
 
     let explicit_card = normalize_model_card(
         "Mexplicit",
@@ -696,17 +705,19 @@ fn mos_model_card_substrate_doping_derives_electrostatics_with_explicit_preceden
             ("TOX", 100.0e-9),
             ("PHI", 0.72),
             ("GAMMA", 0.41),
+            ("VTO", 0.63),
         ],
     )
     .unwrap();
-    let explicit = mosfet_from_model_card("M2", "d", "g", "s", "b", &explicit_card).unwrap();
+    let explicit = mosfet_from_model_card("M3", "d", "g", "s", "b", &explicit_card).unwrap();
     assert_close(explicit.params.phi, 0.72);
     assert_close(explicit.params.gamma, 0.41);
+    assert_close(explicit.params.vt0, 0.63);
 
     let invalid_card =
         normalize_model_card("Minvalid", "nmos", &[("NSUB", 1.0e10), ("TOX", 1.0e-7)]).unwrap();
     assert!(matches!(
-        mosfet_from_model_card("M3", "d", "g", "s", "b", &invalid_card),
+        mosfet_from_model_card("M4", "d", "g", "s", "b", &invalid_card),
         Err(SpiceError::InvalidElement { reason, .. })
             if reason == "MOSFET NSUB must exceed the intrinsic carrier density"
     ));

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Derive Level-1 MOS `VT0` from explicit model-card `NSUB` plus `TOX` using
+  Berkeley MOS1 default gate-work-function and surface-state assumptions,
+  preserving explicit `VTO` / `VT0` precedence for NMOS and PMOS.
 - Derive Level-1 MOS `PHI` and `GAMMA` from explicit model-card `NSUB` plus
   `TOX`, preserving explicit electrostatic parameters and rejecting substrate
   doping at or below the intrinsic carrier density.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -10,6 +10,11 @@ const OXIDE_PERMITTIVITY = 3.453133e-11;
 const SILICON_PERMITTIVITY = 11.70 * 8.854_214_871e-12;
 const INTRINSIC_CARRIER_DENSITY_PER_CUBIC_METER = 1.45e16;
 const CUBIC_CENTIMETERS_PER_CUBIC_METER = 1.0e6;
+
+function siliconBandGapElectronVolts(temperatureKelvin: number): number {
+  return 1.16 - (7.02e-4 * temperatureKelvin * temperatureKelvin) / (temperatureKelvin + 1108.0);
+}
+
 const SPICE_SUFFIX_FACTORS: Readonly<Record<string, number>> = Object.freeze({
   t: 1.0e12,
   g: 1.0e9,
@@ -7747,12 +7752,10 @@ export function mosfetAtTemperature(
     throw invalidElement(element.name, "nominal temperature must be finite and positive");
   }
   const ratio = temperatureKelvin / nominalTemperature;
-  const siliconBandGap = (temperature: number): number =>
-    1.16 - (7.02e-4 * temperature * temperature) / (temperature + 1108.0);
   const potentialCorrection = (temperature: number): number => {
     const thermalVoltage = (BOLTZMANN * temperature) / ELECTRON_CHARGE;
     const argument =
-      (-siliconBandGap(temperature) * ELECTRON_CHARGE) /
+      (-siliconBandGapElectronVolts(temperature) * ELECTRON_CHARGE) /
         (2.0 * BOLTZMANN * temperature) +
       (1.115_087_7 * ELECTRON_CHARGE) /
         (2.0 * BOLTZMANN * referenceTemperatureKelvin);
@@ -7799,7 +7802,8 @@ export function mosfetAtTemperature(
     element.params.VT0 -
     polarity * element.params.GAMMA * Math.sqrt(element.params.PHI) +
     0.5 *
-      (siliconBandGap(nominalTemperature) - siliconBandGap(temperatureKelvin)) +
+      (siliconBandGapElectronVolts(nominalTemperature) -
+        siliconBandGapElectronVolts(temperatureKelvin)) +
     polarity * 0.5 * (temperaturePhi - element.params.PHI);
   const temperatureVt0 =
     temperatureVbi + polarity * element.params.GAMMA * Math.sqrt(temperaturePhi);
@@ -8954,8 +8958,19 @@ export function mosfetFromModelCard(
       }
     }
   }
+  const nominalTemperature = p.T_NOM ?? 300.15;
+  const polarity = model.kind === "NMOS" ? 1.0 : -1.0;
+  const thresholdVoltage =
+    p.VT0 ??
+    (p.N_SUB !== undefined && p.TOX !== undefined && p.TOX > 0.0
+      ? polarity *
+        ((bodyEffectCoefficient ?? 0.0) * Math.sqrt(surfacePotential ?? 0.0) +
+          0.5 *
+            ((surfacePotential ?? 0.0) -
+              siliconBandGapElectronVolts(nominalTemperature)))
+      : undefined);
   const params: Partial<MosfetLevel1Params> = {
-    ...(p.VT0 !== undefined ? { VT0: p.VT0 } : {}),
+    ...(thresholdVoltage !== undefined ? { VT0: thresholdVoltage } : {}),
     ...(transconductance !== undefined ? { KP: transconductance } : {}),
     ...(p.LAMBDA !== undefined ? { LAMBDA: p.LAMBDA } : {}),
     ...(bodyEffectCoefficient !== undefined ? { GAMMA: bodyEffectCoefficient } : {}),

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -530,11 +530,30 @@ describe("dcOp", () => {
         2.0 * (11.70 * 8.854_214_871e-12) * 1.602_176_634e-19 * 4.0e21,
       ) /
       (3.453133e-11 / 100.0e-9);
+    const expectedBandGap =
+      1.16 - (7.02e-4 * 300.15 * 300.15) / (300.15 + 1108.0);
+    const expectedVt0 =
+      expectedGamma * Math.sqrt(expectedPhi) +
+      0.5 * (expectedPhi - expectedBandGap);
     expectClose(derived.params.PHI, expectedPhi);
     expectClose(derived.params.GAMMA, expectedGamma);
+    expectClose(derived.params.VT0, expectedVt0);
+
+    const pmos = mosfetFromModelCard(
+      "M2",
+      "d",
+      "g",
+      "s",
+      "b",
+      normalizeModelCard("Mp", "pmos", {
+        NSUB: 4.0e15,
+        TOX: 100.0e-9,
+      }),
+    );
+    expectClose(pmos.params.VT0, -expectedVt0);
 
     const explicit = mosfetFromModelCard(
-      "M2",
+      "M3",
       "d",
       "g",
       "s",
@@ -544,14 +563,16 @@ describe("dcOp", () => {
         TOX: 100.0e-9,
         PHI: 0.72,
         GAMMA: 0.41,
+        VTO: 0.63,
       }),
     );
     expectClose(explicit.params.PHI, 0.72);
     expectClose(explicit.params.GAMMA, 0.41);
+    expectClose(explicit.params.VT0, 0.63);
 
     expect(() =>
       mosfetFromModelCard(
-        "M3",
+        "M4",
         "d",
         "g",
         "s",

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS substrate-doping electrostatic derivation.
+1. Cross-language Level-1 MOS process-derived threshold voltage.
    - Status: current PR completion candidate.
-   - Derive `PHI` and `GAMMA` from model-card `NSUB` plus `TOX` using the
-     Berkeley MOS1 process-parameter equations.
-   - Preserve explicit `PHI` / `GAMMA` precedence and reject substrate doping
-     at or below the intrinsic carrier density.
+   - Derive polarity-aware `VT0` from model-card `NSUB` plus `TOX` using the
+     Berkeley MOS1 default gate-work-function and surface-state assumptions.
+   - Preserve explicit `VTO` / `VT0` precedence for NMOS and PMOS.
    - Keep Rust, Python, and TypeScript model lowering, tests, and docs aligned.
 
 ## Completed Slices
@@ -3609,6 +3608,13 @@ the Rust, Python, and TypeScript surfaces together.
      circuit nominal temperature as the fallback.
    - Direct MOS helpers and circuit-level temperature transforms preserve
      matching behavior in Rust, Python, and TypeScript.
+
+290. Cross-language Level-1 MOS substrate-doping electrostatic derivation.
+   - Status: completed in PR 9156.
+   - Model-card `NSUB` plus `TOX` derives `PHI` and `GAMMA` using the Berkeley
+     MOS1 process-parameter equations.
+   - Explicit `PHI` / `GAMMA` takes precedence, and substrate doping at or below
+     the intrinsic carrier density is rejected in Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- derive polarity-aware Level-1 MOS `VT0` from explicit `NSUB` plus `TOX` using Berkeley MOS1 default gate-work-function and zero surface-state charge assumptions
- preserve explicit `VTO` / `VT0` precedence and share silicon band-gap preprocessing with temperature scaling
- keep Rust, Python, TypeScript, changelogs, and the SPICE completion plan aligned

Reference: [ngspice MOS1 preprocessing](https://github.com/ngspice/ngspice/blob/master/src/spicelib/devices/mos1/mos1temp.c#L66-L98)

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- `PYTHONPATH=$(printf '%s:' ../*/src) python3.12 -m pytest -q` (674 passed, 88.91% coverage)
- `python3.12 -m ruff check src/spice_engine/model_cards.py tests/test_engine.py`
- `npm test` (417 passed)
- `npm run build`