### PR TITLE
feat(spice): support MOS gate material preprocessing

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Accept Berkeley Level-1 MOS model-card `TPG` gate-material selectors and use
+  their `-1`, `0`, or `1` work-function branches when deriving `VT0`, while
+  preserving explicit threshold-voltage precedence.
 - Accept Level-1 MOS model-card `NSS` surface-state density and include its
   oxide-charge flat-band shift when deriving `VT0` from process parameters,
   while preserving explicit threshold-voltage precedence.

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -323,8 +323,8 @@ _MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES = {
     "PNP": (41, 58, 13, 4),
     "NJF": (22, 30, 7, 3),
     "PJF": (22, 30, 7, 3),
-    "NMOS": (32, 40, 7, 3),
-    "PMOS": (32, 40, 7, 3),
+    "NMOS": (33, 41, 7, 3),
+    "PMOS": (33, 41, 7, 3),
 }
 
 
@@ -487,6 +487,7 @@ _MOS_LEVEL1_PARAMETER_ALIASES: dict[str, str] = {
     "NSUB": "N_SUB",
     "N_SUB": "N_SUB",
     "NSS": "NSS",
+    "TPG": "TPG",
     "TNOM": "T_NOM",
     "T_NOM": "T_NOM",
     "CGSO": "CGSO",
@@ -565,6 +566,8 @@ def normalize_model_card(
             if abs(value - 1.0) > 1.0e-12:
                 raise ValueError(f"{name}: only MOS LEVEL=1 model cards are supported")
             normalized[canonical] = 1.0
+        elif canonical == "TPG" and value not in {-1.0, 0.0, 1.0}:
+            raise ValueError(f"{name}: MOSFET TPG must be -1, 0, or 1")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(
@@ -1125,20 +1128,31 @@ def mosfet_from_model_card(
                 ) / oxide_capacitance
     threshold_voltage = p.get("VT0", defaults.VT0)
     if "VT0" not in p and "N_SUB" in p and "TOX" in p and p["TOX"] > 0.0:
-        polarity = 1.0 if model.kind == "NMOS" else -1.0
         nominal_temperature = p.get("T_NOM", defaults.T_NOM)
         oxide_capacitance = OXIDE_PERMITTIVITY / p["TOX"]
+        polarity = 1.0 if model.kind == "NMOS" else -1.0
+        band_gap = _silicon_band_gap_electron_volts(nominal_temperature)
+        gate_type = p.get("TPG", 1.0)
+        substrate_fermi_potential = polarity * 0.5 * surface_potential
+        gate_work_function = 3.2
+        if gate_type != 0.0:
+            gate_fermi_potential = polarity * gate_type * 0.5 * band_gap
+            gate_work_function = 3.25 + 0.5 * band_gap - gate_fermi_potential
+        gate_substrate_work_function = gate_work_function - (
+            3.25 + 0.5 * band_gap + substrate_fermi_potential
+        )
         surface_state_shift = (
             p.get("NSS", 0.0) * 1.0e4 * _ELECTRON_CHARGE / oxide_capacitance
         )
-        threshold_voltage = polarity * (
-            body_effect_coefficient * math.sqrt(surface_potential)
-            + 0.5
+        threshold_voltage = (
+            gate_substrate_work_function
+            - surface_state_shift
+            + polarity
             * (
-                surface_potential
-                - _silicon_band_gap_electron_volts(nominal_temperature)
+                body_effect_coefficient * math.sqrt(surface_potential)
+                + surface_potential
             )
-        ) - surface_state_shift
+        )
     params = replace(
         defaults,
         VT0=threshold_voltage,

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -409,7 +409,7 @@ def test_model_card_type_aliases_are_normalized() -> None:
 
 def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     coverage = model_card_supported_parameter_coverage()
-    assert len(coverage) == 205
+    assert len(coverage) == 207
     assert coverage[0].kind == "D"
     assert coverage[0].canonical_parameter == "IS"
     assert coverage[0].accepted_names == ("IS", "JS")
@@ -424,7 +424,7 @@ def test_model_card_supported_parameter_coverage_exports_are_stable() -> None:
     assert "NMOS\tVT0\tVT0|VTO|VTH\t3" in table
     assert table.splitlines()[-1] == "PMOS\tAF\tAF\t1"
     records = model_card_supported_parameter_coverage_records()
-    assert len(records) == 205
+    assert len(records) == 207
     assert records[0] == {
         "kind": "D",
         "canonical_parameter": "IS",
@@ -447,8 +447,8 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert summary[0].max_alias_count == 3
     assert summary[0].aliased_parameters == ("IS", "VT", "CJO", "VJ", "M")
     assert summary[5].kind == "NMOS"
-    assert summary[5].canonical_parameter_count == 32
-    assert summary[5].accepted_name_count == 40
+    assert summary[5].canonical_parameter_count == 33
+    assert summary[5].accepted_name_count == 41
     assert summary[5].aliased_parameter_count == 7
     assert summary[5].max_alias_count == 3
     assert summary[5].aliased_parameters == (
@@ -471,7 +471,7 @@ def test_model_card_supported_parameter_coverage_summary_exports_are_stable() ->
     assert table.splitlines()[1] == "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M"
     assert (
         table.splitlines()[-1]
-        == "PMOS\t32\t40\t7\t3\tVT0|LAMBDA|U0|N_SUB|T_NOM|CBS|CBD"
+        == "PMOS\t33\t41\t7\t3\tVT0|LAMBDA|U0|N_SUB|T_NOM|CBS|CBD"
     )
     records = model_card_supported_parameter_coverage_summary_records()
     assert len(records) == 7
@@ -499,9 +499,9 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
     assert report.passed is True
     assert report.kind_count == 7
     assert report.expected_kind_count == 7
-    assert report.canonical_parameter_count == 205
-    assert report.expected_canonical_parameter_count == 205
-    assert report.accepted_name_count == 277
+    assert report.canonical_parameter_count == 207
+    assert report.expected_canonical_parameter_count == 207
+    assert report.accepted_name_count == 279
     assert report.aliased_parameter_count == 59
     assert report.max_alias_count == 4
     assert report.issues == ()
@@ -509,7 +509,7 @@ def test_model_card_supported_parameter_coverage_gate_passes_current_catalog() -
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "true\t7\t7\t205\t205\t277\t59\t4\t0"
+        "true\t7\t7\t207\t207\t279\t59\t4\t0"
     )
     assert (
         format_model_card_supported_parameter_coverage_gate_issue_table(report)
@@ -537,15 +537,15 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
 
     assert report.passed is False
     assert report.kind_count == 7
-    assert report.canonical_parameter_count == 204
-    assert report.accepted_name_count == 274
+    assert report.canonical_parameter_count == 206
+    assert report.accepted_name_count == 276
     assert report.aliased_parameter_count == 58
     assert report.max_alias_count == 4
     assert len(report.issues) == 4
     assert report.issues[0].kind == "NMOS"
     assert report.issues[0].field == "canonical_parameter_count"
     assert report.issues[0].message == (
-        "expected NMOS to expose 32 canonical supported parameters, found 31"
+        "expected NMOS to expose 33 canonical supported parameters, found 32"
     )
     assert report.issues[-1].field == "max_alias_count"
     assert report.issues[-1].message == "expected NMOS max alias count 3, found 2"
@@ -553,12 +553,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
         "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\t"
         "expected_canonical_parameter_count\taccepted_name_count\t"
         "aliased_parameter_count\tmax_alias_count\tissue_count\n"
-        "false\t7\t7\t204\t205\t274\t58\t4\t4\n"
+        "false\t7\t7\t206\t207\t276\t58\t4\t4\n"
         "kind\tfield\tmessage\n"
-        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 32 canonical "
-        "supported parameters, found 31\n"
-        "NMOS\taccepted_name_count\texpected NMOS to expose 40 accepted model-card "
-        "names, found 37\n"
+        "NMOS\tcanonical_parameter_count\texpected NMOS to expose 33 canonical "
+        "supported parameters, found 32\n"
+        "NMOS\taccepted_name_count\texpected NMOS to expose 41 accepted model-card "
+        "names, found 38\n"
         "NMOS\taliased_parameter_count\texpected NMOS to expose 7 alias-bearing "
         "parameters, found 6\n"
         "NMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
@@ -567,12 +567,12 @@ def test_model_card_supported_parameter_coverage_gate_reports_missing_alias_fami
     assert records[0] == {
         "kind": "NMOS",
         "field": "canonical_parameter_count",
-        "message": "expected NMOS to expose 32 canonical supported parameters, found 31",
+        "message": "expected NMOS to expose 33 canonical supported parameters, found 32",
     }
     assert format_model_card_supported_parameter_coverage_gate_issue_csv(report).startswith(
         "kind,field,message\n"
-        'NMOS,canonical_parameter_count,"expected NMOS to expose 32 canonical '
-        'supported parameters, found 31"\n'
+        'NMOS,canonical_parameter_count,"expected NMOS to expose 33 canonical '
+        'supported parameters, found 32"\n'
     )
     assert (
         json.loads(format_model_card_supported_parameter_coverage_gate_issue_json(report))
@@ -930,6 +930,68 @@ def test_mos_model_card_substrate_doping_derives_electrostatics_with_precedence(
                 "Minvalid", "nmos", {"NSUB": 1.0e10, "TOX": 1.0e-7}
             ),
         )
+
+
+def test_mos_model_card_gate_material_shifts_process_derived_threshold() -> None:
+    process = {"NSUB": 4.0e15, "TOX": 100.0e-9}
+    default_nmos = mosfet_from_model_card(
+        "M1", "d", "g", "s", "b", normalize_model_card("Mdefault", "nmos", process)
+    )
+    band_gap = 1.16 - 7.02e-4 * 300.15**2 / (300.15 + 1108.0)
+
+    opposite_nmos = mosfet_from_model_card(
+        "M2",
+        "d",
+        "g",
+        "s",
+        "b",
+        normalize_model_card("Mopposite", "nmos", {**process, "TPG": -1.0}),
+    )
+    assert pytest.approx(
+        default_nmos.model.model.params.VT0 + band_gap
+    ) == opposite_nmos.model.model.params.VT0
+
+    metal_nmos = mosfet_from_model_card(
+        "M3",
+        "d",
+        "g",
+        "s",
+        "b",
+        normalize_model_card("Mmetal", "nmos", {**process, "TPG": 0.0}),
+    )
+    assert pytest.approx(
+        default_nmos.model.model.params.VT0 - 0.05
+    ) == metal_nmos.model.model.params.VT0
+
+    default_pmos = mosfet_from_model_card(
+        "M4", "d", "g", "s", "b", normalize_model_card("Mpdefault", "pmos", process)
+    )
+    opposite_pmos = mosfet_from_model_card(
+        "M5",
+        "d",
+        "g",
+        "s",
+        "b",
+        normalize_model_card("Mpopposite", "pmos", {**process, "TPG": -1.0}),
+    )
+    assert pytest.approx(
+        default_pmos.model.model.params.VT0 - band_gap
+    ) == opposite_pmos.model.model.params.VT0
+
+    explicit = mosfet_from_model_card(
+        "M6",
+        "d",
+        "g",
+        "s",
+        "b",
+        normalize_model_card(
+            "Mexplicit", "nmos", {**process, "TPG": -1.0, "VTO": 0.63}
+        ),
+    )
+    assert pytest.approx(0.63) == explicit.model.model.params.VT0
+
+    with pytest.raises(ValueError, match="MOSFET TPG must be -1, 0, or 1"):
+        normalize_model_card("Minvalid", "nmos", {"TPG": 0.5})
 
 
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Accept Berkeley Level-1 MOS model-card `TPG` gate-material selectors and use
+  their `-1`, `0`, or `1` work-function branches when deriving `VT0`, while
+  preserving explicit threshold-voltage precedence.
 - Accept Level-1 MOS model-card `NSS` surface-state density and include its
   oxide-charge flat-band shift when deriving `VT0` from process parameters,
   while preserving explicit threshold-voltage precedence.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4109,8 +4109,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: &[(
     (ModelCardKind::Pnp, 41, 58, 13, 4),
     (ModelCardKind::Njf, 22, 30, 7, 3),
     (ModelCardKind::Pjf, 22, 30, 7, 3),
-    (ModelCardKind::Nmos, 32, 40, 7, 3),
-    (ModelCardKind::Pmos, 32, 40, 7, 3),
+    (ModelCardKind::Nmos, 33, 41, 7, 3),
+    (ModelCardKind::Pmos, 33, 41, 7, 3),
 ];
 const DIODE_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("IS", "IS"),
@@ -4251,6 +4251,7 @@ const MOS_LEVEL1_PARAMETER_ALIAS_ENTRIES: &[(&str, &str)] = &[
     ("NSUB", "N_SUB"),
     ("N_SUB", "N_SUB"),
     ("NSS", "NSS"),
+    ("TPG", "TPG"),
     ("TNOM", "T_NOM"),
     ("T_NOM", "T_NOM"),
     ("CGSO", "CGSO"),
@@ -4344,6 +4345,11 @@ pub fn normalize_model_card(
                     });
                 }
                 normalized.insert(canonical.to_string(), 1.0);
+            } else if canonical == "TPG" && !matches!(*raw_value, -1.0 | 0.0 | 1.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET TPG must be -1, 0, or 1".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }
@@ -5093,13 +5099,22 @@ pub fn mosfet_from_model_card(
                     MosfetType::Nmos => 1.0,
                     MosfetType::Pmos => -1.0,
                 };
+                let band_gap = silicon_band_gap_electron_volts(params.t_nom);
+                let gate_type = model_card_value(model, "TPG", 1.0);
+                let substrate_fermi_potential = polarity * 0.5 * params.phi;
+                let gate_work_function = if gate_type == 0.0 {
+                    3.2
+                } else {
+                    let gate_fermi_potential = polarity * gate_type * 0.5 * band_gap;
+                    3.25 + 0.5 * band_gap - gate_fermi_potential
+                };
+                let gate_substrate_work_function =
+                    gate_work_function - (3.25 + 0.5 * band_gap + substrate_fermi_potential);
                 let surface_state_shift =
                     model_card_value(model, "NSS", 0.0) * 1.0e4 * ELECTRON_CHARGE
                         / oxide_capacitance;
-                params.vt0 = polarity
-                    * (params.gamma * params.phi.sqrt()
-                        + 0.5 * (params.phi - silicon_band_gap_electron_volts(params.t_nom)))
-                    - surface_state_shift;
+                params.vt0 = gate_substrate_work_function - surface_state_shift
+                    + polarity * (params.gamma * params.phi.sqrt() + params.phi);
             }
         }
     }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -96,7 +96,7 @@ fn model_card_type_aliases_are_normalized() {
 #[test]
 fn model_card_supported_parameter_coverage_exports_are_stable() {
     let coverage = model_card_supported_parameter_coverage();
-    assert_eq!(coverage.len(), 205);
+    assert_eq!(coverage.len(), 207);
     assert_eq!(coverage[0].kind, ModelCardKind::Diode);
     assert_eq!(coverage[0].canonical_parameter, "IS");
     assert_eq!(coverage[0].accepted_names, vec!["IS", "JS"]);
@@ -115,7 +115,7 @@ fn model_card_supported_parameter_coverage_exports_are_stable() {
     assert!(table.contains("NMOS\tVT0\tVT0|VTO|VTH\t3"));
     assert_eq!(lines.last().unwrap(), &"PMOS\tAF\tAF\t1");
     let records = model_card_supported_parameter_coverage_records();
-    assert_eq!(records.len(), 205);
+    assert_eq!(records.len(), 207);
     assert_eq!(records[0]["kind"], "D");
     assert_eq!(records[0]["canonical_parameter"], "IS");
     assert_eq!(records[0]["accepted_names"], "IS|JS");
@@ -148,8 +148,8 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         vec!["IS", "VT", "CJO", "VJ", "M"]
     );
     assert_eq!(summary[5].kind, ModelCardKind::Nmos);
-    assert_eq!(summary[5].canonical_parameter_count, 32);
-    assert_eq!(summary[5].accepted_name_count, 40);
+    assert_eq!(summary[5].canonical_parameter_count, 33);
+    assert_eq!(summary[5].accepted_name_count, 41);
     assert_eq!(summary[5].aliased_parameter_count, 7);
     assert_eq!(summary[5].max_alias_count, 3);
     assert_eq!(
@@ -167,7 +167,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
     assert_eq!(lines[1], "D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\t32\t40\t7\t3\tVT0|LAMBDA|U0|N_SUB|T_NOM|CBS|CBD"
+        &"PMOS\t33\t41\t7\t3\tVT0|LAMBDA|U0|N_SUB|T_NOM|CBS|CBD"
     );
     let records = model_card_supported_parameter_coverage_summary_records();
     assert_eq!(records.len(), 7);
@@ -185,7 +185,7 @@ fn model_card_supported_parameter_coverage_summary_exports_are_stable() {
         "[{\"kind\":\"D\",\"canonical_parameter_count\":\"15\",\"accepted_name_count\":\"21\",\"aliased_parameter_count\":\"5\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"IS|VT|CJO|VJ|M\"}"
     ));
     assert!(json.ends_with(
-        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"32\",\"accepted_name_count\":\"40\",\"aliased_parameter_count\":\"7\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|U0|N_SUB|T_NOM|CBS|CBD\"}]\n"
+        "{\"kind\":\"PMOS\",\"canonical_parameter_count\":\"33\",\"accepted_name_count\":\"41\",\"aliased_parameter_count\":\"7\",\"max_alias_count\":\"3\",\"aliased_parameters\":\"VT0|LAMBDA|U0|N_SUB|T_NOM|CBS|CBD\"}]\n"
     ));
 }
 
@@ -196,15 +196,15 @@ fn model_card_supported_parameter_coverage_gate_passes_current_catalog() {
     assert!(report.passed);
     assert_eq!(report.kind_count, 7);
     assert_eq!(report.expected_kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 205);
-    assert_eq!(report.expected_canonical_parameter_count, 205);
-    assert_eq!(report.accepted_name_count, 277);
+    assert_eq!(report.canonical_parameter_count, 207);
+    assert_eq!(report.expected_canonical_parameter_count, 207);
+    assert_eq!(report.accepted_name_count, 279);
     assert_eq!(report.aliased_parameter_count, 59);
     assert_eq!(report.max_alias_count, 4);
     assert!(report.issues.is_empty());
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t205\t205\t277\t59\t4\t0"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t207\t207\t279\t59\t4\t0"
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_issue_table(&report),
@@ -231,8 +231,8 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
 
     assert!(!report.passed);
     assert_eq!(report.kind_count, 7);
-    assert_eq!(report.canonical_parameter_count, 204);
-    assert_eq!(report.accepted_name_count, 274);
+    assert_eq!(report.canonical_parameter_count, 206);
+    assert_eq!(report.accepted_name_count, 276);
     assert_eq!(report.aliased_parameter_count, 58);
     assert_eq!(report.max_alias_count, 4);
     assert_eq!(report.issues.len(), 4);
@@ -240,7 +240,7 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     assert_eq!(report.issues[0].field, "canonical_parameter_count");
     assert_eq!(
         report.issues[0].message,
-        "expected NMOS to expose 32 canonical supported parameters, found 31"
+        "expected NMOS to expose 33 canonical supported parameters, found 32"
     );
     assert_eq!(report.issues.last().unwrap().field, "max_alias_count");
     assert_eq!(
@@ -249,20 +249,20 @@ fn model_card_supported_parameter_coverage_gate_reports_missing_alias_family() {
     );
     assert_eq!(
         format_model_card_supported_parameter_coverage_gate_report(&report),
-        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t204\t205\t274\t58\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 32 canonical supported parameters, found 31\nNMOS\taccepted_name_count\texpected NMOS to expose 40 accepted model-card names, found 37\nNMOS\taliased_parameter_count\texpected NMOS to expose 7 alias-bearing parameters, found 6\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
+        "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t206\t207\t276\t58\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 33 canonical supported parameters, found 32\nNMOS\taccepted_name_count\texpected NMOS to expose 41 accepted model-card names, found 38\nNMOS\taliased_parameter_count\texpected NMOS to expose 7 alias-bearing parameters, found 6\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2"
     );
     let records = model_card_supported_parameter_coverage_gate_issue_records(&report);
     assert_eq!(records[0]["kind"], "NMOS");
     assert_eq!(records[0]["field"], "canonical_parameter_count");
     assert_eq!(
         records[0]["message"],
-        "expected NMOS to expose 32 canonical supported parameters, found 31"
+        "expected NMOS to expose 33 canonical supported parameters, found 32"
     );
     assert!(format_model_card_supported_parameter_coverage_gate_issue_csv(&report).starts_with(
-        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 32 canonical supported parameters, found 31\"\n"
+        "kind,field,message\nNMOS,canonical_parameter_count,\"expected NMOS to expose 33 canonical supported parameters, found 32\"\n"
     ));
     assert!(format_model_card_supported_parameter_coverage_gate_issue_json(&report).starts_with(
-        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 32 canonical supported parameters, found 31\"}"
+        "[{\"kind\":\"NMOS\",\"field\":\"canonical_parameter_count\",\"message\":\"expected NMOS to expose 33 canonical supported parameters, found 32\"}"
     ));
 }
 
@@ -284,8 +284,8 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(dashboard[0].issue_count, 0);
     assert!(dashboard[0].issue_fields.is_empty());
     assert_eq!(dashboard[5].kind, ModelCardKind::Nmos);
-    assert_eq!(dashboard[5].canonical_parameter_count, 32);
-    assert_eq!(dashboard[5].accepted_name_count, 40);
+    assert_eq!(dashboard[5].canonical_parameter_count, 33);
+    assert_eq!(dashboard[5].accepted_name_count, 41);
     assert_eq!(dashboard[5].issue_count, 0);
 
     let table = format_model_card_supported_parameter_coverage_dashboard_table(&coverage);
@@ -297,7 +297,7 @@ fn model_card_supported_parameter_coverage_dashboard_exports_are_stable() {
     assert_eq!(lines[1], "D\ttrue\t15\t15\t21\t21\t5\t5\t3\t3\t0\t");
     assert_eq!(
         lines.last().unwrap(),
-        &"PMOS\ttrue\t32\t32\t40\t40\t7\t7\t3\t3\t0\t"
+        &"PMOS\ttrue\t33\t33\t41\t41\t7\t7\t3\t3\t0\t"
     );
     let records = model_card_supported_parameter_coverage_dashboard_records(&coverage);
     assert_eq!(records.len(), 7);
@@ -329,10 +329,10 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         .unwrap();
 
     assert!(!nmos.passed);
-    assert_eq!(nmos.canonical_parameter_count, 31);
-    assert_eq!(nmos.expected_canonical_parameter_count, 32);
-    assert_eq!(nmos.accepted_name_count, 37);
-    assert_eq!(nmos.expected_accepted_name_count, 40);
+    assert_eq!(nmos.canonical_parameter_count, 32);
+    assert_eq!(nmos.expected_canonical_parameter_count, 33);
+    assert_eq!(nmos.accepted_name_count, 38);
+    assert_eq!(nmos.expected_accepted_name_count, 41);
     assert_eq!(nmos.aliased_parameter_count, 6);
     assert_eq!(nmos.expected_aliased_parameter_count, 7);
     assert_eq!(nmos.max_alias_count, 2);
@@ -348,7 +348,7 @@ fn model_card_supported_parameter_coverage_dashboard_reports_missing_alias_famil
         ]
     );
     assert!(format_model_card_supported_parameter_coverage_dashboard_table(&coverage).contains(
-        "NMOS\tfalse\t31\t32\t37\t40\t6\t7\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
+        "NMOS\tfalse\t32\t33\t38\t41\t6\t7\t2\t3\t4\tcanonical_parameter_count|accepted_name_count|aliased_parameter_count|max_alias_count"
     ));
 }
 
@@ -731,6 +731,54 @@ fn mos_model_card_substrate_doping_derives_electrostatics_with_explicit_preceden
         mosfet_from_model_card("M4", "d", "g", "s", "b", &invalid_card),
         Err(SpiceError::InvalidElement { reason, .. })
             if reason == "MOSFET NSUB must exceed the intrinsic carrier density"
+    ));
+}
+
+#[test]
+fn mos_model_card_gate_material_shifts_process_derived_threshold() {
+    let process = [("NSUB", 4.0e15), ("TOX", 100.0e-9)];
+    let default_nmos = normalize_model_card("Mdefault", "nmos", &process).unwrap();
+    let default_nmos = mosfet_from_model_card("M1", "d", "g", "s", "b", &default_nmos).unwrap();
+    let band_gap = 1.16 - 7.02e-4 * 300.15 * 300.15 / (300.15 + 1108.0);
+
+    let opposite_nmos = normalize_model_card(
+        "Mopposite",
+        "nmos",
+        &[process[0], process[1], ("TPG", -1.0)],
+    )
+    .unwrap();
+    let opposite_nmos = mosfet_from_model_card("M2", "d", "g", "s", "b", &opposite_nmos).unwrap();
+    assert_close(opposite_nmos.params.vt0, default_nmos.params.vt0 + band_gap);
+
+    let metal_nmos =
+        normalize_model_card("Mmetal", "nmos", &[process[0], process[1], ("TPG", 0.0)]).unwrap();
+    let metal_nmos = mosfet_from_model_card("M3", "d", "g", "s", "b", &metal_nmos).unwrap();
+    assert_close(metal_nmos.params.vt0, default_nmos.params.vt0 - 0.05);
+
+    let default_pmos = normalize_model_card("Mpdefault", "pmos", &process).unwrap();
+    let default_pmos = mosfet_from_model_card("M4", "d", "g", "s", "b", &default_pmos).unwrap();
+    let opposite_pmos = normalize_model_card(
+        "Mpopposite",
+        "pmos",
+        &[process[0], process[1], ("TPG", -1.0)],
+    )
+    .unwrap();
+    let opposite_pmos = mosfet_from_model_card("M5", "d", "g", "s", "b", &opposite_pmos).unwrap();
+    assert_close(opposite_pmos.params.vt0, default_pmos.params.vt0 - band_gap);
+
+    let explicit = normalize_model_card(
+        "Mexplicit",
+        "nmos",
+        &[process[0], process[1], ("TPG", -1.0), ("VTO", 0.63)],
+    )
+    .unwrap();
+    let explicit = mosfet_from_model_card("M6", "d", "g", "s", "b", &explicit).unwrap();
+    assert_close(explicit.params.vt0, 0.63);
+
+    assert!(matches!(
+        normalize_model_card("Minvalid", "nmos", &[("TPG", 0.5)]),
+        Err(SpiceError::InvalidElement { reason, .. })
+            if reason == "MOSFET TPG must be -1, 0, or 1"
     ));
 }
 

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Accept Berkeley Level-1 MOS model-card `TPG` gate-material selectors and use
+  their `-1`, `0`, or `1` work-function branches when deriving `VT0`, while
+  preserving explicit threshold-voltage precedence.
 - Accept Level-1 MOS model-card `NSS` surface-state density and include its
   oxide-charge flat-band shift when deriving `VT0` from process parameters,
   while preserving explicit threshold-voltage precedence.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -2071,8 +2071,8 @@ const MODEL_CARD_SUPPORTED_PARAMETER_COVERAGE_EXPECTED_SUMMARIES: Readonly<
   PNP: [41, 58, 13, 4],
   NJF: [22, 30, 7, 3],
   PJF: [22, 30, 7, 3],
