### PR TITLE
feat(adj-formula-stdlib): renal clearance — StatPearls (Ux×V)/Px clearance-method library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_renal_clearance_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_renal_clearance_e2e.rs
@@ -1,0 +1,143 @@
+//! End-to-end tests for the `clinical/renal-clearance.adj` library — the renal-clearance relation
+//! (clearance = urine concentration × urine flow ÷ plasma concentration) and its two exact
+//! rearrangements — driven through the built CLI binary against the SHIPPED stdlib. The same
+//! invariant as every other formula library: a consumer states NO arithmetic; it imports the grounded
+//! library, binds the measured concentrations and urine flow with `observe`, and the engine applies
+//! the cited equation on the CPU, computing the EXACT value and rendering the citation and trust tier
+//! in the `derived` section (the auditable answer). The three formulas INVERT around the worked case
+//! urine concentration = 90, urine flow = 2, plasma concentration = 3: 90 × 2 ÷ 3 = 60 (clearance),
+//! 60 × 3 ÷ 2 = 90 (urine conc), 90 × 2 ÷ 60 = 3 (plasma conc). The four asserted values (60, 90, 3,
+//! 2) are distinct, none a colon-anchored prefix of another rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped renal-clearance library, resolved from this crate's manifest dir so
+/// the test is location-independent.
+fn shipped_rc_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/renal-clearance.adj")
+        .canonicalize()
+        .expect("shipped renal-clearance.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_rc_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_rc_lib()).unwrap();
+    std::fs::write(dir.join("renal-clearance.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// renal_clearance — the relation: urine concentration × urine flow ÷ plasma concentration.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_renal_clearance_library_and_computes_it_with_citation() {
+    let dir = scratch("rc");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"renal-clearance.adj\"\n\
+         observe urine_concentration(90)\n\
+         observe urine_flow(2)\n\
+         observe plasma_concentration(3)\n\
+         ? renal_clearance(urine_concentration, urine_flow, plasma_concentration)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied equation's result: 90 × 2 ÷ 3 = 60.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"renal_clearance\"") && s.contains("\"value\":60"),
+        "renal_clearance(90, 2, 3) = 60: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// urine_concentration — the same definition solved for the urine concentration: Cx × Px ÷ V.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_urine_concentration_from_clearance_with_citation() {
+    let dir = scratch("ux");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"renal-clearance.adj\"\n\
+         observe renal_clearance(60)\n\
+         observe urine_flow(2)\n\
+         observe plasma_concentration(3)\n\
+         ? urine_concentration(renal_clearance, urine_flow, plasma_concentration)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 60 × 3 ÷ 2 = 90, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"urine_concentration\"") && s.contains("\"value\":90"),
+        "urine_concentration(60, 2, 3) = 90: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "urine_concentration carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// plasma_concentration — the same definition solved for the plasma concentration: Ux × V ÷ Cx, the
+// third reading of the one equation.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_plasma_concentration_from_clearance_with_citation() {
+    let dir = scratch("px");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"renal-clearance.adj\"\n\
+         observe urine_concentration(90)\n\
+         observe urine_flow(2)\n\
+         observe renal_clearance(60)\n\
+         ? plasma_concentration(urine_concentration, urine_flow, renal_clearance)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 90 × 2 ÷ 60 = 3, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"plasma_concentration\"") && s.contains("\"value\":3"),
+        "plasma_concentration(90, 2, 60) = 3: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "plasma_concentration carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/renal-clearance.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/renal-clearance.adj
@@ -1,0 +1,102 @@
+% ============================================================================
+% renal-clearance.adj — the definition of renal clearance
+% (clearance = urine concentration × urine flow rate ÷ plasma concentration) in the ADJ standard
+% library.
+% ============================================================================
+% The renal-clearance entry of the *clinical* track — the foundational nephrology relation behind
+% every measured clearance (creatinine clearance, GFR by a freely-filtered marker, PAH clearance,
+% etc.). It is a product-over-a-value sibling of the shipped drug-clearance.adj (which is the simpler
+% rate ÷ concentration): the amount of a substance appearing in the urine per unit time, expressed as
+% the volume of plasma that would be completely cleared of it per unit time. THE CLEARANCE OF A
+% SUBSTANCE IS ITS URINE CONCENTRATION TIMES THE URINE FLOW RATE, DIVIDED BY ITS PLASMA CONCENTRATION.
+% It ships as an importable, byte-provenanced, PARAMETERIZED `formula`, together with its two exact
+% rearrangements (the urine concentration a clearance implies, and the plasma concentration it
+% implies). As with every compute library, a consumer states NO arithmetic: it `import`s this file,
+% binds the measured concentrations and the urine flow from its own byte-provenance decomposition, and
+% asks the engine to APPLY the cited definition on the CPU. Zero math is performed by the model; the
+% engine computes each value EXACTLY (over exact rationals), carrying the definition's citation.
+%
+%     import "renal-clearance.adj"
+%     observe urine_concentration(90)      % "…urine [X] 90 mg/mL…"     (span cited by the model)
+%     observe urine_flow(2)                 % "…urine flow 2 mL/min…"     (span cited by the model)
+%     observe plasma_concentration(3)       % "…plasma [X] 3 mg/mL…"      (span cited by the model)
+%     ? renal_clearance(urine_concentration, urine_flow, plasma_concentration)
+%                                            % engine → 60, carrying the clearance
+%
+% All three formulas are EXACT over their parameters (a product over a value, and its inversions), so
+% every value the engine returns is exact. They COMPOSE and invert cleanly around the worked case
+% urine concentration = 90, urine flow = 2, plasma concentration = 3 (clearance = 90 × 2 ÷ 3 = 60): the
+% `renal_clearance` a consumer computes is exactly the value the `urine_concentration` formula scales
+% back up to recover 90, and exactly the value the `plasma_concentration` formula divides into to
+% recover 3.
+%
+%   renal_clearance(urine_concentration, urine_flow, plasma_concentration)
+%       = urine_concentration * urine_flow / plasma_concentration   % Cx = (Ux × V) ÷ Px  (definition)
+%   urine_concentration(renal_clearance, urine_flow, plasma_concentration)
+%       = renal_clearance * plasma_concentration / urine_flow        % Ux = (Cx × Px) ÷ V  (solved for Ux)
+%   plasma_concentration(urine_concentration, urine_flow, renal_clearance)
+%       = urine_concentration * urine_flow / renal_clearance         % Px = (Ux × V) ÷ Cx  (solved for Px)
+%
+% NOTE ON UNITS AND MODELLING: the two concentrations must be in the SAME unit (they cancel), and the
+% clearance then carries the unit of the urine flow (e.g. mL/min). The cited article writes this
+% relation for the glomerular filtration rate using a freely-filtered marker substance S — "GFR =
+% [UrineS (mg/mL) × urine flow (mL/min)] / [PlasmaS (mg/mL)]" — but the same equation IS the general
+% renal clearance of ANY substance S (for a marker that is filtered but neither reabsorbed nor
+% secreted, its clearance equals the GFR; for other substances it is that substance's clearance). This
+% library computes that general clearance over whatever consistent inputs it is given. (The
+% Starling-equation form of the GFR — filtration coefficient × net filtration pressure — is grounded
+% separately in glomerular-filtration-rate.adj; this is the independent CLEARANCE-method relation.)
+%
+% All three formulas are defended by the SAME clause — "GFR = [UrineS (mg/mL) × urine flow (mL/min)] /
+% [PlasmaS (mg/mL)]" — because that one equation (clearance IS the urine-concentration × urine-flow ÷
+% plasma-concentration quotient) sanctions the relation read every way. The quote is transcribed
+% verbatim from the StatPearls "Creatinine Clearance" article on the NCBI Bookshelf, so each `formula`
+% carries the provenance envelope every shipped grounded clause carries; the linter rejects an
+% unsourced one. (See feedback_nothing_human_authored — the equation is a verbatim span of the cited
+% page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable quantity the definition ranges over, and each result is
+% a derived quantity. `urine_concentration`, `plasma_concentration` and `renal_clearance` each appear
+% BOTH as a derived result and as an input (of the other formulas), so each is a single dictionary
+% term used in both roles. The `surface` lists are the everyday names a decomposer maps onto the
+% canonical term; the trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary renal_clearance_vocab {
+    define urine_concentration  : finding  surface "urine concentration", "urinary concentration", "Ux"   % mass per volume (e.g. mg/mL)
+    define urine_flow           : finding  surface "urine flow", "urine flow rate", "urinary flow rate"    % volume per time (e.g. mL/min)
+    define plasma_concentration : finding  surface "plasma concentration", "serum concentration", "Px"     % mass per volume (e.g. mg/mL)
+    define renal_clearance      : finding  surface "renal clearance", "clearance"                          % volume per time (e.g. mL/min)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the clearance equation from the StatPearls
+% "Creatinine Clearance" article on the NCBI Bookshelf (a quote is required on a shipped formula). Each
+% is an exact product or quotient of the measured quantities, so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook renal_clearance_laws {
+    use renal_clearance_vocab
+
+    % Renal clearance — the urine concentration times the urine flow, divided by the plasma
+    % concentration (a * b / c parses as (a*b)/c).
+    formula renal_clearance(urine_concentration, urine_flow, plasma_concentration) = urine_concentration * urine_flow / plasma_concentration
+        source "GFR = [UrineS (mg/mL) × urine flow (mL/min)] / [PlasmaS (mg/mL)]"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK544228/"
+        trust authoritative
+
+    % Urine concentration — the same definition solved for the urine concentration (Ux = Cx × Px ÷ V).
+    % Defended by the SAME equation.
+    formula urine_concentration(renal_clearance, urine_flow, plasma_concentration) = renal_clearance * plasma_concentration / urine_flow
+        source "GFR = [UrineS (mg/mL) × urine flow (mL/min)] / [PlasmaS (mg/mL)]"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK544228/"
+        trust authoritative
+
+    % Plasma concentration — the same definition solved for the plasma concentration (Px = Ux × V ÷ Cx):
+    % the excreted mass rate divided by the clearance. The SAME equation, read the third way.
+    formula plasma_concentration(urine_concentration, urine_flow, renal_clearance) = urine_concentration * urine_flow / renal_clearance
+        source "GFR = [UrineS (mg/mL) × urine flow (mL/min)] / [PlasmaS (mg/mL)]"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK544228/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/renal-clearance.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/renal-clearance.query.adj
@@ -1,0 +1,29 @@
+% ============================================================================
+% renal-clearance.query.adj — worked applications of the renal-clearance definition.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a nephrology vignette into observed
+% concentrations and a urine flow: it `import`s the grounded formulabook, `observe`s the urine
+% concentration, the urine flow and the plasma concentration, and asks the engine to APPLY the cited
+% equation. No arithmetic is stated by the consumer; the engine computes each value EXACTLY (over
+% exact rationals) and carries the article's citation as its proof, on the CPU, with zero model calls.
+%
+% Worked case (urine concentration = 90 mg/mL, urine flow = 2 mL/min, plasma concentration = 3 mg/mL):
+% clearance = 90 × 2 ÷ 3 = 60 mL/min. Each query below fixes three of the four quantities and asks the
+% engine to recover the fourth; every answer is exact and the three COMPOSE (each inversion recovers
+% exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli renal-clearance.query.adj
+% ============================================================================
+
+import "renal-clearance.adj"
+
+% --- Definition: the clearance the three quantities imply (expect 60). ------------------------
+observe urine_concentration(90)
+observe urine_flow(2)
+observe plasma_concentration(3)
+? renal_clearance(urine_concentration, urine_flow, plasma_concentration)   % expect 60
+
+% --- Inverse: the urine concentration a clearance of 60 implies (expect 90). ------------------
+observe renal_clearance(60)
+? urine_concentration(renal_clearance, urine_flow, plasma_concentration)   % expect 90


### PR DESCRIPTION
## What

Ships a new **clinical** formula library, `clinical/renal-clearance.adj` (+ `.query.adj`), grounding the **renal-clearance** relation:

> renal clearance = urine concentration × urine flow rate ÷ plasma concentration

grounded **VERBATIM** in the StatPearls *"Creatinine Clearance"* article on the NCBI Bookshelf ([NBK544228](https://www.ncbi.nlm.nih.gov/books/NBK544228/)):

> "GFR = [UrineS (mg/mL) × urine flow (mL/min)] / [PlasmaS (mg/mL)]"

The substance-generic UrineS/PlasmaS form **is** the general renal-clearance equation: for a marker that is freely filtered and neither reabsorbed nor secreted its clearance equals the GFR; for any other substance it is that substance's clearance. The result term is named `renal_clearance` (not `gfr`) so it does not collide with the Starling-form GFR grounded separately in `glomerular-filtration-rate.adj` — this is the independent **clearance-method** relation.

## How it fits the stack

One cited equation defends a `formulabook` of **three exact inversions**, each carrying the same `source`/`locator`/`trust authoritative` envelope:

| formula | equation |
|---|---|
| `renal_clearance(Ux, V, Px)` | `Ux * V / Px` |
| `urine_concentration(Cx, V, Px)` | `Cx * Px / V` |
| `plasma_concentration(Ux, V, Cx)` | `Ux * V / Cx` |

A consumer states **no arithmetic**: it imports the library, `observe`s the measured quantities from its own byte-provenance decomposition, and the engine applies the cited definition on the CPU, computing the value **exactly** over rationals and rendering the citation + trust tier in `derived`.

## Worked case (in the dedicated e2e test)

Ux = 90, V = 2, Px = 3 → clearance **60**; and the inversions recover 90 and 3 exactly (`a * b / c` parses as `(a*b)/c`). The four asserted values (60, 90, 3, 2) are distinct and collision-safe (none a colon-anchored prefix of another rendered value).

## Verification

- 3/3 e2e tests pass (`formula_renal_clearance_e2e.rs`); render-probe confirms `renal_clearance=60`, `urine_concentration=90`, `trust:authoritative`, `ncbi.nlm.nih.gov`.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` clean.
- NUL-scan clean on all three new files.
- Source equation byte-verified via WebFetch against NBK544228.
- **Data + test only — no version bump.**
- Security review: **PASSED** (sub-agent, Rust + declarative-data lens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)