### PR TITLE
feat(spice): apply MOS surface-state threshold shift

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Accept Level-1 MOS model-card `NSS` surface-state density and include its
+  oxide-charge flat-band shift when deriving `VT0` from process parameters,
+  while preserving explicit threshold-voltage precedence.
 - Derive Level-1 MOS `VT0` from explicit model-card `NSUB` plus `TOX` using
   Berkeley MOS1 default gate-work-function and surface-state assumptions,
   preserving explicit `VTO` / `VT0` precedence for NMOS and PMOS.

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -323,8 +323,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "PNP": (41, 58, 13, 4),
     "NJF": (22, 30, 7, 3),
     "PJF": (22, 30, 7, 3),
-    "NMOS": (31, 39, 7, 3),
-    "PMOS": (31, 39, 7, 3),
+    "NMOS": (32, 40, 7, 3),
+    "PMOS": (32, 40, 7, 3),
 }
 
 
@@ -486,6 +486,7 @@ _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
     "JS": "JS",
     "NSUB": "N_SUB",
     "N_SUB": "N_SUB",
+    "NSS": "NSS",
     "TNOM": "T_NOM",
     "T_NOM": "T_NOM",
     "CGSO": "CGSO",
@@ -1126,6 +1127,10 @@ def mosfet_from_model_card(
     if "VT0" not in p and "N_SUB" in p and "TOX" in p and p["TOX"] > 0.0:
         polarity = 1.0 if model.kind == "NMOS" else -1.0
         nominal_temperature = p.get("T_NOM", defaults.T_NOM)
+        oxide_capacitance = OXIDE_PERMITTIVITY / p["TOX"]
+        surface_state_shift = (
+            p.get("NSS", 0.0) * 1.0e4 * _ELECTRON_CHARGE / oxide_capacitance
+        )
         threshold_voltage = polarity * (
             body_effect_coefficient * math.sqrt(surface_potential)
             + 0.5
@@ -1133,7 +1138,7 @@ def mosfet_from_model_card(
                 surface_potential
                 - _silicon_band_gap_electron_volts(nominal_temperature)
             )
-        )
+        ) - surface_state_shift
     params = replace(
         defaults,
         VT0=threshold_voltage,

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -409,7 +409,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 203
+    assert len(coverage) == 205
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -424,7 +424,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tAF\tAF\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 203
+    assert len(records) == 205
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -447,8 +447,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert summary[0].max_alias_count == 3
     assert summary[0].aliased_parameters == ("IS", "VT", "CJO", "VJ", "M")
     assert summary[5].kind == "NMOS"
-    assert summary[5].canonical_parameter_count == 31
-    assert summary[5].accepted_name_count == 39
+    assert summary[5].canonical_parameter_count == 32
+    assert summary[5].accepted_name_count == 40
     assert summary[5].aliased_parameter_count == 7
     assert summary[5].max_alias_count == 3
     assert summary[5].aliased_parameters == (
@@ -471,7 +471,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert table.splitlines()[1] == "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M"
     assert (
         table.splitlines()[-1]
-        == "PMOS\t31\t39\t7\t3\tVT0|LAMBDA|U0|N_SUB|T_NOM|CBS|CBD"
+        == "PMOS\t32\t40\t7\t3\tVT0|LAMBDA|U0|N_SUB|T_NOM|CBS|CBD"
     )
     records = model_card_supported_parameter_coverage_summary_records()
     assert len(records) == 7
@@ -499,9 +499,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 203
-    assert report.expected_canonical_parameter_count == 203
-    assert report.accepted_name_count == 275
+    assert report.canonical_parameter_count == 205
+    assert report.expected_canonical_parameter_count == 205
+    assert report.accepted_name_count == 277
     assert report.aliased_parameter_count == 59
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -509,7 +509,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t203\t203\t275\t59\t4\t0"
+        "true\t7\t7\t205\t205\t277\t59\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -537,15 +537,15 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 202
-    assert report.accepted_name_count == 272
+    assert report.canonical_parameter_count == 204
+    assert report.accepted_name_count == 274
     assert report.aliased_parameter_count == 58
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
     assert report.issues[0].field == "canonical_parameter_count"
     assert report.issues[0].message == (
-        "expected NMOS to expose 31 canonical supported parameters, found 30"
+        "expected NMOS to expose 32 canonical supported parameters, found 31"
     )
     assert report.issues[-1].field == "max_alias_count"
     assert report.issues[-1].message == "expected NMOS max alias count 3, found 2"
@@ -553,12 +553,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t202\t203\t272\t58\t4\t4\n"
+        "false\t7\t7\t204\t205\t274\t58\t4\t4\n"
         "kind\tfield\tmessage\n"
-        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 31 canonical "
-        "supported parameters, found 30\n"
-        "NMOS\taccepted_name_count\texpected NMOS to expose 39 accepted model-card "
-        "names, found 36\n"
+        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 32 canonical "
+        "supported parameters, found 31\n"
+        "NMOS\taccepted_name_count\texpected NMOS to expose 40 accepted model-card "
+        "names, found 37\n"
         "NMOS\taliased_parameter_count\texpected NMOS to expose 7 alias-bearing "
         "parameters, found 6\n"
         "NMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
@@ -567,12 +567,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
     assert records[0] == {
         "kind": "NMOS",
         "field": "canonical_parameter_count",
-        "message": "expected NMOS to expose 31 canonical supported parameters, found 30",
+        "message": "expected NMOS to expose 32 canonical supported parameters, found 31",
     }
     assert format_model_card_supported_parameter_coverage_gate_issue_csv(report).startswith(
         "kind,field,message\n"
-        'NMOS,canonical_parameter_count,"expected NMOS to expose 31 canonical '
-        'supported parameters, found 30"\n'
+        'NMOS,canonical_parameter_count,"expected NMOS to expose 32 canonical '
+        'supported parameters, found 31"\n'
     )
     assert (
         json.loads(format_model_card_supported_parameter_coverage_gate_issue_json(report))
@@ -853,7 +853,9 @@ def test_mos_model_card_substrate_doping_derives_electrostatics_with_precedence(
         "s",
         "b",
         normalize_model_card(
-            "Mderived", "nmos", {"NSUB": 4.0e15, "TOX": 100.0e-9}
+            "Mderived",
+            "nmos",
+            {"NSUB": 4.0e15, "TOX": 100.0e-9, "NSS": 1.0e10},
         ),
     )
     thermal_voltage = 1.380_649e-23 * 300.15 / 1.602_176_634e-19
@@ -864,9 +866,13 @@ def test_mos_model_card_substrate_doping_derives_electrostatics_with_precedence(
         2.0 * (11.70 * 8.854_214_871e-12) * 1.602_176_634e-19 * 4.0e21
     ) / (3.453133e-11 / 100.0e-9)
     expected_band_gap = 1.16 - 7.02e-4 * 300.15**2 / (300.15 + 1108.0)
-    expected_vt0 = expected_gamma * math.sqrt(expected_phi) + 0.5 * (
+    process_vt0 = expected_gamma * math.sqrt(expected_phi) + 0.5 * (
         expected_phi - expected_band_gap
     )
+    surface_state_shift = (
+        1.0e10 * 1.0e4 * 1.602_176_634e-19 / (3.453133e-11 / 100.0e-9)
+    )
+    expected_vt0 = process_vt0 - surface_state_shift
     assert pytest.approx(expected_phi) == derived.model.model.params.PHI
     assert pytest.approx(expected_gamma) == derived.model.model.params.GAMMA
     assert pytest.approx(expected_vt0) == derived.model.model.params.VT0
@@ -878,10 +884,14 @@ def test_mos_model_card_substrate_doping_derives_electrostatics_with_precedence(
         "s",
         "b",
         normalize_model_card(
-            "Mp", "pmos", {"NSUB": 4.0e15, "TOX": 100.0e-9}
+            "Mp",
+            "pmos",
+            {"NSUB": 4.0e15, "TOX": 100.0e-9, "NSS": 1.0e10},
         ),
     )
-    assert pytest.approx(-expected_vt0) == pmos.model.model.params.VT0
+    assert pytest.approx(
+        -process_vt0 - surface_state_shift
+    ) == pmos.model.model.params.VT0
 
     explicit = mosfet_from_model_card(
         "M3",
@@ -897,6 +907,7 @@ def test_mos_model_card_substrate_doping_derives_electrostatics_with_precedence(
                 "TOX": 100.0e-9,
                 "PHI": 0.72,
                 "GAMMA": 0.41,
+                "NSS": 1.0e10,
                 "VTO": 0.63,
             },
         ),

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Accept Level-1 MOS model-card `NSS` surface-state density and include its
+  oxide-charge flat-band shift when deriving `VT0` from process parameters,
+  while preserving explicit threshold-voltage precedence.
 - Derive Level-1 MOS `VT0` from explicit model-card `NSUB` plus `TOX` using
   Berkeley MOS1 default gate-work-function and surface-state assumptions,
   preserving explicit `VTO` / `VT0` precedence for NMOS and PMOS.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4109,8 +4109,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     (ModelCardKind::Pnp, 41, 58, 13, 4),
     (ModelCardKind::Njf, 22, 30, 7, 3),
     (ModelCardKind::Pjf, 22, 30, 7, 3),
-    (ModelCardKind::Nmos, 31, 39, 7, 3),
-    (ModelCardKind::Pmos, 31, 39, 7, 3),
+    (ModelCardKind::Nmos, 32, 40, 7, 3),
+    (ModelCardKind::Pmos, 32, 40, 7, 3),
 ];
 const DIODE_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IS", "IS"),
@@ -4250,6 +4250,7 @@ const MOS_LEVEL1_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("JS", "JS"),
     ("NSUB", "N_SUB"),
     ("N_SUB", "N_SUB"),
+    ("NSS", "NSS"),
     ("TNOM", "T_NOM"),
     ("T_NOM", "T_NOM"),
     ("CGSO", "CGSO"),
@@ -5069,6 +5070,7 @@ pub fn mosfet_from_model_card(
             });
         }
         if *oxide_thickness > 0.0 {
+            let oxide_capacitance = OXIDE_PERMITTIVITY / oxide_thickness;
             if !model.parameters.contains_key("PHI") {
                 let thermal_voltage = BOLTZMANN * params.t_nom / ELECTRON_CHARGE;
                 params.phi = (2.0
@@ -5079,7 +5081,6 @@ pub fn mosfet_from_model_card(
                 .max(0.1);
             }
             if !model.parameters.contains_key("GAMMA") {
-                let oxide_capacitance = OXIDE_PERMITTIVITY / oxide_thickness;
                 params.gamma = (2.0
                     * SILICON_PERMITTIVITY
                     * ELECTRON_CHARGE
@@ -5092,9 +5093,13 @@ pub fn mosfet_from_model_card(
                     MosfetType::Nmos => 1.0,
                     MosfetType::Pmos => -1.0,
                 };
+                let surface_state_shift =
+                    model_card_value(model, "NSS", 0.0) * 1.0e4 * ELECTRON_CHARGE
+                        / oxide_capacitance;
                 params.vt0 = polarity
                     * (params.gamma * params.phi.sqrt()
-                        + 0.5 * (params.phi - silicon_band_gap_electron_volts(params.t_nom)));
+                        + 0.5 * (params.phi - silicon_band_gap_electron_volts(params.t_nom)))
+                    - surface_state_shift;
             }
         }
     }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -96,7 +96,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 203);
+    assert_eq!(coverage.len(), 205);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -115,7 +115,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tAF\tAF\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 203);
+    assert_eq!(records.len(), 205);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -148,8 +148,8 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         vec!["IS", "VT", "CJO", "VJ", "M"]
     );
     assert_eq!(summary[5].kind, ModelCardKind::Nmos);
