### PR TITLE
Add Venture HTTP transport

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -719,6 +719,7 @@ members = [
     "ieee802154-core",
     "ieee802154-security",
     "http1",
+    "http1-client",
     "storage-core",
     "storage-local-folder",
     "vault-sealed-store",

--- a/code/packages/rust/http1-client/BUILD
+++ b/code/packages/rust/http1-client/BUILD
@@ -1,0 +1,1 @@
+cargo test -p http1-client -- --nocapture

--- a/code/packages/rust/http1-client/CHANGELOG.md
+++ b/code/packages/rust/http1-client/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [0.1.0] - 2026-07-29
+
+### Added
+
+- Added bounded synchronous HTTP/1.0 GET requests over `tcp-client`.
+- Added response framing through the shared `http1` and `http-core` contracts.
+- Added relative 301/302 redirect following with a configurable limit.
+- Added response head and body size limits plus request-line/header injection
+  guards.
+- Added localhost acceptance coverage for content-length, EOF, redirects,
+  malformed responses, and unsupported framing.

--- a/code/packages/rust/http1-client/Cargo.toml
+++ b/code/packages/rust/http1-client/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "http1-client"
+version = "0.1.0"
+edition = "2021"
+description = "Bounded synchronous HTTP/1.0 GET transport for Venture browser resources"
+
+[dependencies]
+http-core = { path = "../http-core" }
+http1 = { path = "../http1" }
+tcp-client = { path = "../tcp-client" }
+url-parser = { path = "../url-parser" }

--- a/code/packages/rust/http1-client/README.md
+++ b/code/packages/rust/http1-client/README.md
@@ -1,0 +1,39 @@
+# http1-client
+
+`http1-client` is Venture's first concrete network transport. It composes the
+existing `url-parser`, `tcp-client`, `http1`, and `http-core` packages into a
+bounded synchronous HTTP/1.0 GET client.
+
+## What It Provides
+
+- HTTP-only URL validation and origin-form request construction
+- DNS/TCP connection and one-request-per-connection HTTP/1.0 exchange
+- Content-Length, bodyless, and read-until-EOF response framing
+- Relative 301/302 redirect following
+- Configurable connection, response-head, response-body, and redirect limits
+- Structured errors for every transport stage
+
+```rust,no_run
+use http1_client::get;
+
+let response = get("http://info.cern.ch/")?;
+assert_eq!(response.head.status, 200);
+println!("{} bytes from {}", response.body.len(), response.final_url);
+# Ok::<(), http1_client::HttpClientError>(())
+```
+
+The client deliberately sends HTTP/1.0 with `Connection: close`. HTTPS,
+cookies, caching, authentication, request bodies, and HTTP/1.1 chunk decoding
+remain outside this package.
+
+## Browser Integration
+
+The returned body bytes can be parsed by `coding-adventures-html-parser`.
+Image responses can be adapted to `html-to-paint::FetchedImage` by the Venture
+host without coupling the protocol package to HTML or paint policy.
+
+## Development
+
+```bash
+cargo test -p http1-client -- --nocapture
+```

--- a/code/packages/rust/http1-client/required_capabilities.json
+++ b/code/packages/rust/http1-client/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/http1-client",
+  "capabilities": [],
+  "justification": "Library substrate. It performs no ambient filesystem, process, environment, or network access unless a caller explicitly invokes the GET API; the browser host remains responsible for concrete origin policy."
+}

