### PR TITLE
feat(axiom-to-semantic-ir): SIR23 lowering frontend (MA13e, Wave 7 — Axiom native implementation complete)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -291,6 +291,7 @@ members = [
     "axiom-parser",
     "axiom-runtime",
     "axiom-repl",
+    "axiom-to-semantic-ir",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/axiom-to-semantic-ir/BUILD
+++ b/code/packages/rust/axiom-to-semantic-ir/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-axiom-to-semantic-ir -- --nocapture

--- a/code/packages/rust/axiom-to-semantic-ir/BUILD_windows
+++ b/code/packages/rust/axiom-to-semantic-ir/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-axiom-to-semantic-ir -- --nocapture

--- a/code/packages/rust/axiom-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/axiom-to-semantic-ir/CHANGELOG.md
@@ -1,0 +1,157 @@
+# Changelog
+
+## [0.1.0] - 2026-07-29
+
+### Added
+
+- Initial `axiom-to-semantic-ir` frontend crate (HML01 Stream B, MA-13e) —
+  the **sixth** to target SIR23 (symbolic-expression/pattern domain),
+  sibling to `wolfram-to-semantic-ir`, `macsyma-to-semantic-ir`,
+  `derive-to-semantic-ir`, `reduce-to-semantic-ir`, and
+  `maple-to-semantic-ir`: `compile`/`compile_source` lowering
+  `coding-adventures-axiom-parser`'s `GrammarASTNode` CST into a
+  `semantic_ir::Module`. This is the **last** item in Axiom's own native
+  (non-oracle-tested) pipeline per MA13 §6 — the four prior merged PRs
+  shipped `axiom-lexer` (MA-13b, #8997), `axiom-parser` (MA-13c, #9022), and
+  `axiom-runtime`/`axiom-repl` (MA-13d, #9055).
+- Design: retargets `axiom-runtime::eval::eval_expr`'s own rule-name
+  dispatch (a single-phase tree-walking interpreter, unlike Derive/Reduce/
+  Maple's own two-phase lower-then-evaluate runtimes) onto
+  `semantic_ir::Expr`'s SIR23 vocabulary (`SymSymbol`/`SymApply`) instead —
+  building data rather than evaluating. Every arithmetic/comparison operator
+  lowers to the exact same canonical head Derive/Reduce/Maple already use
+  (`Add`/`Sub`/`Mul`/`Div`/`Pow`/`Neg`/`Equal`/`NotEqual`/`Less`/`Greater`/
+  `LessEqual`/`GreaterEqual`), so the shared JS backend's already-shipped
+  `evalTerm` arithmetic/comparison folding works for Axiom's own arithmetic
+  with zero new backend work.
+- **The central design decision, made and disclosed in this PR (mirroring
+  how MA13a itself made and disclosed its own central design decision):
+  `:`, `::`, and `has` lower as ordinary `Expr::SymApply` nodes with three
+  new, locally-defined reserved head-name constants** —
+  `__axiom_declare` (`a : T` / `(a, b, c) : T`), `__axiom_coerce`
+  (`e :: T`), and `__axiom_has` (`D has C`) — never added to shared
+  `semantic-ir`/`symbolic-ir`. Verified directly (not assumed) that neither
+  `symbolic_ir::IRNode` (MA13 §2's own finding) nor `semantic_ir::Expr`/
+  `SirType`/`Feature` (this crate's own research against the current
+  SIR23 spec, including its already-shipped evaluator addendum) has any
+  domain/category/coercion concept — the same "new construct, no
+  shared-crate change, a local `pub const` head name" pattern this SIR23
+  family already established twice (`reduce-to-semantic-ir`'s
+  `CompoundExpression`/`Cons`/`First`/…, `maple-to-semantic-ir`'s `Set`).
+  A `type_expr` position (`Polynomial(Integer)`, `Fraction Integer`) lowers
+  through a dedicated `lower_type_expr` to the exact same `SymSymbol`/
+  `SymApply` shapes an ordinary call already produces — no new
+  representation needed there either.
+- **Runtime-shim implementation deliberately deferred to the follow-on
+  oracle-testing task, not shipped in this PR.** Verified directly (not
+  assumed from the task's own suggestion to extend `sir-runtime-symbolic`):
+  the JS backend's real, already-shipped SIR23 evaluator (`Symbolic.
+  evalTerm`, `HELD_HEADS = {"Assign", "Define", "If"}`, the full
+  arithmetic/held-form/calculus dispatch) is **inlined** inside
+  `semantic-ir-to-javascript/src/runtime.rs`'s own emitted runtime blob —
+  confirmed by grepping that file directly, not the published
+  `@coding-adventures/sir-runtime-symbolic` TypeScript package. That
+  package (confirmed by reading its own `CHANGELOG.md`) only re-exports
+  `cas-pattern-matching`'s structural matcher and `symbolic-ir`'s leaf-term
+  constructors — it has no evaluator at all, and it only backs the
+  TypeScript backend, which no Stream B frontend's oracle testing exercises
+  yet (SIR23 spec's own "Scope boundary" section says so explicitly).
+  Extending it would therefore not, by itself, make `:`/`::`/`has`
+  evaluate through the path this repo's `node`-execution oracle tests
+  actually use. Given (a) oracle/golden testing for Axiom is this task's
+  own explicitly-named separate follow-on item and (b) every prior "new
+  reserved head, no evaluator yet" precedent in this exact family (`Set`,
+  `CompoundExpression`, `Cons`, `First`, `Second`, `Third`, `Rest`, `Part`,
+  `Append`, `Reverse` — none of which have an evaluation handler in
+  `symbolic-vm` OR `semantic-ir-to-javascript` today) shipped its frontend
+  first and left the evaluator for later, separate work, this crate follows
+  the identical, already-proven sequence. This is the conservative, narrower
+  call made when genuine ambiguity was hit, not a shortcut.
+- **`program` is a SINGLE expression, not a repeated multi-statement
+  worksheet** — a real, disclosed structural difference from
+  `maple-to-semantic-ir`'s/`reduce-to-semantic-ir`'s own multi-statement
+  `lower_file` loops: `axiom.grammar`'s own `program = expr` parses exactly
+  one expression per call (Axiom is modeled as a numbered, per-line
+  interactive session, MA13 §5), so `compile`/`compile_source` always
+  produce a `main` body with exactly one `Stmt::ExprStmt`.
+- **A disclosed widening relative to `axiom-runtime`'s own function
+  bodies**: `axiom-runtime::eval::lower_pure_body` rejects `:=`/`:`/`::`/
+  `has`/a `;`-block inside a held function body (none of those constructs
+  have any representation in that crate's own reduced `IRNode` value
+  model). This crate imposes no equivalent restriction — since everything
+  is data here, all of those constructs already have an ordinary `SymApply`
+  representation, so a function body containing any of them lowers exactly
+  like a top-level statement would. A regression test
+  (`function_body_may_contain_constructs_axiom_runtime_itself_rejects`)
+  confirms this directly.
+- **Declared function definitions drop type annotations, not validate
+  them**: `declared_define`'s typed parameter list and return-type
+  annotation are never located or inspected at lowering time — only each
+  parameter's bare NAME is kept, producing the same 3-argument
+  `Define(name, List(params...), body)` shape Derive's/Reduce's/Maple's own
+  definitions already use. Disclosed as a real, deliberate narrowing (not a
+  bug) relative to `axiom-runtime::eval_declared_define`'s own
+  definition-time-only domain-name validation, which this purely-syntactic
+  frontend does not reproduce.
+- **No logical operators, no `elif`**: `axiom.grammar` has no `and`/`or`/
+  `not` production and no `elif` repetition at all (verified directly
+  against the grammar, not assumed) — a genuinely smaller grammar than
+  Maple's/Macsyma's, needing no `check_elif_chain_length`-equivalent guard.
+- **`postfix` is NOT chainable** — `axiom.grammar`'s `postfix = atom
+  [ call_args ]` allows at most one call suffix (`f(x)(y)` is not valid
+  Axiom syntax in this subset), mirroring `maple-to-semantic-ir`'s
+  identical finding: no `check_postfix_chain_length`-equivalent guard
+  exists anywhere in this crate.
+- **The first SIR23-family frontend to construct `Expr::StrLit`** — none of
+  Derive's/Reduce's/Maple's own grammars have a `STRING` token, but Axiom's
+  does (MA13 §4: domain `String`). `str_lit` is an instance method (not a
+  free function) so every branch immediately calls
+  `self.observed.add(Feature::Strings)` — proactively avoiding the
+  confirmed, previously-shipped `matlab-to-semantic-ir`/
+  `wolfram-to-semantic-ir` bug class where a free literal-constructing
+  helper had no access to feature-tracking state.
+- Recursion-depth hardening carried over proactively from every prior SIR23
+  frontend's own security-review history, even though neither
+  `axiom-parser` nor `axiom-runtime` applies any of these guards
+  themselves:
+  - `MAX_EXPR_DEPTH` (256), matching every sibling SIR23 frontend's
+    identically-named, identically-valued guard.
+  - `check_chain_length` caps `additive`/`multiplicative`'s flat
+    operator-chain fold before any tree is built.
+  - `check_apply_arg_count` caps every flat-`Vec` production's element
+    count (call arguments, list literals, typed-parameter lists,
+    tuple-declaration name lists, type-constructor argument lists, and a
+    `;`-block's statement count — the last a genuinely new call site,
+    since a `;`-block lowers to one FLAT n-ary `CompoundExpression`, never
+    a folded pairwise tree, so this is an allocation-size backstop here
+    too, not a chain-length guard).
+  - `measure_depth_iterative`/`drop_iterative` — the authoritative,
+    construction-composition-independent iterative depth check and
+    iterative teardown, run once per top-level statement.
+  - Every one of Axiom's self-referential (right-recursive or
+    prefix-recursive) productions — parenthesised/block nesting, nested
+    function calls, a unary-minus-prefix chain, the power chain, and
+    (genuinely new to this crate) type-constructor nesting — needs no
+    additional lowering-side guard beyond the ordinary recursion-depth
+    parameter: `axiom-parser`'s own `MAX_RULE_DEPTH` (140) already bounds
+    how deep any of these can nest in the CST this crate ever receives
+    (confirmed directly against that crate's own doc comment, which
+    measures all four of its own shapes independently). Type-constructor
+    nesting in particular pays one real `(` character per level for the
+    explicit form, and cannot recurse at all for the paren-optional
+    shorthand (grammar-restricted to a single bare NAME) — so it carries
+    no adversarial "long flat chain costing one frame each with no real
+    input cost" risk either.
+- No `tests/oracle.rs` in this PR — oracle/golden testing (native
+  `axiom-runtime` vs. this crate → `semantic-ir-to-javascript` → `node`) is
+  an explicitly separate follow-on task, named as such in this crate's own
+  scoping and not attempted here.
+- 60+ unit tests over exact `Expr` shapes for every grammar production
+  (including the type-annotation-dropping and function-body-widening
+  regressions above, and DoS-guard regressions for wide additive chains,
+  arglists, list literals, and tuple declarations), 15 validator/
+  capability-acceptance tests (including the three new reserved-head
+  constructs with no shared-evaluator handler), 11 e2e `node`-execution
+  tests (skip cleanly if `node` is unavailable), 1 doctest.
+- Adds `axiom-to-semantic-ir` to `code/packages/rust/Cargo.toml`'s
+  workspace `members`, immediately after the `axiom-repl` entry.

--- a/code/packages/rust/axiom-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/axiom-to-semantic-ir/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "coding-adventures-axiom-to-semantic-ir"
+version = "0.1.0"
+edition = "2021"
+description = "Axiom CST -> narrow-waist Semantic IR (SIR23 symbolic/pattern domain, Stream B). MA-13e, the last item in Axiom's native pipeline per MA13 §6; front3 of HML01."
+license = "MIT"
+
+[dependencies]
+semantic-ir = { path = "../semantic-ir" }
+coding-adventures-axiom-parser = { path = "../axiom-parser" }
+# The reusable canonical head-name constants (`ADD`/`SUB`/`MUL`/…) so the
+# surface->canonical bridging table stays typo-proof and in lockstep with the
+# native `axiom-runtime`'s own identical table (MA13 §2/§5: the shared
+# `symbolic-vm` arithmetic engine is reused unchanged).
+symbolic-ir = { path = "../symbolic-ir" }
+# The parser emits a generic `parser::grammar_parser::GrammarASTNode` whose
+# leaf tokens are `lexer::token::Token`; we walk both directly.
+parser = { path = "../parser" }
+lexer = { path = "../lexer" }
+
+[dev-dependencies]
+# tests/test_validator.rs (confirms the JS backend structurally accepts every
+# module this frontend produces) and tests/e2e_node.rs (actually runs the
+# compiled JS through `node`). This crate deliberately does NOT depend on
+# `coding-adventures-axiom-runtime` -- lowering only needs the parse-tree
+# shape (`coding-adventures-axiom-parser`), never the evaluator, mirroring
+# every sibling `-to-semantic-ir` frontend's identical choice. Oracle/golden
+# testing against `axiom-runtime` (HML01 §7) is explicitly deferred to a
+# separate follow-on task (see README.md/CHANGELOG.md), so no dev-dependency
+# on that crate is added here either.
+semantic-ir-to-javascript = { path = "../semantic-ir-to-javascript" }

--- a/code/packages/rust/axiom-to-semantic-ir/README.md
+++ b/code/packages/rust/axiom-to-semantic-ir/README.md
@@ -1,0 +1,199 @@
+# axiom-to-semantic-ir
+
+Axiom CST → narrow-waist Semantic IR. The **sixth** frontend to target
+[SIR23](../../../specs/SIR23-symbolic-pattern-semantic-ir.md), the
+symbolic-expression/pattern-matching domain extension of the SIR10
+narrow-waist IR (Stream B of
+[HML01](../../../specs/HML01-math-to-semantic-ir.md)) — sibling to
+`wolfram-to-semantic-ir`, `macsyma-to-semantic-ir`, `derive-to-semantic-ir`,
+`reduce-to-semantic-ir`, and `maple-to-semantic-ir`.
+
+This is **MA-13e**, the last item in Axiom's own native pipeline per
+[MA13](../../../specs/MA13-axiom-language.md) §6:
+
+```
+spec (MA-13a) → axiom.tokens + axiom-lexer (MA-13b)
+              → axiom.grammar + axiom-parser (MA-13c)
+              → axiom-runtime + axiom-repl (MA-13d)
+              → axiom-to-semantic-ir (MA-13e, THIS crate)
+              → oracle/golden testing (native axiom-runtime vs. SIR→JS→node)
+                — a SEPARATE follow-on task, not part of this crate
+```
+
+## Where this fits
+
+```
+Axiom source
+   │
+   ▼  coding_adventures_axiom_parser::try_parse_axiom(src)
+parser::grammar_parser::GrammarASTNode   (generic CST, rooted at `program`
+                                           -- exactly ONE expression, see below)
+   │
+   ▼  axiom_to_semantic_ir::compile
+semantic_ir::Module                      (per SIR10 + SIR23)
+```
+
+## Usage
+
+```rust
+use coding_adventures_axiom_to_semantic_ir::compile_source;
+
+let module = compile_source("1 + 2", "demo")?;
+```
+
+`compile_source` parses and lowers directly, with no worker-thread stack
+enlargement — `axiom-parser`'s own `MAX_RULE_DEPTH` (140) is already
+documented safe on a bare default (~2 MiB) stack with comfortable margin
+(measured at ~33.6% below its own binding-constraint floor of 211 rule
+frames, for nested function calls). `compile` (taking an already-parsed
+`GrammarASTNode`) is pure lowering, exactly like every sibling frontend's
+`compile`.
+
+## `program` is a SINGLE expression, not a repeated worksheet
+
+Unlike every prior SIR23 frontend (`derive.grammar`/`reduce.grammar`/
+`maple.grammar` each parse a whole multi-statement file in one call),
+`axiom.grammar`'s own `program = expr` parses **exactly one** expression per
+call. Axiom is modeled in this repo as a numbered, per-line interactive
+session (`axiom-repl` tracks its own step counter, MA13 §5), not a batch
+worksheet file — this crate's `compile`/`compile_source` mirror that shape,
+lowering one top-level statement into `main`'s body.
+
+## Design: retargeting `axiom-runtime`
+
+`axiom-runtime` already walks this exact CST — but it is a single-phase
+**tree-walking interpreter**, not a two-phase "lower once, evaluate once"
+runtime like Derive/Reduce/Maple's own, because `::`/`:`/`has` have no
+`IRNode` representation at all in its own reduced value model. This crate is
+nonetheless a direct structural retarget of `axiom-runtime::eval::eval_expr`'s
+own rule-name dispatch, building `semantic_ir::Expr` data instead of
+evaluating. See `src/lower.rs`'s module doc comment for the full reasoning
+and the node-by-node mapping.
+
+## The central design decision: how `:` / `::` / `has` lower to SIR23
+
+MA13 §2's own finding is that `symbolic_ir::IRNode` has no domain/category
+concept at all — and this crate's own research confirms
+`semantic_ir::Expr`/`SirType`/`Feature` (SIR23's actual addition) has none
+either. **Decision: `:`, `::`, and `has` lower as ordinary `Expr::SymApply`
+nodes with three new, locally-defined reserved head-name constants** —
+`__axiom_declare`, `__axiom_coerce`, `__axiom_has` — never added to shared
+`semantic-ir`/`symbolic-ir`. This is the same "new construct, no shared-crate
+change, a local `pub const` head name" pattern this repo's SIR23 family
+already established twice: `reduce-to-semantic-ir`'s `CompoundExpression`/
+`Cons`/`First`/… and `maple-to-semantic-ir`'s `Set`.
+
+- `a : T` / `(a, b, c) : T` → `Apply(__axiom_declare, [List(names...), T])`
+- `e :: T` → `Apply(__axiom_coerce, [e, T])`
+- `D has C` → `Apply(__axiom_has, [D, C])`
+
+A `type_expr` position (`Polynomial(Integer)`, `Fraction Integer`) is
+structurally just "a NAME, optionally applied to further arguments" — the
+same shape an ordinary function call already has — so it lowers to the exact
+same `SymSymbol`/`SymApply` shapes, via a dedicated `lower_type_expr`
+function rather than a new node kind.
+
+**Runtime-shim status: deferred to the follow-on oracle-testing task, not
+shipped in this PR.** This crate never evaluates anything (the "everything is
+data" design every SIR23 frontend shares), so it does not need a working
+evaluator to emit correct SIR. Verified directly (not assumed from a
+suggestion to extend `sir-runtime-symbolic`): the JS backend's real SIR23
+evaluator (`Symbolic.evalTerm`, `HELD_HEADS`, …) lives **inline** inside
+`semantic-ir-to-javascript/src/runtime.rs`'s own emitted runtime blob, not in
+the published `@coding-adventures/sir-runtime-symbolic` npm package — that
+package (confirmed by reading its own `CHANGELOG.md`) only re-exports the
+structural pattern matcher and leaf-term constructors, with no evaluator at
+all, and only backs the TypeScript backend, which no Stream B oracle test
+exercises yet. So extending it would not, on its own, make `:`/`::`/`has`
+evaluate through the path this repo's `node`-execution oracle tests actually
+use. Given oracle/golden testing for Axiom is this task's own named separate
+follow-on item, and every prior "new reserved head, no evaluator yet"
+precedent in this exact family (`Set`, `CompoundExpression`, `Cons`, `First`,
+`Second`, `Third`, `Rest`, `Part`, `Append`, `Reverse`) shipped its frontend
+first and left the evaluator as later work, this crate follows the identical
+sequence. See `src/lower.rs`'s module doc comment for the full disclosure.
+
+## A disclosed widening relative to `axiom-runtime`'s own function bodies
+
+`axiom-runtime::eval::lower_pure_body` rejects `:=`/`:`/`::`/`has`/a
+`;`-sequenced block inside a held function body, because none of those
+constructs have any representation in that crate's own reduced `IRNode`
+value model. This crate imposes **no equivalent restriction** — since
+everything is data here, all of those constructs already have an ordinary
+`SymApply` representation, so a function body containing any of them lowers
+exactly like a top-level statement would. This is a real, disclosed widening
+relative to `axiom-runtime`'s own current scope, not a bug: the native
+runtime's restriction is an artifact of its own two-phase-incompatible
+evaluation design, not a limitation of Axiom-the-language or of this SIR
+target.
+
+## Declared function definitions: type annotations are dropped, not validated
+
+`declared_define`'s typed parameter list and return-type annotation are
+dropped entirely at lowering time — only each parameter's bare NAME is kept,
+producing the same 3-argument `Define(name, List(params...), body)` shape
+Derive's/Reduce's/Maple's own definitions already use. `axiom-runtime`
+resolves each annotation against the fixed domain table at
+definition-evaluation time (but never enforces it against call arguments —
+MA13 §4's own "duck-typed" note) — reproducing that check here would mean
+either duplicating the fixed domain table a second time in a purely
+syntactic frontend, or changing `Define`'s established shape. This crate
+takes the narrower path and drops the annotations, matching every sibling
+frontend's `Define`.
+
+### No logical operators, no `elif`
+
+`axiom.grammar` has no `and`/`or`/`not` production and no `elif` repetition
+at all (MA13 §4's own table lists neither) — a genuinely smaller grammar than
+Maple's/Macsyma's, needing no `check_elif_chain_length`-equivalent guard.
+
+### `postfix` is NOT chainable
+
+`axiom.grammar`'s `postfix = atom [ call_args ]` allows at most ONE call
+suffix — `f(x)(y)` is not valid Axiom syntax in this subset — so, mirroring
+`maple-to-semantic-ir`'s identical finding, there is no
+`check_postfix_chain_length`-equivalent guard anywhere in this crate.
+
+### Recursion-depth hardening
+
+Carried over proactively from every prior SIR23 frontend's established
+security-review history, even though `axiom-parser`/`axiom-runtime` apply
+none of these guards themselves:
+
+- `MAX_EXPR_DEPTH` (256) bounds this crate's own lowering recursion,
+  independent of `axiom-parser`'s own grammar-nesting guard (140).
+- `check_chain_length` caps every flat, same-precedence operator-chain fold
+  (`additive`/`multiplicative`) before any tree is built.
+- `check_apply_arg_count` caps every flat-`Vec` production's element count
+  (call arguments, list literals, typed-parameter lists, tuple-declaration
+  name lists, type-constructor argument lists, and a `;`-block's statement
+  count) — an allocation-size backstop, not a stack guard, since a
+  `;`-block lowers to one FLAT n-ary `CompoundExpression`, never a folded
+  tree.
+- `measure_depth_iterative`/`drop_iterative` — the authoritative,
+  construction-composition-independent iterative depth check and iterative
+  teardown, run once per top-level statement.
+
+### Testing
+
+- `tests/test_lower.rs` — unit tests asserting exact `Expr` shapes for every
+  grammar production (literals including the first SIR23-family `STRING`
+  literal, calls in both call forms, lists, arithmetic/comparison operators,
+  `:=` assignment, declared/undeclared `==` definitions with type-annotation
+  dropping, `if`/`then`/`else` with mandatory `else` and dangling-else
+  resolution, the grouping-vs-block `;`-count distinction, `:`/`::`/`has`
+  including the paren-optional type shorthand and precedence relative to
+  `additive`/`comparison`, deeply nested type constructors), error-path
+  regressions, and DoS-guard regression tests.
+- `tests/test_validator.rs` — every lowered module passes `semantic_ir::
+  validate` and is **accepted** by `semantic-ir-to-javascript`'s capability
+  check, including the three new reserved-head constructs with no shared-VM
+  evaluation handler.
+- `tests/e2e_node.rs` — compiles and runs representative Axiom programs
+  (arithmetic, declared/undeclared function definition + call, assignment,
+  lists, `if`/`then`/`else`, a multi-statement block, and `:`/`::`/`has` as
+  inert data construction) through `node`, proving the SIR23 codegen path is
+  genuinely executable end-to-end.
+- No `tests/oracle.rs` in this PR — oracle/golden testing against
+  `axiom-runtime` is an explicitly separate follow-on task (see
+  `CHANGELOG.md`).

--- a/code/packages/rust/axiom-to-semantic-ir/required_capabilities.json
+++ b/code/packages/rust/axiom-to-semantic-ir/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/axiom-to-semantic-ir",
+  "capabilities": [],
+  "justification": "Pure compiler pass: walks an in-memory GrammarASTNode CST and builds an in-memory semantic_ir::Module. No filesystem, network, process, DOM, or environment access -- like every sibling `-to-semantic-ir` frontend (maple-to-semantic-ir, reduce-to-semantic-ir, derive-to-semantic-ir, idl-to-semantic-ir, ...), this crate does not even spawn a worker thread (axiom-parser's own MAX_RULE_DEPTH is already safe on a bare default stack)."
+}

--- a/code/packages/rust/axiom-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/axiom-to-semantic-ir/src/lib.rs
@@ -1,0 +1,89 @@
+//! # axiom-to-semantic-ir
+//!
+//! Axiom CST → narrow-waist Semantic IR, **v0.1.0** (MA-13e).
+//!
+//! This is the **sixth** frontend to target
+//! [SIR23](../../../specs/SIR23-symbolic-pattern-semantic-ir.md), the
+//! symbolic-expression/pattern-matching domain extension of the SIR10
+//! narrow-waist IR (Stream B of
+//! [`HML01`](../../../specs/HML01-math-to-semantic-ir.md)) — sibling to
+//! `wolfram-to-semantic-ir`, `macsyma-to-semantic-ir`, `derive-to-semantic-ir`,
+//! `reduce-to-semantic-ir`, and `maple-to-semantic-ir`. It consumes the
+//! generic `GrammarASTNode` CST produced by
+//! `coding-adventures-axiom-parser` and emits a [`semantic_ir::Module`]. See
+//! `lower.rs`'s module doc comment for the full scope, the central design
+//! decision for `:`/`::`/`has` (this crate's own genuinely new territory
+//! relative to every prior SIR23 frontend), and every other node-by-node
+//! mapping.
+//!
+//! This is the **last** item in Axiom's native (non-oracle-tested) pipeline
+//! per [`MA13`](../../../specs/MA13-axiom-language.md) §6 — the four prior
+//! merged PRs shipped `axiom-lexer` (MA-13b), `axiom-parser` (MA-13c), and
+//! `axiom-runtime`/`axiom-repl` (MA-13d). Oracle/golden testing (native
+//! `axiom-runtime` vs. this crate → `semantic-ir-to-javascript` → `node`) is
+//! an explicitly separate follow-on task, not part of this crate.
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! Axiom source
+//!    │
+//!    ▼  coding_adventures_axiom_parser::try_parse_axiom(src)
+//! parser::grammar_parser::GrammarASTNode   (generic CST, rooted at `program`
+//!                                            -- exactly ONE expression, see
+//!                                            lower.rs's module doc comment)
+//!    │
+//!    ▼  axiom_to_semantic_ir::compile
+//! semantic_ir::Module                      (per SIR10 + SIR23)
+//! ```
+//!
+//! ## Public API
+//!
+//! ```
+//! use coding_adventures_axiom_to_semantic_ir::compile_source;
+//! let module = compile_source("1 + 2", "demo").unwrap();
+//! assert!(module.functions.iter().any(|f| f.name == "main"));
+//! ```
+
+mod lower;
+pub use lower::{compile, AxiomLowerError, AXIOM_COERCE, AXIOM_DECLARE, AXIOM_HAS, COMPOUND_EXPRESSION};
+
+/// Parse `source` as Axiom and lower it into a [`semantic_ir::Module`] in one
+/// step, mirroring every other `-to-semantic-ir` frontend's `compile_source`
+/// convenience wrapper.
+///
+/// `source` is expected to be exactly ONE Axiom expression/statement (see
+/// `lower.rs`'s module doc comment for why `axiom.grammar`'s own `program`
+/// rule is scoped this way) — matching a single line submitted to
+/// `axiom-repl`'s own numbered prompt, not a multi-line worksheet file the
+/// way `maple-to-semantic-ir::compile_source`/`reduce-to-semantic-ir::
+/// compile_source` accept.
+///
+/// Like `maple-to-semantic-ir::compile_source`/`derive-to-semantic-ir::
+/// compile_source`/`reduce-to-semantic-ir::compile_source` (and unlike
+/// `wolfram-to-semantic-ir::compile_source`, which spawns an enlarged-stack
+/// worker thread because Wolfram's own precedence cascade makes its parser's
+/// `MAX_RULE_DEPTH` unsafe on a bare stack), this function needs no worker
+/// thread at all: `coding_adventures_axiom_parser`'s own `MAX_RULE_DEPTH`
+/// (140) is already documented — see that crate's `src/lib.rs` doc comment —
+/// as safe on a bare default (~2 MiB) stack with comfortable margin (its own
+/// doc comment measures four independent recursion shapes in *rule-frame*
+/// terms and finds the binding constraint is nested function calls' floor of
+/// 211 rule frames — 140 sits about 33.6% below that floor). Its own test
+/// suite directly confirms input thousands of levels past the cap still
+/// fails cleanly with a `Result::Err` on a bare default-stack thread, never a
+/// crash. So this crate mirrors `maple-to-semantic-ir`'s (and
+/// `derive-to-semantic-ir`'s / `reduce-to-semantic-ir`'s) simple,
+/// worker-thread-free `compile_source` shape rather than
+/// `wolfram-to-semantic-ir`'s.
+pub fn compile_source(
+    source: &str,
+    module_name: &str,
+) -> Result<semantic_ir::Module, AxiomLowerError> {
+    let tree = coding_adventures_axiom_parser::try_parse_axiom(source).map_err(|msg| AxiomLowerError {
+        message: format!("parse error: {msg}"),
+        line: 1,
+        column: 1,
+    })?;
+    compile(&tree, module_name)
+}

--- a/code/packages/rust/axiom-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/axiom-to-semantic-ir/src/lower.rs
@@ -1,0 +1,1332 @@
+//! The lowering pass from `coding_adventures_axiom_parser`'s generic
+//! [`GrammarASTNode`] CST → [`semantic_ir::Module`], **v0.1.0** (MA-13e).
+//!
+//! This is the **sixth** frontend to target
+//! [SIR23](../../../specs/SIR23-symbolic-pattern-semantic-ir.md), the
+//! symbolic-expression/pattern-matching domain extension of the SIR10
+//! narrow-waist IR (Stream B of
+//! [`HML01`](../../../specs/HML01-math-to-semantic-ir.md)) — sibling to
+//! `wolfram-to-semantic-ir`, `macsyma-to-semantic-ir`, `derive-to-semantic-ir`,
+//! `reduce-to-semantic-ir`, and `maple-to-semantic-ir` (the closest structural
+//! templates: Axiom's arithmetic/comparison/assignment/definition/if/block
+//! core is exactly the same "surface operators + `head(args)` calls, no
+//! pattern/rewrite-rule vocabulary" shape those three already lower, per
+//! [`MA13`](../../../specs/MA13-axiom-language.md) §5). This crate's own
+//! genuinely new territory — not shared with any prior SIR23 frontend — is
+//! Axiom's declaration (`:`), coercion (`::`), and category-membership query
+//! (`has`), fixed by MA13 §3/§4 and resolved by this crate's own central
+//! design decision (below).
+//!
+//! # Retargeting `axiom-runtime`, not starting from scratch
+//!
+//! `axiom-runtime` already walks this exact CST (see that crate's
+//! `src/eval.rs`) — but, unlike Derive/Reduce/Maple's own two-phase
+//! "lower once, evaluate once" runtimes, it is a single-phase **tree-walking
+//! interpreter** (its own module doc comment explains why: `::`/`:`/`has`
+//! have no `IRNode` representation at all, so a clean lower-then-evaluate
+//! split does not exist natively). This crate is nonetheless a **direct
+//! structural retarget** of that same rule-name dispatch — `eval_expr`'s own
+//! `match node.rule_name.as_str() { "if_expr" => ..., "declared_define" =>
+//! ..., ... }` is this module's [`Lowerer::lower_node`], node-for-node, just
+//! building [`semantic_ir::Expr`] data instead of evaluating. Every
+//! arithmetic/comparison operator lowers to the exact same canonical head
+//! name `axiom-runtime`'s own `additive_head`/`multiplicative_head`/
+//! `comparison_head` tables already use (`ADD`/`SUB`/`MUL`/`DIV`/`POW`/`NEG`/
+//! `EQUAL`/`NOT_EQUAL`/`LESS`/`GREATER`/`LESS_EQUAL`/`GREATER_EQUAL`) — the
+//! same heads Derive/Reduce/Maple already lower to, so the shared JS backend's
+//! `evalTerm` dispatch (SIR23's addendum, already shipped) folds Axiom's
+//! ordinary arithmetic exactly the way it folds every sibling language's.
+//!
+//! # `program` is a SINGLE expression, not a repeated multi-statement worksheet
+//!
+//! Unlike every prior SIR23 frontend (`derive.grammar`/`reduce.grammar`/
+//! `maple.grammar` each parse `program = { statement_line }`, a whole
+//! worksheet file in one call), `axiom.grammar`'s own `program = expr` parses
+//! **exactly one** expression per call — see that grammar file's own "WHY
+//! `program` IS A SINGLE EXPRESSION" header comment: Axiom is modeled here as
+//! a numbered, per-line interactive session (`axiom-repl` tracks its own step
+//! counter, MA13 §5), not a batch file, and `axiom.tokens` gives top-level
+//! inputs no separator at all. This crate's [`compile`]/[`compile_source`]
+//! therefore lower exactly one top-level statement into `main`'s body — a
+//! real, disclosed structural difference from `maple-to-semantic-ir`/
+//! `reduce-to-semantic-ir`'s own multi-statement `lower_file` loops, not an
+//! oversight. A caller wanting a multi-line Axiom *session* compiled as one
+//! SIR module would call this crate once per line and concatenate the
+//! resulting `main` bodies — a REPL-層 concern this crate does not need to
+//! solve, exactly as `axiom.grammar` itself leaves it to `axiom-repl`.
+//!
+//! # No logical operators, no `elif` — a genuinely smaller grammar than Maple's
+//!
+//! `axiom.grammar` has no `logical_or`/`logical_and`/`logical_not` production
+//! at all (MA13 §4's own table lists no `and`/`or`/`not` surface), and its
+//! `if_expr = "if" expr "then" expr "else" expr` is a plain ternary — no
+//! `elif`/`elseif` repetition (`else` is even **mandatory** in this cut, MA13
+//! §4's own disclosed narrowing) — so, unlike `maple-to-semantic-ir`/
+//! `macsyma-to-semantic-ir`, this crate needs no `check_elif_chain_length`-
+//! style guard at all: the risk it would guard against is structurally
+//! absent from this grammar, not merely bounded by a cap.
+//!
+//! # The central design decision: how `:` / `::` / `has` lower to SIR23
+//!
+//! MA13 §2's own finding is that `symbolic_ir::IRNode` — and, verified
+//! directly against [SIR23](../../../specs/SIR23-symbolic-pattern-semantic-ir.md)
+//! by this crate's own research, `semantic_ir::Expr`/`SirType`/`Feature` too —
+//! has **no concept of a domain, a category, or a per-value type tag
+//! anywhere**. SIR23 adds `SymExpr`/`Rational`/`Complex` types and
+//! `SymApply`/`SymPatternBlank`/`SymPatternNamed`/`SymRule`/`SymReplaceAll`
+//! node kinds — nothing resembling a coercion or a category-membership query.
+//! So the question MA13 §5 explicitly left open for this item ("depends on
+//! what the shared IR already has by the time the frontend starts") resolves
+//! the same way MA13 §2 itself resolved the identical question for
+//! `axiom-runtime`: **no core-IR change is needed or justified** for three
+//! constructs used by exactly one language in this repo.
+//!
+//! **Decision: lower `:`, `::`, and `has` as ordinary [`Expr::SymApply`]
+//! nodes with three new, locally-defined (NOT added to shared `semantic-ir`
+//! or `symbolic-ir`) reserved head-name constants** — [`AXIOM_DECLARE`],
+//! [`AXIOM_COERCE`], [`AXIOM_HAS`] — exactly the same "new construct, no
+//! shared-crate change, a local `pub const` head name" pattern this repo's
+//! own SIR23 family already established twice: `reduce-to-semantic-ir`'s
+//! [`COMPOUND_EXPRESSION`]/`Cons`/`First`/… (for Reduce-specific list/block
+//! surface `symbolic-vm` has no handler for) and `maple-to-semantic-ir`'s
+//! `Set` (for Maple's second bracketed-aggregate literal). This crate's own
+//! `;`-sequenced block (below) reuses [`COMPOUND_EXPRESSION`] — spelled
+//! identically to Reduce's own constant — for the exact same reason Reduce
+//! needed it: MA13 §4's parenthesised, semicolon-separated block, "value is
+//! the last expression's value," is structurally identical to Reduce's
+//! `<< s1; s2; ... >>`.
+//!
+//! Concretely:
+//!
+//! - **`a : T` / `(a, b, c) : T`** (declaration) lowers to
+//!   `Apply(__axiom_declare, [List(SymSymbol(name)...), type_expr])` — the
+//!   declared name(s) always wrapped in a `List` (even a single name), so a
+//!   future runtime evaluator can iterate uniformly regardless of whether the
+//!   plain-`NAME` or tuple `decl_target` form was used.
+//! - **`e :: T`** (coercion) lowers to `Apply(__axiom_coerce, [e, type_expr])`
+//!   — `e` is an ordinary, arbitrary expression (MA13 §3 confirms
+//!   `(a + b) :: Float` is legal), so it lowers exactly like any other
+//!   `additive` operand; the type-expression argument is never evaluated as
+//!   an ordinary variable reference (see "Type positions" below).
+//! - **`D has C`** (category query) lowers to
+//!   `Apply(__axiom_has, [domain_type_expr, category_type_expr])`.
+//!
+//! **Why this is the correct, narrowest fix — not merely the cheapest one.**
+//! Per this repo's own established discipline (see `HML01` §4's "new runtime
+//! behavior ships as new npm packages, gated on the module's manifest," and
+//! the SIR23 spec's own addendum, which repeatedly chooses "port the
+//! reference architecture with a small, disclosed extension" over "invent a
+//! new mechanism"), extending a shared, `Backend`-agnostic enum
+//! (`semantic_ir::Expr`/`SirType`/`Feature`) for a construct exactly one
+//! language in this repo currently uses would be the disproportionate
+//! response — every existing frontend and every existing backend `match`
+//! would need a new, permanently-unreachable arm. An ordinary `SymApply` with
+//! a reserved head name costs nothing extra anywhere else in the pipeline: it
+//! is exactly as valid, structurally-checkable SIR23 data as any other
+//! `SymApply`, `semantic_ir::validate` accepts it with no special-casing (it
+//! only inspects `Expr` variant shape, never head-name spelling), and
+//! `semantic-ir-to-javascript`'s SIR23 codegen already handles **any**
+//! `SymApply`/`SymSymbol` shape uniformly regardless of head spelling
+//! (confirmed directly, the same fact `maple-to-semantic-ir`'s own `Set` and
+//! `reduce-to-semantic-ir`'s own `CompoundExpression`/`Cons`/… already lean
+//! on). No `Feature` flag beyond the pre-existing `Feature::SymbolicExpr` (and
+//! `Feature::Floats`/`Feature::Strings` for literals) is ever observed for
+//! these three constructs — they need no new capability declaration, only a
+//! head name a runtime *may* one day choose to interpret specially.
+//!
+//! **Runtime-shim status: implementation deferred to the follow-on
+//! oracle-testing item, not shipped in this PR.** This crate "never
+//! evaluates anything" (the same "everything is data" design every SIR23
+//! frontend shares) — so it does not *need* a working evaluator for
+//! `__axiom_declare`/`__axiom_coerce`/`__axiom_has` to emit correct,
+//! well-formed SIR. Verified directly against the actual shipped
+//! architecture (not assumed from the task's own suggestion of extending
+//! `sir-runtime-symbolic`): the JS backend's real SIR23 evaluator
+//! (`Symbolic.evalTerm`, `HELD_HEADS`, the whole held-form/arithmetic
+//! dispatch the SIR23 spec's addendum describes) lives **inline**, inside
+//! `semantic-ir-to-javascript/src/runtime.rs`'s own emitted `RUNTIME` string
+//! blob — confirmed by reading that file directly (`grep -n HELD_HEADS
+//! semantic-ir-to-javascript/src/runtime.rs` finds `const HELD_HEADS = new
+//! Set(["Assign", "Define", "If"])` inside the emitted JS, not inside any
+//! imported package). The published npm package
+//! `@coding-adventures/sir-runtime-symbolic` (`code/packages/typescript/
+//! sir-runtime-symbolic/`), confirmed directly by reading its own
+//! `CHANGELOG.md`, re-exports only `cas-pattern-matching`'s structural
+//! matcher and `symbolic-ir`'s leaf-term constructors — **it has no evaluator
+//! at all**, and is not what `semantic-ir-to-javascript` actually imports for
+//! JS-backend execution; it only backs the TypeScript backend, which no
+//! Stream B frontend's oracle testing exercises yet (SIR23 spec's own
+//! "Scope boundary" section says so explicitly). So extending it would not,
+//! by itself, make `:`/`::`/`has` evaluate through the path this repo's own
+//! `node`-execution oracle tests actually use.
+//!
+//! Given that (a) oracle/golden testing for Axiom is this task's own
+//! explicitly-named separate follow-on item, not part of this PR, and (b)
+//! every prior "new reserved head with no runtime evaluator yet" precedent in
+//! this exact family (`Set`, `CompoundExpression`, `Cons`, `First`, `Second`,
+//! `Third`, `Rest`, `Part`, `Append`, `Reverse` — confirmed, none of these
+//! have an evaluation handler in `symbolic-vm` OR `semantic-ir-to-javascript`
+//! today) shipped its *frontend* first and left the evaluator as later,
+//! separate work, this crate follows the identical, already-proven sequence:
+//! ship the lowering now (this PR), and leave "teach a JS/TS runtime the
+//! fixed `AxiomDomain`/`AxiomCategory` table `axiom-runtime::domains` already
+//! has" as the natural first step of the follow-on oracle-testing task, where
+//! it will actually be exercised end-to-end for the first time. This is the
+//! conservative, narrower call this task's own instructions ask for when
+//! genuine ambiguity is hit, not a shortcut — see `CHANGELOG.md`/`README.md`
+//! for the same disclosure.
+//!
+//! # Type positions (`type_expr`) are ordinary symbolic data too — no new
+//! representation needed
+//!
+//! `axiom.grammar`'s own `type_expr` rule comment observes that a type
+//! position (`Polynomial(Integer)`, `Fraction Integer`, `List(Float)`) is
+//! structurally just "a NAME, optionally applied to further arguments" — the
+//! exact same shape an ordinary function call already has. [`Lowerer::
+//! lower_type_expr`] exploits this directly: a bare `type_expr` with no
+//! `type_ctor_args` lowers to a plain [`Expr::SymSymbol`] (`Integer` →
+//! `SymSymbol("Integer")`); a parameterized one lowers to an ordinary
+//! [`Expr::SymApply`] (`Fraction(Integer)` →
+//! `SymApply(SymSymbol("Fraction"), [SymSymbol("Integer")])`) — **the exact
+//! same node shapes an ordinary call already produces**, just constructed by
+//! a dedicated function so a `type_expr` position is never confused with an
+//! ordinary value-producing `postfix` call at the Rust level (mirroring
+//! `axiom-runtime::builtins::parse_type_spec`'s own identical "separate
+//! function, same underlying shape" design, and `idl.grammar`'s established
+//! "give a semantically distinct position its own rule name even where the
+//! shape overlaps" discipline). The paren-optional shorthand
+//! (`Fraction Integer`) is restricted to a single bare `NAME` argument,
+//! never a further-nested `type_expr` — mirroring `axiom.grammar`'s own
+//! `type_ctor_args`'s documented restriction (and `axiom-runtime::builtins::
+//! parse_type_ctor_args`'s identical reading) exactly, so this crate invents
+//! no syntax the grammar does not already accept.
+//!
+//! Because `__axiom_declare`/`__axiom_coerce`/`__axiom_has`'s type-expression
+//! arguments are never meant to be evaluated as ordinary variable references
+//! (a domain name like `Integer` is not a bound variable — mirroring how
+//! `axiom-runtime::eval_coercion`/`eval_has_query`/`eval_declaration` never
+//! evaluate a `type_expr` node as an ordinary expression either, they walk it
+//! structurally via `parse_type_spec`), a future runtime evaluator for these
+//! three heads would need to treat them as **held** arguments (not
+//! evaluated before dispatch) exactly the way `Assign`'s left-hand-side name
+//! is held today — a design note for the deferred follow-on item, not
+//! something this frontend itself needs to encode (this frontend never
+//! evaluates anything, so "held" vs. "evaluated" is moot at lowering time;
+//! the data shape is identical either way).
+//!
+//! # A disclosed widening relative to `axiom-runtime`'s own function bodies
+//!
+//! `axiom-runtime::eval`'s own `lower_pure_body` rejects `:=`/`:`/`::`/`has`/
+//! a `;`-sequenced block inside a held function body, because none of those
+//! constructs have **any** representation in that crate's own reduced
+//! `IRNode` value model (its own module doc comment explains this at length —
+//! it is a consequence of that crate being a single-phase, eagerly-evaluating
+//! interpreter needing a *representable* body to substitute-and-re-evaluate
+//! at call time). This crate imposes **no equivalent restriction**: because
+//! "everything is data" here (this is the same design every SIR23 frontend
+//! shares — see `wolfram-to-semantic-ir::lower`'s own module doc comment for
+//! why this is necessary, not just convenient, for an uncomputed function
+//! body), `:=`/`:`/`::`/`has`/a block ALL already have an ordinary `SymApply`
+//! representation (per the design decision above), so a function body
+//! containing any of them lowers exactly the same way a top-level statement
+//! would — [`Lowerer::lower_declared_define`]/[`Lowerer::
+//! lower_undeclared_define`] call the SAME [`Lowerer::lower_node`] on a
+//! body that a top-level statement would use, no restricted variant. This is
+//! a real, disclosed WIDENING relative to `axiom-runtime`'s own current
+//! scope, not a bug: the native runtime's restriction is an artifact of ITS
+//! OWN two-phase-incompatible evaluation design (explained in its own module
+//! doc comment), not a limitation of Axiom-the-language or of this SIR
+//! target.
+//!
+//! # Declared function definitions: type annotations are dropped, not
+//! validated, at lowering time
+//!
+//! `declared_define = NAME LPAREN [ typed_param_list ] RPAREN COLON type_expr
+//! DEFINE expr` carries a typed parameter list AND a return-type annotation —
+//! but [`Lowerer::lower_declared_define`] extracts **only** each parameter's
+//! bare NAME (via [`Lowerer::lower_typed_param_list`]), dropping every
+//! `type_expr` annotation entirely (including the return type, which this
+//! function never even locates), producing the exact same 3-argument
+//! `Define(name, List(params...), body)` shape Derive's/Reduce's/Maple's own
+//! (differently-spelled) general-definition idioms already use. This is a
+//! real, disclosed narrowing: `axiom-runtime::eval_declared_define` DOES
+//! resolve each annotation against the fixed domain table at
+//! definition-evaluation time (rejecting an invalid type name, e.g.
+//! `f(x: Matrix): Integer == x`, with a `DomainError`) — but never enforces
+//! it against call arguments (MA13 §4: "duck-typed... evaluated rather than
+//! 'recompiled'"). Reproducing that definition-time-only check here would
+//! mean either (a) duplicating `axiom-runtime::domains`'s fixed table a
+//! second time in this frontend for a validation this crate's own design
+//! otherwise never performs (every sibling SIR23 frontend is a **pure**
+//! syntactic retarget — none of them validate semantic well-formedness at
+//! lowering time), or (b) routing the annotations through the same
+//! `__axiom_declare`-shaped machinery and inserting them as held statements
+//! ahead of the body, which would change `Define`'s own established 3-arg
+//! shape every sibling frontend relies on. Both are real scope expansions
+//! beyond "lower the syntax that's there"; this crate takes the narrower,
+//! more consistent path and drops the annotations, exactly mirroring how
+//! every sibling `Define` never carried argument types to begin with.
+
+use lexer::token::Token;
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span, Stmt,
+};
+use symbolic_ir::{
+    ADD, ASSIGN, DEFINE, DIV, EQUAL, GREATER, GREATER_EQUAL, IF, LESS, LESS_EQUAL, LIST, MUL, NEG,
+    NOT_EQUAL, POW, SUB,
+};
+
+/// `a : T` / `(a, b, c) : T` — declaration (MA13 §3/§4). See the module doc
+/// comment's central design-decision section for the full reasoning. Not
+/// exported by `symbolic-ir`/`semantic-ir` — defined locally, since this is
+/// not a `Backend`-agnostic canonical head any other language in this repo
+/// currently needs.
+pub const AXIOM_DECLARE: &str = "__axiom_declare";
+
+/// `e :: T` — coercion (MA13 §3/§4).
+pub const AXIOM_COERCE: &str = "__axiom_coerce";
+
+/// `D has C` — category-membership query (MA13 §3/§4).
+pub const AXIOM_HAS: &str = "__axiom_has";
+
+/// The canonical head for a parenthesised, `;`-separated block (MA13 §4:
+/// "value is the last expression's value") — spelled identically to
+/// `reduce-to-semantic-ir`'s/`reduce-runtime`'s own `COMPOUND_EXPRESSION`
+/// constant (`reduce-runtime`'s `<< s1; s2; ... >>`), since Axiom's block is
+/// structurally the identical construct under different surface syntax.
+/// Reusing the SAME spelling (rather than inventing a new one) means a
+/// future shared runtime evaluator only needs one `CompoundExpression`
+/// handler to cover both languages, not two differently-named ones.
+pub const COMPOUND_EXPRESSION: &str = "CompoundExpression";
+
+/// Maximum expression-nesting depth for *this crate's own* lowering
+/// recursion — distinct from (and independent of) `axiom-parser`'s own
+/// `MAX_RULE_DEPTH` (140) grammar-nesting guard, which bounds the CST this
+/// crate walks. Kept at 256 for consistency with every sibling SIR23
+/// frontend's identically-named, identically-valued guard.
+const MAX_EXPR_DEPTH: usize = 256;
+
+/// Synthetic file name used for all spans (the CST does not carry the
+/// original path).
+const FILE: &str = "<axiom>";
+
+// ---------------------------------------------------------------------------
+// Public error type
+// ---------------------------------------------------------------------------
+
+/// An error encountered during Axiom → SIR lowering.
+///
+/// Mirrors `MapleLowerError`/`ReduceLowerError`/`DeriveLowerError`'s shape
+/// exactly (`message` + 1-based `line`/`column`) so tooling can treat every
+/// SIR frontend uniformly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AxiomLowerError {
+    pub message: String,
+    pub line: usize,
+    pub column: usize,
+}
+
+impl std::fmt::Display for AxiomLowerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "AxiomLowerError at {}:{}: {}",
+            self.line, self.column, self.message
+        )
+    }
+}
+
+impl std::error::Error for AxiomLowerError {}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Lower a parsed Axiom CST (rooted at the `program` rule) into a SIR
+/// module.
+///
+/// Unlike `maple-to-semantic-ir::compile`/`reduce-to-semantic-ir::compile`
+/// (which lower a repeated `{ statement_line }` worksheet), `program` here is
+/// exactly ONE expression (see the module doc comment) — the returned
+/// module's `main` function body therefore always has exactly one
+/// `Stmt::ExprStmt`.
+///
+/// This function does **not** itself guard against native stack overflow on
+/// deeply-nested input beyond its own [`MAX_EXPR_DEPTH`] cap — it trusts
+/// `tree` was already parsed under a suitable guard (`axiom-parser`'s own
+/// `MAX_RULE_DEPTH`). See `src/lib.rs`'s `compile_source` doc comment for why
+/// no worker-thread stack enlargement is needed here.
+pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, AxiomLowerError> {
+    Lowerer::new(module_name).lower_program(tree)
+}
+
+// ---------------------------------------------------------------------------
+// The lowerer
+// ---------------------------------------------------------------------------
+
+/// The lowering pass's only mutable state: the module name (fixed at
+/// construction) and the set of SIR features observed while lowering (used
+/// to build the manifest so it declares *exactly* what the module emits —
+/// see `semantic-ir/src/validator.rs`'s `check_expr`, the ground truth this
+/// must match node-kind-for-node-kind).
+///
+/// Like every sibling SIR23 frontend's `Lowerer`, there is no per-function
+/// name-resolution context here at all: under the "everything is data"
+/// design (see the module doc comment), there are no host variables,
+/// parameters, or scopes to resolve. This lowerer is a near-stateless
+/// recursive descent over the CST.
+struct Lowerer {
+    module_name: String,
+    observed: FeatureManifest,
+}
+
+impl Lowerer {
+    fn new(module_name: &str) -> Self {
+        Self {
+            module_name: module_name.to_string(),
+            observed: FeatureManifest::new(),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // top level: `program = expr ;` -- a SINGLE expression, see the module
+    // doc comment's "program is a SINGLE expression" section.
+    // -------------------------------------------------------------------
+
+    fn lower_program(&mut self, program: &GrammarASTNode) -> Result<Module, AxiomLowerError> {
+        if program.rule_name != "program" {
+            return Err(self.err_at(
+                program,
+                format!("expected `program` root, got `{}`", program.rule_name),
+            ));
+        }
+
+        // `lower_node` peels `program`'s (and every intermediate transparent
+        // wrapper rule's) own single child away via `unwrap_single` before
+        // dispatching -- safe to call directly on the root, exactly mirroring
+        // `axiom-runtime::eval::eval_expr`'s own documented "safe to call on
+        // any node in the tree, not just program/expr" contract.
+        let expr = self.lower_node(program, 0)?;
+        if measure_depth_iterative(&expr).is_none() {
+            let err = self.err_at(
+                program,
+                format!("expression tree too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            );
+            drop_iterative(expr);
+            return Err(err);
+        }
+
+        let span = expr.span().clone();
+        let stmts = vec![Stmt::ExprStmt {
+            expr,
+            span: span.clone(),
+        }];
+
+        let main = Function {
+            name: "main".to_string(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts,
+                value: Expr::NilLit { span: span.clone() },
+                span: span.clone(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: span.clone(),
+        };
+
+        let metadata = Metadata::new()
+            .with_source_language("axiom")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION);
+
+        Ok(Module {
+            name: self.module_name.clone(),
+            manifest: self.observed.clone(),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![main],
+            globals: vec![],
+            metadata,
+            span,
+        })
+    }
+
+    // -------------------------------------------------------------------
+    // Dispatch -- a direct structural retarget of
+    // `axiom-runtime::eval::eval_expr`'s own rule-name `match`.
+    // -------------------------------------------------------------------
+
+    fn lower_node(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, AxiomLowerError> {
+        if depth > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("expression nesting too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            ));
+        }
+        match unwrap_single(node) {
+            Unwrapped::Token(token) => self.lower_token(token),
+            Unwrapped::Node(node) => match node.rule_name.as_str() {
+                "program" => Err(self.err_at(node, "nested program node is not an expression".to_string())),
+                "if_expr" => self.lower_if(node, depth),
+                "declared_define" => self.lower_declared_define(node, depth),
+                "undeclared_define" => self.lower_undeclared_define(node, depth),
+                "assignment" => self.lower_assignment(node, depth),
+                "declaration" => self.lower_declaration(node, depth),
+                "has_query" => self.lower_has_query(node, depth),
+                "comparison" => self.lower_comparison(node, depth),
+                "coercion" => self.lower_coercion(node, depth),
+                "additive" | "multiplicative" => self.lower_binary_chain(node, depth),
+                "unary" => self.lower_unary(node, depth),
+                "power" => self.lower_power(node, depth),
+                "postfix" => self.lower_postfix(node, depth),
+                "atom" => self.lower_atom(node, depth),
+                "list_literal" => self.lower_list_literal(node, depth),
+                "group" => self.lower_group(node, depth),
+                "call_args" => Err(self.err_at(node, "`call_args` cannot be lowered as a standalone expression".to_string())),
+                "arglist" => Err(self.err_at(node, "an arglist cannot be lowered as a scalar expression".to_string())),
+                "elem_list" => Err(self.err_at(node, "an elem_list cannot be lowered as a scalar expression".to_string())),
+                "type_expr" => Err(self.err_at(node, "a bare type expression is not a value-producing expression".to_string())),
+                other => Err(self.err_at(node, format!("no lowering for rule `{other}`"))),
+            },
+        }
+    }
+
+    /// Lower a raw token (a literal or a bare symbol). Mirrors
+    /// `axiom-runtime::eval::eval_token`'s own token-type dispatch.
+    fn lower_token(&mut self, token: &Token) -> Result<Expr, AxiomLowerError> {
+        let span = self.token_span(token);
+        match token_type(token) {
+            "NUMBER" => Ok(self.number_literal_expr(&token.value, span)),
+            "STRING" => Ok(self.str_lit(token.value.clone(), span)),
+            "NAME" => Ok(self.sym_symbol(token.value.clone(), span)),
+            other => Err(AxiomLowerError {
+                message: format!("unexpected token `{other}` = {:?}", token.value),
+                line: token.line,
+                column: token.column,
+            }),
+        }
+    }
+
+    /// `if_expr = "if" expr "then" expr "else" expr` — a plain ternary,
+    /// `else` mandatory in this cut (MA13 §4). No `elif` repetition exists in
+    /// this grammar (see the module doc comment), so there is no
+    /// right-fold and no analogous chain-length guard to write.
+    fn lower_if(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, AxiomLowerError> {
+        let exprs: Vec<&GrammarASTNode> = child_nodes(node).filter(|n| n.rule_name == "expr").collect();
+        if exprs.len() != 3 {
+            return Err(self.err_at(node, "malformed `if` node".to_string()));
+        }
+        let cond = self.lower_node(exprs[0], depth + 1)?;
+        let then_branch = self.lower_node(exprs[1], depth + 1)?;
+        let else_branch = self.lower_node(exprs[2], depth + 1)?;
+        let span = self.span_of(node);
+        Ok(self.sym_apply(
+            self.sym_symbol_bare(IF, span.clone()),
+            vec![cond, then_branch, else_branch],
+            span,
+        ))
+    }
+
+    // -------------------------------------------------------------------
+    // Function definition -- `==`, held-body (MA13 §4). See the module doc
+    // comment's own sections on the type-annotation-dropping and the
+    // function-body-widening design decisions.
+    // -------------------------------------------------------------------
+
+    /// `declared_define = NAME LPAREN [ typed_param_list ] RPAREN COLON
+    /// type_expr DEFINE expr`.
+    fn lower_declared_define(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, AxiomLowerError> {
+        let name = first_token_value(node, "NAME")
+            .ok_or_else(|| self.err_at(node, "malformed function definition: missing name".to_string()))?;
+
+        let params = match child_nodes(node).find(|n| n.rule_name == "typed_param_list") {
+            Some(list_node) => self.lower_typed_param_list(list_node)?,
+            None => vec![],
+        };
+
+        // The return-type annotation (a direct `type_expr` child) is
+        // deliberately never located or inspected -- see the module doc
+        // comment's "type annotations are dropped, not validated" section.
+        let body_node = child_nodes(node)
+            .find(|n| n.rule_name == "expr")
+            .ok_or_else(|| self.err_at(node, "malformed function definition: missing body".to_string()))?;
+        let body = self.lower_node(body_node, depth + 1)?;
+
+        let span = self.span_of(node);
+        let params_list = self.sym_apply(self.sym_symbol_bare(LIST, span.clone()), params, span.clone());
+        Ok(self.sym_apply(
+            self.sym_symbol_bare(DEFINE, span.clone()),
+            vec![self.sym_symbol_bare(name, span.clone()), params_list, body],
+            span,
+        ))
+    }
+
+    /// `typed_param_list = typed_param { COMMA typed_param } ; typed_param =
+    /// NAME COLON type_expr`. Extracts only each parameter's bare NAME,
+    /// dropping its `type_expr` annotation entirely (see the module doc
+    /// comment). A flat `Vec`, not a folded tree, so
+    /// [`Self::check_apply_arg_count`] bounds it as an allocation-size
+    /// backstop only.
+    fn lower_typed_param_list(&mut self, node: &GrammarASTNode) -> Result<Vec<Expr>, AxiomLowerError> {
+        let params: Vec<&GrammarASTNode> = child_nodes(node).filter(|n| n.rule_name == "typed_param").collect();
+        self.check_apply_arg_count(node, params.len())?;
+        let mut result = Vec::with_capacity(params.len());
+        for p in params {
+            let name = first_token_value(p, "NAME")
+                .ok_or_else(|| self.err_at(p, "malformed parameter: missing name".to_string()))?;
+            let span = self.span_of(p);
+            result.push(self.sym_symbol(name, span));
+        }
+        Ok(result)
+    }
+
+    /// `undeclared_define = NAME NAME DEFINE expr` — the paren-optional
+    /// single-parameter, duck-typed form (MA13 §4: `f x == x * x`).
+    fn lower_undeclared_define(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, AxiomLowerError> {
+        let names: Vec<String> = node
+            .children
+            .iter()
+            .filter_map(as_token)
+            .filter(|t| token_type(t) == "NAME")
+            .map(|t| t.value.clone())
+            .collect();
+        let [name, param] = names.as_slice() else {
+            return Err(self.err_at(node, "malformed undeclared function definition".to_string()));
+        };
+        let body_node = child_nodes(node)
+            .find(|n| n.rule_name == "expr")
+            .ok_or_else(|| self.err_at(node, "malformed function definition: missing body".to_string()))?;
+        let body = self.lower_node(body_node, depth + 1)?;
+
+        let span = self.span_of(node);
+        let param_expr = self.sym_symbol(param.clone(), span.clone());
+        let params_list = self.sym_apply(self.sym_symbol_bare(LIST, span.clone()), vec![param_expr], span.clone());
+        Ok(self.sym_apply(
+            self.sym_symbol_bare(DEFINE, span.clone()),
+            vec![self.sym_symbol_bare(name.clone(), span.clone()), params_list, body],
+            span,
+        ))
+    }
+
+    // -------------------------------------------------------------------
+    // x := e -- immediate assignment (MA13 §4)
+    // -------------------------------------------------------------------
+
+    fn lower_assignment(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, AxiomLowerError> {
+        let name = first_token_value(node, "NAME")
+            .ok_or_else(|| self.err_at(node, "malformed assignment: missing name".to_string()))?;
+        let rhs_node = child_nodes(node)
+            .find(|n| n.rule_name == "expr")
+            .ok_or_else(|| self.err_at(node, "malformed assignment: missing right-hand side".to_string()))?;
+        let rhs = self.lower_node(rhs_node, depth + 1)?;
+        let span = self.span_of(node);
+        Ok(self.sym_apply(
+            self.sym_symbol_bare(ASSIGN, span.clone()),
+            vec![self.sym_symbol_bare(name, span.clone()), rhs],
+            span,
+        ))
+    }
+
+    // -------------------------------------------------------------------
+    // a : T / (a, b, c) : T -- declaration (MA13 §3/§4). See the module doc
+    // comment's central design-decision section.
+    // -------------------------------------------------------------------
+
+    fn lower_declaration(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, AxiomLowerError> {
+        let decl_target = child_nodes(node)
+            .find(|n| n.rule_name == "decl_target")
+            .ok_or_else(|| self.err_at(node, "malformed declaration: missing target".to_string()))?;
+        let type_expr_node = child_nodes(node)
+            .find(|n| n.rule_name == "type_expr")
+            .ok_or_else(|| self.err_at(node, "malformed declaration: missing type".to_string()))?;
+
+        let names = decl_target_names(decl_target);
+        self.check_apply_arg_count(decl_target, names.len())?;
+
+        let span = self.span_of(node);
+        let name_exprs: Vec<Expr> = names.into_iter().map(|n| self.sym_symbol(n, span.clone())).collect();
+        let names_list = self.sym_apply(self.sym_symbol_bare(LIST, span.clone()), name_exprs, span.clone());
+        let target_type = self.lower_type_expr(type_expr_node, depth + 1)?;
+
+        Ok(self.sym_apply(
+            self.sym_symbol_bare(AXIOM_DECLARE, span.clone()),
+            vec![names_list, target_type],
+            span,
+        ))
+    }
+
+    // -------------------------------------------------------------------
+    // D has C -- category-membership query (MA13 §3/§4).
+    // -------------------------------------------------------------------
+
+    fn lower_has_query(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, AxiomLowerError> {
+        let type_exprs: Vec<&GrammarASTNode> = child_nodes(node).filter(|n| n.rule_name == "type_expr").collect();
+        if type_exprs.len() != 2 {
+            return Err(self.err_at(node, "malformed `has` query".to_string()));
+        }
+        let domain = self.lower_type_expr(type_exprs[0], depth + 1)?;
+        let category = self.lower_type_expr(type_exprs[1], depth + 1)?;
+        let span = self.span_of(node);
+        Ok(self.sym_apply(self.sym_symbol_bare(AXIOM_HAS, span.clone()), vec![domain, category], span))
+    }
+
+    // -------------------------------------------------------------------
+    // comparison = coercion [ (EQ|NE|LE|LESS|GREATER|GE) coercion ]
+    // -------------------------------------------------------------------
+
+    /// Non-chaining (one optional suffix), mirroring `axiom-runtime::
+    /// eval::eval_comparison`'s identical shape and comparison-head table.
+    fn lower_comparison(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, AxiomLowerError> {
+        let Some(op_index) = node
+            .children
+            .iter()
+            .position(|c| as_token(c).is_some_and(|t| comparison_head(token_type(t)).is_some()))
+        else {
+            return self.lower_first_node(node, depth);
+        };
+        if op_index == 0 || op_index + 1 >= node.children.len() {
+            return Err(self.err_at(node, "malformed comparison node".to_string()));
+        }
+        let head = comparison_head(token_type(as_token(&node.children[op_index]).unwrap())).unwrap();
+        let lhs = self.lower_child(&node.children[op_index - 1], depth + 1)?;
+        let rhs = self.lower_child(&node.children[op_index + 1], depth + 1)?;
+        let span = self.span_of(node);
+        Ok(self.sym_apply(self.sym_symbol_bare(head, span.clone()), vec![lhs, rhs], span))
+    }
+
+    // -------------------------------------------------------------------
+    // coercion = additive [ COERCE type_expr ]
+    // -------------------------------------------------------------------
+
+    fn lower_coercion(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, AxiomLowerError> {
+        let Some(additive_node) = child_nodes(node).find(|n| n.rule_name == "additive") else {
+            return self.lower_first_node(node, depth);
+        };
+        let type_expr_node = child_nodes(node)
+            .find(|n| n.rule_name == "type_expr")
+            .ok_or_else(|| self.err_at(node, "malformed coercion: missing target type".to_string()))?;
+
+        let lhs = self.lower_node(additive_node, depth + 1)?;
+        let target = self.lower_type_expr(type_expr_node, depth + 1)?;
+        let span = self.span_of(node);
+        Ok(self.sym_apply(self.sym_symbol_bare(AXIOM_COERCE, span.clone()), vec![lhs, target], span))
+    }
+
+    // -------------------------------------------------------------------
+    // additive / multiplicative -- iterative left-associative fold
+    // -------------------------------------------------------------------
+
+    /// Mirrors `axiom-runtime::eval::eval_binary_chain`'s identical fold,
+    /// building `Expr` data instead of evaluating. [`Self::
+    /// check_chain_length`] guards the fold (a flat EBNF repetition folds
+    /// into an N-deep binary tree).
+    fn lower_binary_chain(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, AxiomLowerError> {
+        self.check_chain_length(node)?;
+        let mut children = node.children.iter();
+        let first = children
+            .next()
+            .ok_or_else(|| self.err_at(node, "empty binary chain".to_string()))?;
+        let mut result = self.lower_child(first, depth + 1)?;
+        while let Some(op_child) = children.next() {
+            let head = as_token(op_child)
+                .and_then(|t| binary_head(token_type(t)))
+                .ok_or_else(|| self.err_at(node, "expected a binary operator".to_string()))?;
+            let rhs = children
+                .next()
+                .ok_or_else(|| self.err_at(node, "binary operator with no right operand".to_string()))?;
+            let rhs_expr = self.lower_child(rhs, depth + 1)?;
+            let span = self.span_of(node);
+            result = self.sym_apply(self.sym_symbol_bare(head, span.clone()), vec![result, rhs_expr], span);
+        }
+        Ok(result)
+    }
+
+    // -------------------------------------------------------------------
+    // unary = MINUS unary | power
+    // -------------------------------------------------------------------
+
+    fn lower_unary(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, AxiomLowerError> {
+        match node.children.len() {
+            1 => self.lower_child(&node.children[0], depth + 1),
+            2 => {
+                let operand = self.lower_child(&node.children[1], depth + 1)?;
+                let span = self.span_of(node);
+                Ok(self.sym_apply(self.sym_symbol_bare(NEG, span.clone()), vec![operand], span))
+            }
+            _ => Err(self.err_at(node, "malformed unary node".to_string())),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // power = postfix [ (CARET|POW) unary ]
+    // -------------------------------------------------------------------
+
+    /// `^` and `**` are the SAME operator (MA13 §4), both collapsed onto
+    /// `POW` here, mirroring `axiom-runtime::eval::eval_power`'s identical
+    /// acceptance of either token type.
+    fn lower_power(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, AxiomLowerError> {
+        match node.children.len() {
+            1 => self.lower_child(&node.children[0], depth + 1),
+            3 => {
+                let is_pow_op = as_token(&node.children[1]).is_some_and(|t| matches!(token_type(t), "CARET" | "POW"));
+                if !is_pow_op {
+                    return Err(self.err_at(node, "malformed power node: expected CARET or POW".to_string()));
+                }
+                let lhs = self.lower_child(&node.children[0], depth + 1)?;
+                let rhs = self.lower_child(&node.children[2], depth + 1)?;
+                let span = self.span_of(node);
+                Ok(self.sym_apply(self.sym_symbol_bare(POW, span.clone()), vec![lhs, rhs], span))
+            }
+            _ => Err(self.err_at(node, "malformed power node".to_string())),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // postfix = atom [ call_args ] -- function application, `f(a,b)` AND
+    // paren-optional `f a` (MA13 §4)
+    // -------------------------------------------------------------------
+
+    /// Unlike Reduce's/Derive's own `postfix` (a REPEATED call suffix),
+    /// `axiom.grammar`'s own `postfix = atom [ call_args ]` allows at most
+    /// ONE call suffix (`f(x)(y)` is not valid Axiom syntax in this subset) —
+    /// so, mirroring `maple-to-semantic-ir`'s identical finding, there is no
+    /// `check_postfix_chain_length`-equivalent guard anywhere in this
+    /// function: the axis it would guard is structurally impossible here.
+    ///
+    /// Unlike `maple-to-semantic-ir`/`reduce-to-semantic-ir`, this crate
+    /// bridges no surface builtin-call name to a canonical head at all — MA13
+    /// §4's scope table names no calculus/list-accessor surface bridge for
+    /// Axiom (unlike Maple's `diff`/`int` or Reduce's `first`/`append`), so
+    /// every call's head lowers exactly as written, whatever it is.
+    fn lower_postfix(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, AxiomLowerError> {
+        let atom_node = child_nodes(node)
+            .next()
+            .ok_or_else(|| self.err_at(node, "postfix has no base".to_string()))?;
+        let base = self.lower_node(atom_node, depth + 1)?;
+
+        let Some(call_args_node) = child_nodes(node).find(|n| n.rule_name == "call_args") else {
+            return Ok(base);
+        };
+
+        let arg_nodes = call_args_exprs(call_args_node);
+        self.check_apply_arg_count(call_args_node, arg_nodes.len())?;
+        let mut args = Vec::with_capacity(arg_nodes.len());
+        for a in arg_nodes {
+            args.push(self.lower_node(a, depth + 1)?);
+        }
+        let span = self.span_of(node);
+        Ok(self.sym_apply(base, args, span))
+    }
+
+    // -------------------------------------------------------------------
+    // atom = NUMBER | STRING | NAME | list_literal | group
+    // -------------------------------------------------------------------
+
+    /// In practice [`unwrap_single`] already dissolves a single-child `atom`
+    /// node before `lower_node`'s dispatch ever sees rule_name `"atom"`
+    /// (every alternative here matches to exactly one child) — this function
+    /// mirrors `axiom-runtime::eval`'s identical defensive shape rather than
+    /// being load-bearing for the common case.
+    fn lower_atom(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, AxiomLowerError> {
+        if let Some(child) = child_nodes(node).next() {
+            if matches!(child.rule_name.as_str(), "list_literal" | "group") {
+                return self.lower_node(child, depth + 1);
+            }
+        }
+        let tokens: Vec<&Token> = node.children.iter().filter_map(as_token).collect();
+        match tokens.as_slice() {
+            [single] => self.lower_token(single),
+            _ => Err(self.err_at(
+                node,
+                format!(
+                    "unrecognised atom token shape: {:?}",
+                    tokens.iter().map(|t| &t.value).collect::<Vec<_>>()
+                ),
+            )),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // list_literal = LBRACKET [ elem_list ] RBRACKET
+    // -------------------------------------------------------------------
+
+    /// `[a, b, c]` (MA13 §4) — lowers to the shared, already-handled `List`
+    /// head every CAS-family sibling in this repo reuses.
+    fn lower_list_literal(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, AxiomLowerError> {
+        let args = match child_nodes(node).find(|n| n.rule_name == "elem_list") {
+            Some(elem_list) => {
+                let elems: Vec<&GrammarASTNode> = child_nodes(elem_list).filter(|n| n.rule_name == "expr").collect();
+                self.check_apply_arg_count(elem_list, elems.len())?;
+                elems
+                    .into_iter()
+                    .map(|e| self.lower_node(e, depth + 1))
+                    .collect::<Result<Vec<_>, _>>()?
+            }
+            None => vec![],
+        };
+        let span = self.span_of(node);
+        Ok(self.sym_apply(self.sym_symbol_bare(LIST, span.clone()), args, span))
+    }
+
+    // -------------------------------------------------------------------
+    // group = LPAREN expr { SEMI expr } RPAREN -- grouping OR a `;`-block
+    // -------------------------------------------------------------------
+
+    /// A `group` with exactly ONE `expr` child is ordinary grouping (returns
+    /// the inner expression unchanged, no wrapper node at all); a `group`
+    /// with TWO OR MORE `expr` children (joined by `;`) is a block, lowered
+    /// to [`COMPOUND_EXPRESSION`] (MA13 §4: "value is the last expression's
+    /// value" — matching `reduce-to-semantic-ir`'s identical
+    /// `CompoundExpression[s1, s2, ...]` shape). `axiom.grammar`'s own
+    /// `{ SEMI expr }` repetition is a flat EBNF shape (zero native parser
+    /// stack cost regardless of width, the same established fact every
+    /// sibling frontend's own chain-length guards rely on) and
+    /// [`Self::sym_apply`] builds one FLAT n-ary apply here, not a folded
+    /// pairwise tree — so [`Self::check_apply_arg_count`] (an
+    /// allocation-size backstop) is the correct guard, not a chain-length
+    /// one.
+    fn lower_group(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, AxiomLowerError> {
+        let exprs: Vec<&GrammarASTNode> = child_nodes(node).filter(|n| n.rule_name == "expr").collect();
+        if exprs.is_empty() {
+            return Err(self.err_at(node, "empty group `( )`".to_string()));
+        }
+        self.check_apply_arg_count(node, exprs.len())?;
+        if exprs.len() == 1 {
+            return self.lower_node(exprs[0], depth + 1);
+        }
+        let lowered = exprs
+            .into_iter()
+            .map(|e| self.lower_node(e, depth + 1))
+            .collect::<Result<Vec<_>, _>>()?;
+        let span = self.span_of(node);
+        Ok(self.sym_apply(self.sym_symbol_bare(COMPOUND_EXPRESSION, span.clone()), lowered, span))
+    }
+
+    // -------------------------------------------------------------------
+    // type_expr = NAME [ type_ctor_args ] -- domain/category-shaped
+    // expressions, used by declaration/coercion/has_query/function-header
+    // type-annotation positions. See the module doc comment's "Type
+    // positions" section.
+    // -------------------------------------------------------------------
+
+    fn lower_type_expr(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, AxiomLowerError> {
+        if depth > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("type expression nesting too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            ));
+        }
+        let name = node
+            .children
+            .iter()
+            .find_map(as_token)
+            .filter(|t| token_type(t) == "NAME")
+            .map(|t| t.value.clone())
+            .ok_or_else(|| self.err_at(node, "malformed type expression: missing name".to_string()))?;
+        let span = self.span_of(node);
+
+        let ctor_args_node = node
+            .children
+            .iter()
+            .find_map(as_node)
+            .filter(|n| n.rule_name == "type_ctor_args");
+        let Some(ctor_args_node) = ctor_args_node else {
+            return Ok(self.sym_symbol(name, span));
+        };
+
+        let args = self.lower_type_ctor_args(ctor_args_node, depth + 1)?;
+        Ok(self.sym_apply(self.sym_symbol_bare(name, span.clone()), args, span))
+    }
+
+    /// `type_ctor_args = LPAREN [ type_expr_list ] RPAREN | NAME` — the
+    /// second alternative is the paren-optional shorthand (`Fraction
+    /// Integer`), restricted by the grammar to a single bare NAME argument
+    /// only, never a further-nested `type_expr` (see the module doc
+    /// comment).
+    fn lower_type_ctor_args(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Vec<Expr>, AxiomLowerError> {
+        let has_lparen = node
+            .children
+            .iter()
+            .any(|c| as_token(c).is_some_and(|t| token_type(t) == "LPAREN"));
+
+        if !has_lparen {
+            let name = node
+                .children
+                .iter()
+                .find_map(as_token)
+                .filter(|t| token_type(t) == "NAME")
+                .map(|t| t.value.clone())
+                .ok_or_else(|| self.err_at(node, "malformed paren-optional type argument".to_string()))?;
+            let span = self.span_of(node);
+            return Ok(vec![self.sym_symbol(name, span)]);
+        }
+
+        match child_nodes(node).find(|n| n.rule_name == "type_expr_list") {
+            Some(list_node) => {
+                let items: Vec<&GrammarASTNode> = child_nodes(list_node).filter(|n| n.rule_name == "type_expr").collect();
+                self.check_apply_arg_count(list_node, items.len())?;
+                items.into_iter().map(|te| self.lower_type_expr(te, depth + 1)).collect()
+            }
+            None => Ok(vec![]),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Small constructors (each observes the feature the validator's own
+    // `check_expr` requires for that node kind -- see `semantic-ir/src/
+    // validator.rs`, the ground truth this must match exactly).
+    // -------------------------------------------------------------------
+
+    fn sym_symbol(&mut self, name: String, span: Span) -> Expr {
+        self.observed.add(Feature::SymbolicExpr);
+        Expr::SymSymbol { name, span }
+    }
+
+    /// Build a `SymSymbol` for a *head* name, or any other
+    /// internally-constructed symbol that is always immediately wrapped in a
+    /// [`Self::sym_apply`] call — which itself observes the feature — so
+    /// this helper does not need to (identical shape to [`Self::
+    /// sym_symbol`], named separately only so call sites make their intent
+    /// legible; mirrors every sibling SIR23 frontend's identically-named
+    /// helper).
+    fn sym_symbol_bare(&self, name: impl Into<String>, span: Span) -> Expr {
+        Expr::SymSymbol {
+            name: name.into(),
+            span,
+        }
+    }
+
+    fn sym_apply(&mut self, head: Expr, args: Vec<Expr>, span: Span) -> Expr {
+        self.observed.add(Feature::SymbolicExpr);
+        Expr::SymApply {
+            head: Box::new(head),
+            args,
+            span,
+        }
+    }
+
+    /// `"hello"` (MA13 §4) — domain `String`. The FIRST SIR23 frontend in
+    /// this repo's CAS family to construct `Expr::StrLit` at all (Derive's/
+    /// Reduce's/Maple's own grammars have no `STRING` token) — `StrLit`
+    /// requires `Feature::Strings` per `semantic-ir/src/validator.rs`'s own
+    /// `check_expr`, observed here immediately for the same reason
+    /// [`Self::number_literal_expr`] observes `Feature::Floats` immediately:
+    /// a free function with no access to `self.observed` was a confirmed,
+    /// previously-shipped bug class in `matlab-to-semantic-ir`/
+    /// `wolfram-to-semantic-ir`.
+    fn str_lit(&mut self, value: String, span: Span) -> Expr {
+        self.observed.add(Feature::Strings);
+        Expr::StrLit { value, span }
+    }
+
+    /// Parse a `NUMBER` lexeme into an `IntLit` or `FloatLit` (a `.`, `e`, or
+    /// `E` means a real; otherwise an integer), matching
+    /// `axiom-runtime::eval::parse_number`'s identical rule. An integer
+    /// lexeme too large for `i64` falls back to a float rather than silently
+    /// truncating.
+    ///
+    /// **Must** be an instance method, not a free function — see
+    /// [`Self::str_lit`]'s doc comment for why.
+    fn number_literal_expr(&mut self, text: &str, span: Span) -> Expr {
+        if text.contains('.') || text.contains('e') || text.contains('E') {
+            self.observed.add(Feature::Floats);
+            Expr::FloatLit {
+                value: text.parse::<f64>().unwrap_or(0.0),
+                span,
+            }
+        } else {
+            match text.parse::<i64>() {
+                Ok(v) => Expr::IntLit { value: v, span },
+                Err(_) => {
+                    self.observed.add(Feature::Floats);
+                    Expr::FloatLit {
+                        value: text.parse::<f64>().unwrap_or(0.0),
+                        span,
+                    }
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Guards
+    // -------------------------------------------------------------------
+
+    /// Reject a same-precedence operator chain (`additive`/`multiplicative`)
+    /// with more than `MAX_EXPR_DEPTH` operands. `axiom.grammar`, like every
+    /// sibling CAS-family grammar in this repo, collapses a flat run of
+    /// same-precedence operators into ONE CST node with many children rather
+    /// than nesting through parens, so a long unparenthesized chain never
+    /// trips `axiom-parser`'s own `MAX_RULE_DEPTH` (which counts *nesting*,
+    /// not the length of one flat repetition) — but folding N operands
+    /// left-associatively still builds an N-deep binary `Expr` tree.
+    fn check_chain_length(&self, node: &GrammarASTNode) -> Result<(), AxiomLowerError> {
+        let operand_count = node
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(_)))
+            .count();
+        if operand_count > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!(
+                    "expression chain too long ({operand_count} operands, exceeds \
+                     {MAX_EXPR_DEPTH})"
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Cap the argument count of a single `f(…)` application, the element
+    /// count of a `[…]` list literal, a `typed_param_list`/`name_list`/
+    /// `type_expr_list`'s element count, or a `;`-block's statement count.
+    /// None of these fold into a nested tree (all stay a flat `Vec<Expr>`),
+    /// so this is not a stack-recursion guard — it is a modest
+    /// defense-in-depth cap on a single allocation's size, using the same
+    /// `MAX_EXPR_DEPTH` bound for consistency rather than inventing new
+    /// constants per call site (mirrors `reduce-to-semantic-ir`'s/
+    /// `maple-to-semantic-ir`'s identical reuse across multiple flat-`Vec`
+    /// productions).
+    fn check_apply_arg_count(&self, node: &GrammarASTNode, count: usize) -> Result<(), AxiomLowerError> {
+        if count > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("too many arguments ({count}, exceeds {MAX_EXPR_DEPTH})"),
+            ));
+        }
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------
+    // Small helpers
+    // -------------------------------------------------------------------
+
+    fn lower_first_node(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, AxiomLowerError> {
+        let child = child_nodes(node)
+            .next()
+            .ok_or_else(|| self.err_at(node, format!("`{}` has no expression child", node.rule_name)))?;
+        self.lower_node(child, depth + 1)
+    }
+
+    fn lower_child(&mut self, child: &ASTNodeOrToken, depth: usize) -> Result<Expr, AxiomLowerError> {
+        match child {
+            ASTNodeOrToken::Node(node) => self.lower_node(node, depth),
+            ASTNodeOrToken::Token(token) => self.lower_token(token),
+        }
+    }
+
+    fn span_of(&self, node: &GrammarASTNode) -> Span {
+        Span::new(
+            FILE,
+            node.start_line.unwrap_or(1),
+            node.start_column.unwrap_or(1),
+            node.end_line.unwrap_or(node.start_line.unwrap_or(1)),
+            node.end_column.unwrap_or(node.start_column.unwrap_or(1)),
+        )
+    }
+
+    fn token_span(&self, token: &Token) -> Span {
+        Span::point(FILE, token.line, token.column)
+    }
+
+    fn err_at(&self, node: &GrammarASTNode, message: String) -> AxiomLowerError {
+        AxiomLowerError {
+            message,
+            line: node.start_line.unwrap_or(1),
+            column: node.start_column.unwrap_or(1),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Free helpers (no `&mut self` needed)
+// ---------------------------------------------------------------------------
+
+/// Collect the *node* children of `node` (dropping tokens).
+fn child_nodes(node: &GrammarASTNode) -> impl Iterator<Item = &GrammarASTNode> {
+    node.children.iter().filter_map(as_node)
+}
+
+fn as_node(child: &ASTNodeOrToken) -> Option<&GrammarASTNode> {
+    match child {
+        ASTNodeOrToken::Node(node) => Some(node),
+        ASTNodeOrToken::Token(_) => None,
+    }
+}
+
+fn as_token(child: &ASTNodeOrToken) -> Option<&Token> {
+    match child {
+        ASTNodeOrToken::Token(token) => Some(token),
+        ASTNodeOrToken::Node(_) => None,
+    }
+}
+
+fn token_type(token: &Token) -> &str {
+    token.effective_type_name()
+}
+
+/// Find the first direct `NAME` token among `node`'s IMMEDIATE children only
+/// (never recursing into child *nodes*) — used for a rule whose grammar
+/// guarantees its own name token is a direct child (`declared_define`,
+/// `assignment`, `typed_param`). Mirrors `axiom-runtime::eval::
+/// first_token_value` exactly.
+fn first_token_value(node: &GrammarASTNode, token_ty: &str) -> Option<String> {
+    node.children
+        .iter()
+        .filter_map(as_token)
+        .find(|t| token_type(t) == token_ty)
+        .map(|t| t.value.clone())
+}
+
+/// `decl_target = NAME | LPAREN name_list RPAREN ; name_list = NAME { COMMA
+/// NAME }`. Mirrors `axiom-runtime::eval::decl_target_names` exactly.
+fn decl_target_names(node: &GrammarASTNode) -> Vec<String> {
+    if let Some(name_list) = child_nodes(node).find(|n| n.rule_name == "name_list") {
+        return name_list
+            .children
+            .iter()
+            .filter_map(as_token)
+            .filter(|t| token_type(t) == "NAME")
+            .map(|t| t.value.clone())
+            .collect();
+    }
+    node.children
+        .iter()
+        .filter_map(as_token)
+        .filter(|t| token_type(t) == "NAME")
+        .map(|t| t.value.clone())
+        .collect()
+}
+
+/// Map an arithmetic token type to its canonical IR head — the exact heads
+/// `symbolic_vm::handlers::build_handler_table` wires and `axiom-runtime`
+/// itself already uses (`additive_head`/`multiplicative_head`, combined
+/// here since both tables are disjoint on token type).
+fn binary_head(token_type: &str) -> Option<&'static str> {
+    match token_type {
+        "PLUS" => Some(ADD),
+        "MINUS" => Some(SUB),
+        "TIMES" => Some(MUL),
+        "SLASH" => Some(DIV),
+        _ => None,
+    }
+}
+
+/// Map a comparison token to its canonical IR head — mirrors
+/// `axiom-runtime::eval::comparison_head`'s identical table exactly (`~=` is
+/// tokenized as `NE`, not Maple's `NEQ`/Reduce's `neq` keyword — MA13 §4's
+/// own confirmed not-equal spelling).
+fn comparison_head(token_type: &str) -> Option<&'static str> {
+    match token_type {
+        "EQ" => Some(EQUAL),
+        "NE" => Some(NOT_EQUAL),
+        "LE" => Some(LESS_EQUAL),
+        "LESS" => Some(LESS),
+        "GREATER" => Some(GREATER),
+        "GE" => Some(GREATER_EQUAL),
+        _ => None,
+    }
+}
+
+/// `call_args = LPAREN [ arglist ] RPAREN | atom` — returns the argument
+/// expression nodes to lower, uniformly for both the explicit-parens form
+/// and the paren-optional single-bare-atom form (`f a`). Mirrors
+/// `axiom-runtime::eval::call_args_exprs` exactly.
+fn call_args_exprs(node: &GrammarASTNode) -> Vec<&GrammarASTNode> {
+    if let Some(arglist) = child_nodes(node).find(|n| n.rule_name == "arglist") {
+        return child_nodes(arglist).filter(|n| n.rule_name == "expr").collect();
+    }
+    let has_lparen = node
+        .children
+        .iter()
+        .any(|c| as_token(c).is_some_and(|t| token_type(t) == "LPAREN"));
+    if has_lparen {
+        Vec::new() // f() -- explicit, empty argument list
+    } else {
+        // f a -- the paren-optional single bare atom IS the one argument.
+        child_nodes(node).filter(|n| n.rule_name == "atom").collect()
+    }
+}
+
+/// Measure `expr`'s true tree depth **iteratively**, using an explicit
+/// heap-allocated work stack rather than native recursion, so calling this
+/// can never itself overflow the stack no matter how deep `expr` already is.
+///
+/// Returns `None` as soon as the depth is certain to exceed
+/// `MAX_EXPR_DEPTH`, `Some(depth)` otherwise.
+///
+/// Only needs a match arm for [`Expr::SymApply`] (recursing into `head` and
+/// `args`) — every other `Expr` variant is a leaf for this crate's purposes,
+/// since this crate never constructs a `SymPatternBlank`/`SymPatternNamed`/
+/// `SymRule`/`SymReplaceAll` node (Axiom's grammar has no pattern-matching or
+/// rewrite-rule syntax at all). `If`/`Assign`/`Define`/`__axiom_declare`/
+/// `__axiom_coerce`/`__axiom_has`/`CompoundExpression` are all `SymApply`
+/// with a different head symbol, not new `Expr` variants, so this one match
+/// arm already covers them.
+///
+/// Called once per top-level statement in [`Lowerer::lower_program`], so no
+/// tree this crate hands to a caller can ever actually exceed
+/// `MAX_EXPR_DEPTH`, regardless of how its construction was composed —
+/// mirrors every sibling SIR23 frontend's identical authoritative,
+/// construction-composition-independent depth check.
+fn measure_depth_iterative(expr: &Expr) -> Option<usize> {
+    let mut stack: Vec<(&Expr, usize)> = vec![(expr, 0)];
+    let mut max_depth = 0;
+    while let Some((node, d)) = stack.pop() {
+        if d > MAX_EXPR_DEPTH {
+            return None;
+        }
+        max_depth = max_depth.max(d);
+        if let Expr::SymApply { head, args, .. } = node {
+            stack.push((head, d + 1));
+            for a in args {
+                stack.push((a, d + 1));
+            }
+        }
+    }
+    Some(max_depth)
+}
+
+/// Tear down a rejected, pathologically-deep `Expr` tree **iteratively**, so
+/// freeing it can never itself overflow the stack — see
+/// `wolfram-to-semantic-ir`'s security-review history (referenced by every
+/// sibling SIR23 frontend) for why letting a detected-oversized tree simply
+/// fall out of scope (recursive `Drop` glue) just relocates the same native
+/// stack overflow from "walking forward" to "walking backward".
+fn drop_iterative(expr: Expr) {
+    let mut stack: Vec<Expr> = vec![expr];
+    while let Some(node) = stack.pop() {
+        if let Expr::SymApply { head, args, .. } = node {
+            stack.push(*head);
+            stack.extend(args);
+        }
+    }
+}
+
+enum Unwrapped<'a> {
+    Node(&'a GrammarASTNode),
+    Token(&'a Token),
+}
+
+/// Peel away single-child wrapper nodes until we reach a node with structure
+/// (or a leaf token). A precedence-cascade rule that did not apply its own
+/// operator still emits its own node with exactly one child — this skips
+/// straight to the rule that actually matters. Mirrors `axiom-runtime::
+/// eval::unwrap_single`/every sibling SIR23 frontend's identically-named
+/// helper exactly — the shared `parser::GrammarParser` engine's node shape
+/// is identical across every grammar built on it.
+fn unwrap_single(mut node: &GrammarASTNode) -> Unwrapped<'_> {
+    loop {
+        if node.children.len() != 1 {
+            return Unwrapped::Node(node);
+        }
+        match &node.children[0] {
+            ASTNodeOrToken::Node(child) => node = child,
+            ASTNodeOrToken::Token(token) => return Unwrapped::Token(token),
+        }
+    }
+}

--- a/code/packages/rust/axiom-to-semantic-ir/tests/e2e_node.rs
+++ b/code/packages/rust/axiom-to-semantic-ir/tests/e2e_node.rs
@@ -1,0 +1,184 @@
+//! End-to-end round-trip: Axiom → SIR → JavaScript → `node`.
+//!
+//! Mirrors `maple-to-semantic-ir`'s (and `reduce-to-semantic-ir`'s /
+//! `derive-to-semantic-ir`'s) own `tests/e2e_node.rs` harnesses: lower an
+//! Axiom program to SIR with this crate, validate the module, emit
+//! JavaScript with the merged `semantic-ir-to-javascript` backend (a
+//! dev-dependency), write it to a temp file, and **execute it with `node`**.
+//!
+//! # Why these tests check "runs cleanly", not a printed value
+//!
+//! See `wolfram-to-semantic-ir/tests/e2e_node.rs`'s own module doc comment
+//! for the full explanation — the same "everything is symbolic data" design
+//! applies here (`src/lower.rs`'s module doc comment): an Axiom program never
+//! produces a host-language computed value through this pipeline, so there
+//! is no `axiom-repl`-equivalent stdout to assert on. These tests prove
+//! instead that every one of these programs compiles to JavaScript that
+//! `node` actually executes without throwing.
+//!
+//! # `__axiom_declare`/`__axiom_coerce`/`__axiom_has` are proven RUNNABLE,
+//! not (yet) evaluable
+//!
+//! Per `src/lower.rs`'s own disclosed design decision, this repo's shared JS
+//! backend has no evaluation handler for these three reserved heads today
+//! (deferred to the follow-on oracle-testing task) — but that only means the
+//! compiled program constructs inert `__Sir.Symbolic.apply("__axiom_declare",
+//! …)`-shaped data rather than performing a real domain check; it does not
+//! mean the compiled program fails to run. The tests below include
+//! `:`/`::`/`has` programs for exactly that reason, mirroring
+//! `maple-to-semantic-ir`'s own `Set` construct (also no shared evaluator,
+//! also proven to run cleanly as pure data construction).
+
+use std::fs::OpenOptions;
+use std::io::Write as _;
+use std::process::Command;
+
+use coding_adventures_axiom_to_semantic_ir::compile_source;
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn run_via_node(name: &str, src: &str) {
+    let module = compile_source(src, "prog").expect("lowering should succeed");
+    let report = semantic_ir::validate(&module);
+    assert!(
+        report.is_ok(),
+        "SIR validation failed for {name}: {:?}",
+        report.issues
+    );
+    let artifact = semantic_ir_to_javascript::compile(&module).expect("backend emit should succeed");
+
+    let mut path = std::env::temp_dir();
+    path.push(format!("axiom_sir_e2e_{name}_{}.js", std::process::id()));
+    // `create_new` (not `std::fs::write`) fails loudly on an existing path
+    // (including a symlink) instead of silently following/truncating
+    // through it -- mirrors `maple-to-semantic-ir`'s/`reduce-to-semantic-ir`'s
+    // identical helper. Each test uses a unique name+PID, so this should
+    // never legitimately collide.
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .expect("create temp js (create_new, not following an existing symlink)");
+    file.write_all(artifact.source.as_bytes()).expect("write temp js");
+    drop(file);
+
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        output.status.success(),
+        "node failed for {name}: stderr=\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn plain_arithmetic_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping plain_arithmetic_runs_in_node: `node` not available");
+        return;
+    }
+    run_via_node("arithmetic", "1 + 2 * 3");
+}
+
+#[test]
+fn a_declared_function_definition_and_call_run_in_node() {
+    if !node_available() {
+        eprintln!("skipping a_declared_function_definition_and_call_run_in_node: `node` not available");
+        return;
+    }
+    run_via_node(
+        "declared_define_call",
+        "(power(x: Integer, n: NonNegativeInteger): Integer == x ** n; power(2, 3))",
+    );
+}
+
+#[test]
+fn an_undeclared_function_definition_and_call_run_in_node() {
+    if !node_available() {
+        eprintln!("skipping an_undeclared_function_definition_and_call_run_in_node: `node` not available");
+        return;
+    }
+    run_via_node("undeclared_define_call", "(f x == x * x; f(3))");
+}
+
+#[test]
+fn assignment_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping assignment_runs_in_node: `node` not available");
+        return;
+    }
+    run_via_node("assignment", "(x := 5; y := x + 1)");
+}
+
+#[test]
+fn a_list_literal_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping a_list_literal_runs_in_node: `node` not available");
+        return;
+    }
+    run_via_node("list", "[1, 2, 3]");
+}
+
+#[test]
+fn if_then_else_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping if_then_else_runs_in_node: `node` not available");
+        return;
+    }
+    run_via_node("if_then_else", "if 1 > 0 then 1 else -1");
+}
+
+#[test]
+fn a_multi_statement_block_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping a_multi_statement_block_runs_in_node: `node` not available");
+        return;
+    }
+    run_via_node("block", "(a := 1; b := 2; a + b)");
+}
+
+#[test]
+fn a_declaration_runs_in_node_as_inert_data() {
+    if !node_available() {
+        eprintln!("skipping a_declaration_runs_in_node_as_inert_data: `node` not available");
+        return;
+    }
+    run_via_node("declaration", "a : PositiveInteger");
+}
+
+#[test]
+fn a_coercion_runs_in_node_as_inert_data() {
+    if !node_available() {
+        eprintln!("skipping a_coercion_runs_in_node_as_inert_data: `node` not available");
+        return;
+    }
+    run_via_node("coercion", "3 :: Fraction(Integer)");
+}
+
+#[test]
+fn a_has_query_runs_in_node_as_inert_data() {
+    if !node_available() {
+        eprintln!("skipping a_has_query_runs_in_node_as_inert_data: `node` not available");
+        return;
+    }
+    run_via_node("has_query", "Polynomial(Integer) has Ring");
+}
+
+#[test]
+fn a_complex_multi_construct_program_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping a_complex_multi_construct_program_runs_in_node: `node` not available");
+        return;
+    }
+    run_via_node(
+        "complex",
+        "(a : PositiveInteger; a := 5; f(x: Integer): Integer == if x > 0 then x else -x; f(a))",
+    );
+}

--- a/code/packages/rust/axiom-to-semantic-ir/tests/malformed_ast.rs
+++ b/code/packages/rust/axiom-to-semantic-ir/tests/malformed_ast.rs
@@ -1,0 +1,543 @@
+//! Defensive-path coverage: `compile()` accepts an arbitrary, already-parsed
+//! `GrammarASTNode` — not only trees `axiom-parser` itself produces. These
+//! tests hand-build malformed or pathologically-deep trees directly
+//! (bypassing `axiom-parser`'s own `MAX_RULE_DEPTH` guard entirely) to
+//! exercise this crate's defensive "malformed node" / depth-guard branches
+//! that no `compile_source` call through a real parse can ever reach —
+//! adversarial-input testing in the same spirit as this repo's own
+//! `lessons.md` guidance ("DoS guards need adversarial repro").
+//!
+//! None of these shapes can arise from `axiom-parser`'s own grammar (every
+//! branch here defends against a hypothetical malformed or hand-built tree,
+//! e.g. from a future alternate frontend reusing this crate's `compile`
+//! entry point over some other CST) — but a public `compile(&GrammarASTNode,
+//! &str)` API that panics or misbehaves on malformed input is a real
+//! robustness gap, so this crate proactively returns a clean `Err` on all of
+//! them instead.
+
+use coding_adventures_axiom_to_semantic_ir::compile;
+use lexer::token::{Token, TokenType};
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+
+fn leaf(rule_name: &str) -> GrammarASTNode {
+    GrammarASTNode {
+        rule_name: rule_name.to_string(),
+        children: vec![],
+        start_line: Some(1),
+        start_column: Some(1),
+        end_line: Some(1),
+        end_column: Some(1),
+    }
+}
+
+fn node(rule_name: &str, children: Vec<ASTNodeOrToken>) -> GrammarASTNode {
+    GrammarASTNode {
+        rule_name: rule_name.to_string(),
+        children,
+        start_line: Some(1),
+        start_column: Some(1),
+        end_line: Some(1),
+        end_column: Some(1),
+    }
+}
+
+fn wrap_program(child: GrammarASTNode) -> GrammarASTNode {
+    node("program", vec![ASTNodeOrToken::Node(child)])
+}
+
+fn tok(type_name: &str, value: &str) -> Token {
+    Token {
+        type_: TokenType::Name,
+        value: value.to_string(),
+        line: 1,
+        column: 1,
+        type_name: Some(type_name.to_string()),
+        flags: None,
+        cv: None,
+    }
+}
+
+fn t(type_name: &str, value: &str) -> ASTNodeOrToken {
+    ASTNodeOrToken::Token(tok(type_name, value))
+}
+
+// --- lower_program: wrong root / nested `program` --------------------------
+
+#[test]
+fn a_non_program_root_is_rejected() {
+    let tree = leaf("not_program");
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("expected `program` root"), "{}", err.message);
+}
+
+#[test]
+fn a_program_node_with_more_than_one_child_is_rejected_as_nested() {
+    // `program` itself is meant to have exactly one child (the chosen `expr`
+    // alternative); a >1-child `program` node stops `unwrap_single` from
+    // peeling past it, landing squarely on `lower_node`'s own
+    // `"program" => Err(...)` dispatch arm.
+    let tree = node("program", vec![ASTNodeOrToken::Node(leaf("a")), ASTNodeOrToken::Node(leaf("b"))]);
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("nested program node"), "{}", err.message);
+}
+
+// --- lower_node: unknown rule name / non-expression rule names -------------
+
+#[test]
+fn an_unrecognised_rule_name_is_rejected() {
+    let tree = wrap_program(leaf("totally_unknown_rule"));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("no lowering for rule"), "{}", err.message);
+}
+
+#[test]
+fn call_args_cannot_be_lowered_as_a_standalone_expression() {
+    let tree = wrap_program(leaf("call_args"));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("call_args"), "{}", err.message);
+}
+
+#[test]
+fn arglist_cannot_be_lowered_as_a_standalone_expression() {
+    let tree = wrap_program(leaf("arglist"));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("arglist"), "{}", err.message);
+}
+
+#[test]
+fn elem_list_cannot_be_lowered_as_a_standalone_expression() {
+    let tree = wrap_program(leaf("elem_list"));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("elem_list"), "{}", err.message);
+}
+
+#[test]
+fn a_bare_type_expr_cannot_be_lowered_as_a_standalone_expression() {
+    let tree = wrap_program(leaf("type_expr"));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("type expression"), "{}", err.message);
+}
+
+// --- lower_token: unexpected token type --------------------------------
+
+#[test]
+fn an_unexpected_token_type_is_rejected() {
+    let tree = node("program", vec![t("SEMI", ";")]);
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("unexpected token"), "{}", err.message);
+}
+
+// --- lower_if: malformed shape --------------------------------------------
+
+#[test]
+fn an_if_expr_with_the_wrong_number_of_branches_is_rejected() {
+    // A second, dummy child (a KEYWORD token) keeps `if_expr` from being a
+    // single-child node -- `unwrap_single` would otherwise peel straight
+    // through it into the lone `expr` child before `lower_node`'s dispatch
+    // ever saw rule_name `"if_expr"` at all.
+    let tree = wrap_program(node(
+        "if_expr",
+        vec![t("KEYWORD", "if"), ASTNodeOrToken::Node(node("expr", vec![t("NUMBER", "1")]))],
+    ));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("malformed `if`"), "{}", err.message);
+}
+
+// --- lower_declared_define / lower_undeclared_define: missing pieces -------
+
+#[test]
+fn a_declared_define_with_no_name_token_is_rejected() {
+    let body = node("expr", vec![t("NUMBER", "1")]);
+    let tree = wrap_program(node(
+        "declared_define",
+        vec![t("LPAREN", "("), ASTNodeOrToken::Node(body)],
+    ));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("missing name"), "{}", err.message);
+}
+
+#[test]
+fn a_declared_define_with_no_body_is_rejected() {
+    let tree = wrap_program(node("declared_define", vec![t("NAME", "f"), t("LPAREN", "(")]));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("missing body"), "{}", err.message);
+}
+
+#[test]
+fn an_undeclared_define_with_the_wrong_name_token_count_is_rejected() {
+    let tree = wrap_program(node("undeclared_define", vec![t("NAME", "f"), t("LPAREN", "(")]));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("malformed undeclared function definition"), "{}", err.message);
+}
+
+#[test]
+fn an_undeclared_define_with_no_body_is_rejected() {
+    let tree = wrap_program(node(
+        "undeclared_define",
+        vec![t("NAME", "f"), t("NAME", "x")],
+    ));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("missing body"), "{}", err.message);
+}
+
+// --- lower_assignment: missing pieces --------------------------------------
+
+#[test]
+fn an_assignment_with_no_name_is_rejected() {
+    let tree = wrap_program(node(
+        "assignment",
+        vec![t("LPAREN", "("), ASTNodeOrToken::Node(node("expr", vec![t("NUMBER", "1")]))],
+    ));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("missing name"), "{}", err.message);
+}
+
+#[test]
+fn an_assignment_with_no_right_hand_side_is_rejected() {
+    let tree = wrap_program(node("assignment", vec![t("NAME", "x"), t("ASSIGN", ":=")]));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("missing right-hand side"), "{}", err.message);
+}
+
+// --- lower_declaration / lower_has_query: missing pieces -------------------
+
+#[test]
+fn a_declaration_with_no_target_is_rejected() {
+    let type_expr = node("type_expr", vec![t("NAME", "Integer")]);
+    let tree = wrap_program(node(
+        "declaration",
+        vec![t("COLON", ":"), ASTNodeOrToken::Node(type_expr)],
+    ));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("missing target"), "{}", err.message);
+}
+
+#[test]
+fn a_declaration_with_no_type_is_rejected() {
+    let decl_target = node("decl_target", vec![t("NAME", "a")]);
+    let tree = wrap_program(node(
+        "declaration",
+        vec![ASTNodeOrToken::Node(decl_target), t("COLON", ":")],
+    ));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("missing type"), "{}", err.message);
+}
+
+#[test]
+fn a_has_query_with_the_wrong_number_of_type_exprs_is_rejected() {
+    let type_expr = node("type_expr", vec![t("NAME", "Integer")]);
+    let tree = wrap_program(node(
+        "has_query",
+        vec![ASTNodeOrToken::Node(type_expr), t("KEYWORD", "has")],
+    ));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("malformed `has` query"), "{}", err.message);
+}
+
+// --- lower_coercion: missing target type ------------------------------------
+
+#[test]
+fn a_coercion_with_no_target_type_is_rejected() {
+    let additive = node("additive", vec![t("NUMBER", "1")]);
+    let tree = wrap_program(node(
+        "coercion",
+        vec![ASTNodeOrToken::Node(additive), t("COERCE", "::")],
+    ));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("missing target type"), "{}", err.message);
+}
+
+// --- lower_comparison / lower_coercion: the defensive "no operator found"
+// fallback to `lower_first_node` -- unreachable via any real parse (a
+// single-child `comparison`/`coercion` node is already peeled away by
+// `unwrap_single` before `lower_node` ever dispatches on its rule name), but
+// a real robustness property of a public `compile` entry point that accepts
+// an arbitrary hand-built tree.
+
+#[test]
+fn a_comparison_node_with_no_matching_operator_token_falls_back_to_its_first_child() {
+    let coercion = node("coercion", vec![t("NUMBER", "1")]);
+    let tree = wrap_program(node(
+        "comparison",
+        vec![ASTNodeOrToken::Node(coercion), t("SEMI", ";")],
+    ));
+    let module = compile(&tree, "test").expect("should fall back to lowering the first child");
+    let main = module.functions.iter().find(|f| f.name == "main").unwrap();
+    assert_eq!(main.body.stmts.len(), 1);
+}
+
+#[test]
+fn a_comparison_node_with_no_node_children_at_all_is_rejected() {
+    let tree = wrap_program(node("comparison", vec![t("SEMI", ";"), t("COMMA", ",")]));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("has no expression child"), "{}", err.message);
+}
+
+#[test]
+fn a_coercion_node_with_no_additive_child_falls_back_to_its_first_child() {
+    // The fallback target must have >1 child of its own (else `unwrap_single`
+    // would peel straight through it to its own bare NAME token, lowering
+    // successfully) AND an unrecognised rule name, so `lower_first_node`'s
+    // recursive dispatch on the fallback path (line ~706) genuinely fails.
+    let undispatchable = node("some_undispatchable_rule", vec![t("NAME", "a"), t("SEMI", ";")]);
+    let tree = wrap_program(node(
+        "coercion",
+        vec![ASTNodeOrToken::Node(undispatchable), t("SEMI", ";")],
+    ));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("no lowering for rule"), "{}", err.message);
+}
+
+// --- lower_comparison: operator at position 0 (malformed shape) ------------
+
+#[test]
+fn a_comparison_node_with_the_operator_in_the_first_position_is_rejected() {
+    let coercion = node("coercion", vec![t("NUMBER", "1")]);
+    let tree = wrap_program(node(
+        "comparison",
+        vec![t("EQ", "="), ASTNodeOrToken::Node(coercion)],
+    ));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("malformed comparison node"), "{}", err.message);
+}
+
+// --- lower_postfix: a `call_args`-less second child (defensive fallback) ---
+
+#[test]
+fn a_postfix_node_with_no_call_args_child_returns_the_bare_atom() {
+    let atom = node("atom", vec![t("NUMBER", "1")]);
+    let tree = wrap_program(node(
+        "postfix",
+        vec![ASTNodeOrToken::Node(atom), t("SEMI", ";")],
+    ));
+    let module = compile(&tree, "test").expect("should lower to the bare atom");
+    let main = module.functions.iter().find(|f| f.name == "main").unwrap();
+    assert_eq!(main.body.stmts.len(), 1);
+}
+
+// --- lower_atom: the list_literal/group short-circuit + single-token arm ---
+
+#[test]
+fn an_atom_node_wrapping_a_list_literal_child_directly_lowers_through_it() {
+    let list_literal = node("list_literal", vec![t("LBRACKET", "["), t("RBRACKET", "]")]);
+    let tree = wrap_program(node(
+        "atom",
+        vec![ASTNodeOrToken::Node(list_literal), t("SEMI", ";")],
+    ));
+    let module = compile(&tree, "test").expect("should lower through the list_literal child");
+    let main = module.functions.iter().find(|f| f.name == "main").unwrap();
+    assert_eq!(main.body.stmts.len(), 1);
+}
+
+#[test]
+fn an_atom_node_with_one_non_list_group_node_child_and_one_token_lowers_the_token() {
+    let tree = wrap_program(node(
+        "atom",
+        vec![ASTNodeOrToken::Node(leaf("some_other_rule")), t("NUMBER", "1")],
+    ));
+    let module = compile(&tree, "test").expect("should fall through to the lone token");
+    let main = module.functions.iter().find(|f| f.name == "main").unwrap();
+    assert_eq!(main.body.stmts.len(), 1);
+}
+
+// --- lower_unary: a bare-token operand (defensive robustness) --------------
+
+#[test]
+fn a_unary_operand_that_is_a_bare_token_still_lowers() {
+    let tree = wrap_program(node("unary", vec![t("MINUS", "-"), t("NUMBER", "5")]));
+    let module = compile(&tree, "test").expect("a bare-token unary operand should still lower");
+    let main = module.functions.iter().find(|f| f.name == "main").unwrap();
+    assert_eq!(main.body.stmts.len(), 1);
+}
+
+// --- lower_type_expr: MAX_EXPR_DEPTH guard via a hand-built deep chain -----
+//
+// `axiom-parser`'s own `MAX_RULE_DEPTH` (140) never lets a real parse build a
+// `type_expr` chain deep enough to trip this crate's own `MAX_EXPR_DEPTH`
+// (256) either -- mirrors the plain-expression depth-guard tests above.
+
+fn deep_type_expr_chain(levels: usize) -> GrammarASTNode {
+    let mut current = node("type_expr", vec![t("NAME", "Integer")]);
+    for _ in 0..levels {
+        let type_expr_list = node("type_expr_list", vec![ASTNodeOrToken::Node(current)]);
+        let ctor_args = node(
+            "type_ctor_args",
+            vec![t("LPAREN", "("), ASTNodeOrToken::Node(type_expr_list), t("RPAREN", ")")],
+        );
+        current = node(
+            "type_expr",
+            vec![t("NAME", "List"), ASTNodeOrToken::Node(ctor_args)],
+        );
+    }
+    current
+}
+
+#[test]
+fn a_pathologically_deep_hand_built_type_expr_trips_its_own_depth_guard() {
+    let decl_target = node("decl_target", vec![t("NAME", "a")]);
+    let tree = wrap_program(node(
+        "declaration",
+        vec![ASTNodeOrToken::Node(decl_target), ASTNodeOrToken::Node(deep_type_expr_chain(300))],
+    ));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("type expression nesting too deep"), "{}", err.message);
+}
+
+#[test]
+fn a_moderately_deep_hand_built_type_expr_stays_under_its_own_depth_guard() {
+    let decl_target = node("decl_target", vec![t("NAME", "a")]);
+    let tree = wrap_program(node(
+        "declaration",
+        vec![ASTNodeOrToken::Node(decl_target), ASTNodeOrToken::Node(deep_type_expr_chain(5))],
+    ));
+    assert!(compile(&tree, "test").is_ok());
+}
+
+// --- lower_binary_chain: malformed shapes ----------------------------------
+
+#[test]
+fn a_binary_chain_with_a_trailing_operator_and_no_right_operand_is_rejected() {
+    let operand = node("multiplicative", vec![t("NUMBER", "1")]);
+    let tree = wrap_program(node("additive", vec![ASTNodeOrToken::Node(operand), t("PLUS", "+")]));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("no right operand"), "{}", err.message);
+}
+
+#[test]
+fn a_binary_chain_with_an_unrecognised_operator_token_is_rejected() {
+    let a = node("multiplicative", vec![t("NUMBER", "1")]);
+    let b = node("multiplicative", vec![t("NUMBER", "2")]);
+    let tree = wrap_program(node(
+        "additive",
+        vec![ASTNodeOrToken::Node(a), t("SEMI", ";"), ASTNodeOrToken::Node(b)],
+    ));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("expected a binary operator"), "{}", err.message);
+}
+
+// --- lower_unary / lower_power: malformed shapes ---------------------------
+
+#[test]
+fn a_unary_node_with_the_wrong_child_count_is_rejected() {
+    let tree = wrap_program(node(
+        "unary",
+        vec![t("MINUS", "-"), t("NUMBER", "1"), t("NUMBER", "2")],
+    ));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("malformed unary"), "{}", err.message);
+}
+
+#[test]
+fn a_power_node_with_a_non_pow_operator_token_is_rejected() {
+    let base = node("postfix", vec![t("NUMBER", "1")]);
+    let exp = node("unary", vec![t("NUMBER", "2")]);
+    let tree = wrap_program(node(
+        "power",
+        vec![ASTNodeOrToken::Node(base), t("SEMI", ";"), ASTNodeOrToken::Node(exp)],
+    ));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("expected CARET or POW"), "{}", err.message);
+}
+
+#[test]
+fn a_power_node_with_the_wrong_child_count_is_rejected() {
+    let base = node("postfix", vec![t("NUMBER", "1")]);
+    let mid = node("unary", vec![t("NUMBER", "2")]);
+    let extra = node("unary", vec![t("NUMBER", "3")]);
+    let tree = wrap_program(node(
+        "power",
+        vec![
+            ASTNodeOrToken::Node(base),
+            t("CARET", "^"),
+            ASTNodeOrToken::Node(mid),
+            ASTNodeOrToken::Node(extra),
+        ],
+    ));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("malformed power node"), "{}", err.message);
+}
+
+// --- lower_atom: unrecognised token shape -----------------------------------
+
+#[test]
+fn an_atom_with_an_unrecognised_token_shape_is_rejected() {
+    let tree = wrap_program(node("atom", vec![t("SEMI", ";"), t("SEMI", ";")]));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("unrecognised atom token shape"), "{}", err.message);
+}
+
+// --- lower_group: empty group ------------------------------------------------
+
+#[test]
+fn an_empty_group_is_rejected() {
+    let tree = wrap_program(node("group", vec![t("LPAREN", "("), t("RPAREN", ")")]));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("empty group"), "{}", err.message);
+}
+
+// --- lower_type_expr / lower_type_ctor_args: malformed shapes ---------------
+
+#[test]
+fn a_type_expr_with_no_name_token_is_rejected() {
+    let tree = wrap_program(node("declaration", vec![
+        ASTNodeOrToken::Node(node("decl_target", vec![t("NAME", "a")])),
+        ASTNodeOrToken::Node(node("type_expr", vec![t("LPAREN", "(")])),
+    ]));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("malformed type expression"), "{}", err.message);
+}
+
+#[test]
+fn a_paren_optional_type_ctor_arg_with_no_name_token_is_rejected() {
+    let ctor_args = node("type_ctor_args", vec![t("SEMI", ";")]);
+    let type_expr = node("type_expr", vec![t("NAME", "Fraction"), ASTNodeOrToken::Node(ctor_args)]);
+    let tree = wrap_program(node(
+        "declaration",
+        vec![
+            ASTNodeOrToken::Node(node("decl_target", vec![t("NAME", "a")])),
+            ASTNodeOrToken::Node(type_expr),
+        ],
+    ));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("malformed paren-optional type argument"), "{}", err.message);
+}
+
+// --- MAX_EXPR_DEPTH guard: a pathologically deep hand-built tree ------------
+//
+// `axiom-parser`'s own `MAX_RULE_DEPTH` (140) never lets a real parse build a
+// CST deep enough to trip this crate's own `MAX_EXPR_DEPTH` (256) -- so this
+// guard's only adversarial-input test is a directly hand-built tree that
+// bypasses the parser entirely, mirroring how a hostile or buggy alternate
+// CST producer might reuse this crate's public `compile` entry point.
+
+fn deep_unary_chain(levels: usize) -> GrammarASTNode {
+    let mut current = node("power", vec![t("NUMBER", "1")]);
+    for _ in 0..levels {
+        current = node("unary", vec![t("MINUS", "-"), ASTNodeOrToken::Node(current)]);
+    }
+    current
+}
+
+#[test]
+fn a_pathologically_deep_hand_built_tree_trips_the_depth_guard() {
+    let tree = wrap_program(deep_unary_chain(300));
+    let err = compile(&tree, "test").unwrap_err();
+    assert!(err.message.contains("too deep"), "{}", err.message);
+}
+
+#[test]
+fn a_moderately_deep_hand_built_tree_stays_under_the_depth_guard() {
+    let tree = wrap_program(deep_unary_chain(10));
+    assert!(compile(&tree, "test").is_ok());
+}
+
+// --- AxiomLowerError::Display -------------------------------------------
+
+#[test]
+fn the_error_display_impl_includes_position_and_message() {
+    let tree = leaf("not_program");
+    let err = compile(&tree, "test").unwrap_err();
+    let rendered = format!("{err}");
+    assert!(rendered.contains("AxiomLowerError"));
+    assert!(rendered.contains("expected `program` root"));
+}

