### PR TITLE
feat(sir-c): class methods (C OOP mirror slice 5)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.19.0 — OOP mirror slice 5: class methods
+
+Class (singleton) methods — the fifth slice of the C OOP mirror. No new
+`Feature` (class methods lower to builtins).
+
+- `def self.m` → a hoisted function + `__def_class_method__("C", "m",
+  MakeClosure(fn))` → `_sir_def_class_method`, which registers the closure in a
+  **separate** `(class, method) → closure` table from instance methods. A class
+  method `m` and an instance method `m` on the same class therefore never
+  collide (both are legal and distinct in Ruby).
+- `Class.m(args…)` → `__class_method__("C", "m", args…)` →
+  `_sir_call_class_method`, an explicit table lookup — never reflection — that
+  **walks the ancestry** (`_sir_class_super`), so a subclass inherits its
+  parent's class methods (`class A; def self.m; end; end; class B < A; end; B.m`).
+- A class method has no instance receiver, so `_sir_current_self` is bound to
+  **nil** for its body (and restored after) — a class method called from inside
+  an instance method never sees the caller's `self`.
+
+**Anti-RCE / totality.** Class and method names emit as **quoted C string
+literals** used only as table keys (no injection). A `__class_method__` dispatch
+to a name the module never registers via `__def_class_method__` is a built-in
+class method (`Foo.name`, the Collections batch) and is rejected cleanly via a
+`DEFINED_CLASS_METHODS` allowlist (collected in the same walk as the instance-
+method allowlist); a malformed registration/dispatch, or one carrying a
+control-flow argument, is likewise rejected rather than mis-emitted. `@@class`
+variables and modules remain the last two slices (still rejected cleanly).
+
 ## 0.18.0 — `fmt_float`: C-printf-faithful float formatting
 
 One builtin, mirroring the Ruby backend, for the C frontend's faithful `printf`

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/README.md
+++ b/code/packages/rust/semantic-ir-to-c/README.md
@@ -129,12 +129,16 @@ its parent's methods; and `super` → `_sir_call_super`, resolving the method fr
 the superclass of the defining class and applying it to the current `self`.  Every
 ancestry walk is bounded (`SIR_ANCESTRY_MAX`), so a cyclic hand-built hierarchy
 cannot hang.  Class / method / super-class names are all quoted C string literals
-(no injection).
+(no injection).  And **slice 5** — class methods: `def self.m` →
+`_sir_def_class_method` into a SEPARATE class-method (singleton) table (so a class
+method and an instance method of the same name never collide), and `Class.m(args)`
+→ `_sir_call_class_method`, an ancestry-walking table lookup (class methods
+inherit) that binds `self` to nil (no instance receiver).
 
 **Rejects** (cleanly, with a source-positioned error): `TailCalls`,
-`Intrinsics`, `NDArrays`, the rest of OOP (`@@class vars`, class methods,
-modules — later mirror slices, so `__new__` with constructor args, a
-`class << self` singleton, and the `@@` scope are all refused for now), and
+`Intrinsics`, `NDArrays`, the rest of OOP (`@@class vars`, modules — later mirror
+slices, so `__new__` with constructor args, a `class << self` singleton, and the
+`@@` scope are all refused for now), and
 every other not-yet-wired feature until its batch lands.  `Bignum` stays rejected
 until a bignum runtime ships — a module needing arbitrary precision is refused,
 never silently truncated.

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -1469,6 +1469,46 @@ fn emit_builtin_simple(out: &mut String, name: &str, args: &[Expr], indent: usiz
         }
         return;
     }
