### PR TITLE
fix(sql-vm): replace() with an empty search returns the subject unchanged

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.69 — `replace()` with an empty search returns the subject unchanged
+
+`replace('abc', '', 'X')` now returns `'abc'`, matching SQLite — an empty search
+string is a no-op, not a splice of the replacement between every character (which
+`'XaXbXcX'` would be). Non-empty searches are unaffected. Found by probing real
+SQLite. Verified against bundled real SQLite. Spans sql-vm 0.4.39.
+
 ## 0.5.68 — `round()` returns positive zero
 
 `round(-0.4)` and `round(-0.0)` now return `0.0`, not `-0.0`, matching SQLite —

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.68"
+version = "0.5.69"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -2323,6 +2323,15 @@ const CASES: &[Case] = &[
         setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
         query: "SELECT round(-0.4) AS a, round(-0.0) AS b, round(-0.5) AS c, round(-0.004, 2) AS d FROM t",
     },
+    // `replace(X, '', Y)` — an EMPTY search string returns X unchanged, matching
+    // SQLite (which short-circuits to avoid splicing Y between every character).
+    // A non-empty search still replaces every occurrence, including replacing
+    // with the empty string (`replace('aaa','a','')` = '').
+    Case {
+        id: "replace_empty_search_returns_subject",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT replace('abc', '', 'X') AS a, replace('aaa', 'a', 'bb') AS b, replace('aaa', 'a', '') AS c FROM t",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.39] - Unreleased
+
+### Fixed
+
+- **`replace(X, '', Y)` returns X unchanged.** With an empty search string SQLite
+  returns the subject as-is; Rust's `str::replace` would splice `Y` between every
+  character (`replace('abc','','X')` → `'XaXbXcX'`). The `REPLACE` builtin now
+  short-circuits an empty search. Non-empty searches are unchanged, including
+  replacing with the empty string (`replace('aaa','a','')` = `''`).
+
 ## [0.4.38] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.38"
+version = "0.4.39"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -1570,6 +1570,14 @@ fn call_builtin(name: &str, args: Vec<SqlValue>) -> Result<SqlValue, VmError> {
                 (SqlValue::Text(a), SqlValue::Text(b), SqlValue::Text(c)) => (a, b, c),
                 _ => return Err(VmError::TypeMismatch("REPLACE expects TEXT, TEXT, TEXT".to_string())),
             };
+            // An empty search string returns the subject UNCHANGED, matching
+            // SQLite. Rust's `str::replace("", to)` would instead splice `to`
+            // between every character (and at both ends) — `replace('abc','','X')`
+            // → `'XaXbXcX'` — which is wrong; SQLite short-circuits empty search to
+            // avoid that (and the unbounded expansion it implies).
+            if from.is_empty() {
+                return Ok(SqlValue::Text(s.clone()));
+            }
             Ok(SqlValue::Text(s.replace(from.as_str(), to.as_str())))
         }
 


### PR DESCRIPTION
## What

`replace(X, Y, Z)` with an **empty search string `Y`** now returns `X` unchanged, matching SQLite:

```sql
SELECT replace('abc', '', 'X');   -- 'abc'   (was 'XaXbXcX')
SELECT replace('aaa', 'a', 'bb'); -- 'bbbbbb' (unchanged)
SELECT replace('aaa', 'a', '');   -- ''       (unchanged)
```

Rust's `str::replace("", Z)` splices `Z` between every character (and both ends); SQLite short-circuits an empty search to avoid that expansion.

## How

One guard in the `REPLACE` VM builtin: `if from.is_empty() { return Ok(Text(s.clone())); }`. Non-empty searches keep the existing behavior, including replacing with the empty string.

Found by probing real SQLite for value divergences.

## Verification
- Differential oracle green vs **bundled real SQLite** (`replace_empty_search_returns_subject`, covering empty-search, normal replace, and replace-with-empty).
- Full `sql-vm` / `mini-sqlite` / `storage-sqlite` suites pass; clippy clean.
- Security posture: a pure-string short-circuit with no untrusted-input, allocation, or memory-safety surface — inline assessment, no security-relevant surface.

Versions: `sql-vm` 0.4.39, `mini-sqlite` 0.5.69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