--- a/code/packages/rust/axiom-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/axiom-to-semantic-ir/tests/test_lower.rs
@@ -1,0 +1,640 @@
+//! Unit tests asserting exact `Expr` shapes produced by
+//! `coding_adventures_axiom_to_semantic_ir::compile_source` — one per grammar
+//! production, mirroring `maple-to-semantic-ir`'s/`reduce-to-semantic-ir`'s
+//! own `tests/test_lower.rs` structure. `axiom.grammar`'s own `program` rule
+//! parses exactly ONE expression (see `src/lower.rs`'s module doc comment),
+//! so — unlike Maple's/Reduce's own test sources — none of these need a
+//! trailing `;`/`$` statement terminator.
+
+use coding_adventures_axiom_to_semantic_ir::{compile_source, AXIOM_COERCE, AXIOM_DECLARE, AXIOM_HAS, COMPOUND_EXPRESSION};
+use semantic_ir::{Expr, Feature, Module, Stmt};
+
+/// Lower a single-statement source to its one top-level `Expr`.
+fn lower_one(src: &str) -> Expr {
+    let module = compile_source(src, "test").unwrap_or_else(|e| panic!("lowering failed for {src:?}: {e}"));
+    let main = module
+        .functions
+        .iter()
+        .find(|f| f.name == "main")
+        .expect("no main function");
+    assert_eq!(
+        main.body.stmts.len(),
+        1,
+        "expected exactly one statement for {src:?}, got {}",
+        main.body.stmts.len()
+    );
+    match &main.body.stmts[0] {
+        Stmt::ExprStmt { expr, .. } => expr.clone(),
+        other => panic!("expected an ExprStmt, got {other:?}"),
+    }
+}
+
+fn manifest_has(module: &Module, feature: Feature) -> bool {
+    module.manifest.iter().any(|f| f == feature)
+}
+
+fn sym(name: &str) -> Expr {
+    Expr::SymSymbol {
+        name: name.to_string(),
+        span: semantic_ir::Span::synthetic(),
+    }
+}
+
+fn int(v: i64) -> Expr {
+    Expr::IntLit {
+        value: v,
+        span: semantic_ir::Span::synthetic(),
+    }
+}
+
+fn float(v: f64) -> Expr {
+    Expr::FloatLit {
+        value: v,
+        span: semantic_ir::Span::synthetic(),
+    }
+}
+
+fn str_lit(v: &str) -> Expr {
+    Expr::StrLit {
+        value: v.to_string(),
+        span: semantic_ir::Span::synthetic(),
+    }
+}
+
+fn apply(head: Expr, args: Vec<Expr>) -> Expr {
+    Expr::SymApply {
+        head: Box::new(head),
+        args,
+        span: semantic_ir::Span::synthetic(),
+    }
+}
+
+fn list(args: Vec<Expr>) -> Expr {
+    apply(sym("List"), args)
+}
+
+/// Equality that ignores spans (every helper above uses a synthetic span;
+/// real lowered spans point at real source positions) — recursively zero
+/// out spans on both sides before comparing.
+fn assert_shape_eq(actual: Expr, expected: Expr) {
+    assert_eq!(strip_spans(actual), strip_spans(expected));
+}
+
+fn strip_spans(expr: Expr) -> Expr {
+    let z = semantic_ir::Span::synthetic();
+    match expr {
+        Expr::IntLit { value, .. } => Expr::IntLit { value, span: z },
+        Expr::FloatLit { value, .. } => Expr::FloatLit { value, span: z },
+        Expr::StrLit { value, .. } => Expr::StrLit { value, span: z },
+        Expr::SymSymbol { name, .. } => Expr::SymSymbol { name, span: z },
+        Expr::SymApply { head, args, .. } => Expr::SymApply {
+            head: Box::new(strip_spans(*head)),
+            args: args.into_iter().map(strip_spans).collect(),
+            span: z,
+        },
+        other => other,
+    }
+}
+
+// --- literals ---------------------------------------------------------
+
+#[test]
+fn integer_and_float_literals() {
+    assert_shape_eq(lower_one("42"), int(42));
+    assert_shape_eq(lower_one("1.5"), float(1.5));
+}
+
+#[test]
+fn string_literal_declares_feature_strings() {
+    let module = compile_source("\"hello\"", "test").unwrap();
+    assert!(manifest_has(&module, Feature::Strings));
+    assert_shape_eq(lower_one("\"hello\""), str_lit("hello"));
+}
+
+#[test]
+fn bare_symbol_declares_symbolic_expr() {
+    let module = compile_source("x", "test").unwrap();
+    assert!(manifest_has(&module, Feature::SymbolicExpr));
+    assert_shape_eq(lower_one("x"), sym("x"));
+}
+
+#[test]
+fn float_literal_module_declares_floats() {
+    let module = compile_source("1.5", "test").unwrap();
+    assert!(manifest_has(&module, Feature::Floats));
+}
+
+#[test]
+fn large_integer_lexeme_falls_back_to_float() {
+    // i64::MAX is 9223372036854775807; one more digit overflows i64.
+    assert_shape_eq(lower_one("99999999999999999999"), float(99999999999999999999.0));
+}
+
+// --- function calls: f(a, b) and paren-optional single-argument f a -----
+
+#[test]
+fn explicit_paren_call_lowers_to_sym_apply() {
+    assert_shape_eq(lower_one("f(a, b)"), apply(sym("f"), vec![sym("a"), sym("b")]));
+}
+
+#[test]
+fn paren_optional_single_argument_call_lowers_identically() {
+    assert_shape_eq(lower_one("factorial 7"), apply(sym("factorial"), vec![int(7)]));
+    assert_shape_eq(lower_one("ff z"), apply(sym("ff"), vec![sym("z")]));
+}
+
+#[test]
+fn call_with_no_arguments_lowers_to_empty_args() {
+    assert_shape_eq(lower_one("f()"), apply(sym("f"), vec![]));
+}
+
+#[test]
+fn nested_function_calls_lower() {
+    assert_shape_eq(lower_one("f(g(x))"), apply(sym("f"), vec![apply(sym("g"), vec![sym("x")])]));
+}
+
+#[test]
+fn paren_optional_call_with_a_string_or_list_argument() {
+    assert_shape_eq(lower_one("f \"hello\""), apply(sym("f"), vec![str_lit("hello")]));
+    assert_shape_eq(lower_one("f [1, 2, 3]"), apply(sym("f"), vec![list(vec![int(1), int(2), int(3)])]));
+}
+
+#[test]
+fn no_builtin_name_bridging_exists_for_axiom() {
+    // Unlike Maple's diff/int or Reduce's first/append, MA13 §4 names no
+    // surface-call bridge for Axiom -- every call head lowers exactly as
+    // written.
+    assert_shape_eq(lower_one("diff(x)"), apply(sym("diff"), vec![sym("x")]));
+}
+
+// --- lists --------------------------------------------------------------
+
+#[test]
+fn list_literal_lowers_to_list_apply() {
+    assert_shape_eq(lower_one("[a, b, c]"), list(vec![sym("a"), sym("b"), sym("c")]));
+}
+
+#[test]
+fn empty_list_literal_lowers_to_empty_list_apply() {
+    assert_shape_eq(lower_one("[]"), list(vec![]));
+}
+
+// --- arithmetic -----------------------------------------------------------
+
+#[test]
+fn additive_lowers_to_add_and_sub() {
+    assert_shape_eq(lower_one("1 + 2"), apply(sym("Add"), vec![int(1), int(2)]));
+    assert_shape_eq(lower_one("1 - 2"), apply(sym("Sub"), vec![int(1), int(2)]));
+}
+
+#[test]
+fn subtraction_is_left_associative() {
+    assert_shape_eq(
+        lower_one("a - b - c"),
+        apply(sym("Sub"), vec![apply(sym("Sub"), vec![sym("a"), sym("b")]), sym("c")]),
+    );
+}
+
+#[test]
+fn multiplicative_lowers_to_mul_and_div() {
+    assert_shape_eq(lower_one("a * b"), apply(sym("Mul"), vec![sym("a"), sym("b")]));
+    assert_shape_eq(lower_one("a / b"), apply(sym("Div"), vec![sym("a"), sym("b")]));
+}
+
+#[test]
+fn caret_and_double_star_both_lower_to_pow() {
+    assert_shape_eq(lower_one("a ^ b"), apply(sym("Pow"), vec![sym("a"), sym("b")]));
+    assert_shape_eq(lower_one("a ** b"), apply(sym("Pow"), vec![sym("a"), sym("b")]));
+}
+
+#[test]
+fn power_is_right_associative() {
+    assert_shape_eq(
+        lower_one("a ^ b ^ c"),
+        apply(sym("Pow"), vec![sym("a"), apply(sym("Pow"), vec![sym("b"), sym("c")])]),
+    );
+}
+
+#[test]
+fn unary_minus_lowers_to_neg() {
+    assert_shape_eq(lower_one("-x"), apply(sym("Neg"), vec![sym("x")]));
+}
+
+#[test]
+fn unary_minus_binds_looser_than_power() {
+    // -x^2 == Neg(Pow(x, 2)), not Pow(Neg(x), 2)
+    assert_shape_eq(
+        lower_one("-x^2"),
+        apply(sym("Neg"), vec![apply(sym("Pow"), vec![sym("x"), int(2)])]),
+    );
+}
+
+#[test]
+fn arithmetic_precedence_full_expression() {
+    // 2 + 3 * 4 ^ 2  ==  Add(2, Mul(3, Pow(4, 2)))
+    assert_shape_eq(
+        lower_one("2 + 3 * 4 ^ 2"),
+        apply(
+            sym("Add"),
+            vec![int(2), apply(sym("Mul"), vec![int(3), apply(sym("Pow"), vec![int(4), int(2)])])],
+        ),
+    );
+}
+
+// --- comparisons ------------------------------------------------------------
+
+#[test]
+fn every_comparison_operator_lowers_to_its_canonical_head() {
+    assert_shape_eq(lower_one("a = b"), apply(sym("Equal"), vec![sym("a"), sym("b")]));
+    assert_shape_eq(lower_one("a ~= b"), apply(sym("NotEqual"), vec![sym("a"), sym("b")]));
+    assert_shape_eq(lower_one("a < b"), apply(sym("Less"), vec![sym("a"), sym("b")]));
+    assert_shape_eq(lower_one("a <= b"), apply(sym("LessEqual"), vec![sym("a"), sym("b")]));
+    assert_shape_eq(lower_one("a > b"), apply(sym("Greater"), vec![sym("a"), sym("b")]));
+    assert_shape_eq(lower_one("a >= b"), apply(sym("GreaterEqual"), vec![sym("a"), sym("b")]));
+}
+
+#[test]
+fn comparison_binds_looser_than_additive() {
+    assert_shape_eq(
+        lower_one("a + 1 = b - 1"),
+        apply(
+            sym("Equal"),
+            vec![
+                apply(sym("Add"), vec![sym("a"), int(1)]),
+                apply(sym("Sub"), vec![sym("b"), int(1)]),
+            ],
+        ),
+    );
+}
+
+// --- `:=` immediate assignment --------------------------------------------
+
+#[test]
+fn assignment_lowers_to_assign_apply() {
+    assert_shape_eq(lower_one("x := 5"), apply(sym("Assign"), vec![sym("x"), int(5)]));
+}
+
+#[test]
+fn chained_assignment_right_associates() {
+    assert_shape_eq(
+        lower_one("a := b := 5"),
+        apply(sym("Assign"), vec![sym("a"), apply(sym("Assign"), vec![sym("b"), int(5)])]),
+    );
+}
+
+// --- `==` function definition: declared and undeclared forms -------------
+
+#[test]
+fn declared_function_definition_lowers_to_define_dropping_type_annotations() {
+    // power(x: Integer, n: NonNegativeInteger): Integer == x ** n
+    // -- parameter/return type annotations are dropped entirely (see
+    // src/lower.rs's own disclosed design decision).
+    assert_shape_eq(
+        lower_one("power(x: Integer, n: NonNegativeInteger): Integer == x ** n"),
+        apply(
+            sym("Define"),
+            vec![
+                sym("power"),
+                list(vec![sym("x"), sym("n")]),
+                apply(sym("Pow"), vec![sym("x"), sym("n")]),
+            ],
+        ),
+    );
+}
+
+#[test]
+fn declared_function_definition_with_no_parameters_lowers() {
+    assert_shape_eq(
+        lower_one("halfDollar(): Float == 2.5"),
+        apply(sym("Define"), vec![sym("halfDollar"), list(vec![]), float(2.5)]),
+    );
+}
+
+#[test]
+fn undeclared_function_definition_lowers_to_define_with_one_param() {
+    assert_shape_eq(
+        lower_one("f x == x * x"),
+        apply(
+            sym("Define"),
+            vec![sym("f"), list(vec![sym("x")]), apply(sym("Mul"), vec![sym("x"), sym("x")])],
+        ),
+    );
+}
+
+#[test]
+fn function_body_may_contain_constructs_axiom_runtime_itself_rejects() {
+    // A disclosed, real WIDENING relative to axiom-runtime's own
+    // `lower_pure_body` (see src/lower.rs's module doc comment): since
+    // everything is data here, `if` inside a body lowers exactly like a
+    // top-level `if` would.
+    assert_shape_eq(
+        lower_one("f x == if x > 0 then 1 else -1"),
+        apply(
+            sym("Define"),
+            vec![
+                sym("f"),
+                list(vec![sym("x")]),
+                apply(
+                    sym("If"),
+                    vec![
+                        apply(sym("Greater"), vec![sym("x"), int(0)]),
+                        int(1),
+                        apply(sym("Neg"), vec![int(1)]),
+                    ],
+                ),
+            ],
+        ),
+    );
+}
+
+// --- `if p then e1 else e2` -- mandatory else, no elif -------------------
+
+#[test]
+fn if_then_else_lowers_to_if_apply() {
+    assert_shape_eq(
+        lower_one("if a > 0 then 1 else -1"),
+        apply(
+            sym("If"),
+            vec![
+                apply(sym("Greater"), vec![sym("a"), int(0)]),
+                int(1),
+                apply(sym("Neg"), vec![int(1)]),
+            ],
+        ),
+    );
+}
+
+#[test]
+fn if_is_usable_as_an_assignment_right_hand_side() {
+    assert_shape_eq(
+        lower_one("x := if a > 0 then 1 else -1"),
+        apply(
+            sym("Assign"),
+            vec![
+                sym("x"),
+                apply(
+                    sym("If"),
+                    vec![
+                        apply(sym("Greater"), vec![sym("a"), int(0)]),
+                        int(1),
+                        apply(sym("Neg"), vec![int(1)]),
+                    ],
+                ),
+            ],
+        ),
+    );
+}
+
+#[test]
+fn dangling_else_attaches_to_the_nearest_if() {
+    // if a then (if b then 1 else 2) else 3
+    assert_shape_eq(
+        lower_one("if a then if b then 1 else 2 else 3"),
+        apply(
+            sym("If"),
+            vec![sym("a"), apply(sym("If"), vec![sym("b"), int(1), int(2)]), int(3)],
+        ),
+    );
+}
+
+// --- `( e1; e2; ...; eN )` parenthesised block ---------------------------
+
+#[test]
+fn a_single_expression_group_is_plain_grouping_not_a_block() {
+    assert_shape_eq(lower_one("(1 + 2) * 3"), apply(sym("Mul"), vec![apply(sym("Add"), vec![int(1), int(2)]), int(3)]));
+}
+
+#[test]
+fn a_multi_statement_group_lowers_to_compound_expression() {
+    assert_shape_eq(
+        lower_one("(a := 1; a + 1)"),
+        apply(
+            sym(COMPOUND_EXPRESSION),
+            vec![apply(sym("Assign"), vec![sym("a"), int(1)]), apply(sym("Add"), vec![sym("a"), int(1)])],
+        ),
+    );
+}
+
+#[test]
+fn a_three_statement_block_lowers_to_a_flat_n_ary_compound_expression() {
+    assert_shape_eq(
+        lower_one("(a := 1; b := 2; a + b)"),
+        apply(
+            sym(COMPOUND_EXPRESSION),
+            vec![
+                apply(sym("Assign"), vec![sym("a"), int(1)]),
+                apply(sym("Assign"), vec![sym("b"), int(2)]),
+                apply(sym("Add"), vec![sym("a"), sym("b")]),
+            ],
+        ),
+    );
+}
+
+// --- `:` declaration -- the AXIOM_DECLARE reserved head -------------------
+
+#[test]
+fn plain_declaration_lowers_to_axiom_declare() {
+    assert_shape_eq(
+        lower_one("a : PositiveInteger"),
+        apply(sym(AXIOM_DECLARE), vec![list(vec![sym("a")]), sym("PositiveInteger")]),
+    );
+}
+
+#[test]
+fn tuple_declaration_wraps_every_name_in_one_list() {
+    assert_shape_eq(
+        lower_one("(a, b, c) : Integer"),
+        apply(sym(AXIOM_DECLARE), vec![list(vec![sym("a"), sym("b"), sym("c")]), sym("Integer")]),
+    );
+}
+
+#[test]
+fn declaration_type_can_be_a_parameterized_domain() {
+    assert_shape_eq(
+        lower_one("a : Fraction(Integer)"),
+        apply(sym(AXIOM_DECLARE), vec![list(vec![sym("a")]), apply(sym("Fraction"), vec![sym("Integer")])]),
+    );
+}
+
+#[test]
+fn declaration_manifest_only_declares_symbolic_expr_never_pattern_matching() {
+    let module = compile_source("a : Integer", "test").unwrap();
+    assert!(manifest_has(&module, Feature::SymbolicExpr));
+    assert!(!manifest_has(&module, Feature::PatternMatching));
+}
+
+// --- `::` coercion -- the AXIOM_COERCE reserved head ----------------------
+
+#[test]
+fn coercion_lowers_to_axiom_coerce() {
+    assert_shape_eq(
+        lower_one("3 :: Fraction(Integer)"),
+        apply(sym(AXIOM_COERCE), vec![int(3), apply(sym("Fraction"), vec![sym("Integer")])]),
+    );
+}
+
+#[test]
+fn coercion_type_accepts_the_paren_optional_shorthand() {
+    // `3 :: Fraction Integer` -- the shorthand's single bare-NAME argument
+    // is itself lowered as a leaf SymSymbol, never further nested.
+    assert_shape_eq(
+        lower_one("3 :: Fraction Integer"),
+        apply(sym(AXIOM_COERCE), vec![int(3), apply(sym("Fraction"), vec![sym("Integer")])]),
+    );
+}
+
+#[test]
+fn coercion_left_hand_side_can_be_a_computed_expression() {
+    assert_shape_eq(
+        lower_one("(1 + 2) :: Float"),
+        apply(sym(AXIOM_COERCE), vec![apply(sym("Add"), vec![int(1), int(2)]), sym("Float")]),
+    );
+}
+
+#[test]
+fn coercion_binds_tighter_than_comparison() {
+    // x :: Integer = y  ==  Equal(Coerce(x, Integer), y)
+    assert_shape_eq(
+        lower_one("x :: Integer = y"),
+        apply(
+            sym("Equal"),
+            vec![apply(sym(AXIOM_COERCE), vec![sym("x"), sym("Integer")]), sym("y")],
+        ),
+    );
+}
+
+#[test]
+fn coercion_binds_looser_than_additive() {
+    // a + b :: Float  ==  Coerce(Add(a, b), Float)
+    assert_shape_eq(
+        lower_one("a + b :: Float"),
+        apply(sym(AXIOM_COERCE), vec![apply(sym("Add"), vec![sym("a"), sym("b")]), sym("Float")]),
+    );
+}
+
+// --- `has` category-membership query -- the AXIOM_HAS reserved head ------
+
+#[test]
+fn has_query_lowers_to_axiom_has() {
+    assert_shape_eq(
+        lower_one("Polynomial(Integer) has Ring"),
+        apply(sym(AXIOM_HAS), vec![apply(sym("Polynomial"), vec![sym("Integer")]), sym("Ring")]),
+    );
+}
+
+#[test]
+fn has_query_over_a_list_domain() {
+    assert_shape_eq(
+        lower_one("List(Integer) has Ring"),
+        apply(sym(AXIOM_HAS), vec![apply(sym("List"), vec![sym("Integer")]), sym("Ring")]),
+    );
+}
+
+#[test]
+fn has_query_reachable_through_explicit_parens_as_an_arithmetic_operand() {
+    assert_shape_eq(
+        lower_one("1 + (Integer has Ring)"),
+        apply(sym("Add"), vec![int(1), apply(sym(AXIOM_HAS), vec![sym("Integer"), sym("Ring")])]),
+    );
+}
+
+// --- deeply nested explicit type constructors -----------------------------
+
+#[test]
+fn deeply_nested_type_constructor_lowers_structurally() {
+    assert_shape_eq(
+        lower_one("a : List(Matrix(Polynomial(Integer)))"),
+        apply(
+            sym(AXIOM_DECLARE),
+            vec![
+                list(vec![sym("a")]),
+                apply(
+                    sym("List"),
+                    vec![apply(sym("Matrix"), vec![apply(sym("Polynomial"), vec![sym("Integer")])])],
+                ),
+            ],
+        ),
+    );
+}
+
+#[test]
+fn explicit_empty_paren_type_constructor_lowers_to_zero_args() {
+    // `Integer()` -- syntactically valid (type_ctor_args' explicit-paren
+    // alternative allows an empty `type_expr_list`), even though no fixed
+    // built-in domain in MA13 §4's table actually takes zero constructor
+    // arguments this way; this crate is a pure syntactic lowering and does
+    // not validate arity against the fixed domain table (that is
+    // `axiom-runtime`'s own, deferred, evaluation-time concern).
+    assert_shape_eq(lower_one("a : Integer()"), apply(sym(AXIOM_DECLARE), vec![list(vec![sym("a")]), apply(sym("Integer"), vec![])]));
+}
+
+// --- error paths -----------------------------------------------------------
+
+#[test]
+fn a_parse_error_surfaces_as_a_lower_error() {
+    assert!(compile_source("1 +", "test").is_err());
+    assert!(compile_source("has Ring", "test").is_err());
+}
+
+#[test]
+fn trailing_garbage_after_one_full_expression_is_rejected() {
+    // program = expr, so a second statement with no separator is a syntax
+    // error, matching axiom-parser's own confirmed behaviour.
+    assert!(compile_source("a := 1 b := 2", "test").is_err());
+}
+
+// --- DoS guards -------------------------------------------------------------
+
+#[test]
+fn a_wide_flat_additive_chain_is_rejected_before_building_an_oversized_tree() {
+    let src = (0..2000).map(|_| "1").collect::<Vec<_>>().join(" + ");
+    assert!(compile_source(&src, "test").is_err());
+}
+
+#[test]
+fn a_wide_arglist_is_rejected() {
+    let args = (0..2000).map(|i| i.to_string()).collect::<Vec<_>>().join(", ");
+    let src = format!("f({args})");
+    assert!(compile_source(&src, "test").is_err());
+}
+
+#[test]
+fn a_wide_list_literal_is_rejected() {
+    let elems = (0..2000).map(|i| i.to_string()).collect::<Vec<_>>().join(", ");
+    let src = format!("[{elems}]");
+    assert!(compile_source(&src, "test").is_err());
+}
+
+#[test]
+fn a_wide_tuple_declaration_is_rejected() {
+    let names = (0..2000).map(|i| format!("v{i}")).collect::<Vec<_>>().join(", ");
+    let src = format!("({names}) : Integer");
+    assert!(compile_source(&src, "test").is_err());
+}
+
+#[test]
+fn reasonable_nesting_still_lowers_successfully() {
+    assert!(compile_source("1 + 1 + 1 + 1 + 1", "test").is_ok());
+    assert!(compile_source("f(g(h(1)))", "test").is_ok());
+    assert!(compile_source("a : List(Matrix(Polynomial(Integer)))", "test").is_ok());
+}
+
+// --- comments (lexer-level, invisible here) -------------------------------
+
+#[test]
+fn comments_are_skipped() {
+    assert_shape_eq(lower_one("-- a comment\nx := 1 -- trailing"), apply(sym("Assign"), vec![sym("x"), int(1)]));
+}
+
+// --- a complex, multi-construct program -----------------------------------
+
+#[test]
+fn a_realistic_program_combining_declaration_definition_and_if_lowers_end_to_end() {
+    let module = compile_source(
+        "(a : PositiveInteger; a := 5; f(x: Integer): Integer == if x > 0 then x else -x; f(a))",
+        "test",
+    )
+    .unwrap_or_else(|e| panic!("lowering failed: {e}"));
+    assert!(manifest_has(&module, Feature::SymbolicExpr));
+    assert!(!manifest_has(&module, Feature::PatternMatching));
+}

