### PR TITLE
fix(spice): validate MOS substrate doping

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-positive or non-finite Level-1 MOS model-card `NSUB` values with a
+  stable diagnostic before process-parameter preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `TNOM` values with a
   stable diagnostic before temperature and electrostatic preprocessing.
 - Reject negative or non-finite Level-1 MOS model-card `NSS` surface-state

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -572,6 +572,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET NSS must be finite and non-negative")
         elif canonical == "T_NOM" and (not math.isfinite(value) or value <= 0.0):
             raise ValueError(f"{name}: MOSFET TNOM must be finite and positive")
+        elif canonical == "N_SUB" and (not math.isfinite(value) or value <= 0.0):
+            raise ValueError(f"{name}: MOSFET NSUB must be finite and positive")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1011,6 +1011,17 @@ def test_mos_model_card_rejects_invalid_nominal_temperature() -> None:
             normalize_model_card("Minvalid", "nmos", {"TNOM": invalid_temperature})
 
 
+def test_mos_model_card_rejects_invalid_substrate_doping() -> None:
+    valid = normalize_model_card("Mvalid", "nmos", {"NSUB": 4.0e15})
+    assert valid.parameters["N_SUB"] == pytest.approx(4.0e15)
+
+    for invalid_doping in (0.0, -1.0, math.inf, math.nan):
+        with pytest.raises(
+            ValueError, match="MOSFET NSUB must be finite and positive"
+        ):
+            normalize_model_card("Minvalid", "nmos", {"NSUB": invalid_doping})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-positive or non-finite Level-1 MOS model-card `NSUB` values with a
+  stable diagnostic before process-parameter preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `TNOM` values with a
   stable diagnostic before temperature and electrostatic preprocessing.
 - Reject negative or non-finite Level-1 MOS model-card `NSS` surface-state

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4360,6 +4360,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET TNOM must be finite and positive".to_string(),
                 });
+            } else if canonical == "N_SUB" && (!raw_value.is_finite() || *raw_value <= 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET NSUB must be finite and positive".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -805,6 +805,20 @@ fn mos_model_card_rejects_invalid_nominal_temperature() {
 }
 
 #[test]
+fn mos_model_card_rejects_invalid_substrate_doping() {
+    let valid = normalize_model_card("Mvalid", "nmos", &[("NSUB", 4.0e15)]).unwrap();
+    assert_close(*valid.parameters.get("N_SUB").unwrap(), 4.0e15);
+
+    for invalid_doping in [0.0, -1.0, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("NSUB", invalid_doping)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET NSUB must be finite and positive"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-positive or non-finite Level-1 MOS model-card `NSUB` values with a
+  stable diagnostic before process-parameter preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `TNOM` values with a
   stable diagnostic before temperature and electrostatic preprocessing.
 - Reject negative or non-finite Level-1 MOS model-card `NSS` surface-state

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8434,6 +8434,8 @@ export function normalizeModelCard(
       throw invalidElement(name, "MOSFET NSS must be finite and non-negative");
     } else if (canonical === "T_NOM" && (!Number.isFinite(value) || value <= 0.0)) {
       throw invalidElement(name, "MOSFET TNOM must be finite and positive");
+    } else if (canonical === "N_SUB" && (!Number.isFinite(value) || value <= 0.0)) {
+      throw invalidElement(name, "MOSFET NSUB must be finite and positive");
     } else {
       normalized[canonical] = value;
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -679,6 +679,17 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects invalid MOS substrate doping", () => {
+    const valid = normalizeModelCard("Mvalid", "nmos", { NSUB: 4.0e15 });
+    expect(valid.parameters.N_SUB).toBe(4.0e15);
+
+    for (const invalidDoping of [0.0, -1.0, Number.POSITIVE_INFINITY, Number.NaN]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { NSUB: invalidDoping }),
+      ).toThrow("MOSFET NSUB must be finite and positive");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS nominal-temperature validation.
+1. Cross-language Level-1 MOS substrate-doping validation.
    - Status: current PR completion candidate.
-   - Reject non-positive or non-finite model-card `TNOM` values before
-     temperature and electrostatic preprocessing.
-   - Preserve positive nominal temperatures and stable parameter coverage
-     across Rust, Python, and TypeScript.
+   - Reject non-positive or non-finite model-card `NSUB` values before
+     process-parameter preprocessing, including when `TOX` is absent.
+   - Preserve positive substrate doping and the stricter intrinsic-density
+     requirement when `NSUB` plus `TOX` derives process parameters.
 
 ## Completed Slices
 
@@ -3643,6 +3643,13 @@ the Rust, Python, and TypeScript surfaces together.
      process-parameter preprocessing.
    - Zero and positive surface-state densities, parameter coverage, and stable
      diagnostics remain aligned across Rust, Python, and TypeScript.
+
+295. Cross-language Level-1 MOS nominal-temperature validation.
+   - Status: completed in PR 9173.
+   - Non-positive and non-finite model-card `TNOM` values are rejected before
+     temperature and electrostatic preprocessing.
+   - Positive nominal temperatures, parameter coverage, and stable diagnostics
+     remain aligned across Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject non-positive and non-finite Berkeley MOS1 `NSUB` values during model-card normalization
- preserve the stricter intrinsic-carrier-density check when `NSUB` and `TOX` drive process derivation
- keep Rust, Python, and TypeScript diagnostics, tests, changelogs, and the completion plan aligned

## Verification
- `cargo fmt -p spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- `PYTHONPATH=$(printf '%s:' ../*/src) python3.12 -m ruff check src tests`\n- `PYTHONPATH=$(printf '%s:' ../*/src) python3.12 -m pytest -q` (677 passed)\n- `npm ci`\n- `npm test` (420 passed)\n- `npm run build`