### PR TITLE
feat(build-tool): close pure-domain conformance corpus

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,7 +8,12 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": null,
+  "active_pr": {
+    "item_id": "build-tool-pure-domain-corpus",
+    "pr_number": 9167,
+    "branch": "codex/build-tool-pure-domain-corpus",
+    "url": "https://github.com/adhithyan15/coding-adventures/pull/9167"
+  },
   "last_inventory": {
     "revision": "3201fb42078f40ef27f11aefb5e3b4b1bcf8551e",
     "schema_version": 2,
@@ -60,11 +65,11 @@
     {
       "id": "build-tool-pure-domain-corpus",
       "title": "Close the remaining non-execution build-tool domain schemas and fixtures",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-fixtures"],
       "branch": "codex/build-tool-pure-domain-corpus",
-      "pr_number": null,
-      "notes": "Selected after PR #9157 merged because this pure, process-free corpus expansion unlocks the Go oracle, Java/Kotlin, Dart, every existing front door, and OCaml promotion. The branch now validates 30 cases across all 11 process-free domains with closed pure records, semantic oracles, conservative diff behavior, typed cache states, inline-only Starlark loads, sharding verification, normalized BUILD-file validation, and the OCaml-aware toolchain registry."
+      "pr_number": 9167,
+      "notes": "Ready-for-review PR #9167. Selected after PR #9157 merged because this pure, process-free corpus expansion unlocks the Go oracle, Java/Kotlin, Dart, every existing front door, and OCaml promotion. The branch validates 30 cases across all 11 process-free domains with closed pure records, semantic oracles, conservative diff behavior, typed cache states, inline-only Starlark loads, sharding verification, normalized BUILD-file validation, and the OCaml-aware toolchain registry."
     },
     {
       "id": "build-tool-cli-parser-corpus",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -10,7 +10,7 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "cdb596b99523e557fc83b4ea6932f8728e662088",
+    "revision": "24fc8e2d097be1cb9ffeb9e8a0be5ab46d3e867e",
     "schema_version": 2,
     "established_languages": 15,
     "implementation_identities": 1184,

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -64,7 +64,25 @@
       "depends_on": ["build-tool-fixtures"],
       "branch": "codex/build-tool-pure-domain-corpus",
       "pr_number": null,
-      "notes": "Selected after PR #9157 merged because this pure, process-free corpus expansion unlocks the Go oracle, Java/Kotlin, Dart, every existing front door, and OCaml promotion. Add closed inputs/results and positive plus adversarial cases for diff selection, hashing/cache, Starlark, sharding, validation, toolchain detection, and CLI before those domains can report success."
+      "notes": "Selected after PR #9157 merged because this pure, process-free corpus expansion unlocks the Go oracle, Java/Kotlin, Dart, every existing front door, and OCaml promotion. The branch now validates 30 cases across all 11 process-free domains with closed pure records, semantic oracles, conservative diff behavior, typed cache states, inline-only Starlark loads, sharding verification, normalized validation, and the OCaml-aware toolchain registry."
+    },
+    {
+      "id": "build-tool-cli-parser-corpus",
+      "title": "Define the inert cross-language CLI argv grammar and parser corpus",
+      "status": "pending",
+      "depends_on": ["build-tool-pure-domain-corpus"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered during the pure-domain security review. Replace exit-decision-only coverage with bounded argv parsing, typed parse results, reserved-flag/path rejection, and adversarial shell/env/@file tokens without dispatch or host reads."
+    },
+    {
+      "id": "build-tool-starlark-metering-corpus",
+      "title": "Add adversarial Starlark evaluator metering fixtures",
+      "status": "pending",
+      "depends_on": ["build-tool-pure-domain-corpus"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered during the pure-domain security review. Cover fuel, recursion, aggregate allocations, range/value sizes, load depth/count/cycles, and print/trace limits before any native evaluator claims final Starlark conformance."
     },
     {
       "id": "build-file-standalone-integrity",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -10,7 +10,7 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "24fc8e2d097be1cb9ffeb9e8a0be5ab46d3e867e",
+    "revision": "3201fb42078f40ef27f11aefb5e3b4b1bcf8551e",
     "schema_version": 2,
     "established_languages": 15,
     "implementation_identities": 1184,

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -64,7 +64,7 @@
       "depends_on": ["build-tool-fixtures"],
       "branch": "codex/build-tool-pure-domain-corpus",
       "pr_number": null,
-      "notes": "Selected after PR #9157 merged because this pure, process-free corpus expansion unlocks the Go oracle, Java/Kotlin, Dart, every existing front door, and OCaml promotion. The branch now validates 30 cases across all 11 process-free domains with closed pure records, semantic oracles, conservative diff behavior, typed cache states, inline-only Starlark loads, sharding verification, normalized validation, and the OCaml-aware toolchain registry."
+      "notes": "Selected after PR #9157 merged because this pure, process-free corpus expansion unlocks the Go oracle, Java/Kotlin, Dart, every existing front door, and OCaml promotion. The branch now validates 30 cases across all 11 process-free domains with closed pure records, semantic oracles, conservative diff behavior, typed cache states, inline-only Starlark loads, sharding verification, normalized BUILD-file validation, and the OCaml-aware toolchain registry."
     },
     {
       "id": "build-tool-cli-parser-corpus",
@@ -83,6 +83,15 @@
       "branch": null,
       "pr_number": null,
       "notes": "Discovered during the pure-domain security review. Cover fuel, recursion, aggregate allocations, range/value sizes, load depth/count/cycles, and print/trace limits before any native evaluator claims final Starlark conformance."
+    },
+    {
+      "id": "build-tool-validation-oracle-corpus",
+      "title": "Close the remaining build-tool validation checks with semantic oracles",
+      "status": "pending",
+      "depends_on": ["build-tool-pure-domain-corpus"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered during the pure-domain security review. Add deterministic inline inputs, positive and adversarial fixtures, and input-to-diagnostic oracles for declared dependencies, standalone prerequisites, Starlark declarations, identity, toolchain support, and path safety before those checks enter the closed schema."
     },
     {
       "id": "build-file-standalone-integrity",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,14 +8,9 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": {
-    "number": 9157,
-    "url": "https://github.com/adhithyan15/coding-adventures/pull/9157",
-    "branch": "codex/build-tool-conformance-runner",
-    "status": "open"
-  },
+  "active_pr": null,
   "last_inventory": {
-    "revision": "edddc9b46af7662ce08799c1b5d9cd4d373025aa",
+    "revision": "cdb596b99523e557fc83b4ea6932f8728e662088",
     "schema_version": 2,
     "established_languages": 15,
     "implementation_identities": 1184,
@@ -47,7 +42,7 @@
     {
       "id": "build-tool-fixtures",
       "title": "Cross-implementation build-tool fixture runner and inventory gate",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-contract"],
       "branch": "codex/build-tool-conformance-runner",
       "pr_number": 9157,
@@ -65,11 +60,11 @@
     {
       "id": "build-tool-pure-domain-corpus",
       "title": "Close the remaining non-execution build-tool domain schemas and fixtures",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-fixtures"],
-      "branch": null,
+      "branch": "codex/build-tool-pure-domain-corpus",
       "pr_number": null,
-      "notes": "Newly explicit after the bootstrap schema audit. Add closed inputs/results and positive plus adversarial cases for diff selection, hashing/cache, Starlark, sharding, validation, toolchain detection, and CLI before those domains can report success."
+      "notes": "Selected after PR #9157 merged because this pure, process-free corpus expansion unlocks the Go oracle, Java/Kotlin, Dart, every existing front door, and OCaml promotion. Add closed inputs/results and positive plus adversarial cases for diff selection, hashing/cache, Starlark, sharding, validation, toolchain detection, and CLI before those domains can report success."
     },
     {
       "id": "build-file-standalone-integrity",

--- a/code/scripts/build_tool_conformance.py
+++ b/code/scripts/build_tool_conformance.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 import argparse
 import base64
 import binascii
+import hashlib
 import json
 import os
+import posixpath
 import re
 import stat
 import sys
@@ -24,9 +26,7 @@ from typing import Any, Sequence
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_FIXTURE_ROOT = (
-    REPO_ROOT / "code" / "specs" / "fixtures" / "build-tool-v1"
-)
+DEFAULT_FIXTURE_ROOT = REPO_ROOT / "code" / "specs" / "fixtures" / "build-tool-v1"
 MAX_SAFE_INTEGER = 9_007_199_254_740_991
 MAX_DOCUMENT_BYTES = 2_000_000
 MAX_RESULT_BYTES = 16_777_216
@@ -35,7 +35,22 @@ MAX_WORKSPACE_FILES = 4096
 MAX_WORKSPACE_BYTES = 268_435_456
 RESERVED_ADAPTER_FLAGS = ("--conformance", "--workspace-root", "--output")
 EXECUTION_CAPABILITIES = {"execution", "trusted_execution"}
-BOOTSTRAP_DOMAINS = {"discovery", "graph", "plan", "resolution"}
+PURE_DOMAINS = {
+    "cli",
+    "diff_selection",
+    "hashing_cache",
+    "sharding",
+    "starlark",
+    "toolchain_detection",
+    "validation",
+}
+BOOTSTRAP_DOMAINS = {
+    "discovery",
+    "graph",
+    "plan",
+    "resolution",
+    *PURE_DOMAINS,
+}
 ESTABLISHED_LANGUAGES = (
     "csharp",
     "dart",
@@ -67,6 +82,44 @@ DOMAIN_CAPABILITIES = {
     "toolchain_detection": {"toolchain_detection"},
     "cli": {"cli"},
 }
+TOOLCHAINS = (
+    "cpp",
+    "dart",
+    "dotnet",
+    "elixir",
+    "go",
+    "haskell",
+    "java",
+    "kotlin",
+    "lua",
+    "ocaml",
+    "perl",
+    "python",
+    "ruby",
+    "rust",
+    "swift",
+    "typescript",
+)
+LANGUAGE_TOOLCHAINS = {
+    **{toolchain: toolchain for toolchain in TOOLCHAINS},
+    "c": "cpp",
+    "csharp": "dotnet",
+    "fsharp": "dotnet",
+    "wasm": "rust",
+}
+TOOLCHAIN_WEIGHTS = {
+    "rust": 6,
+    "dotnet": 4,
+    "haskell": 4,
+    "swift": 4,
+    "typescript": 4,
+    "java": 3,
+    "kotlin": 3,
+    "elixir": 2,
+    "python": 2,
+    "ruby": 2,
+}
+DISPLAY_SAFE_TOKEN = re.compile(r"^[A-Za-z0-9_@%+=:,./-]+$")
 WINDOWS_RESERVED_BASENAMES = {
     "CON",
     "PRN",
@@ -377,10 +430,7 @@ def portable_path_error(path: Any) -> str | None:
         or re.match(r"^[A-Za-z]:", path)
         or "\\" in path
         or "//" in path
-        or any(
-            ord(character) < 32 or character in '<>:"|?*'
-            for character in path
-        )
+        or any(ord(character) < 32 or character in '<>:"|?*' for character in path)
     ):
         return "path is not a portable relative path"
     for segment in path.split("/"):
@@ -394,20 +444,52 @@ def portable_path_error(path: Any) -> str | None:
     return None
 
 
+def portable_glob_error(value: Any) -> str | None:
+    if not isinstance(value, str) or not value:
+        return "glob is empty or not a string"
+    if len(value) > 512:
+        return "glob exceeds 512 characters"
+    if value != unicodedata.normalize("NFC", value):
+        return "glob is not NFC-normalized"
+    if (
+        value.startswith("/")
+        or re.match(r"^[A-Za-z]:", value)
+        or "\\" in value
+        or "//" in value
+        or any(ord(character) < 32 or character in '<>:"|?' for character in value)
+    ):
+        return "glob is not portable"
+    for segment in value.split("/"):
+        if segment in {"", ".", ".."}:
+            return "glob contains an empty or dot segment"
+        literal = segment.replace("*", "")
+        if literal.endswith((" ", ".")):
+            return "glob segment has a trailing dot or space"
+        if not any(character in segment for character in "*[]{}"):
+            basename = segment.split(".", 1)[0].upper()
+            if basename in WINDOWS_RESERVED_BASENAMES:
+                return "glob segment uses a Windows reserved basename"
+    return None
+
+
 def reject_execution_intent(case: dict[str, Any]) -> None:
     domain = case.get("domain")
     input_value = case.get("input")
-    operation = (
-        input_value.get("operation") if isinstance(input_value, dict) else None
-    )
+    operation = input_value.get("operation") if isinstance(input_value, dict) else None
     capabilities = case.get("capabilities")
     capability_values = capabilities if isinstance(capabilities, list) else []
+    cli_requires_execution = (
+        domain == "cli"
+        and isinstance(input_value, dict)
+        and isinstance(input_value.get("options"), dict)
+        and input_value["options"].get("requires_execution") is True
+    )
     if (
         domain == "execution"
         or operation == "execution"
+        or cli_requires_execution
         or any(
-            isinstance(capability, str)
-            and capability in EXECUTION_CAPABILITIES
+            isinstance(capability, str) and capability in EXECUTION_CAPABILITIES
             for capability in capability_values
         )
     ):
@@ -495,9 +577,8 @@ def preflight_workspace(case: dict[str, Any]) -> list[WorkspaceFile]:
                 f"workspace path collides with {normalized_paths[normalized]}",
             )
         for existing, original in normalized_paths.items():
-            if (
-                normalized.startswith(f"{existing}/")
-                or existing.startswith(f"{normalized}/")
+            if normalized.startswith(f"{existing}/") or existing.startswith(
+                f"{normalized}/"
             ):
                 raise ConformanceError(
                     "WORKSPACE_PATH_PREFIX_CONFLICT",
@@ -689,12 +770,591 @@ def _validate_plan_semantics(plan: dict[str, Any]) -> None:
                 )
 
 
+def _pure_record(
+    case: dict[str, Any],
+    result: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "domain": case["domain"],
+        "outcome": result["outcome"],
+        "input": case["input"],
+        "result": result["result"],
+    }
+
+
+def _validate_pure_domain_record(
+    case: dict[str, Any],
+    result: dict[str, Any],
+    schema: dict[str, Any],
+    code: str,
+) -> None:
+    if case["domain"] in PURE_DOMAINS:
+        _validate_schema(_pure_record(case, result), schema, code)
+
+
+def _package_index(
+    packages: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    normalized: set[str] = set()
+    for package in packages:
+        name = package["name"]
+        identity = unicodedata.normalize("NFC", name).casefold()
+        if identity in normalized:
+            raise ConformanceError(
+                "CASE_PACKAGE_DUPLICATE",
+                f"duplicate normalized package identity: {name}",
+            )
+        normalized.add(identity)
+        result[name] = package
+    return result
+
+
+def _validate_known_edges(
+    edges: list[list[str]],
+    package_names: set[str],
+) -> None:
+    for edge in edges:
+        if edge[0] == edge[1]:
+            raise ConformanceError(
+                "CASE_EDGE_SELF",
+                f"self dependency edge is forbidden: {edge[0]}",
+            )
+        if edge[0] not in package_names or edge[1] not in package_names:
+            raise ConformanceError(
+                "CASE_EDGE_UNKNOWN",
+                f"dependency edge references an unknown package: {edge}",
+            )
+
+
+def _validate_unique_paths(
+    paths: list[str],
+    code: str,
+) -> None:
+    normalized: dict[str, str] = {}
+    for path in paths:
+        if error := portable_path_error(path):
+            raise ConformanceError(code, f"unsafe nested path {path!r}: {error}")
+        identity = unicodedata.normalize("NFC", path).casefold()
+        if identity in normalized:
+            raise ConformanceError(
+                code,
+                f"nested path collides with {normalized[identity]}: {path}",
+            )
+        for existing, original in normalized.items():
+            if identity.startswith(f"{existing}/") or existing.startswith(
+                f"{identity}/"
+            ):
+                raise ConformanceError(
+                    code,
+                    f"nested paths have a prefix conflict: {original} and {path}",
+                )
+        normalized[identity] = path
+
+
+def _toolchain_for_language(language: str) -> str:
+    toolchain = LANGUAGE_TOOLCHAINS.get(language)
+    if toolchain is None:
+        raise ConformanceError(
+            "CASE_TOOLCHAIN_UNSUPPORTED",
+            f"unsupported implementation language: {language}",
+        )
+    return toolchain
+
+
+def _validate_pure_case_semantics(
+    case: dict[str, Any],
+    staged_files: list[WorkspaceFile],
+) -> None:
+    domain = case["domain"]
+    if domain not in PURE_DOMAINS:
+        return
+    if any(file.executable for file in staged_files):
+        raise ConformanceError(
+            "CASE_PURE_AUTHORITY",
+            "pure-domain workspace files must not be executable",
+        )
+
+    options = case["input"]["options"]
+    if domain == "diff_selection":
+        packages = options["packages"]
+        by_name = _package_index(packages)
+        roots = [package["rel_path"] for package in packages]
+        _validate_unique_paths(roots, "CASE_NESTED_PATH_UNSAFE")
+        for package in packages:
+            for pattern in package.get("source_globs", []):
+                if error := portable_glob_error(pattern):
+                    raise ConformanceError(
+                        "CASE_NESTED_GLOB_UNSAFE",
+                        f"unsafe source glob {pattern!r}: {error}",
+                    )
+        _validate_known_edges(options["edges"], set(by_name))
+        for name in options["forced_packages"]:
+            if name not in by_name:
+                raise ConformanceError(
+                    "CASE_PACKAGE_REFERENCE_UNKNOWN",
+                    f"forced package is not declared: {name}",
+                )
+    elif domain == "hashing_cache":
+        workspace_paths = {entry.path for entry in staged_files}
+        include_paths = options["include_paths"]
+        _validate_unique_paths(include_paths, "CASE_NESTED_PATH_UNSAFE")
+        for path in include_paths:
+            if path not in workspace_paths:
+                raise ConformanceError(
+                    "CASE_HASH_PATH_UNKNOWN",
+                    f"hash include path is not in the inline workspace: {path}",
+                )
+        dependency_names: set[str] = set()
+        for dependency in options["dependency_digests"]:
+            name = dependency["package"]
+            if name == options["package"] or name in dependency_names:
+                raise ConformanceError(
+                    "CASE_HASH_DEPENDENCY_DUPLICATE",
+                    f"invalid or duplicate hash dependency: {name}",
+                )
+            dependency_names.add(name)
+        if options["package"] in options["dependents"]:
+            raise ConformanceError(
+                "CASE_HASH_DEPENDENT_SELF",
+                "a package cannot be its own dependent",
+            )
+    elif domain == "starlark":
+        workspace_paths = {entry.path for entry in staged_files}
+        entrypoint = options["entrypoint"]
+        if entrypoint not in workspace_paths:
+            raise ConformanceError(
+                "CASE_STARLARK_ENTRYPOINT_MISSING",
+                f"Starlark entrypoint is not in the inline workspace: {entrypoint}",
+            )
+    elif domain == "sharding":
+        by_name = _package_index(options["packages"])
+        _validate_known_edges(options["edges"], set(by_name))
+        for name in options["scheduled_packages"]:
+            if name not in by_name:
+                raise ConformanceError(
+                    "CASE_PACKAGE_REFERENCE_UNKNOWN",
+                    f"scheduled package is not declared: {name}",
+                )
+        for package in by_name.values():
+            _toolchain_for_language(package["language"])
+    elif domain == "validation":
+        by_name = _package_index(options["packages"])
+        _validate_unique_paths(
+            [package["rel_path"] for package in by_name.values()],
+            "CASE_NESTED_PATH_UNSAFE",
+        )
+        _validate_known_edges(options["dependency_edges"], set(by_name))
+        for package in by_name.values():
+            for pattern in package["declared_srcs"]:
+                if error := portable_glob_error(pattern):
+                    raise ConformanceError(
+                        "CASE_NESTED_GLOB_UNSAFE",
+                        f"unsafe declared source {pattern!r}: {error}",
+                    )
+            for field in ("build_references", "declared_deps"):
+                for name in package[field]:
+                    if name not in by_name:
+                        raise ConformanceError(
+                            "CASE_PACKAGE_REFERENCE_UNKNOWN",
+                            f"{field} references an unknown package: {name}",
+                        )
+    elif domain == "toolchain_detection":
+        by_name = _package_index(options["packages"])
+        selected = options["scheduled_packages"]
+        if isinstance(selected, list):
+            for name in selected:
+                if name not in by_name:
+                    raise ConformanceError(
+                        "CASE_PACKAGE_REFERENCE_UNKNOWN",
+                        f"scheduled package is not declared: {name}",
+                    )
+
+
+def _framed_digest(items: list[tuple[str, bytes]]) -> bytes:
+    digest = hashlib.sha256()
+    for name, content in sorted(items, key=lambda item: item[0]):
+        name_bytes = name.encode("utf-8")
+        digest.update(len(name_bytes).to_bytes(8, "big"))
+        digest.update(name_bytes)
+        digest.update(len(content).to_bytes(8, "big"))
+        digest.update(content)
+    return digest.digest()
+
+
+def _expected_hashes(
+    options: dict[str, Any],
+    staged_files: list[WorkspaceFile],
+) -> tuple[str, str, str]:
+    workspace = {entry.path: entry.content for entry in staged_files}
+    package_digest = _framed_digest(
+        [(path, workspace[path]) for path in options["include_paths"]]
+    )
+    dependencies_digest = _framed_digest(
+        [
+            (entry["package"], bytes.fromhex(entry["digest"]))
+            for entry in options["dependency_digests"]
+        ]
+    )
+    combined = hashlib.sha256(package_digest + dependencies_digest).hexdigest()
+    return package_digest.hex(), dependencies_digest.hex(), combined
+
+
+def _render_display_command(command: dict[str, Any]) -> str:
+    tokens = [command["program"], *command["args"]]
+    rendered = [
+        token
+        if DISPLAY_SAFE_TOKEN.fullmatch(token)
+        else json.dumps(token, ensure_ascii=False, separators=(",", ":"))
+        for token in tokens
+    ]
+    return " ".join(rendered)
+
+
+def _starlark_module_error(
+    options: dict[str, Any],
+    staged_files: list[WorkspaceFile],
+) -> tuple[str, str] | None:
+    sources = {entry.path: entry.content for entry in staged_files}
+    pending = [(options["entrypoint"], 0)]
+    visited: set[str] = set()
+    limits = options["evaluation_limits"]
+    load_pattern = re.compile(r"""load\(\s*(?P<quote>["'])(?P<label>.+?)(?P=quote)""")
+    while pending:
+        module, depth = pending.pop()
+        if module in visited:
+            continue
+        visited.add(module)
+        if len(visited) > limits["module_count"]:
+            return "STARLARK_MODULE_LIMIT", module
+        if depth > limits["load_depth"]:
+            return "STARLARK_LOAD_DEPTH_LIMIT", module
+        try:
+            source = sources[module].decode("utf-8", errors="strict")
+        except UnicodeDecodeError:
+            return "STARLARK_SOURCE_INVALID", module
+        for match in load_pattern.finditer(source):
+            label = match.group("label")
+            if label.startswith("//"):
+                resolved = label[2:]
+            elif label.startswith(("./", "../")):
+                resolved = posixpath.normpath(
+                    posixpath.join(posixpath.dirname(module), label)
+                )
+            else:
+                resolved = label
+            if (
+                resolved in {"", ".", ".."}
+                or resolved.startswith("../")
+                or portable_path_error(resolved)
+            ):
+                return "STARLARK_LOAD_OUTSIDE_REPOSITORY", module
+            if resolved not in sources:
+                return "STARLARK_MODULE_MISSING", resolved
+            pending.append((resolved, depth + 1))
+    return None
+
+
+def _expected_toolchains(
+    options: dict[str, Any],
+) -> dict[str, bool]:
+    by_name = {package["name"]: package for package in options["packages"]}
+    selected = options["scheduled_packages"]
+    selected_names = sorted(by_name) if selected is None else selected
+    enabled = {
+        _toolchain_for_language(by_name[name]["language"]) for name in selected_names
+    }
+    enabled.update(options["forced_toolchains"])
+    return {toolchain: toolchain in enabled for toolchain in TOOLCHAINS}
+
+
+def _package_cost(package: dict[str, Any]) -> int:
+    toolchain = _toolchain_for_language(package["language"])
+    return 1 + package["build_command_count"] + TOOLCHAIN_WEIGHTS.get(toolchain, 0)
+
+
+def _expected_shards(options: dict[str, Any]) -> list[dict[str, Any]]:
+    packages = {package["name"]: package for package in options["packages"]}
+    scheduled = options["scheduled_packages"]
+    count = 1 if not scheduled else min(options["shard_count"], len(scheduled))
+    assigned: list[list[str]] = [[] for _ in range(count)]
+    direct_costs = [0] * count
+    for name in sorted(
+        scheduled,
+        key=lambda item: (-_package_cost(packages[item]), item),
+    ):
+        index = min(range(count), key=lambda item: (direct_costs[item], item))
+        assigned[index].append(name)
+        direct_costs[index] += _package_cost(packages[name])
+
+    prerequisites: dict[str, set[str]] = {name: set() for name in packages}
+    for prerequisite, dependent in options["edges"]:
+        prerequisites[dependent].add(prerequisite)
+
+    def closure(roots: list[str]) -> set[str]:
+        result = set(roots)
+        pending = list(roots)
+        while pending:
+            package = pending.pop()
+            for prerequisite in prerequisites[package]:
+                if prerequisite not in result:
+                    result.add(prerequisite)
+                    pending.append(prerequisite)
+        return result
+
+    shards: list[dict[str, Any]] = []
+    for index, roots in enumerate(assigned):
+        package_names = closure(roots)
+        toolchains = sorted(
+            {
+                _toolchain_for_language(packages[name]["language"])
+                for name in package_names
+            }
+        )
+        shards.append(
+            {
+                "index": index,
+                "name": f"shard-{index + 1}-of-{count}",
+                "assigned_packages": sorted(roots),
+                "package_names": sorted(package_names),
+                "toolchains": toolchains,
+                "estimated_cost": sum(
+                    _package_cost(packages[name]) for name in package_names
+                ),
+            }
+        )
+    return shards
+
+
+def _validate_pure_result_semantics(
+    case: dict[str, Any],
+    result: dict[str, Any],
+    staged_files: list[WorkspaceFile],
+    prefix: str,
+) -> None:
+    domain = case["domain"]
+    if domain not in PURE_DOMAINS:
+        return
+    options = case["input"]["options"]
+    payload = result["result"]
+    outcome = result["outcome"]
+    diagnostic_codes = [item["code"] for item in result["diagnostics"]]
+
+    if domain == "diff_selection":
+        package_names = {package["name"] for package in options["packages"]}
+        unknown_paths = [
+            path
+            for path in case["input"]["changed_paths"]
+            if not any(
+                path == package["rel_path"]
+                or path.startswith(f"{package['rel_path']}/")
+                for package in options["packages"]
+            )
+        ]
+        if unknown_paths and options["unknown_path_policy"] == "error":
+            if outcome != "error" or "DIFF_UNKNOWN_PATH" not in diagnostic_codes:
+                raise ConformanceError(
+                    f"{prefix}_DIFF_UNKNOWN_PATH_INVALID",
+                    "unknown changed paths require a stable error",
+                )
+            return
+        if outcome != "ok":
+            return
+        changed = set(payload["changed_packages"])
+        affected = set(payload["affected_packages"])
+        prerequisites = set(payload["prerequisite_packages"])
+        if (
+            not (changed | affected | prerequisites).issubset(package_names)
+            or not changed.issubset(affected)
+            or affected.intersection(prerequisites)
+        ):
+            raise ConformanceError(
+                f"{prefix}_DIFF_RESULT_INVALID",
+                "diff result contains unknown or inconsistent package sets",
+            )
+        if unknown_paths and (
+            changed != package_names or affected != package_names or prerequisites
+        ):
+            raise ConformanceError(
+                f"{prefix}_DIFF_UNKNOWN_PATH_INVALID",
+                "unknown changed paths under all policy must select every package",
+            )
+    elif domain == "hashing_cache" and outcome == "ok":
+        expected_hashes = _expected_hashes(options, staged_files)
+        actual_hashes = (
+            payload["package_digest"],
+            payload["dependencies_digest"],
+            payload["combined_digest"],
+        )
+        allowed_invalidations = {
+            options["package"],
+            *options["dependents"],
+        }
+        if actual_hashes != expected_hashes:
+            raise ConformanceError(
+                f"{prefix}_HASH_MISMATCH",
+                "hash result does not match the framed SHA-256 oracle",
+            )
+        prior = options["prior_cache"]
+        if prior["state"] == "corrupt":
+            expected_status = "recovered"
+            expected_invalidations = allowed_invalidations
+        elif prior["state"] == "missing":
+            expected_status = "miss"
+            expected_invalidations = allowed_invalidations
+        elif (
+            prior["status"] == "success"
+            and prior["combined_digest"] == expected_hashes[2]
+        ):
+            expected_status = "hit"
+            expected_invalidations = set()
+        else:
+            expected_status = "miss"
+            expected_invalidations = allowed_invalidations
+        if (
+            payload["cache_status"] != expected_status
+            or set(payload["invalidated_packages"]) != expected_invalidations
+        ):
+            raise ConformanceError(
+                f"{prefix}_HASH_INVALIDATION_INVALID",
+                "cache status and invalidations do not match the prior record",
+            )
+        if prior["state"] == "corrupt" and (
+            "CACHE_CORRUPT_RECOVERED" not in diagnostic_codes
+        ):
+            raise ConformanceError(
+                f"{prefix}_HASH_RECOVERY_DIAGNOSTIC_MISSING",
+                "corrupt cache recovery requires a stable diagnostic",
+            )
+    elif domain == "starlark":
+        module_error = _starlark_module_error(options, staged_files)
+        if module_error is not None:
+            code, path = module_error
+            matching = [
+                diagnostic
+                for diagnostic in result["diagnostics"]
+                if diagnostic["code"] == code and diagnostic.get("path") == path
+            ]
+            if outcome != "error" or not matching:
+                raise ConformanceError(
+                    f"{prefix}_STARLARK_MODULE_ERROR_INVALID",
+                    f"Starlark module resolution must report {code}: {path}",
+                )
+            return
+        if outcome != "ok":
+            return
+        target_ids: set[tuple[str, str]] = set()
+        for target in payload["targets"]:
+            identity = (target["rule"], target["name"])
+            if identity in target_ids:
+                raise ConformanceError(
+                    f"{prefix}_STARLARK_TARGET_DUPLICATE",
+                    f"duplicate Starlark target: {identity}",
+                )
+            target_ids.add(identity)
+            rendered = [
+                _render_display_command(command) for command in target["commands"]
+            ]
+            if rendered != target["rendered_commands"]:
+                raise ConformanceError(
+                    f"{prefix}_STARLARK_RENDER_MISMATCH",
+                    "rendered commands do not match structured commands",
+                )
+            if (
+                target["command_source"] == "legacy_fallback"
+                and options["legacy_fallback"] == "error"
+            ):
+                raise ConformanceError(
+                    f"{prefix}_STARLARK_FALLBACK_FORBIDDEN",
+                    "legacy fallback was used under the error policy",
+                )
+    elif domain == "sharding":
+        shard_count = options["shard_count"]
+        scheduled = options["scheduled_packages"]
+        produced_count = 1 if not scheduled else min(shard_count, len(scheduled))
+        index = options.get("shard_index")
+        invalid_code = None
+        if shard_count < 1:
+            invalid_code = "SHARD_COUNT_INVALID"
+        elif index is not None and (index < 0 or index >= produced_count):
+            invalid_code = "SHARD_INDEX_INVALID"
+        if invalid_code is not None:
+            if outcome != "error" or diagnostic_codes != [invalid_code]:
+                raise ConformanceError(
+                    f"{prefix}_SHARD_ERROR_INVALID",
+                    f"invalid shard input must report {invalid_code}",
+                )
+        elif outcome == "ok":
+            expected = _expected_shards(options)
+            actual = sorted(payload["shards"], key=lambda item: item["index"])
+            normalized = []
+            for shard in actual:
+                copy_value = dict(shard)
+                for key in (
+                    "assigned_packages",
+                    "package_names",
+                    "toolchains",
+                ):
+                    copy_value[key] = sorted(copy_value[key])
+                normalized.append(copy_value)
+            if normalized != expected:
+                raise ConformanceError(
+                    f"{prefix}_SHARD_MISMATCH",
+                    "shard result does not match the closed balancing oracle",
+                )
+    elif domain == "validation":
+        codes = payload.get("diagnostic_codes", [])
+        valid = payload.get("valid")
+        consistent = (
+            outcome == "ok" and valid is True and not codes and not diagnostic_codes
+        ) or (
+            outcome == "error"
+            and valid is False
+            and bool(codes)
+            and sorted(codes) == sorted(diagnostic_codes)
+        )
+        if not consistent:
+            raise ConformanceError(
+                f"{prefix}_VALIDATION_INCONSISTENT",
+                "validation outcome, valid flag, and diagnostics disagree",
+            )
+    elif domain == "toolchain_detection":
+        unsupported = any(
+            package["language"] not in LANGUAGE_TOOLCHAINS
+            for package in options["packages"]
+        ) or any(
+            toolchain not in TOOLCHAINS for toolchain in options["forced_toolchains"]
+        )
+        if unsupported:
+            if outcome != "error" or "TOOLCHAIN_UNSUPPORTED" not in diagnostic_codes:
+                raise ConformanceError(
+                    f"{prefix}_TOOLCHAIN_ERROR_INVALID",
+                    "unsupported toolchains require a stable error",
+                )
+        elif outcome != "ok" or payload["toolchains"] != _expected_toolchains(options):
+            raise ConformanceError(
+                f"{prefix}_TOOLCHAIN_MISMATCH",
+                "toolchain map does not match the selected packages",
+            )
+    elif domain == "cli":
+        expected_exit = {
+            "success": 0,
+            "package_failure": 1,
+            "validation_failure": 1,
+            "invalid_usage": 2,
+            "unsafe_input": 2,
+        }[options["condition"]]
+        expected_outcome = "ok" if expected_exit == 0 else "error"
+        if payload["exit_code"] != expected_exit or outcome != expected_outcome:
+            raise ConformanceError(
+                f"{prefix}_CLI_EXIT_MISMATCH",
+                "CLI condition, outcome, and exit code disagree",
+            )
+
+
 def _sort_json_objects(value: Any) -> Any:
     if isinstance(value, dict):
-        return {
-            key: _sort_json_objects(value[key])
-            for key in sorted(value)
-        }
+        return {key: _sort_json_objects(value[key]) for key in sorted(value)}
     if isinstance(value, list):
         return [_sort_json_objects(item) for item in value]
     return value
@@ -735,6 +1395,30 @@ def canonicalize_result(result: dict[str, Any]) -> dict[str, Any]:
             for shard in plan["shards"]:
                 shard["assigned_packages"].sort()
                 shard["package_names"].sort()
+    elif domain == "diff_selection":
+        for key in (
+            "changed_packages",
+            "affected_packages",
+            "prerequisite_packages",
+        ):
+            if key in payload:
+                payload[key].sort()
+    elif domain == "hashing_cache":
+        if "invalidated_packages" in payload:
+            payload["invalidated_packages"].sort()
+    elif domain == "starlark" and "targets" in payload:
+        payload["targets"].sort(key=lambda target: (target["rule"], target["name"]))
+        for target in payload["targets"]:
+            target["srcs"].sort()
+            target["deps"].sort()
+    elif domain == "sharding" and "shards" in payload:
+        payload["shards"].sort(key=lambda shard: shard["index"])
+        for shard in payload["shards"]:
+            shard["assigned_packages"].sort()
+            shard["package_names"].sort()
+            shard["toolchains"].sort()
+    elif domain == "validation" and "diagnostic_codes" in payload:
+        payload["diagnostic_codes"].sort()
 
     return _sort_json_objects(canonical)
 
@@ -745,9 +1429,21 @@ def _validate_result_shape(
     *,
     result_schema: dict[str, Any],
     plan_schema: dict[str, Any],
+    pure_domain_schema: dict[str, Any],
     code: str,
 ) -> None:
     _validate_schema(result, result_schema, code)
+    pure_code = (
+        "RESULT_PURE_SCHEMA_INVALID"
+        if code == "RESULT_SCHEMA_INVALID"
+        else "EXPECTED_PURE_SCHEMA_INVALID"
+    )
+    _validate_pure_domain_record(
+        case,
+        result,
+        pure_domain_schema,
+        pure_code,
+    )
     if result["case_id"] != case["id"]:
         raise ConformanceError(
             "RESULT_CASE_ID_MISMATCH",
@@ -759,6 +1455,28 @@ def _validate_result_shape(
             "result domain does not match the fixture",
         )
     payload = result["result"]
+    diagnostic_identities = [
+        (
+            item["code"],
+            item.get("path", ""),
+            item.get("package", ""),
+            json.dumps(item.get("details", {}), sort_keys=True),
+        )
+        for item in result["diagnostics"]
+    ]
+    if len(diagnostic_identities) != len(set(diagnostic_identities)):
+        raise ConformanceError(
+            "RESULT_DIAGNOSTIC_DUPLICATE",
+            "result contains a duplicate diagnostic identity",
+        )
+    if (
+        result["outcome"] in {"error", "unsupported", "skipped"}
+        and not result["diagnostics"]
+    ):
+        raise ConformanceError(
+            "RESULT_DIAGNOSTIC_MISSING",
+            f"{result['outcome']} requires a diagnostic",
+        )
     if result["outcome"] == "ok" and result["domain"] == "discovery":
         names = [package["name"] for package in payload["packages"]]
         if len(names) != len(set(names)):
@@ -767,22 +1485,14 @@ def _validate_result_shape(
                 "discovery result contains a duplicate package name",
             )
     if result["outcome"] == "ok" and result["domain"] == "graph":
-        flattened = [
-            package
-            for level in payload["levels"]
-            for package in level
-        ]
+        flattened = [package for level in payload["levels"] for package in level]
         if len(flattened) != len(set(flattened)):
             raise ConformanceError(
                 "RESULT_GRAPH_LEVEL_DUPLICATE",
                 "a graph package appears in more than one level",
             )
         level_packages = set(flattened)
-        edge_packages = {
-            package
-            for edge in payload["edges"]
-            for package in edge
-        }
+        edge_packages = {package for edge in payload["edges"] for package in edge}
         if not edge_packages.issubset(level_packages):
             raise ConformanceError(
                 "RESULT_GRAPH_LEVEL_MISSING",
@@ -804,6 +1514,7 @@ def assert_result_matches(
     *,
     result_schema: dict[str, Any] | None = None,
     plan_schema: dict[str, Any] | None = None,
+    pure_domain_schema: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     reject_execution_intent(case)
     reject_unmodeled_domain(case)
@@ -813,12 +1524,24 @@ def assert_result_matches(
     plan_schema = plan_schema or load_document(
         REPO_ROOT / "code" / "specs" / "schemas" / "build-plan-v1.schema.json"
     )
+    pure_domain_schema = pure_domain_schema or load_document(
+        DEFAULT_FIXTURE_ROOT / "pure-domains.schema.json"
+    )
     _validate_result_shape(
         case,
         actual,
         result_schema=result_schema,
         plan_schema=plan_schema,
+        pure_domain_schema=pure_domain_schema,
         code="RESULT_SCHEMA_INVALID",
+    )
+    staged_files = preflight_workspace(case)
+    _validate_pure_case_semantics(case, staged_files)
+    _validate_pure_result_semantics(
+        case,
+        actual,
+        staged_files,
+        "RESULT",
     )
     canonical_actual = canonicalize_result(actual)
     canonical_expected = canonicalize_result(case["expected"])
@@ -836,6 +1559,7 @@ def validate_case_document(
     case_schema: dict[str, Any],
     result_schema: dict[str, Any],
     plan_schema: dict[str, Any],
+    pure_domain_schema: dict[str, Any] | None = None,
 ) -> list[WorkspaceFile]:
     reject_execution_intent(case)
     _validate_schema(case, case_schema, "CASE_SCHEMA_INVALID")
@@ -843,12 +1567,23 @@ def validate_case_document(
     _validate_case_identity(case)
     _validate_input_paths(case)
     staged_files = preflight_workspace(case)
+    pure_domain_schema = pure_domain_schema or load_document(
+        DEFAULT_FIXTURE_ROOT / "pure-domains.schema.json"
+    )
+    _validate_pure_case_semantics(case, staged_files)
     _validate_result_shape(
         case,
         case["expected"],
         result_schema=result_schema,
         plan_schema=plan_schema,
+        pure_domain_schema=pure_domain_schema,
         code="EXPECTED_SCHEMA_INVALID",
+    )
+    _validate_pure_result_semantics(
+        case,
+        case["expected"],
+        staged_files,
+        "EXPECTED",
     )
     expected = case["expected"]
     if expected["outcome"] in {"unsupported", "skipped"}:
@@ -948,8 +1683,7 @@ def _validate_manifest(
             for item in implementations
         ),
         "adapter_ready_count": sum(
-            item["adapter_status"] == "ready"
-            for item in implementations
+            item["adapter_status"] == "ready" for item in implementations
         ),
     }
 
@@ -960,6 +1694,9 @@ def validate_corpus(
     fixture_root = fixture_root.resolve()
     case_schema = load_document(DEFAULT_FIXTURE_ROOT / "schema.json")
     result_schema = load_document(DEFAULT_FIXTURE_ROOT / "result.schema.json")
+    pure_domain_schema = load_document(
+        DEFAULT_FIXTURE_ROOT / "pure-domains.schema.json"
+    )
     manifest_schema = load_document(
         DEFAULT_FIXTURE_ROOT / "implementations.schema.json"
     )
@@ -990,6 +1727,7 @@ def validate_corpus(
             case_schema=case_schema,
             result_schema=result_schema,
             plan_schema=plan_schema,
+            pure_domain_schema=pure_domain_schema,
         )
         case_ids.add(case["id"])
         domains.add(case["domain"])
@@ -1016,6 +1754,9 @@ def validate_result_files(case_path: Path, result_path: Path) -> dict[str, Any]:
     reject_execution_intent(case)
     case_schema = load_document(DEFAULT_FIXTURE_ROOT / "schema.json")
     result_schema = load_document(DEFAULT_FIXTURE_ROOT / "result.schema.json")
+    pure_domain_schema = load_document(
+        DEFAULT_FIXTURE_ROOT / "pure-domains.schema.json"
+    )
     plan_schema = load_document(
         REPO_ROOT / "code" / "specs" / "schemas" / "build-plan-v1.schema.json"
     )
@@ -1024,6 +1765,7 @@ def validate_result_files(case_path: Path, result_path: Path) -> dict[str, Any]:
         case_schema=case_schema,
         result_schema=result_schema,
         plan_schema=plan_schema,
+        pure_domain_schema=pure_domain_schema,
     )
     output_limit = min(case["limits"]["output_bytes"], MAX_RESULT_BYTES)
     result = load_document(result_path, max_bytes=output_limit)
@@ -1032,6 +1774,7 @@ def validate_result_files(case_path: Path, result_path: Path) -> dict[str, Any]:
         result,
         result_schema=result_schema,
         plan_schema=plan_schema,
+        pure_domain_schema=pure_domain_schema,
     )
 
 

--- a/code/scripts/build_tool_conformance.py
+++ b/code/scripts/build_tool_conformance.py
@@ -10,6 +10,7 @@ later trusted-sandbox tranche.
 from __future__ import annotations
 
 import argparse
+import ast
 import base64
 import binascii
 import fnmatch
@@ -464,8 +465,7 @@ def portable_glob_error(value: Any) -> str | None:
     for segment in value.split("/"):
         if segment in {"", ".", ".."}:
             return "glob contains an empty or dot segment"
-        literal = segment.replace("*", "")
-        if literal.endswith((" ", ".")):
+        if segment.endswith((" ", ".")):
             return "glob segment has a trailing dot or space"
         if not any(character in segment for character in "*[]{}"):
             basename = segment.split(".", 1)[0].upper()
@@ -816,6 +816,8 @@ def _validate_known_edges(
     edges: list[list[str]],
     package_names: set[str],
 ) -> None:
+    adjacency = {name: [] for name in package_names}
+    indegree = dict.fromkeys(package_names, 0)
     for edge in edges:
         if edge[0] == edge[1]:
             raise ConformanceError(
@@ -827,6 +829,23 @@ def _validate_known_edges(
                 "CASE_EDGE_UNKNOWN",
                 f"dependency edge references an unknown package: {edge}",
             )
+        adjacency[edge[0]].append(edge[1])
+        indegree[edge[1]] += 1
+
+    ready = [name for name, degree in indegree.items() if degree == 0]
+    visited = 0
+    while ready:
+        name = ready.pop()
+        visited += 1
+        for dependent in adjacency[name]:
+            indegree[dependent] -= 1
+            if indegree[dependent] == 0:
+                ready.append(dependent)
+    if visited != len(package_names):
+        raise ConformanceError(
+            "CASE_EDGE_CYCLE",
+            "dependency edges contain a cycle",
+        )
 
 
 def _validate_unique_paths(
@@ -938,8 +957,19 @@ def _validate_pure_case_semantics(
                     "CASE_PACKAGE_REFERENCE_UNKNOWN",
                     f"scheduled package is not declared: {name}",
                 )
-        for package in by_name.values():
-            _toolchain_for_language(package["language"])
+        selected = set(options["scheduled_packages"])
+        pending = list(selected)
+        prerequisites = {name: set() for name in by_name}
+        for prerequisite, dependent in options["edges"]:
+            prerequisites[dependent].add(prerequisite)
+        while pending:
+            name = pending.pop()
+            for prerequisite in prerequisites[name]:
+                if prerequisite not in selected:
+                    selected.add(prerequisite)
+                    pending.append(prerequisite)
+        for name in selected:
+            _toolchain_for_language(by_name[name]["language"])
     elif domain == "validation":
         by_name = _package_index(options["packages"])
         _validate_unique_paths(
@@ -1108,7 +1138,6 @@ def _starlark_module_error(
     pending = [(options["entrypoint"], 0)]
     visited: set[str] = set()
     limits = options["evaluation_limits"]
-    load_pattern = re.compile(r"""load\(\s*(?P<quote>["'])(?P<label>.+?)(?P=quote)""")
     while pending:
         module, depth = pending.pop()
         if module in visited:
@@ -1122,8 +1151,48 @@ def _starlark_module_error(
             source = sources[module].decode("utf-8", errors="strict")
         except UnicodeDecodeError:
             return "STARLARK_SOURCE_INVALID", module
-        for match in load_pattern.finditer(source):
-            label = match.group("label")
+        try:
+            syntax = ast.parse(source, mode="exec")
+        except SyntaxError:
+            return "STARLARK_SOURCE_INVALID", module
+        parents = {
+            child: parent
+            for parent in ast.walk(syntax)
+            for child in ast.iter_child_nodes(parent)
+        }
+        top_level_loads: list[ast.Call] = []
+        for statement in syntax.body:
+            if not (
+                isinstance(statement, ast.Expr)
+                and isinstance(statement.value, ast.Call)
+                and isinstance(statement.value.func, ast.Name)
+                and statement.value.func.id == "load"
+            ):
+                continue
+            top_level_loads.append(statement.value)
+        top_level_load_ids = {id(call) for call in top_level_loads}
+        for name in (
+            node
+            for node in ast.walk(syntax)
+            if isinstance(node, ast.Name) and node.id == "load"
+        ):
+            parent = parents.get(name)
+            if not (
+                isinstance(parent, ast.Call)
+                and parent.func is name
+                and id(parent) in top_level_load_ids
+            ):
+                return "STARLARK_SOURCE_INVALID", module
+        for call in top_level_loads:
+            if not call.args:
+                return "STARLARK_SOURCE_INVALID", module
+            label_node = call.args[0]
+            if not (
+                isinstance(label_node, ast.Constant)
+                and isinstance(label_node.value, str)
+            ):
+                return "STARLARK_SOURCE_INVALID", module
+            label = label_node.value
             if label.startswith("//"):
                 resolved = label[2:]
             elif label.startswith(("./", "../")):
@@ -1401,7 +1470,7 @@ def _validate_pure_result_semantics(
             outcome == "error"
             and valid is False
             and bool(codes)
-            and sorted(codes) == sorted(diagnostic_codes)
+            and set(codes) == set(diagnostic_codes)
         )
         if not consistent:
             raise ConformanceError(
@@ -1409,9 +1478,12 @@ def _validate_pure_result_semantics(
                 "validation outcome, valid flag, and diagnostics disagree",
             )
     elif domain == "toolchain_detection":
+        packages = {package["name"]: package for package in options["packages"]}
+        selected = options["scheduled_packages"]
+        selected_names = packages if selected is None else selected
         unsupported = any(
-            package["language"] not in LANGUAGE_TOOLCHAINS
-            for package in options["packages"]
+            packages[name]["language"] not in LANGUAGE_TOOLCHAINS
+            for name in selected_names
         ) or any(
             toolchain not in TOOLCHAINS for toolchain in options["forced_toolchains"]
         )
@@ -1933,7 +2005,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             ),
             file=sys.stderr,
         )
-        return 1 if error.code == "RESULT_MISMATCH" else 2
+        return 1 if error.code.startswith("RESULT_") else 2
 
     print(json.dumps(output, sort_keys=True))
     return exit_code

--- a/code/scripts/build_tool_conformance.py
+++ b/code/scripts/build_tool_conformance.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import base64
 import binascii
+import fnmatch
 import hashlib
 import json
 import os
@@ -21,6 +22,7 @@ import stat
 import sys
 import unicodedata
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Sequence
 
@@ -982,6 +984,93 @@ def _framed_digest(items: list[tuple[str, bytes]]) -> bytes:
     return digest.digest()
 
 
+def _portable_glob_matches(pattern: str, path: str) -> bool:
+    pattern_segments = pattern.split("/")
+    path_segments = path.split("/")
+
+    @lru_cache(maxsize=None)
+    def matches(pattern_index: int, path_index: int) -> bool:
+        if pattern_index == len(pattern_segments):
+            return path_index == len(path_segments)
+        segment = pattern_segments[pattern_index]
+        if segment == "**":
+            return matches(pattern_index + 1, path_index) or (
+                path_index < len(path_segments)
+                and matches(pattern_index, path_index + 1)
+            )
+        return (
+            path_index < len(path_segments)
+            and fnmatch.fnmatchcase(path_segments[path_index], segment)
+            and matches(pattern_index + 1, path_index + 1)
+        )
+
+    return matches(0, 0)
+
+
+def _expected_diff_selection(
+    options: dict[str, Any],
+    changed_paths: list[str],
+) -> tuple[set[str], set[str], set[str]] | None:
+    packages = options["packages"]
+    changed: set[str] = set(options["forced_packages"])
+    unknown = False
+    build_names = {
+        "BUILD",
+        "BUILD_windows",
+        "BUILD_mac",
+        "BUILD_linux",
+        "BUILD_mac_and_linux",
+    }
+    for path in changed_paths:
+        path_known = False
+        for package in packages:
+            root = package["rel_path"]
+            if path != root and not path.startswith(f"{root}/"):
+                continue
+            path_known = True
+            relative = path[len(root) :].lstrip("/")
+            if package["source_mode"] == "package_prefix":
+                changed.add(package["name"])
+            elif relative in build_names or any(
+                _portable_glob_matches(pattern, relative)
+                for pattern in package["source_globs"]
+            ):
+                changed.add(package["name"])
+        if not path_known:
+            unknown = True
+
+    package_names = {package["name"] for package in packages}
+    if unknown:
+        if options["unknown_path_policy"] == "error":
+            return None
+        changed = set(package_names)
+
+    dependents: dict[str, set[str]] = {name: set() for name in package_names}
+    prerequisites: dict[str, set[str]] = {name: set() for name in package_names}
+    for prerequisite, dependent in options["edges"]:
+        dependents[prerequisite].add(dependent)
+        prerequisites[dependent].add(prerequisite)
+
+    affected = set(changed)
+    pending = list(changed)
+    while pending:
+        name = pending.pop()
+        for dependent in dependents[name]:
+            if dependent not in affected:
+                affected.add(dependent)
+                pending.append(dependent)
+
+    closed = set(affected)
+    pending = list(affected)
+    while pending:
+        name = pending.pop()
+        for prerequisite in prerequisites[name]:
+            if prerequisite not in closed:
+                closed.add(prerequisite)
+                pending.append(prerequisite)
+    return changed, affected, closed - affected
+
+
 def _expected_hashes(
     options: dict[str, Any],
     staged_files: list[WorkspaceFile],
@@ -1141,17 +1230,11 @@ def _validate_pure_result_semantics(
     diagnostic_codes = [item["code"] for item in result["diagnostics"]]
 
     if domain == "diff_selection":
-        package_names = {package["name"] for package in options["packages"]}
-        unknown_paths = [
-            path
-            for path in case["input"]["changed_paths"]
-            if not any(
-                path == package["rel_path"]
-                or path.startswith(f"{package['rel_path']}/")
-                for package in options["packages"]
-            )
-        ]
-        if unknown_paths and options["unknown_path_policy"] == "error":
+        expected_sets = _expected_diff_selection(
+            options,
+            case["input"]["changed_paths"],
+        )
+        if expected_sets is None:
             if outcome != "error" or "DIFF_UNKNOWN_PATH" not in diagnostic_codes:
                 raise ConformanceError(
                     f"{prefix}_DIFF_UNKNOWN_PATH_INVALID",
@@ -1160,24 +1243,15 @@ def _validate_pure_result_semantics(
             return
         if outcome != "ok":
             return
-        changed = set(payload["changed_packages"])
-        affected = set(payload["affected_packages"])
-        prerequisites = set(payload["prerequisite_packages"])
-        if (
-            not (changed | affected | prerequisites).issubset(package_names)
-            or not changed.issubset(affected)
-            or affected.intersection(prerequisites)
-        ):
+        actual_sets = (
+            set(payload["changed_packages"]),
+            set(payload["affected_packages"]),
+            set(payload["prerequisite_packages"]),
+        )
+        if actual_sets != expected_sets:
             raise ConformanceError(
                 f"{prefix}_DIFF_RESULT_INVALID",
-                "diff result contains unknown or inconsistent package sets",
-            )
-        if unknown_paths and (
-            changed != package_names or affected != package_names or prerequisites
-        ):
-            raise ConformanceError(
-                f"{prefix}_DIFF_UNKNOWN_PATH_INVALID",
-                "unknown changed paths under all policy must select every package",
+                "diff result does not match changed, affected, and prerequisite closure",
             )
     elif domain == "hashing_cache" and outcome == "ok":
         expected_hashes = _expected_hashes(options, staged_files)
@@ -1305,6 +1379,22 @@ def _validate_pure_result_semantics(
     elif domain == "validation":
         codes = payload.get("diagnostic_codes", [])
         valid = payload.get("valid")
+        if set(options["checks"]) == {"build_file_presence"}:
+            expected_codes = sorted(
+                {
+                    {
+                        "missing": "BUILD_FILE_MISSING",
+                        "empty": "BUILD_FILE_EMPTY",
+                    }[package["build_file_state"]]
+                    for package in options["packages"]
+                    if package["build_file_state"] != "present"
+                }
+            )
+            if sorted(codes) != expected_codes:
+                raise ConformanceError(
+                    f"{prefix}_VALIDATION_INCONSISTENT",
+                    "build-file diagnostics do not match the normalized snapshot",
+                )
         consistent = (
             outcome == "ok" and valid is True and not codes and not diagnostic_codes
         ) or (

--- a/code/scripts/tests/test_build_tool_conformance_runner.py
+++ b/code/scripts/tests/test_build_tool_conformance_runner.py
@@ -128,7 +128,7 @@ class CorpusTests(unittest.TestCase):
         summary = runner.validate_corpus(FIXTURE_ROOT)
 
         self.assertEqual(summary["schema_version"], 1)
-        self.assertEqual(summary["case_count"], 26)
+        self.assertEqual(summary["case_count"], 30)
         self.assertEqual(summary["implementation_count"], 16)
         self.assertEqual(summary["established_languages"], 15)
         self.assertEqual(summary["execution_case_count"], 0)
@@ -218,12 +218,9 @@ class CorpusTests(unittest.TestCase):
             runner.validate_case_document(
                 case,
                 case_schema=runner.load_document(FIXTURE_ROOT / "schema.json"),
-                result_schema=runner.load_document(
-                    FIXTURE_ROOT / "result.schema.json"
-                ),
+                result_schema=runner.load_document(FIXTURE_ROOT / "result.schema.json"),
                 plan_schema=runner.load_document(
-                    runner.REPO_ROOT
-                    / "code/specs/schemas/build-plan-v1.schema.json"
+                    runner.REPO_ROOT / "code/specs/schemas/build-plan-v1.schema.json"
                 ),
             )
         self.assertEqual(raised.exception.code, "CASE_SCHEMA_INVALID")
@@ -278,6 +275,29 @@ class ExecutionDenialTests(unittest.TestCase):
                 runner.validate_result_files(case_path, missing_result)
         self.assertEqual(raised.exception.code, "EXECUTION_DISABLED")
 
+    def test_cli_execution_intent_is_denied_before_workspace_decoding(
+        self,
+    ) -> None:
+        case = load_case("cli-dry-run-success.json")
+        case["input"]["options"]["requires_execution"] = True
+        case["workspace"]["files"] = [
+            {
+                "path": "fixtures/invalid.bin",
+                "content_base64": "not base64!",
+            }
+        ]
+        with (
+            mock.patch.object(tempfile, "TemporaryDirectory") as temporary,
+            mock.patch.object(runner.base64, "b64decode") as decode,
+            mock.patch.object(subprocess, "run") as process,
+            self.assertRaises(runner.ConformanceError) as raised,
+        ):
+            runner.preflight_workspace(case)
+        self.assertEqual(raised.exception.code, "EXECUTION_DISABLED")
+        temporary.assert_not_called()
+        decode.assert_not_called()
+        process.assert_not_called()
+
 
 class WorkspacePreflightTests(unittest.TestCase):
     def test_decodes_exact_files_without_creating_a_workspace(self) -> None:
@@ -294,8 +314,7 @@ class WorkspacePreflightTests(unittest.TestCase):
             "TemporaryDirectory",
         ) as temporary:
             staged = {
-                entry.path: entry.content
-                for entry in runner.preflight_workspace(case)
+                entry.path: entry.content for entry in runner.preflight_workspace(case)
             }
 
         temporary.assert_not_called()
@@ -465,9 +484,7 @@ class ResultValidationTests(unittest.TestCase):
         case = load_case("plan-affected-empty.json")
 
         duplicate = copy.deepcopy(case["expected"])
-        duplicate_package = copy.deepcopy(
-            duplicate["result"]["plan"]["packages"][0]
-        )
+        duplicate_package = copy.deepcopy(duplicate["result"]["plan"]["packages"][0])
         duplicate_package["build_commands"] = ["different"]
         duplicate["result"]["plan"]["packages"].append(duplicate_package)
         with self.assertRaises(runner.ConformanceError) as raised:
@@ -483,9 +500,7 @@ class ResultValidationTests(unittest.TestCase):
         self.assertEqual(raised.exception.code, "RESULT_PLAN_EDGE_UNKNOWN")
 
         unknown_affected = copy.deepcopy(case["expected"])
-        unknown_affected["result"]["plan"]["affected_packages"] = [
-            "python/missing"
-        ]
+        unknown_affected["result"]["plan"]["affected_packages"] = ["python/missing"]
         with self.assertRaises(runner.ConformanceError) as raised:
             runner.assert_result_matches(case, unknown_affected)
         self.assertEqual(raised.exception.code, "RESULT_PLAN_AFFECTED_UNKNOWN")
@@ -522,17 +537,12 @@ class ResultValidationTests(unittest.TestCase):
 
 class PureDomainValidationTests(unittest.TestCase):
     def test_semantics_reject_unknown_references_and_bad_oracles(self) -> None:
-        pure_schema = runner.load_document(
-            FIXTURE_ROOT / "pure-domains.schema.json"
-        )
+        pure_schema = runner.load_document(FIXTURE_ROOT / "pure-domains.schema.json")
         schema_args = {
             "case_schema": runner.load_document(FIXTURE_ROOT / "schema.json"),
-            "result_schema": runner.load_document(
-                FIXTURE_ROOT / "result.schema.json"
-            ),
+            "result_schema": runner.load_document(FIXTURE_ROOT / "result.schema.json"),
             "plan_schema": runner.load_document(
-                runner.REPO_ROOT
-                / "code/specs/schemas/build-plan-v1.schema.json"
+                runner.REPO_ROOT / "code/specs/schemas/build-plan-v1.schema.json"
             ),
             "pure_domain_schema": pure_schema,
         }
@@ -566,9 +576,7 @@ class PureDomainValidationTests(unittest.TestCase):
             ),
             (
                 "validation-missing-build.json",
-                lambda result: result["result"].__setitem__(
-                    "diagnostic_codes", []
-                ),
+                lambda result: result["result"].__setitem__("diagnostic_codes", []),
                 "RESULT_VALIDATION_INCONSISTENT",
             ),
             (
@@ -597,6 +605,55 @@ class PureDomainValidationTests(unittest.TestCase):
                     )
                 self.assertEqual(raised.exception.code, code)
 
+    def test_nested_paths_and_pure_authority_are_rejected(self) -> None:
+        schema_args = {
+            "case_schema": runner.load_document(FIXTURE_ROOT / "schema.json"),
+            "result_schema": runner.load_document(FIXTURE_ROOT / "result.schema.json"),
+            "plan_schema": runner.load_document(
+                runner.REPO_ROOT / "code/specs/schemas/build-plan-v1.schema.json"
+            ),
+            "pure_domain_schema": runner.load_document(
+                FIXTURE_ROOT / "pure-domains.schema.json"
+            ),
+        }
+        mutations = (
+            (
+                "diff-selection-transitive.json",
+                lambda case: case["input"]["options"]["packages"][0].__setitem__(
+                    "rel_path", "code/packages/python/NUL"
+                ),
+                "CASE_NESTED_PATH_UNSAFE",
+            ),
+            (
+                "hashing-cache-hit.json",
+                lambda case: case["input"]["options"]["include_paths"].append(
+                    "code/packages/python/demo/host-only"
+                ),
+                "CASE_HASH_PATH_UNKNOWN",
+            ),
+            (
+                "starlark-structured-context.json",
+                lambda case: case["input"]["options"].__setitem__(
+                    "entrypoint", "code/packages/python/demo/missing.star"
+                ),
+                "CASE_STARLARK_ENTRYPOINT_MISSING",
+            ),
+            (
+                "hashing-cache-hit.json",
+                lambda case: case["workspace"]["files"][0].__setitem__(
+                    "executable", True
+                ),
+                "CASE_PURE_AUTHORITY",
+            ),
+        )
+        for filename, mutate, code in mutations:
+            with self.subTest(filename=filename, code=code):
+                case = load_case(filename)
+                mutate(case)
+                with self.assertRaises(runner.ConformanceError) as raised:
+                    runner.validate_case_document(case, **schema_args)
+                self.assertEqual(raised.exception.code, code)
+
     def test_pure_domain_set_order_is_canonicalized(self) -> None:
         diff = load_case("diff-selection-transitive.json")
         actual = copy.deepcopy(diff["expected"])
@@ -614,18 +671,13 @@ class PureDomainValidationTests(unittest.TestCase):
         )
 
     def test_pure_domain_validation_has_no_host_side_effects(self) -> None:
-        pure_schema = runner.load_document(
-            FIXTURE_ROOT / "pure-domains.schema.json"
-        )
+        pure_schema = runner.load_document(FIXTURE_ROOT / "pure-domains.schema.json")
         pure_domains = set(pure_schema["$defs"]["pure_domain"]["enum"])
         schema_args = {
             "case_schema": runner.load_document(FIXTURE_ROOT / "schema.json"),
-            "result_schema": runner.load_document(
-                FIXTURE_ROOT / "result.schema.json"
-            ),
+            "result_schema": runner.load_document(FIXTURE_ROOT / "result.schema.json"),
             "plan_schema": runner.load_document(
-                runner.REPO_ROOT
-                / "code/specs/schemas/build-plan-v1.schema.json"
+                runner.REPO_ROOT / "code/specs/schemas/build-plan-v1.schema.json"
             ),
             "pure_domain_schema": pure_schema,
         }
@@ -662,7 +714,7 @@ class CommandLineTests(unittest.TestCase):
 
         self.assertEqual(exit_code, 0)
         summary = json.loads(stdout.getvalue())
-        self.assertEqual(summary["case_count"], 26)
+        self.assertEqual(summary["case_count"], 30)
 
     def test_validate_result_reports_match_and_rejects_execution_override(self) -> None:
         case_path = CASES_ROOT / "graph-diamond.json"

--- a/code/scripts/tests/test_build_tool_conformance_runner.py
+++ b/code/scripts/tests/test_build_tool_conformance_runner.py
@@ -128,7 +128,7 @@ class CorpusTests(unittest.TestCase):
         summary = runner.validate_corpus(FIXTURE_ROOT)
 
         self.assertEqual(summary["schema_version"], 1)
-        self.assertEqual(summary["case_count"], 7)
+        self.assertEqual(summary["case_count"], 26)
         self.assertEqual(summary["implementation_count"], 16)
         self.assertEqual(summary["established_languages"], 15)
         self.assertEqual(summary["execution_case_count"], 0)
@@ -138,7 +138,19 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(summary["conformance_status"], "not-run")
         self.assertEqual(
             summary["domains"],
-            ["discovery", "graph", "plan", "resolution"],
+            [
+                "cli",
+                "diff_selection",
+                "discovery",
+                "graph",
+                "hashing_cache",
+                "plan",
+                "resolution",
+                "sharding",
+                "starlark",
+                "toolchain_detection",
+                "validation",
+            ],
         )
 
     def test_manifest_classifies_every_established_front_door(self) -> None:
@@ -193,33 +205,11 @@ class CorpusTests(unittest.TestCase):
                 case_path.name,
             )
 
-    def test_unmodeled_domains_cannot_claim_bootstrap_success(self) -> None:
-        case = load_case("discovery-simple.json")
-        case["id"] = "diff-selection/unmodeled"
-        case["domain"] = "diff_selection"
-        case["capabilities"] = ["diff_selection"]
-        case["input"]["operation"] = "diff_selection"
-        case["expected"] = {
-            "schema_version": 1,
-            "case_id": "diff-selection/unmodeled",
-            "domain": "diff_selection",
-            "outcome": "ok",
-            "result": {"affected_packges": []},
-            "diagnostics": [],
-        }
-        with self.assertRaises(runner.ConformanceError) as raised:
-            runner.validate_case_document(
-                case,
-                case_schema=runner.load_document(FIXTURE_ROOT / "schema.json"),
-                result_schema=runner.load_document(
-                    FIXTURE_ROOT / "result.schema.json"
-                ),
-                plan_schema=runner.load_document(
-                    runner.REPO_ROOT
-                    / "code/specs/schemas/build-plan-v1.schema.json"
-                ),
-            )
-        self.assertEqual(raised.exception.code, "CASE_DOMAIN_UNMODELED")
+    def test_every_process_free_domain_is_bootstrap_modeled(self) -> None:
+        self.assertEqual(
+            runner.BOOTSTRAP_DOMAINS,
+            set(runner.DOMAIN_CAPABILITIES) - {"execution"},
+        )
 
     def test_malformed_capabilities_fail_schema_validation_not_routing(self) -> None:
         case = load_case("discovery-simple.json")
@@ -425,6 +415,16 @@ class ResultValidationTests(unittest.TestCase):
             runner.assert_result_matches(discovery, typo)
         self.assertEqual(raised.exception.code, "RESULT_SCHEMA_INVALID")
 
+        toolchains = load_case("toolchain-detection-shared.json")
+        incomplete = copy.deepcopy(toolchains["expected"])
+        del incomplete["result"]["toolchains"]["ocaml"]
+        with self.assertRaises(runner.ConformanceError) as raised:
+            runner.assert_result_matches(toolchains, incomplete)
+        self.assertEqual(
+            raised.exception.code,
+            "RESULT_PURE_SCHEMA_INVALID",
+        )
+
         graph = load_case("graph-diamond.json")
         extra = copy.deepcopy(graph["expected"])
         extra["result"]["unexpected"] = []
@@ -520,6 +520,138 @@ class ResultValidationTests(unittest.TestCase):
         self.assertEqual(raised.exception.code, "JSON_INPUT_TOO_LARGE")
 
 
+class PureDomainValidationTests(unittest.TestCase):
+    def test_semantics_reject_unknown_references_and_bad_oracles(self) -> None:
+        pure_schema = runner.load_document(
+            FIXTURE_ROOT / "pure-domains.schema.json"
+        )
+        schema_args = {
+            "case_schema": runner.load_document(FIXTURE_ROOT / "schema.json"),
+            "result_schema": runner.load_document(
+                FIXTURE_ROOT / "result.schema.json"
+            ),
+            "plan_schema": runner.load_document(
+                runner.REPO_ROOT
+                / "code/specs/schemas/build-plan-v1.schema.json"
+            ),
+            "pure_domain_schema": pure_schema,
+        }
+
+        unknown_edge = load_case("diff-selection-transitive.json")
+        unknown_edge["input"]["options"]["edges"][0][0] = "python/missing"
+        with self.assertRaises(runner.ConformanceError) as raised:
+            runner.validate_case_document(unknown_edge, **schema_args)
+        self.assertEqual(raised.exception.code, "CASE_EDGE_UNKNOWN")
+
+        hashing = load_case("hashing-cache-corrupt.json")
+        hashing["expected"]["result"]["package_digest"] = "0" * 64
+        with self.assertRaises(runner.ConformanceError) as raised:
+            runner.validate_case_document(hashing, **schema_args)
+        self.assertEqual(raised.exception.code, "EXPECTED_HASH_MISMATCH")
+
+        mutations = (
+            (
+                "starlark-structured-context.json",
+                lambda result: result["result"]["targets"][0][
+                    "rendered_commands"
+                ].__setitem__(0, "wrong"),
+                "RESULT_STARLARK_RENDER_MISMATCH",
+            ),
+            (
+                "sharding-prerequisite-closed.json",
+                lambda result: result["result"]["shards"][0].__setitem__(
+                    "estimated_cost", 10
+                ),
+                "RESULT_SHARD_MISMATCH",
+            ),
+            (
+                "validation-missing-build.json",
+                lambda result: result["result"].__setitem__(
+                    "diagnostic_codes", []
+                ),
+                "RESULT_VALIDATION_INCONSISTENT",
+            ),
+            (
+                "toolchain-detection-shared.json",
+                lambda result: result["result"]["toolchains"].__setitem__(
+                    "ocaml", True
+                ),
+                "RESULT_TOOLCHAIN_MISMATCH",
+            ),
+            (
+                "cli-dry-run-success.json",
+                lambda result: result["result"].__setitem__("exit_code", 2),
+                "RESULT_CLI_EXIT_MISMATCH",
+            ),
+        )
+        for filename, mutate, code in mutations:
+            with self.subTest(filename=filename):
+                case = load_case(filename)
+                actual = copy.deepcopy(case["expected"])
+                mutate(actual)
+                with self.assertRaises(runner.ConformanceError) as raised:
+                    runner.assert_result_matches(
+                        case,
+                        actual,
+                        pure_domain_schema=pure_schema,
+                    )
+                self.assertEqual(raised.exception.code, code)
+
+    def test_pure_domain_set_order_is_canonicalized(self) -> None:
+        diff = load_case("diff-selection-transitive.json")
+        actual = copy.deepcopy(diff["expected"])
+        actual["result"]["affected_packages"].reverse()
+        self.assertEqual(runner.assert_result_matches(diff, actual), diff["expected"])
+
+        shard = load_case("sharding-prerequisite-closed.json")
+        actual = copy.deepcopy(shard["expected"])
+        actual["result"]["shards"].reverse()
+        actual["result"]["shards"][0]["package_names"].reverse()
+        actual["result"]["shards"][0]["toolchains"].reverse()
+        self.assertEqual(
+            runner.assert_result_matches(shard, actual),
+            shard["expected"],
+        )
+
+    def test_pure_domain_validation_has_no_host_side_effects(self) -> None:
+        pure_schema = runner.load_document(
+            FIXTURE_ROOT / "pure-domains.schema.json"
+        )
+        pure_domains = set(pure_schema["$defs"]["pure_domain"]["enum"])
+        schema_args = {
+            "case_schema": runner.load_document(FIXTURE_ROOT / "schema.json"),
+            "result_schema": runner.load_document(
+                FIXTURE_ROOT / "result.schema.json"
+            ),
+            "plan_schema": runner.load_document(
+                runner.REPO_ROOT
+                / "code/specs/schemas/build-plan-v1.schema.json"
+            ),
+            "pure_domain_schema": pure_schema,
+        }
+        cases = [
+            runner.load_document(path)
+            for path in sorted(CASES_ROOT.glob("*.json"))
+            if runner.load_document(path)["domain"] in pure_domains
+        ]
+
+        with (
+            mock.patch.object(tempfile, "TemporaryDirectory") as temporary,
+            mock.patch.object(subprocess, "run") as process,
+            mock.patch.object(subprocess, "Popen") as popen,
+            mock.patch.object(os, "system") as system,
+            mock.patch.object(os, "chmod") as chmod,
+        ):
+            for case in cases:
+                runner.validate_case_document(case, **schema_args)
+
+        temporary.assert_not_called()
+        process.assert_not_called()
+        popen.assert_not_called()
+        system.assert_not_called()
+        chmod.assert_not_called()
+
+
 class CommandLineTests(unittest.TestCase):
     def test_validate_corpus_prints_a_machine_readable_summary(self) -> None:
         stdout = io.StringIO()
@@ -530,7 +662,7 @@ class CommandLineTests(unittest.TestCase):
 
         self.assertEqual(exit_code, 0)
         summary = json.loads(stdout.getvalue())
-        self.assertEqual(summary["case_count"], 7)
+        self.assertEqual(summary["case_count"], 26)
 
     def test_validate_result_reports_match_and_rejects_execution_override(self) -> None:
         case_path = CASES_ROOT / "graph-diamond.json"

--- a/code/scripts/tests/test_build_tool_conformance_runner.py
+++ b/code/scripts/tests/test_build_tool_conformance_runner.py
@@ -106,6 +106,9 @@ class StrictJsonTests(unittest.TestCase):
         self.assertIsNotNone(runner.portable_path_error("fixtures/COM¹.txt"))
         self.assertIsNotNone(runner.portable_path_error("fixtures/LPT².txt"))
         self.assertIsNone(runner.portable_path_error("fixtures/.hidden"))
+        self.assertIsNone(runner.portable_glob_error("src/foo.*"))
+        self.assertIsNone(runner.portable_glob_error("src/*.*"))
+        self.assertIsNotNone(runner.portable_glob_error("src/foo."))
 
     def test_schema_validation_never_retrieves_external_references(self) -> None:
         for keyword in ("$ref", "$dynamicRef"):
@@ -536,6 +539,140 @@ class ResultValidationTests(unittest.TestCase):
 
 
 class PureDomainValidationTests(unittest.TestCase):
+    def _schema_args(self) -> dict[str, object]:
+        return {
+            "case_schema": runner.load_document(FIXTURE_ROOT / "schema.json"),
+            "result_schema": runner.load_document(FIXTURE_ROOT / "result.schema.json"),
+            "plan_schema": runner.load_document(
+                runner.REPO_ROOT / "code/specs/schemas/build-plan-v1.schema.json"
+            ),
+            "pure_domain_schema": runner.load_document(
+                FIXTURE_ROOT / "pure-domains.schema.json"
+            ),
+        }
+
+    def test_validation_allows_repeated_envelope_diagnostic_codes(self) -> None:
+        case = load_case("validation-missing-build.json")
+        case["input"]["options"]["packages"].append(
+            {
+                "name": "python/other",
+                "rel_path": "code/packages/python/other",
+                "language": "python",
+                "build_file_state": "missing",
+                "build_references": [],
+                "is_starlark": False,
+                "declared_srcs": [],
+                "declared_deps": [],
+            }
+        )
+        case["expected"]["diagnostics"].append(
+            {
+                "code": "BUILD_FILE_MISSING",
+                "severity": "error",
+                "path": "code/packages/python/other",
+            }
+        )
+
+        runner.validate_case_document(case, **self._schema_args())
+        runner.assert_result_matches(
+            case,
+            copy.deepcopy(case["expected"]),
+            pure_domain_schema=self._schema_args()["pure_domain_schema"],
+        )
+
+    def test_starlark_load_scanner_handles_lexical_literal_forms(self) -> None:
+        commented = load_case("starlark-structured-context.json")
+        commented["workspace"]["files"][0]["content_utf8"] = (
+            '# load("../../../../../outside.star", "x")\n'
+            + commented["workspace"]["files"][0]["content_utf8"]
+        )
+        runner.validate_case_document(commented, **self._schema_args())
+
+        escaping_literals = (
+            '"../../../../../outside.star"',
+            'r"../../../../../outside.star"',
+            'b"../../../../../outside.star"',
+            '"""../../../../../outside.star"""',
+        )
+        for literal in escaping_literals:
+            with self.subTest(literal=literal):
+                escaping = load_case("starlark-structured-context.json")
+                escaping["workspace"]["files"][0]["content_utf8"] = escaping[
+                    "workspace"
+                ]["files"][0]["content_utf8"].replace(
+                    '"code/build/defs.star"',
+                    literal,
+                )
+                with self.assertRaises(runner.ConformanceError) as raised:
+                    runner.validate_case_document(escaping, **self._schema_args())
+                self.assertEqual(
+                    raised.exception.code,
+                    "EXPECTED_STARLARK_MODULE_ERROR_INVALID",
+                )
+
+        spaced = load_case("starlark-structured-context.json")
+        spaced["workspace"]["files"][0]["content_utf8"] = spaced["workspace"]["files"][
+            0
+        ]["content_utf8"].replace("load(", "load (", 1)
+        runner.validate_case_document(spaced, **self._schema_args())
+
+        member = load_case("starlark-structured-context.json")
+        member["workspace"]["files"][0]["content_utf8"] = (
+            'rules.load("../../../../../outside.star")\n'
+            + member["workspace"]["files"][0]["content_utf8"]
+        )
+        runner.validate_case_document(member, **self._schema_args())
+
+        split = load_case("starlark-structured-context.json")
+        split["workspace"]["files"][0]["content_utf8"] = split["workspace"]["files"][0][
+            "content_utf8"
+        ].replace("load(", "load\n(", 1)
+        with self.assertRaises(runner.ConformanceError) as raised:
+            runner.validate_case_document(split, **self._schema_args())
+        self.assertEqual(
+            raised.exception.code,
+            "EXPECTED_STARLARK_MODULE_ERROR_INVALID",
+        )
+
+    def test_toolchain_detection_ignores_unscheduled_unsupported_packages(
+        self,
+    ) -> None:
+        case = load_case("toolchain-detection-empty.json")
+        case["input"]["options"]["packages"].append(
+            {"name": "zig/unused", "language": "zig"}
+        )
+
+        runner.validate_case_document(case, **self._schema_args())
+
+    def test_sharding_ignores_unscheduled_unreferenced_toolchains(self) -> None:
+        case = load_case("sharding-prerequisite-closed.json")
+        case["input"]["options"]["packages"].append(
+            {
+                "name": "zig/unused",
+                "language": "zig",
+                "build_command_count": 0,
+            }
+        )
+
+        runner.validate_case_document(case, **self._schema_args())
+
+    def test_dependency_cycles_are_rejected_without_recursion(self) -> None:
+        cyclic = load_case("diff-selection-transitive.json")
+        cyclic["input"]["options"]["edges"].append(["python/app", "python/base"])
+        with self.assertRaises(runner.ConformanceError) as raised:
+            runner.validate_case_document(cyclic, **self._schema_args())
+        self.assertEqual(raised.exception.code, "CASE_EDGE_CYCLE")
+
+        names = {f"python/package-{index}" for index in range(2000)}
+        edges = [
+            [f"python/package-{index}", f"python/package-{index + 1}"]
+            for index in range(1999)
+        ]
+        edges.append(["python/package-1999", "python/package-0"])
+        with self.assertRaises(runner.ConformanceError) as raised:
+            runner._validate_known_edges(edges, names)
+        self.assertEqual(raised.exception.code, "CASE_EDGE_CYCLE")
+
     def test_semantics_reject_unknown_references_and_bad_oracles(self) -> None:
         pure_schema = runner.load_document(FIXTURE_ROOT / "pure-domains.schema.json")
         schema_args = {
@@ -770,6 +907,31 @@ class CommandLineTests(unittest.TestCase):
                 )
         self.assertEqual(exit_code, 1)
         self.assertEqual(json.loads(stderr.getvalue())["code"], "RESULT_MISMATCH")
+
+    def test_pure_semantic_mismatch_is_a_conformance_exit(self) -> None:
+        case_path = CASES_ROOT / "hashing-cache-hit.json"
+        case = load_case(case_path.name)
+        mismatch = copy.deepcopy(case["expected"])
+        mismatch["result"]["package_digest"] = "0" * 64
+        with tempfile.TemporaryDirectory() as directory:
+            result_path = Path(directory) / "result.json"
+            result_path.write_text(json.dumps(mismatch), encoding="utf-8")
+            stderr = io.StringIO()
+            with redirect_stderr(stderr):
+                exit_code = runner.main(
+                    [
+                        "validate-result",
+                        "--case",
+                        str(case_path),
+                        "--result",
+                        str(result_path),
+                    ]
+                )
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(
+            json.loads(stderr.getvalue())["code"],
+            "RESULT_HASH_MISMATCH",
+        )
 
     def test_matching_unsupported_result_is_never_reported_as_passing(self) -> None:
         case = load_case("discovery-simple.json")

--- a/code/scripts/tests/test_build_tool_conformance_schema.py
+++ b/code/scripts/tests/test_build_tool_conformance_schema.py
@@ -143,7 +143,9 @@ def semantic_errors(case: dict[str, Any]) -> list[str]:
     required_capabilities = DOMAIN_CAPABILITIES.get(domain, set())
     if domain == "plan":
         if not required_capabilities.intersection(capabilities):
-            errors.append("plan cases require a plan_v1_read or plan_v1_write capability")
+            errors.append(
+                "plan cases require a plan_v1_read or plan_v1_write capability"
+            )
     elif not required_capabilities.issubset(capabilities):
         errors.append(f"{domain} case is missing its domain capability")
 
@@ -222,9 +224,7 @@ class BuildToolConformanceSchemaTests(unittest.TestCase):
         cls.pure_schema = load_json(PURE_SCHEMA_PATH)
         cls.examples = [load_json(path) for path in sorted(EXAMPLE_ROOT.glob("*.json"))]
         cls.base_example = next(
-            example
-            for example in cls.examples
-            if example["id"] == "discovery/simple"
+            example for example in cls.examples if example["id"] == "discovery/simple"
         )
 
     def test_schema_is_draft_2020_12_and_closed_at_the_boundary(self) -> None:
@@ -256,7 +256,9 @@ class BuildToolConformanceSchemaTests(unittest.TestCase):
         jsonschema.Draft202012Validator.check_schema(self.schema)
         validator = jsonschema.Draft202012Validator(self.schema)
         for example in self.examples:
-            errors = sorted(validator.iter_errors(example), key=lambda error: list(error.path))
+            errors = sorted(
+                validator.iter_errors(example), key=lambda error: list(error.path)
+            )
             self.assertEqual(
                 errors,
                 [],
@@ -328,11 +330,25 @@ class BuildToolConformanceSchemaTests(unittest.TestCase):
         }
         record["result"]["targets"][0]["srcs"] = ["src/**/*.py"]
         errors = list(
-            jsonschema.Draft202012Validator(self.pure_schema).iter_errors(
-                record
-            )
+            jsonschema.Draft202012Validator(self.pure_schema).iter_errors(record)
         )
         self.assertEqual(errors, [])
+
+    def test_package_names_require_nonempty_safe_segments(self) -> None:
+        pattern = re.compile(self.pure_schema["$defs"]["package_name"]["pattern"])
+        for valid in (
+            "python/demo",
+            "rust/http-core",
+            "typescript/pkg/subpkg",
+        ):
+            self.assertIsNotNone(pattern.fullmatch(valid), valid)
+        for invalid in (
+            "python/",
+            "python//demo",
+            "python/../demo",
+            "python/./demo",
+        ):
+            self.assertIsNone(pattern.fullmatch(invalid), invalid)
 
     def test_pure_domain_cases_carry_no_executable_or_host_input(self) -> None:
         pure_domains = set(self.pure_schema["$defs"]["pure_domain"]["enum"])
@@ -380,9 +396,9 @@ class BuildToolConformanceSchemaTests(unittest.TestCase):
 
     def test_fixture_environment_is_data_with_a_narrow_key_namespace(self) -> None:
         environment_pattern = re.compile(
-            self.schema["$defs"]["input"]["properties"]["environment"][
-                "propertyNames"
-            ]["pattern"]
+            self.schema["$defs"]["input"]["properties"]["environment"]["propertyNames"][
+                "pattern"
+            ]
         )
         self.assertIsNotNone(environment_pattern.fullmatch("CONFORMANCE_MODE"))
         for dangerous in (
@@ -433,7 +449,10 @@ class BuildToolConformanceSchemaTests(unittest.TestCase):
             mismatch = copy.deepcopy(base)
             mismatch["input"]["options"]["code_root"] = unsafe
             self.assertTrue(
-                any(error.startswith("unsafe portable path") for error in semantic_errors(mismatch)),
+                any(
+                    error.startswith("unsafe portable path")
+                    for error in semantic_errors(mismatch)
+                ),
                 unsafe,
             )
 
@@ -446,7 +465,10 @@ class BuildToolConformanceSchemaTests(unittest.TestCase):
             }
         )
         self.assertTrue(
-            any(error.startswith("duplicate normalized path:") for error in semantic_errors(duplicate))
+            any(
+                error.startswith("duplicate normalized path:")
+                for error in semantic_errors(duplicate)
+            )
         )
 
         prefix_conflict = copy.deepcopy(self.base_example)
@@ -474,7 +496,10 @@ class BuildToolConformanceSchemaTests(unittest.TestCase):
         invalid_base64["workspace"]["files"][0].pop("content_utf8")
         invalid_base64["workspace"]["files"][0]["content_base64"] = "not base64!"
         self.assertTrue(
-            any(error.startswith("invalid base64 content:") for error in semantic_errors(invalid_base64))
+            any(
+                error.startswith("invalid base64 content:")
+                for error in semantic_errors(invalid_base64)
+            )
         )
 
         noncanonical_base64 = copy.deepcopy(self.base_example)
@@ -487,12 +512,17 @@ class BuildToolConformanceSchemaTests(unittest.TestCase):
             )
         )
 
-    def test_windows_reserved_and_trailing_names_are_semantically_rejected(self) -> None:
+    def test_windows_reserved_and_trailing_names_are_semantically_rejected(
+        self,
+    ) -> None:
         for unsafe in ("fixtures/NUL.txt", "fixtures/name.", "fixtures/name "):
             invalid = copy.deepcopy(self.base_example)
             invalid["workspace"]["files"][0]["path"] = unsafe
             self.assertTrue(
-                any(error.startswith("unsafe portable path") for error in semantic_errors(invalid)),
+                any(
+                    error.startswith("unsafe portable path")
+                    for error in semantic_errors(invalid)
+                ),
                 unsafe,
             )
 

--- a/code/scripts/tests/test_build_tool_conformance_schema.py
+++ b/code/scripts/tests/test_build_tool_conformance_schema.py
@@ -334,6 +334,12 @@ class BuildToolConformanceSchemaTests(unittest.TestCase):
         )
         self.assertEqual(errors, [])
 
+    def test_validation_v1_exposes_only_checks_with_semantic_oracles(self) -> None:
+        self.assertEqual(
+            self.pure_schema["$defs"]["validation_check"]["enum"],
+            ["build_file_presence"],
+        )
+
     def test_package_names_require_nonempty_safe_segments(self) -> None:
         pattern = re.compile(self.pure_schema["$defs"]["package_name"]["pattern"])
         for valid in (

--- a/code/scripts/tests/test_build_tool_conformance_schema.py
+++ b/code/scripts/tests/test_build_tool_conformance_schema.py
@@ -13,6 +13,7 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[3]
 FIXTURE_ROOT = ROOT / "code" / "specs" / "fixtures" / "build-tool-v1"
 SCHEMA_PATH = FIXTURE_ROOT / "schema.json"
+PURE_SCHEMA_PATH = FIXTURE_ROOT / "pure-domains.schema.json"
 EXAMPLE_ROOT = FIXTURE_ROOT / "cases"
 MAX_SAFE_INTEGER = 9_007_199_254_740_991
 RESERVED_ADAPTER_FLAGS = ("--conformance", "--workspace-root", "--output")
@@ -218,7 +219,13 @@ class BuildToolConformanceSchemaTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.schema = load_json(SCHEMA_PATH)
+        cls.pure_schema = load_json(PURE_SCHEMA_PATH)
         cls.examples = [load_json(path) for path in sorted(EXAMPLE_ROOT.glob("*.json"))]
+        cls.base_example = next(
+            example
+            for example in cls.examples
+            if example["id"] == "discovery/simple"
+        )
 
     def test_schema_is_draft_2020_12_and_closed_at_the_boundary(self) -> None:
         self.assertEqual(
@@ -254,6 +261,92 @@ class BuildToolConformanceSchemaTests(unittest.TestCase):
                 errors,
                 [],
                 "\n".join(error.message for error in errors),
+            )
+
+    def test_checked_in_pure_domain_records_are_closed_and_formally_valid(
+        self,
+    ) -> None:
+        import jsonschema
+
+        jsonschema.Draft202012Validator.check_schema(self.pure_schema)
+        validator = jsonschema.Draft202012Validator(self.pure_schema)
+        pure_domains = set(self.pure_schema["$defs"]["pure_domain"]["enum"])
+        seen: set[str] = set()
+        for example in self.examples:
+            if example["domain"] not in pure_domains:
+                continue
+            record = {
+                "domain": example["domain"],
+                "outcome": example["expected"]["outcome"],
+                "input": example["input"],
+                "result": example["expected"]["result"],
+            }
+            errors = list(validator.iter_errors(record))
+            self.assertEqual(
+                errors,
+                [],
+                "\n".join(error.message for error in errors),
+            )
+            seen.add(example["domain"])
+
+        self.assertEqual(seen, pure_domains)
+
+    def test_every_pure_domain_rejects_unknown_input_fields(self) -> None:
+        import jsonschema
+
+        validator = jsonschema.Draft202012Validator(self.pure_schema)
+        pure_domains = set(self.pure_schema["$defs"]["pure_domain"]["enum"])
+        examples = {
+            example["domain"]: example
+            for example in self.examples
+            if example["domain"] in pure_domains
+        }
+        for domain, example in examples.items():
+            with self.subTest(domain=domain):
+                record = {
+                    "domain": domain,
+                    "outcome": example["expected"]["outcome"],
+                    "input": copy.deepcopy(example["input"]),
+                    "result": example["expected"]["result"],
+                }
+                record["input"]["options"]["unexpected"] = True
+                self.assertTrue(list(validator.iter_errors(record)))
+
+    def test_starlark_sources_accept_portable_recursive_globs(self) -> None:
+        import jsonschema
+
+        example = next(
+            example
+            for example in self.examples
+            if example["id"] == "starlark/structured-context"
+        )
+        record = {
+            "domain": example["domain"],
+            "outcome": example["expected"]["outcome"],
+            "input": example["input"],
+            "result": copy.deepcopy(example["expected"]["result"]),
+        }
+        record["result"]["targets"][0]["srcs"] = ["src/**/*.py"]
+        errors = list(
+            jsonschema.Draft202012Validator(self.pure_schema).iter_errors(
+                record
+            )
+        )
+        self.assertEqual(errors, [])
+
+    def test_pure_domain_cases_carry_no_executable_or_host_input(self) -> None:
+        pure_domains = set(self.pure_schema["$defs"]["pure_domain"]["enum"])
+        for example in self.examples:
+            if example["domain"] not in pure_domains:
+                continue
+            self.assertNotIn("arguments", example["input"])
+            self.assertNotIn("environment", example["input"])
+            self.assertFalse(
+                any(
+                    entry.get("executable", False)
+                    for entry in example["workspace"]["files"]
+                ),
+                example["id"],
             )
 
     def test_checked_in_examples_satisfy_semantic_invariants(self) -> None:
@@ -308,7 +401,7 @@ class BuildToolConformanceSchemaTests(unittest.TestCase):
     def test_domain_operation_and_expected_identity_mismatches_are_rejected(
         self,
     ) -> None:
-        base = self.examples[0]
+        base = self.base_example
 
         mismatch = copy.deepcopy(base)
         mismatch["input"]["operation"] = "execution"
@@ -345,7 +438,7 @@ class BuildToolConformanceSchemaTests(unittest.TestCase):
             )
 
     def test_normalized_duplicate_paths_and_invalid_base64_are_rejected(self) -> None:
-        duplicate = copy.deepcopy(self.examples[0])
+        duplicate = copy.deepcopy(self.base_example)
         duplicate["workspace"]["files"].append(
             {
                 "path": "CODE/PACKAGES/PYTHON/DEMO/build",
@@ -356,7 +449,7 @@ class BuildToolConformanceSchemaTests(unittest.TestCase):
             any(error.startswith("duplicate normalized path:") for error in semantic_errors(duplicate))
         )
 
-        prefix_conflict = copy.deepcopy(self.examples[0])
+        prefix_conflict = copy.deepcopy(self.base_example)
         prefix_conflict["workspace"]["files"] = [
             {"path": "fixtures/data", "content_utf8": "file\n"},
             {"path": "FIXTURES/DATA/child", "content_utf8": "child\n"},
@@ -368,7 +461,7 @@ class BuildToolConformanceSchemaTests(unittest.TestCase):
             )
         )
 
-        changed_duplicate = copy.deepcopy(self.examples[0])
+        changed_duplicate = copy.deepcopy(self.base_example)
         changed_duplicate["input"]["changed_paths"] = ["Code/X", "code/x"]
         self.assertTrue(
             any(
@@ -377,14 +470,14 @@ class BuildToolConformanceSchemaTests(unittest.TestCase):
             )
         )
 
-        invalid_base64 = copy.deepcopy(self.examples[0])
+        invalid_base64 = copy.deepcopy(self.base_example)
         invalid_base64["workspace"]["files"][0].pop("content_utf8")
         invalid_base64["workspace"]["files"][0]["content_base64"] = "not base64!"
         self.assertTrue(
             any(error.startswith("invalid base64 content:") for error in semantic_errors(invalid_base64))
         )
 
-        noncanonical_base64 = copy.deepcopy(self.examples[0])
+        noncanonical_base64 = copy.deepcopy(self.base_example)
         noncanonical_base64["workspace"]["files"][0].pop("content_utf8")
         noncanonical_base64["workspace"]["files"][0]["content_base64"] = "AB=="
         self.assertTrue(
@@ -396,7 +489,7 @@ class BuildToolConformanceSchemaTests(unittest.TestCase):
 
     def test_windows_reserved_and_trailing_names_are_semantically_rejected(self) -> None:
         for unsafe in ("fixtures/NUL.txt", "fixtures/name.", "fixtures/name "):
-            invalid = copy.deepcopy(self.examples[0])
+            invalid = copy.deepcopy(self.base_example)
             invalid["workspace"]["files"][0]["path"] = unsafe
             self.assertTrue(
                 any(error.startswith("unsafe portable path") for error in semantic_errors(invalid)),

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -527,6 +527,13 @@ Validation input is the sole normalized repository-data snapshot for this
 domain. It does not carry a second inline BUILD-file source of truth, and the
 adapter MUST NOT consult the workspace or host checkout.
 
+The closed process-free v1 record currently exposes only
+`build_file_presence`, whose result is derived exactly from each package's
+normalized `build_file_state`. The other diagnostic families above remain the
+target contract, but they are not valid pure-domain check values until their
+inputs and deterministic semantic oracles are added. A self-consistent result
+is never sufficient evidence for an unmodeled validation check.
+
 Canonical result ordering is domain-aware:
 
 - every package, path, toolchain, diagnostic-code, and invalidation set is

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -283,7 +283,8 @@ the host Git binary. Implementations MUST map:
 - shared workflow/toolchain changes to the declared toolchain set;
 - strict Starlark `srcs` globs only to matching packages;
 - package changes to all transitive dependents; and
-- changes outside known packages according to explicit fixture policy.
+- changes outside known packages according to the explicit conservative
+  fixture policy: select all declared packages or return an error.
 
 The adapter must not read the caller's real checkout, Git config, hooks, or
 credentials.
@@ -438,8 +439,8 @@ structured command fields use the shared definitions in the corpus schema.
 
 | Domain | `input.options` | Successful `result` |
 |---|---|---|
-| `diff_selection` | packages with repository-relative roots and an explicit `package_prefix` or `strict_globs` source mode, dependency edges, forced packages, and an `ignore` or `all` unknown-path policy | sorted `changed_packages`, `affected_packages`, and prerequisite-only `prerequisite_packages` |
-| `hashing_cache` | SHA-256 mode, package, included paths, dependency digests, dependents, and missing or raw serialized prior-cache data | lowercase `package_digest`, `dependencies_digest`, `combined_digest`, cache status, and sorted invalidated packages |
+| `diff_selection` | packages with repository-relative roots and an explicit `package_prefix` or `strict_globs` source mode, dependency edges, forced packages, and an `all` or `error` unknown-path policy | sorted `changed_packages`, `affected_packages`, and prerequisite-only `prerequisite_packages` |
+| `hashing_cache` | SHA-256 mode, package, included paths, dependency digests, dependents, and a closed missing, corrupt, or typed prior-cache record | lowercase `package_digest`, `dependencies_digest`, `combined_digest`, cache status, and sorted invalidated packages |
 | `starlark` | repository-contained entrypoint, v1 `_ctx`, and declared legacy fallback policy | sorted targets containing rule metadata, structured commands, deterministic display rendering, and the per-target command source |
 | `sharding` | package languages and build-command counts, dependency edges, scheduled packages, shard count, and optional shard index | stable prerequisite-closed shard records with assignments, package closure, toolchains, and estimated cost |
 | `validation` | platform, selected checks, normalized package declarations, and dependency edges | `valid` plus sorted stable diagnostic codes |
@@ -465,6 +466,12 @@ first byte string and the 32 decoded digest bytes as the second. The package
 stream and dependency stream are hashed separately; `combined_digest` is
 SHA-256 over the 32 package-digest bytes followed by the 32 dependency-digest
 bytes. An empty stream therefore has the standard SHA-256 empty digest.
+Prior cache records are data, not nested executable or parser input:
+`missing` and `corrupt` carry no payload; `record` carries exactly a combined
+digest and `success` or `failed` status. A matching successful record is a
+`hit` with no invalidations. Missing, failed, or stale records are a `miss`;
+corrupt records are `recovered`. Every non-hit invalidates the package and its
+declared dependent closure.
 
 Sharding v1 normalizes package languages to the canonical toolchain registry
 before computing cost. Each package costs `1 + build_command_count` plus the
@@ -491,9 +498,15 @@ reference a declared package.
 
 Starlark v1 injects `repo_root` into `_ctx` from the runner-owned workspace; it
 is never accepted from fixture input. Repository `load()` labels are resolved
-only against inline files and cannot escape the root. A target with structured
-commands reports `command_source: "structured"`; a target that uses the
-declared generator reports `"legacy_fallback"`. For process-free comparison,
+only against the immutable inline file table and cannot escape the root.
+`//` labels and normalized labels without a `./` or `../` prefix are
+repository-root-relative; explicit dot-prefixed labels are relative to the
+loading module. Missing inline modules never fall back to the host filesystem.
+Each fixture declares bounded step, recursion, load-depth, module-count,
+aggregate-value, and diagnostic-output requests, all capped by stricter
+runner policy. A target with structured commands reports
+`command_source: "structured"`; a target that uses the declared generator
+reports `"legacy_fallback"`. For process-free comparison,
 `rendered_commands` is a deterministic display form, not executable authority:
 tokens containing only ASCII letters, digits, `_`, `@`, `%`, `+`, `=`, `:`,
 `,`, `.`, `/`, and `-` are emitted unchanged; every other token is emitted as a
@@ -510,6 +523,9 @@ Validation v1 uses the stable diagnostic registry
 `valid: false`, one or more codes, and matching diagnostic-envelope codes.
 Platform BUILD precedence is a discovery decision; validation does not invent
 a missing-platform error when canonical `BUILD` fallback is available.
+Validation input is the sole normalized repository-data snapshot for this
+domain. It does not carry a second inline BUILD-file source of truth, and the
+adapter MUST NOT consult the workspace or host checkout.
 
 Canonical result ordering is domain-aware:
 

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -438,13 +438,13 @@ structured command fields use the shared definitions in the corpus schema.
 
 | Domain | `input.options` | Successful `result` |
 |---|---|---|
-| `diff_selection` | packages with repository-relative roots and optional strict source globs, dependency edges, forced packages, and an `ignore` or `all` unknown-path policy | sorted `changed_packages`, `affected_packages`, and prerequisite-only `prerequisite_packages` |
-| `hashing_cache` | SHA-256 mode, package, included paths, dependency digests, and prior-cache state | lowercase `package_digest`, `dependencies_digest`, `combined_digest`, cache status, and sorted invalidated packages |
-| `starlark` | repository-contained entrypoint, v1 `_ctx`, and declared legacy fallback | sorted targets containing structured commands and a fallback-use flag |
-| `sharding` | package costs and languages, dependency edges, scheduled packages, shard count, and optional shard index | stable prerequisite-closed shard records with assignments, package closure, toolchains, and estimated cost |
-| `validation` | platform and an explicit set of validation checks | `valid` plus sorted stable diagnostic codes |
+| `diff_selection` | packages with repository-relative roots and an explicit `package_prefix` or `strict_globs` source mode, dependency edges, forced packages, and an `ignore` or `all` unknown-path policy | sorted `changed_packages`, `affected_packages`, and prerequisite-only `prerequisite_packages` |
+| `hashing_cache` | SHA-256 mode, package, included paths, dependency digests, dependents, and missing or raw serialized prior-cache data | lowercase `package_digest`, `dependencies_digest`, `combined_digest`, cache status, and sorted invalidated packages |
+| `starlark` | repository-contained entrypoint, v1 `_ctx`, and declared legacy fallback policy | sorted targets containing rule metadata, structured commands, deterministic display rendering, and the per-target command source |
+| `sharding` | package languages and build-command counts, dependency edges, scheduled packages, shard count, and optional shard index | stable prerequisite-closed shard records with assignments, package closure, toolchains, and estimated cost |
+| `validation` | platform, selected checks, normalized package declarations, and dependency edges | `valid` plus sorted stable diagnostic codes |
 | `toolchain_detection` | package-language records, `null`/empty/explicit package selection, and forced toolchains | the complete canonical toolchain registry as a sorted boolean map |
-| `cli` | portable build-tool arguments and an invocation condition | exit code, normalized mode, and bounded machine-output data |
+| `cli` | a portable action, decision condition, and whether the action would require later execution | exit code only |
 
 These records intentionally model decisions, not host operations:
 
@@ -453,7 +453,8 @@ These records intentionally model decisions, not host operations:
 - Starlark receives inline source and context; it never executes a command;
 - validation inspects inline repository data only;
 - toolchain detection never probes installed programs; and
-- CLI fixtures model parsing/reporting outcomes without launching a build.
+- CLI fixtures classify exit decisions without standardizing native argument
+  grammar, invoking a front door, or launching a build.
 
 Hashing v1 uses SHA-256 over an unambiguous byte stream. Included files are
 sorted by normalized forward-slash path. For each file, append the unsigned
@@ -464,6 +465,51 @@ first byte string and the 32 decoded digest bytes as the second. The package
 stream and dependency stream are hashed separately; `combined_digest` is
 SHA-256 over the 32 package-digest bytes followed by the 32 dependency-digest
 bytes. An empty stream therefore has the standard SHA-256 empty digest.
+
+Sharding v1 normalizes package languages to the canonical toolchain registry
+before computing cost. Each package costs `1 + build_command_count` plus the
+following toolchain weight:
+
+| Toolchain | Weight |
+|---|---:|
+| `rust` | 6 |
+| `dotnet`, `haskell`, `swift`, `typescript` | 4 |
+| `java`, `kotlin` | 3 |
+| `elixir`, `python`, `ruby` | 2 |
+| every other registered toolchain | 0 |
+
+Scheduled roots sort by descending package cost and then qualified package
+name. Each root is assigned to the shard with the lowest current direct-root
+cost, breaking ties by lowest shard index. A positive shard count larger than
+the number of scheduled roots is clamped to that number. An empty selection
+produces one stable empty shard. Zero or negative counts are
+`SHARD_COUNT_INVALID`; an index outside the produced shard range is
+`SHARD_INDEX_INVALID`. `package_names` is the transitive prerequisite closure
+of each shard's direct assignments, and `estimated_cost` is the sum of every
+closed package's cost. Every declared edge endpoint and scheduled name MUST
+reference a declared package.
+
+Starlark v1 injects `repo_root` into `_ctx` from the runner-owned workspace; it
+is never accepted from fixture input. Repository `load()` labels are resolved
+only against inline files and cannot escape the root. A target with structured
+commands reports `command_source: "structured"`; a target that uses the
+declared generator reports `"legacy_fallback"`. For process-free comparison,
+`rendered_commands` is a deterministic display form, not executable authority:
+tokens containing only ASCII letters, digits, `_`, `@`, `%`, `+`, `=`, `:`,
+`,`, `.`, `/`, and `-` are emitted unchanged; every other token is emitted as a
+JSON string; tokens are joined by one ASCII space. Trusted execution MUST use
+the structured `program` and `args` through the platform executor rather than
+executing this display string.
+
+Validation v1 uses the stable diagnostic registry
+`BUILD_FILE_MISSING`, `BUILD_FILE_EMPTY`, `LOCAL_DEPENDENCY_UNDECLARED`,
+`STANDALONE_PREREQUISITE_MISSING`, `STARLARK_SOURCE_INVALID`,
+`STARLARK_DEPENDENCY_INVALID`, `IDENTITY_AMBIGUOUS`, `MANIFEST_AMBIGUOUS`,
+`TOOLCHAIN_UNSUPPORTED`, and `PATH_UNSAFE`. `outcome: "ok"` requires
+`valid: true` with no diagnostic codes. `outcome: "error"` requires
+`valid: false`, one or more codes, and matching diagnostic-envelope codes.
+Platform BUILD precedence is a discovery decision; validation does not invent
+a missing-platform error when canonical `BUILD` fallback is available.
 
 Canonical result ordering is domain-aware:
 
@@ -485,6 +531,21 @@ The canonical v1 toolchain registry is:
 maps to `rust`. OCaml is present in this decision registry before its build-tool
 implementation is promoted. Unknown package languages and unknown forced
 toolchains are stable validation errors rather than new result-map keys.
+`scheduled_packages: null` selects every supplied package, while `[]` selects
+none. Forced toolchains are unioned into the derived set.
+
+The process-free CLI record is a decision table only:
+
+| Condition | Exit code |
+|---|---:|
+| `success` | `0` |
+| `package_failure`, `validation_failure` | `1` |
+| `invalid_usage`, `unsafe_input` | `2` |
+
+An action marked `requires_execution: true` remains inert fixture data in this
+tranche. Native argument parsing and machine-output compatibility become
+conformance claims only when a later sandbox executes each language front
+door.
 
 ## Security and trust boundary
 

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -429,6 +429,63 @@ Required stable process semantics:
 Machine output is JSON. Human progress output may vary and is not compared by
 the conformance runner.
 
+### 13. Closed pure-domain fixture model
+
+The process-free bootstrap closes the remaining non-execution domains with the
+following v1 input and result records. All lists named below are bounded by the
+fixture schema. Package names, paths, toolchain keys, diagnostic codes, and
+structured command fields use the shared definitions in the corpus schema.
+
+| Domain | `input.options` | Successful `result` |
+|---|---|---|
+| `diff_selection` | packages with repository-relative roots and optional strict source globs, dependency edges, forced packages, and an `ignore` or `all` unknown-path policy | sorted `changed_packages`, `affected_packages`, and prerequisite-only `prerequisite_packages` |
+| `hashing_cache` | SHA-256 mode, package, included paths, dependency digests, and prior-cache state | lowercase `package_digest`, `dependencies_digest`, `combined_digest`, cache status, and sorted invalidated packages |
+| `starlark` | repository-contained entrypoint, v1 `_ctx`, and declared legacy fallback | sorted targets containing structured commands and a fallback-use flag |
+| `sharding` | package costs and languages, dependency edges, scheduled packages, shard count, and optional shard index | stable prerequisite-closed shard records with assignments, package closure, toolchains, and estimated cost |
+| `validation` | platform and an explicit set of validation checks | `valid` plus sorted stable diagnostic codes |
+| `toolchain_detection` | package-language records, `null`/empty/explicit package selection, and forced toolchains | the complete canonical toolchain registry as a sorted boolean map |
+| `cli` | portable build-tool arguments and an invocation condition | exit code, normalized mode, and bounded machine-output data |
+
+These records intentionally model decisions, not host operations:
+
+- diff selection receives `changed_paths`; it never invokes Git;
+- hashing receives inline bytes; it never reads host metadata;
+- Starlark receives inline source and context; it never executes a command;
+- validation inspects inline repository data only;
+- toolchain detection never probes installed programs; and
+- CLI fixtures model parsing/reporting outcomes without launching a build.
+
+Hashing v1 uses SHA-256 over an unambiguous byte stream. Included files are
+sorted by normalized forward-slash path. For each file, append the unsigned
+64-bit big-endian path-byte length, UTF-8 path bytes, unsigned 64-bit
+big-endian content length, and exact content bytes. Dependency digests are
+sorted by package name and encoded the same way, using the package name as the
+first byte string and the 32 decoded digest bytes as the second. The package
+stream and dependency stream are hashed separately; `combined_digest` is
+SHA-256 over the 32 package-digest bytes followed by the 32 dependency-digest
+bytes. An empty stream therefore has the standard SHA-256 empty digest.
+
+Canonical result ordering is domain-aware:
+
+- every package, path, toolchain, diagnostic-code, and invalidation set is
+  lexicographically sorted;
+- diff-selection sets are disjoint where
+  `prerequisite_packages` excludes already affected packages;
+- targets sort by `(rule, name)` and commands retain execution order;
+- shards sort by index while their assignment, closure, and toolchain sets
+  sort lexicographically; and
+- toolchain maps contain every registry key even when all values are false.
+
+The canonical v1 toolchain registry is:
+
+`cpp`, `dart`, `dotnet`, `elixir`, `go`, `haskell`, `java`, `kotlin`, `lua`,
+`ocaml`, `perl`, `python`, `ruby`, `rust`, `swift`, and `typescript`.
+
+`c` and `cpp` packages map to `cpp`; C#, F#, and .NET map to `dotnet`; WASM
+maps to `rust`. OCaml is present in this decision registry before its build-tool
+implementation is promoted. Unknown package languages and unknown forced
+toolchains are stable validation errors rather than new result-map keys.
+
 ## Security and trust boundary
 
 A fixture is data supplied to a program that can execute commands. Therefore:

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -542,10 +542,10 @@ The process-free CLI record is a decision table only:
 | `package_failure`, `validation_failure` | `1` |
 | `invalid_usage`, `unsafe_input` | `2` |
 
-An action marked `requires_execution: true` remains inert fixture data in this
-tranche. Native argument parsing and machine-output compatibility become
-conformance claims only when a later sandbox executes each language front
-door.
+Every process-free CLI case requires `requires_execution: false`; a true value
+is rejected before workspace decoding. Native argument parsing and
+machine-output compatibility become conformance claims only when a later
+sandbox executes each language front door.
 
 ## Security and trust boundary
 

--- a/code/specs/fixtures/build-tool-v1/CHANGELOG.md
+++ b/code/specs/fixtures/build-tool-v1/CHANGELOG.md
@@ -9,3 +9,12 @@
 - Added seven representative discovery, resolution, graph, and plan cases.
 - Added bounded parsing, two-phase in-memory workspace preflight,
   domain-aware canonical comparison, and fail-closed execution rejection.
+- Expanded the corpus from seven cases and four domains to 30 cases covering
+  all 11 process-free v1 domains.
+- Added a closed pure-domain schema, conservative unknown-path handling,
+  framed hash/cache oracles, bounded inline-only Starlark records,
+  prerequisite-closed shard verification, normalized validation snapshots,
+  the complete toolchain registry including OCaml, and CLI exit decisions.
+- Added semantic reference, path, hash, cache, Starlark load, shard,
+  diagnostic, and toolchain checks while preserving the zero-process,
+  zero-materialization bootstrap boundary.

--- a/code/specs/fixtures/build-tool-v1/CHANGELOG.md
+++ b/code/specs/fixtures/build-tool-v1/CHANGELOG.md
@@ -13,8 +13,9 @@
   all 11 process-free v1 domains.
 - Added a closed pure-domain schema, conservative unknown-path handling,
   framed hash/cache oracles, bounded inline-only Starlark records,
-  prerequisite-closed shard verification, normalized validation snapshots,
-  the complete toolchain registry including OCaml, and CLI exit decisions.
+  prerequisite-closed shard verification, normalized BUILD-file validation
+  snapshots, the complete toolchain registry including OCaml, and CLI exit
+  decisions.
 - Added semantic reference, path, hash, cache, Starlark load, shard,
   diagnostic, and toolchain checks while preserving the zero-process,
   zero-materialization bootstrap boundary.

--- a/code/specs/fixtures/build-tool-v1/README.md
+++ b/code/specs/fixtures/build-tool-v1/README.md
@@ -34,7 +34,7 @@ The 30-case bootstrap corpus covers every process-free v1 domain:
 - inline-only Starlark module resolution, bounded evaluation requests,
   structured command extraction, and stable missing/outside errors;
 - deterministic prerequisite-closed sharding and invalid input handling;
-- normalized validation snapshots and the complete toolchain registry,
+- normalized BUILD-file validation snapshots and the complete toolchain registry,
   including OCaml; and
 - process-free CLI exit-decision classification.
 
@@ -67,7 +67,8 @@ bounded in-memory decoding of pure fixture workspaces so invalid base64, path
 aliases, collisions, prefix conflicts, and aggregate size violations fail
 without creating a filesystem root. Domain checks verify reference integrity,
 framed hashes, cache state, inline Starlark loads, shard closure/cost,
-validation diagnostics, complete toolchain maps, and CLI exit decisions.
+BUILD-file validation diagnostics, complete toolchain maps, and CLI exit
+decisions.
 
 ## Security boundary
 
@@ -99,7 +100,7 @@ The corpus now closes all process-free v1 domains:
 - diff selection and hashing/cache;
 - Starlark evaluation and structured-command extraction;
 - prerequisite-closed sharding;
-- validation and toolchain detection; and
+- BUILD-file validation and toolchain detection; and
 - CLI exit-decision semantics.
 
 Execution remains the only intentionally unmodeled domain.

--- a/code/specs/fixtures/build-tool-v1/README.md
+++ b/code/specs/fixtures/build-tool-v1/README.md
@@ -78,6 +78,23 @@ trusted-sandbox item implements atomic no-follow filesystem access, network
 isolation, a sanitized environment, direct argument vectors, and complete
 process-tree resource limits.
 
+The pure-domain expansion keeps that boundary intact. Diff selection consumes
+declared changed paths instead of Git, hashing consumes inline bytes instead of
+filesystem metadata, Starlark returns structured commands without running
+them, validation reads only fixture data, toolchain detection never probes the
+host, and CLI cases model parse/report behavior without invoking a build.
+
+The corpus now closes all process-free v1 domains:
+
+- discovery, resolution, graph, and plan;
+- diff selection and hashing/cache;
+- Starlark evaluation and structured-command extraction;
+- prerequisite-closed sharding;
+- validation and toolchain detection; and
+- CLI exit/report semantics.
+
+Execution remains the only intentionally unmodeled domain.
+
 ## Validation
 
 ```text

--- a/code/specs/fixtures/build-tool-v1/README.md
+++ b/code/specs/fixtures/build-tool-v1/README.md
@@ -9,17 +9,12 @@ defined by `code/specs/build-tool-conformance.md`.
 build-tool-v1/
   schema.json
   result.schema.json
+  pure-domains.schema.json
   implementations.schema.json
   implementations.json
   CHANGELOG.md
   cases/
-    discovery-simple.json
-    discovery-windows-override.json
-    graph-diamond.json
-    plan-affected-empty.json
-    plan-affected-null.json
-    plan-future-version.json
-    resolution-python-diamond.json
+    *.json
 ```
 
 `implementations.json` inventories all 15 established language lanes plus the
@@ -27,16 +22,27 @@ emerging OCaml lane. It records front-door and shared-engine state but contains
 no executable commands. Every adapter is currently marked missing, so a valid
 inventory is not reported as conformance success.
 
-The bootstrap corpus covers:
+The 30-case bootstrap corpus covers every process-free v1 domain:
 
-- canonical and Windows-override discovery;
+- canonical membership plus Windows, macOS, and Linux BUILD precedence;
 - the shared Python dependency diamond;
 - deterministic diamond graph levels;
 - the build-plan distinction between `affected_packages: null` and `[]`; and
-- fail-closed rejection of a future plan version.
+- fail-closed rejection of a future plan version;
+- conservative diff selection and prerequisite closure;
+- framed SHA-256 hashing plus hit, miss, and corrupt-cache recovery;
+- inline-only Starlark module resolution, bounded evaluation requests,
+  structured command extraction, and stable missing/outside errors;
+- deterministic prerequisite-closed sharding and invalid input handling;
+- normalized validation snapshots and the complete toolchain registry,
+  including OCaml; and
+- process-free CLI exit-decision classification.
 
-The build-plan payload is validated against
-`code/specs/schemas/build-plan-v1.schema.json`.
+The outer envelope and build-plan payload use `schema.json`,
+`result.schema.json`, and `code/specs/schemas/build-plan-v1.schema.json`.
+The seven added decision domains additionally validate a closed
+`{domain,outcome,input,result}` projection against
+`pure-domains.schema.json`; generic JSON is never a fallback.
 
 ## Runner
 
@@ -59,7 +65,9 @@ semantic path and identity checks, domain-aware result canonicalization, and
 stable error codes. `validate-corpus` also performs two-phase validation and
 bounded in-memory decoding of pure fixture workspaces so invalid base64, path
 aliases, collisions, prefix conflicts, and aggregate size violations fail
-without creating a filesystem root.
+without creating a filesystem root. Domain checks verify reference integrity,
+framed hashes, cache state, inline Starlark loads, shard closure/cost,
+validation diagnostics, complete toolchain maps, and CLI exit decisions.
 
 ## Security boundary
 
@@ -82,7 +90,8 @@ The pure-domain expansion keeps that boundary intact. Diff selection consumes
 declared changed paths instead of Git, hashing consumes inline bytes instead of
 filesystem metadata, Starlark returns structured commands without running
 them, validation reads only fixture data, toolchain detection never probes the
-host, and CLI cases model parse/report behavior without invoking a build.
+host, and CLI cases classify exit decisions without parsing native argv or
+invoking a build.
 
 The corpus now closes all process-free v1 domains:
 
@@ -91,7 +100,7 @@ The corpus now closes all process-free v1 domains:
 - Starlark evaluation and structured-command extraction;
 - prerequisite-closed sharding;
 - validation and toolchain detection; and
-- CLI exit/report semantics.
+- CLI exit-decision semantics.
 
 Execution remains the only intentionally unmodeled domain.
 

--- a/code/specs/fixtures/build-tool-v1/cases/cli-dry-run-success.json
+++ b/code/specs/fixtures/build-tool-v1/cases/cli-dry-run-success.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": 1,
+  "id": "cli/dry-run-success",
+  "domain": "cli",
+  "summary": "A successful dry-run decision returns the stable success exit code without dispatching work.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "cli"
+  ],
+  "workspace": {
+    "files": []
+  },
+  "input": {
+    "operation": "cli",
+    "options": {
+      "action": "dry_run",
+      "condition": "success",
+      "requires_execution": false
+    }
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "cli/dry-run-success",
+    "domain": "cli",
+    "outcome": "ok",
+    "result": {
+      "exit_code": 0
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 1000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 128,
+    "cpu_time_ms": 1000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/cli-invalid-usage.json
+++ b/code/specs/fixtures/build-tool-v1/cases/cli-invalid-usage.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": 1,
+  "id": "cli/invalid-usage",
+  "domain": "cli",
+  "summary": "Invalid CLI usage maps to exit code two without calling the build dispatcher.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "cli"
+  ],
+  "workspace": {
+    "files": []
+  },
+  "input": {
+    "operation": "cli",
+    "options": {
+      "action": "emit_plan",
+      "condition": "invalid_usage",
+      "requires_execution": false
+    }
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "cli/invalid-usage",
+    "domain": "cli",
+    "outcome": "error",
+    "result": {
+      "exit_code": 2
+    },
+    "diagnostics": [
+      {
+        "code": "CLI_USAGE_INVALID",
+        "severity": "error"
+      }
+    ]
+  },
+  "limits": {
+    "wall_time_ms": 1000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 128,
+    "cpu_time_ms": 1000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/cli-validation-failure.json
+++ b/code/specs/fixtures/build-tool-v1/cases/cli-validation-failure.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": 1,
+  "id": "cli/validation-failure",
+  "domain": "cli",
+  "summary": "A completed validation failure maps to exit code one rather than an invalid-input exit.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "cli"
+  ],
+  "workspace": {
+    "files": []
+  },
+  "input": {
+    "operation": "cli",
+    "options": {
+      "action": "validate",
+      "condition": "validation_failure",
+      "requires_execution": false
+    }
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "cli/validation-failure",
+    "domain": "cli",
+    "outcome": "error",
+    "result": {
+      "exit_code": 1
+    },
+    "diagnostics": [
+      {
+        "code": "CLI_VALIDATION_FAILED",
+        "severity": "error"
+      }
+    ]
+  },
+  "limits": {
+    "wall_time_ms": 1000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 128,
+    "cpu_time_ms": 1000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/diff-selection-transitive.json
+++ b/code/specs/fixtures/build-tool-v1/cases/diff-selection-transitive.json
@@ -54,7 +54,7 @@
         ]
       ],
       "forced_packages": [],
-      "unknown_path_policy": "ignore"
+      "unknown_path_policy": "error"
     },
     "changed_paths": [
       "code/packages/python/lib/src/lib.py"

--- a/code/specs/fixtures/build-tool-v1/cases/diff-selection-transitive.json
+++ b/code/specs/fixtures/build-tool-v1/cases/diff-selection-transitive.json
@@ -1,0 +1,90 @@
+{
+  "schema_version": 1,
+  "id": "diff-selection/transitive-package-change",
+  "domain": "diff_selection",
+  "summary": "A package-local source change selects the package, its dependents, and prerequisite-only closure.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "diff_selection"
+  ],
+  "workspace": {
+    "files": []
+  },
+  "input": {
+    "operation": "diff_selection",
+    "options": {
+      "packages": [
+        {
+          "name": "python/base",
+          "rel_path": "code/packages/python/base",
+          "source_mode": "strict_globs",
+          "source_globs": [
+            "src/**/*.py"
+          ]
+        },
+        {
+          "name": "python/lib",
+          "rel_path": "code/packages/python/lib",
+          "source_mode": "strict_globs",
+          "source_globs": [
+            "src/**/*.py"
+          ]
+        },
+        {
+          "name": "python/app",
+          "rel_path": "code/packages/python/app",
+          "source_mode": "strict_globs",
+          "source_globs": [
+            "src/**/*.py"
+          ]
+        }
+      ],
+      "edges": [
+        [
+          "python/base",
+          "python/lib"
+        ],
+        [
+          "python/lib",
+          "python/app"
+        ]
+      ],
+      "forced_packages": [],
+      "unknown_path_policy": "ignore"
+    },
+    "changed_paths": [
+      "code/packages/python/lib/src/lib.py"
+    ]
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "diff-selection/transitive-package-change",
+    "domain": "diff_selection",
+    "outcome": "ok",
+    "result": {
+      "changed_packages": [
+        "python/lib"
+      ],
+      "affected_packages": [
+        "python/app",
+        "python/lib"
+      ],
+      "prerequisite_packages": [
+        "python/base"
+      ]
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 1000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 128,
+    "cpu_time_ms": 1000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/diff-selection-unknown-all.json
+++ b/code/specs/fixtures/build-tool-v1/cases/diff-selection-unknown-all.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
-  "id": "diff-selection/unknown-path-ignore",
+  "id": "diff-selection/unknown-path-all",
   "domain": "diff_selection",
-  "summary": "An unknown repository path is ignored only when the fixture policy explicitly says so.",
+  "summary": "An unknown repository path conservatively selects every declared package.",
   "platforms": [
     "darwin",
     "linux",
@@ -29,7 +29,7 @@
       ],
       "edges": [],
       "forced_packages": [],
-      "unknown_path_policy": "ignore"
+      "unknown_path_policy": "all"
     },
     "changed_paths": [
       "docs/notes.md"
@@ -37,12 +37,16 @@
   },
   "expected": {
     "schema_version": 1,
-    "case_id": "diff-selection/unknown-path-ignore",
+    "case_id": "diff-selection/unknown-path-all",
     "domain": "diff_selection",
     "outcome": "ok",
     "result": {
-      "changed_packages": [],
-      "affected_packages": [],
+      "changed_packages": [
+        "python/demo"
+      ],
+      "affected_packages": [
+        "python/demo"
+      ],
       "prerequisite_packages": []
     },
     "diagnostics": []

--- a/code/specs/fixtures/build-tool-v1/cases/diff-selection-unknown-ignore.json
+++ b/code/specs/fixtures/build-tool-v1/cases/diff-selection-unknown-ignore.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": 1,
+  "id": "diff-selection/unknown-path-ignore",
+  "domain": "diff_selection",
+  "summary": "An unknown repository path is ignored only when the fixture policy explicitly says so.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "diff_selection"
+  ],
+  "workspace": {
+    "files": []
+  },
+  "input": {
+    "operation": "diff_selection",
+    "options": {
+      "packages": [
+        {
+          "name": "python/demo",
+          "rel_path": "code/packages/python/demo",
+          "source_mode": "strict_globs",
+          "source_globs": [
+            "src/**/*.py"
+          ]
+        }
+      ],
+      "edges": [],
+      "forced_packages": [],
+      "unknown_path_policy": "ignore"
+    },
+    "changed_paths": [
+      "docs/notes.md"
+    ]
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "diff-selection/unknown-path-ignore",
+    "domain": "diff_selection",
+    "outcome": "ok",
+    "result": {
+      "changed_packages": [],
+      "affected_packages": [],
+      "prerequisite_packages": []
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 1000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 128,
+    "cpu_time_ms": 1000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/discovery-linux-precedence.json
+++ b/code/specs/fixtures/build-tool-v1/cases/discovery-linux-precedence.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": 1,
+  "id": "discovery/linux-precedence",
+  "domain": "discovery",
+  "summary": "The Linux-specific BUILD file wins over the shared macOS/Linux and canonical files.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "discovery"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/haskell/demo/BUILD",
+        "content_utf8": "cabal test\n"
+      },
+      {
+        "path": "code/packages/haskell/demo/BUILD_linux",
+        "content_utf8": "cabal test --test-show-details=direct\n"
+      },
+      {
+        "path": "code/packages/haskell/demo/BUILD_mac_and_linux",
+        "content_utf8": "cabal test --enable-tests\n"
+      }
+    ]
+  },
+  "input": {
+    "operation": "discovery",
+    "options": {
+      "code_root": "code",
+      "platform": "linux"
+    },
+    "arguments": [],
+    "environment": {},
+    "changed_paths": []
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "discovery/linux-precedence",
+    "domain": "discovery",
+    "outcome": "ok",
+    "result": {
+      "packages": [
+        {
+          "build_file": "code/packages/haskell/demo/BUILD_linux",
+          "is_starlark": false,
+          "language": "haskell",
+          "name": "haskell/demo",
+          "rel_path": "code/packages/haskell/demo"
+        }
+      ]
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 5000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 256,
+    "cpu_time_ms": 5000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/discovery-mac-precedence.json
+++ b/code/specs/fixtures/build-tool-v1/cases/discovery-mac-precedence.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": 1,
+  "id": "discovery/mac-precedence",
+  "domain": "discovery",
+  "summary": "The macOS-specific BUILD file wins over the shared macOS/Linux and canonical files.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "discovery"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/swift/demo/BUILD",
+        "content_utf8": "swift test\n"
+      },
+      {
+        "path": "code/packages/swift/demo/BUILD_mac",
+        "content_utf8": "swift test --parallel\n"
+      },
+      {
+        "path": "code/packages/swift/demo/BUILD_mac_and_linux",
+        "content_utf8": "swift test --filter portable\n"
+      }
+    ]
+  },
+  "input": {
+    "operation": "discovery",
+    "options": {
+      "code_root": "code",
+      "platform": "darwin"
+    },
+    "arguments": [],
+    "environment": {},
+    "changed_paths": []
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "discovery/mac-precedence",
+    "domain": "discovery",
+    "outcome": "ok",
+    "result": {
+      "packages": [
+        {
+          "build_file": "code/packages/swift/demo/BUILD_mac",
+          "is_starlark": false,
+          "language": "swift",
+          "name": "swift/demo",
+          "rel_path": "code/packages/swift/demo"
+        }
+      ]
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 5000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 256,
+    "cpu_time_ms": 5000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/discovery-variant-without-canonical.json
+++ b/code/specs/fixtures/build-tool-v1/cases/discovery-variant-without-canonical.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": 1,
+  "id": "discovery/variant-without-canonical",
+  "domain": "discovery",
+  "summary": "Platform BUILD variants do not establish package membership without a canonical BUILD file.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "discovery"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/python/not-a-package/BUILD_windows",
+        "content_utf8": "python -m unittest\n"
+      },
+      {
+        "path": "code/packages/python/not-a-package/BUILD_mac",
+        "content_utf8": "python -m unittest\n"
+      }
+    ]
+  },
+  "input": {
+    "operation": "discovery",
+    "options": {
+      "code_root": "code",
+      "platform": "windows"
+    },
+    "arguments": [],
+    "environment": {},
+    "changed_paths": []
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "discovery/variant-without-canonical",
+    "domain": "discovery",
+    "outcome": "ok",
+    "result": {
+      "packages": []
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 5000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 256,
+    "cpu_time_ms": 5000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/hashing-cache-corrupt.json
+++ b/code/specs/fixtures/build-tool-v1/cases/hashing-cache-corrupt.json
@@ -46,8 +46,7 @@
         "python/app"
       ],
       "prior_cache": {
-        "state": "record",
-        "content_utf8": "{not valid json"
+        "state": "corrupt"
       }
     }
   },

--- a/code/specs/fixtures/build-tool-v1/cases/hashing-cache-corrupt.json
+++ b/code/specs/fixtures/build-tool-v1/cases/hashing-cache-corrupt.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": 1,
+  "id": "hashing-cache/corrupt-cache-recovery",
+  "domain": "hashing_cache",
+  "summary": "Exact inline bytes and dependency digests produce deterministic hashes while a corrupt cache recovers safely.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "hashing_cache"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/python/demo/src/demo.py",
+        "content_utf8": "VALUE = 1\n"
+      },
+      {
+        "path": "code/packages/python/demo/.venv/ignored",
+        "content_utf8": "ignore\n"
+      },
+      {
+        "path": "code/packages/python/demo/BUILD",
+        "content_utf8": "python -m unittest\n"
+      }
+    ]
+  },
+  "input": {
+    "operation": "hashing_cache",
+    "options": {
+      "algorithm": "sha256-v1",
+      "package": "python/demo",
+      "include_paths": [
+        "code/packages/python/demo/BUILD",
+        "code/packages/python/demo/src/demo.py"
+      ],
+      "dependency_digests": [
+        {
+          "package": "python/base",
+          "digest": "0000000000000000000000000000000000000000000000000000000000000000"
+        }
+      ],
+      "dependents": [
+        "python/app"
+      ],
+      "prior_cache": {
+        "state": "record",
+        "content_utf8": "{not valid json"
+      }
+    }
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "hashing-cache/corrupt-cache-recovery",
+    "domain": "hashing_cache",
+    "outcome": "ok",
+    "result": {
+      "package_digest": "e12569d3648a33838d0bc363c42503e01146af8d3e9d40752d1acb7c5c914750",
+      "dependencies_digest": "ebb0556468049bcf84d265e6727c3dc959232bf8c897efbf9ded4e923bd22539",
+      "combined_digest": "1baaba8a64ddf3b3dade2bccd74e50432e04f96beff6c6b97f396cdf222155a4",
+      "cache_status": "recovered",
+      "invalidated_packages": [
+        "python/app",
+        "python/demo"
+      ]
+    },
+    "diagnostics": [
+      {
+        "code": "CACHE_CORRUPT_RECOVERED",
+        "severity": "warning",
+        "package": "python/demo"
+      }
+    ]
+  },
+  "limits": {
+    "wall_time_ms": 1000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 128,
+    "cpu_time_ms": 1000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/hashing-cache-hit.json
+++ b/code/specs/fixtures/build-tool-v1/cases/hashing-cache-hit.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": 1,
+  "id": "hashing-cache/matching-record-hit",
+  "domain": "hashing_cache",
+  "summary": "A successful cache record with the exact combined digest is a hit with no invalidations.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "hashing_cache"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/python/demo/src/data.bin",
+        "content_utf8": "abc"
+      }
+    ]
+  },
+  "input": {
+    "operation": "hashing_cache",
+    "options": {
+      "algorithm": "sha256-v1",
+      "package": "python/demo",
+      "include_paths": [
+        "code/packages/python/demo/src/data.bin"
+      ],
+      "dependency_digests": [],
+      "dependents": [
+        "python/app"
+      ],
+      "prior_cache": {
+        "state": "record",
+        "combined_digest": "3486546e6dbe30f8130f24b760b4bfd7dc7e7729e0f04b46056bb07a4b39fa8a",
+        "status": "success"
+      }
+    }
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "hashing-cache/matching-record-hit",
+    "domain": "hashing_cache",
+    "outcome": "ok",
+    "result": {
+      "package_digest": "6a2dc6b1e5428211f6f19387deb1c84836e61384745e7e0e5986fe49b17ff24f",
+      "dependencies_digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "combined_digest": "3486546e6dbe30f8130f24b760b4bfd7dc7e7729e0f04b46056bb07a4b39fa8a",
+      "cache_status": "hit",
+      "invalidated_packages": []
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 1000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 128,
+    "cpu_time_ms": 1000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/hashing-cache-missing.json
+++ b/code/specs/fixtures/build-tool-v1/cases/hashing-cache-missing.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": 1,
+  "id": "hashing-cache/missing-record-miss",
+  "domain": "hashing_cache",
+  "summary": "A missing cache record is a deterministic miss that invalidates the package and its declared dependents.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "hashing_cache"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/python/demo/src/data.bin",
+        "content_utf8": "abc"
+      }
+    ]
+  },
+  "input": {
+    "operation": "hashing_cache",
+    "options": {
+      "algorithm": "sha256-v1",
+      "package": "python/demo",
+      "include_paths": [
+        "code/packages/python/demo/src/data.bin"
+      ],
+      "dependency_digests": [],
+      "dependents": [
+        "python/app"
+      ],
+      "prior_cache": {
+        "state": "missing"
+      }
+    }
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "hashing-cache/missing-record-miss",
+    "domain": "hashing_cache",
+    "outcome": "ok",
+    "result": {
+      "package_digest": "6a2dc6b1e5428211f6f19387deb1c84836e61384745e7e0e5986fe49b17ff24f",
+      "dependencies_digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "combined_digest": "3486546e6dbe30f8130f24b760b4bfd7dc7e7729e0f04b46056bb07a4b39fa8a",
+      "cache_status": "miss",
+      "invalidated_packages": [
+        "python/app",
+        "python/demo"
+      ]
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 1000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 128,
+    "cpu_time_ms": 1000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/sharding-invalid-count.json
+++ b/code/specs/fixtures/build-tool-v1/cases/sharding-invalid-count.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": 1,
+  "id": "sharding/invalid-count",
+  "domain": "sharding",
+  "summary": "A zero shard count is a stable input error and is never silently clamped.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "sharding"
+  ],
+  "workspace": {
+    "files": []
+  },
+  "input": {
+    "operation": "sharding",
+    "options": {
+      "packages": [
+        {
+          "name": "python/demo",
+          "language": "python",
+          "build_command_count": 0
+        }
+      ],
+      "edges": [],
+      "scheduled_packages": [
+        "python/demo"
+      ],
+      "shard_count": 0
+    }
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "sharding/invalid-count",
+    "domain": "sharding",
+    "outcome": "error",
+    "result": {},
+    "diagnostics": [
+      {
+        "code": "SHARD_COUNT_INVALID",
+        "severity": "error"
+      }
+    ]
+  },
+  "limits": {
+    "wall_time_ms": 1000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 128,
+    "cpu_time_ms": 1000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/sharding-invalid-index.json
+++ b/code/specs/fixtures/build-tool-v1/cases/sharding-invalid-index.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": 1,
+  "id": "sharding/invalid-index",
+  "domain": "sharding",
+  "summary": "A shard index outside the produced matrix is a stable input error.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "sharding"
+  ],
+  "workspace": {
+    "files": []
+  },
+  "input": {
+    "operation": "sharding",
+    "options": {
+      "packages": [
+        {
+          "name": "python/demo",
+          "language": "python",
+          "build_command_count": 0
+        }
+      ],
+      "edges": [],
+      "scheduled_packages": [
+        "python/demo"
+      ],
+      "shard_count": 1,
+      "shard_index": 1
+    }
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "sharding/invalid-index",
+    "domain": "sharding",
+    "outcome": "error",
+    "result": {},
+    "diagnostics": [
+      {
+        "code": "SHARD_INDEX_INVALID",
+        "severity": "error"
+      }
+    ]
+  },
+  "limits": {
+    "wall_time_ms": 1000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 128,
+    "cpu_time_ms": 1000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/sharding-prerequisite-closed.json
+++ b/code/specs/fixtures/build-tool-v1/cases/sharding-prerequisite-closed.json
@@ -1,0 +1,105 @@
+{
+  "schema_version": 1,
+  "id": "sharding/prerequisite-closed",
+  "domain": "sharding",
+  "summary": "Stable greedy assignments expand into prerequisite-closed shards with shared C/C++ toolchains.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "sharding"
+  ],
+  "workspace": {
+    "files": []
+  },
+  "input": {
+    "operation": "sharding",
+    "options": {
+      "packages": [
+        {
+          "name": "c/base",
+          "language": "c",
+          "build_command_count": 0
+        },
+        {
+          "name": "rust/heavy",
+          "language": "rust",
+          "build_command_count": 1
+        },
+        {
+          "name": "typescript/ui",
+          "language": "typescript",
+          "build_command_count": 0
+        }
+      ],
+      "edges": [
+        [
+          "c/base",
+          "rust/heavy"
+        ],
+        [
+          "c/base",
+          "typescript/ui"
+        ]
+      ],
+      "scheduled_packages": [
+        "rust/heavy",
+        "typescript/ui"
+      ],
+      "shard_count": 2
+    }
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "sharding/prerequisite-closed",
+    "domain": "sharding",
+    "outcome": "ok",
+    "result": {
+      "shards": [
+        {
+          "index": 0,
+          "name": "shard-1-of-2",
+          "assigned_packages": [
+            "rust/heavy"
+          ],
+          "package_names": [
+            "c/base",
+            "rust/heavy"
+          ],
+          "toolchains": [
+            "cpp",
+            "rust"
+          ],
+          "estimated_cost": 9
+        },
+        {
+          "index": 1,
+          "name": "shard-2-of-2",
+          "assigned_packages": [
+            "typescript/ui"
+          ],
+          "package_names": [
+            "c/base",
+            "typescript/ui"
+          ],
+          "toolchains": [
+            "cpp",
+            "typescript"
+          ],
+          "estimated_cost": 6
+        }
+      ]
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 1000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 128,
+    "cpu_time_ms": 1000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/starlark-host-load-denied.json
+++ b/code/specs/fixtures/build-tool-v1/cases/starlark-host-load-denied.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": 1,
+  "id": "starlark/host-load-denied",
+  "domain": "starlark",
+  "summary": "A Starlark load that escapes the inline repository is rejected without consulting the host.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "starlark"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/python/demo/BUILD",
+        "content_utf8": "load(\"../../../../outside.star\", \"secret\")\n"
+      }
+    ]
+  },
+  "input": {
+    "operation": "starlark",
+    "options": {
+      "entrypoint": "code/packages/python/demo/BUILD",
+      "context": {
+        "version": 1,
+        "os": "windows",
+        "arch": "amd64",
+        "cpu_count": 2,
+        "ci": true
+      },
+      "legacy_fallback": "error"
+    }
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "starlark/host-load-denied",
+    "domain": "starlark",
+    "outcome": "error",
+    "result": {},
+    "diagnostics": [
+      {
+        "code": "STARLARK_LOAD_OUTSIDE_REPOSITORY",
+        "severity": "error",
+        "path": "code/packages/python/demo/BUILD"
+      }
+    ]
+  },
+  "limits": {
+    "wall_time_ms": 1000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 128,
+    "cpu_time_ms": 1000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/starlark-module-missing.json
+++ b/code/specs/fixtures/build-tool-v1/cases/starlark-module-missing.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
-  "id": "starlark/host-load-denied",
+  "id": "starlark/module-missing",
   "domain": "starlark",
-  "summary": "A Starlark load that escapes the inline repository is rejected without consulting the host.",
+  "summary": "A contained module absent from the inline source table fails without falling back to the host filesystem.",
   "platforms": [
     "darwin",
     "linux",
@@ -15,7 +15,7 @@
     "files": [
       {
         "path": "code/packages/python/demo/BUILD",
-        "content_utf8": "load(\"../../../../../outside.star\", \"secret\")\n"
+        "content_utf8": "load(\"code/build/host-only.star\", \"target\")\n_targets = [target]\n"
       }
     ]
   },
@@ -25,7 +25,7 @@
       "entrypoint": "code/packages/python/demo/BUILD",
       "context": {
         "version": 1,
-        "os": "windows",
+        "os": "linux",
         "arch": "amd64",
         "cpu_count": 2,
         "ci": true
@@ -43,15 +43,15 @@
   },
   "expected": {
     "schema_version": 1,
-    "case_id": "starlark/host-load-denied",
+    "case_id": "starlark/module-missing",
     "domain": "starlark",
     "outcome": "error",
     "result": {},
     "diagnostics": [
       {
-        "code": "STARLARK_LOAD_OUTSIDE_REPOSITORY",
+        "code": "STARLARK_MODULE_MISSING",
         "severity": "error",
-        "path": "code/packages/python/demo/BUILD"
+        "path": "code/build/host-only.star"
       }
     ]
   },

--- a/code/specs/fixtures/build-tool-v1/cases/starlark-structured-context.json
+++ b/code/specs/fixtures/build-tool-v1/cases/starlark-structured-context.json
@@ -38,7 +38,15 @@
         "cpu_count": 4,
         "ci": true
       },
-      "legacy_fallback": "generate_commands"
+      "legacy_fallback": "generate_commands",
+      "evaluation_limits": {
+        "step_count": 100000,
+        "recursion_depth": 64,
+        "load_depth": 32,
+        "module_count": 128,
+        "value_items": 100000,
+        "output_bytes": 65536
+      }
     }
   },
   "expected": {

--- a/code/specs/fixtures/build-tool-v1/cases/starlark-structured-context.json
+++ b/code/specs/fixtures/build-tool-v1/cases/starlark-structured-context.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": 1,
+  "id": "starlark/structured-context",
+  "domain": "starlark",
+  "summary": "Nested repository loads receive v1 context and return structured commands without execution.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "starlark"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/python/demo/BUILD",
+        "content_utf8": "load(\"code/build/defs.star\", \"demo_target\")\n_targets = [demo_target(name = \"demo\")]\n"
+      },
+      {
+        "path": "code/build/defs.star",
+        "content_utf8": "load(\"code/build/cmd.star\", \"test_command\")\ndef demo_target(name):\n    return {\"rule\": \"python_library\", \"name\": name, \"srcs\": [\"src/demo.py\"], \"deps\": [], \"commands\": [test_command()]}\n"
+      },
+      {
+        "path": "code/build/cmd.star",
+        "content_utf8": "def test_command():\n    if _ctx[\"os\"] != \"linux\":\n        return None\n    return {\"type\": \"cmd\", \"program\": \"python\", \"args\": [\"-m\", \"pytest\"]}\n"
+      }
+    ]
+  },
+  "input": {
+    "operation": "starlark",
+    "options": {
+      "entrypoint": "code/packages/python/demo/BUILD",
+      "context": {
+        "version": 1,
+        "os": "linux",
+        "arch": "amd64",
+        "cpu_count": 4,
+        "ci": true
+      },
+      "legacy_fallback": "generate_commands"
+    }
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "starlark/structured-context",
+    "domain": "starlark",
+    "outcome": "ok",
+    "result": {
+      "targets": [
+        {
+          "rule": "python_library",
+          "name": "demo",
+          "srcs": [
+            "src/demo.py"
+          ],
+          "deps": [],
+          "commands": [
+            {
+              "type": "cmd",
+              "program": "python",
+              "args": [
+                "-m",
+                "pytest"
+              ]
+            }
+          ],
+          "rendered_commands": [
+            "python -m pytest"
+          ],
+          "command_source": "structured"
+        }
+      ]
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 1000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 128,
+    "cpu_time_ms": 1000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/toolchain-detection-empty.json
+++ b/code/specs/fixtures/build-tool-v1/cases/toolchain-detection-empty.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "id": "toolchain-detection/empty-selects-none",
+  "domain": "toolchain_detection",
+  "summary": "An empty selection enables no package toolchains and still returns every registry key.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "toolchain_detection"
+  ],
+  "workspace": {
+    "files": []
+  },
+  "input": {
+    "operation": "toolchain_detection",
+    "options": {
+      "packages": [
+        {
+          "name": "python/app",
+          "language": "python"
+        }
+      ],
+      "scheduled_packages": [],
+      "forced_toolchains": []
+    }
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "toolchain-detection/empty-selects-none",
+    "domain": "toolchain_detection",
+    "outcome": "ok",
+    "result": {
+      "toolchains": {
+        "cpp": false,
+        "dart": false,
+        "dotnet": false,
+        "elixir": false,
+        "go": false,
+        "haskell": false,
+        "java": false,
+        "kotlin": false,
+        "lua": false,
+        "ocaml": false,
+        "perl": false,
+        "python": false,
+        "ruby": false,
+        "rust": false,
+        "swift": false,
+        "typescript": false
+      }
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 1000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 128,
+    "cpu_time_ms": 1000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/toolchain-detection-null-all.json
+++ b/code/specs/fixtures/build-tool-v1/cases/toolchain-detection-null-all.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": 1,
+  "id": "toolchain-detection/null-selects-all-packages",
+  "domain": "toolchain_detection",
+  "summary": "A null selection schedules every supplied package while retaining a complete false-filled registry.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "toolchain_detection"
+  ],
+  "workspace": {
+    "files": []
+  },
+  "input": {
+    "operation": "toolchain_detection",
+    "options": {
+      "packages": [
+        {
+          "name": "dart/app",
+          "language": "dart"
+        },
+        {
+          "name": "ocaml/graph",
+          "language": "ocaml"
+        }
+      ],
+      "scheduled_packages": null,
+      "forced_toolchains": []
+    }
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "toolchain-detection/null-selects-all-packages",
+    "domain": "toolchain_detection",
+    "outcome": "ok",
+    "result": {
+      "toolchains": {
+        "cpp": false,
+        "dart": true,
+        "dotnet": false,
+        "elixir": false,
+        "go": false,
+        "haskell": false,
+        "java": false,
+        "kotlin": false,
+        "lua": false,
+        "ocaml": true,
+        "perl": false,
+        "python": false,
+        "ruby": false,
+        "rust": false,
+        "swift": false,
+        "typescript": false
+      }
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 1000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 128,
+    "cpu_time_ms": 1000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/toolchain-detection-shared.json
+++ b/code/specs/fixtures/build-tool-v1/cases/toolchain-detection-shared.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": 1,
+  "id": "toolchain-detection/shared-and-forced",
+  "domain": "toolchain_detection",
+  "summary": "Selected shared-language families collapse to canonical toolchains and forced CI toolchains union in.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "toolchain_detection"
+  ],
+  "workspace": {
+    "files": []
+  },
+  "input": {
+    "operation": "toolchain_detection",
+    "options": {
+      "packages": [
+        {
+          "name": "csharp/app",
+          "language": "csharp"
+        },
+        {
+          "name": "python/unused",
+          "language": "python"
+        },
+        {
+          "name": "wasm/plugin",
+          "language": "wasm"
+        }
+      ],
+      "scheduled_packages": [
+        "csharp/app",
+        "wasm/plugin"
+      ],
+      "forced_toolchains": [
+        "kotlin"
+      ]
+    }
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "toolchain-detection/shared-and-forced",
+    "domain": "toolchain_detection",
+    "outcome": "ok",
+    "result": {
+      "toolchains": {
+        "cpp": false,
+        "dart": false,
+        "dotnet": true,
+        "elixir": false,
+        "go": false,
+        "haskell": false,
+        "java": false,
+        "kotlin": true,
+        "lua": false,
+        "ocaml": false,
+        "perl": false,
+        "python": false,
+        "ruby": false,
+        "rust": true,
+        "swift": false,
+        "typescript": false
+      }
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 1000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 128,
+    "cpu_time_ms": 1000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/toolchain-detection-unsupported.json
+++ b/code/specs/fixtures/build-tool-v1/cases/toolchain-detection-unsupported.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": 1,
+  "id": "toolchain-detection/unsupported-language",
+  "domain": "toolchain_detection",
+  "summary": "An unregistered implementation language is a stable toolchain-detection error.",
+  "platforms": [
+    "darwin",
+    "linux",
+    "windows"
+  ],
+  "capabilities": [
+    "toolchain_detection"
+  ],
+  "workspace": {
+    "files": []
+  },
+  "input": {
+    "operation": "toolchain_detection",
+    "options": {
+      "packages": [
+        {
+          "name": "zig/app",
+          "language": "zig"
+        }
+      ],
+      "scheduled_packages": null,
+      "forced_toolchains": []
+    }
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "toolchain-detection/unsupported-language",
+    "domain": "toolchain_detection",
+    "outcome": "error",
+    "result": {},
+    "diagnostics": [
+      {
+        "code": "TOOLCHAIN_UNSUPPORTED",
+        "severity": "error",
+        "package": "zig/app"
+      }
+    ]
+  },
+  "limits": {
+    "wall_time_ms": 1000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 128,
+    "cpu_time_ms": 1000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/validation-clean-build.json
+++ b/code/specs/fixtures/build-tool-v1/cases/validation-clean-build.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "id": "validation/clean-build",
+  "domain": "validation",
+  "summary": "A non-empty canonical BUILD file passes the selected repository-data checks.",
+  "platforms": [
+    "linux"
+  ],
+  "capabilities": [
+    "validation"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/python/demo/BUILD",
+        "content_utf8": "python -m unittest\n"
+      }
+    ]
+  },
+  "input": {
+    "operation": "validation",
+    "options": {
+      "platform": "linux",
+      "checks": [
+        "build_file_presence"
+      ],
+      "packages": [
+        {
+          "name": "python/demo",
+          "rel_path": "code/packages/python/demo",
+          "language": "python",
+          "build_file_state": "present",
+          "build_references": [],
+          "is_starlark": false,
+          "declared_srcs": [],
+          "declared_deps": []
+        }
+      ],
+      "dependency_edges": []
+    }
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "validation/clean-build",
+    "domain": "validation",
+    "outcome": "ok",
+    "result": {
+      "valid": true,
+      "diagnostic_codes": []
+    },
+    "diagnostics": []
+  },
+  "limits": {
+    "wall_time_ms": 1000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 128,
+    "cpu_time_ms": 1000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/cases/validation-clean-build.json
+++ b/code/specs/fixtures/build-tool-v1/cases/validation-clean-build.json
@@ -10,12 +10,7 @@
     "validation"
   ],
   "workspace": {
-    "files": [
-      {
-        "path": "code/packages/python/demo/BUILD",
-        "content_utf8": "python -m unittest\n"
-      }
-    ]
+    "files": []
   },
   "input": {
     "operation": "validation",

--- a/code/specs/fixtures/build-tool-v1/cases/validation-missing-build.json
+++ b/code/specs/fixtures/build-tool-v1/cases/validation-missing-build.json
@@ -10,12 +10,7 @@
     "validation"
   ],
   "workspace": {
-    "files": [
-      {
-        "path": "code/packages/python/demo/pyproject.toml",
-        "content_utf8": "[project]\nname = \"demo\"\nversion = \"0.1.0\"\n"
-      }
-    ]
+    "files": []
   },
   "input": {
     "operation": "validation",

--- a/code/specs/fixtures/build-tool-v1/cases/validation-missing-build.json
+++ b/code/specs/fixtures/build-tool-v1/cases/validation-missing-build.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": 1,
+  "id": "validation/missing-build",
+  "domain": "validation",
+  "summary": "A package marker without a canonical or platform BUILD file reports a stable validation diagnostic.",
+  "platforms": [
+    "windows"
+  ],
+  "capabilities": [
+    "validation"
+  ],
+  "workspace": {
+    "files": [
+      {
+        "path": "code/packages/python/demo/pyproject.toml",
+        "content_utf8": "[project]\nname = \"demo\"\nversion = \"0.1.0\"\n"
+      }
+    ]
+  },
+  "input": {
+    "operation": "validation",
+    "options": {
+      "platform": "windows",
+      "checks": [
+        "build_file_presence"
+      ],
+      "packages": [
+        {
+          "name": "python/demo",
+          "rel_path": "code/packages/python/demo",
+          "language": "python",
+          "build_file_state": "missing",
+          "build_references": [],
+          "is_starlark": false,
+          "declared_srcs": [],
+          "declared_deps": []
+        }
+      ],
+      "dependency_edges": []
+    }
+  },
+  "expected": {
+    "schema_version": 1,
+    "case_id": "validation/missing-build",
+    "domain": "validation",
+    "outcome": "error",
+    "result": {
+      "valid": false,
+      "diagnostic_codes": [
+        "BUILD_FILE_MISSING"
+      ]
+    },
+    "diagnostics": [
+      {
+        "code": "BUILD_FILE_MISSING",
+        "severity": "error",
+        "path": "code/packages/python/demo"
+      }
+    ]
+  },
+  "limits": {
+    "wall_time_ms": 1000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 1048576,
+    "process_count": 1,
+    "memory_mib": 128,
+    "cpu_time_ms": 1000
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/pure-domains.schema.json
+++ b/code/specs/fixtures/build-tool-v1/pure-domains.schema.json
@@ -1004,13 +1004,7 @@
     },
     "validation_check": {
       "enum": [
-        "build_file_presence",
-        "declared_dependencies",
-        "standalone_prerequisites",
-        "starlark_declarations",
-        "identity",
-        "toolchain_support",
-        "path_safety"
+        "build_file_presence"
       ]
     },
     "validation_diagnostic_code": {

--- a/code/specs/fixtures/build-tool-v1/pure-domains.schema.json
+++ b/code/specs/fixtures/build-tool-v1/pure-domains.schema.json
@@ -658,7 +658,7 @@
           "maxItems": 4096,
           "uniqueItems": true,
           "items": {
-            "$ref": "#/$defs/safe_path"
+            "$ref": "#/$defs/portable_glob"
           }
         },
         "deps": {
@@ -1419,7 +1419,7 @@
               ]
             },
             "requires_execution": {
-              "type": "boolean"
+              "const": false
             }
           }
         }

--- a/code/specs/fixtures/build-tool-v1/pure-domains.schema.json
+++ b/code/specs/fixtures/build-tool-v1/pure-domains.schema.json
@@ -78,7 +78,7 @@
     },
     "package_name": {
       "type": "string",
-      "pattern": "^[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._/-]*$",
+      "pattern": "^[a-z0-9][a-z0-9._-]*(/[a-z0-9][a-z0-9._-]*)+$",
       "maxLength": 240
     },
     "language": {
@@ -246,8 +246,8 @@
             },
             "unknown_path_policy": {
               "enum": [
-                "ignore",
-                "all"
+                "all",
+                "error"
               ]
             }
           }
@@ -400,41 +400,50 @@
               "$ref": "#/$defs/package_names"
             },
             "prior_cache": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": [
-                "state"
-              ],
-              "properties": {
-                "state": {
-                  "enum": [
-                    "missing",
-                    "record"
-                  ]
-                },
-                "content_utf8": {
-                  "type": "string",
-                  "maxLength": 1048576
-                }
-              },
-              "allOf": [
+              "oneOf": [
                 {
-                  "if": {
-                    "properties": {
-                      "state": {
-                        "const": "record"
-                      }
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "state"
+                  ],
+                  "properties": {
+                    "state": {
+                      "const": "missing"
                     }
-                  },
-                  "then": {
-                    "required": [
-                      "content_utf8"
-                    ]
-                  },
-                  "else": {
-                    "not": {
-                      "required": [
-                        "content_utf8"
+                  }
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "state"
+                  ],
+                  "properties": {
+                    "state": {
+                      "const": "corrupt"
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "state",
+                    "combined_digest",
+                    "status"
+                  ],
+                  "properties": {
+                    "state": {
+                      "const": "record"
+                    },
+                    "combined_digest": {
+                      "$ref": "#/$defs/digest"
+                    },
+                    "status": {
+                      "enum": [
+                        "success",
+                        "failed"
                       ]
                     }
                   }
@@ -567,6 +576,50 @@
         }
       }
     },
+    "starlark_evaluation_limits": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "step_count",
+        "recursion_depth",
+        "load_depth",
+        "module_count",
+        "value_items",
+        "output_bytes"
+      ],
+      "properties": {
+        "step_count": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000000
+        },
+        "recursion_depth": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 128
+        },
+        "load_depth": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 64
+        },
+        "module_count": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1024
+        },
+        "value_items": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000000
+        },
+        "output_bytes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1048576
+        }
+      }
+    },
     "starlark_input": {
       "type": "object",
       "additionalProperties": false,
@@ -584,7 +637,8 @@
           "required": [
             "entrypoint",
             "context",
-            "legacy_fallback"
+            "legacy_fallback",
+            "evaluation_limits"
           ],
           "properties": {
             "entrypoint": {
@@ -598,6 +652,9 @@
                 "generate_commands",
                 "error"
               ]
+            },
+            "evaluation_limits": {
+              "$ref": "#/$defs/starlark_evaluation_limits"
             }
           }
         }