-    assert_eq!(summary[5].canonical_parameter_count, 31);
-    assert_eq!(summary[5].accepted_name_count, 39);
+    assert_eq!(summary[5].canonical_parameter_count, 32);
+    assert_eq!(summary[5].accepted_name_count, 40);
     assert_eq!(summary[5].aliased_parameter_count, 7);
     assert_eq!(summary[5].max_alias_count, 3);
     assert_eq!(
@@ -167,7 +167,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     assert_eq!(lines[1], "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\t31\t39\t7\t3\tVT0|LAMBDA|U0|N_SUB|T_NOM|CBS|CBD"
+        &"PMOS\t32\t40\t7\t3\tVT0|LAMBDA|U0|N_SUB|T_NOM|CBS|CBD"
     );
     let records = model_card_supported_parameter_coverage_summary_records();
     assert_eq!(records.len(), 7);
@@ -185,7 +185,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         "[{\"kind\":\"D\",\"canonical_parameter_count\":\"15\",\"accepted_name_count\":\"21\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
     ));
     assert!(json.ends_with(
-        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"31\",\"accepted_name_count\":\"39\",\"aliased_parameter_count\":\"7\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|U0|N_SUB|T_NOM|CBS|CBD\"}]\n"
+        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"32\",\"accepted_name_count\":\"40\",\"aliased_parameter_count\":\"7\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|U0|N_SUB|T_NOM|CBS|CBD\"}]\n"
     ));
 }
 
