### PR TITLE
feat(adj-formula-stdlib): P/F ratio — StatPearls PaO2/FiO2 oxygenation ratio library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_pf_ratio_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_pf_ratio_e2e.rs
@@ -1,0 +1,140 @@
+//! End-to-end tests for the `clinical/pf-ratio.adj` library — the P/F-ratio relation
+//! (P/F ratio = arterial oxygen partial pressure ÷ fraction of inspired oxygen) and its two exact
+//! rearrangements — driven through the built CLI binary against the SHIPPED stdlib. The same
+//! invariant as every other formula library: a consumer states NO arithmetic; it imports the grounded
+//! library, binds the measured oxygenation values with `observe`, and the engine applies the cited
+//! definition on the CPU, computing the EXACT value and rendering the definition's citation and trust
+//! tier in the `derived` section (the auditable answer). The three formulas INVERT around the worked
+//! case PaO2 = 200 mmHg, FiO2 = 0.5: 200 ÷ 0.5 = 400 (P/F ratio), 400 × 0.5 = 200 (PaO2), 200 ÷ 400 =
+//! 0.5 (FiO2). The asserted values (400, 200, 0.5) — none is a colon-anchored prefix of another
+//! rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped P/F-ratio library, resolved from this crate's manifest dir so the
+/// test is location-independent.
+fn shipped_pf_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/pf-ratio.adj")
+        .canonicalize()
+        .expect("shipped pf-ratio.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_pf_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_pf_lib()).unwrap();
+    std::fs::write(dir.join("pf-ratio.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// pf_ratio — the relation: arterial oxygen partial pressure ÷ fraction of inspired oxygen.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_pf_ratio_library_and_computes_it_with_citation() {
+    let dir = scratch("pf");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"pf-ratio.adj\"\n\
+         observe arterial_oxygen_partial_pressure(200)\n\
+         observe fraction_of_inspired_oxygen(0.5)\n\
+         ? pf_ratio(arterial_oxygen_partial_pressure, fraction_of_inspired_oxygen)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied definition's result: 200 ÷ 0.5 = 400.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"pf_ratio\"") && s.contains("\"value\":400"),
+        "pf_ratio(200, 0.5) = 400: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// arterial_oxygen_partial_pressure — the same definition solved for the PaO2: P/F × FiO2.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_pao2_from_ratio_and_fio2_with_citation() {
+    let dir = scratch("pao2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"pf-ratio.adj\"\n\
+         observe pf_ratio(400)\n\
+         observe fraction_of_inspired_oxygen(0.5)\n\
+         ? arterial_oxygen_partial_pressure(pf_ratio, fraction_of_inspired_oxygen)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 400 × 0.5 = 200, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"arterial_oxygen_partial_pressure\"") && s.contains("\"value\":200"),
+        "arterial_oxygen_partial_pressure(400, 0.5) = 200: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "arterial_oxygen_partial_pressure carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// fraction_of_inspired_oxygen — the same definition solved for the FiO2: PaO2 ÷ P/F, the third
+// reading of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_fio2_from_pao2_and_ratio_with_citation() {
+    let dir = scratch("fio2");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"pf-ratio.adj\"\n\
+         observe arterial_oxygen_partial_pressure(200)\n\
+         observe pf_ratio(400)\n\
+         ? fraction_of_inspired_oxygen(arterial_oxygen_partial_pressure, pf_ratio)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 200 ÷ 400 = 0.5, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"fraction_of_inspired_oxygen\"") && s.contains("\"value\":0.5"),
+        "fraction_of_inspired_oxygen(200, 400) = 0.5: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "fraction_of_inspired_oxygen carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/pf-ratio.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/pf-ratio.adj
@@ -1,0 +1,96 @@
+% ============================================================================
+% pf-ratio.adj — the definition of the PaO2/FiO2 (P/F) ratio
+% (P/F ratio = arterial oxygen partial pressure ÷ fraction of inspired oxygen) in the ADJ standard
+% library.
+% ============================================================================
+% The P/F-ratio entry of the *clinical* track — a critical-care oxygenation index, a ratio sibling of
+% the shipped cardiac-index.adj and ejection-fraction.adj. The P/F ratio grades the severity of
+% hypoxaemia and is the oxygenation criterion of the Berlin ARDS definition: THE P/F RATIO IS THE
+% ARTERIAL OXYGEN PARTIAL PRESSURE (PaO2) DIVIDED BY THE FRACTION OF INSPIRED OXYGEN (FiO2) — a normal
+% value is ~400–500, and ARDS is defined by a P/F ratio ≤ 300 (mild ≤ 300, moderate ≤ 200, severe
+% ≤ 100). It ships as an importable, byte-provenanced, PARAMETERIZED `formula`, together with its two
+% exact rearrangements (the PaO2 a ratio implies at a given FiO2, and the FiO2 it implies at a given
+% PaO2). As with every compute library, a consumer states NO arithmetic: it `import`s this file, binds
+% the measured oxygen values from its own byte-provenance decomposition, and asks the engine to APPLY
+% the cited definition on the CPU. Zero math is performed by the model; the engine computes each value
+% EXACTLY (over exact rationals), carrying the definition's citation.
+%
+%     import "pf-ratio.adj"
+%     observe arterial_oxygen_partial_pressure(200)  % "…PaO2 200 mmHg…"     (span cited by the model)
+%     observe fraction_of_inspired_oxygen(0.5)        % "…FiO2 0.5 (50%)…"     (span cited by the model)
+%     ? pf_ratio(arterial_oxygen_partial_pressure, fraction_of_inspired_oxygen)
+%                                                      % engine → 400, carrying the P/F ratio
+%
+% All three formulas are EXACT over their parameters (a quotient or a product of the PaO2 and the
+% FiO2), so every value the engine returns is exact. They COMPOSE and invert cleanly around the worked
+% case PaO2 = 200 mmHg, FiO2 = 0.5 (P/F ratio = 200 ÷ 0.5 = 400 — a normal ratio): the `pf_ratio` a
+% consumer computes is exactly the value the `arterial_oxygen_partial_pressure` formula multiplies by
+% the FiO2 to recover 200, and exactly the value the `fraction_of_inspired_oxygen` formula divides the
+% PaO2 by to recover 0.5.
+%
+%   pf_ratio(arterial_oxygen_partial_pressure, fraction_of_inspired_oxygen)
+%       = arterial_oxygen_partial_pressure / fraction_of_inspired_oxygen   % P/F = PaO2 ÷ FiO2   (definition)
+%   arterial_oxygen_partial_pressure(pf_ratio, fraction_of_inspired_oxygen)
+%       = pf_ratio * fraction_of_inspired_oxygen                           % PaO2 = P/F × FiO2   (solved for PaO2)
+%   fraction_of_inspired_oxygen(arterial_oxygen_partial_pressure, pf_ratio)
+%       = arterial_oxygen_partial_pressure / pf_ratio                      % FiO2 = PaO2 ÷ P/F   (solved for FiO2)
+%
+% NOTE ON UNITS: the PaO2 is in millimetres of mercury (mmHg) and the FiO2 is the DECIMAL fraction of
+% inspired oxygen (0.21 for room air up to 1.0 for pure oxygen — NOT a percentage); the P/F ratio then
+% carries mmHg as its unit, and its diagnostic cut-offs (300/200/100) are quoted in mmHg. If a
+% consumer has FiO2 as a percentage it must be converted to the fraction first (that conversion is a
+% SEPARATE step); the engine computes the exact quotient over whatever consistent inputs it is given.
+%
+% All three formulas are defended by the SAME clause — "using the PaO2/FiO2 (P/F) ratio, where PaO2
+% represents the partial pressure of oxygen" — because that one definition (the P/F ratio IS the
+% PaO2-over-FiO2 quotient, the "/" being the division) sanctions the relation read every way (the
+% ratio from the two oxygen values, the PaO2 from the ratio and the FiO2, or the FiO2 from the PaO2
+% and the ratio). The quote is transcribed verbatim from the StatPearls "Fraction of Inspired Oxygen"
+% article on the NCBI Bookshelf, so each `formula` carries the provenance envelope every shipped
+% grounded clause carries; the linter rejects an unsourced one. (See feedback_nothing_human_authored —
+% the clause is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable oxygenation value the definition ranges over, and each
+% result is a derived quantity. `arterial_oxygen_partial_pressure`, `fraction_of_inspired_oxygen` and
+% `pf_ratio` each appear BOTH as a derived result and as an input (of the other formulas), so each is a
+% single dictionary term used in both roles. The `surface` lists are the everyday names a decomposer
+% maps onto the canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary pf_ratio_vocab {
+    define arterial_oxygen_partial_pressure : finding  surface "PaO2", "arterial oxygen partial pressure", "partial pressure of oxygen"  % millimetres of mercury (mmHg)
+    define fraction_of_inspired_oxygen      : finding  surface "FiO2", "fraction of inspired oxygen"                                     % decimal fraction (0.21–1.0)
+    define pf_ratio                         : finding  surface "P/F ratio", "PaO2/FiO2 ratio", "PF ratio"                                 % millimetres of mercury (mmHg)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the definitional clause from the StatPearls
+% "Fraction of Inspired Oxygen" article on the NCBI Bookshelf (a quote is required on a shipped
+% formula). Each is an exact quotient or product of the PaO2 and the FiO2, so the engine returns each
+% value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook pf_ratio_laws {
+    use pf_ratio_vocab
+
+    % P/F ratio — the arterial oxygen partial pressure divided by the fraction of inspired oxygen.
+    formula pf_ratio(arterial_oxygen_partial_pressure, fraction_of_inspired_oxygen) = arterial_oxygen_partial_pressure / fraction_of_inspired_oxygen
+        source "using the PaO2/FiO2 (P/F) ratio, where PaO2 represents the partial pressure of oxygen"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560867/"
+        trust authoritative
+
+    % Arterial oxygen partial pressure — the same definition solved for the PaO2 a ratio implies at a
+    % given FiO2 (PaO2 = P/F × FiO2). Defended by the SAME clause.
+    formula arterial_oxygen_partial_pressure(pf_ratio, fraction_of_inspired_oxygen) = pf_ratio * fraction_of_inspired_oxygen
+        source "using the PaO2/FiO2 (P/F) ratio, where PaO2 represents the partial pressure of oxygen"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560867/"
+        trust authoritative
+
+    % Fraction of inspired oxygen — the same definition solved for the FiO2 (FiO2 = PaO2 ÷ P/F): the
+    % PaO2 divided by the ratio. The SAME clause, read the third way.
+    formula fraction_of_inspired_oxygen(arterial_oxygen_partial_pressure, pf_ratio) = arterial_oxygen_partial_pressure / pf_ratio
+        source "using the PaO2/FiO2 (P/F) ratio, where PaO2 represents the partial pressure of oxygen"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560867/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/pf-ratio.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/pf-ratio.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% pf-ratio.query.adj — worked applications of the P/F-ratio definition.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a critical-care oxygenation vignette into an
+% observed PaO2 and FiO2: it `import`s the grounded formulabook, `observe`s the arterial oxygen
+% partial pressure and the fraction of inspired oxygen, and asks the engine to APPLY the cited
+% definition. No arithmetic is stated by the consumer; the engine computes each value EXACTLY (over
+% exact rationals) and carries the article's citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (PaO2 = 200 mmHg, FiO2 = 0.5): P/F ratio = 200 ÷ 0.5 = 400 mmHg — a normal ratio (well
+% above the ARDS cut-off of 300). Each query below fixes two of the three quantities and asks the
+% engine to recover the third; every answer is exact and the three COMPOSE (each inversion recovers
+% exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli pf-ratio.query.adj
+% ============================================================================
+
+import "pf-ratio.adj"
+
+% --- Definition: the P/F ratio the two oxygen values imply (expect 400). ----------------------
+observe arterial_oxygen_partial_pressure(200)
+observe fraction_of_inspired_oxygen(0.5)
+? pf_ratio(arterial_oxygen_partial_pressure, fraction_of_inspired_oxygen)   % expect 400
+
+% --- Inverse: the PaO2 a P/F ratio of 400 implies at that FiO2 (expect 200). ------------------
+observe pf_ratio(400)
+? arterial_oxygen_partial_pressure(pf_ratio, fraction_of_inspired_oxygen)   % expect 200


### PR DESCRIPTION
## What

Ships a new grounded clinical formula library for the **PaO2/FiO2 (P/F) ratio** — the critical-care oxygenation index and Berlin ARDS oxygenation criterion — in the ADJ formula stdlib:

- `code/specs/data/adj-formula-stdlib/clinical/pf-ratio.adj` — a `dictionary` + `formulabook` defining **P/F ratio = arterial oxygen partial pressure (PaO2) ÷ fraction of inspired oxygen (FiO2)** plus its two exact rearrangements (PaO2 = ratio × FiO2; FiO2 = PaO2 ÷ ratio).
- `…/clinical/pf-ratio.query.adj` — worked applications.
- `code/packages/rust/adj-lang-cli/tests/formula_pf_ratio_e2e.rs` — a dedicated 3-test e2e driving the built CLI against the shipped stdlib.

## Grounding

Every formula carries the SAME verbatim clause, transcribed byte-for-byte from the StatPearls **"Fraction of Inspired Oxygen"** article on the NCBI Bookshelf:

> "using the PaO2/FiO2 (P/F) ratio, where PaO2 represents the partial pressure of oxygen"

The `/` in "PaO2/FiO2" IS the division operator; locator `https://www.ncbi.nlm.nih.gov/books/NBK560867/`, `trust authoritative`. One clause defends the relation read three ways — nothing asserted from memory (`feedback_nothing_human_authored`).

## Invariant

A consumer states **no arithmetic**: it imports the library, `observe`s PaO2 and FiO2, and the engine applies the cited definition on the CPU, computing the EXACT value (over rationals) and rendering the citation + trust tier in `derived`. Worked case PaO2 200 mmHg, FiO2 0.5 → P/F 400 mmHg (a normal ratio, above the ARDS cut-off of 300); the three formulas compose and invert exactly. FiO2 is the decimal fraction (0.21–1.0), so the ratio carries mmHg.

## Verification

- `cargo test -p adj-lang-cli --test formula_pf_ratio_e2e` → 3 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean.
- Render-probe confirms `pf_ratio=400`, `arterial_oxygen_partial_pressure=200`, `fraction_of_inspired_oxygen=0.5`, exact rationals, verbatim source + NBK560867 locator + authoritative trust.
- NUL-scan clean. Security review: clean (no vulnerabilities) — conducted inline this run because the review sub-agent was unavailable due to a sustained upstream 529 outage.

Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)