--- a/code/packages/rust/http1-client/src/lib.rs
+++ b/code/packages/rust/http1-client/src/lib.rs
@@ -1,0 +1,543 @@
+//! Bounded synchronous HTTP/1.0 GET transport.
+//!
+//! This crate is intentionally an orchestrator. URL parsing, TCP I/O, HTTP
+//! syntax, and semantic message types remain in their existing packages.
+
+use http1::{parse_response_head, Http1ParseError};
+use http_core::{BodyKind, ResponseHead};
+use std::fmt;
+use tcp_client::{connect, ConnectOptions, TcpConnection, TcpError};
+use url_parser::{Url, UrlError};
+
+pub const VERSION: &str = "0.1.0";
+pub const DEFAULT_USER_AGENT: &str = "Venture/0.1";
+pub const DEFAULT_MAX_REDIRECTS: usize = 5;
+pub const DEFAULT_MAX_HEAD_BYTES: usize = 64 * 1024;
+pub const DEFAULT_MAX_BODY_BYTES: usize = 64 * 1024 * 1024;
+
+/// A complete HTTP response plus the final URL after redirects.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HttpResponse {
+    pub final_url: String,
+    pub head: ResponseHead,
+    pub body: Vec<u8>,
+}
+
+/// Configuration for one-request-per-connection HTTP/1.0 GETs.
+#[derive(Debug, Clone)]
+pub struct HttpClient {
+    pub connect_options: ConnectOptions,
+    pub max_redirects: usize,
+    pub max_head_bytes: usize,
+    pub max_body_bytes: usize,
+    pub user_agent: String,
+}
+
+impl Default for HttpClient {
+    fn default() -> Self {
+        Self {
+            connect_options: ConnectOptions::default(),
+            max_redirects: DEFAULT_MAX_REDIRECTS,
+            max_head_bytes: DEFAULT_MAX_HEAD_BYTES,
+            max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            user_agent: DEFAULT_USER_AGENT.to_string(),
+        }
+    }
+}
+
+impl HttpClient {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Perform an HTTP/1.0 GET, following relative or absolute 301/302
+    /// redirects up to `max_redirects`.
+    pub fn get(&self, url: &str) -> Result<HttpResponse, HttpClientError> {
+        let mut current = Url::parse(url).map_err(HttpClientError::Url)?;
+        let mut redirects_followed = 0;
+
+        loop {
+            let response = self.get_once(&current)?;
+            let is_redirect = matches!(response.head.status, 301 | 302);
+            let Some(location) = response.head.header("Location") else {
+                return Ok(response);
+            };
+            if !is_redirect {
+                return Ok(response);
+            }
+            if redirects_followed >= self.max_redirects {
+                return Err(HttpClientError::TooManyRedirects {
+                    limit: self.max_redirects,
+                });
+            }
+
+            current = current.resolve(location).map_err(HttpClientError::Url)?;
+            redirects_followed += 1;
+        }
+    }
+
+    fn get_once(&self, url: &Url) -> Result<HttpResponse, HttpClientError> {
+        validate_url(url)?;
+        validate_header_value("User-Agent", &self.user_agent)?;
+        let host = url.host.as_deref().ok_or(HttpClientError::MissingHost)?;
+        let port = url.effective_port().ok_or(HttpClientError::MissingPort)?;
+        let target = request_target(url);
+        validate_request_target(&target)?;
+        let host_header = host_header(url, host, port);
+        validate_header_value("Host", &host_header)?;
+        let request = format!(
+            "GET {target} HTTP/1.0\r\n\
+             Host: {host_header}\r\n\
+             User-Agent: {}\r\n\
+             Accept: */*\r\n\
+             Connection: close\r\n\
+             \r\n",
+            self.user_agent
+        );
+
+        let mut connection =
+            connect(host, port, self.connect_options.clone()).map_err(HttpClientError::Tcp)?;
+        connection
+            .write_all(request.as_bytes())
+            .map_err(HttpClientError::Tcp)?;
+        connection.shutdown_write().map_err(HttpClientError::Tcp)?;
+
+        let parsed = read_response_head(&mut connection, self.max_head_bytes)?;
+        let body = read_response_body(&mut connection, &parsed.body_kind, self.max_body_bytes)?;
+
+        Ok(HttpResponse {
+            final_url: url.to_url_string(),
+            head: parsed.head,
+            body,
+        })
+    }
+}
+
+/// Perform a GET with [`HttpClient::default`].
+pub fn get(url: &str) -> Result<HttpResponse, HttpClientError> {
+    HttpClient::new().get(url)
+}
+
+#[derive(Debug)]
+pub enum HttpClientError {
+    Url(UrlError),
+    Tcp(TcpError),
+    Http(Http1ParseError),
+    UnsupportedScheme(String),
+    UnsupportedCredentials,
+    MissingHost,
+    MissingPort,
+    InvalidRequestTarget,
+    InvalidHeaderValue { name: &'static str },
+    IncompleteResponseHead,
+    ResponseHeadTooLarge { limit: usize },
+    ResponseBodyTooLarge { limit: usize },
+    UnsupportedBodyFraming(BodyKind),
+    TooManyRedirects { limit: usize },
+}
+
+impl fmt::Display for HttpClientError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Url(error) => write!(formatter, "URL error: {error}"),
+            Self::Tcp(error) => write!(formatter, "TCP error: {error}"),
+            Self::Http(error) => write!(formatter, "HTTP response error: {error}"),
+            Self::UnsupportedScheme(scheme) => {
+                write!(formatter, "unsupported URL scheme: {scheme}")
+            }
+            Self::UnsupportedCredentials => {
+                formatter.write_str("userinfo credentials are not supported")
+            }
+            Self::MissingHost => formatter.write_str("HTTP URL is missing a host"),
+            Self::MissingPort => formatter.write_str("HTTP URL has no effective port"),
+            Self::InvalidRequestTarget => {
+                formatter.write_str("HTTP request target contains unsafe characters")
+            }
+            Self::InvalidHeaderValue { name } => {
+                write!(formatter, "{name} contains unsafe control characters")
+            }
+            Self::IncompleteResponseHead => formatter.write_str("incomplete HTTP response head"),
+            Self::ResponseHeadTooLarge { limit } => {
+                write!(formatter, "HTTP response head exceeds {limit} bytes")
+            }
+            Self::ResponseBodyTooLarge { limit } => {
+                write!(formatter, "HTTP response body exceeds {limit} bytes")
+            }
+            Self::UnsupportedBodyFraming(kind) => {
+                write!(
+                    formatter,
+                    "unsupported HTTP response body framing: {kind:?}"
+                )
+            }
+            Self::TooManyRedirects { limit } => {
+                write!(formatter, "HTTP redirect limit exceeded ({limit})")
+            }
+        }
+    }
+}
+
+impl std::error::Error for HttpClientError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Tcp(error) => Some(error),
+            Self::Http(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+fn validate_url(url: &Url) -> Result<(), HttpClientError> {
+    if url.scheme != "http" {
+        return Err(HttpClientError::UnsupportedScheme(url.scheme.clone()));
+    }
+    if url.userinfo.is_some() {
+        return Err(HttpClientError::UnsupportedCredentials);
+    }
+    Ok(())
+}
+
+fn validate_header_value(name: &'static str, value: &str) -> Result<(), HttpClientError> {
+    if value.bytes().any(|byte| !(b' '..=b'~').contains(&byte)) {
+        return Err(HttpClientError::InvalidHeaderValue { name });
+    }
+    Ok(())
+}
+
+fn validate_request_target(target: &str) -> Result<(), HttpClientError> {
+    if target.bytes().any(|byte| !byte.is_ascii_graphic()) {
+        return Err(HttpClientError::InvalidRequestTarget);
+    }
+    Ok(())
+}
+
+fn request_target(url: &Url) -> String {
+    let mut target = if url.path.is_empty() {
+        "/".to_string()
+    } else {
+        url.path.clone()
+    };
+    if let Some(query) = &url.query {
+        target.push('?');
+        target.push_str(query);
+    }
+    target
+}
+
+fn host_header(url: &Url, host: &str, port: u16) -> String {
+    if url.port.is_some() && port != 80 {
+        format!("{host}:{port}")
+    } else {
+        host.to_string()
+    }
+}
+
+fn read_response_head(
+    connection: &mut TcpConnection,
+    max_head_bytes: usize,
+) -> Result<http1::ParsedResponseHead, HttpClientError> {
+    let mut bytes = Vec::new();
+    loop {
+        let remaining = max_head_bytes.saturating_sub(bytes.len());
+        let line = connection
+            .read_until_limit(b'\n', remaining)
+            .map_err(|error| match error {
+                TcpError::ReadLimitExceeded { .. } => HttpClientError::ResponseHeadTooLarge {
+                    limit: max_head_bytes,
+                },
+                other => HttpClientError::Tcp(other),
+            })?;
+        if line.is_empty() {
+            return Err(HttpClientError::IncompleteResponseHead);
+        }
+        let is_blank = line == b"\n" || line == b"\r\n";
+        bytes.extend_from_slice(&line);
+        if is_blank {
+            break;
+        }
+    }
+
+    parse_response_head(&bytes).map_err(HttpClientError::Http)
+}
+
+fn read_response_body(
+    connection: &mut TcpConnection,
+    kind: &BodyKind,
+    max_body_bytes: usize,
+) -> Result<Vec<u8>, HttpClientError> {
+    match kind {
+        BodyKind::None => Ok(Vec::new()),
+        BodyKind::ContentLength(length) => {
+            if *length > max_body_bytes {
+                return Err(HttpClientError::ResponseBodyTooLarge {
+                    limit: max_body_bytes,
+                });
+            }
+            connection.read_exact(*length).map_err(HttpClientError::Tcp)
+        }
+        BodyKind::UntilEof => read_until_eof(connection, max_body_bytes),
+        BodyKind::Chunked => Err(HttpClientError::UnsupportedBodyFraming(BodyKind::Chunked)),
+    }
+}
+
+fn read_until_eof(
+    connection: &mut TcpConnection,
+    max_body_bytes: usize,
+) -> Result<Vec<u8>, HttpClientError> {
+    let mut body = Vec::new();
+    loop {
+        let remaining = max_body_bytes.saturating_sub(body.len());
+        let read_size = if remaining == 0 {
+            1
+        } else {
+            remaining.min(8 * 1024)
+        };
+        let chunk = connection
+            .read_chunk(read_size)
+            .map_err(HttpClientError::Tcp)?;
+        if chunk.is_empty() {
+            return Ok(body);
+        }
+        if chunk.len() > remaining {
+            return Err(HttpClientError::ResponseBodyTooLarge {
+                limit: max_body_bytes,
+            });
+        }
+        body.extend_from_slice(&chunk);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
+    use std::sync::mpsc::{self, Receiver};
+    use std::thread::{self, JoinHandle};
+    use std::time::Duration;
+
+    fn serve(responses: Vec<Vec<u8>>) -> (String, Receiver<Vec<u8>>, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (request_tx, request_rx) = mpsc::channel();
+        let handle = thread::spawn(move || {
+            for response in responses {
+                let (mut stream, _) = listener.accept().unwrap();
+                let request = read_request_head(&mut stream);
+                let _ = request_tx.send(request);
+                stream.write_all(&response).unwrap();
+                stream.flush().unwrap();
+            }
+        });
+        (format!("http://{address}"), request_rx, handle)
+    }
+
+    fn read_request_head(stream: &mut TcpStream) -> Vec<u8> {
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let mut request = Vec::new();
+        let mut byte = [0_u8; 1];
+        while !request.ends_with(b"\r\n\r\n") {
+            let count = stream.read(&mut byte).unwrap();
+            if count == 0 {
+                break;
+            }
+            request.push(byte[0]);
+        }
+        request
+    }
+
+    fn test_client() -> HttpClient {
+        HttpClient {
+            connect_options: ConnectOptions {
+                connect_timeout: Duration::from_secs(5),
+                read_timeout: Some(Duration::from_secs(5)),
+                write_timeout: Some(Duration::from_secs(5)),
+                buffer_size: 1024,
+            },
+            ..HttpClient::default()
+        }
+    }
+
+    #[test]
+    fn gets_content_length_response() {
+        let response = b"HTTP/1.0 200 OK\r\n\
+                         Content-Length: 5\r\n\
+                         Content-Type: text/html; charset=utf-8\r\n\
+                         \r\n\
+                         hello"
+            .to_vec();
+        let (origin, requests, server) = serve(vec![response]);
+        let url = format!("{origin}/docs/index.html?q=venture#top");
+
+        let result = test_client().get(&url).unwrap();
+
+        assert_eq!(result.head.status, 200);
+        assert_eq!(result.body, b"hello");
+        assert_eq!(result.final_url, url);
+        assert_eq!(
+            result.head.content_type(),
+            Some(("text/html".to_string(), Some("utf-8".to_string())))
+        );
+        let request = String::from_utf8(requests.recv().unwrap()).unwrap();
+        assert!(request.starts_with("GET /docs/index.html?q=venture HTTP/1.0\r\n"));
+        assert!(request.contains("\r\nUser-Agent: Venture/0.1\r\n"));
+        assert!(request.contains("\r\nConnection: close\r\n"));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn reads_binary_body_until_eof() {
+        let mut response = b"HTTP/1.0 200 OK\r\nContent-Type: image/gif\r\n\r\n".to_vec();
+        response.extend_from_slice(b"a\0b");
+        let (origin, _, server) = serve(vec![response]);
+
+        let result = test_client().get(&format!("{origin}/image.gif")).unwrap();
+
+        assert_eq!(result.body, b"a\0b");
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn follows_relative_redirect() {
+        let first =
+            b"HTTP/1.0 302 Found\r\nLocation: /target\r\nContent-Length: 0\r\n\r\n".to_vec();
+        let second = b"HTTP/1.0 200 OK\r\nContent-Length: 4\r\n\r\ndone".to_vec();
+        let (origin, requests, server) = serve(vec![first, second]);
+
+        let result = test_client().get(&format!("{origin}/start")).unwrap();
+
+        assert_eq!(result.head.status, 200);
+        assert_eq!(result.body, b"done");
+        assert_eq!(result.final_url, format!("{origin}/target"));
+        assert!(String::from_utf8(requests.recv().unwrap())
+            .unwrap()
+            .starts_with("GET /start HTTP/1.0\r\n"));
+        assert!(String::from_utf8(requests.recv().unwrap())
+            .unwrap()
+            .starts_with("GET /target HTTP/1.0\r\n"));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn enforces_redirect_limit() {
+        let redirect =
+            b"HTTP/1.0 302 Found\r\nLocation: /again\r\nContent-Length: 0\r\n\r\n".to_vec();
+        let (origin, _, server) = serve(vec![redirect.clone(), redirect.clone(), redirect]);
+        let mut client = test_client();
+        client.max_redirects = 2;
+
+        let error = client.get(&format!("{origin}/start")).unwrap_err();
+
+        assert!(matches!(
+            error,
+            HttpClientError::TooManyRedirects { limit: 2 }
+        ));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn rejects_oversized_declared_body_before_allocating() {
+        let response = b"HTTP/1.0 200 OK\r\nContent-Length: 6\r\n\r\nabcdef".to_vec();
+        let (origin, _, server) = serve(vec![response]);
+        let mut client = test_client();
+        client.max_body_bytes = 5;
+
+        let error = client.get(&origin).unwrap_err();
+
+        assert!(matches!(
+            error,
+            HttpClientError::ResponseBodyTooLarge { limit: 5 }
+        ));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn rejects_oversized_eof_body() {
+        let response = b"HTTP/1.0 200 OK\r\n\r\nabcdef".to_vec();
+        let (origin, _, server) = serve(vec![response]);
+        let mut client = test_client();
+        client.max_body_bytes = 5;
+
+        let error = client.get(&origin).unwrap_err();
+
+        assert!(matches!(
+            error,
+            HttpClientError::ResponseBodyTooLarge { limit: 5 }
+        ));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn rejects_chunked_http11_response() {
+        let response =
+            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ntest\r\n0\r\n\r\n".to_vec();
+        let (origin, _, server) = serve(vec![response]);
+
+        let error = test_client().get(&origin).unwrap_err();
+
+        assert!(matches!(
+            error,
+            HttpClientError::UnsupportedBodyFraming(BodyKind::Chunked)
+        ));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn rejects_incomplete_response_head() {
+        let response = b"HTTP/1.0 200 OK\r\nContent-Length: 0\r\n".to_vec();
+        let (origin, _, server) = serve(vec![response]);
+
+        let error = test_client().get(&origin).unwrap_err();
+
+        assert!(matches!(error, HttpClientError::IncompleteResponseHead));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn rejects_response_head_line_over_limit() {
+        let response = b"HTTP/1.0 200 This-reason-is-too-long\r\n\r\n".to_vec();
+        let (origin, _, server) = serve(vec![response]);
+        let mut client = test_client();
+        client.max_head_bytes = 16;
+
+        let error = client.get(&origin).unwrap_err();
+
+        assert!(matches!(
+            error,
+            HttpClientError::ResponseHeadTooLarge { limit: 16 }
+        ));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn validates_scheme_credentials_and_request_metadata_before_connecting() {
+        assert!(matches!(
+            test_client().get("https://example.test/"),
+            Err(HttpClientError::UnsupportedScheme(scheme)) if scheme == "https"
+        ));
+        assert!(matches!(
+            test_client().get("http://user@example.test/"),
+            Err(HttpClientError::UnsupportedCredentials)
+        ));
+        assert!(matches!(
+            test_client().get("http:///missing"),
+            Err(HttpClientError::MissingHost)
+        ));
+
+        let mut client = test_client();
+        client.user_agent = "Venture\r\nInjected: yes".to_string();
+        assert!(matches!(
+            client.get("http://example.test/"),
+            Err(HttpClientError::InvalidHeaderValue { name: "User-Agent" })
+        ));
+        assert!(matches!(
+            test_client().get("http://example.test/bad path"),
+            Err(HttpClientError::InvalidRequestTarget)
+        ));
+        assert!(matches!(
+            test_client().get("http://bad\nhost/"),
+            Err(HttpClientError::InvalidHeaderValue { name: "Host" })
+        ));
+    }
+}

--- a/code/packages/rust/tcp-client/CHANGELOG.md
+++ b/code/packages/rust/tcp-client/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this package will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- Added `TcpConnection::read_chunk` and `read_until_limit` for bounded
+  streaming and delimiter-framed reads.
+
 ## [0.1.0] - 2026-04-12
 
 ### Added

--- a/code/packages/rust/tcp-client/README.md
+++ b/code/packages/rust/tcp-client/README.md
@@ -30,6 +30,8 @@ println!("{}", status); // "HTTP/1.0 200 OK\r\n"
 - `read_line()` — read until `\n`
 - `read_exact(n)` — read exactly n bytes
 - `read_until(delimiter)` — read until delimiter byte
+- `read_until_limit(delimiter, max_bytes)` — delimiter read with a hard bound
+- `read_chunk(max_bytes)` — bounded streaming read, empty at EOF
 - `write_all(data)` — buffered write
 - `flush()` — send buffered data
 - `shutdown_write()` — half-close (signal "done writing")

--- a/code/packages/rust/tcp-client/src/lib.rs
+++ b/code/packages/rust/tcp-client/src/lib.rs
@@ -131,6 +131,8 @@ pub enum TcpError {
     BrokenPipe,
     /// Connection closed before the expected number of bytes arrived.
     UnexpectedEof { expected: usize, received: usize },
+    /// A delimiter-framed read exceeded its caller-supplied byte limit.
+    ReadLimitExceeded { limit: usize },
     /// A low-level I/O error not covered by the specific variants.
     IoError(io::Error),
 }
@@ -155,6 +157,9 @@ impl fmt::Display for TcpError {
                     "unexpected EOF: expected {} bytes, got {}",
                     expected, received
                 )
+            }
+            TcpError::ReadLimitExceeded { limit } => {
+                write!(f, "read exceeded the configured {limit}-byte limit")
             }
             TcpError::IoError(e) => write!(f, "I/O error: {}", e),
         }
@@ -402,6 +407,57 @@ impl TcpConnection {
         Ok(buf)
     }
 
+    /// Read through `delimiter` without buffering more than `max_bytes`.
+    ///
+    /// The delimiter is included in the returned bytes. Clean EOF returns the
+    /// bytes accumulated so far; if more than `max_bytes` would be required,
+    /// the read fails with [`TcpError::ReadLimitExceeded`].
+    pub fn read_until_limit(
+        &mut self,
+        delimiter: u8,
+        max_bytes: usize,
+    ) -> Result<Vec<u8>, TcpError> {
+        let mut output = Vec::with_capacity(max_bytes.min(8 * 1024));
+        loop {
+            let available = self.reader.fill_buf().map_err(map_io_error)?;
+            if available.is_empty() {
+                return Ok(output);
+            }
+
+            let through_delimiter = available
+                .iter()
+                .position(|byte| *byte == delimiter)
+                .map_or(available.len(), |index| index + 1);
+            let remaining = max_bytes.saturating_sub(output.len());
+            if through_delimiter > remaining {
+                self.reader.consume(remaining);
+                return Err(TcpError::ReadLimitExceeded { limit: max_bytes });
+            }
+
+            output.extend_from_slice(&available[..through_delimiter]);
+            self.reader.consume(through_delimiter);
+            if output.last() == Some(&delimiter) {
+                return Ok(output);
+            }
+        }
+    }
+
+    /// Read up to `max_bytes` from the connection.
+    ///
+    /// Returns an empty vector only when `max_bytes` is zero or the peer has
+    /// closed its write half. This bounded primitive lets higher-level
+    /// protocols stream bodies without allocating an unbounded buffer.
+    pub fn read_chunk(&mut self, max_bytes: usize) -> Result<Vec<u8>, TcpError> {
+        if max_bytes == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut buf = vec![0; max_bytes];
+        let bytes_read = self.reader.read(&mut buf).map_err(map_io_error)?;
+        buf.truncate(bytes_read);
+        Ok(buf)
+    }
+
     /// Write all bytes to the connection.
     ///
     /// Data is buffered internally. You **must** call [`flush()`](Self::flush)
@@ -617,6 +673,26 @@ mod tests {
     }
 
     #[test]
+    fn read_chunk_is_bounded_and_reports_eof() {
+        let (port, _stop) = start_partial_server(b"abcdef".to_vec());
+        let mut conn = connect("127.0.0.1", port, test_options()).unwrap();
+
+        assert_eq!(conn.read_chunk(2).unwrap(), b"ab");
+        assert_eq!(conn.read_chunk(3).unwrap(), b"cde");
+        assert_eq!(conn.read_chunk(3).unwrap(), b"f");
+        assert!(conn.read_chunk(3).unwrap().is_empty());
+    }
+
+    #[test]
+    fn zero_length_read_chunk_does_not_consume_input() {
+        let (port, _stop) = start_partial_server(b"ok".to_vec());
+        let mut conn = connect("127.0.0.1", port, test_options()).unwrap();
+
+        assert!(conn.read_chunk(0).unwrap().is_empty());
+        assert_eq!(conn.read_chunk(2).unwrap(), b"ok");
+    }
+
+    #[test]
     fn read_exact_from_echo() {
         let (port, _stop) = start_echo_server();
         let mut conn = connect("127.0.0.1", port, test_options()).unwrap();
@@ -639,6 +715,27 @@ mod tests {
 
         let result = conn.read_until(b'\0').unwrap();
         assert_eq!(result, b"key:value\0");
+    }
+
+    #[test]
+    fn read_until_limit_bounds_delimiter_frames() {
+        let (port, _stop) = start_partial_server(b"header\nbody".to_vec());
+        let mut conn = connect("127.0.0.1", port, test_options()).unwrap();
+
+        assert_eq!(conn.read_until_limit(b'\n', 7).unwrap(), b"header\n");
+        assert_eq!(conn.read_chunk(4).unwrap(), b"body");
+    }
+
+    #[test]
+    fn read_until_limit_rejects_oversized_frames() {
+        let (port, _stop) = start_partial_server(b"toolong\n".to_vec());
+        let mut conn = connect("127.0.0.1", port, test_options()).unwrap();
+
+        let error = conn.read_until_limit(b'\n', 4).unwrap_err();
+        assert!(matches!(
+            error,
+            TcpError::ReadLimitExceeded { limit: 4 }
+        ));
     }
 
     #[test]

--- a/code/specs/BR01-venture-browser.md
+++ b/code/specs/BR01-venture-browser.md
@@ -56,7 +56,9 @@ through shared layout into a backend-neutral `PaintScene`, extracts clickable
 link regions, resolves host-fetched GIF/JPEG image bytes into shared pixels,
 and proves text and inline-image scenes rasterize to RGBA pixels with Cairo.
 Fetch/decode failures now render clipped bordered HTML `alt` text. The concrete
-network transport and platform host must still wire navigation through pixels.
+`http1-client` now composes URL parsing, bounded TCP I/O, HTTP response framing,
+and relative redirects into a synchronous HTTP/1.0 GET transport. The platform
+host must still wire fetched page and image bytes through navigation to pixels.
 
 ## Where It Fits
 
@@ -443,10 +445,9 @@ system window color and felt "native."
 [dependencies]
 url-parser             = { path = "../../../packages/rust/url-parser" }
 tcp-client             = { path = "../../../packages/rust/tcp-client" }
-frame-extractor        = { path = "../../../packages/rust/frame-extractor" }
-http1_0_lexer          = { path = "../../../packages/rust/http1.0-lexer" }
-http1_0_parser         = { path = "../../../packages/rust/http1.0-parser" }
-http1_0_client         = { path = "../../../packages/rust/http1.0-client" }
+http-core              = { path = "../../../packages/rust/http-core" }
+http1                  = { path = "../../../packages/rust/http1" }
+http1-client           = { path = "../../../packages/rust/http1-client" }
 coding-adventures-html-parser = { path = "../../../packages/rust/html-parser" }
 html-to-layout         = { path = "../../../packages/rust/html-to-layout" }
 layout_ir              = { path = "../../../packages/rust/layout-ir" }

--- a/code/specs/NET05-http1.0-client.md
+++ b/code/specs/NET05-http1.0-client.md
@@ -2,8 +2,8 @@
 
 ## Overview
 
-The HTTP/1.0 client is a thin orchestrator — roughly 100 lines of glue code that
-wires together five independent packages into a complete HTTP client. It does
+The HTTP/1.0 client is a thin orchestrator that wires together three
+independent packages into a complete HTTP client. It does
 almost nothing on its own. Instead, it sequences calls through a pipeline of
 single-purpose packages, each handling one layer of the problem:
 
@@ -12,9 +12,13 @@ single-purpose packages, each handling one layer of the problem:
 | 1    | url-parser (NET00)   | Parse URL into scheme, host, port, path |
 | 2    | tcp-client (NET01)   | Open a TCP socket to the server         |
 | 3    | *(inline)*           | Write the HTTP request line + headers   |
-| 4    | frame-extractor (NET02) | Extract header frame, then body      |
-| 5    | http1.0-lexer (NET03)   | Tokenize the raw response bytes      |
-| 6    | http1.0-parser (NET04)  | Build a structured HttpResponse      |
+| 4    | http1                    | Parse the response head and framing  |
+| 5    | tcp-client               | Read the bounded response body       |
+
+The current Rust implementation consolidates the original NET02–NET04 wire
+pipeline behind the shared `http1` and `http-core` contracts. The older
+component names below explain the educational decomposition; `http1-client`
+uses the current package boundaries.
 
 This is the unix-pipe philosophy made concrete: each package does one thing
 well, and the client simply connects them in sequence.
@@ -29,12 +33,11 @@ well, and the client simply connects them in sequence.
                            │
 ┌──────────────────────────▼───────────────────────────────────────────┐
 │                  HTTP/1.0 Client (NET05)                             │
-│          ~100 lines of orchestration glue                            │
+│        bounded synchronous orchestration                             │
 │                                                                      │
-│  ┌──────────┐  ┌──────────┐  ┌───────────────┐  ┌────────┐  ┌─────┐│
-│  │url-parser│→ │tcp-client│→ │frame-extractor│→ │ lexer  │→ │parse││
-│  │  NET00   │  │  NET01   │  │    NET02      │  │ NET03  │  │NET04││
-│  └──────────┘  └──────────┘  └───────────────┘  └────────┘  └─────┘│
+│  │url-parser│ → │tcp-client│ → │ http1 + http-core │             │
+│  │  NET00   │   │  NET01   │   │ response framing  │             │
+│  └──────────┘   └──────────┘   └───────────────────┘             │
 └──────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -45,12 +48,11 @@ plumbing; this is the faucet.
 ### Dependency Tree
 
 ```
-http1.0-client (NET05)
+http1-client (NET05)
 ├── url-parser (NET00)
 ├── tcp-client (NET01)
-├── frame-extractor (NET02)
-├── http1.0-lexer (NET03)
-└── http1.0-parser (NET04)
+├── http1
+└── http-core
 ```
 
 ## Concepts
@@ -75,19 +77,16 @@ Step 3: Write request
         TcpConnection.write_all(b"GET /hypertext/WWW/TheProject.html HTTP/1.0\r\nHost: info.cern.ch\r\nUser-Agent: Venture/0.1\r\n\r\n")
         TcpConnection.shutdown_write() — signal we're done sending
 
-Step 4: frame-extractor (NET02)
-        Phase A: DelimiterStrategy("\r\n\r\n").extract(conn) → header bytes
-        Phase B: Parse Content-Length from raw headers, or fall back to ReadToEnd
-        Phase C: LengthPrefixedStrategy(len).extract(conn) → body bytes
-                 OR ReadToEndStrategy.extract(conn) → body bytes
+Step 4: tcp-client + http1
+        Read bounded header lines through the blank-line terminator
+        parse_response_head(&raw_head) → ResponseHead + BodyKind
 
-Step 5: http1.0-lexer (NET03)
-        lex_response(&raw_bytes) → Vec<HttpToken>
+Step 5: tcp-client
+        BodyKind::ContentLength(n) → read exactly n bounded bytes
+        BodyKind::UntilEof         → stream bounded chunks through clean EOF
+        BodyKind::None             → empty body
 
-Step 6: http1.0-parser (NET04)
-        parse_response(&tokens) → HttpResponse { status: 200, headers: [...], body: b"<html>..." }
-
-Step 7: Redirect following (if status is 301 or 302)
+Step 6: Redirect following (if status is 301 or 302)
         Extract Location header → resolve against base URL → go to Step 1
         Max 5 redirects to prevent infinite loops
 
@@ -140,48 +139,42 @@ Both include a `Location` header with the new URL. The client:
 3. Starts the pipeline over from Step 1 with the new URL
 4. Caps at 5 total redirects to prevent infinite loops
 
-### 5. Why This Is ~100 Lines
+### 5. Why This Stays Small
 
-All the complexity lives in the five dependency packages:
+Most complexity lives in the dependency packages:
 
 - URL parsing? NET00 handles it.
 - TCP sockets? NET01 handles it.
-- Framing (knowing where headers end and body begins)? NET02 handles it.
-- Tokenizing HTTP? NET03 handles it.
-- Building structured responses? NET04 handles it.
+- HTTP syntax and semantic response heads? `http1` and `http-core` handle it.
 
-The client just calls them in order. This is the payoff of the unix-pipe
-architecture: the integration layer is trivial because the components are
-well-defined.
+The client sequences those components and owns only transport policy: bounds,
+redirects, request metadata validation, and the HTTP/1.0 connection lifecycle.
 
 ## Public API
 
 ### Rust
 
 ```rust
-use std::time::Duration;
-
-/// An HTTP/1.0 client that orchestrates the NET00–NET04 pipeline.
+/// An HTTP/1.0 client that orchestrates the current NET00–NET05 packages.
 ///
 /// All configuration has sensible defaults. For most use cases, the
 /// free function `get()` is sufficient — you only need `HttpClient`
-/// if you want to customize timeouts, user-agent, or redirect limits.
+/// if you want to customize timeouts, bounds, user-agent, or redirects.
 pub struct HttpClient {
+    /// TCP connect/read/write options.
+    pub connect_options: tcp_client::ConnectOptions,
+
     /// Maximum number of redirects to follow before returning
     /// TooManyRedirects. Default: 5.
-    max_redirects: usize,
+    pub max_redirects: usize,
+
+    /// Hard response head and body bounds.
+    pub max_head_bytes: usize,
+    pub max_body_bytes: usize,
 
     /// The User-Agent header sent with every request.
     /// Default: "Venture/0.1".
-    user_agent: String,
-
-    /// How long to wait for the TCP connection to establish.
-    /// Default: 30 seconds.
-    connect_timeout: Duration,
-
-    /// How long to wait for data during response reading.
-    /// Default: 30 seconds.
-    read_timeout: Duration,
+    pub user_agent: String,
 }
 
 impl HttpClient {
@@ -191,7 +184,7 @@ impl HttpClient {
     /// Perform an HTTP/1.0 GET request.
     ///
     /// This runs the full pipeline: parse URL → connect → send request →
-    /// extract frames → lex → parse → follow redirects if needed.
+    /// parse a bounded response → follow redirects if needed.
     pub fn get(&self, url: &str) -> Result<HttpResponse, HttpClientError>;
 }
 
@@ -209,25 +202,23 @@ exactly what went wrong and at which pipeline stage:
 ```rust
 pub enum HttpClientError {
     /// URL parsing failed (NET00).
-    UrlError(url_parser::UrlError),
+    Url(url_parser::UrlError),
 
     /// TCP connection failed (NET01).
-    ConnectionError(tcp_client::ConnectionError),
+    Tcp(tcp_client::TcpError),
 
-    /// Frame extraction failed (NET02).
-    FrameError(frame_extractor::FrameError),
-
-    /// Lexing failed (NET03).
-    LexError(http1_lexer::LexError),
-
-    /// Parsing failed (NET04).
-    ParseError(http1_parser::ParseError),
+    /// HTTP response-head parsing failed.
+    Http(http1::Http1ParseError),
 
     /// Followed too many redirects (default limit: 5).
     TooManyRedirects { limit: usize },
 
     /// The URL scheme is not "http". HTTPS is out of scope for NET05.
     UnsupportedScheme(String),
+
+    /// A response exceeded the configured head or body bound.
+    ResponseHeadTooLarge { limit: usize },
+    ResponseBodyTooLarge { limit: usize },
 }
 ```
 
@@ -265,12 +256,12 @@ read-to-end fallback strategy.
 ### 6. Connection Refused
 
 Attempt to connect to a port with no listener. Verify the client returns
-`HttpClientError::ConnectionError`.
+`HttpClientError::Tcp`.
 
 ### 7. DNS Failure
 
 Attempt to connect to `"nonexistent.invalid"`. Verify the client returns
-`HttpClientError::ConnectionError` (DNS resolution is part of TCP connect).
+`HttpClientError::Tcp` (DNS resolution is part of TCP connect).
 
 ### 8. Large Response
 
@@ -289,9 +280,9 @@ network access) but runnable via `cargo test -- --ignored`.
 
 - HTTP/1.0 GET requests
 - Request line and header construction
-- Pipeline orchestration (NET00 → NET01 → NET02 → NET03 → NET04)
+- Pipeline orchestration (`url-parser` → `tcp-client` → `http1`)
 - Redirect following (301, 302) with configurable limit
-- Configurable timeouts and user-agent
+- Configurable timeouts, bounds, redirect limit, and user-agent
 - Error propagation from all pipeline stages
 
 ### Out of Scope


### PR DESCRIPTION
## Summary

- add `http1-client`, a bounded synchronous HTTP/1.0 GET transport for Venture over the existing `url-parser`, `tcp-client`, `http1`, and `http-core` crates
- add bounded TCP chunk and delimiter reads so response heads and EOF-framed bodies cannot grow without a caller-controlled limit
- support relative 301/302 redirects, configurable timeouts and size limits, and explicit errors for unsupported framing
- guard request targets, host values, user-agent values, and URL credentials before any connection is opened
- reconcile BR01/NET05 documentation with the current Rust package boundaries

## Why

The HTML tokenizer/tree-construction ratchets and the HTML-to-layout/paint/image path are green, but Venture still lacked the concrete transport that turns an HTTP URL into page or image bytes. This closes that bounded layer while keeping origin policy, HTML parsing, image adaptation, navigation, and platform-window behavior in their existing domains.

## Validation

- `cargo test -p tcp-client -p http1-client -p http1 -p http-core -p url-parser -- --nocapture`
- `cargo clippy -p tcp-client -p http1-client --all-targets -- -D warnings`
- `cargo test -p coding-adventures-html-parser --test html5lib_coverage_audit_test -- --nocapture`
- `python3 html-parser/tests/fixtures/test_html_conformance_coverage_audit.py`
- `python3 html-parser/tests/fixtures/check_whatwg_audit_manifest.py`
- `python3 html-parser/tests/fixtures/check_whatwg_audit_coverage.py`
- `git diff --check`

The checked parser ratchets remain unchanged: tree construction indexes 2,637 local cases with zero missing/stale; the upstream coverage artifact records 1,934 WPT tree cases and 6,806 html5lib tokenizer cases with zero missing and zero tokenizer skips.

This does not claim full browser completion: the platform host still needs to wire fetched page/image bytes through navigation to pixels, and text fragmentation/baseline alignment remain separate layout gates.