@@ -196,15 +196,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 203);
-    assert_eq!(report.expected_canonical_parameter_count, 203);
-    assert_eq!(report.accepted_name_count, 275);
+    assert_eq!(report.canonical_parameter_count, 205);
+    assert_eq!(report.expected_canonical_parameter_count, 205);
+    assert_eq!(report.accepted_name_count, 277);
     assert_eq!(report.aliased_parameter_count, 59);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t203\t203\t275\t59\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t205\t205\t277\t59\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -231,8 +231,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 202);
-    assert_eq!(report.accepted_name_count, 272);
+    assert_eq!(report.canonical_parameter_count, 204);
+    assert_eq!(report.accepted_name_count, 274);
     assert_eq!(report.aliased_parameter_count, 58);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -240,7 +240,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     assert_eq!(report.issues[0].field, "canonical_parameter_count");
     assert_eq!(
         report.issues[0].message,
-        "expected NMOS to expose 31 canonical supported parameters, found 30"
+        "expected NMOS to expose 32 canonical supported parameters, found 31"
     );
     assert_eq!(report.issues.last().unwrap().field, "max_alias_count");
     assert_eq!(
@@ -249,20 +249,20 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t202\t203\t272\t58\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 31 canonical supported parameters, found 30\nNMOS\taccepted_name_count\texpected NMOS to expose 39 accepted model-card names, found 36\nNMOS\taliased_parameter_count\texpected NMOS to expose 7 alias-bearing parameters, found 6\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t204\t205\t274\t58\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 32 canonical supported parameters, found 31\nNMOS\taccepted_name_count\texpected NMOS to expose 40 accepted model-card names, found 37\nNMOS\taliased_parameter_count\texpected NMOS to expose 7 alias-bearing parameters, found 6\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
     assert_eq!(records[0]["field"], "canonical_parameter_count");
     assert_eq!(
         records[0]["message"],
-        "expected NMOS to expose 31 canonical supported parameters, found 30"
+        "expected NMOS to expose 32 canonical supported parameters, found 31"
     );
     assert!(format_model_card_supported_parameter_coverage_gate_issue_csv(&report).starts_with(
-        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 31 canonical supported parameters, found 30\"\n"
+        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 32 canonical supported parameters, found 31\"\n"
     ));
     assert!(format_model_card_supported_parameter_coverage_gate_issue_json(&report).starts_with(
-        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 31 canonical supported parameters, found 30\"}"
+        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 32 canonical supported parameters, found 31\"}"
     ));
 }
 
