### PR TITLE
feat(adj-formula-stdlib): mass density — NIST SP 811 B.9 g/cm³→kg/m³ table (b33, RS-5, new dimension)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -1473,6 +1473,49 @@ fn shipped_temperature_interval_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// (b33) The shipped NIST SP 811 B.9 mass-density → kilogram-per-cubic-metre table resolves the exact
+//       gram-per-cubic-centimetre factor with its citation, and ABSTAINS on a wrong-dimension unit.
+//       This opens a NEW dimension — MASS DENSITY (mass per unit VOLUME) — beyond the length/mass/…/
+//       linear-mass-density/temperature-interval and electric families. One gram per cubic centimetre
+//       is exactly 1000 kg/m³ (the metric units relate by exact powers of ten). The gram per cubic
+//       centimetre (mass density → kg/m³) and the pound (plain mass → kg) are DIFFERENT quantities
+//       converting to DIFFERENT SI units (kg/m³ vs kg), so the abstain guards the mass-versus-mass-
+//       per-volume confusion (dropping the "per cubic metre") directly, not mere absence of a value.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_mass_density_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_massdensity");
+    let src = stdlib().join("reference/mass-density-conversions.adj");
+    std::fs::copy(&src, dir.join("mass-density-conversions.adj"))
+        .expect("copy shipped mass-density-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"mass-density-conversions.adj\"\n\
+         ? mass_density_to_kilogram_per_cubic_metre(gram_per_cubic_centimetre, $v)\n\
+         ? mass_density_to_kilogram_per_cubic_metre(pound, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 exact factor resolves, character-for-character from the table
+    // (boldface = exact; one gram per cubic centimetre is exactly 1 E+03 kilograms per cubic metre).
+    assert!(out.contains("\"v\":\"1000\""), "gram per cubic centimetre = 1 E+03 kg/m^3: {out}");
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `pound` is a MASS unit (it converts to the kilogram, a DIFFERENT quantity), so this mass-density
+    // table has no row for it — the engine abstains rather than mis-converting a mass unit as if it
+    // were a mass-per-volume unit.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a wrong-dimension unit abstains, never a cross-dimension fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/mass-density-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/mass-density-conversions.adj
@@ -1,0 +1,60 @@
+% ============================================================================
+% mass-density-conversions — mass-density-unit → kilogram-per-cubic-metre factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of the NIST-cited conversion tables (length, mass, area, volume, energy, the
+% electric-EMU family, wave number, linear mass density, temperature interval, and the rest): a native
+% tabular relation ingested VERBATIM from a published NIST conversion table. The row states the factor
+% converting the common metric unit of MASS DENSITY (mass per unit VOLUME) to the SI coherent derived
+% unit, the kilogram per cubic metre (kg/m³):
+%
+%     ? mass_density_to_kilogram_per_cubic_metre(gram_per_cubic_centimetre, $v)   % 1000
+%
+% This opens a NEW dimension — MASS DENSITY (a.k.a. volumetric mass density: the mass per unit volume
+% of a substance) — alongside the already-tabulated length/mass/area/volume/time/speed/energy/
+% pressure/force/acceleration/dynamic-viscosity/kinematic-viscosity/magnetic-flux-density/magnetic-
+% flux/illuminance/luminance/radioactivity/absorbed-dose/dose-equivalent/exposure/power/wave-number/
+% linear-mass-density/temperature-interval tables and the electric charge/potential/resistance/
+% capacitance/inductance/conductance/current tables. The gram per cubic centimetre is the everyday
+% laboratory density unit (water is ~1 g/cm³); one gram per cubic centimetre is exactly 1000 kilograms
+% per cubic metre. Do NOT confuse MASS DENSITY (mass per VOLUME → the kilogram per cubic metre, kg/m³)
+% with plain MASS (the kilogram, kg) or with LINEAR MASS DENSITY (mass per LENGTH → the kilogram per
+% metre, kg/m, the tex's dimension): those are DIFFERENT quantities that convert to DIFFERENT SI units.
+% A quantity given in g/cm³ must be put into SI first, then reasoned over (write-once-use-many). Why a
+% `table` and not a hand-written `relate` clause: this is exactly the shape reference data comes in —
+% a published table, not prose. The citable artifact IS the NIST conversion-factors table at the
+% `locator` below; the factor here is a CELL of NIST Special Publication 811, Appendix B.9, defended by
+% one provenance envelope. Each `row` lowers to a ground relation
+% `mass_density_to_kilogram_per_cubic_metre(unit, v)`, so the exact lookup above is the ordinary SLD
+% binding query — the engine returns the factor WITH this table's citation as its proof, on the CPU,
+% with zero model calls.
+%
+% HONESTY NOTE (like every other NIST table, only the EXACT defined factor gets a row): NIST SP 811
+% B.9 prints the "gram per cubic centimeter" density factor in BOLDFACE, its convention for factors
+% that are EXACT by definition, transcribed here as the plain decimal number of kilograms per cubic
+% metre it names:
+%
+%     gram per cubic centimeter (g/cm³)   1.0 E+03  →  1000
+%
+% This is exact because the metric definitions relate the gram/centimetre to the kilogram/metre by
+% exact powers of ten: 1 g/cm³ = (10⁻³ kg)/(10⁻² m)³ = 10⁻³/10⁻⁶ kg/m³ = 10³ kg/m³. It terminates;
+% nothing here is a rounded measurement. This table is SPECIFIC to mass density: a unit of a DIFFERENT
+% quantity — e.g. the "pound", which NIST SP 811 B.9 lists separately as a MASS unit converting to the
+% kilogram, NOT the kilogram per cubic metre — therefore gets no row here, and a
+% `? mass_density_to_kilogram_per_cubic_metre(pound, $v)` ABSTAINS rather than mis-converting a mass
+% unit as if it were a mass-per-volume unit (dropping the "per cubic metre"). The only claim this table
+% makes is "this is the exact factor NIST SP 811 B.9 prints for the gram per cubic centimetre's
+% conversion to the kilogram per cubic metre" — which is exactly what a byte-check against the cited
+% table verifies. `trust authoritative` — a primary, re-fetchable standards reference. (See
+% ADJ-TABLES.md; and feedback_nothing_human_authored — the factor is a verbatim cell of the cited
+% table, nothing asserted from memory.)
+% ============================================================================
+
+table mass_density_to_kilogram_per_cubic_metre {
+    columns unit, kilogram_per_cubic_metre
+
+    row (gram_per_cubic_centimetre, 1000)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/mass-density-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/mass-density-conversions.query.adj
@@ -1,0 +1,26 @@
+% ============================================================================
+% mass-density-conversions.query.adj — worked lookups over the NIST mass-density → kilogram-per-cubic-
+% metre table.
+% ============================================================================
+% The shape a consumer produces to convert a mass density given in the everyday metric unit into SI:
+% it `import`s the grounded table and asks the engine to bind the factor. No arithmetic and no factor
+% is stated by the consumer; the engine returns the cell WITH the table's NIST citation as its proof,
+% on the CPU.
+%
+%   ? mass_density_to_kilogram_per_cubic_metre(gram_per_cubic_centimetre, $v)   % 1000
+%
+% And the dimension guard: a unit of a DIFFERENT quantity has no row, so the lookup ABSTAINS rather
+% than mis-converting across dimensions. The "pound" is a MASS unit (it converts to the kilogram), NOT
+% a mass-density unit — so dropping the "per cubic metre" that separates mass from mass-per-volume is
+% caught rather than silently mis-converted:
+%
+%   ? mass_density_to_kilogram_per_cubic_metre(pound, $v)   % abstains (pound is mass → kilogram)
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli mass-density-conversions.query.adj
+% ============================================================================
+
+import "mass-density-conversions.adj"
+
+? mass_density_to_kilogram_per_cubic_metre(gram_per_cubic_centimetre, $v)   % expect 1000     (exact NIST SP 811 B.9 factor)
+? mass_density_to_kilogram_per_cubic_metre(pound, $v)                       % expect abstain  (mass unit, wrong dimension)


### PR DESCRIPTION
## What

Ships a new grounded NIST SP 811 B.9 conversion table opening a **NEW dimension — MASS DENSITY** (mass per unit volume) in the ADJ formula stdlib:

- `code/specs/data/adj-formula-stdlib/reference/mass-density-conversions.adj` — a native RS-5 `table` with the exact row **gram per cubic centimetre → kilogram per cubic metre = 1000** (1.0 E+03).
- `…/reference/mass-density-conversions.query.adj` — a worked exact-lookup + a dimension-guard abstain.
- `code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs` — appends the **b33** e2e block (37 → 38 tests).

## Grounding

The factor is a verbatim BOLDFACE (= exact) cell of NIST Special Publication 811, Appendix B.9:

> gram per cubic centimeter (g/cm3)   1.0 E+03

locator `https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9`, `trust authoritative`. One gram per cubic centimetre is exactly 1000 kg/m³ — the metric units relate by exact powers of ten (1 g/cm³ = 10⁻³ kg / (10⁻² m)³ = 10³ kg/m³).

## Dimension safety

`? mass_density_to_kilogram_per_cubic_metre(gram_per_cubic_centimetre, $v)` binds `1000` with the NIST citation as proof. A wrong-dimension probe — the **pound** (a plain MASS unit → kilogram) — **abstains** (`"abstained":true`) rather than mis-converting a mass as a mass-per-volume (guarding the dropped "per cubic metre"; distinct from both plain mass kg and the tex's linear mass density kg/m).

## Verification

- `cargo test -p adj-lang-cli --test rs5_table_e2e` → 38 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean.
- Render-probe confirms `"v":"1000"` for g/cm³ + `"abstained":true` for the pound + the NIST locator.
- NUL-scan clean. Security review: clean (no vulnerabilities) — conducted inline this run because the review sub-agent was unavailable due to a sustained upstream 529 outage.

Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)