@@ -820,12 +877,12 @@
             },
             "shard_count": {
               "type": "integer",
-              "minimum": 0,
+              "minimum": -64,
               "maximum": 64
             },
             "shard_index": {
               "type": "integer",
-              "minimum": 0,
+              "minimum": -64,
               "maximum": 63
             }
           }
@@ -1236,7 +1293,7 @@
               "maxItems": 16,
               "uniqueItems": true,
               "items": {
-                "$ref": "#/$defs/toolchain"
+                "$ref": "#/$defs/language"
               }
             }
           }

--- a/code/specs/fixtures/build-tool-v1/pure-domains.schema.json
+++ b/code/specs/fixtures/build-tool-v1/pure-domains.schema.json
@@ -1,0 +1,1472 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/build-tool-pure-domains-v1.json",
+  "title": "Build-tool process-free domain record v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "domain",
+    "outcome",
+    "input",
+    "result"
+  ],
+  "properties": {
+    "domain": {
+      "$ref": "#/$defs/pure_domain"
+    },
+    "outcome": {
+      "enum": [
+        "ok",
+        "error",
+        "unsupported",
+        "skipped"
+      ]
+    },
+    "input": {
+      "type": "object"
+    },
+    "result": {
+      "type": "object"
+    }
+  },
+  "oneOf": [
+    {
+      "$ref": "#/$defs/diff_selection_record"
+    },
+    {
+      "$ref": "#/$defs/hashing_cache_record"
+    },
+    {
+      "$ref": "#/$defs/starlark_record"
+    },
+    {
+      "$ref": "#/$defs/sharding_record"
+    },
+    {
+      "$ref": "#/$defs/validation_record"
+    },
+    {
+      "$ref": "#/$defs/toolchain_detection_record"
+    },
+    {
+      "$ref": "#/$defs/cli_record"
+    }
+  ],
+  "$defs": {
+    "pure_domain": {
+      "enum": [
+        "diff_selection",
+        "hashing_cache",
+        "starlark",
+        "sharding",
+        "validation",
+        "toolchain_detection",
+        "cli"
+      ]
+    },
+    "safe_path": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^(?!/)(?![A-Za-z]:)(?!.*\\\\)(?!.*(?:^|/)\\.\\.?(?:/|$))(?!.*//)[^<>:\"|?*\\u0000-\\u001F/]+(?:/[^<>:\"|?*\\u0000-\\u001F/]+)*$"
+    },
+    "portable_glob": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^(?!/)(?![A-Za-z]:)(?!.*\\\\)(?!.*(?:^|/)\\.\\.?(?:/|$))(?!.*//)[^<>:\"|?\\u0000-\\u001F]+$"
+    },
+    "package_name": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._/-]*$",
+      "maxLength": 240
+    },
+    "language": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "maxLength": 64
+    },
+    "digest": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "edge": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "$ref": "#/$defs/package_name"
+        },
+        {
+          "$ref": "#/$defs/package_name"
+        }
+      ],
+      "items": false,
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "package_names": {
+      "type": "array",
+      "maxItems": 4096,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/package_name"
+      }
+    },
+    "empty_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 0
+    },
+    "json_value": {
+      "oneOf": [
+        {
+          "type": "string",
+          "maxLength": 1048576
+        },
+        {
+          "type": "integer",
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        },
+        {
+          "type": "array",
+          "maxItems": 4096,
+          "items": {
+            "$ref": "#/$defs/json_value"
+          }
+        },
+        {
+          "type": "object",
+          "maxProperties": 1024,
+          "additionalProperties": {
+            "$ref": "#/$defs/json_value"
+          }
+        }
+      ]
+    },
+    "diff_package": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "rel_path",
+        "source_mode"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/package_name"
+        },
+        "rel_path": {
+          "$ref": "#/$defs/safe_path"
+        },
+        "source_mode": {
+          "enum": [
+            "package_prefix",
+            "strict_globs"
+          ]
+        },
+        "source_globs": {
+          "type": "array",
+          "maxItems": 256,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/portable_glob"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "source_mode": {
+                "const": "strict_globs"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "source_globs"
+            ]
+          },
+          "else": {
+            "not": {
+              "required": [
+                "source_globs"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "diff_selection_input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operation",
+        "options",
+        "changed_paths"
+      ],
+      "properties": {
+        "operation": {
+          "const": "diff_selection"
+        },
+        "options": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "packages",
+            "edges",
+            "forced_packages",
+            "unknown_path_policy"
+          ],
+          "properties": {
+            "packages": {
+              "type": "array",
+              "maxItems": 4096,
+              "items": {
+                "$ref": "#/$defs/diff_package"
+              }
+            },
+            "edges": {
+              "type": "array",
+              "maxItems": 16384,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/edge"
+              }
+            },
+            "forced_packages": {
+              "$ref": "#/$defs/package_names"
+            },
+            "unknown_path_policy": {
+              "enum": [
+                "ignore",
+                "all"
+              ]
+            }
+          }
+        },
+        "changed_paths": {
+          "type": "array",
+          "maxItems": 4096,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/safe_path"
+          }
+        }
+      }
+    },
+    "diff_selection_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "changed_packages",
+        "affected_packages",
+        "prerequisite_packages"
+      ],
+      "properties": {
+        "changed_packages": {
+          "$ref": "#/$defs/package_names"
+        },
+        "affected_packages": {
+          "$ref": "#/$defs/package_names"
+        },
+        "prerequisite_packages": {
+          "$ref": "#/$defs/package_names"
+        }
+      }
+    },
+    "diff_selection_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "domain",
+        "outcome",
+        "input",
+        "result"
+      ],
+      "properties": {
+        "domain": {
+          "const": "diff_selection"
+        },
+        "outcome": {
+          "enum": [
+            "ok",
+            "error",
+            "unsupported",
+            "skipped"
+          ]
+        },
+        "input": {
+          "$ref": "#/$defs/diff_selection_input"
+        },
+        "result": {
+          "type": "object"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "const": "ok"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "result": {
+                "$ref": "#/$defs/diff_selection_result"
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "result": {
+                "$ref": "#/$defs/empty_result"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "dependency_digest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "package",
+        "digest"
+      ],
+      "properties": {
+        "package": {
+          "$ref": "#/$defs/package_name"
+        },
+        "digest": {
+          "$ref": "#/$defs/digest"
+        }
+      }
+    },
+    "hashing_cache_input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operation",
+        "options"
+      ],
+      "properties": {
+        "operation": {
+          "const": "hashing_cache"
+        },
+        "options": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "algorithm",
+            "package",
+            "include_paths",
+            "dependency_digests",
+            "dependents",
+            "prior_cache"
+          ],
+          "properties": {
+            "algorithm": {
+              "const": "sha256-v1"
+            },
+            "package": {
+              "$ref": "#/$defs/package_name"
+            },
+            "include_paths": {
+              "type": "array",
+              "maxItems": 4096,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/safe_path"
+              }
+            },
+            "dependency_digests": {
+              "type": "array",
+              "maxItems": 4096,
+              "items": {
+                "$ref": "#/$defs/dependency_digest"
+              }
+            },
+            "dependents": {
+              "$ref": "#/$defs/package_names"
+            },
+            "prior_cache": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "state"
+              ],
+              "properties": {
+                "state": {
+                  "enum": [
+                    "missing",
+                    "record"
+                  ]
+                },
+                "content_utf8": {
+                  "type": "string",
+                  "maxLength": 1048576
+                }
+              },
+              "allOf": [
+                {
+                  "if": {
+                    "properties": {
+                      "state": {
+                        "const": "record"
+                      }
+                    }
+                  },
+                  "then": {
+                    "required": [
+                      "content_utf8"
+                    ]
+                  },
+                  "else": {
+                    "not": {
+                      "required": [
+                        "content_utf8"
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "hashing_cache_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "package_digest",
+        "dependencies_digest",
+        "combined_digest",
+        "cache_status",
+        "invalidated_packages"
+      ],
+      "properties": {
+        "package_digest": {
+          "$ref": "#/$defs/digest"
+        },
+        "dependencies_digest": {
+          "$ref": "#/$defs/digest"
+        },
+        "combined_digest": {
+          "$ref": "#/$defs/digest"
+        },
+        "cache_status": {
+          "enum": [
+            "hit",
+            "miss",
+            "recovered"
+          ]
+        },
+        "invalidated_packages": {
+          "$ref": "#/$defs/package_names"
+        }
+      }
+    },
+    "hashing_cache_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "domain",
+        "outcome",
+        "input",
+        "result"
+      ],
+      "properties": {
+        "domain": {
+          "const": "hashing_cache"
+        },
+        "outcome": {
+          "enum": [
+            "ok",
+            "error",
+            "unsupported",
+            "skipped"
+          ]
+        },
+        "input": {
+          "$ref": "#/$defs/hashing_cache_input"
+        },
+        "result": {
+          "type": "object"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "const": "ok"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "result": {
+                "$ref": "#/$defs/hashing_cache_result"
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "result": {
+                "$ref": "#/$defs/empty_result"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "starlark_context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "version",
+        "os",
+        "arch",
+        "cpu_count",
+        "ci"
+      ],
+      "properties": {
+        "version": {
+          "const": 1
+        },
+        "os": {
+          "enum": [
+            "darwin",
+            "linux",
+            "windows"
+          ]
+        },
+        "arch": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9_-]*$",
+          "maxLength": 32
+        },
+        "cpu_count": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1024
+        },
+        "ci": {
+          "type": "boolean"
+        }
+      }
+    },
+    "starlark_input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operation",
+        "options"
+      ],
+      "properties": {
+        "operation": {
+          "const": "starlark"
+        },
+        "options": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "entrypoint",
+            "context",
+            "legacy_fallback"
+          ],
+          "properties": {
+            "entrypoint": {
+              "$ref": "#/$defs/safe_path"
+            },
+            "context": {
+              "$ref": "#/$defs/starlark_context"
+            },
+            "legacy_fallback": {
+              "enum": [
+                "generate_commands",
+                "error"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "structured_command": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "program",
+        "args"
+      ],
+      "properties": {
+        "type": {
+          "const": "cmd"
+        },
+        "program": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9._+-]+$",
+          "maxLength": 128
+        },
+        "args": {
+          "type": "array",
+          "maxItems": 256,
+          "items": {
+            "type": "string",
+            "maxLength": 4096
+          }
+        }
+      }
+    },
+    "starlark_target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "rule",
+        "name",
+        "srcs",
+        "deps",
+        "commands",
+        "rendered_commands",
+        "command_source"
+      ],
+      "properties": {
+        "rule": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "maxLength": 96
+        },
+        "name": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+          "maxLength": 160
+        },
+        "srcs": {
+          "type": "array",
+          "maxItems": 4096,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/safe_path"
+          }
+        },
+        "deps": {
+          "$ref": "#/$defs/package_names"
+        },
+        "commands": {
+          "type": "array",
+          "maxItems": 4096,
+          "items": {
+            "$ref": "#/$defs/structured_command"
+          }
+        },
+        "rendered_commands": {
+          "type": "array",
+          "maxItems": 4096,
+          "items": {
+            "type": "string",
+            "maxLength": 16384
+          }
+        },
+        "command_source": {
+          "enum": [
+            "structured",
+            "legacy_fallback"
+          ]
+        }
+      }
+    },
+    "starlark_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "targets"
+      ],
+      "properties": {
+        "targets": {
+          "type": "array",
+          "maxItems": 4096,
+          "items": {
+            "$ref": "#/$defs/starlark_target"
+          }
+        }
+      }
+    },
+    "starlark_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "domain",
+        "outcome",
+        "input",
+        "result"
+      ],
+      "properties": {
+        "domain": {
+          "const": "starlark"
+        },
+        "outcome": {
+          "enum": [
+            "ok",
+            "error",
+            "unsupported",
+            "skipped"
+          ]
+        },
+        "input": {
+          "$ref": "#/$defs/starlark_input"
+        },
+        "result": {
+          "type": "object"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "const": "ok"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "result": {
+                "$ref": "#/$defs/starlark_result"
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "result": {
+                "$ref": "#/$defs/empty_result"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "shard_package": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "language",
+        "build_command_count"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/package_name"
+        },
+        "language": {
+          "$ref": "#/$defs/language"
+        },
+        "build_command_count": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 1000000
+        }
+      }
+    },
+    "sharding_input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operation",
+        "options"
+      ],
+      "properties": {
+        "operation": {
+          "const": "sharding"
+        },
+        "options": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "packages",
+            "edges",
+            "scheduled_packages",
+            "shard_count"
+          ],
+          "properties": {
+            "packages": {
+              "type": "array",
+              "maxItems": 4096,
+              "items": {
+                "$ref": "#/$defs/shard_package"
+              }
+            },
+            "edges": {
+              "type": "array",
+              "maxItems": 16384,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/edge"
+              }
+            },
+            "scheduled_packages": {
+              "$ref": "#/$defs/package_names"
+            },
+            "shard_count": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 64
+            },
+            "shard_index": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 63
+            }
+          }
+        }
+      }
+    },
+    "shard": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "index",
+        "name",
+        "assigned_packages",
+        "package_names",
+        "toolchains",
+        "estimated_cost"
+      ],
+      "properties": {
+        "index": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 63
+        },
+        "name": {
+          "type": "string",
+          "pattern": "^shard-[1-9][0-9]*-of-[1-9][0-9]*$",
+          "maxLength": 64
+        },
+        "assigned_packages": {
+          "$ref": "#/$defs/package_names"
+        },
+        "package_names": {
+          "$ref": "#/$defs/package_names"
+        },
+        "toolchains": {
+          "type": "array",
+          "maxItems": 16,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/toolchain"
+          }
+        },
+        "estimated_cost": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991
+        }
+      }
+    },
+    "sharding_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "shards"
+      ],
+      "properties": {
+        "shards": {
+          "type": "array",
+          "maxItems": 64,
+          "items": {
+            "$ref": "#/$defs/shard"
+          }
+        }
+      }
+    },
+    "sharding_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "domain",
+        "outcome",
+        "input",
+        "result"
+      ],
+      "properties": {
+        "domain": {
+          "const": "sharding"
+        },
+        "outcome": {
+          "enum": [
+            "ok",
+            "error",
+            "unsupported",
+            "skipped"
+          ]
+        },
+        "input": {
+          "$ref": "#/$defs/sharding_input"
+        },
+        "result": {
+          "type": "object"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "const": "ok"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "result": {
+                "$ref": "#/$defs/sharding_result"
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "result": {
+                "$ref": "#/$defs/empty_result"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "validation_check": {
+      "enum": [
+        "build_file_presence",
+        "declared_dependencies",
+        "standalone_prerequisites",
+        "starlark_declarations",
+        "identity",
+        "toolchain_support",
+        "path_safety"
+      ]
+    },
+    "validation_diagnostic_code": {
+      "enum": [
+        "BUILD_FILE_MISSING",
+        "BUILD_FILE_EMPTY",
+        "LOCAL_DEPENDENCY_UNDECLARED",
+        "STANDALONE_PREREQUISITE_MISSING",
+        "STARLARK_SOURCE_INVALID",
+        "STARLARK_DEPENDENCY_INVALID",
+        "IDENTITY_AMBIGUOUS",
+        "MANIFEST_AMBIGUOUS",
+        "TOOLCHAIN_UNSUPPORTED",
+        "PATH_UNSAFE"
+      ]
+    },
+    "validation_package": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "rel_path",
+        "language",
+        "build_file_state",
+        "build_references",
+        "is_starlark",
+        "declared_srcs",
+        "declared_deps"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/package_name"
+        },
+        "rel_path": {
+          "$ref": "#/$defs/safe_path"
+        },
+        "language": {
+          "$ref": "#/$defs/language"
+        },
+        "build_file_state": {
+          "enum": [
+            "present",
+            "empty",
+            "missing"
+          ]
+        },
+        "build_references": {
+          "type": "array",
+          "maxItems": 4096,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/package_name"
+          }
+        },
+        "is_starlark": {
+          "type": "boolean"
+        },
+        "declared_srcs": {
+          "type": "array",
+          "maxItems": 4096,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/portable_glob"
+          }
+        },
+        "declared_deps": {
+          "$ref": "#/$defs/package_names"
+        }
+      }
+    },
+    "validation_input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operation",
+        "options"
+      ],
+      "properties": {
+        "operation": {
+          "const": "validation"
+        },
+        "options": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "platform",
+            "checks",
+            "packages",
+            "dependency_edges"
+          ],
+          "properties": {
+            "platform": {
+              "enum": [
+                "darwin",
+                "linux",
+                "windows"
+              ]
+            },
+            "checks": {
+              "type": "array",
+              "minItems": 1,
+              "maxItems": 8,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/validation_check"
+              }
+            },
+            "packages": {
+              "type": "array",
+              "maxItems": 4096,
+              "items": {
+                "$ref": "#/$defs/validation_package"
+              }
+            },
+            "dependency_edges": {
+              "type": "array",
+              "maxItems": 16384,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/edge"
+              }
+            }
+          }
+        }
+      }
+    },
+    "validation_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "valid",
+        "diagnostic_codes"
+      ],
+      "properties": {
+        "valid": {
+          "type": "boolean"
+        },
+        "diagnostic_codes": {
+          "type": "array",
+          "maxItems": 4096,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/validation_diagnostic_code"
+          }
+        }
+      }
+    },
+    "validation_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "domain",
+        "outcome",
+        "input",
+        "result"
+      ],
+      "properties": {
+        "domain": {
+          "const": "validation"
+        },
+        "outcome": {
+          "enum": [
+            "ok",
+            "error",
+            "unsupported",
+            "skipped"
+          ]
+        },
+        "input": {
+          "$ref": "#/$defs/validation_input"
+        },
+        "result": {
+          "type": "object"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "enum": [
+                  "ok",
+                  "error"
+                ]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "result": {
+                "$ref": "#/$defs/validation_result"
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "result": {
+                "$ref": "#/$defs/empty_result"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "toolchain": {
+      "enum": [
+        "cpp",
+        "dart",
+        "dotnet",
+        "elixir",
+        "go",
+        "haskell",
+        "java",
+        "kotlin",
+        "lua",
+        "ocaml",
+        "perl",
+        "python",
+        "ruby",
+        "rust",
+        "swift",
+        "typescript"
+      ]
+    },
+    "toolchain_package": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "language"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/package_name"
+        },
+        "language": {
+          "$ref": "#/$defs/language"
+        }
+      }
+    },
+    "toolchain_detection_input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operation",
+        "options"
+      ],
+      "properties": {
+        "operation": {
+          "const": "toolchain_detection"
+        },
+        "options": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "packages",
+            "scheduled_packages",
+            "forced_toolchains"
+          ],
+          "properties": {
+            "packages": {
+              "type": "array",
+              "maxItems": 4096,
+              "items": {
+                "$ref": "#/$defs/toolchain_package"
+              }
+            },
+            "scheduled_packages": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/$defs/package_names"
+                }
+              ]
+            },
+            "forced_toolchains": {
+              "type": "array",
+              "maxItems": 16,
+              "uniqueItems": true,
+              "items": {
+                "$ref": "#/$defs/toolchain"
+              }
+            }
+          }
+        }
+      }
+    },
+    "toolchain_map": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "cpp",
+        "dart",
+        "dotnet",
+        "elixir",
+        "go",
+        "haskell",
+        "java",
+        "kotlin",
+        "lua",
+        "ocaml",
+        "perl",
+        "python",
+        "ruby",
+        "rust",
+        "swift",
+        "typescript"
+      ],
+      "properties": {
+        "cpp": {
+          "type": "boolean"
+        },
+        "dart": {
+          "type": "boolean"
+        },
+        "dotnet": {
+          "type": "boolean"
+        },
+        "elixir": {
+          "type": "boolean"
+        },
+        "go": {
+          "type": "boolean"
+        },
+        "haskell": {
+          "type": "boolean"
+        },
+        "java": {
+          "type": "boolean"
+        },
+        "kotlin": {
+          "type": "boolean"
+        },
+        "lua": {
+          "type": "boolean"
+        },
+        "ocaml": {
+          "type": "boolean"
+        },
+        "perl": {
+          "type": "boolean"
+        },
+        "python": {
+          "type": "boolean"
+        },
+        "ruby": {
+          "type": "boolean"
+        },
+        "rust": {
+          "type": "boolean"
+        },
+        "swift": {
+          "type": "boolean"
+        },
+        "typescript": {
+          "type": "boolean"
+        }
+      }
+    },
+    "toolchain_detection_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "toolchains"
+      ],
+      "properties": {
+        "toolchains": {
+          "$ref": "#/$defs/toolchain_map"
+        }
+      }
+    },
+    "toolchain_detection_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "domain",
+        "outcome",
+        "input",
+        "result"
+      ],
+      "properties": {
+        "domain": {
+          "const": "toolchain_detection"
+        },
+        "outcome": {
+          "enum": [
+            "ok",
+            "error",
+            "unsupported",
+            "skipped"
+          ]
+        },
+        "input": {
+          "$ref": "#/$defs/toolchain_detection_input"
+        },
+        "result": {
+          "type": "object"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "const": "ok"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "result": {
+                "$ref": "#/$defs/toolchain_detection_result"
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "result": {
+                "$ref": "#/$defs/empty_result"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "cli_input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operation",
+        "options"
+      ],
+      "properties": {
+        "operation": {
+          "const": "cli"
+        },
+        "options": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "action",
+            "condition",
+            "requires_execution"
+          ],
+          "properties": {
+            "action": {
+              "enum": [
+                "build",
+                "validate",
+                "dry_run",
+                "emit_plan"
+              ]
+            },
+            "condition": {
+              "enum": [
+                "success",
+                "package_failure",
+                "validation_failure",
+                "invalid_usage",
+                "unsafe_input"
+              ]
+            },
+            "requires_execution": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "cli_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "exit_code"
+      ],
+      "properties": {
+        "exit_code": {
+          "enum": [
+            0,
+            1,
+            2
+          ]
+        }
+      }
+    },
+    "cli_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "domain",
+        "outcome",
+        "input",
+        "result"
+      ],
+      "properties": {
+        "domain": {
+          "const": "cli"
+        },
+        "outcome": {
+          "enum": [
+            "ok",
+            "error"
+          ]
+        },
+        "input": {
+          "$ref": "#/$defs/cli_input"
+        },
+        "result": {
+          "$ref": "#/$defs/cli_result"
+        }
+      }
+    }
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/result.schema.json
+++ b/code/specs/fixtures/build-tool-v1/result.schema.json
@@ -213,7 +213,7 @@
     },
     "package_name": {
       "type": "string",
-      "pattern": "^[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._/-]*$",
+      "pattern": "^[a-z0-9][a-z0-9._-]*(/[a-z0-9][a-z0-9._-]*)+$",
       "maxLength": 240
     },
     "edge": {

--- a/code/specs/fixtures/build-tool-v1/schema.json
+++ b/code/specs/fixtures/build-tool-v1/schema.json
@@ -338,7 +338,7 @@
     },
     "package_name": {
       "type": "string",
-      "pattern": "^[a-z0-9][a-z0-9._-]*/[a-z0-9][a-z0-9._/-]*$",
+      "pattern": "^[a-z0-9][a-z0-9._-]*(/[a-z0-9][a-z0-9._-]*)+$",
       "maxLength": 240
     },
     "edge": {

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -908,10 +908,14 @@ Delivery order:
 2. Add a cross-implementation runner. The runner may orchestrate processes in
    Python, but the fixtures and canonical JSON are the behavior oracle. Start
    with non-execution domains and fail closed on every execution case.
+   Completed by PR #9157 with the process-free bootstrap runner, implementation
+   inventory, and closed discovery, resolution, graph, and plan corpus.
 3. Expand the bootstrap's closed input/result schemas and positive plus
    adversarial corpus from discovery, resolution, graph, and plan into the
    remaining non-execution domains: diff selection, hashing/cache, Starlark,
-   sharding, validation, toolchain detection, and CLI.
+   sharding, validation, toolchain detection, and CLI. This is the current
+   selected tranche because it unlocks every implementation workstream without
+   entering the trusted-execution boundary.
 4. Add the trusted-execution sandbox and adversarial execution corpus. No
    repository command may run until filesystem and network isolation,
    no-follow path handling, sanitized environments, direct argv, and hard

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -917,7 +917,7 @@ Delivery order:
    tranche now provides a 30-case, 11-domain process-free corpus, including
    conservative unknown-path handling, typed cache states, inline-only
    Starlark loads, prerequisite-closed shard verification, the OCaml-aware
-   toolchain registry, and fail-closed semantic validation.
+   toolchain registry, and fail-closed BUILD-file validation.
 4. Add the trusted-execution sandbox and adversarial execution corpus. No
    repository command may run until filesystem and network isolation,
    no-follow path handling, sanitized environments, direct argv, and hard
@@ -935,7 +935,7 @@ Delivery order:
 10. Gate completion in CI: every supported implementation runs the same
    conformance corpus on its applicable operating systems.
 
-The pure-domain security review also discovered two follow-on gates that must
+The pure-domain security review also discovered three follow-on gates that must
 land before final adapter parity:
 
 - define a common inert CLI argv grammar and typed parse-result corpus; the
@@ -943,6 +943,9 @@ land before final adapter parity:
 - add adversarial Starlark metering fixtures for fuel, recursion, allocation,
   load depth/count/cycles, and diagnostic output before any native evaluator
   can claim final Starlark conformance.
+- model deterministic inline inputs and semantic oracles for dependency,
+  standalone-prerequisite, Starlark-declaration, identity, toolchain, and path
+  validation checks before admitting them to the closed v1 schema.
 
 ## Cross-Cutting Stream B: Introduce OCaml Safely
 

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -913,9 +913,11 @@ Delivery order:
 3. Expand the bootstrap's closed input/result schemas and positive plus
    adversarial corpus from discovery, resolution, graph, and plan into the
    remaining non-execution domains: diff selection, hashing/cache, Starlark,
-   sharding, validation, toolchain detection, and CLI. This is the current
-   selected tranche because it unlocks every implementation workstream without
-   entering the trusted-execution boundary.
+   sharding, validation, toolchain detection, and CLI. The current selected
+   tranche now provides a 30-case, 11-domain process-free corpus, including
+   conservative unknown-path handling, typed cache states, inline-only
+   Starlark loads, prerequisite-closed shard verification, the OCaml-aware
+   toolchain registry, and fail-closed semantic validation.
 4. Add the trusted-execution sandbox and adversarial execution corpus. No
    repository command may run until filesystem and network isolation,
    no-follow path handling, sanitized environments, direct argv, and hard
@@ -932,6 +934,15 @@ Delivery order:
    either emerging lane graduates.
 10. Gate completion in CI: every supported implementation runs the same
    conformance corpus on its applicable operating systems.
+
+The pure-domain security review also discovered two follow-on gates that must
+land before final adapter parity:
+
+- define a common inert CLI argv grammar and typed parse-result corpus; the
+  current process-free CLI cases intentionally classify exit decisions only;
+- add adversarial Starlark metering fixtures for fuel, recursion, allocation,
+  load depth/count/cycles, and diagnostic output before any native evaluator
+  can claim final Starlark conformance.
 
 ## Cross-Cutting Stream B: Introduce OCaml Safely
 


### PR DESCRIPTION
## Summary

- expand the shared build-tool corpus from 7 cases / 4 domains to 30 cases across all 11 process-free v1 domains
- add a closed pure-domain schema and semantic oracles for diff selection, hashing/cache, inline Starlark loads, sharding, BUILD-file validation, toolchain detection (including OCaml), and CLI exit decisions
- keep the bootstrap process-free and zero-materialization while rejecting graph cycles, host-escaping loads, executable fixtures, unknown paths, malformed cache states, and result-side semantic drift
- record follow-up gates for inert CLI argv parsing, adversarial Starlark metering, and the six validation families that remain outside the closed v1 schema until they have deterministic input-to-diagnostic oracles

## Security boundary

- no adapters, shells, Git commands, network access, host environment reads, or fixture commands are invoked by corpus validation
- pure fixtures cannot request executable files or execution-capable CLI actions
- Starlark loads are parsed as top-level statements, resolved only from inline bytes, and cannot escape the repository root
- dependency graphs must be acyclic; cache records are typed; unknown diff paths conservatively select all or fail

## Validation

- `python -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_schema.py'` — 17 passed
- `python -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_runner.py'` — 40 passed
- `python code/scripts/build_tool_conformance.py validate-corpus` — 30 cases, 11 domains, valid
- branch coverage for `build_tool_conformance.py` — 86%
- Ruff lint and format checks — passed
- Python compileall — passed
- Bandit — passed
- local `pip-audit` — no known vulnerabilities
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` — 1,184 implementation identities, 4,325 slots, 15 established lanes, 0 collisions, 0 unknown buckets
- `git diff --check origin/main...HEAD` — passed

Rebased and revalidated on `origin/main` at `3201fb42078f40ef27f11aefb5e3b4b1bcf8551e`.