-  NMOS: [32, 40, 7, 3],
-  PMOS: [32, 40, 7, 3],
+  NMOS: [33, 41, 7, 3],
+  PMOS: [33, 41, 7, 3],
 };
 
 export interface Vccs {
@@ -8355,6 +8355,7 @@ const MOS_LEVEL1_PARAMETER_ALIASES: Readonly<Record<string, string>> = {
   NSUB: "N_SUB",
   N_SUB: "N_SUB",
   NSS: "NSS",
+  TPG: "TPG",
   TNOM: "T_NOM",
   T_NOM: "T_NOM",
   CGSO: "CGSO",
@@ -8427,6 +8428,8 @@ export function normalizeModelCard(
         throw invalidElement(name, "only MOS LEVEL=1 model cards are supported");
       }
       normalized[canonical] = 1.0;
+    } else if (canonical === "TPG" && value !== -1.0 && value !== 0.0 && value !== 1.0) {
+      throw invalidElement(name, "MOSFET TPG must be -1, 0, or 1");
     } else {
       normalized[canonical] = value;
     }
@@ -8961,6 +8964,15 @@ export function mosfetFromModelCard(
   }
   const nominalTemperature = p.T_NOM ?? 300.15;
   const polarity = model.kind === "NMOS" ? 1.0 : -1.0;
+  const bandGap = siliconBandGapElectronVolts(nominalTemperature);
+  const gateType = p.TPG ?? 1.0;
+  const substrateFermiPotential = polarity * 0.5 * (surfacePotential ?? 0.0);
+  const gateWorkFunction =
+    gateType === 0.0
+      ? 3.2
+      : 3.25 + 0.5 * bandGap - polarity * gateType * 0.5 * bandGap;
+  const gateSubstrateWorkFunction =
+    gateWorkFunction - (3.25 + 0.5 * bandGap + substrateFermiPotential);
   const surfaceStateShift =
     p.TOX !== undefined && p.TOX > 0.0
       ? ((p.NSS ?? 0.0) * 1.0e4 * ELECTRON_CHARGE) /
@@ -8969,12 +8981,11 @@ export function mosfetFromModelCard(
   const thresholdVoltage =
     p.VT0 ??
     (p.N_SUB !== undefined && p.TOX !== undefined && p.TOX > 0.0
-      ? polarity *
-        ((bodyEffectCoefficient ?? 0.0) * Math.sqrt(surfacePotential ?? 0.0) +
-          0.5 *
-            ((surfacePotential ?? 0.0) -
-              siliconBandGapElectronVolts(nominalTemperature))) -
-        surfaceStateShift
+      ? gateSubstrateWorkFunction -
+        surfaceStateShift +
+        polarity *
+          ((bodyEffectCoefficient ?? 0.0) * Math.sqrt(surfacePotential ?? 0.0) +
+            (surfacePotential ?? 0.0))
       : undefined);
   const params: Partial<MosfetLevel1Params> = {
     ...(thresholdVoltage !== undefined ? { VT0: thresholdVoltage } : {}),

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -122,7 +122,7 @@ describe("dcOp", () => {
 
   it("exports stable model-card supported parameter coverage", () => {
     const coverage = modelCardSupportedParameterCoverage();
-    expect(coverage).toHaveLength(205);
+    expect(coverage).toHaveLength(207);
     expect(coverage[0]).toStrictEqual({
       kind: "D",
       canonicalParameter: "IS",
@@ -142,7 +142,7 @@ describe("dcOp", () => {
     expect(table).toContain("NMOS\tVT0\tVT0|VTO|VTH\t3");
     expect(table.split("\n").at(-1)).toBe("PMOS\tAF\tAF\t1");
     const records = modelCardSupportedParameterCoverageRecords();
-    expect(records).toHaveLength(205);
+    expect(records).toHaveLength(207);
     expect(records[0]).toStrictEqual({
       kind: "D",
       canonical_parameter: "IS",
@@ -168,8 +168,8 @@ describe("dcOp", () => {
     });
     expect(summary[5]).toStrictEqual({
       kind: "NMOS",
-      canonicalParameterCount: 32,
-      acceptedNameCount: 40,
+      canonicalParameterCount: 33,
+      acceptedNameCount: 41,
       aliasedParameterCount: 7,
       maxAliasCount: 3,
       aliasedParameters: ["VT0", "LAMBDA", "U0", "N_SUB", "T_NOM", "CBS", "CBD"],
@@ -182,7 +182,7 @@ describe("dcOp", () => {
     );
     expect(table.split("\n")[1]).toBe("D\t15\t21\t5\t3\tIS|VT|CJO|VJ|M");
     expect(table.split("\n").at(-1)).toBe(
-      "PMOS\t32\t40\t7\t3\tVT0|LAMBDA|U0|N_SUB|T_NOM|CBS|CBD",
+      "PMOS\t33\t41\t7\t3\tVT0|LAMBDA|U0|N_SUB|T_NOM|CBS|CBD",
     );
     const records = modelCardSupportedParameterCoverageSummaryRecords();
     expect(records).toHaveLength(7);
@@ -207,15 +207,15 @@ describe("dcOp", () => {
       passed: true,
       kindCount: 7,
       expectedKindCount: 7,
-      canonicalParameterCount: 205,
-      expectedCanonicalParameterCount: 205,
-      acceptedNameCount: 277,
+      canonicalParameterCount: 207,
+      expectedCanonicalParameterCount: 207,
+      acceptedNameCount: 279,
       aliasedParameterCount: 59,
       maxAliasCount: 4,
       issues: [],
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t205\t205\t277\t59\t4\t0",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\ntrue\t7\t7\t207\t207\t279\t59\t4\t0",
     );
     expect(formatModelCardSupportedParameterCoverageGateIssueTable(report)).toBe(
       "kind\tfield\tmessage",
@@ -238,15 +238,15 @@ describe("dcOp", () => {
 
     expect(report.passed).toBe(false);
     expect(report.kindCount).toBe(7);
-    expect(report.canonicalParameterCount).toBe(204);
-    expect(report.acceptedNameCount).toBe(274);
+    expect(report.canonicalParameterCount).toBe(206);
+    expect(report.acceptedNameCount).toBe(276);
     expect(report.aliasedParameterCount).toBe(58);
     expect(report.maxAliasCount).toBe(4);
     expect(report.issues).toHaveLength(4);
     expect(report.issues[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 32 canonical supported parameters, found 31",
+      message: "expected NMOS to expose 33 canonical supported parameters, found 32",
     });
     expect(report.issues.at(-1)).toStrictEqual({
       kind: "NMOS",
@@ -254,16 +254,16 @@ describe("dcOp", () => {
       message: "expected NMOS max alias count 3, found 2",
     });
     expect(formatModelCardSupportedParameterCoverageGateReport(report)).toBe(
-      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t204\t205\t274\t58\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 32 canonical supported parameters, found 31\nNMOS\taccepted_name_count\texpected NMOS to expose 40 accepted model-card names, found 37\nNMOS\taliased_parameter_count\texpected NMOS to expose 7 alias-bearing parameters, found 6\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
+      "passed\tkind_count\texpected_kind_count\tcanonical_parameter_count\texpected_canonical_parameter_count\taccepted_name_count\taliased_parameter_count\tmax_alias_count\tissue_count\nfalse\t7\t7\t206\t207\t276\t58\t4\t4\nkind\tfield\tmessage\nNMOS\tcanonical_parameter_count\texpected NMOS to expose 33 canonical supported parameters, found 32\nNMOS\taccepted_name_count\texpected NMOS to expose 41 accepted model-card names, found 38\nNMOS\taliased_parameter_count\texpected NMOS to expose 7 alias-bearing parameters, found 6\nNMOS\tmax_alias_count\texpected NMOS max alias count 3, found 2",
     );
     const records = modelCardSupportedParameterCoverageGateIssueRecords(report);
     expect(records[0]).toStrictEqual({
       kind: "NMOS",
       field: "canonical_parameter_count",
-      message: "expected NMOS to expose 32 canonical supported parameters, found 31",
+      message: "expected NMOS to expose 33 canonical supported parameters, found 32",
     });
     expect(formatModelCardSupportedParameterCoverageGateIssueCsv(report)).toMatch(
-      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 32 canonical supported parameters, found 31"\n/,
+      /^kind,field,message\nNMOS,canonical_parameter_count,"expected NMOS to expose 33 canonical supported parameters, found 32"\n/,
     );
     expect(JSON.parse(formatModelCardSupportedParameterCoverageGateIssueJson(report))).toStrictEqual(
       records,
@@ -590,6 +590,76 @@ describe("dcOp", () => {
         }),
       ),
     ).toThrow("MOSFET NSUB must exceed the intrinsic carrier density");
+  });
+
+  it("shifts process-derived MOS threshold voltage by gate material", () => {
+    const process = { NSUB: 4.0e15, TOX: 100.0e-9 };
+    const defaultNmos = mosfetFromModelCard(
+      "M1",
+      "d",
+      "g",
+      "s",
+      "b",
+      normalizeModelCard("Mdefault", "nmos", process),
+    );
+    const bandGap =
+      1.16 - (7.02e-4 * 300.15 * 300.15) / (300.15 + 1108.0);
+
+    const oppositeNmos = mosfetFromModelCard(
+      "M2",
+      "d",
+      "g",
+      "s",
+      "b",
+      normalizeModelCard("Mopposite", "nmos", { ...process, TPG: -1.0 }),
+    );
+    expectClose(oppositeNmos.params.VT0, defaultNmos.params.VT0! + bandGap);
+
+    const metalNmos = mosfetFromModelCard(
+      "M3",
+      "d",
+      "g",
+      "s",
+      "b",
+      normalizeModelCard("Mmetal", "nmos", { ...process, TPG: 0.0 }),
+    );
+    expectClose(metalNmos.params.VT0, defaultNmos.params.VT0! - 0.05);
+
+    const defaultPmos = mosfetFromModelCard(
+      "M4",
+      "d",
+      "g",
+      "s",
+      "b",
+      normalizeModelCard("Mpdefault", "pmos", process),
+    );
+    const oppositePmos = mosfetFromModelCard(
+      "M5",
+      "d",
+      "g",
+      "s",
+      "b",
+      normalizeModelCard("Mpopposite", "pmos", { ...process, TPG: -1.0 }),
+    );
+    expectClose(oppositePmos.params.VT0, defaultPmos.params.VT0! - bandGap);
+
+    const explicit = mosfetFromModelCard(
+      "M6",
+      "d",
+      "g",
+      "s",
+      "b",
+      normalizeModelCard("Mexplicit", "nmos", {
+        ...process,
+        TPG: -1.0,
+        VTO: 0.63,
+      }),
+    );
+    expectClose(explicit.params.VT0, 0.63);
+
+    expect(() => normalizeModelCard("Minvalid", "nmos", { TPG: 0.5 })).toThrow(
+      "MOSFET TPG must be -1, 0, or 1",
+    );
   });
 
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,10 +33,10 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS surface-state density.
+1. Cross-language Level-1 MOS gate material.
    - Status: current PR completion candidate.
-   - Accept model-card `NSS` and include its oxide-charge flat-band shift when
-     deriving `VT0` from `NSUB` plus `TOX`.
+   - Accept Berkeley model-card `TPG` values `-1`, `0`, and `1` and include the
+     selected gate work function when deriving `VT0` from `NSUB` plus `TOX`.
    - Preserve explicit `VTO` / `VT0` precedence and stable parameter coverage.
    - Keep Rust, Python, and TypeScript model lowering, tests, and docs aligned.
 
@@ -3622,6 +3622,13 @@ the Rust, Python, and TypeScript surfaces together.
      MOS1 default gate-work-function and surface-state assumptions.
    - Explicit `VTO` / `VT0` takes precedence for NMOS and PMOS across Rust,
      Python, and TypeScript.
+
+292. Cross-language Level-1 MOS surface-state density.
+   - Status: completed in PR 9163.
+   - Model-card `NSS` contributes the Berkeley oxide-charge flat-band shift
+     when `VT0` is derived from `NSUB` plus `TOX`.
+   - Explicit `VTO` / `VT0` precedence, normalized parameter coverage, and
+     matching NMOS/PMOS behavior are preserved across all three languages.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- accept Berkeley MOS1 `TPG` gate-material selectors `-1`, `0`, and `1` in Rust, Python, and TypeScript
- apply the selected gate work function when deriving `VT0` from `NSUB` plus `TOX`, while preserving `NSS` and explicit `VTO`/`VT0` precedence
- update stable model-card coverage artifacts, mirrored tests, changelogs, and the implementation plan

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- `PYTHONPATH=$(printf '%s:' ../*/src) python3.12 -m ruff check src tests`
- `PYTHONPATH=$(printf '%s:' ../*/src) python3.12 -m pytest -q` (675 passed, 88.93% coverage)
- `npm test` (418 passed)
- `npm run build`