@@ -284,8 +284,8 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(dashboard[0].issue_count, 0);
     assert!(dashboard[0].issue_fields.is_empty());
     assert_eq!(dashboard[5].kind, ModelCardKind::Nmos);
-    assert_eq!(dashboard[5].canonical_parameter_count, 31);
-    assert_eq!(dashboard[5].accepted_name_count, 39);
+    assert_eq!(dashboard[5].canonical_parameter_count, 32);
+    assert_eq!(dashboard[5].accepted_name_count, 40);
     assert_eq!(dashboard[5].issue_count, 0);
 
     let table = format_model_card_supported_parameter_coverage_dashboard_table(&coverage);
@@ -297,7 +297,7 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(lines[1], "D\ttrue\t15\t15\t21\t21\t5\t5\t3\t3\t0\t");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\ttrue\t31\t31\t39\t39\t7\t7\t3\t3\t0\t"
+        &"PMOS\ttrue\t32\t32\t40\t40\t7\t7\t3\t3\t0\t"
     );
     let records = model_card_supported_parameter_coverage_dashboard_records(&coverage);
     assert_eq!(records.len(), 7);
@@ -329,10 +329,10 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         .unwrap();
 
     assert!(!nmos.passed);
-    assert_eq!(nmos.canonical_parameter_count, 30);
-    assert_eq!(nmos.expected_canonical_parameter_count, 31);
-    assert_eq!(nmos.accepted_name_count, 36);
-    assert_eq!(nmos.expected_accepted_name_count, 39);
+    assert_eq!(nmos.canonical_parameter_count, 31);
+    assert_eq!(nmos.expected_canonical_parameter_count, 32);
+    assert_eq!(nmos.accepted_name_count, 37);
+    assert_eq!(nmos.expected_accepted_name_count, 40);
     assert_eq!(nmos.aliased_parameter_count, 6);
     assert_eq!(nmos.expected_aliased_parameter_count, 7);
     assert_eq!(nmos.max_alias_count, 2);
