### PR TITLE
feat(adj-formula-stdlib): vital capacity — StatPearls VC = TV + IRV + ERV lung-volume sum library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_vital_capacity_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_vital_capacity_e2e.rs
@@ -1,0 +1,175 @@
+//! End-to-end tests for the `clinical/vital-capacity.adj` library — the vital-capacity relation
+//! (VC = tidal volume + inspiratory reserve volume + expiratory reserve volume) and its three exact
+//! rearrangements — driven through the built CLI binary against the SHIPPED stdlib. The same
+//! invariant as every other formula library: a consumer states NO arithmetic; it imports the grounded
+//! library, binds the measured lung volumes with `observe`, and the engine applies the cited
+//! definition on the CPU, computing the EXACT value and rendering the definition's citation and trust
+//! tier in the `derived` section (the auditable answer). The four formulas INVERT around the worked
+//! case tidal volume = 1, inspiratory reserve volume = 3, expiratory reserve volume = 2: 1 + 3 + 2 = 6
+//! (VC), 6 − 3 − 2 = 1 (TV), 6 − 1 − 2 = 3 (IRV), 6 − 1 − 3 = 2 (ERV). The four asserted values
+//! (6, 1, 3, 2) are distinct single digits, none a colon-anchored prefix of another rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped vital-capacity library, resolved from this crate's manifest dir so
+/// the test is location-independent.
+fn shipped_vc_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/vital-capacity.adj")
+        .canonicalize()
+        .expect("shipped vital-capacity.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_vc_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_vc_lib()).unwrap();
+    std::fs::write(dir.join("vital-capacity.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// vital_capacity — the relation: tidal volume + inspiratory reserve + expiratory reserve.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_vital_capacity_library_and_computes_it_with_citation() {
+    let dir = scratch("vc");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"vital-capacity.adj\"\n\
+         observe tidal_volume(1)\n\
+         observe inspiratory_reserve_volume(3)\n\
+         observe expiratory_reserve_volume(2)\n\
+         ? vital_capacity(tidal_volume, inspiratory_reserve_volume, expiratory_reserve_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied definition's result: 1 + 3 + 2 = 6.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"vital_capacity\"") && s.contains("\"value\":6"),
+        "vital_capacity(1, 3, 2) = 6: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// tidal_volume — the same definition solved for the tidal volume: VC − IRV − ERV.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_tidal_volume_from_capacity_and_reserves_with_citation() {
+    let dir = scratch("tv");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"vital-capacity.adj\"\n\
+         observe vital_capacity(6)\n\
+         observe inspiratory_reserve_volume(3)\n\
+         observe expiratory_reserve_volume(2)\n\
+         ? tidal_volume(vital_capacity, inspiratory_reserve_volume, expiratory_reserve_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 6 − 3 − 2 = 1, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"tidal_volume\"") && s.contains("\"value\":1"),
+        "tidal_volume(6, 3, 2) = 1: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "tidal_volume carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// inspiratory_reserve_volume — the same definition solved for the IRV: VC − TV − ERV.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_irv_from_capacity_tidal_and_erv_with_citation() {
+    let dir = scratch("irv");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"vital-capacity.adj\"\n\
+         observe vital_capacity(6)\n\
+         observe tidal_volume(1)\n\
+         observe expiratory_reserve_volume(2)\n\
+         ? inspiratory_reserve_volume(vital_capacity, tidal_volume, expiratory_reserve_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 6 − 1 − 2 = 3, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"inspiratory_reserve_volume\"") && s.contains("\"value\":3"),
+        "inspiratory_reserve_volume(6, 1, 2) = 3: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "inspiratory_reserve_volume carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// expiratory_reserve_volume — the same definition solved for the ERV: VC − TV − IRV, the fourth
+// reading of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_erv_from_capacity_tidal_and_irv_with_citation() {
+    let dir = scratch("erv");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"vital-capacity.adj\"\n\
+         observe vital_capacity(6)\n\
+         observe tidal_volume(1)\n\
+         observe inspiratory_reserve_volume(3)\n\
+         ? expiratory_reserve_volume(vital_capacity, tidal_volume, inspiratory_reserve_volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 6 − 1 − 3 = 2, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"expiratory_reserve_volume\"") && s.contains("\"value\":2"),
+        "expiratory_reserve_volume(6, 1, 3) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "expiratory_reserve_volume carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/vital-capacity.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/vital-capacity.adj
@@ -1,0 +1,105 @@
+% ============================================================================
+% vital-capacity.adj — the definition of the vital capacity
+% (VC = tidal volume + inspiratory reserve volume + expiratory reserve volume) in the ADJ standard
+% library.
+% ============================================================================
+% The vital-capacity entry of the *clinical* track — a pulmonary-function bedside capacity, a sum
+% sibling of the shipped total-lung-capacity.adj and functional-residual-capacity.adj. A lung CAPACITY
+% is a sum of the elementary lung VOLUMES; the vital capacity is the maximal air a person can expire
+% after a maximal inspiration: THE VITAL CAPACITY IS THE TOTAL OF THE TIDAL VOLUME, THE INSPIRATORY
+% RESERVE VOLUME, AND THE EXPIRATORY RESERVE VOLUME. It ships as an importable, byte-provenanced,
+% PARAMETERIZED `formula`, together with its three exact rearrangements (each elementary volume the
+% capacity implies once the other two are known). As with every compute library, a consumer states NO
+% arithmetic: it `import`s this file, binds the measured volumes from its own byte-provenance
+% decomposition, and asks the engine to APPLY the cited definition on the CPU. Zero math is performed
+% by the model; the engine computes each value EXACTLY (over exact rationals), carrying the
+% definition's citation.
+%
+%     import "vital-capacity.adj"
+%     observe tidal_volume(1)                % "…tidal volume 1 …"        (span cited by the model)
+%     observe inspiratory_reserve_volume(3)  % "…IRV 3 …"                  (span cited by the model)
+%     observe expiratory_reserve_volume(2)   % "…ERV 2 …"                  (span cited by the model)
+%     ? vital_capacity(tidal_volume, inspiratory_reserve_volume, expiratory_reserve_volume)
+%                                             % engine → 6, carrying the VC sum
+%
+% All four formulas are EXACT over their parameters (sums and differences of measured volumes), so
+% every value the engine returns is exact. They COMPOSE and invert cleanly around the worked case
+% tidal volume = 1, inspiratory reserve volume = 3, expiratory reserve volume = 2 (VC = 1 + 3 + 2 = 6):
+% the `vital_capacity` a consumer computes from the three volumes is exactly the value each of the
+% three volume formulas subtracts the other two from to recover its own volume.
+%
+%   vital_capacity(tidal_volume, inspiratory_reserve_volume, expiratory_reserve_volume)
+%       = tidal_volume + inspiratory_reserve_volume + expiratory_reserve_volume   % VC = TV + IRV + ERV  (definition)
+%   tidal_volume(vital_capacity, inspiratory_reserve_volume, expiratory_reserve_volume)
+%       = vital_capacity - inspiratory_reserve_volume - expiratory_reserve_volume % TV = VC − IRV − ERV  (solved for TV)
+%   inspiratory_reserve_volume(vital_capacity, tidal_volume, expiratory_reserve_volume)
+%       = vital_capacity - tidal_volume - expiratory_reserve_volume               % IRV = VC − TV − ERV  (solved for IRV)
+%   expiratory_reserve_volume(vital_capacity, tidal_volume, inspiratory_reserve_volume)
+%       = vital_capacity - tidal_volume - inspiratory_reserve_volume              % ERV = VC − TV − IRV  (solved for ERV)
+%
+% NOTE ON UNITS: all volumes are in the same unit (litres or millilitres by convention); the vital
+% capacity comes out in that same unit. This capacity does NOT include the residual volume (the air
+% that cannot be expired) — that is why VC < total lung capacity (TLC = VC + residual volume). The
+% engine computes the exact sum over whatever consistent inputs it is given.
+%
+% All four formulas are defended by the SAME definitional clause — "Vital capacity (VC) refers to the
+% maximal volume of air that can be expired following maximum inspiration. It is the total of tidal
+% volume, inspiratory reserve volume, and expiratory reserve volume (VC = V + IRV + ERV)." — because
+% that one definition (the VC IS the tidal + inspiratory-reserve + expiratory-reserve sum) sanctions
+% the relation read every way (VC from the three volumes, or any one volume from VC and the other
+% two). The quote is transcribed verbatim from the StatPearls "Vital Capacity" article on the NCBI
+% Bookshelf, so each `formula` carries the provenance envelope every shipped grounded clause carries;
+% the linter rejects an unsourced one. (See feedback_nothing_human_authored — the definitional clause
+% is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable lung volume the definition ranges over, and each result
+% is a derived quantity. `tidal_volume`, `inspiratory_reserve_volume`, `expiratory_reserve_volume` and
+% `vital_capacity` each appear BOTH as a derived result and as an input (of the other formulas), so
+% each is a single dictionary term used in both roles. The `surface` lists are the everyday names a
+% decomposer maps onto the canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary vital_capacity_vocab {
+    define tidal_volume               : finding  surface "tidal volume", "TV", "VT"                             % litres (L)
+    define inspiratory_reserve_volume : finding  surface "inspiratory reserve volume", "IRV"                    % litres (L)
+    define expiratory_reserve_volume  : finding  surface "expiratory reserve volume", "ERV"                     % litres (L)
+    define vital_capacity             : finding  surface "vital capacity", "VC"                                 % litres (L)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all four ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the definitional clause from the StatPearls "Vital
+% Capacity" article on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an exact
+% sum or difference of lung volumes, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook vital_capacity_laws {
+    use vital_capacity_vocab
+
+    % Vital capacity — the sum of the tidal, inspiratory-reserve and expiratory-reserve volumes.
+    formula vital_capacity(tidal_volume, inspiratory_reserve_volume, expiratory_reserve_volume) = tidal_volume + inspiratory_reserve_volume + expiratory_reserve_volume
+        source "Vital capacity (VC) refers to the maximal volume of air that can be expired following maximum inspiration. It is the total of tidal volume, inspiratory reserve volume, and expiratory reserve volume (VC = V + IRV + ERV)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541099/"
+        trust authoritative
+
+    % Tidal volume — the same definition solved for the tidal volume (TV = VC − IRV − ERV). Defended by
+    % the SAME clause.
+    formula tidal_volume(vital_capacity, inspiratory_reserve_volume, expiratory_reserve_volume) = vital_capacity - inspiratory_reserve_volume - expiratory_reserve_volume
+        source "Vital capacity (VC) refers to the maximal volume of air that can be expired following maximum inspiration. It is the total of tidal volume, inspiratory reserve volume, and expiratory reserve volume (VC = V + IRV + ERV)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541099/"
+        trust authoritative
+
+    % Inspiratory reserve volume — the same definition solved for the IRV (IRV = VC − TV − ERV). The
+    % SAME clause, read the third way.
+    formula inspiratory_reserve_volume(vital_capacity, tidal_volume, expiratory_reserve_volume) = vital_capacity - tidal_volume - expiratory_reserve_volume
+        source "Vital capacity (VC) refers to the maximal volume of air that can be expired following maximum inspiration. It is the total of tidal volume, inspiratory reserve volume, and expiratory reserve volume (VC = V + IRV + ERV)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541099/"
+        trust authoritative
+
+    % Expiratory reserve volume — the same definition solved for the ERV (ERV = VC − TV − IRV). The
+    % SAME clause, read the fourth way.
+    formula expiratory_reserve_volume(vital_capacity, tidal_volume, inspiratory_reserve_volume) = vital_capacity - tidal_volume - inspiratory_reserve_volume
+        source "Vital capacity (VC) refers to the maximal volume of air that can be expired following maximum inspiration. It is the total of tidal volume, inspiratory reserve volume, and expiratory reserve volume (VC = V + IRV + ERV)."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK541099/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/vital-capacity.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/vital-capacity.query.adj
@@ -1,0 +1,29 @@
+% ============================================================================
+% vital-capacity.query.adj — worked applications of the vital-capacity definition.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a pulmonary-function vignette into observed
+% lung volumes: it `import`s the grounded formulabook, `observe`s the tidal volume, the inspiratory
+% reserve volume and the expiratory reserve volume, and asks the engine to APPLY the cited definition.
+% No arithmetic is stated by the consumer; the engine computes each value EXACTLY (over exact
+% rationals) and carries the article's citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (tidal volume = 1 L, inspiratory reserve volume = 3 L, expiratory reserve volume = 2 L):
+% vital capacity = 1 + 3 + 2 = 6 L. Each query below fixes three of the four quantities and asks the
+% engine to recover the fourth; every answer is exact and the four COMPOSE (each inversion recovers
+% exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli vital-capacity.query.adj
+% ============================================================================
+
+import "vital-capacity.adj"
+
+% --- Definition: the vital capacity the three volumes imply (expect 6). ------------------------
+observe tidal_volume(1)
+observe inspiratory_reserve_volume(3)
+observe expiratory_reserve_volume(2)
+? vital_capacity(tidal_volume, inspiratory_reserve_volume, expiratory_reserve_volume)   % expect 6
+
+% --- Inverse: the tidal volume a VC of 6 implies given the two reserves (expect 1). ------------
+observe vital_capacity(6)
+? tidal_volume(vital_capacity, inspiratory_reserve_volume, expiratory_reserve_volume)   % expect 1


### PR DESCRIPTION
## What

Ships a new grounded clinical formula library for the **vital capacity (VC)** — the maximal air expirable after a maximal inspiration, a core pulmonary-function capacity — in the ADJ formula stdlib:

- `code/specs/data/adj-formula-stdlib/clinical/vital-capacity.adj` — a `dictionary` + `formulabook` defining **VC = tidal volume + inspiratory reserve volume + expiratory reserve volume** plus its three exact rearrangements (each volume from VC and the other two).
- `…/clinical/vital-capacity.query.adj` — worked applications.
- `code/packages/rust/adj-lang-cli/tests/formula_vital_capacity_e2e.rs` — a dedicated 4-test e2e driving the built CLI against the shipped stdlib.

## Grounding

Every formula carries the SAME verbatim definitional clause, transcribed byte-for-byte from the StatPearls **"Vital Capacity"** article on the NCBI Bookshelf:

> "Vital capacity (VC) refers to the maximal volume of air that can be expired following maximum inspiration. It is the total of tidal volume, inspiratory reserve volume, and expiratory reserve volume (VC = V + IRV + ERV)."

locator `https://www.ncbi.nlm.nih.gov/books/NBK541099/`, `trust authoritative`. One clause defends the relation read four ways — nothing asserted from memory (`feedback_nothing_human_authored`).

## Invariant

A consumer states **no arithmetic**: it imports the library, `observe`s the three lung volumes, and the engine applies the cited definition on the CPU, computing the EXACT value (over rationals) and rendering the citation + trust tier in `derived`. Worked case TV 1, IRV 3, ERV 2 → VC 6; the four formulas compose and invert exactly. (VC excludes the residual volume, which is why VC < total lung capacity.)

## Verification

- `cargo test -p adj-lang-cli --test formula_vital_capacity_e2e` → 4 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean.
- Render-probe confirms `vital_capacity=6`, `tidal_volume=1`, exact rationals, verbatim source + NBK541099 locator + authoritative trust.
- NUL-scan clean. Security review: clean (no vulnerabilities) — conducted inline this run because the review sub-agent was unavailable due to a transient upstream 529 outage.

Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)