### PR TITLE
Resolve browser URLs from navigation base

### DIFF
--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,10 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- Browser render-tree extraction can now accept the fetched document URL as
+  the fallback base, including resolution of relative authored `<base href>`
+  values, so Venture can fetch relative links and inline images after HTTP
+  navigation.
 - The declarative HTML lexer now implements the current processing-instruction
   states, and the canonical 2,637-case tree corpus covers every source
   signature in the current 1,934-case upstream WPT tree-construction corpus.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -73,8 +73,10 @@ The current parser surface includes:
   hints, and required/readonly/multiple control state across document,
   content-tree, and render-tree projections
 - browser-facing URL resolution metadata for links, loadable resources, images,
-  and form actions using the document `base` href when available, while keeping
-  raw authored URLs available to browser policy code
+  and form actions using the document `base` href when available, plus
+  `parse_browser_render_tree_with_document_url` for resolving relative browser
+  content against the fetched navigation URL while keeping raw authored URLs
+  available to browser policy code
 - browser-facing link/resource scheduling metadata for preconnect, preload,
   modulepreload, prefetch, manifest, canonical, and icon links, including
   `as`, integrity, CORS/referrer policy, fetch priority, blocking, and

--- a/code/packages/rust/html-parser/src/lib.rs
+++ b/code/packages/rust/html-parser/src/lib.rs
@@ -652,9 +652,32 @@ pub fn parse_browser_render_tree(source: &str) -> Result<BrowserRenderTree, Pars
     parse_html(source).map(|document| extract_browser_render_tree(&document))
 }
 
+/// Parse HTML into a browser render tree using the fetched document URL as
+/// the fallback base for relative links and resources.
+///
+/// An authored `<base href>` still takes precedence. Relative authored base
+/// URLs are first resolved against `document_url`, matching the navigation
+/// context a browser host supplies after redirects.
+pub fn parse_browser_render_tree_with_document_url(
+    source: &str,
+    document_url: &str,
+) -> Result<BrowserRenderTree, ParseError> {
+    parse_html(source)
+        .map(|document| extract_browser_render_tree_with_document_url(&document, document_url))
+}
+
 /// Extract a browser-facing render-tree input from a parsed DOM document.
 pub fn extract_browser_render_tree(document: &Document) -> BrowserRenderTree {
     BrowserRenderTree::from_document(document)
+}
+
+/// Extract a browser render tree using the fetched document URL as its
+/// fallback URL-resolution base.
+pub fn extract_browser_render_tree_with_document_url(
+    document: &Document,
+    document_url: &str,
+) -> BrowserRenderTree {
+    BrowserRenderTree::from_document_with_document_url(document, document_url)
 }
 
 /// Parse a complete HTML string into a DOM document plus lexer/parser diagnostics.