--- a/code/packages/rust/axiom-to-semantic-ir/tests/test_validator.rs
+++ b/code/packages/rust/axiom-to-semantic-ir/tests/test_validator.rs
@@ -1,0 +1,146 @@
+//! Structural verification of lowered modules: every module this frontend
+//! produces must pass the shared SIR validator (confirming the manifest
+//! declares exactly the SIR23 features the module actually uses — the same
+//! ground truth `semantic-ir/src/validator.rs`'s `check_expr` enforces node
+//! kind for node kind), and every module must be **accepted** by the JS
+//! backend.
+//!
+//! The three reserved head names this crate introduces
+//! (`__axiom_declare`/`__axiom_coerce`/`__axiom_has`, see `src/lower.rs`'s
+//! module doc comment for the full design decision) have no evaluation
+//! handler in any backend today — but that is a runtime-evaluation concern,
+//! not a SIR validation or backend-*acceptance* one: each is an ordinary
+//! `SymApply` node with an unusual head *name*, and the JS backend's SIR23
+//! codegen handles any `SymApply`/`SymSymbol` shape uniformly regardless of
+//! head spelling (confirmed directly by reading `semantic-ir-to-javascript`'s
+//! SIR23 `match` arms — the same fact `maple-to-semantic-ir`'s own `Set` and
+//! `reduce-to-semantic-ir`'s own `CompoundExpression`/`Cons`/… already lean
+//! on). So every construct here is still expected to validate and be
+//! accepted.
+
+use coding_adventures_axiom_to_semantic_ir::compile_source;
+use semantic_ir::backend::Backend;
+use semantic_ir::Feature;
+use semantic_ir_to_javascript::JavaScriptBackend;
+
+fn assert_valid(src: &str) -> semantic_ir::Module {
+    let module = compile_source(src, "prog").unwrap_or_else(|e| panic!("lowering failed: {e}"));
+    let report = semantic_ir::validate(&module);
+    assert!(
+        report.is_ok(),
+        "SIR validation failed for `{src}`: {:?}",
+        report.issues
+    );
+    module
+}
+
+fn assert_js_backend_accepts(module: &semantic_ir::Module) {
+    let backend = JavaScriptBackend;
+    let errors = backend.check_module(module);
+    assert!(
+        errors.is_empty(),
+        "expected the JS backend to accept a module using only SIR23 features \
+         (codegen for them has been implemented since HML01 Stream B rollout item 7): {errors:?}"
+    );
+}
+
+#[test]
+fn bare_arithmetic_validates_and_declares_symbolic_expr() {
+    let module = assert_valid("1 + 2");
+    assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
+    assert!(!module.manifest.iter().any(|f| f == Feature::PatternMatching));
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn a_string_literal_validates_and_declares_strings() {
+    let module = assert_valid("\"hello\"");
+    assert!(module.manifest.iter().any(|f| f == Feature::Strings));
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn a_declared_function_definition_and_call_validates() {
+    let module = assert_valid("power(x: Integer, n: NonNegativeInteger): Integer == x ** n");
+    assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
+    assert!(!module.manifest.iter().any(|f| f == Feature::PatternMatching));
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn an_undeclared_function_definition_validates() {
+    let module = assert_valid("f x == x * x");
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn assignment_validates() {
+    let module = assert_valid("x := 5");
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn a_list_literal_validates() {
+    let module = assert_valid("[1, 2, 3]");
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn if_then_else_validates() {
+    let module = assert_valid("if x > 0 then 1 else -1");
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn a_multi_statement_block_validates() {
+    let module = assert_valid("(a := 1; a + 1)");
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn a_declaration_validates_despite_no_shared_evaluator_for_axiom_declare() {
+    let module = assert_valid("a : PositiveInteger");
+    assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn a_tuple_declaration_validates() {
+    let module = assert_valid("(a, b, c) : Integer");
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn a_coercion_validates_despite_no_shared_evaluator_for_axiom_coerce() {
+    let module = assert_valid("3 :: Fraction(Integer)");
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn a_has_query_validates_despite_no_shared_evaluator_for_axiom_has() {
+    let module = assert_valid("Polynomial(Integer) has Ring");
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn a_deeply_nested_type_constructor_validates() {
+    let module = assert_valid("a : List(Matrix(Polynomial(Integer)))");
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn a_float_literal_module_validates_and_declares_floats() {
+    let module = assert_valid("1.5");
+    assert!(module.manifest.iter().any(|f| f == Feature::Floats));
+    assert_js_backend_accepts(&module);
+}
+
+#[test]
+fn a_complex_multi_construct_program_validates_end_to_end() {
+    let module = assert_valid(
+        "(a : PositiveInteger; a := 5; f(x: Integer): Integer == if x > 0 then x else -x; f(a))",
+    );
+    assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
+    assert!(!module.manifest.iter().any(|f| f == Feature::PatternMatching));
+    assert_js_backend_accepts(&module);
+}


### PR DESCRIPTION
## Summary

Adds `axiom-to-semantic-ir`, the frontend crate lowering `axiom-parser`'s `GrammarASTNode` CST to `semantic_ir::Module`, targeting the SIR23 symbolic-domain backend every other CAS-family language in this repo already targets (Macsyma/Wolfram/Derive/Reduce/Maple). This is **MA-13e**, the **last item in Axiom's native (non-oracle-tested) pipeline** per `code/specs/MA13-axiom-language.md` §6 — the four prior merged PRs shipped:

1. #8997 — `axiom-lexer` (MA-13b)
2. #9022 — `axiom-parser` (MA-13c)
3. #9055 — `axiom-runtime` + `axiom-repl` (MA-13d)

The next item — oracle/golden testing (native `axiom-runtime` vs. this crate → `semantic-ir-to-javascript` → `node`) — is an **explicitly separate follow-on task**, not part of this PR.

## The central design decision: how `:` / `::` / `has` lower to SIR23

MA13 §2's own finding is that `symbolic_ir::IRNode` has no domain/category concept at all. This PR's own research confirms the same is true of `semantic_ir::Expr`/`SirType`/`Feature` (SIR23's actual addition, including its already-shipped evaluator addendum) — verified directly against the current SIR23 spec and source, not assumed.

**Decision: `:`, `::`, and `has` lower as ordinary `Expr::SymApply` nodes with three new, locally-defined reserved head-name constants** — `__axiom_declare`, `__axiom_coerce`, `__axiom_has` — never added to shared `semantic-ir`/`symbolic-ir`. This mirrors the exact pattern this SIR23 family already established twice: `reduce-to-semantic-ir`'s `CompoundExpression`/`Cons`/`First`/… and `maple-to-semantic-ir`'s `Set`.

- `a : T` / `(a, b, c) : T` → `Apply(__axiom_declare, [List(names...), T])`
- `e :: T` → `Apply(__axiom_coerce, [e, T])`
- `D has C` → `Apply(__axiom_has, [D, C])`

A `type_expr` position (`Polynomial(Integer)`, `Fraction Integer`) is structurally just "a NAME, optionally applied to further arguments" — the same shape an ordinary call already has — so it lowers to the exact same `SymSymbol`/`SymApply` shapes via a dedicated `lower_type_expr`, no new node kind needed.

**Runtime-shim implementation is deliberately deferred to the follow-on oracle-testing task, not shipped in this PR.** This was a genuine judgment call, made and disclosed rather than assumed:

- The task's own suggestion was to extend the published `@coding-adventures/sir-runtime-symbolic` npm package. Verified directly (not assumed) that this is **not actually where JS-backend SIR23 evaluation lives**: the real, already-shipped evaluator (`Symbolic.evalTerm`, `HELD_HEADS = {"Assign", "Define", "If"}`, the full arithmetic/held-form/calculus dispatch) is **inlined** inside `semantic-ir-to-javascript/src/runtime.rs`'s own emitted runtime blob — confirmed by grepping that file directly.
- The `sir-runtime-symbolic` TS package (confirmed by reading its own `CHANGELOG.md`) only re-exports the structural pattern matcher and leaf-term constructors — it has no evaluator at all, and only backs the TypeScript backend, which no Stream B frontend's oracle testing exercises yet.
- Since (a) oracle/golden testing for Axiom is this task's own named separate follow-on item, and (b) every prior "new reserved head, no evaluator yet" precedent in this exact family (`Set`, `CompoundExpression`, `Cons`, `First`, `Second`, `Third`, `Rest`, `Part`, `Append`, `Reverse` — none of which have an evaluation handler in `symbolic-vm` OR `semantic-ir-to-javascript` today) shipped its frontend first and left the evaluator as later, separate work, this crate follows the identical, already-proven sequence.

Full reasoning is in `src/lower.rs`'s module doc comment and `README.md`/`CHANGELOG.md`.

## Other notable design points (all disclosed in the module doc comment)

- **`program` is a SINGLE expression**, not a repeated multi-statement worksheet — `axiom.grammar`'s own `program = expr` parses exactly one expression per call (Axiom is modeled as a numbered, per-line interactive session), a real structural difference from Maple's/Reduce's own multi-statement `lower_file` loops.
- **A disclosed widening relative to `axiom-runtime`'s own function bodies**: since everything is data here, a function body may contain `:=`/`:`/`::`/`has`/a `;`-block, none of which `axiom-runtime`'s own `lower_pure_body` currently supports (its own two-phase-incompatible interpreter design forces that narrower scope; this SIR frontend has no such constraint).
- **Declared function definitions drop type annotations rather than validate them** — matching every sibling `Define`'s shape (no argument-type field), a deliberate, narrower choice over duplicating the fixed domain table a second time in a purely syntactic frontend.
- **No logical operators, no `elif`** — `axiom.grammar` genuinely has neither, so no `check_elif_chain_length`-equivalent guard is needed.
- **The first SIR23-family frontend to construct `Expr::StrLit`** (Axiom has a `STRING` token; Derive/Reduce/Maple don't).

## Test plan

- [x] `cargo build --workspace` (excluding two known, pre-existing, unrelated platform-gated crates — `os-kernel`/`uefi` and `paint-vm-direct2d` — both fail on this host for reasons unrelated to this change, per `lessons.md`'s own documented "platform-only crates fail on the wrong OS" precedent)
- [x] `cargo test -p coding-adventures-axiom-to-semantic-ir` — 126 tests (58 unit shape tests, 41 defensive/malformed-AST adversarial tests, 15 validator/capability tests, 11 e2e `node`-execution tests, 1 doctest), all passing
- [x] `cargo test` for sibling crates (`semantic-ir`, `semantic-ir-to-javascript`, `maple-to-semantic-ir`, `reduce-to-semantic-ir`, `derive-to-semantic-ir`, `coding-adventures-idl-to-semantic-ir`) — all still passing, no regressions
- [x] `cargo clippy -p coding-adventures-axiom-to-semantic-ir --all-targets -- -D warnings` — clean
- [x] Coverage: 430/444 lines (96.85%) via `cargo tarpaulin` — exceeds the repo's 95%+ library target; remaining uncovered lines are redundant defense-in-depth safety nets (a final authoritative depth re-check after per-call depth guards already prevent construction of an oversized tree) that are structurally unreachable given the crate's own consistent depth-bookkeeping, the same situation every sibling SIR23 frontend's identical guard is in
- [x] Security review (sub-agent, Rust-specialist): **PASSED — no vulnerabilities found** (full report covers panic-safety, recursion-depth-guard consistency across all ~25 recursive call sites, allocation-size ordering relative to count guards, and test-file temp-file/subprocess handling)
- [x] Registered in `code/packages/rust/Cargo.toml` workspace `members`

Do not merge — awaiting review/CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