+    // OOP slice 5: register a CLASS method.  `args = [StrLit(class),
+    // StrLit(method), MakeClosure(fn)]` — same shape as `__def_method__`, but it
+    // populates the SEPARATE class-method (singleton) table.
+    if name == "__def_class_method__" {
+        if let (Some(Expr::StrLit { value: cls, .. }), Some(Expr::StrLit { value: m, .. }), Some(clo)) =
+            (args.first(), args.get(1), args.get(2))
+        {
+            let _ = write!(out, "_sir_def_class_method({}, {}, ", quote_c_string(cls), quote_c_string(m));
+            emit_expr(out, clo, indent);
+            out.push(')');
+        } else {
+            let _ = write!(out, "_sir_unknown_builtin({})", quote_c_string(name));
+        }
+        return;
+    }
+    // OOP slice 5: dispatch a CLASS method.  `args = [StrLit(class),
+    // StrLit(method), call-args…]` — the receiver is the class NAME (a StrLit),
+    // not an instance expression, so both leading args are quoted C literals.
+    if name == "__class_method__" {
+        if let (Some(Expr::StrLit { value: cls, .. }), Some(Expr::StrLit { value: m, .. })) =
+            (args.first(), args.get(1))
+        {
+            let call_args = &args[2..];
+            let _ = write!(
+                out,
+                "_sir_call_class_method({}, {}, {}",
+                quote_c_string(cls),
+                quote_c_string(m),
+                call_args.len()
+            );
+            for a in call_args {
+                out.push_str(", ");
+                emit_expr(out, a, indent);
+            }
+            out.push(')');
+        } else {
+            let _ = write!(out, "_sir_unknown_builtin({})", quote_c_string(name));
+        }
+        return;
+    }
     // OOP slice 4: `super` — `args = [StrLit(method), StrLit(definingClass),
     // call-args…]`.  Resolve `method` from the SUPERCLASS of the defining class
     // and apply to the current self.  Method / defining-class are QUOTED C string