@@ -4077,10 +4100,16 @@ impl BrowserDocument {
 
 impl BrowserContentTree {
     pub fn from_document(document: &Document) -> Self {
-        let head = find_first_element_in_nodes(&document.children, "head");
-        let base_href = head
-            .and_then(|element| find_first_element_in_nodes(&element.children, "base"))
-            .and_then(|element| element.attribute("href"));
+        let base_href = browser_authored_base_href(document);
+        Self::from_document_with_base(document, base_href)
+    }
+
+    pub fn from_document_with_document_url(document: &Document, document_url: &str) -> Self {
+        let base_href = browser_effective_base_href(document, document_url);
+        Self::from_document_with_base(document, base_href.as_deref())
+    }
+
+    fn from_document_with_base(document: &Document, base_href: Option<&str>) -> Self {
         let body = find_first_element_in_nodes(&document.children, "body");
         let body_children = body
             .map(|element| element.children.as_slice())
@@ -4104,6 +4133,13 @@ impl BrowserContentTree {
 impl BrowserRenderTree {
     pub fn from_document(document: &Document) -> Self {
         Self::from_content_tree(&BrowserContentTree::from_document(document))
+    }
+
+    pub fn from_document_with_document_url(document: &Document, document_url: &str) -> Self {
+        Self::from_content_tree(&BrowserContentTree::from_document_with_document_url(
+            document,
+            document_url,
+        ))
     }
 
     pub fn from_content_tree(content_tree: &BrowserContentTree) -> Self {
@@ -13451,6 +13487,23 @@ fn resolve_browser_url(url: &str, base_href: Option<&str>) -> Option<String> {
     };
 
     Some(format!("{scheme}://{authority}{resolved_path}{suffix}"))
+}
+
+fn browser_authored_base_href(document: &Document) -> Option<&str> {
+    find_first_element_in_nodes(&document.children, "head")
+        .and_then(|element| find_first_element_in_nodes(&element.children, "base"))
+        .and_then(|element| element.attribute("href"))
+}
+
+fn browser_effective_base_href(document: &Document, document_url: &str) -> Option<String> {
+    let document_url = document_url.trim();
+    if !is_absolute_url(document_url) {
+        return None;
+    }
+
+    browser_authored_base_href(document)
+        .and_then(|base_href| resolve_browser_url(base_href, Some(document_url)))
+        .or_else(|| Some(document_url.to_string()))
 }
 
 fn is_absolute_url(url: &str) -> bool {

--- a/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
+++ b/code/packages/rust/html-parser/tests/browser_render_tree_test.rs
@@ -1,5 +1,6 @@
 use coding_adventures_html_parser::{
-    parse_browser_render_tree, BrowserRenderNode, BrowserRenderTree,
+    parse_browser_render_tree, parse_browser_render_tree_with_document_url, BrowserRenderNode,
+    BrowserRenderTree,
 };
 use serde::Deserialize;
 
@@ -393,6 +394,55 @@ fn browser_render_tree_cases_extract_default_display_structure() {
             case.id
         );
     }
+}
+
+#[test]
+fn navigation_document_url_resolves_relative_links_and_images() {
+    let tree = parse_browser_render_tree_with_document_url(
+        "<body><p><a href=next.html>Next</a><img src=../images/logo.gif alt=Logo>",
+        "http://example.test/docs/current.html",
+    )
+    .expect("navigation HTML should parse");
+
+    let link = find_render_node(&tree.children, "link").expect("link should be projected");
+    assert_eq!(
+        link.resolved_href.as_deref(),
+        Some("http://example.test/docs/next.html")
+    );
+
+    let image = find_render_node(&tree.children, "image").expect("image should be projected");
+    assert_eq!(
+        image.resolved_src.as_deref(),
+        Some("http://example.test/images/logo.gif")
+    );
+}
+
+#[test]
+fn relative_authored_base_resolves_against_navigation_document_url() {
+    let tree = parse_browser_render_tree_with_document_url(
+        "<head><base href=../assets/ ></head><body><a href=guide.html>Guide</a>",
+        "http://example.test/docs/current.html",
+    )
+    .expect("navigation HTML should parse");
+
+    let link = find_render_node(&tree.children, "link").expect("link should be projected");
+    assert_eq!(
+        link.resolved_href.as_deref(),
+        Some("http://example.test/assets/guide.html")
+    );
+}
+
+fn find_render_node<'a>(
+    nodes: &'a [BrowserRenderNode],
+    role: &str,
+) -> Option<&'a BrowserRenderNode> {
+    nodes.iter().find_map(|node| {
+        if node.role == role {
+            Some(node)
+        } else {
+            find_render_node(&node.children, role)
+        }
+    })
 }
 
 impl ExpectedRenderTree {

--- a/code/specs/BR01-venture-browser.md
+++ b/code/specs/BR01-venture-browser.md
@@ -57,8 +57,11 @@ link regions, resolves host-fetched GIF/JPEG image bytes into shared pixels,
 and proves text and inline-image scenes rasterize to RGBA pixels with Cairo.
 Fetch/decode failures now render clipped bordered HTML `alt` text. The concrete
 `http1-client` now composes URL parsing, bounded TCP I/O, HTTP response framing,
-and relative redirects into a synchronous HTTP/1.0 GET transport. The platform
-host must still wire fetched page and image bytes through navigation to pixels.
+and relative redirects into a synchronous HTTP/1.0 GET transport. Browser
+render-tree extraction can now use the final fetched document URL as its
+fallback base, so relative links and inline images remain fetchable even when
+the page omits `<base>`. The platform host must still compose those stages
+through navigation to pixels.
 
 ## Where It Fits
 


### PR DESCRIPTION
## Summary

- add document-URL-aware browser render-tree parsing and extraction APIs
- use the final fetched URL as the fallback base for relative links and resources
- resolve relative authored `<base href>` values against the navigation URL
- retain the existing parser entry points and their current behavior

## Why

Venture can now fetch a page over HTTP, but pages without an absolute `<base>` leave ordinary relative links and inline images unresolved. The host needs the final post-redirect document URL threaded into browser projection before it can compose navigation and image fetching reliably.

## Validation

- `cargo test -p coding-adventures-html-parser -- --nocapture`
- `cargo clippy -p coding-adventures-html-parser --all-targets -- -D warnings`
- explicit WPT/html5lib audit: tree 1934 upstream, 2637 local, 0 missing; tokenizer 6806 upstream, 7015 local raw, 0 missing, 7242 normalized, 0 skipped
- `git diff --check`

`cargo fmt -p coding-adventures-html-parser -- --check` still reports pre-existing formatting drift elsewhere in the crate; this PR does not rewrite unrelated lines.