### PR TITLE
feat(adj-formula-stdlib): driving pressure — StatPearls plateau−PEEP ventilator library (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_driving_pressure_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_driving_pressure_e2e.rs
@@ -1,0 +1,139 @@
+//! End-to-end tests for the `clinical/driving-pressure.adj` library — the driving-pressure relation
+//! (driving pressure = plateau pressure − PEEP) and its two exact rearrangements — driven through the
+//! built CLI binary against the SHIPPED stdlib. The same invariant as every other formula library: a
+//! consumer states NO arithmetic; it imports the grounded library, binds the measured airway pressures
+//! with `observe`, and the engine applies the cited definition on the CPU, computing the EXACT value
+//! and rendering the citation and trust tier in the `derived` section (the auditable answer). The three
+//! formulas INVERT around the worked case plateau pressure = 30, PEEP = 10: 30 − 10 = 20 (driving
+//! pressure), 20 + 10 = 30 (plateau pressure), 30 − 20 = 10 (PEEP). The three asserted values (20, 30,
+//! 10) are distinct, none a colon-anchored prefix of another rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped driving-pressure library, resolved from this crate's manifest dir so
+/// the test is location-independent.
+fn shipped_dp_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/driving-pressure.adj")
+        .canonicalize()
+        .expect("shipped driving-pressure.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_dp_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_dp_lib()).unwrap();
+    std::fs::write(dir.join("driving-pressure.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// driving_pressure — the relation: plateau pressure − PEEP.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_driving_pressure_library_and_computes_it_with_citation() {
+    let dir = scratch("dp");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"driving-pressure.adj\"\n\
+         observe plateau_pressure(30)\n\
+         observe peep(10)\n\
+         ? driving_pressure(plateau_pressure, peep)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied definition's result: 30 − 10 = 20.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"driving_pressure\"") && s.contains("\"value\":20"),
+        "driving_pressure(30, 10) = 20: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// plateau_pressure — the same definition solved for the plateau pressure: ΔP + PEEP.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_plateau_pressure_from_driving_pressure_with_citation() {
+    let dir = scratch("pplat");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"driving-pressure.adj\"\n\
+         observe driving_pressure(20)\n\
+         observe peep(10)\n\
+         ? plateau_pressure(driving_pressure, peep)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 20 + 10 = 30, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"plateau_pressure\"") && s.contains("\"value\":30"),
+        "plateau_pressure(20, 10) = 30: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "plateau_pressure carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// peep — the same definition solved for the PEEP: plateau pressure − ΔP, the third reading of the one
+// definition.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_peep_from_plateau_and_driving_pressure_with_citation() {
+    let dir = scratch("peep");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"driving-pressure.adj\"\n\
+         observe plateau_pressure(30)\n\
+         observe driving_pressure(20)\n\
+         ? peep(plateau_pressure, driving_pressure)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 30 − 20 = 10, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"peep\"") && s.contains("\"value\":10"),
+        "peep(30, 20) = 10: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "peep carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/driving-pressure.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/driving-pressure.adj
@@ -1,0 +1,91 @@
+% ============================================================================
+% driving-pressure.adj — the ventilator driving pressure
+% (driving pressure = plateau pressure − PEEP) in the ADJ standard library.
+% ============================================================================
+% The driving-pressure entry of the *clinical* track — the lung-protective-ventilation quantity that,
+% in ARDS and mechanically ventilated patients, indexes the tidal volume delivered relative to the
+% aerated ("functional") lung compliance, and whose elevation tracks mortality. THE DRIVING PRESSURE
+% IS THE PLATEAU PRESSURE MINUS THE POSITIVE END-EXPIRATORY PRESSURE (PEEP). It ships as an importable,
+% byte-provenanced, PARAMETERIZED `formula`, together with its two exact rearrangements (the plateau
+% pressure a driving pressure implies at a given PEEP, and the PEEP it implies at a given plateau
+% pressure). As with every compute library, a consumer states NO arithmetic: it `import`s this file,
+% binds the measured airway pressures from its own byte-provenance decomposition, and asks the engine
+% to APPLY the cited definition on the CPU. Zero math is performed by the model; the engine computes
+% each value EXACTLY (over exact rationals), carrying the definition's citation.
+%
+%     import "driving-pressure.adj"
+%     observe plateau_pressure(30)   % "…plateau pressure 30 cmH2O…"   (span cited by the model)
+%     observe peep(10)                % "…PEEP 10 cmH2O…"               (span cited by the model)
+%     ? driving_pressure(plateau_pressure, peep)
+%                                      % engine → 20, carrying the driving pressure
+%
+% All three formulas are EXACT differences/sums over their parameters, so every value the engine
+% returns is exact. They COMPOSE and invert cleanly around the worked case plateau pressure = 30,
+% PEEP = 10 (driving pressure = 30 − 10 = 20): the `driving_pressure` a consumer computes is exactly the
+% value the `plateau_pressure` formula adds the PEEP back onto to recover 30, and exactly the value the
+% `peep` formula subtracts from the plateau pressure to recover 10.
+%
+%   driving_pressure(plateau_pressure, peep) = plateau_pressure - peep   % ΔP = Pplat − PEEP  (definition)
+%   plateau_pressure(driving_pressure, peep) = driving_pressure + peep    % Pplat = ΔP + PEEP  (solved for Pplat)
+%   peep(plateau_pressure, driving_pressure) = plateau_pressure - driving_pressure  % PEEP = Pplat − ΔP  (solved for PEEP)
+%
+% NOTE ON UNITS AND MODELLING: the plateau pressure and PEEP must be in the SAME pressure unit (they
+% subtract), and the driving pressure carries that unit (customarily cmH2O). The plateau pressure is
+% the end-inspiratory airway pressure measured during an inspiratory hold (no gas flow); PEEP is the
+% end-expiratory airway pressure. The cited article states the relation as prose — "Calculating the
+% driving pressure involves subtracting the PEEP level from the plateau pressure" — which is exactly
+% the definition read forward; the two rearrangements are the same relation solved for each input.
+%
+% All three formulas are defended by the SAME clause — "Calculating the driving pressure involves
+% subtracting the PEEP level from the plateau pressure." — because that one statement (the driving
+% pressure IS the plateau-pressure-minus-PEEP difference) sanctions the relation read every way. The
+% quote is transcribed verbatim from the StatPearls "Mechanical Ventilation" article on the NCBI
+% Bookshelf (a current, non-archived article), so each `formula` carries the provenance envelope every
+% shipped grounded clause carries; the linter rejects an unsourced one. (See
+% feedback_nothing_human_authored — the statement is a verbatim span of the cited page, not asserted
+% from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable airway pressure the definition ranges over, and each
+% result is a derived pressure. `plateau_pressure`, `peep` and `driving_pressure` each appear BOTH as a
+% derived result and as an input (of the other formulas), so each is a single dictionary term used in
+% both roles. The `surface` lists are the everyday names a decomposer maps onto the canonical term; the
+% trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary driving_pressure_vocab {
+    define plateau_pressure : finding  surface "plateau pressure", "Pplat", "plateau airway pressure"   % pressure (e.g. cmH2O)
+    define peep             : finding  surface "PEEP", "positive end-expiratory pressure"                % pressure (e.g. cmH2O)
+    define driving_pressure : finding  surface "driving pressure", "delta P", "transpulmonary driving pressure"  % pressure (e.g. cmH2O)
+}
+
+% ----------------------------------------------------------------------------
+% The definition, all three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the driving-pressure statement from the StatPearls
+% "Mechanical Ventilation" article on the NCBI Bookshelf (a quote is required on a shipped formula).
+% Each is an exact difference or sum of the measured pressures, so the engine returns each value
+% EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook driving_pressure_laws {
+    use driving_pressure_vocab
+
+    % Driving pressure — the plateau pressure minus the PEEP.
+    formula driving_pressure(plateau_pressure, peep) = plateau_pressure - peep
+        source "Calculating the driving pressure involves subtracting the PEEP level from the plateau pressure."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK539742/"
+        trust authoritative
+
+    % Plateau pressure — the same definition solved for the plateau pressure (Pplat = ΔP + PEEP).
+    % Defended by the SAME statement.
+    formula plateau_pressure(driving_pressure, peep) = driving_pressure + peep
+        source "Calculating the driving pressure involves subtracting the PEEP level from the plateau pressure."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK539742/"
+        trust authoritative
+
+    % PEEP — the same definition solved for the PEEP (PEEP = Pplat − ΔP): the plateau pressure minus the
+    % driving pressure. The SAME statement, read the third way.
+    formula peep(plateau_pressure, driving_pressure) = plateau_pressure - driving_pressure
+        source "Calculating the driving pressure involves subtracting the PEEP level from the plateau pressure."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK539742/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/driving-pressure.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/driving-pressure.query.adj
@@ -1,0 +1,27 @@
+% ============================================================================
+% driving-pressure.query.adj — worked applications of the driving-pressure definition.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a ventilator vignette into observed airway
+% pressures: it `import`s the grounded formulabook, `observe`s the plateau pressure and the PEEP, and
+% asks the engine to APPLY the cited definition. No arithmetic is stated by the consumer; the engine
+% computes each value EXACTLY (over exact rationals) and carries the article's citation as its proof,
+% on the CPU, with zero model calls.
+%
+% Worked case (plateau pressure = 30 cmH2O, PEEP = 10 cmH2O): driving pressure = 30 − 10 = 20 cmH2O.
+% Each query below fixes two of the three quantities and asks the engine to recover the third; every
+% answer is exact and the three COMPOSE (each inversion recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli driving-pressure.query.adj
+% ============================================================================
+
+import "driving-pressure.adj"
+
+% --- Definition: the driving pressure the two airway pressures imply (expect 20). -------------------
+observe plateau_pressure(30)
+observe peep(10)
+? driving_pressure(plateau_pressure, peep)     % expect 20
+
+% --- Inverse: the plateau pressure a driving pressure of 20 implies at PEEP 10 (expect 30). ---------
+observe driving_pressure(20)
+? plateau_pressure(driving_pressure, peep)     % expect 30


### PR DESCRIPTION
## What

Ships a new **clinical** formula library, `clinical/driving-pressure.adj` (+ `.query.adj`), grounding the ventilator **driving pressure**:

> driving pressure = plateau pressure − PEEP

grounded **VERBATIM** in the current (non-archived) StatPearls *"Mechanical Ventilation"* article on the NCBI Bookshelf ([NBK539742](https://www.ncbi.nlm.nih.gov/books/NBK539742/)):

> "Calculating the driving pressure involves subtracting the PEEP level from the plateau pressure."

The lung-protective-ventilation quantity that, in ARDS and mechanically ventilated patients, indexes the tidal volume relative to the aerated ("functional") lung compliance, and whose elevation tracks mortality.

## How it fits the stack

One cited statement defends a `formulabook` of **three exact readings**, each carrying the same `source`/`locator`/`trust authoritative` envelope:

| formula | equation |
|---|---|
| `driving_pressure(plateau_pressure, peep)` | `plateau_pressure - peep` |
| `plateau_pressure(driving_pressure, peep)` | `driving_pressure + peep` |
| `peep(plateau_pressure, driving_pressure)` | `plateau_pressure - driving_pressure` |

A consumer states **no arithmetic**: it imports the library, `observe`s the measured airway pressures from its own byte-provenance decomposition, and the engine applies the cited definition on the CPU, computing the value **exactly** over rationals and rendering the citation + trust tier in `derived`.

## Worked case (in the dedicated e2e test)

Pplat = 30, PEEP = 10 → ΔP **20**; the inversions recover 30 and 10 exactly. The three asserted values (20, 30, 10) are distinct and collision-safe (none a colon-anchored prefix of another rendered value).

## Verification

- 3/3 e2e tests pass (`formula_driving_pressure_e2e.rs`); render-probe confirms `driving_pressure=20`, `plateau_pressure=30`, `trust:authoritative`, `ncbi.nlm.nih.gov`.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` clean.
- NUL-scan clean on all three new files.
- Source statement byte-verified via WebFetch against the current NBK539742.
- **Data + test only — no version bump.**
- Security review: **PASSED** (sub-agent, Rust + declarative-data lens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)