### PR TITLE
fix(spice): validate MOS surface-state density

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject negative or non-finite Level-1 MOS model-card `NSS` surface-state
+  densities with a stable diagnostic before threshold preprocessing.
 - Accept Berkeley Level-1 MOS model-card `TPG` gate-material selectors and use
   their `-1`, `0`, or `1` work-function branches when deriving `VT0`, while
   preserving explicit threshold-voltage precedence.

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -568,6 +568,8 @@ def normalize_model_card(
             normalized[canonical] = 1.0
         elif canonical == "TPG" and value not in {-1.0, 0.0, 1.0}:
             raise ValueError(f"{name}: MOSFET TPG must be -1, 0, or 1")
+        elif canonical == "NSS" and (not math.isfinite(value) or value < 0.0):
+            raise ValueError(f"{name}: MOSFET NSS must be finite and non-negative")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -993,6 +993,12 @@ def test_mos_model_card_gate_material_shifts_process_derived_threshold() -> None
     with pytest.raises(ValueError, match="MOSFET TPG must be -1, 0, or 1"):
         normalize_model_card("Minvalid", "nmos", {"TPG": 0.5})
 
+    for invalid_nss in (-1.0, math.inf, math.nan):
+        with pytest.raises(
+            ValueError, match="MOSFET NSS must be finite and non-negative"
+        ):
+            normalize_model_card("Minvalid", "nmos", {"NSS": invalid_nss})
+
 
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject negative or non-finite Level-1 MOS model-card `NSS` surface-state
+  densities with a stable diagnostic before threshold preprocessing.
 - Accept Berkeley Level-1 MOS model-card `TPG` gate-material selectors and use
   their `-1`, `0`, or `1` work-function branches when deriving `VT0`, while
   preserving explicit threshold-voltage precedence.

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4350,6 +4350,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET TPG must be -1, 0, or 1".to_string(),
                 });
+            } else if canonical == "NSS" && (!raw_value.is_finite() || *raw_value < 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET NSS must be finite and non-negative".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -780,6 +780,14 @@ fn mos_model_card_gate_material_shifts_process_derived_threshold() {
         Err(SpiceError::InvalidElement { reason, .. })
             if reason == "MOSFET TPG must be -1, 0, or 1"
     ));
+
+    for invalid_nss in [-1.0, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("NSS", invalid_nss)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET NSS must be finite and non-negative"
+        ));
+    }
 }
 
 #[test]

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject negative or non-finite Level-1 MOS model-card `NSS` surface-state
+  densities with a stable diagnostic before threshold preprocessing.
 - Accept Berkeley Level-1 MOS model-card `TPG` gate-material selectors and use
   their `-1`, `0`, or `1` work-function branches when deriving `VT0`, while
   preserving explicit threshold-voltage precedence.

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8430,6 +8430,8 @@ export function normalizeModelCard(
       normalized[canonical] = 1.0;
     } else if (canonical === "TPG" && value !== -1.0 && value !== 0.0 && value !== 1.0) {
       throw invalidElement(name, "MOSFET TPG must be -1, 0, or 1");
+    } else if (canonical === "NSS" && (!Number.isFinite(value) || value < 0.0)) {
+      throw invalidElement(name, "MOSFET NSS must be finite and non-negative");
     } else {
       normalized[canonical] = value;
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -660,6 +660,12 @@ describe("dcOp", () => {
     expect(() => normalizeModelCard("Minvalid", "nmos", { TPG: 0.5 })).toThrow(
       "MOSFET TPG must be -1, 0, or 1",
     );
+
+    for (const invalidNss of [-1.0, Number.POSITIVE_INFINITY, Number.NaN]) {
+      expect(() => normalizeModelCard("Minvalid", "nmos", { NSS: invalidNss })).toThrow(
+        "MOSFET NSS must be finite and non-negative",
+      );
+    }
   });
 
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS gate material.
+1. Cross-language Level-1 MOS surface-state density validation.
    - Status: current PR completion candidate.
-   - Accept Berkeley model-card `TPG` values `-1`, `0`, and `1` and include the
-     selected gate work function when deriving `VT0` from `NSUB` plus `TOX`.
-   - Preserve explicit `VTO` / `VT0` precedence and stable parameter coverage.
-   - Keep Rust, Python, and TypeScript model lowering, tests, and docs aligned.
+   - Reject negative or non-finite model-card `NSS` values before process
+     parameter preprocessing, including when explicit `VTO` / `VT0` is present.
+   - Preserve zero and positive surface-state densities and stable parameter
+     coverage across Rust, Python, and TypeScript.
 
 ## Completed Slices
 
@@ -3629,6 +3629,13 @@ the Rust, Python, and TypeScript surfaces together.
      when `VT0` is derived from `NSUB` plus `TOX`.
    - Explicit `VTO` / `VT0` precedence, normalized parameter coverage, and
      matching NMOS/PMOS behavior are preserved across all three languages.
+
+293. Cross-language Level-1 MOS gate material.
+   - Status: completed in PR 9165.
+   - Model-card `TPG` values `-1`, `0`, and `1` select the Berkeley MOS1 gate
+     work-function branch used to derive `VT0` from `NSUB` plus `TOX`.
+   - Explicit threshold precedence, `NSS` composition, parameter coverage, and
+     NMOS/PMOS parity are preserved across Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite Berkeley MOS1 `NSS` values during model-card normalization
- keep Rust, Python, and TypeScript diagnostics and regression coverage aligned
- advance the SPICE completion plan past merged gate-material support

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- `PYTHONPATH=$(printf '%s:' ../*/src) python3.12 -m ruff check src tests`\n- `PYTHONPATH=$(printf '%s:' ../*/src) python3.12 -m pytest -q` (675 passed)\n- `npm ci`\n- `npm test` (418 passed)\n- `npm run build`