### PR TITLE
feat(adj-formula-stdlib): temperature interval — NIST SP 811 B.9 degree-Celsius→kelvin table (b32, RS-5, new dimension)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -1429,6 +1429,50 @@ fn shipped_linear_mass_density_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b32) The shipped NIST SP 811 B.9 temperature-interval → kelvin table resolves the exact degree-
+//       Celsius factor with its citation, and ABSTAINS on a wrong-dimension unit. This opens a NEW
+//       dimension — TEMPERATURE INTERVAL (a DIFFERENCE of temperatures, not a point reading) — beyond
+//       the length/mass/…/linear-mass-density and electric families. A Celsius-degree interval is
+//       EXACTLY one kelvin (the scales share a unit step; the 273.15 offset applies only to POINTS,
+//       which are an ADDITION, not a factor, hence absent). The Celsius degree (temperature interval →
+//       kelvin) and the bare "degree" (plane angle → radian) are DIFFERENT quantities that convert to
+//       DIFFERENT SI units (K vs rad) yet share the "°" symbol, so the abstain guards that notational
+//       confusion directly, not mere absence of a value.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_temperature_interval_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_tempinterval");
+    let src = stdlib().join("reference/temperature-interval-conversions.adj");
+    std::fs::copy(&src, dir.join("temperature-interval-conversions.adj"))
+        .expect("copy shipped temperature-interval-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"temperature-interval-conversions.adj\"\n\
+         ? temperature_interval_to_kelvin(degree_celsius, $v)\n\
+         ? temperature_interval_to_kelvin(degree, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 exact factor resolves, character-for-character from the table
+    // (boldface = exact; a Celsius-degree interval is exactly 1 kelvin).
+    assert!(out.contains("\"v\":\"1\""), "degree Celsius interval = 1.0 E+00 K: {out}");
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // The bare `degree` is a PLANE-ANGLE unit (it converts to the radian, a DIFFERENT quantity), so
+    // this temperature-interval table has no row for it — the engine abstains rather than mis-
+    // converting an angle as if it were a temperature, despite the shared "°" symbol.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a wrong-dimension unit abstains, never a cross-dimension fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/temperature-interval-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/temperature-interval-conversions.adj
@@ -1,0 +1,64 @@
+% ============================================================================
+% temperature-interval-conversions — temperature-INTERVAL-unit → kelvin factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of the NIST-cited conversion tables (length, mass, energy, the electric-EMU
+% family, wave number, linear mass density, and the rest): a native tabular relation ingested VERBATIM
+% from a published NIST conversion table. The row states the factor converting a temperature INTERVAL
+% (a DIFFERENCE of temperatures, e.g. "the temperature rose by 5 degrees Celsius") expressed in
+% degrees Celsius to the SI base unit, the kelvin (K):
+%
+%     ? temperature_interval_to_kelvin(degree_celsius, $v)   % 1
+%
+% This opens a NEW dimension — TEMPERATURE INTERVAL — alongside the already-tabulated length/mass/
+% area/volume/time/speed/energy/pressure/force/acceleration/dynamic-viscosity/kinematic-viscosity/
+% magnetic-flux-density/magnetic-flux/illuminance/luminance/radioactivity/absorbed-dose/dose-
+% equivalent/exposure/power/wave-number/linear-mass-density tables and the electric charge/potential/
+% resistance/capacitance/inductance/conductance/current tables. A Celsius-degree INTERVAL equals
+% exactly one kelvin: the two scales are offset (0 °C = 273.15 K) but share the SAME step size, so a
+% DIFFERENCE of temperatures converts by the exact factor 1.
+%
+% CRUCIAL DISTINCTION — INTERVAL vs POINT: this table converts temperature INTERVALS (differences),
+% NOT temperature POINTS (a reading on the scale). A temperature POINT in °C converts to kelvin by the
+% OFFSET formula T/K = t/°C + 273.15, which is an addition, NOT a multiplicative factor — so it is not
+% a conversion-factor row at all and is deliberately absent here (this table only holds multiplicative
+% factors). Do NOT use this factor to convert a thermometer reading; use it to convert a temperature
+% CHANGE or a per-degree quantity (a heat capacity in J/°C, a gradient in °C/m, etc.).
+%
+% Why a `table` and not a hand-written `relate` clause: this is exactly the shape reference data comes
+% in — a published table, not prose. The citable artifact IS the NIST conversion-factors table at the
+% `locator` below; the factor here is a CELL of NIST Special Publication 811, Appendix B.9, defended by
+% one provenance envelope. Each `row` lowers to a ground relation
+% `temperature_interval_to_kelvin(unit, v)`, so the exact lookup above is the ordinary SLD binding
+% query — the engine returns the factor WITH this table's citation as its proof, on the CPU, with zero
+% model calls.
+%
+% HONESTY NOTE (like every other NIST table, only the EXACT defined factor gets a row): NIST SP 811
+% B.9 prints the "degree Celsius" interval factor in BOLDFACE, its convention for factors that are
+% EXACT by definition, transcribed here as the plain decimal number of kelvins it names:
+%
+%     degree Celsius (°C)   1.0 E+00  →  1
+%
+% This is exact because the Celsius and kelvin scales are defined with an identical unit step, so one
+% Celsius-degree interval IS one kelvin, exactly. It terminates; nothing here is a rounded measurement.
+% (The "degree Fahrenheit" interval, by contrast, is 5/9 K — a NON-terminating factor — so, like every
+% non-exact factor, it gets no row.) This table is SPECIFIC to temperature interval: a unit of a
+% DIFFERENT quantity — e.g. the "degree" of PLANE ANGLE, which NIST SP 811 B.9 lists separately as
+% converting to the radian, NOT the kelvin — therefore gets no row here, and a
+% `? temperature_interval_to_kelvin(degree, $v)` ABSTAINS rather than mis-converting an angle as if it
+% were a temperature. (The degree symbol "°" is shared by the Celsius degree and the angular degree,
+% so this abstain guards a real notational confusion.) The only claim this table makes is "this is the
+% exact factor NIST SP 811 B.9 prints for the Celsius interval's conversion to the kelvin" — which is
+% exactly what a byte-check against the cited table verifies. `trust authoritative` — a primary,
+% re-fetchable standards reference. (See ADJ-TABLES.md; and feedback_nothing_human_authored — the
+% factor is a verbatim cell of the cited table, nothing asserted from memory.)
+% ============================================================================
+
+table temperature_interval_to_kelvin {
+    columns unit, kelvin
+
+    row (degree_celsius, 1)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/temperature-interval-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/temperature-interval-conversions.query.adj
@@ -1,0 +1,26 @@
+% ============================================================================
+% temperature-interval-conversions.query.adj — worked lookups over the NIST temperature-interval →
+% kelvin table.
+% ============================================================================
+% The shape a consumer produces to convert a temperature INTERVAL (a difference of temperatures, or a
+% per-degree quantity) given in degrees Celsius into SI: it `import`s the grounded table and asks the
+% engine to bind the factor. No arithmetic and no factor is stated by the consumer; the engine returns
+% the cell WITH the table's NIST citation as its proof, on the CPU.
+%
+%   ? temperature_interval_to_kelvin(degree_celsius, $v)   % 1   (a 1 °C interval = exactly 1 K)
+%
+% And the dimension guard: a unit of a DIFFERENT quantity has no row, so the lookup ABSTAINS rather
+% than mis-converting across dimensions. The bare "degree" is a PLANE-ANGLE unit (it converts to the
+% radian), NOT a temperature-interval unit — and since the degree symbol "°" is shared by the Celsius
+% degree and the angular degree, this abstain guards that notational confusion directly:
+%
+%   ? temperature_interval_to_kelvin(degree, $v)   % abstains (degree is plane angle → radian)
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli temperature-interval-conversions.query.adj
+% ============================================================================
+
+import "temperature-interval-conversions.adj"
+
+? temperature_interval_to_kelvin(degree_celsius, $v)   % expect 1        (exact NIST SP 811 B.9 factor)
+? temperature_interval_to_kelvin(degree, $v)           % expect abstain  (plane-angle unit, wrong dimension)


### PR DESCRIPTION
## What

Ships a new grounded NIST SP 811 B.9 conversion table opening a **NEW dimension — TEMPERATURE INTERVAL** (a *difference* of temperatures, not a point reading) in the ADJ formula stdlib:

- `code/specs/data/adj-formula-stdlib/reference/temperature-interval-conversions.adj` — a native RS-5 `table` with the exact row **degree Celsius → kelvin = 1** (1.0 E+00).
- `…/reference/temperature-interval-conversions.query.adj` — a worked exact-lookup + a dimension-guard abstain.
- `code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs` — appends the **b32** e2e block (36 → 37 tests).

## Grounding

The factor is a verbatim BOLDFACE (= exact) cell of NIST Special Publication 811, Appendix B.9:

> degree Celsius (°C)   1.0 E+00

locator `https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9`, `trust authoritative`. A Celsius-degree **interval** is exactly one kelvin — the two scales share a unit step; the 273.15 offset applies only to temperature **points** (an addition, not a multiplicative factor), so it is deliberately absent from this factor table.

## Dimension safety

`? temperature_interval_to_kelvin(degree_celsius, $v)` binds `1` with the NIST citation as proof. A wrong-dimension probe — the bare **degree** of PLANE ANGLE (→ radian, a DIFFERENT quantity that shares the "°" symbol) — **abstains** (`"abstained":true`) rather than mis-converting an angle as a temperature.

## Verification

- `cargo test -p adj-lang-cli --test rs5_table_e2e` → 37 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean.
- Render-probe confirms `"v":"1"` for the Celsius interval + `"abstained":true` for the angular degree + the NIST locator.
- NUL-scan clean. Security review: clean (no vulnerabilities) — conducted inline this run because the review sub-agent was unavailable due to a transient upstream 529 outage.

Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)