### PR TITLE
feat(adj-formula-stdlib): Apgar score — StatPearls sum-of-five-signs neonatal score library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_apgar_score_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_apgar_score_e2e.rs
@@ -1,0 +1,150 @@
+//! End-to-end tests for the `clinical/apgar-score.adj` library — the Apgar-score relation
+//! (Apgar = appearance + pulse + grimace + activity + respiration) and two representative
+//! rearrangements — driven through the built CLI binary against the SHIPPED stdlib. The same
+//! invariant as every other formula library: a consumer states NO arithmetic; it imports the grounded
+//! library, binds the five component scores with `observe`, and the engine applies the cited
+//! definition on the CPU, computing the EXACT value and rendering the definition's citation and trust
+//! tier in the `derived` section (the auditable answer). The formulas INVERT around the worked case
+//! appearance = 2, pulse = 2, grimace = 2, activity = 1, respiration = 1: 2 + 2 + 2 + 1 + 1 = 8
+//! (Apgar), 8 − 2 − 2 − 2 − 1 = 1 (activity), 8 − 2 − 2 − 1 − 1 = 2 (appearance). The three asserted
+//! values (8, 1, 2) are distinct single digits, none a colon-anchored prefix of another rendered
+//! value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped Apgar-score library, resolved from this crate's manifest dir so the
+/// test is location-independent.
+fn shipped_apgar_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/apgar-score.adj")
+        .canonicalize()
+        .expect("shipped apgar-score.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_apgar_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_apgar_lib()).unwrap();
+    std::fs::write(dir.join("apgar-score.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// apgar_score — the relation: appearance + pulse + grimace + activity + respiration.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_apgar_library_and_computes_it_with_citation() {
+    let dir = scratch("apgar");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"apgar-score.adj\"\n\
+         observe appearance(2)\n\
+         observe pulse(2)\n\
+         observe grimace(2)\n\
+         observe activity(1)\n\
+         observe respiration(1)\n\
+         ? apgar_score(appearance, pulse, grimace, activity, respiration)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied definition's result: 2 + 2 + 2 + 1 + 1 = 8.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"apgar_score\"") && s.contains("\"value\":8"),
+        "apgar_score(2, 2, 2, 1, 1) = 8: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// activity — the same definition solved for the activity sign: total minus the other four.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_activity_from_total_and_others_with_citation() {
+    let dir = scratch("activity");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"apgar-score.adj\"\n\
+         observe apgar_score(8)\n\
+         observe appearance(2)\n\
+         observe pulse(2)\n\
+         observe grimace(2)\n\
+         observe respiration(1)\n\
+         ? activity(apgar_score, appearance, pulse, grimace, respiration)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 8 − 2 − 2 − 2 − 1 = 1, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"activity\"") && s.contains("\"value\":1"),
+        "activity(8, 2, 2, 2, 1) = 1: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "activity carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// appearance — the same definition solved for the appearance sign: total minus the other four, the
+// third reading of the one definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_appearance_from_total_and_others_with_citation() {
+    let dir = scratch("appearance");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"apgar-score.adj\"\n\
+         observe apgar_score(8)\n\
+         observe pulse(2)\n\
+         observe grimace(2)\n\
+         observe activity(1)\n\
+         observe respiration(1)\n\
+         ? appearance(apgar_score, pulse, grimace, activity, respiration)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 8 − 2 − 2 − 1 − 1 = 2, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"appearance\"") && s.contains("\"value\":2"),
+        "appearance(8, 2, 2, 1, 1) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "appearance carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/apgar-score.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/apgar-score.adj
@@ -1,0 +1,100 @@
+% ============================================================================
+% apgar-score.adj — the definition of the Apgar score
+% (Apgar = appearance + pulse + grimace + activity + respiration) in the ADJ standard library.
+% ============================================================================
+% The Apgar-score entry of the *clinical* track — a neonatology bedside index scored at 1 and 5
+% minutes after birth, a sum sibling of the shipped glasgow-coma-scale.adj (which sums three component
+% scores). The Apgar score is the SUM of five clinical signs — Appearance (colour), Pulse (heart
+% rate), Grimace (reflex irritability), Activity (muscle tone), and Respiration — EACH scored 0, 1, or
+% 2, giving a total from 0 to 10: THE FIVE COMPONENTS ARE ADDED TO GIVE THE SCORE. It ships as an
+% importable, byte-provenanced, PARAMETERIZED `formula`, together with exact rearrangements that
+% recover a component from the total and the other four. As with every compute library, a consumer
+% states NO arithmetic: it `import`s this file, binds the five component scores from its own
+% byte-provenance decomposition, and asks the engine to APPLY the cited definition on the CPU. Zero
+% math is performed by the model; the engine computes each value EXACTLY (over exact rationals),
+% carrying the definition's citation.
+%
+%     import "apgar-score.adj"
+%     observe appearance(2)     % "…pink all over → 2…"     (span cited by the model)
+%     observe pulse(2)          % "…HR > 100 → 2…"           (span cited by the model)
+%     observe grimace(2)        % "…cries on stimulation → 2…"
+%     observe activity(1)       % "…some flexion → 1…"
+%     observe respiration(1)    % "…slow, irregular → 1…"
+%     ? apgar_score(appearance, pulse, grimace, activity, respiration)
+%                                % engine → 8, carrying the Apgar sum
+%
+% Every formula is EXACT over its parameters (sums and differences of the component scores), so every
+% value the engine returns is exact. They COMPOSE and invert cleanly around the worked case appearance
+% = 2, pulse = 2, grimace = 2, activity = 1, respiration = 1 (Apgar = 2 + 2 + 2 + 1 + 1 = 8): the
+% `apgar_score` a consumer computes from the five signs is exactly the total each component formula
+% subtracts the other four from to recover its own sign. The SAME clause sanctions solving for ANY of
+% the five components; this library ships the total plus two representative inversions (the pattern is
+% identical for the rest).
+%
+%   apgar_score(appearance, pulse, grimace, activity, respiration)
+%       = appearance + pulse + grimace + activity + respiration       % Apgar = A + P + G + A + R  (definition)
+%   activity(apgar_score, appearance, pulse, grimace, respiration)
+%       = apgar_score - appearance - pulse - grimace - respiration     % Activity = Apgar − the other four
+%   appearance(apgar_score, pulse, grimace, activity, respiration)
+%       = apgar_score - pulse - grimace - activity - respiration       % Appearance = Apgar − the other four
+%
+% NOTE: each component is an integer 0, 1, or 2 and the total is the integer 0–10; the score is
+% dimensionless (it is a count of points, not a physical quantity). The engine computes the exact sum
+% over whatever consistent integer inputs it is given.
+%
+% All formulas are defended by the SAME definitional clause — "Each category is weighted evenly and
+% assigned a 0, 1, or 2 value. The components are then added to give a score recorded 1 and 5 minutes
+% after birth." — because that one definition (the score IS the sum of the five 0-to-2 component
+% values) sanctions the relation read every way (the total from the five signs, or any one sign from
+% the total and the other four). The quote is transcribed verbatim from the StatPearls "APGAR Score"
+% article on the NCBI Bookshelf, so each `formula` carries the provenance envelope every shipped
+% grounded clause carries; the linter rejects an unsourced one. (See feedback_nothing_human_authored —
+% the definitional clause is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable Apgar component score the definition ranges over, and
+% each result is a derived quantity. Each of the five components and the `apgar_score` appears BOTH as
+% a derived result and as an input (of the other formulas), so each is a single dictionary term used
+% in both roles. The `surface` lists are the everyday names a decomposer maps onto the canonical term;
+% the trailing comment records the intended range.
+% ----------------------------------------------------------------------------
+dictionary apgar_score_vocab {
+    define appearance  : finding  surface "appearance", "colour", "color", "skin colour"          % 0, 1, or 2 (A of APGAR)
+    define pulse       : finding  surface "pulse", "heart rate"                                    % 0, 1, or 2 (P of APGAR)
+    define grimace     : finding  surface "grimace", "reflex irritability"                         % 0, 1, or 2 (G of APGAR)
+    define activity    : finding  surface "activity", "muscle tone", "tone"                        % 0, 1, or 2 (A of APGAR)
+    define respiration : finding  surface "respiration", "respiratory effort", "breathing"         % 0, 1, or 2 (R of APGAR)
+    define apgar_score : finding  surface "Apgar score", "APGAR", "Apgar"                           % 0 to 10 (sum of the five)
+}
+
+% ----------------------------------------------------------------------------
+% The definition and two representative inversions. Each is a named, importable, reusable formula over
+% its formal parameters, bound at apply time, and each carries the definitional clause from the
+% StatPearls "APGAR Score" article on the NCBI Bookshelf (a quote is required on a shipped formula).
+% Each is an exact sum or difference of the component scores, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook apgar_score_laws {
+    use apgar_score_vocab
+
+    % Apgar score — the sum of the five component signs (appearance, pulse, grimace, activity,
+    % respiration), each 0–2.
+    formula apgar_score(appearance, pulse, grimace, activity, respiration) = appearance + pulse + grimace + activity + respiration
+        source "Each category is weighted evenly and assigned a 0, 1, or 2 value. The components are then added to give a score recorded 1 and 5 minutes after birth."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470569/"
+        trust authoritative
+
+    % Activity — the same definition solved for the activity (muscle-tone) sign: the total minus the
+    % other four. Defended by the SAME clause.
+    formula activity(apgar_score, appearance, pulse, grimace, respiration) = apgar_score - appearance - pulse - grimace - respiration
+        source "Each category is weighted evenly and assigned a 0, 1, or 2 value. The components are then added to give a score recorded 1 and 5 minutes after birth."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470569/"
+        trust authoritative
+
+    % Appearance — the same definition solved for the appearance (colour) sign: the total minus the
+    % other four. The SAME clause, read another way.
+    formula appearance(apgar_score, pulse, grimace, activity, respiration) = apgar_score - pulse - grimace - activity - respiration
+        source "Each category is weighted evenly and assigned a 0, 1, or 2 value. The components are then added to give a score recorded 1 and 5 minutes after birth."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK470569/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/apgar-score.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/apgar-score.query.adj
@@ -1,0 +1,30 @@
+% ============================================================================
+% apgar-score.query.adj — worked applications of the Apgar-score definition.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a delivery-room vignette into the five observed
+% Apgar signs: it `import`s the grounded formulabook, `observe`s appearance, pulse, grimace, activity
+% and respiration, and asks the engine to APPLY the cited definition. No arithmetic is stated by the
+% consumer; the engine computes each value EXACTLY (over exact rationals) and carries the article's
+% citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (appearance = 2, pulse = 2, grimace = 2, activity = 1, respiration = 1): Apgar = 2 + 2 +
+% 2 + 1 + 1 = 8. Each query below fixes five of the six quantities and asks the engine to recover the
+% sixth; every answer is exact and the inversions COMPOSE (each recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli apgar-score.query.adj
+% ============================================================================
+
+import "apgar-score.adj"
+
+% --- Definition: the Apgar the five signs imply (expect 8). -----------------------------------
+observe appearance(2)
+observe pulse(2)
+observe grimace(2)
+observe activity(1)
+observe respiration(1)
+? apgar_score(appearance, pulse, grimace, activity, respiration)   % expect 8
+
+% --- Inverse: the activity sign an Apgar of 8 implies given the other four (expect 1). --------
+observe apgar_score(8)
+? activity(apgar_score, appearance, pulse, grimace, respiration)   % expect 1


### PR DESCRIPTION
## What

Ships a new grounded clinical formula library for the **Apgar score** — the standardized neonatal assessment scored at 1 and 5 minutes after birth — in the ADJ formula stdlib:

- `code/specs/data/adj-formula-stdlib/clinical/apgar-score.adj` — a `dictionary` + `formulabook` defining **Apgar = appearance + pulse + grimace + activity + respiration** (each 0–2, total 0–10) plus two representative inversions (a component recovered from the total and the other four).
- `…/clinical/apgar-score.query.adj` — worked applications.
- `code/packages/rust/adj-lang-cli/tests/formula_apgar_score_e2e.rs` — a dedicated 3-test e2e driving the built CLI against the shipped stdlib.

## Grounding

Every formula carries the SAME verbatim clause, transcribed byte-for-byte from the StatPearls **"APGAR Score"** article on the NCBI Bookshelf:

> "Each category is weighted evenly and assigned a 0, 1, or 2 value. The components are then added to give a score recorded 1 and 5 minutes after birth."

locator `https://www.ncbi.nlm.nih.gov/books/NBK470569/`, `trust authoritative`. One clause defends the total plus the inversions — nothing asserted from memory (`feedback_nothing_human_authored`). A sum-of-component-scores sibling of the shipped Glasgow Coma Scale.

## Invariant

A consumer states **no arithmetic**: it imports the library, `observe`s the five signs, and the engine applies the cited definition on the CPU, computing the EXACT value (over rationals) and rendering the citation + trust tier in `derived`. Worked case appearance 2, pulse 2, grimace 2, activity 1, respiration 1 → Apgar 8; total and inversions compose exactly.

## Verification

- `cargo test -p adj-lang-cli --test formula_apgar_score_e2e` → 3 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` → clean.
- Render-probe confirms `apgar_score=8`, `activity=1`, exact rationals, verbatim source + NBK470569 locator + authoritative trust.
- NUL-scan clean; `/security-review` PASSED (sub-agent).

Data + test only — **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)