@@ -348,7 +348,7 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         ]
     );
     assert!(format_model_card_supported_parameter_coverage_dashboard_table(&coverage).contains(
-        "NMOS\tfalse\t30\t31\t36\t39\t6\t7\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
+        "NMOS\tfalse\t31\t32\t37\t40\t6\t7\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
     ));
 }
 
@@ -677,8 +677,12 @@ fn mos_model_card_surface_mobility_derives_kp_with_explicit_precedence() {
 
 #[test]
 fn mos_model_card_substrate_doping_derives_electrostatics_with_explicit_precedence() {
-    let derived_card =
-        normalize_model_card("Mderived", "nmos", &[("NSUB", 4.0e15), ("TOX", 100.0e-9)]).unwrap();
+    let derived_card = normalize_model_card(
+        "Mderived",
+        "nmos",
+        &[("NSUB", 4.0e15), ("TOX", 100.0e-9), ("NSS", 1.0e10)],
+    )
+    .unwrap();
     let derived = mosfet_from_model_card("M1", "d", "g", "s", "b", &derived_card).unwrap();
     let thermal_voltage = 1.380_649e-23 * 300.15 / 1.602_176_634e-19;
     let expected_phi = (2.0 * thermal_voltage * (4.0e21_f64 / 1.45e16).ln()).max(0.1);
@@ -686,16 +690,22 @@ fn mos_model_card_substrate_doping_derives_electrostatics_with_explicit_preceden
         .sqrt()
         / (3.453_133e-11 / 100.0e-9);
     let expected_band_gap = 1.16 - 7.02e-4 * 300.15 * 300.15 / (300.15 + 1108.0);
-    let expected_vt0 =
+    let process_vt0 =
         expected_gamma * expected_phi.sqrt() + 0.5 * (expected_phi - expected_band_gap);
+    let surface_state_shift = 1.0e10 * 1.0e4 * 1.602_176_634e-19 / (3.453_133e-11 / 100.0e-9);
+    let expected_vt0 = process_vt0 - surface_state_shift;
     assert_close(derived.params.phi, expected_phi);
     assert_close(derived.params.gamma, expected_gamma);
     assert_close(derived.params.vt0, expected_vt0);
 
-    let pmos_card =
-        normalize_model_card("Mp", "pmos", &[("NSUB", 4.0e15), ("TOX", 100.0e-9)]).unwrap();
+    let pmos_card = normalize_model_card(
+        "Mp",
+        "pmos",
+        &[("NSUB", 4.0e15), ("TOX", 100.0e-9), ("NSS", 1.0e10)],
+    )
+    .unwrap();
     let pmos = mosfet_from_model_card("M2", "d", "g", "s", "b", &pmos_card).unwrap();
-    assert_close(pmos.params.vt0, -expected_vt0);
+    assert_close(pmos.params.vt0, -process_vt0 - surface_state_shift);
 
     let explicit_card = normalize_model_card(
         "Mexplicit",
@@ -705,6 +715,7 @@ fn mos_model_card_substrate_doping_derives_electrostatics_with_explicit_preceden
             ("TOX", 100.0e-9),
             ("PHI", 0.72),
             ("GAMMA", 0.41),
+            ("NSS", 1.0e10),
             ("VTO", 0.63),
         ],
     )

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Accept Level-1 MOS model-card `NSS` surface-state density and include its
+  oxide-charge flat-band shift when deriving `VT0` from process parameters,
+  while preserving explicit threshold-voltage precedence.
 - Derive Level-1 MOS `VT0` from explicit model-card `NSUB` plus `TOX` using
   Berkeley MOS1 default gate-work-function and surface-state assumptions,
   preserving explicit `VTO` / `VT0` precedence for NMOS and PMOS.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -2071,8 +2071,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   PNP: [41, 58, 13, 4],
   NJF: [22, 30, 7, 3],
   PJF: [22, 30, 7, 3],
-  NMOS: [31, 39, 7, 3],
-  PMOS: [31, 39, 7, 3],
+  NMOS: [32, 40, 7, 3],
+  PMOS: [32, 40, 7, 3],
 };
 
 export interface Vccs {
@@ -8354,6 +8354,7 @@ const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   JS: "JS",
   NSUB: "N_SUB",
   N_SUB: "N_SUB",
+  NSS: "NSS",
   TNOM: "T_NOM",
   T_NOM: "T_NOM",
   CGSO: "CGSO",
@@ -8960,6 +8961,11 @@ export function mosfetFromModelCard(
   }
   const nominalTemperature = p.T_NOM ?? 300.15;
   const polarity = model.kind === "NMOS" ? 1.0 : -1.0;
+  const surfaceStateShift =
+    p.TOX !== undefined && p.TOX > 0.0
+      ? ((p.NSS ?? 0.0) * 1.0e4 * ELECTRON_CHARGE) /
+        (OXIDE_PERMITTIVITY / p.TOX)
+      : 0.0;
   const thresholdVoltage =
     p.VT0 ??
     (p.N_SUB !== undefined && p.TOX !== undefined && p.TOX > 0.0
@@ -8967,7 +8973,8 @@ export function mosfetFromModelCard(
         ((bodyEffectCoefficient ?? 0.0) * Math.sqrt(surfacePotential ?? 0.0) +
           0.5 *
             ((surfacePotential ?? 0.0) -
-              siliconBandGapElectronVolts(nominalTemperature)))
+              siliconBandGapElectronVolts(nominalTemperature))) -
+        surfaceStateShift
       : undefined);
   const params: Partial<MosfetLevel1Params> = {
     ...(thresholdVoltage !== undefined ? { VT0: thresholdVoltage } : {}),

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -122,7 +122,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(203);
+    expect(coverage).toHaveLength(205);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -142,7 +142,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tAF\tAF\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(203);
+    expect(records).toHaveLength(205);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -168,8 +168,8 @@ describe("dcOp", () => {
     });
     expect(summary[5]).toStrictEqual({
       kind: "NMOS",
-      canonicalParameterCount: 31,
-      acceptedNameCount: 39,
+      canonicalParameterCount: 32,
+      acceptedNameCount: 40,
       aliasedParameterCount: 7,
       maxAliasCount: 3,
       aliasedParameters: ["VT0", "LAMBDA", "U0", "N_SUB", "T_NOM", "CBS", "CBD"],
@@ -182,7 +182,7 @@ describe("dcOp", () => {
     );
     expect(table.split("\n")[1]).toBe("D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     expect(table.split("\n").at(-1)).toBe(
-      "PMOS\t31\t39\t7\t3\tVT0|LAMBDA|U0|N_SUB|T_NOM|CBS|CBD",
+      "PMOS\t32\t40\t7\t3\tVT0|LAMBDA|U0|N_SUB|T_NOM|CBS|CBD",
     );
     const records = modelCardSupportedParameterCoverageSummaryRecords();
     expect(records).toHaveLength(7);
@@ -207,15 +207,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 203,
-      expectedCanonicalParameterCount: 203,
-      acceptedNameCount: 275,
+      canonicalParameterCount: 205,
+      expectedCanonicalParameterCount: 205,
+      acceptedNameCount: 277,
       aliasedParameterCount: 59,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t203\t203\t275\t59\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t205\t205\t277\t59\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -238,15 +238,15 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(202);
-    expect(report.acceptedNameCount).toBe(272);
+    expect(report.canonicalParameterCount).toBe(204);
+    expect(report.acceptedNameCount).toBe(274);
     expect(report.aliasedParameterCount).toBe(58);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 31 canonical supported parameters, found 30",
+      message: "expected NMOS to expose 32 canonical supported parameters, found 31",
     });
     expect(report.issues.at(-1)).toStrictEqual({
       kind: "NMOS",
@@ -254,16 +254,16 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t202\t203\t272\t58\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 31 canonical supported parameters, found 30\nNMOS\taccepted_name_count\texpected NMOS to expose 39 accepted model-card names, found 36\nNMOS\taliased_parameter_count\texpected NMOS to expose 7 alias-bearing parameters, found 6\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t204\t205\t274\t58\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 32 canonical supported parameters, found 31\nNMOS\taccepted_name_count\texpected NMOS to expose 40 accepted model-card names, found 37\nNMOS\taliased_parameter_count\texpected NMOS to expose 7 alias-bearing parameters, found 6\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 31 canonical supported parameters, found 30",
+      message: "expected NMOS to expose 32 canonical supported parameters, found 31",
     });
     expect(formatModelCardSupportedParameterCoverageGateIssueCsv(report)).toMatch(
-      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 31 canonical supported parameters, found 30"\n/,
+      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 32 canonical supported parameters, found 31"\n/,
     );
     expect(JSON.parse(formatModelCardSupportedParameterCoverageGateIssueJson(report))).toStrictEqual(
       records,
@@ -518,6 +518,7 @@ describe("dcOp", () => {
       normalizeModelCard("Mderived", "nmos", {
         NSUB: 4.0e15,
         TOX: 100.0e-9,
+        NSS: 1.0e10,
       }),
     );
     const thermalVoltage = 1.380_649e-23 * 300.15 / 1.602_176_634e-19;
@@ -532,9 +533,13 @@ describe("dcOp", () => {
       (3.453133e-11 / 100.0e-9);
     const expectedBandGap =
       1.16 - (7.02e-4 * 300.15 * 300.15) / (300.15 + 1108.0);
-    const expectedVt0 =
+    const processVt0 =
       expectedGamma * Math.sqrt(expectedPhi) +
       0.5 * (expectedPhi - expectedBandGap);
+    const surfaceStateShift =
+      (1.0e10 * 1.0e4 * 1.602_176_634e-19) /
+      (3.453133e-11 / 100.0e-9);
+    const expectedVt0 = processVt0 - surfaceStateShift;
     expectClose(derived.params.PHI, expectedPhi);
     expectClose(derived.params.GAMMA, expectedGamma);
     expectClose(derived.params.VT0, expectedVt0);
@@ -548,9 +553,10 @@ describe("dcOp", () => {
       normalizeModelCard("Mp", "pmos", {
         NSUB: 4.0e15,
         TOX: 100.0e-9,
+        NSS: 1.0e10,
       }),
     );
-    expectClose(pmos.params.VT0, -expectedVt0);
+    expectClose(pmos.params.VT0, -processVt0 - surfaceStateShift);
 
     const explicit = mosfetFromModelCard(
       "M3",
@@ -563,6 +569,7 @@ describe("dcOp", () => {
         TOX: 100.0e-9,
         PHI: 0.72,
         GAMMA: 0.41,
+        NSS: 1.0e10,
         VTO: 0.63,
       }),
     );

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,11 +33,11 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS process-derived threshold voltage.
+1. Cross-language Level-1 MOS surface-state density.
    - Status: current PR completion candidate.
-   - Derive polarity-aware `VT0` from model-card `NSUB` plus `TOX` using the
-     Berkeley MOS1 default gate-work-function and surface-state assumptions.
-   - Preserve explicit `VTO` / `VT0` precedence for NMOS and PMOS.
+   - Accept model-card `NSS` and include its oxide-charge flat-band shift when
+     deriving `VT0` from `NSUB` plus `TOX`.
+   - Preserve explicit `VTO` / `VT0` precedence and stable parameter coverage.
    - Keep Rust, Python, and TypeScript model lowering, tests, and docs aligned.
 
 ## Completed Slices
@@ -3615,6 +3615,13 @@ the Rust, Python, and TypeScript surfaces together.
      MOS1 process-parameter equations.
    - Explicit `PHI` / `GAMMA` takes precedence, and substrate doping at or below
      the intrinsic carrier density is rejected in Rust, Python, and TypeScript.
+
+291. Cross-language Level-1 MOS process-derived threshold voltage.
+   - Status: completed in PR 9160.
+   - Model-card `NSUB` plus `TOX` derives polarity-aware `VT0` using Berkeley
+     MOS1 default gate-work-function and surface-state assumptions.
+   - Explicit `VTO` / `VT0` takes precedence for NMOS and PMOS across Rust,
+     Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- accept Berkeley Level-1 MOS `NSS` surface-state density in Rust, Python, and TypeScript model cards
- apply the `NSS * 1e4 * q / Cox` flat-band shift when `VT0` is process-derived while preserving explicit `VTO` / `VT0`
- update stable supported-parameter coverage artifacts, changelogs, and the SPICE completion plan

Reference: [ngspice MOS1 model parameters](https://github.com/ngspice/ngspice/blob/master/src/spicelib/devices/mos1/mos1mpar.c#L115-L125) and [MOS1 threshold preprocessing](https://github.com/ngspice/ngspice/blob/master/src/spicelib/devices/mos1/mos1temp.c#L88-L98)

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- `PYTHONPATH=$(printf '%s:' ../*/src) python3.12 -m pytest -q` (674 passed, 88.91% coverage)
- `python3.12 -m ruff check src/spice_engine/model_cards.py tests/test_engine.py`
- `npm test` (417 passed)
- `npm run build`