### PR TITLE
feat(build-tool): define trusted execution policy core

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -10,7 +10,7 @@
   },
   "active_pr": null,
   "last_inventory": {
-    "revision": "e09002be681716c3dc0cfbbda25a69f93b97ae4b",
+    "revision": "40eff9c4432049d7bd704141136662014467e167",
     "schema_version": 2,
     "established_languages": 15,
     "implementation_identities": 1184,

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,7 +8,12 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": null,
+  "active_pr": {
+    "item_id": "build-tool-execution-sandbox",
+    "pr_number": 9178,
+    "branch": "codex/build-tool-execution-sandbox",
+    "url": "https://github.com/adhithyan15/coding-adventures/pull/9178"
+  },
   "last_inventory": {
     "revision": "40eff9c4432049d7bd704141136662014467e167",
     "schema_version": 2,
@@ -51,11 +56,11 @@
     {
       "id": "build-tool-execution-sandbox",
       "title": "Define the trusted-execution policy, closed schema, and fail-closed backend contract",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-fixtures"],
       "branch": "codex/build-tool-execution-sandbox",
-      "pr_number": null,
-      "notes": "Refined after the contract and security audits: land the process-free policy core first, with closed execution records, immutable corpus and adapter identities, explicit operator authorization, and a backend interface that cannot fall back to host execution. This item must not execute fixture code."
+      "pr_number": 9178,
+      "notes": "Ready-for-review PR #9178. Refined after the contract and security audits: land the process-free policy core first, with closed execution records, immutable corpus and adapter identities, explicit operator authorization, and a backend interface that cannot fall back to host execution. This item does not execute fixture code."
     },
     {
       "id": "build-tool-linux-oci-sandbox",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,14 +8,9 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": {
-    "item_id": "build-tool-pure-domain-corpus",
-    "pr_number": 9167,
-    "branch": "codex/build-tool-pure-domain-corpus",
-    "url": "https://github.com/adhithyan15/coding-adventures/pull/9167"
-  },
+  "active_pr": null,
   "last_inventory": {
-    "revision": "3201fb42078f40ef27f11aefb5e3b4b1bcf8551e",
+    "revision": "e09002be681716c3dc0cfbbda25a69f93b97ae4b",
     "schema_version": 2,
     "established_languages": 15,
     "implementation_identities": 1184,
@@ -56,16 +51,16 @@
     {
       "id": "build-tool-execution-sandbox",
       "title": "Add the trusted execution sandbox and adversarial execution corpus",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": ["build-tool-fixtures"],
-      "branch": null,
+      "branch": "codex/build-tool-execution-sandbox",
       "pr_number": null,
-      "notes": "Newly separated after the contract security review. Require fail-closed filesystem and network isolation, no-follow materialization/output, direct argv, sanitized environments, and process-tree wall/CPU/memory/output/workspace/process-count limits before any execution fixture can run."
+      "notes": "Selected after PR #9167 merged because this is the highest-leverage pending dependency: it directly gates the Go oracle, all existing build-tool remediation, Java/Kotlin, Dart, OCaml promotion, and C/C++ graduation. Require fail-closed filesystem and network isolation, no-follow materialization/output, direct argv, sanitized environments, and process-tree wall/CPU/memory/output/workspace/process-count limits before any execution fixture can run."
     },
     {
       "id": "build-tool-pure-domain-corpus",
       "title": "Close the remaining non-execution build-tool domain schemas and fixtures",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-fixtures"],
       "branch": "codex/build-tool-pure-domain-corpus",
       "pr_number": 9167,

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -50,12 +50,52 @@
     },
     {
       "id": "build-tool-execution-sandbox",
-      "title": "Add the trusted execution sandbox and adversarial execution corpus",
+      "title": "Define the trusted-execution policy, closed schema, and fail-closed backend contract",
       "status": "in-progress",
       "depends_on": ["build-tool-fixtures"],
       "branch": "codex/build-tool-execution-sandbox",
       "pr_number": null,
-      "notes": "Selected after PR #9167 merged because this is the highest-leverage pending dependency: it directly gates the Go oracle, all existing build-tool remediation, Java/Kotlin, Dart, OCaml promotion, and C/C++ graduation. Require fail-closed filesystem and network isolation, no-follow materialization/output, direct argv, sanitized environments, and process-tree wall/CPU/memory/output/workspace/process-count limits before any execution fixture can run."
+      "notes": "Refined after the contract and security audits: land the process-free policy core first, with closed execution records, immutable corpus and adapter identities, explicit operator authorization, and a backend interface that cannot fall back to host execution. This item must not execute fixture code."
+    },
+    {
+      "id": "build-tool-linux-oci-sandbox",
+      "title": "Implement the Linux OCI trusted-execution sandbox",
+      "status": "pending",
+      "depends_on": ["build-tool-execution-sandbox"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Use a pinned pre-existing image identity, private mount/user/PID/network namespaces, read-only rootfs, no-new-privileges, dropped capabilities, non-root execution, bounded tmpfs, cgroup limits, streaming output accounting, and whole-container termination. Never pull or fall back to the host."
+    },
+    {
+      "id": "build-tool-windows-appcontainer-sandbox",
+      "title": "Implement the Windows AppContainer trusted-execution sandbox",
+      "status": "pending",
+      "depends_on": ["build-tool-execution-sandbox"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Require a capability-less AppContainer or LPAC, private DACLs, root-handle reparse-safe filesystem operations, and a Job Object assigned before resume with no breakaway and whole-tree CPU, memory, process, wall, output, and workspace limits."
+    },
+    {
+      "id": "build-tool-macos-isolated-sandbox",
+      "title": "Implement a provable macOS trusted-execution sandbox",
+      "status": "pending",
+      "depends_on": ["build-tool-execution-sandbox"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Fail closed until a signed sandbox helper or isolated VM backend can enforce filesystem and network denial plus aggregate process-tree CPU, memory, process, wall, output, workspace, and termination limits. sandbox-exec alone is not sufficient evidence."
+    },
+    {
+      "id": "build-tool-execution-semantics-corpus",
+      "title": "Add execution semantics cases and adversarial sandbox probes",
+      "status": "pending",
+      "depends_on": [
+        "build-tool-linux-oci-sandbox",
+        "build-tool-windows-appcontainer-sandbox",
+        "build-tool-macos-isolated-sandbox"
+      ],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Keep sequencing, dependency skip, dry-run, jobs, resource locks, legacy shell, and direct argv as closed behavior fixtures. Keep filesystem, network, environment, link-race, descendant-kill, and every hard-limit check as runner-owned non-oracular probes."
     },
     {
       "id": "build-tool-pure-domain-corpus",
@@ -106,7 +146,10 @@
       "id": "build-tool-go-oracle",
       "title": "Bring the Go build tool to the canonical contract",
       "status": "pending",
-      "depends_on": ["build-tool-pure-domain-corpus", "build-tool-execution-sandbox"],
+      "depends_on": [
+        "build-tool-pure-domain-corpus",
+        "build-tool-execution-semantics-corpus"
+      ],
       "branch": null,
       "pr_number": null,
       "notes": "Wire structured Starlark context/commands and complete the B05 Windows executor contract."
@@ -124,7 +167,10 @@
       "id": "build-tool-jvm",
       "title": "Add language-native Java and Kotlin build tools",
       "status": "pending",
-      "depends_on": ["build-tool-pure-domain-corpus", "build-tool-execution-sandbox"],
+      "depends_on": [
+        "build-tool-pure-domain-corpus",
+        "build-tool-execution-semantics-corpus"
+      ],
       "branch": null,
       "pr_number": null,
       "notes": "Use shared JVM fixture infrastructure but separate idiomatic engines."
@@ -133,7 +179,10 @@
       "id": "build-tool-dart",
       "title": "Add the Dart build tool",
       "status": "pending",
-      "depends_on": ["build-tool-pure-domain-corpus", "build-tool-execution-sandbox"],
+      "depends_on": [
+        "build-tool-pure-domain-corpus",
+        "build-tool-execution-semantics-corpus"
+      ],
       "branch": null,
       "pr_number": null,
       "notes": "Must pass the same plan, resolver, execution, and platform fixtures as the reference."
@@ -169,7 +218,11 @@
       "id": "ocaml-build-tool-and-promotion",
       "title": "Implement the OCaml build tool and review 16-lane promotion",
       "status": "pending",
-      "depends_on": ["ocaml-representative-core", "build-tool-pure-domain-corpus", "build-tool-execution-sandbox"],
+      "depends_on": [
+        "ocaml-representative-core",
+        "build-tool-pure-domain-corpus",
+        "build-tool-execution-semantics-corpus"
+      ],
       "branch": null,
       "pr_number": null,
       "notes": "Require conformance, two-way Go plan interchange, three-OS CI, capability enforcement, and explicit backlog acceptance."
@@ -241,7 +294,10 @@
       "id": "c-cpp-graduation",
       "title": "Review C/C++ graduation and native build-tool requirements",
       "status": "pending",
-      "depends_on": ["build-tool-pure-domain-corpus", "build-tool-execution-sandbox"],
+      "depends_on": [
+        "build-tool-pure-domain-corpus",
+        "build-tool-execution-semantics-corpus"
+      ],
       "branch": null,
       "pr_number": null,
       "notes": "Keep both emerging until package/scaffold/build-tool maturity and applicability are explicit."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,10 @@ jobs:
           python3 -m unittest discover -s code/scripts/tests -p 'test_package_parity_report.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_schema.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_runner.py'
+          python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_execution_schema.py'
+          python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_execution_runner.py'
           python3 code/scripts/build_tool_conformance.py validate-corpus
+          python3 code/scripts/build_tool_conformance_execution.py validate-contract
           python3 code/scripts/package_parity_report.py --format json --fail-on-collisions > /tmp/package-parity-report.json
 
       - name: Determine diff base

--- a/code/scripts/build_tool_conformance_execution.py
+++ b/code/scripts/build_tool_conformance_execution.py
@@ -1,0 +1,611 @@
+#!/usr/bin/env python3
+"""Validate trusted-execution policy without executing fixture code.
+
+This module is the process-free policy layer. It deliberately imports no
+process API, creates no workspace, and has no host-execution fallback. Platform
+backends land separately; until then ``run-case`` can only return a stable
+non-passing result after authority checks succeed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import stat
+import struct
+import sys
+import unicodedata
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+from typing import Any
+
+import build_tool_conformance as bootstrap
+
+DEFAULT_FIXTURE_ROOT = bootstrap.DEFAULT_FIXTURE_ROOT
+DEFAULT_EXECUTION_CASE_ROOT = DEFAULT_FIXTURE_ROOT / "execution-cases"
+MAX_EXECUTION_CASE_BYTES = bootstrap.MAX_DOCUMENT_BYTES
+SHA256_PATTERN = "0123456789abcdef"
+PLATFORM_BACKEND_KINDS = {
+    "darwin": "macos_isolated",
+    "linux": "linux_oci",
+    "windows": "windows_appcontainer",
+}
+
+
+def _read_raw_regular(
+    path: Path,
+    *,
+    max_bytes: int = MAX_EXECUTION_CASE_BYTES,
+) -> bytes:
+    """Read a bounded regular file without following its final link."""
+
+    try:
+        with bootstrap._open_regular_no_follow(path) as source:
+            if not stat.S_ISREG(os.fstat(source.fileno()).st_mode):
+                raise bootstrap.ConformanceError(
+                    "EXECUTION_CORPUS_FILE_INVALID",
+                    f"execution corpus member is not a regular file: {path}",
+                )
+            raw = source.read(max_bytes + 1)
+    except bootstrap.ConformanceError:
+        raise
+    except (OSError, ValueError) as error:
+        raise bootstrap.ConformanceError(
+            "EXECUTION_CORPUS_READ_FAILED",
+            f"could not read execution corpus member: {path}",
+        ) from error
+    if len(raw) > max_bytes:
+        raise bootstrap.ConformanceError(
+            "EXECUTION_CORPUS_FILE_TOO_LARGE",
+            f"execution corpus member exceeds {max_bytes} bytes: {path}",
+        )
+    return raw
+
+
+def framed_corpus_digest(entries: Iterable[tuple[str, bytes]]) -> str:
+    """Hash sorted portable paths and exact bytes with length framing."""
+
+    digest = hashlib.sha256()
+    previous_path: str | None = None
+    for relative_path, raw in sorted(entries, key=lambda item: item[0]):
+        if error := bootstrap.portable_path_error(relative_path):
+            raise bootstrap.ConformanceError(
+                "EXECUTION_CORPUS_PATH_UNSAFE",
+                f"unsafe execution corpus path {relative_path!r}: {error}",
+            )
+        if relative_path != unicodedata.normalize("NFC", relative_path):
+            raise bootstrap.ConformanceError(
+                "EXECUTION_CORPUS_PATH_UNSAFE",
+                f"execution corpus path is not NFC-normalized: {relative_path}",
+            )
+        if relative_path == previous_path:
+            raise bootstrap.ConformanceError(
+                "EXECUTION_CORPUS_PATH_DUPLICATE",
+                f"duplicate execution corpus path: {relative_path}",
+            )
+        previous_path = relative_path
+        path_bytes = relative_path.encode("utf-8")
+        digest.update(struct.pack(">Q", len(path_bytes)))
+        digest.update(path_bytes)
+        digest.update(struct.pack(">Q", len(raw)))
+        digest.update(raw)
+    return digest.hexdigest()
+
+
+def _execution_corpus_entries(case_root: Path) -> list[tuple[str, bytes]]:
+    """Open one stable bounded snapshot of direct execution-case members."""
+
+    try:
+        root_status = case_root.lstat()
+    except OSError as error:
+        raise bootstrap.ConformanceError(
+            "EXECUTION_CORPUS_DIRECTORY_MISSING",
+            f"execution corpus directory does not exist: {case_root}",
+        ) from error
+    is_reparse = bool(
+        getattr(root_status, "st_file_attributes", 0)
+        & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+    )
+    if (
+        not stat.S_ISDIR(root_status.st_mode)
+        or stat.S_ISLNK(root_status.st_mode)
+        or is_reparse
+    ):
+        raise bootstrap.ConformanceError(
+            "EXECUTION_CORPUS_DIRECTORY_INVALID",
+            f"execution corpus path is not a regular directory: {case_root}",
+        )
+    return [
+        (path.relative_to(case_root).as_posix(), _read_raw_regular(path))
+        for path in sorted(case_root.glob("*.json"), key=lambda item: item.name)
+    ]
+
+
+def execution_corpus_digest(case_root: Path) -> str:
+    """Compute the reviewed execution-corpus digest without JSON decoding."""
+
+    return framed_corpus_digest(_execution_corpus_entries(case_root))
+
+
+def _is_sha256(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in SHA256_PATTERN for character in value)
+    )
+
+
+def validate_policy_semantics(policy: dict[str, Any]) -> dict[str, int]:
+    """Validate cross-field identities that JSON Schema cannot express."""
+
+    backends = policy["backends"]
+    platforms = [item["platform"] for item in backends]
+    if platforms != sorted(PLATFORM_BACKEND_KINDS):
+        raise bootstrap.ConformanceError(
+            "EXECUTION_BACKENDS_NOT_CANONICAL",
+            "backends must contain darwin, linux, and windows in sorted order",
+        )
+    for backend in backends:
+        expected_kind = PLATFORM_BACKEND_KINDS[backend["platform"]]
+        if backend["kind"] != expected_kind:
+            raise bootstrap.ConformanceError(
+                "EXECUTION_BACKEND_KIND_MISMATCH",
+                f"{backend['platform']} requires backend kind {expected_kind}",
+            )
+
+    adapter_keys: set[tuple[str, str]] = set()
+    for adapter in policy["adapters"]:
+        key = (adapter["language"], adapter["platform"])
+        if key in adapter_keys:
+            raise bootstrap.ConformanceError(
+                "EXECUTION_ADAPTER_DUPLICATE",
+                f"duplicate execution adapter identity: {key[0]}/{key[1]}",
+            )
+        adapter_keys.add(key)
+        if error := bootstrap.portable_path_error(adapter["executable"]):
+            raise bootstrap.ConformanceError(
+                "EXECUTION_ADAPTER_PATH_UNSAFE",
+                f"unsafe adapter path {adapter['executable']!r}: {error}",
+            )
+    return {
+        "ready_backend_count": sum(item["status"] == "ready" for item in backends),
+        "adapter_count": len(policy["adapters"]),
+    }
+
+
+def _execution_options(case: dict[str, Any]) -> dict[str, Any]:
+    input_value = case.get("input")
+    if not isinstance(input_value, dict):
+        return {}
+    options = input_value.get("options")
+    return options if isinstance(options, dict) else {}
+
+
+def _validate_execution_graph(
+    package_names: set[str],
+    edges: list[list[str]],
+) -> None:
+    outgoing = {name: [] for name in package_names}
+    indegree = {name: 0 for name in package_names}
+    for prerequisite, dependent in edges:
+        if prerequisite not in package_names or dependent not in package_names:
+            raise bootstrap.ConformanceError(
+                "EXECUTION_EDGE_UNKNOWN",
+                "execution dependency edge references an unknown package",
+            )
+        outgoing[prerequisite].append(dependent)
+        indegree[dependent] += 1
+    ready = sorted(name for name, count in indegree.items() if count == 0)
+    visited = 0
+    while ready:
+        current = ready.pop(0)
+        visited += 1
+        for dependent in sorted(outgoing[current]):
+            indegree[dependent] -= 1
+            if indegree[dependent] == 0:
+                ready.append(dependent)
+                ready.sort()
+    if visited != len(package_names):
+        raise bootstrap.ConformanceError(
+            "EXECUTION_GRAPH_CYCLE",
+            "execution dependency graph contains a cycle",
+        )
+
+
+def validate_execution_semantics(case: dict[str, Any]) -> None:
+    """Validate execution case identities and deterministic result ordering."""
+
+    if case.get("domain") != "execution":
+        raise bootstrap.ConformanceError(
+            "EXECUTION_DOMAIN_INVALID",
+            "execution cases require domain=execution",
+        )
+    input_value = case.get("input")
+    if not isinstance(input_value, dict) or input_value.get("operation") != "execution":
+        raise bootstrap.ConformanceError(
+            "EXECUTION_OPERATION_INVALID",
+            "execution cases require input.operation=execution",
+        )
+    capabilities = case.get("capabilities")
+    if not isinstance(capabilities, list) or not {
+        "execution",
+        "trusted_execution",
+    }.issubset(capabilities):
+        raise bootstrap.ConformanceError(
+            "EXECUTION_CAPABILITY_MISSING",
+            "execution cases require execution and trusted_execution",
+        )
+    expected = case.get("expected")
+    if (
+        not isinstance(expected, dict)
+        or expected.get("case_id") != case.get("id")
+        or expected.get("domain") != "execution"
+    ):
+        raise bootstrap.ConformanceError(
+            "EXECUTION_IDENTITY_MISMATCH",
+            "execution case and expected result identities must match",
+        )
+
+    options = _execution_options(case)
+    platform_name = options.get("platform")
+    platforms = case.get("platforms")
+    if not isinstance(platforms, list) or platform_name not in platforms:
+        raise bootstrap.ConformanceError(
+            "EXECUTION_PLATFORM_MISMATCH",
+            "execution options.platform must be listed in top-level platforms",
+        )
+    limits = case.get("limits")
+    process_limit = limits.get("process_count") if isinstance(limits, dict) else None
+    jobs = options.get("jobs")
+    if (
+        not isinstance(jobs, int)
+        or not isinstance(process_limit, int)
+        or jobs > process_limit
+    ):
+        raise bootstrap.ConformanceError(
+            "EXECUTION_JOB_LIMIT",
+            "execution jobs cannot exceed the requested process_count limit",
+        )
+
+    packages = options.get("packages")
+    if not isinstance(packages, list):
+        raise bootstrap.ConformanceError(
+            "EXECUTION_PACKAGES_INVALID",
+            "execution packages must be an array",
+        )
+    package_names: set[str] = set()
+    normalized_paths: set[str] = set()
+    for package in packages:
+        name = package["name"]
+        if name in package_names:
+            raise bootstrap.ConformanceError(
+                "EXECUTION_PACKAGE_DUPLICATE",
+                f"duplicate execution package: {name}",
+            )
+        package_names.add(name)
+        rel_path = package["rel_path"]
+        if error := bootstrap.portable_path_error(rel_path):
+            raise bootstrap.ConformanceError(
+                "EXECUTION_PACKAGE_PATH_UNSAFE",
+                f"unsafe execution package path {rel_path!r}: {error}",
+            )
+        normalized = unicodedata.normalize("NFC", rel_path).casefold()
+        if normalized in normalized_paths:
+            raise bootstrap.ConformanceError(
+                "EXECUTION_PACKAGE_PATH_DUPLICATE",
+                f"duplicate normalized execution package path: {rel_path}",
+            )
+        normalized_paths.add(normalized)
+        if package["resource_locks"] != sorted(package["resource_locks"]):
+            raise bootstrap.ConformanceError(
+                "EXECUTION_LOCKS_NOT_CANONICAL",
+                f"resource locks are not sorted for {name}",
+            )
+
+    edges = options.get("dependency_edges")
+    if not isinstance(edges, list):
+        raise bootstrap.ConformanceError(
+            "EXECUTION_EDGES_INVALID",
+            "execution dependency_edges must be an array",
+        )
+    _validate_execution_graph(package_names, edges)
+
+    outcome = expected["outcome"]
+    if outcome in {"ok", "error"}:
+        result_packages = expected["result"]["packages"]
+        result_names = [package["name"] for package in result_packages]
+        if result_names != sorted(result_names):
+            raise bootstrap.ConformanceError(
+                "EXECUTION_RESULT_NOT_CANONICAL",
+                "execution result packages must be sorted by name",
+            )
+        if set(result_names) != package_names:
+            raise bootstrap.ConformanceError(
+                "EXECUTION_RESULT_PACKAGE_MISMATCH",
+                "execution result must classify every input package exactly once",
+            )
+        package_by_name = {package["name"]: package for package in packages}
+        for package_result in result_packages:
+            command_results = package_result["commands"]
+            indices = [command["index"] for command in command_results]
+            if indices != list(range(len(command_results))):
+                raise bootstrap.ConformanceError(
+                    "EXECUTION_COMMAND_INDEX_INVALID",
+                    f"command indices are not canonical for {package_result['name']}",
+                )
+            command_count = len(package_by_name[package_result["name"]]["commands"])
+            if len(command_results) != command_count:
+                raise bootstrap.ConformanceError(
+                    "EXECUTION_COMMAND_COUNT_MISMATCH",
+                    f"command result count differs for {package_result['name']}",
+                )
+
+
+def _load_contract_documents(
+    fixture_root: Path,
+) -> tuple[
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+]:
+    return (
+        bootstrap.load_document(fixture_root / "schema.json"),
+        bootstrap.load_document(fixture_root / "result.schema.json"),
+        bootstrap.load_document(fixture_root / "execution.schema.json"),
+        bootstrap.load_document(fixture_root / "execution-policy.schema.json"),
+        bootstrap.load_document(fixture_root / "execution-policy.json"),
+    )
+
+
+def validate_contract(
+    fixture_root: Path = DEFAULT_FIXTURE_ROOT,
+) -> dict[str, Any]:
+    """Validate schemas, policy, digest, and inert execution cases."""
+
+    fixture_root = fixture_root.resolve()
+    (
+        case_schema,
+        result_schema,
+        execution_schema,
+        policy_schema,
+        policy,
+    ) = _load_contract_documents(fixture_root)
+    for schema in (case_schema, result_schema, execution_schema, policy_schema):
+        bootstrap._schema_errors({}, schema)
+    bootstrap._validate_schema(
+        policy,
+        policy_schema,
+        "EXECUTION_POLICY_SCHEMA_INVALID",
+    )
+    summary = validate_policy_semantics(policy)
+    case_root = fixture_root / "execution-cases"
+    corpus_entries = _execution_corpus_entries(case_root)
+    digest = framed_corpus_digest(corpus_entries)
+    if digest != policy["execution_corpus_sha256"]:
+        raise bootstrap.ConformanceError(
+            "EXECUTION_POLICY_CORPUS_MISMATCH",
+            "checked-in execution policy does not match the execution corpus",
+        )
+
+    case_ids: set[str] = set()
+    for relative_path, raw in corpus_entries:
+        case = bootstrap.strict_load_bytes(raw)
+        bootstrap._validate_schema(
+            case,
+            case_schema,
+            "EXECUTION_CASE_SCHEMA_INVALID",
+        )
+        expected = case.get("expected")
+        if not isinstance(expected, dict):
+            raise bootstrap.ConformanceError(
+                "EXECUTION_EXPECTED_INVALID",
+                "execution case expected result is missing",
+            )
+        bootstrap._validate_schema(
+            expected,
+            result_schema,
+            "EXECUTION_RESULT_SCHEMA_INVALID",
+        )
+        projection = {
+            "domain": case.get("domain"),
+            "outcome": expected.get("outcome"),
+            "input": case.get("input"),
+            "result": expected.get("result"),
+        }
+        bootstrap._validate_schema(
+            projection,
+            execution_schema,
+            "EXECUTION_PROJECTION_SCHEMA_INVALID",
+        )
+        validate_execution_semantics(case)
+        case_id = case["id"]
+        if case_id in case_ids:
+            raise bootstrap.ConformanceError(
+                "EXECUTION_CASE_ID_DUPLICATE",
+                f"duplicate execution case id in {relative_path}: {case_id}",
+            )
+        case_ids.add(case_id)
+
+    return {
+        "schema_version": 1,
+        "execution_case_count": len(corpus_entries),
+        "execution_corpus_sha256": digest,
+        "ready_backend_count": summary["ready_backend_count"],
+        "adapter_count": summary["adapter_count"],
+        "status": "valid",
+        "conformance_status": "not-run",
+    }
+
+
+def _platform_name() -> str:
+    if sys.platform.startswith("linux"):
+        return "linux"
+    if sys.platform == "darwin":
+        return "darwin"
+    if os.name == "nt":
+        return "windows"
+    return "unsupported"
+
+
+def _nonpassing_skip(code: str, message: str) -> dict[str, Any]:
+    return {
+        "status": "skipped",
+        "outcome": "skipped",
+        "conformance_status": "non-passing",
+        "diagnostics": [
+            {
+                "code": code,
+                "severity": "error",
+                "message": message,
+            }
+        ],
+    }
+
+
+def run_case(
+    case_path: Path,
+    *,
+    language: str,
+    approved_digest: str,
+    allow_trusted_execution: bool,
+    fixture_root: Path = DEFAULT_FIXTURE_ROOT,
+    platform_name: str | None = None,
+) -> dict[str, Any]:
+    """Check execution authority and fail closed before any process operation."""
+
+    del case_path  # The policy-only tranche never decodes executable case data.
+    if not allow_trusted_execution:
+        raise bootstrap.ConformanceError(
+            "EXECUTION_AUTHORIZATION_REQUIRED",
+            "trusted execution requires --allow-trusted-execution",
+        )
+
+    fixture_root = fixture_root.resolve()
+    _, _, _, policy_schema, policy = _load_contract_documents(fixture_root)
+    bootstrap._validate_schema(
+        policy,
+        policy_schema,
+        "EXECUTION_POLICY_SCHEMA_INVALID",
+    )
+    validate_policy_semantics(policy)
+    actual_digest = execution_corpus_digest(fixture_root / "execution-cases")
+    if (
+        not _is_sha256(approved_digest)
+        or approved_digest != actual_digest
+        or approved_digest != policy["execution_corpus_sha256"]
+    ):
+        raise bootstrap.ConformanceError(
+            "EXECUTION_DIGEST_MISMATCH",
+            "approved digest, policy digest, and corpus digest must match exactly",
+        )
+
+    if not policy["enabled"]:
+        return _nonpassing_skip(
+            "EXECUTION_POLICY_DISABLED",
+            "trusted execution policy is disabled",
+        )
+
+    selected_platform = platform_name or _platform_name()
+    backend = next(
+        (item for item in policy["backends"] if item["platform"] == selected_platform),
+        None,
+    )
+    if backend is None or backend["status"] != "ready":
+        return _nonpassing_skip(
+            "EXECUTION_BACKEND_UNAVAILABLE",
+            f"no enforcing trusted-execution backend for {selected_platform}",
+        )
+
+    adapter = next(
+        (
+            item
+            for item in policy["adapters"]
+            if item["language"] == language and item["platform"] == selected_platform
+        ),
+        None,
+    )
+    if adapter is None:
+        return _nonpassing_skip(
+            "EXECUTION_ADAPTER_UNAVAILABLE",
+            f"no reviewed adapter for {language}/{selected_platform}",
+        )
+    return _nonpassing_skip(
+        "EXECUTION_BACKEND_UNIMPLEMENTED",
+        "policy authority is valid, but this tranche contains no process backend",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate trusted-execution policy without executing code."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate_parser = subparsers.add_parser(
+        "validate-contract",
+        help="Validate execution schemas, policy, digest, and inert cases.",
+    )
+    validate_parser.add_argument(
+        "--fixture-root",
+        type=Path,
+        default=DEFAULT_FIXTURE_ROOT,
+    )
+
+    run_parser = subparsers.add_parser(
+        "run-case",
+        help="Check execution authority and return a fail-closed result.",
+    )
+    run_parser.add_argument("--case", type=Path, required=True)
+    run_parser.add_argument("--language", required=True)
+    run_parser.add_argument("--approved-corpus-sha256", required=True)
+    run_parser.add_argument("--allow-trusted-execution", action="store_true")
+    run_parser.add_argument(
+        "--fixture-root",
+        type=Path,
+        default=DEFAULT_FIXTURE_ROOT,
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    try:
+        arguments = parser.parse_args(argv)
+    except SystemExit as error:
+        return int(error.code)
+    try:
+        if arguments.command == "validate-contract":
+            output = validate_contract(arguments.fixture_root)
+            exit_code = 0
+        else:
+            output = run_case(
+                arguments.case,
+                language=arguments.language,
+                approved_digest=arguments.approved_corpus_sha256,
+                allow_trusted_execution=arguments.allow_trusted_execution,
+                fixture_root=arguments.fixture_root,
+            )
+            exit_code = 1
+    except bootstrap.ConformanceError as error:
+        print(
+            json.dumps(
+                {
+                    "code": error.code,
+                    "message": error.message,
+                    "status": "error",
+                },
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 2
+    print(json.dumps(output, sort_keys=True))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/tests/test_build_tool_conformance_execution_runner.py
+++ b/code/scripts/tests/test_build_tool_conformance_execution_runner.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import copy
+import io
+import json
+import shutil
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import build_tool_conformance as bootstrap
+import build_tool_conformance_execution as execution
+
+FIXTURE_ROOT = bootstrap.DEFAULT_FIXTURE_ROOT
+EMPTY_DIGEST = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+
+def write_policy_fixture(root: Path, policy: dict[str, object]) -> Path:
+    fixture_root = root / "fixtures"
+    fixture_root.mkdir()
+    for name in (
+        "schema.json",
+        "result.schema.json",
+        "execution.schema.json",
+        "execution-policy.schema.json",
+    ):
+        shutil.copyfile(FIXTURE_ROOT / name, fixture_root / name)
+    (fixture_root / "execution-cases").mkdir()
+    (fixture_root / "execution-policy.json").write_text(
+        json.dumps(policy),
+        encoding="utf-8",
+    )
+    return fixture_root
+
+
+class ExecutionPolicyRunnerTests(unittest.TestCase):
+    def test_checked_in_contract_validates_without_execution(self) -> None:
+        summary = execution.validate_contract(FIXTURE_ROOT)
+        self.assertEqual(summary["schema_version"], 1)
+        self.assertEqual(summary["execution_case_count"], 0)
+        self.assertEqual(summary["execution_corpus_sha256"], EMPTY_DIGEST)
+        self.assertEqual(summary["ready_backend_count"], 0)
+        self.assertEqual(summary["status"], "valid")
+        self.assertEqual(summary["conformance_status"], "not-run")
+
+    def test_operator_authorization_is_checked_before_case_read(self) -> None:
+        missing = Path("definitely-not-present.json")
+        with (
+            mock.patch.object(execution, "_read_raw_regular") as reader,
+            self.assertRaises(bootstrap.ConformanceError) as raised,
+        ):
+            execution.run_case(
+                missing,
+                language="go",
+                approved_digest=EMPTY_DIGEST,
+                allow_trusted_execution=False,
+                fixture_root=FIXTURE_ROOT,
+            )
+        self.assertEqual(raised.exception.code, "EXECUTION_AUTHORIZATION_REQUIRED")
+        reader.assert_not_called()
+
+    def test_approved_digest_is_checked_before_case_decode(self) -> None:
+        missing = Path("definitely-not-present.json")
+        with (
+            mock.patch.object(execution, "_read_raw_regular") as reader,
+            self.assertRaises(bootstrap.ConformanceError) as raised,
+        ):
+            execution.run_case(
+                missing,
+                language="go",
+                approved_digest="0" * 64,
+                allow_trusted_execution=True,
+                fixture_root=FIXTURE_ROOT,
+            )
+        self.assertEqual(raised.exception.code, "EXECUTION_DIGEST_MISMATCH")
+        reader.assert_not_called()
+
+    def test_disabled_policy_returns_nonpassing_skip_without_process_api(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            case = Path(directory) / "case.json"
+            case.write_text("{}", encoding="utf-8")
+            result = execution.run_case(
+                case,
+                language="go",
+                approved_digest=EMPTY_DIGEST,
+                allow_trusted_execution=True,
+                fixture_root=FIXTURE_ROOT,
+            )
+        self.assertEqual(result["outcome"], "skipped")
+        self.assertEqual(result["conformance_status"], "non-passing")
+        self.assertEqual(
+            result["diagnostics"][0]["code"],
+            "EXECUTION_POLICY_DISABLED",
+        )
+        self.assertFalse(hasattr(execution, "subprocess"))
+
+    def test_ready_backend_is_still_fail_closed_in_policy_only_tranche(self) -> None:
+        policy = bootstrap.load_document(FIXTURE_ROOT / "execution-policy.json")
+        policy["enabled"] = True
+        linux = next(item for item in policy["backends"] if item["platform"] == "linux")
+        linux["status"] = "ready"
+        linux["identity_sha256"] = "1" * 64
+        policy["adapters"] = [
+            {
+                "language": "go",
+                "platform": "linux",
+                "executable": "code/programs/go/build-tool",
+                "executable_sha256": "2" * 64,
+            }
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fixture_root = write_policy_fixture(root, policy)
+            case = root / "case.json"
+            case.write_text("{}", encoding="utf-8")
+            result = execution.run_case(
+                case,
+                language="go",
+                approved_digest=EMPTY_DIGEST,
+                allow_trusted_execution=True,
+                fixture_root=fixture_root,
+                platform_name="linux",
+            )
+        self.assertEqual(result["outcome"], "skipped")
+        self.assertEqual(
+            result["diagnostics"][0]["code"],
+            "EXECUTION_BACKEND_UNIMPLEMENTED",
+        )
+
+    def test_enabled_policy_skips_unavailable_backend_and_missing_adapter(self) -> None:
+        policy = bootstrap.load_document(FIXTURE_ROOT / "execution-policy.json")
+        policy["enabled"] = True
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fixture_root = write_policy_fixture(root, policy)
+            result = execution.run_case(
+                root / "unused.json",
+                language="go",
+                approved_digest=EMPTY_DIGEST,
+                allow_trusted_execution=True,
+                fixture_root=fixture_root,
+                platform_name="windows",
+            )
+        self.assertEqual(
+            result["diagnostics"][0]["code"],
+            "EXECUTION_BACKEND_UNAVAILABLE",
+        )
+
+        linux = next(item for item in policy["backends"] if item["platform"] == "linux")
+        linux["status"] = "ready"
+        linux["identity_sha256"] = "1" * 64
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fixture_root = write_policy_fixture(root, policy)
+            result = execution.run_case(
+                root / "unused.json",
+                language="go",
+                approved_digest=EMPTY_DIGEST,
+                allow_trusted_execution=True,
+                fixture_root=fixture_root,
+                platform_name="linux",
+            )
+        self.assertEqual(
+            result["diagnostics"][0]["code"],
+            "EXECUTION_ADAPTER_UNAVAILABLE",
+        )
+
+    def test_platform_mapping_is_explicit_and_fail_closed(self) -> None:
+        with mock.patch.object(execution.sys, "platform", "linux-x"):
+            self.assertEqual(execution._platform_name(), "linux")
+        with mock.patch.object(execution.sys, "platform", "darwin"):
+            self.assertEqual(execution._platform_name(), "darwin")
+        with (
+            mock.patch.object(execution.sys, "platform", "other"),
+            mock.patch.object(execution.os, "name", "nt"),
+        ):
+            self.assertEqual(execution._platform_name(), "windows")
+        with (
+            mock.patch.object(execution.sys, "platform", "other"),
+            mock.patch.object(execution.os, "name", "posix"),
+        ):
+            self.assertEqual(execution._platform_name(), "unsupported")
+
+    def test_cli_validate_contract_and_disabled_run_case_have_stable_exit_codes(
+        self,
+    ) -> None:
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            exit_code = execution.main(["validate-contract"])
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(json.loads(stdout.getvalue())["status"], "valid")
+
+        with tempfile.TemporaryDirectory() as directory:
+            case = Path(directory) / "case.json"
+            case.write_text("{}", encoding="utf-8")
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                exit_code = execution.main(
+                    [
+                        "run-case",
+                        "--case",
+                        str(case),
+                        "--language",
+                        "go",
+                        "--approved-corpus-sha256",
+                        EMPTY_DIGEST,
+                        "--allow-trusted-execution",
+                    ]
+                )
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(json.loads(stdout.getvalue())["outcome"], "skipped")
+        self.assertEqual(stderr.getvalue(), "")
+
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            exit_code = execution.main(
+                [
+                    "run-case",
+                    "--case",
+                    str(case),
+                    "--language",
+                    "go",
+                    "--approved-corpus-sha256",
+                    EMPTY_DIGEST,
+                ]
+            )
+        self.assertEqual(exit_code, 2)
+        self.assertEqual(
+            json.loads(stderr.getvalue())["code"],
+            "EXECUTION_AUTHORIZATION_REQUIRED",
+        )
+
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(execution.main([]), 2)
+
+    def test_fixture_arguments_environment_and_manifest_never_select_authority(
+        self,
+    ) -> None:
+        policy = bootstrap.load_document(FIXTURE_ROOT / "execution-policy.json")
+        mutated = copy.deepcopy(policy)
+        mutated["fixture_arguments"] = ["--replace-adapter", "host.exe"]
+        schema = bootstrap.load_document(FIXTURE_ROOT / "execution-policy.schema.json")
+        self.assertTrue(bootstrap._schema_errors(mutated, schema))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/scripts/tests/test_build_tool_conformance_execution_schema.py
+++ b/code/scripts/tests/test_build_tool_conformance_execution_schema.py
@@ -1,0 +1,470 @@
+from __future__ import annotations
+
+import copy
+import json
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import build_tool_conformance as bootstrap
+import build_tool_conformance_execution as execution
+
+FIXTURE_ROOT = bootstrap.DEFAULT_FIXTURE_ROOT
+
+
+def base_case() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "id": "execution/structured-command",
+        "domain": "execution",
+        "summary": "A structured command remains a direct argument vector.",
+        "platforms": ["linux"],
+        "capabilities": ["execution", "trusted_execution"],
+        "workspace": {"files": []},
+        "input": {
+            "operation": "execution",
+            "options": {
+                "platform": "linux",
+                "jobs": 1,
+                "dry_run": False,
+                "packages": [
+                    {
+                        "name": "python/example",
+                        "rel_path": "code/packages/python/example",
+                        "language": "python",
+                        "commands": [
+                            {
+                                "kind": "structured",
+                                "program": "tools/conformance-probe",
+                                "args": ["literal;not-shell", "$(still-data)"],
+                            }
+                        ],
+                        "resource_locks": [],
+                    }
+                ],
+                "dependency_edges": [],
+            },
+            "arguments": ["--fixture-data-only"],
+            "environment": {"CONFORMANCE_MODE": "test"},
+        },
+        "expected": {
+            "schema_version": 1,
+            "case_id": "execution/structured-command",
+            "domain": "execution",
+            "outcome": "ok",
+            "result": {
+                "packages": [
+                    {
+                        "name": "python/example",
+                        "status": "built",
+                        "return_code": 0,
+                        "commands": [
+                            {
+                                "index": 0,
+                                "status": "succeeded",
+                                "exit_code": 0,
+                            }
+                        ],
+                    }
+                ]
+            },
+            "diagnostics": [],
+        },
+        "limits": {
+            "wall_time_ms": 1000,
+            "output_bytes": 4096,
+            "workspace_bytes": 4096,
+            "process_count": 2,
+            "memory_mib": 64,
+            "cpu_time_ms": 1000,
+        },
+    }
+
+
+class ExecutionSchemaTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.case_schema = bootstrap.load_document(FIXTURE_ROOT / "schema.json")
+        cls.result_schema = bootstrap.load_document(FIXTURE_ROOT / "result.schema.json")
+        cls.execution_schema = bootstrap.load_document(
+            FIXTURE_ROOT / "execution.schema.json"
+        )
+        cls.policy_schema = bootstrap.load_document(
+            FIXTURE_ROOT / "execution-policy.schema.json"
+        )
+
+    def assert_schema_error(
+        self,
+        instance: dict[str, object],
+        schema: dict[str, object],
+    ) -> None:
+        self.assertTrue(bootstrap._schema_errors(instance, schema))
+
+    def projection(self, case: dict[str, object]) -> dict[str, object]:
+        expected = case["expected"]
+        assert isinstance(expected, dict)
+        return {
+            "domain": case["domain"],
+            "outcome": expected["outcome"],
+            "input": case["input"],
+            "result": expected["result"],
+        }
+
+    def test_closed_execution_case_and_projection_validate(self) -> None:
+        case = base_case()
+        self.assertEqual(bootstrap._schema_errors(case, self.case_schema), [])
+        self.assertEqual(
+            bootstrap._schema_errors(self.projection(case), self.execution_schema),
+            [],
+        )
+        self.assertEqual(
+            bootstrap._schema_errors(case["expected"], self.result_schema),
+            [],
+        )
+        execution.validate_execution_semantics(case)
+
+    def test_unknown_execution_fields_are_rejected(self) -> None:
+        case = base_case()
+        options = case["input"]["options"]  # type: ignore[index]
+        options["shell"] = "host"  # type: ignore[index]
+        self.assert_schema_error(case, self.case_schema)
+        self.assert_schema_error(self.projection(case), self.execution_schema)
+
+        case = base_case()
+        command = case["input"]["options"]["packages"][0]["commands"][0]  # type: ignore[index]
+        command["cwd"] = "../../host"  # type: ignore[index]
+        self.assert_schema_error(case, self.case_schema)
+        self.assert_schema_error(self.projection(case), self.execution_schema)
+
+    def test_empty_or_nul_legacy_commands_are_rejected(self) -> None:
+        for line in ("", "printf ok\u0000printf escaped"):
+            case = base_case()
+            commands = case["input"]["options"]["packages"][0]["commands"]  # type: ignore[index]
+            commands[0] = {"kind": "legacy", "line": line}  # type: ignore[index]
+            with self.subTest(line=repr(line)):
+                self.assert_schema_error(case, self.case_schema)
+
+    def test_command_result_exit_code_matches_status(self) -> None:
+        case = base_case()
+        command = case["expected"]["result"]["packages"][0]["commands"][0]  # type: ignore[index]
+        command["status"] = "not-run"  # type: ignore[index]
+        self.assert_schema_error(case["expected"], self.result_schema)  # type: ignore[arg-type]
+
+        command["exit_code"] = None  # type: ignore[index]
+        self.assertEqual(
+            bootstrap._schema_errors(case["expected"], self.result_schema),  # type: ignore[arg-type]
+            [],
+        )
+
+    def test_semantics_reject_duplicate_identities_unknown_edges_and_cycles(
+        self,
+    ) -> None:
+        duplicate = base_case()
+        packages = duplicate["input"]["options"]["packages"]  # type: ignore[index]
+        packages.append(copy.deepcopy(packages[0]))  # type: ignore[attr-defined]
+        with self.assertRaises(bootstrap.ConformanceError) as raised:
+            execution.validate_execution_semantics(duplicate)
+        self.assertEqual(raised.exception.code, "EXECUTION_PACKAGE_DUPLICATE")
+
+        unknown = base_case()
+        unknown["input"]["options"]["dependency_edges"] = [  # type: ignore[index]
+            ["python/missing", "python/example"]
+        ]
+        with self.assertRaises(bootstrap.ConformanceError) as raised:
+            execution.validate_execution_semantics(unknown)
+        self.assertEqual(raised.exception.code, "EXECUTION_EDGE_UNKNOWN")
+
+        cyclic = base_case()
+        packages = cyclic["input"]["options"]["packages"]  # type: ignore[index]
+        second = copy.deepcopy(packages[0])  # type: ignore[index]
+        second["name"] = "python/second"
+        second["rel_path"] = "code/packages/python/second"
+        packages.append(second)  # type: ignore[attr-defined]
+        cyclic["input"]["options"]["dependency_edges"] = [  # type: ignore[index]
+            ["python/example", "python/second"],
+            ["python/second", "python/example"],
+        ]
+        with self.assertRaises(bootstrap.ConformanceError) as raised:
+            execution.validate_execution_semantics(cyclic)
+        self.assertEqual(raised.exception.code, "EXECUTION_GRAPH_CYCLE")
+
+    def test_semantics_reject_platform_and_process_limit_mismatch(self) -> None:
+        case = base_case()
+        case["input"]["options"]["platform"] = "windows"  # type: ignore[index]
+        with self.assertRaises(bootstrap.ConformanceError) as raised:
+            execution.validate_execution_semantics(case)
+        self.assertEqual(raised.exception.code, "EXECUTION_PLATFORM_MISMATCH")
+
+        case = base_case()
+        case["input"]["options"]["jobs"] = 3  # type: ignore[index]
+        with self.assertRaises(bootstrap.ConformanceError) as raised:
+            execution.validate_execution_semantics(case)
+        self.assertEqual(raised.exception.code, "EXECUTION_JOB_LIMIT")
+
+    def test_checked_in_policy_is_closed_disabled_and_complete(self) -> None:
+        policy = bootstrap.load_document(FIXTURE_ROOT / "execution-policy.json")
+        self.assertEqual(bootstrap._schema_errors(policy, self.policy_schema), [])
+        summary = execution.validate_policy_semantics(policy)
+        self.assertFalse(policy["enabled"])
+        self.assertEqual(summary["ready_backend_count"], 0)
+        self.assertEqual(summary["adapter_count"], 0)
+        self.assertEqual(
+            [item["platform"] for item in policy["backends"]],
+            ["darwin", "linux", "windows"],
+        )
+
+    def test_corpus_digest_is_framed_and_detects_path_or_content_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.assertEqual(
+                execution.execution_corpus_digest(root),
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            )
+            (root / "a.json").write_bytes(b"{}")
+            first = execution.execution_corpus_digest(root)
+            (root / "a.json").write_bytes(b'{ "changed": true }')
+            self.assertNotEqual(execution.execution_corpus_digest(root), first)
+            (root / "a.json").rename(root / "b.json")
+            self.assertNotEqual(
+                execution.execution_corpus_digest(root),
+                execution.framed_corpus_digest([("a.json", b'{ "changed": true }')]),
+            )
+
+    def test_corpus_digest_rejects_unsafe_duplicate_and_missing_inputs(self) -> None:
+        with self.assertRaises(bootstrap.ConformanceError) as raised:
+            execution.framed_corpus_digest([("../escape.json", b"{}")])
+        self.assertEqual(raised.exception.code, "EXECUTION_CORPUS_PATH_UNSAFE")
+
+        with self.assertRaises(bootstrap.ConformanceError) as raised:
+            execution.framed_corpus_digest([("same.json", b"{}"), ("same.json", b"{}")])
+        self.assertEqual(raised.exception.code, "EXECUTION_CORPUS_PATH_DUPLICATE")
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            missing = root / "missing"
+            with self.assertRaises(bootstrap.ConformanceError) as raised:
+                execution.execution_corpus_digest(missing)
+            self.assertEqual(
+                raised.exception.code,
+                "EXECUTION_CORPUS_DIRECTORY_MISSING",
+            )
+            regular = root / "regular"
+            regular.write_text("not a directory", encoding="utf-8")
+            with self.assertRaises(bootstrap.ConformanceError) as raised:
+                execution.execution_corpus_digest(regular)
+            self.assertEqual(
+                raised.exception.code,
+                "EXECUTION_CORPUS_DIRECTORY_INVALID",
+            )
+
+    def test_corpus_reader_rejects_oversized_and_nonregular_members(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            oversized = root / "oversized.json"
+            oversized.write_bytes(b"12345")
+            with self.assertRaises(bootstrap.ConformanceError) as raised:
+                execution._read_raw_regular(oversized, max_bytes=4)
+            self.assertEqual(
+                raised.exception.code,
+                "EXECUTION_CORPUS_FILE_TOO_LARGE",
+            )
+            with self.assertRaises(bootstrap.ConformanceError) as raised:
+                execution._read_raw_regular(root)
+            self.assertIn(
+                raised.exception.code,
+                {
+                    "EXECUTION_CORPUS_FILE_INVALID",
+                    "EXECUTION_CORPUS_READ_FAILED",
+                },
+            )
+
+    def test_policy_semantics_reject_invalid_platform_and_adapter_identities(
+        self,
+    ) -> None:
+        policy = bootstrap.load_document(FIXTURE_ROOT / "execution-policy.json")
+        mutations = []
+
+        unsorted = copy.deepcopy(policy)
+        unsorted["backends"].reverse()
+        mutations.append((unsorted, "EXECUTION_BACKENDS_NOT_CANONICAL"))
+
+        duplicate = copy.deepcopy(policy)
+        duplicate["backends"][1]["platform"] = "darwin"
+        mutations.append((duplicate, "EXECUTION_BACKENDS_NOT_CANONICAL"))
+
+        kind = copy.deepcopy(policy)
+        kind["backends"][1]["kind"] = "macos_isolated"
+        mutations.append((kind, "EXECUTION_BACKEND_KIND_MISMATCH"))
+
+        adapter = {
+            "language": "go",
+            "platform": "linux",
+            "executable": "code/programs/go/build-tool",
+            "executable_sha256": "1" * 64,
+        }
+        adapters = copy.deepcopy(policy)
+        adapters["adapters"] = [adapter, copy.deepcopy(adapter)]
+        mutations.append((adapters, "EXECUTION_ADAPTER_DUPLICATE"))
+
+        unsafe = copy.deepcopy(policy)
+        unsafe_adapter = copy.deepcopy(adapter)
+        unsafe_adapter["executable"] = "../host"
+        unsafe["adapters"] = [unsafe_adapter]
+        mutations.append((unsafe, "EXECUTION_ADAPTER_PATH_UNSAFE"))
+
+        for mutated, code in mutations:
+            with (
+                self.subTest(code=code),
+                self.assertRaises(bootstrap.ConformanceError) as raised,
+            ):
+                execution.validate_policy_semantics(mutated)
+            self.assertEqual(raised.exception.code, code)
+
+    def test_execution_semantics_reject_invalid_envelope_and_package_records(
+        self,
+    ) -> None:
+        mutations = []
+
+        domain = base_case()
+        domain["domain"] = "graph"
+        mutations.append((domain, "EXECUTION_DOMAIN_INVALID"))
+
+        operation = base_case()
+        operation["input"]["operation"] = "graph"  # type: ignore[index]
+        mutations.append((operation, "EXECUTION_OPERATION_INVALID"))
+
+        capability = base_case()
+        capability["capabilities"] = ["execution"]
+        mutations.append((capability, "EXECUTION_CAPABILITY_MISSING"))
+
+        identity = base_case()
+        identity["expected"]["case_id"] = "execution/other"  # type: ignore[index]
+        mutations.append((identity, "EXECUTION_IDENTITY_MISMATCH"))
+
+        packages = base_case()
+        packages["input"]["options"]["packages"] = None  # type: ignore[index]
+        mutations.append((packages, "EXECUTION_PACKAGES_INVALID"))
+
+        unsafe_path = base_case()
+        unsafe_path["input"]["options"]["packages"][0]["rel_path"] = "../host"  # type: ignore[index]
+        mutations.append((unsafe_path, "EXECUTION_PACKAGE_PATH_UNSAFE"))
+
+        path_collision = base_case()
+        package_values = path_collision["input"]["options"]["packages"]  # type: ignore[index]
+        second = copy.deepcopy(package_values[0])  # type: ignore[index]
+        second["name"] = "python/second"
+        second["rel_path"] = "CODE/packages/python/example"
+        package_values.append(second)  # type: ignore[attr-defined]
+        mutations.append((path_collision, "EXECUTION_PACKAGE_PATH_DUPLICATE"))
+
+        locks = base_case()
+        locks["input"]["options"]["packages"][0]["resource_locks"] = [  # type: ignore[index]
+            "z",
+            "a",
+        ]
+        mutations.append((locks, "EXECUTION_LOCKS_NOT_CANONICAL"))
+
+        edges = base_case()
+        edges["input"]["options"]["dependency_edges"] = None  # type: ignore[index]
+        mutations.append((edges, "EXECUTION_EDGES_INVALID"))
+
+        for mutated, code in mutations:
+            with (
+                self.subTest(code=code),
+                self.assertRaises(bootstrap.ConformanceError) as raised,
+            ):
+                execution.validate_execution_semantics(mutated)
+            self.assertEqual(raised.exception.code, code)
+
+    def test_execution_semantics_reject_noncanonical_or_incomplete_results(
+        self,
+    ) -> None:
+        unsorted = base_case()
+        packages = unsorted["input"]["options"]["packages"]  # type: ignore[index]
+        second = copy.deepcopy(packages[0])  # type: ignore[index]
+        second["name"] = "python/aaa"
+        second["rel_path"] = "code/packages/python/aaa"
+        packages.append(second)  # type: ignore[attr-defined]
+        result_packages = unsorted["expected"]["result"]["packages"]  # type: ignore[index]
+        second_result = copy.deepcopy(result_packages[0])  # type: ignore[index]
+        second_result["name"] = "python/aaa"
+        result_packages.append(second_result)  # type: ignore[attr-defined]
+        with self.assertRaises(bootstrap.ConformanceError) as raised:
+            execution.validate_execution_semantics(unsorted)
+        self.assertEqual(raised.exception.code, "EXECUTION_RESULT_NOT_CANONICAL")
+
+        missing = base_case()
+        missing["expected"]["result"]["packages"] = []  # type: ignore[index]
+        with self.assertRaises(bootstrap.ConformanceError) as raised:
+            execution.validate_execution_semantics(missing)
+        self.assertEqual(
+            raised.exception.code,
+            "EXECUTION_RESULT_PACKAGE_MISMATCH",
+        )
+
+        index = base_case()
+        index["expected"]["result"]["packages"][0]["commands"][0]["index"] = 1  # type: ignore[index]
+        with self.assertRaises(bootstrap.ConformanceError) as raised:
+            execution.validate_execution_semantics(index)
+        self.assertEqual(
+            raised.exception.code,
+            "EXECUTION_COMMAND_INDEX_INVALID",
+        )
+
+        count = base_case()
+        count["expected"]["result"]["packages"][0]["commands"] = []  # type: ignore[index]
+        with self.assertRaises(bootstrap.ConformanceError) as raised:
+            execution.validate_execution_semantics(count)
+        self.assertEqual(
+            raised.exception.code,
+            "EXECUTION_COMMAND_COUNT_MISMATCH",
+        )
+
+    def test_contract_validates_one_inert_case_and_detects_policy_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for name in (
+                "schema.json",
+                "result.schema.json",
+                "execution.schema.json",
+                "execution-policy.schema.json",
+            ):
+                shutil.copyfile(FIXTURE_ROOT / name, root / name)
+            case_root = root / "execution-cases"
+            case_root.mkdir()
+            case = base_case()
+            (case_root / "structured.json").write_text(
+                json.dumps(case, sort_keys=True),
+                encoding="utf-8",
+            )
+            policy = bootstrap.load_document(FIXTURE_ROOT / "execution-policy.json")
+            policy["execution_corpus_sha256"] = execution.execution_corpus_digest(
+                case_root
+            )
+            (root / "execution-policy.json").write_text(
+                json.dumps(policy, sort_keys=True),
+                encoding="utf-8",
+            )
+            summary = execution.validate_contract(root)
+            self.assertEqual(summary["execution_case_count"], 1)
+
+            policy["execution_corpus_sha256"] = "0" * 64
+            (root / "execution-policy.json").write_text(
+                json.dumps(policy, sort_keys=True),
+                encoding="utf-8",
+            )
+            with self.assertRaises(bootstrap.ConformanceError) as raised:
+                execution.validate_contract(root)
+            self.assertEqual(
+                raised.exception.code,
+                "EXECUTION_POLICY_CORPUS_MISMATCH",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -641,6 +641,67 @@ A fixture is data supplied to a program that can execute commands. Therefore:
     Different language runtimes MUST NOT apply first-key/last-key or permissive
     numeric behavior to security decisions.
 
+### 14. Trusted-execution delivery profile
+
+Trusted execution is delivered in independently reviewable layers. A policy or
+schema layer MUST NOT be treated as an execution sandbox:
+
+1. The process-free policy layer closes the execution input and result records,
+   computes a framed SHA-256 digest over the execution corpus, validates
+   runner-owned adapter and backend identities, and returns stable
+   non-passing results for unavailable backends. It imports no process API and
+   never materializes a workspace.
+2. The Linux layer may execute only through a pinned, already-present OCI image
+   identity. The runner MUST NOT pull, build, tag, or resolve a mutable image
+   name during a conformance run. The container uses private mount, user, PID,
+   and network namespaces; a read-only root filesystem; no new privileges; no
+   capabilities; no host devices; a non-root identity; only explicit
+   read-only inputs; a size-bounded writable tmpfs; cgroup-backed aggregate
+   limits; streaming output accounting; and whole-container termination.
+3. The Windows layer requires a capability-less AppContainer or LPAC and
+   private filesystem ACLs. The child is created suspended, assigned to a Job
+   Object with kill-on-close, no-breakaway, process, CPU, and memory limits,
+   and only then resumed. Every filesystem operation is root-handle-relative
+   and rejects reparse points.
+4. The macOS layer remains unavailable until a signed helper or isolated VM
+   backend can prove filesystem and network containment, aggregate resource
+   ceilings, bounded writable storage, and full descendant termination.
+   `sandbox-exec`, a copied working directory, process groups, or `rlimit`
+   alone do not satisfy this contract.
+5. Execution semantics enter the reviewed corpus only after an enforcing
+   backend exists. Command ordering, fail-stop, dependency skips, dry-run,
+   jobs, resource locks, legacy shell behavior, and structured direct argv are
+   fixture oracles. Filesystem escape, network denial, environment leakage,
+   link races, cancellation, descendant termination, and every hard ceiling
+   remain runner-owned invariant probes; fixtures cannot define them away.
+
+The execution policy is separate from `implementations.json`. It contains an
+exact conformance revision, exact execution-corpus SHA-256, runner-controlled
+hard ceilings, backend identities, and adapter executable digests. A backend
+or adapter marked ready requires an immutable SHA-256 identity. The policy does
+not contain operator authorization: `run-case` additionally requires an
+explicit `--allow-trusted-execution` invocation flag.
+
+The execution-corpus digest is SHA-256 over all `*.json` cases sorted by their
+portable path relative to `execution-cases/`. For each case, append the
+unsigned 64-bit big-endian path-byte length, UTF-8 path bytes, unsigned 64-bit
+big-endian raw-content length, and exact raw bytes. The empty corpus therefore
+has the standard SHA-256 empty digest. Any byte, filename, addition, or removal
+changes the authority.
+
+The process-free `validate-corpus` and `validate-result` bootstrap commands
+remain unchanged and MUST reject execution intent. A separate execution
+contract validator may validate schemas, semantic invariants, policy, and
+digests without decoding executable file payloads, setting permissions,
+creating a workspace, probing a toolchain, importing a process API, or
+launching anything.
+
+Pull-request workflows may run only these process-free checks and fake-backend
+unit tests. Real execution requires a protected reviewed revision, read-only
+repository permissions, no repository secrets, and the approved digest
+supplied out of band. `pull_request_target` MUST NOT execute changed fixtures
+or runner code.
+
 ## Capability registry
 
 V1 capabilities are:

--- a/code/specs/fixtures/build-tool-v1/CHANGELOG.md
+++ b/code/specs/fixtures/build-tool-v1/CHANGELOG.md
@@ -19,3 +19,14 @@
 - Added semantic reference, path, hash, cache, Starlark load, shard,
   diagnostic, and toolchain checks while preserving the zero-process,
   zero-materialization bootstrap boundary.
+- Added the closed execution input/result projection and runner-owned execution
+  policy schema.
+- Added framed execution-corpus digests, immutable backend/adapter identity
+  records, explicit hard ceilings, and a disabled-by-default checked-in policy.
+- Added a separate process-free execution contract validator. Its `run-case`
+  entry point checks explicit operator authorization and the exact reviewed
+  digest, then returns a stable non-passing result because no enforcing backend
+  exists in this tranche.
+- Split Linux OCI, Windows AppContainer, macOS isolation, and the later
+  execution-semantics/security-probe corpus into explicit dependent backlog
+  items. The bootstrap runner remains execution-disabled.

--- a/code/specs/fixtures/build-tool-v1/README.md
+++ b/code/specs/fixtures/build-tool-v1/README.md
@@ -10,11 +10,16 @@ build-tool-v1/
   schema.json
   result.schema.json
   pure-domains.schema.json
+  execution.schema.json
+  execution-policy.schema.json
+  execution-policy.json
   implementations.schema.json
   implementations.json
   CHANGELOG.md
   cases/
     *.json
+  execution-cases/
+    README.md
 ```
 
 `implementations.json` inventories all 15 established language lanes plus the
@@ -44,6 +49,21 @@ The seven added decision domains additionally validate a closed
 `{domain,outcome,input,result}` projection against
 `pure-domains.schema.json`; generic JSON is never a fallback.
 
+Execution has a separate closed `{domain,outcome,input,result}` projection in
+`execution.schema.json`. `schema.json` and `result.schema.json` enforce the
+same closed command, package, dependency, resource-lock, and canonical result
+records in the outer envelope. Structured commands contain only `program` and
+`args`; they have no fixture-controlled cwd, shell, redirection, or per-command
+environment. Legacy commands remain distinct line records.
+
+`execution-policy.json` is runner-owned authority rather than fixture data or
+implementation metadata. It records the exact execution-corpus digest, hard
+ceilings, backend identities, and adapter executable digests. The checked-in
+policy is disabled, has no adapters, and marks all three platform backends
+unavailable. The empty `execution-cases/*.json` set therefore has the standard
+empty SHA-256 digest. Execution cases are added only after an enforcing backend
+is reviewed.
+
 ## Runner
 
 Validate the complete corpus and inventory:
@@ -59,6 +79,18 @@ python code/scripts/build_tool_conformance.py validate-result \
   --case code/specs/fixtures/build-tool-v1/cases/graph-diamond.json \
   --result path/to/result.json
 ```
+
+Validate the process-free trusted-execution contract:
+
+```text
+python code/scripts/build_tool_conformance_execution.py validate-contract
+```
+
+The separate `run-case` command requires both
+`--allow-trusted-execution` and an exact
+`--approved-corpus-sha256`. In this policy-only tranche it can only return a
+stable non-passing skip. It never imports a process API, decodes executable
+workspace payloads, materializes files, or launches an adapter.
 
 Both commands use bounded strict JSON parsing, formal Draft 2020-12 validation,
 semantic path and identity checks, domain-aware result canonicalization, and
@@ -103,7 +135,26 @@ The corpus now closes all process-free v1 domains:
 - BUILD-file validation and toolchain detection; and
 - CLI exit-decision semantics.
 
-Execution remains the only intentionally unmodeled domain.
+Execution now has a closed data model and authority policy, but no execution
+backend. This distinction is deliberate: schemas and digests are prerequisites
+for a sandbox, not evidence that one exists.
+
+The platform delivery order is explicit:
+
+1. Linux OCI with a pinned pre-existing image, namespace isolation,
+   read-only rootfs, dropped capabilities, bounded tmpfs, cgroups, streaming
+   output accounting, and whole-container termination.
+2. Windows AppContainer or LPAC plus private ACLs, reparse-safe root-handle
+   operations, and a no-breakaway Job Object assigned before resume.
+3. macOS signed-helper or isolated-VM containment. `sandbox-exec` alone is not
+   accepted.
+4. Closed execution-semantics fixtures and runner-owned adversarial boundary
+   probes after all required platform boundaries exist.
+
+Pull-request CI validates only the process-free schemas, policy, digest, and
+unit tests. Real execution belongs to a protected reviewed revision with
+read-only repository permissions, no repository secrets, and the approved
+digest supplied out of band.
 
 ## Validation
 
@@ -114,7 +165,14 @@ python -m unittest discover \
 python -m unittest discover \
   -s code/scripts/tests \
   -p "test_build_tool_conformance_runner.py"
+python -m unittest discover \
+  -s code/scripts/tests \
+  -p "test_build_tool_conformance_execution_schema.py"
+python -m unittest discover \
+  -s code/scripts/tests \
+  -p "test_build_tool_conformance_execution_runner.py"
+python code/scripts/build_tool_conformance_execution.py validate-contract
 ```
 
-CI installs the pinned `jsonschema==4.26.0` validator before running both suites
-and the corpus validator.
+CI installs the pinned `jsonschema==4.26.0` validator before running the suites
+and both process-free corpus validators.

--- a/code/specs/fixtures/build-tool-v1/execution-cases/README.md
+++ b/code/specs/fixtures/build-tool-v1/execution-cases/README.md
@@ -1,0 +1,9 @@
+# Trusted execution cases
+
+Only `*.json` files in this directory belong to the trusted execution corpus.
+The process-free policy tranche intentionally contains no cases, so its framed
+corpus SHA-256 is the standard empty digest. Execution semantics enter this
+directory only after an enforcing platform backend is reviewed.
+
+The bootstrap `cases/` directory remains process-free. Never move an execution
+case there or add an execution-enabling flag to the bootstrap validator.

--- a/code/specs/fixtures/build-tool-v1/execution-policy.json
+++ b/code/specs/fixtures/build-tool-v1/execution-policy.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "conformance_revision": "v1",
+  "enabled": false,
+  "execution_corpus_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "hard_limits": {
+    "wall_time_ms": 60000,
+    "output_bytes": 1048576,
+    "workspace_bytes": 67108864,
+    "process_count": 32,
+    "memory_mib": 1024,
+    "cpu_time_ms": 60000
+  },
+  "backends": [
+    {
+      "platform": "darwin",
+      "kind": "macos_isolated",
+      "status": "unavailable",
+      "identity_sha256": null
+    },
+    {
+      "platform": "linux",
+      "kind": "linux_oci",
+      "status": "unavailable",
+      "identity_sha256": null
+    },
+    {
+      "platform": "windows",
+      "kind": "windows_appcontainer",
+      "status": "unavailable",
+      "identity_sha256": null
+    }
+  ],
+  "adapters": []
+}

--- a/code/specs/fixtures/build-tool-v1/execution-policy.schema.json
+++ b/code/specs/fixtures/build-tool-v1/execution-policy.schema.json
@@ -1,0 +1,207 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/build-tool-conformance-execution-policy-v1.json",
+  "title": "Build-tool trusted-execution policy v1",
+  "description": "Runner-owned identities and ceilings. Operator authorization is deliberately out of band.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "conformance_revision",
+    "enabled",
+    "execution_corpus_sha256",
+    "hard_limits",
+    "backends",
+    "adapters"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "conformance_revision": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*$",
+      "maxLength": 80
+    },
+    "enabled": {
+      "type": "boolean"
+    },
+    "execution_corpus_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "hard_limits": {
+      "$ref": "#/$defs/limits"
+    },
+    "backends": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "$ref": "#/$defs/backend"
+      }
+    },
+    "adapters": {
+      "type": "array",
+      "maxItems": 64,
+      "items": {
+        "$ref": "#/$defs/adapter"
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "safe_path": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^(?!/)(?![A-Za-z]:)(?!.*\\\\)(?!.*(?:^|/)\\.\\.?(?:/|$))(?!.*//)[^<>:\"|?*\\u0000-\\u001F/]+(?:/[^<>:\"|?*\\u0000-\\u001F/]+)*$"
+    },
+    "limits": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "wall_time_ms",
+        "output_bytes",
+        "workspace_bytes",
+        "process_count",
+        "memory_mib",
+        "cpu_time_ms"
+      ],
+      "properties": {
+        "wall_time_ms": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 600000
+        },
+        "output_bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 16777216
+        },
+        "workspace_bytes": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 268435456
+        },
+        "process_count": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 64
+        },
+        "memory_mib": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 2048
+        },
+        "cpu_time_ms": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 600000
+        }
+      }
+    },
+    "backend": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "platform",
+        "kind",
+        "status",
+        "identity_sha256"
+      ],
+      "properties": {
+        "platform": {
+          "enum": [
+            "darwin",
+            "linux",
+            "windows"
+          ]
+        },
+        "kind": {
+          "enum": [
+            "linux_oci",
+            "windows_appcontainer",
+            "macos_isolated"
+          ]
+        },
+        "status": {
+          "enum": [
+            "unavailable",
+            "ready"
+          ]
+        },
+        "identity_sha256": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/sha256"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "ready"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "properties": {
+              "identity_sha256": {
+                "$ref": "#/$defs/sha256"
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "identity_sha256": {
+                "type": "null"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "adapter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "language",
+        "platform",
+        "executable",
+        "executable_sha256"
+      ],
+      "properties": {
+        "language": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$",
+          "maxLength": 64
+        },
+        "platform": {
+          "enum": [
+            "darwin",
+            "linux",
+            "windows"
+          ]
+        },
+        "executable": {
+          "$ref": "#/$defs/safe_path"
+        },
+        "executable_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    }
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/execution.schema.json
+++ b/code/specs/fixtures/build-tool-v1/execution.schema.json
@@ -1,0 +1,404 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/build-tool-conformance-execution-v1.json",
+  "title": "Build-tool execution projection v1",
+  "description": "Closed data-only execution input and canonical result records. This schema grants no execution authority.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "domain",
+    "outcome",
+    "input",
+    "result"
+  ],
+  "properties": {
+    "domain": {
+      "const": "execution"
+    },
+    "outcome": {
+      "enum": [
+        "ok",
+        "error",
+        "unsupported",
+        "skipped"
+      ]
+    },
+    "input": {
+      "$ref": "#/$defs/execution_input"
+    },
+    "result": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/execution_result"
+        },
+        {
+          "$ref": "#/$defs/empty_result"
+        }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "outcome": {
+            "enum": [
+              "ok",
+              "error"
+            ]
+          }
+        },
+        "required": [
+          "outcome"
+        ]
+      },
+      "then": {
+        "properties": {
+          "result": {
+            "$ref": "#/$defs/execution_result"
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "result": {
+            "$ref": "#/$defs/empty_result"
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "safe_path": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^(?!/)(?![A-Za-z]:)(?!.*\\\\)(?!.*(?:^|/)\\.\\.?(?:/|$))(?!.*//)[^<>:\"|?*\\u0000-\\u001F/]+(?:/[^<>:\"|?*\\u0000-\\u001F/]+)*$"
+    },
+    "package_name": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*(/[a-z0-9][a-z0-9._-]*)+$",
+      "maxLength": 240
+    },
+    "lock_name": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9._/-]*$",
+      "maxLength": 160
+    },
+    "legacy_command": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "line"
+      ],
+      "properties": {
+        "kind": {
+          "const": "legacy"
+        },
+        "line": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4096,
+          "pattern": "^[^\\u0000]+$"
+        }
+      }
+    },
+    "structured_command": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "program",
+        "args"
+      ],
+      "properties": {
+        "kind": {
+          "const": "structured"
+        },
+        "program": {
+          "$ref": "#/$defs/safe_path"
+        },
+        "args": {
+          "type": "array",
+          "maxItems": 128,
+          "items": {
+            "type": "string",
+            "maxLength": 4096,
+            "pattern": "^[^\\u0000]*$"
+          }
+        }
+      }
+    },
+    "command": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/legacy_command"
+        },
+        {
+          "$ref": "#/$defs/structured_command"
+        }
+      ]
+    },
+    "package": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "rel_path",
+        "language",
+        "commands",
+        "resource_locks"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/package_name"
+        },
+        "rel_path": {
+          "$ref": "#/$defs/safe_path"
+        },
+        "language": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$",
+          "maxLength": 64
+        },
+        "commands": {
+          "type": "array",
+          "maxItems": 256,
+          "items": {
+            "$ref": "#/$defs/command"
+          }
+        },
+        "resource_locks": {
+          "type": "array",
+          "uniqueItems": true,
+          "maxItems": 64,
+          "items": {
+            "$ref": "#/$defs/lock_name"
+          }
+        }
+      }
+    },
+    "edge": {
+      "type": "array",
+      "prefixItems": [
+        {
+          "$ref": "#/$defs/package_name"
+        },
+        {
+          "$ref": "#/$defs/package_name"
+        }
+      ],
+      "items": false,
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "execution_options": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "platform",
+        "jobs",
+        "dry_run",
+        "packages",
+        "dependency_edges"
+      ],
+      "properties": {
+        "platform": {
+          "enum": [
+            "darwin",
+            "linux",
+            "windows"
+          ]
+        },
+        "jobs": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 64
+        },
+        "dry_run": {
+          "type": "boolean"
+        },
+        "packages": {
+          "type": "array",
+          "maxItems": 4096,
+          "items": {
+            "$ref": "#/$defs/package"
+          }
+        },
+        "dependency_edges": {
+          "type": "array",
+          "uniqueItems": true,
+          "maxItems": 16384,
+          "items": {
+            "$ref": "#/$defs/edge"
+          }
+        }
+      }
+    },
+    "execution_input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operation",
+        "options"
+      ],
+      "properties": {
+        "operation": {
+          "const": "execution"
+        },
+        "options": {
+          "$ref": "#/$defs/execution_options"
+        },
+        "arguments": {
+          "type": "array",
+          "default": [],
+          "maxItems": 128,
+          "items": {
+            "type": "string",
+            "maxLength": 4096
+          }
+        },
+        "environment": {
+          "type": "object",
+          "default": {},
+          "propertyNames": {
+            "pattern": "^CONFORMANCE_[A-Z0-9_]+$"
+          },
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 4096
+          }
+        }
+      }
+    },
+    "command_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "index",
+        "status",
+        "exit_code"
+      ],
+      "properties": {
+        "index": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "status": {
+          "enum": [
+            "succeeded",
+            "failed",
+            "not-run"
+          ]
+        },
+        "exit_code": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": -2147483648,
+              "maximum": 2147483647
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "not-run"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "properties": {
+              "exit_code": {
+                "type": "null"
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "exit_code": {
+                "type": "integer",
+                "minimum": -2147483648,
+                "maximum": 2147483647
+              }
+            }
+          }
+        }
+      ]
+    },
+    "package_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "status",
+        "return_code",
+        "commands"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/package_name"
+        },
+        "status": {
+          "enum": [
+            "built",
+            "failed",
+            "dependency-skipped",
+            "would-build"
+          ]
+        },
+        "return_code": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": -2147483648,
+              "maximum": 2147483647
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "commands": {
+          "type": "array",
+          "maxItems": 256,
+          "items": {
+            "$ref": "#/$defs/command_result"
+          }
+        }
+      }
+    },
+    "execution_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "packages"
+      ],
+      "properties": {
+        "packages": {
+          "type": "array",
+          "maxItems": 4096,
+          "items": {
+            "$ref": "#/$defs/package_result"
+          }
+        }
+      }
+    },
+    "empty_result": {
+      "type": "object",
+      "maxProperties": 0,
+      "additionalProperties": false
+    }
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/result.schema.json
+++ b/code/specs/fixtures/build-tool-v1/result.schema.json
@@ -138,6 +138,32 @@
       "if": {
         "properties": {
           "domain": {
+            "const": "execution"
+          },
+          "outcome": {
+            "enum": [
+              "ok",
+              "error"
+            ]
+          }
+        },
+        "required": [
+          "domain",
+          "outcome"
+        ]
+      },
+      "then": {
+        "properties": {
+          "result": {
+            "$ref": "#/$defs/execution_result"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "domain": {
             "const": "plan"
           },
           "outcome": {
@@ -328,6 +354,129 @@
       "properties": {
         "plan": {
           "type": "object"
+        }
+      }
+    },
+    "execution_command_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "index",
+        "status",
+        "exit_code"
+      ],
+      "properties": {
+        "index": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 255
+        },
+        "status": {
+          "enum": [
+            "succeeded",
+            "failed",
+            "not-run"
+          ]
+        },
+        "exit_code": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": -2147483648,
+              "maximum": 2147483647
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "not-run"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "properties": {
+              "exit_code": {
+                "type": "null"
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "exit_code": {
+                "type": "integer",
+                "minimum": -2147483648,
+                "maximum": 2147483647
+              }
+            }
+          }
+        }
+      ]
+    },
+    "execution_package_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "status",
+        "return_code",
+        "commands"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/package_name"
+        },
+        "status": {
+          "enum": [
+            "built",
+            "failed",
+            "dependency-skipped",
+            "would-build"
+          ]
+        },
+        "return_code": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": -2147483648,
+              "maximum": 2147483647
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "commands": {
+          "type": "array",
+          "maxItems": 256,
+          "items": {
+            "$ref": "#/$defs/execution_command_result"
+          }
+        }
+      }
+    },
+    "execution_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "packages"
+      ],
+      "properties": {
+        "packages": {
+          "type": "array",
+          "maxItems": 4096,
+          "items": {
+            "$ref": "#/$defs/execution_package_result"
+          }
         }
       }
     },

--- a/code/specs/fixtures/build-tool-v1/schema.json
+++ b/code/specs/fixtures/build-tool-v1/schema.json
@@ -333,6 +333,32 @@
               }
             }
           }
+        },
+        {
+          "if": {
+            "properties": {
+              "operation": {
+                "const": "execution"
+              }
+            },
+            "required": [
+              "operation"
+            ]
+          },
+          "then": {
+            "required": [
+              "options"
+            ],
+            "properties": {
+              "options": {
+                "$ref": "#/$defs/execution_options"
+              },
+              "changed_paths": {
+                "type": "array",
+                "maxItems": 0
+              }
+            }
+          }
         }
       ]
     },
@@ -437,6 +463,148 @@
           "maxProperties": 1024,
           "additionalProperties": {
             "$ref": "#/$defs/json_value"
+          }
+        }
+      }
+    },
+    "lock_name": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9._/-]*$",
+      "maxLength": 160
+    },
+    "execution_legacy_command": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "line"
+      ],
+      "properties": {
+        "kind": {
+          "const": "legacy"
+        },
+        "line": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4096,
+          "pattern": "^[^\\u0000]+$"
+        }
+      }
+    },
+    "execution_structured_command": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "program",
+        "args"
+      ],
+      "properties": {
+        "kind": {
+          "const": "structured"
+        },
+        "program": {
+          "$ref": "#/$defs/safe_path"
+        },
+        "args": {
+          "type": "array",
+          "maxItems": 128,
+          "items": {
+            "type": "string",
+            "maxLength": 4096,
+            "pattern": "^[^\\u0000]*$"
+          }
+        }
+      }
+    },
+    "execution_command": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/execution_legacy_command"
+        },
+        {
+          "$ref": "#/$defs/execution_structured_command"
+        }
+      ]
+    },
+    "execution_package": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "rel_path",
+        "language",
+        "commands",
+        "resource_locks"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/package_name"
+        },
+        "rel_path": {
+          "$ref": "#/$defs/safe_path"
+        },
+        "language": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$",
+          "maxLength": 64
+        },
+        "commands": {
+          "type": "array",
+          "maxItems": 256,
+          "items": {
+            "$ref": "#/$defs/execution_command"
+          }
+        },
+        "resource_locks": {
+          "type": "array",
+          "uniqueItems": true,
+          "maxItems": 64,
+          "items": {
+            "$ref": "#/$defs/lock_name"
+          }
+        }
+      }
+    },
+    "execution_options": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "platform",
+        "jobs",
+        "dry_run",
+        "packages",
+        "dependency_edges"
+      ],
+      "properties": {
+        "platform": {
+          "enum": [
+            "darwin",
+            "linux",
+            "windows"
+          ]
+        },
+        "jobs": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 64
+        },
+        "dry_run": {
+          "type": "boolean"
+        },
+        "packages": {
+          "type": "array",
+          "maxItems": 4096,
+          "items": {
+            "$ref": "#/$defs/execution_package"
+          }
+        },
+        "dependency_edges": {
+          "type": "array",
+          "uniqueItems": true,
+          "maxItems": 16384,
+          "items": {
+            "$ref": "#/$defs/edge"
           }
         }
       }

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -918,22 +918,46 @@ Delivery order:
    conservative unknown-path handling, typed cache states, inline-only
    Starlark loads, prerequisite-closed shard verification, the OCaml-aware
    toolchain registry, and fail-closed BUILD-file validation.
-4. Add the trusted-execution sandbox and adversarial execution corpus. No
-   repository command may run until filesystem and network isolation,
-   no-follow path handling, sanitized environments, direct argv, and hard
-   process-tree limits are enforced.
-5. Make the Go reference pass the contract, including structured Starlark
+4. Define the process-free trusted-execution policy core: closed execution
+   input/result records, reviewed corpus and adapter digests, explicit operator
+   authorization, stable backend-unavailable results, and a backend interface
+   with no host-execution fallback. This tranche validates authority but never
+   executes fixture code.
+5. Implement the Linux OCI backend first. Require a pinned pre-existing image
+   identity, private mount/user/PID/network namespaces, a read-only root,
+   dropped capabilities, `no_new_privileges`, non-root execution, bounded
+   writable tmpfs, streaming output accounting, cgroup limits, and
+   whole-container termination.
+6. Implement the native Windows boundary with AppContainer or LPAC plus Job
+   Objects and root-handle reparse-safe filesystem operations. Keep macOS
+   non-passing until a signed helper or isolated VM can prove the same
+   filesystem, network, resource, and tree-termination guarantees;
+   `sandbox-exec` alone is not sufficient evidence.
+7. Add closed execution-semantics cases for command ordering, failure
+   propagation, dependency skips, dry-run, jobs, resource locks, legacy shell
+   behavior, and direct argv. Keep escape, network, environment, link-race,
+   cancellation, and resource-exhaustion checks as runner-owned non-oracular
+   probes.
+8. Make the Go reference pass the contract, including structured Starlark
    context/commands and the B05 Windows executor contract.
-6. Remediate existing ports in fixture-failure order: C#/F#, Python, Ruby,
+9. Remediate existing ports in fixture-failure order: C#/F#, Python, Ruby,
    Swift, TypeScript, Elixir, Rust, Perl, Haskell, and Lua. Each independent
    engine is its own PR; a reviewed shared-engine exception must be explicit.
-7. Add language-native Java and Kotlin implementations using shared JVM fixture
+10. Add language-native Java and Kotlin implementations using shared JVM fixture
    infrastructure but separate engines, then add Dart.
-8. Add the OCaml implementation after the lane foundation is stable.
-9. Decide and document whether C and C++ require native build tools before
+11. Add the OCaml implementation after the lane foundation is stable.
+12. Decide and document whether C and C++ require native build tools before
    either emerging lane graduates.
-10. Gate completion in CI: every supported implementation runs the same
+13. Gate completion in CI: every supported implementation runs the same
    conformance corpus on its applicable operating systems.
+
+Pull-request CI may validate the policy, schemas, digests, and fake-backend
+tests, but it must not authorize execution from branch-modifiable code or
+fixtures. Real sandbox probes run only from reviewed immutable revisions in a
+protected `push`/manual workflow with read-only repository permissions, no
+repository secrets, and an out-of-band approved corpus digest. The trusted
+runner never pulls a container image and never falls back to unsandboxed host
+execution.
 
 The pure-domain security review also discovered three follow-on gates that must
 land before final adapter parity:


### PR DESCRIPTION
## What changed

- close execution input and result records with structured direct-argv commands, distinct legacy command lines, explicit packages/dependencies/jobs/resource locks, and canonical per-command results
- add a runner-owned execution policy with exact corpus, backend, and adapter SHA-256 identities plus hard ceilings
- add a separate process-free authority validator whose `run-case` entry point requires explicit operator authorization and the exact reviewed corpus digest
- keep the checked-in policy disabled, all platform backends unavailable, and every adapter absent; the policy layer has no process API or host-execution fallback
- split Linux OCI, Windows AppContainer, macOS isolation, and the later execution-semantics/security-probe corpus into explicit dependency-shaped backlog items
- wire the process-free policy/schema suites into PR CI

## Why

The governing conformance contract requires real filesystem and network containment before any fixture code may run. The prior backlog item combined authority, three distinct OS boundaries, and behavior probes into one unsafe review unit. This PR lands the common authority layer first without claiming or attempting execution.

It deliberately does **not** implement a sandbox. Linux OCI, Windows AppContainer/LPAC + Job Objects, and a provable macOS backend remain non-passing follow-up gates. Execution cases remain empty until an enforcing backend is reviewed.

## Validation

- 17 bootstrap schema tests
- 40 bootstrap runner tests
- 23 trusted-execution policy/schema tests
- 94% branch-aware coverage for `build_tool_conformance_execution.py`
- bootstrap 30-case / 11-domain corpus valid; execution count remains 0
- execution contract valid with exact empty-corpus SHA-256 and 0 ready backends/adapters
- Ruff check + format check
- Bandit security scan
- `git diff --check` and JSON parse validation
- collision-checked parity report: schema v2, 1,184 implementation identities, 4,325 slots, 172 high-consensus packages, 278 missing slots, 0 collisions, 0 unknown buckets
- Go build-tool `go test ./...` and `go vet ./...`
- Go build-tool dry-run/build-file validation for all 301 Go packages; no package files changed and no build was launched

## Security boundary

Pull-request CI only validates schemas, policy, digests, and fake/fail-closed paths. Real execution must come from a reviewed immutable revision in a protected push/manual workflow with read-only repository permissions, no repository secrets, and an out-of-band approved digest. The runner never pulls an image and never falls back to host execution.