@@ -1612,8 +1652,9 @@ fn is_supported_builtin(name: &str) -> bool {
         // `__method__` (dispatch it).  (`__super__`/`__self__`/`__class_method__`/
         // … stay unsupported — later slices.)
         // Slice 3 adds `__self__` (a bare `self`); slice 4 adds `__super__`
-        // (`super`).  (`__class_method__`/`__def_class_method__`/… stay
-        // unsupported — later slices.)
+        // (`super`); slice 5 adds class methods `__def_class_method__` /
+        // `__class_method__`.  (`@@class` vars and modules stay unsupported —
+        // later slices.)
         || matches!(
             name,
             "and" | "or"
@@ -1623,6 +1664,8 @@ fn is_supported_builtin(name: &str) -> bool {
                 | "__method__"
                 | "__self__"
                 | "__super__"
+                | "__def_class_method__"
+                | "__class_method__"
         )
 }
 
@@ -1640,18 +1683,31 @@ thread_local! {
     // anti-RCE by construction — an explicit (class,method) table lookup — so this
     // allowlist is purely for clean COMPILE-TIME rejection.)
     static DEFINED_METHODS: RefCell<HashSet<String>> = RefCell::new(HashSet::new());
+    // OOP slice 5: the same closed-set idea for CLASS methods — the names the
+    // module registers via `__def_class_method__`, the only names a
+    // `__class_method__` dispatch may target (else it is a built-in class method,
+    // the Collections batch, rejected until then).
+    static DEFINED_CLASS_METHODS: RefCell<HashSet<String>> = RefCell::new(HashSet::new());
 }
 
 /// Collect the `__def_method__("Class", "m", …)` method names anywhere in `m`
 /// (a full recursive walk, so a dispatch is never wrongly rejected for a
 /// registration nested in a loop/branch/closure).
-fn collect_defined_methods(m: &Module, out: &mut HashSet<String>) {
-    fn from_expr(e: &Expr, out: &mut HashSet<String>) {
+fn collect_defined_methods(m: &Module, out: &mut (HashSet<String>, HashSet<String>)) {
+    // `out.0` = instance-method names (`__def_method__`); `out.1` = class-method
+    // names (`__def_class_method__`).  Both are collected in ONE walk so the two
+    // dispatch allowlists (instance `__method__`, class `__class_method__`) stay
+    // in lockstep with what the module actually registers.
+    fn from_expr(e: &Expr, out: &mut (HashSet<String>, HashSet<String>)) {
         match e {
             Expr::BuiltinCall { name, args, .. } => {
                 if name == "__def_method__" {
                     if let Some(Expr::StrLit { value, .. }) = args.get(1) {
-                        out.insert(value.clone());
+                        out.0.insert(value.clone());
+                    }
+                } else if name == "__def_class_method__" {
+                    if let Some(Expr::StrLit { value, .. }) = args.get(1) {
+                        out.1.insert(value.clone());
                     }
                 }
                 args.iter().for_each(|a| from_expr(a, out));
@@ -1698,7 +1754,7 @@ fn collect_defined_methods(m: &Module, out: &mut HashSet<String>) {
             _ => {}
         }
     }
-    fn from_stmt(s: &Stmt, out: &mut HashSet<String>) {
+    fn from_stmt(s: &Stmt, out: &mut (HashSet<String>, HashSet<String>)) {
         match s {
             Stmt::LetBinding { value, .. }
             | Stmt::LetStarBinding { value, .. }
@@ -1755,7 +1811,7 @@ fn collect_defined_methods(m: &Module, out: &mut HashSet<String>) {
             _ => {}
         }
     }
-    fn from_block(b: &Block, out: &mut HashSet<String>) {
+    fn from_block(b: &Block, out: &mut (HashSet<String>, HashSet<String>)) {
         b.stmts.iter().for_each(|s| from_stmt(s, out));
         from_expr(&b.value, out);
     }
@@ -1770,9 +1826,10 @@ fn collect_defined_methods(m: &Module, out: &mut HashSet<String>) {
 }
 
 pub fn first_unsupported_builtin(m: &Module) -> Option<(String, Span)> {
-    let mut defined = HashSet::new();
+    let mut defined = (HashSet::new(), HashSet::new());
     collect_defined_methods(m, &mut defined);
-    DEFINED_METHODS.with(|d| *d.borrow_mut() = defined);
+    DEFINED_METHODS.with(|d| *d.borrow_mut() = defined.0);
+    DEFINED_CLASS_METHODS.with(|d| *d.borrow_mut() = defined.1);
     for f in &m.functions {
         // A SIR19 parameter default is an expression the prologue evaluates at
         // call time, so a deferred builtin nested in one must be pre-checked
@@ -1925,11 +1982,41 @@ fn scan_expr_for_builtin(e: &Expr) -> Option<(String, Span)> {
             {
                 return Some(("a malformed __super__ call".to_string(), span.clone()));
             }
-            // `__def_method__`/`__method__`/`__super__` carry `StrLit` class/method
-            // names that must stay raw C literals.  The compound (control-flow-
-            // argument) path cannot recover them, so reject a call that is not
-            // `is_simple` — deferred, not mis-emitted.
-            if matches!(name.as_str(), "__def_method__" | "__method__" | "__super__") && !is_simple(e)
+            // OOP slice 5: `__def_class_method__` mirrors `__def_method__` —
+            // `[StrLit(class), StrLit(method), MakeClosure]`.
+            if name == "__def_class_method__"
+                && !matches!(
+                    args.as_slice(),
+                    [Expr::StrLit { .. }, Expr::StrLit { .. }, Expr::MakeClosure { .. }]
+                )
+            {
+                return Some((
+                    "a malformed __def_class_method__ registration".to_string(),
+                    span.clone(),
+                ));
+            }
+            // OOP slice 5: `__class_method__` is `[StrLit(class), StrLit(method), …]`
+            // — the receiver is the class NAME (a `StrLit`), not an instance expr.
+            if name == "__class_method__"
+                && !matches!(
+                    (args.first(), args.get(1)),
+                    (Some(Expr::StrLit { .. }), Some(Expr::StrLit { .. }))
+                )
+            {
+                return Some(("a malformed __class_method__ dispatch".to_string(), span.clone()));
+            }
+            // These OOP builtins carry `StrLit` class/method names that must stay
+            // raw C literals.  The compound (control-flow-argument) path cannot
+            // recover them, so reject a call that is not `is_simple` — deferred,
+            // not mis-emitted.
+            if matches!(
+                name.as_str(),
+                "__def_method__"
+                    | "__method__"
+                    | "__super__"
+                    | "__def_class_method__"
+                    | "__class_method__"
+            ) && !is_simple(e)
             {
                 return Some((
                     format!("a `{name}` call with a control-flow argument"),
@@ -1948,6 +2035,24 @@ fn scan_expr_for_builtin(e: &Expr) -> Option<(String, Span)> {
                             format!(
                                 "a call to the built-in method `{value}` (only \
                                  user-defined methods dispatch this slice)"
+                            ),
+                            span.clone(),
+                        ));
+                    }
+                }
+            }
+            // OOP slice 5: same allowlist for a `__class_method__` dispatch — a
+            // name the module never registers via `__def_class_method__` is a
+            // built-in class method (`Foo.name`, the Collections batch), rejected
+            // cleanly.  (The method name is args[1]; args[0] is the class NAME.)
+            if name == "__class_method__" {
+                if let Some(Expr::StrLit { value, .. }) = args.get(1) {
+                    let known = DEFINED_CLASS_METHODS.with(|d| d.borrow().contains(value));
+                    if !known {
+                        return Some((
+                            format!(
+                                "a call to the built-in class method `{value}` (only \
+                                 user-defined class methods dispatch this slice)"
                             ),
                             span.clone(),
                         ));

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -1248,6 +1248,85 @@ SirValue _sir_call_super(const char *method, const char *defining_class, int arg
     return r;
 }
 
+/* ---- OOP slice 5: class (singleton) methods --------------------------------
+ *
+ * A class method (`def self.m`) belongs to the class's OWN namespace — Ruby's
+ * singleton class — NOT the instance-method table.  Keeping a SEPARATE table
+ * means an instance method `m` and a class method `m` on the same class never
+ * collide (both are legal, and distinct, in Ruby).  Class methods ARE inherited
+ * (`class A; def self.m; end; end; class B < A; end; B.m` works), so dispatch
+ * walks the SAME user-ancestry (`_sir_class_super`) as instance methods. */
+static struct { const char *cls; const char *method; SirValue fn; } _sir_class_method_tab[SIR_METHOD_MAX];
+static int _sir_class_method_n = 0;
+
+SirValue _sir_def_class_method(const char *cls, const char *method, SirValue fn) {
+    const char *c = _sir_intern(cls), *m = _sir_intern(method);
+    int i;
+    for (i = 0; i < _sir_class_method_n; i++) {
+        if (_sir_class_method_tab[i].cls == c && _sir_class_method_tab[i].method == m) {
+            _sir_class_method_tab[i].fn = fn;
+            return fn;
+        }
+    }
+    if (_sir_class_method_n < SIR_METHOD_MAX) {
+        _sir_class_method_tab[_sir_class_method_n].cls = c;
+        _sir_class_method_tab[_sir_class_method_n].method = m;
+        _sir_class_method_tab[_sir_class_method_n].fn = fn;
+        _sir_class_method_n++;
+    }
+    return fn;
+}
+
+/* Look up a class method on THIS class only (no ancestry). */
+static SirValue _sir_lookup_class_method(const char *cls, const char *method) {
+    const char *c = _sir_intern(cls), *m = _sir_intern(method);
+    int i;
+    for (i = 0; i < _sir_class_method_n; i++) {
+        if (_sir_class_method_tab[i].cls == c && _sir_class_method_tab[i].method == m) {
+            return _sir_class_method_tab[i].fn;
+        }
+    }
+    return _sir_nil();
+}
+
+/* Resolve a class method starting at `cls`, walking UP the ancestry (so a
+ * subclass inherits its parent's class methods).  Bounded by SIR_ANCESTRY_MAX. */
+static SirValue _sir_resolve_class_method(const char *cls, const char *method) {
+    const char *cur = cls;
+    int steps = 0;
+    while (cur && steps++ < SIR_ANCESTRY_MAX) {
+        SirValue fn = _sir_lookup_class_method(cur, method);
+        if (fn.tag == SIR_CLOSURE) return fn;
+        cur = _sir_class_super(cur);
+    }
+    return _sir_nil();
+}
+
+/* Dispatch a class method `cls.method(args…)`.  A class method has NO instance
+ * receiver, so `self` is bound to NIL for the body (and restored after) — it
+ * never leaks the caller's instance `self` into a class method (e.g. when an
+ * instance method calls `Foo.bar`).  Unresolved => a (rescuable) NoMethodError. */
+SirValue _sir_call_class_method(const char *cls, const char *method, int argc, ...) {
+    va_list ap;
+    SirValue *args, fn, r;
+    fn = _sir_resolve_class_method(cls, method);
+    if (fn.tag != SIR_CLOSURE) {
+        return _sir_raise(_sir_error(
+            "NoMethodError", _sir_str(_sir_cat("undefined class method ", method))));
+    }
+    va_start(ap, argc);
+    args = _sir_va_collect(argc, ap);
+    va_end(ap);
+    {
+        SirValue saved_self = _sir_current_self;
+        _sir_current_self = _sir_nil();
+        r = fn.as.clo->fn(fn.as.clo->caps, args, argc);
+        _sir_current_self = saved_self;
+    }
+    if (args) free(args);
+    return r;
+}
+
 SirValue _sir_print_v(SirValue *xs, int n) {
     int i;
     for (i = 0; i < n; i++) _sir_fmt(stdout, xs[i]);

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_class_methods.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_class_methods.rs
@@ -1,0 +1,107 @@
+//! Execution proof for OOP mirror slice 5 (class methods) on the C backend —
+//! lower REAL Ruby source, emit C, compile with a real cc, run, assert stdout.
+//! Skips gracefully when no `cc` is present.
+//!
+//! `def self.m` lowers to a hoisted function + `__def_class_method__` (registering
+//! the closure in the SEPARATE class-method / singleton table); `Class.m(args)`
+//! lowers to `__class_method__(StrLit(class), StrLit(method), …args)` →
+//! `_sir_call_class_method`, an explicit table lookup that walks the ancestry
+//! (class methods inherit) — never reflection.
+
+use std::process::Command;
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    ["cc", "clang", "gcc"]
+        .iter()
+        .find(|c| {
+            Command::new(c)
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        })
+        .map(|s| s.to_string())
+}
+
+fn run_ruby(src: &str) -> Option<String> {
+    let cc = find_cc()?;
+    let module = ruby_to_semantic_ir::compile_source(src, "prog").expect("ruby lowering");
+    let art = semantic_ir_to_c::compile(&module).expect("C compile (no panic)");
+    let dir = std::env::temp_dir();
+    let stem = format!("sirc_cm_{}_{}", std::process::id(), src.len());
+    let cpath = dir.join(format!("{stem}.c"));
+    let exe = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::write(&cpath, &art.source).expect("write .c");
+    let out = Command::new(&cc)
+        .args(["-std=c99", "-Wall", "-o"])
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn cc");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        art.source
+    );
+    let r = Command::new(&exe).output().expect("run");
+    assert!(r.status.success(), "program exited non-zero");
+    Some(String::from_utf8_lossy(&r.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn class_method_with_an_argument() {
+    match run_ruby(
+        "class Math2\n  def self.double(x)\n    x + x\n  end\nend\n\
+         puts Math2.double(21)\n",
+    ) {
+        Some(out) => assert_eq!(out, "42\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn class_method_is_inherited_by_a_subclass() {
+    // `Sub` defines no class method, so `Sub.double` resolves up the ancestry to
+    // `Math2.double` (class methods inherit).
+    match run_ruby(
+        "class Math2\n  def self.double(x)\n    x + x\n  end\nend\n\
+         class Sub < Math2\nend\n\
+         puts Sub.double(50)\n",
+    ) {
+        Some(out) => assert_eq!(out, "100\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn class_and_instance_methods_of_the_same_name_coexist() {
+    // A class method `tag` and an instance method `tag` live in SEPARATE tables,
+    // so each dispatches to its own closure with no collision.
+    match run_ruby(
+        "class Foo\n  def self.tag\n    1\n  end\n  def tag\n    2\n  end\nend\n\
+         puts Foo.tag\nf = Foo.new\nputs f.tag\n",
+    ) {
+        Some(out) => assert_eq!(out, "1\n2\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}
+
+#[test]
+fn class_method_calls_another_class_method() {
+    // One class method dispatches to another on the same class.
+    match run_ruby(
+        "class Calc\n  def self.inc(x)\n    x + 1\n  end\n  def self.twice_inc(x)\n    \
+         a = Calc.inc(x)\n    Calc.inc(a)\n  end\nend\n\
+         puts Calc.twice_inc(10)\n",
+    ) {
+        // twice_inc(10): inc(10)=11, inc(11)=12.
+        Some(out) => assert_eq!(out, "12\n"),
+        None => eprintln!("skip: no cc"),
+    }
+}

--- a/code/packages/rust/semantic-ir-to-c/tests/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/emit.rs
@@ -226,6 +226,24 @@ fn super_lowers_to_call_super() {
 }
 
 #[test]
+fn class_methods_route_through_the_singleton_table() {
+    // OOP slice 5: `def self.m` → `_sir_def_class_method`; `Class.m(x)` →
+    // `_sir_call_class_method` (receiver is the class NAME, a quoted C literal).
+    let m = lower_ruby(
+        "class Math2\n  def self.double(x)\n    x + x\n  end\nend\nputs Math2.double(21)",
+    );
+    let src = compile(&m).unwrap().source;
+    assert!(
+        src.contains("_sir_def_class_method(\"Math2\", \"double\""),
+        "a class method registers in the class-method table\n{src}"
+    );
+    assert!(
+        src.contains("_sir_call_class_method(\"Math2\", \"double\""),
+        "a `Class.m` call dispatches through the class-method table\n{src}"
+    );
+}
+
+#[test]
 fn sanitize_ident_maps_into_c() {
     assert_eq!(sanitize_ident("foo"), "foo");
     assert_eq!(sanitize_ident("foo_bar1"), "foo_bar1");

--- a/code/specs/SIR24-semantic-ir-to-c.md
+++ b/code/specs/SIR24-semantic-ir-to-c.md
@@ -378,7 +378,11 @@ lockstep:
    resolution; `_sir_call_method` resolves up the chain, `super` → `_sir_call_super`
    from the superclass of the defining class; every walk bounded by
    `SIR_ANCESTRY_MAX` against a cyclic hand-built hierarchy) landed in 0.16.0;
-   then class methods, `ClassVars`, and `Modules` (mixins / MRO).
+   class methods (`def self.m` → `__def_class_method__` into a SEPARATE
+   class-method/singleton table — no collision with an instance method of the
+   same name — and `Class.m` → `__class_method__` → `_sir_call_class_method`, an
+   ancestry-walking lookup so class methods inherit, binding `self` to nil)
+   landed in 0.19.0; then `ClassVars`, and `Modules` (mixins / MRO).
 7. **Optional / later** — `Bignum`; SIR21 sized-integer native lowering
    (`int64_t`/`uint32_t` from `IntSpec`); `Range` / regex / backtick shims.
 


### PR DESCRIPTION
## What

Fifth slice of the **C backend OOP mirror** — class (singleton) methods. No new `Feature` (class methods lower to builtins). Mirrors the Ruby backend's landed slice 5.

- `def self.m` → hoisted fn + `__def_class_method__("C", "m", MakeClosure)` → `_sir_def_class_method`, registering the closure in a **separate** `(class, method) → closure` table from instance methods. A class method `m` and an instance method `m` on the same class never collide (both legal + distinct in Ruby).
- `Class.m(args…)` → `__class_method__("C", "m", args…)` → `_sir_call_class_method`: an explicit table lookup (never reflection) that **walks the ancestry** (`_sir_resolve_class_method` via `_sir_class_super`), so a subclass inherits its parent's class methods.
- A class method has no instance receiver, so `_sir_current_self` is bound to **nil** for its body (saved/restored) — never leaks a caller's instance `self` into a class method.

## Anti-RCE / totality

Class + method names emit as **quoted C string literals** used only as table keys. A `__class_method__` dispatch to a name never registered via `__def_class_method__` is a built-in class method (`Foo.name`, the Collections batch) → rejected cleanly via a `DEFINED_CLASS_METHODS` allowlist (collected in the *same* walk as the instance allowlist — the collector now fills a `(instance, class)` tuple); malformed shapes and control-flow-argument calls are rejected too.

## Tests / quality

- **Emit-shape**: `class_methods_route_through_the_singleton_table` (15/15 emit tests pass).
- **cc-exec e2e** (`compile_and_run_class_methods.rs`): class method w/ arg → 42; inherited class method `Sub.double` → 100; class + instance method of the same name coexist → 1/2; class method calls another → 12. 4/4 pass.
- **Regression:** instance-method e2e (3) green; clippy clean; security review passed (Rust+C: no injection, memory-safe, bounded ancestry walk, no reachable `unreachable!`).

Bumps `semantic-ir-to-c` 0.18.0 → 0.19.0; updates CHANGELOG, README, SIR24 spec. `@@class` vars and modules remain the last two slices (still rejected cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)