### PR TITLE
fix(spice): validate MOS nominal temperature

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-positive or non-finite Level-1 MOS model-card `TNOM` values with a
+  stable diagnostic before temperature and electrostatic preprocessing.
 - Reject negative or non-finite Level-1 MOS model-card `NSS` surface-state
   densities with a stable diagnostic before threshold preprocessing.
 - Accept Berkeley Level-1 MOS model-card `TPG` gate-material selectors and use

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -570,6 +570,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET TPG must be -1, 0, or 1")
         elif canonical == "NSS" and (not math.isfinite(value) or value < 0.0):
             raise ValueError(f"{name}: MOSFET NSS must be finite and non-negative")
+        elif canonical == "T_NOM" and (not math.isfinite(value) or value <= 0.0):
+            raise ValueError(f"{name}: MOSFET TNOM must be finite and positive")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1000,6 +1000,17 @@ def test_mos_model_card_gate_material_shifts_process_derived_threshold() -> None
             normalize_model_card("Minvalid", "nmos", {"NSS": invalid_nss})
 
 
+def test_mos_model_card_rejects_invalid_nominal_temperature() -> None:
+    valid = normalize_model_card("Mvalid", "nmos", {"TNOM": 325.0})
+    assert valid.parameters["T_NOM"] == pytest.approx(325.0)
+
+    for invalid_temperature in (0.0, -1.0, math.inf, math.nan):
+        with pytest.raises(
+            ValueError, match="MOSFET TNOM must be finite and positive"
+        ):
+            normalize_model_card("Minvalid", "nmos", {"TNOM": invalid_temperature})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-positive or non-finite Level-1 MOS model-card `TNOM` values with a
+  stable diagnostic before temperature and electrostatic preprocessing.
 - Reject negative or non-finite Level-1 MOS model-card `NSS` surface-state
   densities with a stable diagnostic before threshold preprocessing.
 - Accept Berkeley Level-1 MOS model-card `TPG` gate-material selectors and use

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4355,6 +4355,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET NSS must be finite and non-negative".to_string(),
                 });
+            } else if canonical == "T_NOM" && (!raw_value.is_finite() || *raw_value <= 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET TNOM must be finite and positive".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -791,6 +791,20 @@ fn mos_model_card_gate_material_shifts_process_derived_threshold() {
 }
 
 #[test]
+fn mos_model_card_rejects_invalid_nominal_temperature() {
+    let valid = normalize_model_card("Mvalid", "nmos", &[("TNOM", 325.0)]).unwrap();
+    assert_close(*valid.parameters.get("T_NOM").unwrap(), 325.0);
+
+    for invalid_temperature in [0.0, -1.0, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("TNOM", invalid_temperature)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET TNOM must be finite and positive"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-positive or non-finite Level-1 MOS model-card `TNOM` values with a
+  stable diagnostic before temperature and electrostatic preprocessing.
 - Reject negative or non-finite Level-1 MOS model-card `NSS` surface-state
   densities with a stable diagnostic before threshold preprocessing.
 - Accept Berkeley Level-1 MOS model-card `TPG` gate-material selectors and use

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8432,6 +8432,8 @@ export function normalizeModelCard(
       throw invalidElement(name, "MOSFET TPG must be -1, 0, or 1");
     } else if (canonical === "NSS" && (!Number.isFinite(value) || value < 0.0)) {
       throw invalidElement(name, "MOSFET NSS must be finite and non-negative");
+    } else if (canonical === "T_NOM" && (!Number.isFinite(value) || value <= 0.0)) {
+      throw invalidElement(name, "MOSFET TNOM must be finite and positive");
     } else {
       normalized[canonical] = value;
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -668,6 +668,17 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects invalid MOS model nominal temperatures", () => {
+    const valid = normalizeModelCard("Mvalid", "nmos", { TNOM: 325.0 });
+    expect(valid.parameters.T_NOM).toBe(325.0);
+
+    for (const invalidTemperature of [0.0, -1.0, Number.POSITIVE_INFINITY, Number.NaN]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { TNOM: invalidTemperature }),
+      ).toThrow("MOSFET TNOM must be finite and positive");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS surface-state density validation.
+1. Cross-language Level-1 MOS nominal-temperature validation.
    - Status: current PR completion candidate.
-   - Reject negative or non-finite model-card `NSS` values before process
-     parameter preprocessing, including when explicit `VTO` / `VT0` is present.
-   - Preserve zero and positive surface-state densities and stable parameter
-     coverage across Rust, Python, and TypeScript.
+   - Reject non-positive or non-finite model-card `TNOM` values before
+     temperature and electrostatic preprocessing.
+   - Preserve positive nominal temperatures and stable parameter coverage
+     across Rust, Python, and TypeScript.
 
 ## Completed Slices
 
@@ -3636,6 +3636,13 @@ the Rust, Python, and TypeScript surfaces together.
      work-function branch used to derive `VT0` from `NSUB` plus `TOX`.
    - Explicit threshold precedence, `NSS` composition, parameter coverage, and
      NMOS/PMOS parity are preserved across Rust, Python, and TypeScript.
+
+294. Cross-language Level-1 MOS surface-state density validation.
+   - Status: completed in PR 9168.
+   - Negative and non-finite model-card `NSS` values are rejected before
+     process-parameter preprocessing.
+   - Zero and positive surface-state densities, parameter coverage, and stable
+     diagnostics remain aligned across Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject non-positive and non-finite Berkeley MOS1 `TNOM` values during model-card normalization
- keep Rust, Python, and TypeScript diagnostics and regression coverage aligned
- advance the SPICE completion plan past merged surface-state validation

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- `PYTHONPATH=$(printf '%s:' ../*/src) python3.12 -m ruff check src tests`\n- `PYTHONPATH=$(printf '%s:' ../*/src) python3.12 -m pytest -q` (676 passed)\n- `npm ci`\n- `npm test` (419 passed)\n- `npm run build`