### PR TITLE
feat(build-tool): add Linux OCI capability preflight

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,18 +8,13 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": {
-    "item_id": "build-tool-execution-sandbox",
-    "pr_number": 9178,
-    "branch": "codex/build-tool-execution-sandbox",
-    "url": "https://github.com/adhithyan15/coding-adventures/pull/9178"
-  },
+  "active_pr": null,
   "last_inventory": {
-    "revision": "40eff9c4432049d7bd704141136662014467e167",
+    "revision": "bee64b4774b87cd43bea6c9e413e647742334f96",
     "schema_version": 2,
     "established_languages": 15,
-    "implementation_identities": 1184,
-    "implementation_package_slots": 4325,
+    "implementation_identities": 1187,
+    "implementation_package_slots": 4328,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 278,
     "canonical_collisions": 0,
@@ -56,20 +51,61 @@
     {
       "id": "build-tool-execution-sandbox",
       "title": "Define the trusted-execution policy, closed schema, and fail-closed backend contract",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-fixtures"],
       "branch": "codex/build-tool-execution-sandbox",
       "pr_number": 9178,
-      "notes": "Ready-for-review PR #9178. Refined after the contract and security audits: land the process-free policy core first, with closed execution records, immutable corpus and adapter identities, explicit operator authorization, and a backend interface that cannot fall back to host execution. This item does not execute fixture code."
+      "notes": "Merged PR #9178. The process-free policy core provides closed execution records, immutable corpus and adapter identities, explicit operator authorization, and a backend interface that cannot fall back to host execution. This item does not execute fixture code."
     },
     {
       "id": "build-tool-linux-oci-sandbox",
-      "title": "Implement the Linux OCI trusted-execution sandbox",
+      "title": "Define the Linux OCI identity, capability preflight, and invariant-probe container",
+      "status": "in-progress",
+      "depends_on": ["build-tool-execution-sandbox"],
+      "branch": "codex/build-tool-linux-oci-sandbox",
+      "pr_number": null,
+      "notes": "Selected after PR #9178 merged. Security review split the backend into a safe first tranche: a closed identity binding rootless Podman, crun, exact OCI manifest/config, seccomp, shim, and probe; fail-closed host/image preflight; and exact probe-container argv with no fixture decode or launch. The checked-in policy remains disabled and Linux unavailable until protected enforcement evidence exists."
+    },
+    {
+      "id": "build-tool-trusted-authority-bundle",
+      "title": "Bind trusted execution to the complete reviewed authority bundle",
       "status": "pending",
       "depends_on": ["build-tool-execution-sandbox"],
       "branch": null,
       "pr_number": null,
-      "notes": "Use a pinned pre-existing image identity, private mount/user/PID/network namespaces, read-only rootfs, no-new-privileges, dropped capabilities, non-root execution, bounded tmpfs, cgroup limits, streaming output accounting, and whole-container termination. Never pull or fall back to the host."
+      "notes": "Discovered during the Linux OCI security review. Replace corpus-only operator approval with one domain-separated digest binding exact source revision, policy, schemas, runner, launcher, seccomp, shim, OCI manifest/config, and adapter identity before any executable payload decode."
+    },
+    {
+      "id": "build-tool-execution-case-snapshot",
+      "title": "Bind execution to the exact approved in-memory case snapshot",
+      "status": "pending",
+      "depends_on": ["build-tool-trusted-authority-bundle"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered during the Linux OCI security review. Select the requested direct corpus member from one root-handle/no-follow bounded snapshot and execute the same hashed bytes; reject outside paths, renames, symlinks, hardlinks, case/Unicode aliases, and post-digest mutation."
+    },
+    {
+      "id": "build-tool-execution-status-normalization",
+      "title": "Normalize dependency-skip terminology and result-state invariants",
+      "status": "pending",
+      "depends_on": ["build-tool-execution-sandbox"],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered during the fixture audit. Replace the duplicated schema term dependency-skipped with normative dep-skipped and enforce built, failed, dep-skipped, would-build, return-code, command-state, and outcome consistency before execution cases enter the corpus."
+    },
+    {
+      "id": "build-tool-linux-oci-enforcement",
+      "title": "Run and police the Linux OCI invariant probe and trusted cases",
+      "status": "pending",
+      "depends_on": [
+        "build-tool-linux-oci-sandbox",
+        "build-tool-trusted-authority-bundle",
+        "build-tool-execution-case-snapshot",
+        "build-tool-execution-status-normalization"
+      ],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Execute only after the first preflight tranche. Add aggregate cgroup CPU metering, combined streaming output/result accounting, hard workspace semantics, cancellation, whole-container kill/reap/removal, image-contained adapters, adversarial runner-owned probes, and protected Linux workflow evidence before marking Linux ready."
     },
     {
       "id": "build-tool-windows-appcontainer-sandbox",
@@ -94,7 +130,7 @@
       "title": "Add execution semantics cases and adversarial sandbox probes",
       "status": "pending",
       "depends_on": [
-        "build-tool-linux-oci-sandbox",
+        "build-tool-linux-oci-enforcement",
         "build-tool-windows-appcontainer-sandbox",
         "build-tool-macos-isolated-sandbox"
       ],
@@ -293,7 +329,16 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "Current singleton leaders are Rust 538, Python 86, and TypeScript 84; do not port blindly."
+      "notes": "Current singleton leaders are Rust 542, Python 86, and TypeScript 84; do not port blindly."
+    },
+    {
+      "id": "rust-singletons-20260730-classification",
+      "title": "Classify the July 30 Rust singleton additions",
+      "status": "pending",
+      "depends_on": [],
+      "branch": null,
+      "pr_number": null,
+      "notes": "The bee64b477 inventory added axiom-to-semantic-ir, http1-client, and smart-home-discovery-service. Review axiom-to-semantic-ir as a likely portable deterministic lowering, http1-client for portable-core versus native transport boundaries, and smart-home-discovery-service as a likely native/service applicability case before opening any port PR."
     },
     {
       "id": "c-cpp-graduation",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,7 +8,12 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": null,
+  "active_pr": {
+    "item_id": "build-tool-linux-oci-sandbox",
+    "pr_number": 9189,
+    "branch": "codex/build-tool-linux-oci-sandbox",
+    "url": "https://github.com/adhithyan15/coding-adventures/pull/9189"
+  },
   "last_inventory": {
     "revision": "bee64b4774b87cd43bea6c9e413e647742334f96",
     "schema_version": 2,
@@ -60,11 +65,11 @@
     {
       "id": "build-tool-linux-oci-sandbox",
       "title": "Define the Linux OCI identity, capability preflight, and invariant-probe container",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": ["build-tool-execution-sandbox"],
       "branch": "codex/build-tool-linux-oci-sandbox",
-      "pr_number": null,
-      "notes": "Selected after PR #9178 merged. Security review split the backend into a safe first tranche: a closed identity binding rootless Podman, crun, exact OCI manifest/config, seccomp, shim, and probe; fail-closed host/image preflight; and exact probe-container argv with no fixture decode or launch. The checked-in policy remains disabled and Linux unavailable until protected enforcement evidence exists."
+      "pr_number": 9189,
+      "notes": "Ready-for-review PR #9189. Security review split the backend into a safe first tranche: a closed identity binding rootless Podman, crun, exact OCI manifest/config, seccomp, shim, and probe; fail-closed host/image preflight; and exact probe-container argv with no fixture decode or launch. Local validation covers 100 focused tests, 83% branch-aware module coverage, Ruff, Bandit, Go build-tool tests/build, parity collision checks, and build-file auditing. The checked-in policy remains disabled and Linux unavailable until protected enforcement evidence exists."
     },
     {
       "id": "build-tool-trusted-authority-bundle",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_runner.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_execution_schema.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_execution_runner.py'
+          python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_linux_oci.py'
           python3 code/scripts/build_tool_conformance.py validate-corpus
           python3 code/scripts/build_tool_conformance_execution.py validate-contract
           python3 code/scripts/package_parity_report.py --format json --fail-on-collisions > /tmp/package-parity-report.json

--- a/code/scripts/build_tool_conformance_execution.py
+++ b/code/scripts/build_tool_conformance_execution.py
@@ -3,7 +3,9 @@
 
 This module is the process-free policy layer. It deliberately imports no
 process API, creates no workspace, and has no host-execution fallback. Platform
-backends land separately; until then ``run-case`` can only return a stable
+backends land separately. The Linux OCI identity schema is checked here, but
+its process-owning capability preflight is never imported. Until later
+authority and execution tranches land, ``run-case`` can only return a stable
 non-passing result after authority checks succeed.
 """
 
@@ -374,7 +376,16 @@ def validate_contract(
         policy_schema,
         policy,
     ) = _load_contract_documents(fixture_root)
-    for schema in (case_schema, result_schema, execution_schema, policy_schema):
+    linux_oci_schema = bootstrap.load_document(
+        fixture_root / "linux-oci-backend.schema.json"
+    )
+    for schema in (
+        case_schema,
+        result_schema,
+        execution_schema,
+        policy_schema,
+        linux_oci_schema,
+    ):
         bootstrap._schema_errors({}, schema)
     bootstrap._validate_schema(
         policy,

--- a/code/scripts/build_tool_conformance_linux_oci.py
+++ b/code/scripts/build_tool_conformance_linux_oci.py
@@ -1,0 +1,727 @@
+#!/usr/bin/env python3
+"""Fail-closed Linux OCI capability preflight for trusted conformance.
+
+This is deliberately separate from ``build_tool_conformance_execution``:
+this module owns process APIs, while the authority and contract validator
+remain process-free. The first Linux tranche validates immutable backend
+identities, proves required rootless-Podman host capabilities, and constructs
+the runner-owned invariant-probe container. It never decodes or executes a
+fixture case.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import stat
+
+# This is the deliberately isolated process-owning backend.
+import subprocess  # nosec B404
+import sys
+import tempfile
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import build_tool_conformance as bootstrap
+
+DEFAULT_FIXTURE_ROOT = bootstrap.DEFAULT_FIXTURE_ROOT
+DEFAULT_IDENTITY_SCHEMA = DEFAULT_FIXTURE_ROOT / "linux-oci-backend.schema.json"
+PODMAN_PATH = Path("/usr/bin/podman")
+CRUN_PATH = Path("/usr/bin/crun")
+PODMAN_COMMAND = "/usr/bin/podman"
+CRUN_COMMAND = "/usr/bin/crun"
+MAX_RUNTIME_OUTPUT_BYTES = 262_144
+RUNTIME_TIMEOUT_SECONDS = 15.0
+REQUIRED_CGROUP_CONTROLLERS = frozenset({"cpu", "memory", "pids"})
+
+
+class LinuxOciUnavailable(RuntimeError):
+    """A stable fail-closed backend capability failure."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """Bounded result returned by a direct runtime command."""
+
+    returncode: int
+    stdout: bytes
+    stderr: bytes
+
+
+CommandRunner = Callable[[list[str], dict[str, str], float], CommandResult]
+DigestReader = Callable[[Path], str]
+
+
+def identity_sha256(raw: bytes) -> str:
+    """Return the identity of the exact descriptor bytes."""
+
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _mapping(value: object, *, code: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise LinuxOciUnavailable(code, "backend identity record is invalid")
+    return value
+
+
+def validate_identity(
+    identity: dict[str, Any],
+    schema: dict[str, Any] | None = None,
+) -> None:
+    """Validate the closed identity and cross-field digest bindings."""
+
+    selected_schema = schema or bootstrap.load_document(DEFAULT_IDENTITY_SCHEMA)
+    errors = bootstrap._schema_errors(identity, selected_schema)
+    if errors:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_IDENTITY_SCHEMA_INVALID",
+            "Linux OCI backend identity does not match its closed schema",
+        )
+    image = _mapping(identity.get("image"), code="LINUX_OCI_IDENTITY_SCHEMA_INVALID")
+    manifest = image.get("manifest_sha256")
+    reference = image.get("reference")
+    if not isinstance(reference, str) or reference.rsplit("@sha256:", 1)[-1] != manifest:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_IMAGE_IDENTITY_MISMATCH",
+            "image reference and manifest identity must match exactly",
+        )
+    shim = _mapping(identity.get("shim"), code="LINUX_OCI_IDENTITY_SCHEMA_INVALID")
+    probe = _mapping(identity.get("probe"), code="LINUX_OCI_IDENTITY_SCHEMA_INVALID")
+    if shim.get("path") == probe.get("path"):
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_IMAGE_ARTIFACT_COLLISION",
+            "shim and invariant probe must be distinct image artifacts",
+        )
+
+
+def load_identity(
+    path: Path,
+    *,
+    schema_path: Path = DEFAULT_IDENTITY_SCHEMA,
+) -> tuple[dict[str, Any], str]:
+    """Load a bounded strict identity and return it with its raw digest."""
+
+    try:
+        with bootstrap._open_regular_no_follow(path) as source:
+            raw = source.read(bootstrap.MAX_DOCUMENT_BYTES + 1)
+    except (OSError, ValueError) as error:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_IDENTITY_READ_FAILED",
+            "Linux OCI backend identity could not be read",
+        ) from error
+    if len(raw) > bootstrap.MAX_DOCUMENT_BYTES:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_IDENTITY_TOO_LARGE",
+            "Linux OCI backend identity exceeds the document ceiling",
+        )
+    try:
+        value = bootstrap.strict_load_bytes(raw)
+    except bootstrap.ConformanceError as error:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_IDENTITY_PARSE_FAILED",
+            "Linux OCI backend identity is not strict JSON",
+        ) from error
+    if not isinstance(value, dict):
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_IDENTITY_SCHEMA_INVALID",
+            "Linux OCI backend identity must be an object",
+        )
+    schema = bootstrap.load_document(schema_path)
+    validate_identity(value, schema)
+    return value, identity_sha256(raw)
+
+
+def runtime_environment(state_root: Path) -> dict[str, str]:
+    """Build the entire fixed environment for local Podman commands."""
+
+    return {
+        "HOME": str(state_root / "home"),
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "PATH": "/usr/sbin:/usr/bin:/sbin:/bin",
+        "TZ": "UTC",
+        "XDG_CONFIG_HOME": str(state_root / "config"),
+        "XDG_RUNTIME_DIR": str(state_root / "runtime"),
+    }
+
+
+def _prepare_state_root(state_root: Path) -> None:
+    if not state_root.is_absolute():
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_STATE_ROOT_INVALID",
+            "runner-owned state root must be absolute",
+        )
+    try:
+        root_status = state_root.lstat()
+    except OSError as error:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_STATE_ROOT_INVALID",
+            "runner-owned state root is unavailable",
+        ) from error
+    is_reparse = bool(
+        getattr(root_status, "st_file_attributes", 0)
+        & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+    )
+    if (
+        not stat.S_ISDIR(root_status.st_mode)
+        or stat.S_ISLNK(root_status.st_mode)
+        or is_reparse
+    ):
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_STATE_ROOT_INVALID",
+            "runner-owned state root is not a regular directory",
+        )
+    if os.name == "posix" and (
+        root_status.st_uid != os.geteuid() or stat.S_IMODE(root_status.st_mode) & 0o077
+    ):
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_STATE_ROOT_INVALID",
+            "runner-owned state root must be private to the invoking user",
+        )
+    for name in ("config", "home", "runtime", "runroot", "storage"):
+        child = state_root / name
+        try:
+            child.mkdir(mode=0o700)
+        except FileExistsError:
+            child_status = child.lstat()
+            child_reparse = bool(
+                getattr(child_status, "st_file_attributes", 0)
+                & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+            )
+            child_not_private = os.name == "posix" and (
+                child_status.st_uid != os.geteuid()
+                or stat.S_IMODE(child_status.st_mode) & 0o077
+            )
+            if (
+                not stat.S_ISDIR(child_status.st_mode)
+                or stat.S_ISLNK(child_status.st_mode)
+                or child_reparse
+                or child_not_private
+            ):
+                raise LinuxOciUnavailable(
+                    "LINUX_OCI_STATE_ROOT_INVALID",
+                    "runner-owned state directory is invalid",
+                )
+        except OSError as error:
+            raise LinuxOciUnavailable(
+                "LINUX_OCI_STATE_ROOT_INVALID",
+                "runner-owned state directory could not be created",
+            ) from error
+
+
+def _binary_digest(path: Path) -> str:
+    """Hash one root-owned, non-privileged regular binary without link following."""
+
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as error:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_BINARY_UNAVAILABLE",
+            "required Linux OCI backend binary is unavailable",
+        ) from error
+    digest = hashlib.sha256()
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode):
+            raise LinuxOciUnavailable(
+                "LINUX_OCI_BINARY_INVALID",
+                "required Linux OCI backend binary is not regular",
+            )
+        if before.st_mode & (stat.S_ISUID | stat.S_ISGID):
+            raise LinuxOciUnavailable(
+                "LINUX_OCI_BINARY_INVALID",
+                "privileged Linux OCI backend binaries are forbidden",
+            )
+        if hasattr(before, "st_uid") and before.st_uid != 0:
+            raise LinuxOciUnavailable(
+                "LINUX_OCI_BINARY_INVALID",
+                "Linux OCI backend binaries must be root-owned",
+            )
+        while chunk := os.read(descriptor, 1024 * 1024):
+            digest.update(chunk)
+        after = os.fstat(descriptor)
+        before_identity = (
+            before.st_dev,
+            before.st_ino,
+            before.st_size,
+            before.st_mtime_ns,
+        )
+        after_identity = (
+            after.st_dev,
+            after.st_ino,
+            after.st_size,
+            after.st_mtime_ns,
+        )
+        if before_identity != after_identity:
+            raise LinuxOciUnavailable(
+                "LINUX_OCI_BINARY_CHANGED",
+                "Linux OCI backend binary changed while it was hashed",
+            )
+    finally:
+        os.close(descriptor)
+    return digest.hexdigest()
+
+
+def _runtime_prefix(state_root: Path) -> list[str]:
+    return [
+        PODMAN_COMMAND,
+        "--root",
+        str(state_root / "storage"),
+        "--runroot",
+        str(state_root / "runroot"),
+        "--runtime",
+        CRUN_COMMAND,
+        "--storage-driver",
+        "vfs",
+    ]
+
+
+def _run_command(
+    argv: list[str],
+    environment: dict[str, str],
+    timeout_seconds: float,
+) -> CommandResult:
+    """Run one fixed direct command and bound all captured runtime output."""
+
+    try:
+        completed = subprocess.run(
+            argv,
+            check=False,
+            cwd=environment["HOME"],
+            env=environment,
+            input=b"",
+            capture_output=True,
+            timeout=timeout_seconds,
+            # The direct argv is constructed only by this module.
+            shell=False,  # nosec B603
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_RUNTIME_UNAVAILABLE",
+            "local Linux OCI runtime capability probe failed",
+        ) from error
+    if len(completed.stdout) + len(completed.stderr) > MAX_RUNTIME_OUTPUT_BYTES:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_RUNTIME_OUTPUT_LIMIT",
+            "local Linux OCI runtime exceeded the preflight output ceiling",
+        )
+    return CommandResult(
+        returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+    )
+
+
+def _runtime_json(result: CommandResult) -> object:
+    if result.returncode != 0:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_RUNTIME_UNAVAILABLE",
+            "local Linux OCI runtime capability probe was not successful",
+        )
+    if len(result.stdout) > MAX_RUNTIME_OUTPUT_BYTES:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_RUNTIME_OUTPUT_LIMIT",
+            "local Linux OCI runtime exceeded the preflight output ceiling",
+        )
+    try:
+        decoded = result.stdout.decode("utf-8", errors="strict")
+
+        def reject_duplicates(
+            pairs: list[tuple[str, object]],
+        ) -> dict[str, object]:
+            value: dict[str, object] = {}
+            for key, item in pairs:
+                if key in value:
+                    raise ValueError("duplicate runtime response key")
+                value[key] = item
+            return value
+
+        return json.loads(decoded, object_pairs_hook=reject_duplicates)
+    except (UnicodeDecodeError, ValueError) as error:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_RUNTIME_RESPONSE_INVALID",
+            "local Linux OCI runtime returned invalid capability data",
+        ) from error
+
+
+def validate_host_info(info_value: object, identity: Mapping[str, Any]) -> None:
+    """Prove the required local rootless-Podman host capabilities."""
+
+    info = _mapping(info_value, code="LINUX_OCI_RUNTIME_RESPONSE_INVALID")
+    host = _mapping(info.get("host"), code="LINUX_OCI_RUNTIME_RESPONSE_INVALID")
+    version = _mapping(info.get("version"), code="LINUX_OCI_RUNTIME_RESPONSE_INVALID")
+    runtime = _mapping(identity.get("runtime"), code="LINUX_OCI_IDENTITY_SCHEMA_INVALID")
+    oci_runtime = _mapping(
+        identity.get("oci_runtime"),
+        code="LINUX_OCI_IDENTITY_SCHEMA_INVALID",
+    )
+
+    if host.get("serviceIsRemote") is not False:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_REMOTE_RUNTIME",
+            "remote Podman is not a conforming Linux OCI backend",
+        )
+    security = _mapping(
+        host.get("security"),
+        code="LINUX_OCI_RUNTIME_RESPONSE_INVALID",
+    )
+    if security.get("rootless") is not True:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_ROOTFUL_RUNTIME",
+            "rootful Podman is not a conforming Linux OCI backend",
+        )
+    if security.get("seccompEnabled") is not True:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_SECCOMP_REQUIRED",
+            "seccomp is required for the Linux OCI backend",
+        )
+    if host.get("cgroupVersion") != "v2":
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_CGROUP_V2_REQUIRED",
+            "cgroup v2 is required for the Linux OCI backend",
+        )
+    controllers = host.get("cgroupControllers")
+    if (
+        not isinstance(controllers, list)
+        or not REQUIRED_CGROUP_CONTROLLERS.issubset(
+            item for item in controllers if isinstance(item, str)
+        )
+    ):
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_CGROUP_CONTROLLERS_MISSING",
+            "delegated cpu, memory, and pids controllers are required",
+        )
+    if host.get("cgroupManager") != "systemd":
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_CGROUP_MANAGER_UNSUPPORTED",
+            "rootless systemd cgroup delegation is required",
+        )
+    detected_oci_runtime = _mapping(
+        host.get("ociRuntime"),
+        code="LINUX_OCI_RUNTIME_RESPONSE_INVALID",
+    )
+    if (
+        detected_oci_runtime.get("name") != oci_runtime.get("implementation")
+        or detected_oci_runtime.get("path") != oci_runtime.get("path")
+    ):
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_CRUN_REQUIRED",
+            "the reviewed local crun runtime is required",
+        )
+    if host.get("os") != "linux" or host.get("arch") != "amd64":
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_HOST_PLATFORM_MISMATCH",
+            "Linux amd64 is required for this OCI backend identity",
+        )
+    if version.get("Version") != runtime.get("version"):
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_RUNTIME_VERSION_MISMATCH",
+            "local Podman version does not match the reviewed identity",
+        )
+
+
+def validate_image_info(
+    image_value: object,
+    identity: Mapping[str, Any],
+) -> None:
+    """Prove the exact already-present image and reject writable volumes."""
+
+    if not isinstance(image_value, list) or len(image_value) != 1:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_IMAGE_UNAVAILABLE",
+            "exact reviewed OCI image is not present locally",
+        )
+    image_info = _mapping(
+        image_value[0],
+        code="LINUX_OCI_RUNTIME_RESPONSE_INVALID",
+    )
+    image_identity = _mapping(
+        identity.get("image"),
+        code="LINUX_OCI_IDENTITY_SCHEMA_INVALID",
+    )
+    actual_config = image_info.get("Id")
+    if isinstance(actual_config, str) and actual_config.startswith("sha256:"):
+        actual_config = actual_config.removeprefix("sha256:")
+    if actual_config != image_identity.get("config_sha256"):
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_IMAGE_CONFIG_MISMATCH",
+            "local OCI image config identity does not match policy",
+        )
+    expected_manifest = f"sha256:{image_identity.get('manifest_sha256')}"
+    if image_info.get("Digest") != expected_manifest:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_IMAGE_MANIFEST_MISMATCH",
+            "local OCI image manifest identity does not match policy",
+        )
+    repo_digests = image_info.get("RepoDigests")
+    if (
+        not isinstance(repo_digests, list)
+        or image_identity.get("reference") not in repo_digests
+    ):
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_IMAGE_REFERENCE_MISMATCH",
+            "local OCI image does not retain the reviewed manifest reference",
+        )
+    if (
+        image_info.get("Os") != image_identity.get("os")
+        or image_info.get("Architecture") != image_identity.get("architecture")
+    ):
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_IMAGE_PLATFORM_MISMATCH",
+            "local OCI image platform does not match policy",
+        )
+    config = _mapping(
+        image_info.get("Config"),
+        code="LINUX_OCI_RUNTIME_RESPONSE_INVALID",
+    )
+    if config.get("Volumes") not in (None, {}):
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_IMAGE_VOLUMES_FORBIDDEN",
+            "image-declared writable volumes are forbidden",
+        )
+
+
+def _require_runner_path(path: Path, state_root: Path, label: str) -> str:
+    if not path.is_absolute():
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_RUNNER_PATH_INVALID",
+            f"runner-owned {label} path must be absolute",
+        )
+    try:
+        path.relative_to(state_root)
+    except ValueError as error:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_RUNNER_PATH_INVALID",
+            f"runner-owned {label} path escapes the private state root",
+        ) from error
+    return str(path)
+
+
+def build_probe_create_argv(
+    identity: Mapping[str, Any],
+    *,
+    limits: Mapping[str, int],
+    state_root: Path,
+    cidfile: Path,
+    seccomp_profile: Path,
+) -> list[str]:
+    """Construct the exact non-executing invariant-probe container request."""
+
+    workspace_bytes = limits.get("workspace_bytes")
+    output_bytes = limits.get("output_bytes")
+    if not isinstance(workspace_bytes, int) or workspace_bytes <= 0:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_ZERO_WORKSPACE_UNSUPPORTED",
+            "Linux OCI tmpfs workspace must have a positive hard ceiling",
+        )
+    if not isinstance(output_bytes, int) or output_bytes <= 0:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_ZERO_OUTPUT_UNSUPPORTED",
+            "Linux OCI probe output must have a positive hard ceiling",
+        )
+    process_count = limits.get("process_count")
+    memory_mib = limits.get("memory_mib")
+    if not isinstance(process_count, int) or process_count <= 0:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_LIMIT_INVALID",
+            "Linux OCI task ceiling must be positive",
+        )
+    if not isinstance(memory_mib, int) or memory_mib <= 0:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_LIMIT_INVALID",
+            "Linux OCI memory ceiling must be positive",
+        )
+
+    cidfile_value = _require_runner_path(cidfile, state_root, "container id")
+    seccomp_value = _require_runner_path(
+        seccomp_profile,
+        state_root,
+        "seccomp profile",
+    )
+    image = _mapping(identity.get("image"), code="LINUX_OCI_IDENTITY_SCHEMA_INVALID")
+    probe = _mapping(identity.get("probe"), code="LINUX_OCI_IDENTITY_SCHEMA_INVALID")
+    image_id = f"sha256:{image.get('config_sha256')}"
+    memory_bytes = memory_mib * 1024 * 1024
+
+    return [
+        *_runtime_prefix(state_root),
+        "create",
+        "--pull=never",
+        "--platform=linux/amd64",
+        f"--cidfile={cidfile_value}",
+        "--userns=nomap",
+        "--user=65532:65532",
+        "--network=none",
+        "--pid=private",
+        "--ipc=none",
+        "--uts=private",
+        "--cgroupns=private",
+        "--cgroups=enabled",
+        "--read-only=true",
+        "--read-only-tmpfs=false",
+        "--image-volume=ignore",
+        "--cap-drop=ALL",
+        "--security-opt=no-new-privileges=true",
+        f"--security-opt=seccomp={seccomp_value}",
+        f"--pids-limit={process_count}",
+        f"--memory={memory_bytes}b",
+        "--cgroup-conf=memory.swap.max=0",
+        "--cpus=1.0",
+        f"--tmpfs=/sandbox:rw,nosuid,nodev,noexec,size={workspace_bytes},mode=0700",
+        "--ulimit=core=0:0",
+        "--ulimit=nofile=64:64",
+        "--log-driver=none",
+        "--restart=no",
+        "--stop-signal=SIGKILL",
+        "--stop-timeout=0",
+        "--no-healthcheck",
+        "--systemd=false",
+        "--http-proxy=false",
+        "--no-hosts",
+        "--hostname=conformance",
+        "--umask=077",
+        "--unsetenv-all",
+        "--env=HOME=/sandbox/home",
+        "--env=TMPDIR=/sandbox/tmp",
+        "--env=LANG=C.UTF-8",
+        "--env=LC_ALL=C.UTF-8",
+        "--env=PATH=/usr/local/bin:/usr/bin:/bin",
+        "--env=TZ=UTC",
+        "--workdir=/sandbox",
+        f"--entrypoint={probe.get('path')}",
+        image_id,
+    ]
+
+
+def preflight(
+    identity: dict[str, Any],
+    *,
+    state_root: Path,
+    command_runner: CommandRunner = _run_command,
+    binary_digest: DigestReader = _binary_digest,
+    platform_name: str | None = None,
+    effective_uid: int | None = None,
+) -> dict[str, Any]:
+    """Prove host and image capabilities without creating a container."""
+
+    validate_identity(identity)
+    selected_platform = platform_name or sys.platform
+    if not selected_platform.startswith("linux"):
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_PLATFORM_UNSUPPORTED",
+            "Linux OCI backend preflight requires Linux",
+        )
+    uid = effective_uid if effective_uid is not None else os.geteuid()
+    if uid == 0:
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_ROOT_USER_FORBIDDEN",
+            "Linux OCI backend preflight must run as a non-root user",
+        )
+    runtime = _mapping(identity["runtime"], code="LINUX_OCI_IDENTITY_SCHEMA_INVALID")
+    oci_runtime = _mapping(
+        identity["oci_runtime"],
+        code="LINUX_OCI_IDENTITY_SCHEMA_INVALID",
+    )
+    if binary_digest(PODMAN_PATH) != runtime.get("sha256"):
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_RUNTIME_IDENTITY_MISMATCH",
+            "local Podman binary does not match the reviewed identity",
+        )
+    if binary_digest(CRUN_PATH) != oci_runtime.get("sha256"):
+        raise LinuxOciUnavailable(
+            "LINUX_OCI_CRUN_IDENTITY_MISMATCH",
+            "local crun binary does not match the reviewed identity",
+        )
+
+    _prepare_state_root(state_root)
+    environment = runtime_environment(state_root)
+    prefix = _runtime_prefix(state_root)
+    info = _runtime_json(
+        command_runner(
+            [*prefix, "info", "--format", "json"],
+            environment,
+            RUNTIME_TIMEOUT_SECONDS,
+        )
+    )
+    validate_host_info(info, identity)
+
+    image = _mapping(identity["image"], code="LINUX_OCI_IDENTITY_SCHEMA_INVALID")
+    image_id = f"sha256:{image.get('config_sha256')}"
+    image_details = _runtime_json(
+        command_runner(
+            [*prefix, "image", "inspect", "--format", "json", image_id],
+            environment,
+            RUNTIME_TIMEOUT_SECONDS,
+        )
+    )
+    validate_image_info(image_details, identity)
+    return {
+        "schema_version": 1,
+        "backend_kind": "linux_oci",
+        "platform": "linux",
+        "architecture": "amd64",
+        "runtime": "rootless-podman",
+        "status": "available",
+        "conformance_status": "not-run",
+    }
+
+
+def _unavailable_result(error: LinuxOciUnavailable) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "backend_kind": "linux_oci",
+        "status": "unavailable",
+        "conformance_status": "non-passing",
+        "diagnostics": [
+            {
+                "code": error.code,
+                "severity": "error",
+                "message": error.message,
+            }
+        ],
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Fail-closed Linux OCI trusted-execution capability preflight."
+    )
+    parser.add_argument("--identity", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    try:
+        arguments = parser.parse_args(argv)
+        identity, digest = load_identity(arguments.identity)
+        with tempfile.TemporaryDirectory(prefix="btconf-linux-oci-") as directory:
+            result = preflight(identity, state_root=Path(directory))
+        result["identity_sha256"] = digest
+        print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+        return 0
+    except LinuxOciUnavailable as error:
+        print(
+            json.dumps(
+                _unavailable_result(error),
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        )
+        return 1
+    except SystemExit as error:
+        return int(error.code)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/tests/test_build_tool_conformance_execution_runner.py
+++ b/code/scripts/tests/test_build_tool_conformance_execution_runner.py
@@ -29,6 +29,7 @@ def write_policy_fixture(root: Path, policy: dict[str, object]) -> Path:
         "result.schema.json",
         "execution.schema.json",
         "execution-policy.schema.json",
+        "linux-oci-backend.schema.json",
     ):
         shutil.copyfile(FIXTURE_ROOT / name, fixture_root / name)
     (fixture_root / "execution-cases").mkdir()

--- a/code/scripts/tests/test_build_tool_conformance_execution_schema.py
+++ b/code/scripts/tests/test_build_tool_conformance_execution_schema.py
@@ -433,6 +433,7 @@ class ExecutionSchemaTests(unittest.TestCase):
                 "result.schema.json",
                 "execution.schema.json",
                 "execution-policy.schema.json",
+                "linux-oci-backend.schema.json",
             ):
                 shutil.copyfile(FIXTURE_ROOT / name, root / name)
             case_root = root / "execution-cases"

--- a/code/scripts/tests/test_build_tool_conformance_linux_oci.py
+++ b/code/scripts/tests/test_build_tool_conformance_linux_oci.py
@@ -1,0 +1,639 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import build_tool_conformance as bootstrap
+import build_tool_conformance_linux_oci as linux_oci
+
+FIXTURE_ROOT = bootstrap.DEFAULT_FIXTURE_ROOT
+
+
+def backend_identity() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "backend_kind": "linux_oci",
+        "platform": "linux",
+        "architecture": "amd64",
+        "runtime": {
+            "implementation": "podman",
+            "path": "/usr/bin/podman",
+            "version": "4.9.3",
+            "sha256": "1" * 64,
+        },
+        "oci_runtime": {
+            "implementation": "crun",
+            "path": "/usr/bin/crun",
+            "sha256": "2" * 64,
+        },
+        "image": {
+            "reference": f"ghcr.io/coding-adventures/build-tool-probe@sha256:{'3' * 64}",
+            "manifest_sha256": "3" * 64,
+            "config_sha256": "4" * 64,
+            "os": "linux",
+            "architecture": "amd64",
+        },
+        "seccomp_profile_sha256": "5" * 64,
+        "shim": {
+            "path": "/usr/local/bin/build-tool-conformance-shim",
+            "sha256": "6" * 64,
+        },
+        "probe": {
+            "path": "/usr/local/bin/build-tool-conformance-probe",
+            "sha256": "7" * 64,
+        },
+    }
+
+
+def host_info() -> dict[str, object]:
+    return {
+        "host": {
+            "arch": "amd64",
+            "os": "linux",
+            "cgroupManager": "systemd",
+            "cgroupVersion": "v2",
+            "cgroupControllers": ["cpu", "io", "memory", "pids"],
+            "serviceIsRemote": False,
+            "ociRuntime": {
+                "name": "crun",
+                "path": "/usr/bin/crun",
+            },
+            "security": {
+                "rootless": True,
+                "seccompEnabled": True,
+            },
+        },
+        "version": {
+            "Version": "4.9.3",
+        },
+    }
+
+
+def image_info() -> list[dict[str, object]]:
+    identity = backend_identity()
+    image = identity["image"]
+    assert isinstance(image, dict)
+    return [
+        {
+            "Id": image["config_sha256"],
+            "Digest": f"sha256:{image['manifest_sha256']}",
+            "RepoDigests": [image["reference"]],
+            "Os": "linux",
+            "Architecture": "amd64",
+            "Config": {
+                "Volumes": None,
+            },
+        }
+    ]
+
+
+class LinuxOciBackendTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.schema = bootstrap.load_document(
+            FIXTURE_ROOT / "linux-oci-backend.schema.json"
+        )
+
+    def test_identity_schema_is_closed_and_semantics_bind_manifest(self) -> None:
+        identity = backend_identity()
+        self.assertEqual(bootstrap._schema_errors(identity, self.schema), [])
+        linux_oci.validate_identity(identity, self.schema)
+
+        unknown = copy.deepcopy(identity)
+        unknown["runtime"]["arguments"] = ["--fixture-controlled"]  # type: ignore[index]
+        self.assertTrue(bootstrap._schema_errors(unknown, self.schema))
+
+        mismatch = copy.deepcopy(identity)
+        mismatch["image"]["manifest_sha256"] = "8" * 64  # type: ignore[index]
+        with self.assertRaises(linux_oci.LinuxOciUnavailable) as raised:
+            linux_oci.validate_identity(mismatch, self.schema)
+        self.assertEqual(raised.exception.code, "LINUX_OCI_IMAGE_IDENTITY_MISMATCH")
+
+        collision = copy.deepcopy(identity)
+        collision["probe"]["path"] = collision["shim"]["path"]  # type: ignore[index]
+        with self.assertRaises(linux_oci.LinuxOciUnavailable) as raised:
+            linux_oci.validate_identity(collision, self.schema)
+        self.assertEqual(
+            raised.exception.code,
+            "LINUX_OCI_IMAGE_ARTIFACT_COLLISION",
+        )
+
+    def test_identity_loader_hashes_exact_bytes_and_rejects_invalid_input(self) -> None:
+        raw = json.dumps(
+            backend_identity(),
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "identity.json"
+            path.write_bytes(raw)
+            loaded, digest = linux_oci.load_identity(path)
+            self.assertEqual(loaded, backend_identity())
+            self.assertEqual(digest, hashlib.sha256(raw).hexdigest())
+
+            path.write_bytes(b"[]")
+            with self.assertRaises(linux_oci.LinuxOciUnavailable) as raised:
+                linux_oci.load_identity(path)
+            self.assertEqual(
+                raised.exception.code,
+                "LINUX_OCI_IDENTITY_PARSE_FAILED",
+            )
+
+            path.write_bytes(b'{"schema_version":1}')
+            with self.assertRaises(linux_oci.LinuxOciUnavailable) as raised:
+                linux_oci.load_identity(path)
+            self.assertEqual(
+                raised.exception.code,
+                "LINUX_OCI_IDENTITY_SCHEMA_INVALID",
+            )
+
+            path.write_bytes(b'{"schema_version":1,"schema_version":1}')
+            with self.assertRaises(linux_oci.LinuxOciUnavailable) as raised:
+                linux_oci.load_identity(path)
+            self.assertEqual(
+                raised.exception.code,
+                "LINUX_OCI_IDENTITY_PARSE_FAILED",
+            )
+
+        with self.assertRaises(linux_oci.LinuxOciUnavailable) as raised:
+            linux_oci.load_identity(Path("definitely-missing-identity.json"))
+        self.assertEqual(raised.exception.code, "LINUX_OCI_IDENTITY_READ_FAILED")
+
+    def test_fixed_environment_drops_host_authority(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            state_root = Path(directory)
+            environment = linux_oci.runtime_environment(state_root)
+        self.assertEqual(
+            environment,
+            {
+                "HOME": str(state_root / "home"),
+                "LANG": "C.UTF-8",
+                "LC_ALL": "C.UTF-8",
+                "PATH": "/usr/sbin:/usr/bin:/sbin:/bin",
+                "TZ": "UTC",
+                "XDG_CONFIG_HOME": str(state_root / "config"),
+                "XDG_RUNTIME_DIR": str(state_root / "runtime"),
+            },
+        )
+        for forbidden in (
+            "CONTAINER_HOST",
+            "DOCKER_HOST",
+            "GITHUB_TOKEN",
+            "HTTP_PROXY",
+            "SSH_AUTH_SOCK",
+        ):
+            self.assertNotIn(forbidden, environment)
+
+    def test_state_root_must_be_runner_owned_and_absolute(self) -> None:
+        with self.assertRaises(linux_oci.LinuxOciUnavailable) as raised:
+            linux_oci._prepare_state_root(Path("relative-state"))
+        self.assertEqual(raised.exception.code, "LINUX_OCI_STATE_ROOT_INVALID")
+
+    def test_host_preflight_requires_every_containment_primitive(self) -> None:
+        identity = backend_identity()
+        linux_oci.validate_host_info(host_info(), identity)
+
+        mutations = [
+            (("host", "serviceIsRemote"), True, "LINUX_OCI_REMOTE_RUNTIME"),
+            (("host", "security", "rootless"), False, "LINUX_OCI_ROOTFUL_RUNTIME"),
+            (("host", "cgroupVersion"), "v1", "LINUX_OCI_CGROUP_V2_REQUIRED"),
+            (
+                ("host", "cgroupControllers"),
+                ["memory", "pids"],
+                "LINUX_OCI_CGROUP_CONTROLLERS_MISSING",
+            ),
+            (
+                ("host", "ociRuntime", "name"),
+                "runc",
+                "LINUX_OCI_CRUN_REQUIRED",
+            ),
+            (
+                ("host", "security", "seccompEnabled"),
+                False,
+                "LINUX_OCI_SECCOMP_REQUIRED",
+            ),
+            (
+                ("host", "cgroupManager"),
+                "cgroupfs",
+                "LINUX_OCI_CGROUP_MANAGER_UNSUPPORTED",
+            ),
+            (
+                ("host", "arch"),
+                "arm64",
+                "LINUX_OCI_HOST_PLATFORM_MISMATCH",
+            ),
+            (
+                ("version", "Version"),
+                "5.8.3",
+                "LINUX_OCI_RUNTIME_VERSION_MISMATCH",
+            ),
+        ]
+        for path, value, code in mutations:
+            mutated = copy.deepcopy(host_info())
+            cursor = mutated
+            for part in path[:-1]:
+                cursor = cursor[part]  # type: ignore[assignment,index]
+            cursor[path[-1]] = value  # type: ignore[index]
+            with (
+                self.subTest(code=code),
+                self.assertRaises(linux_oci.LinuxOciUnavailable) as raised,
+            ):
+                linux_oci.validate_host_info(mutated, identity)
+            self.assertEqual(raised.exception.code, code)
+
+    def test_image_preflight_requires_exact_local_identity_and_no_volumes(self) -> None:
+        identity = backend_identity()
+        linux_oci.validate_image_info(image_info(), identity)
+
+        mutations = [
+            ("Id", "9" * 64, "LINUX_OCI_IMAGE_CONFIG_MISMATCH"),
+            ("Digest", f"sha256:{'9' * 64}", "LINUX_OCI_IMAGE_MANIFEST_MISMATCH"),
+            ("Os", "windows", "LINUX_OCI_IMAGE_PLATFORM_MISMATCH"),
+            ("Architecture", "arm64", "LINUX_OCI_IMAGE_PLATFORM_MISMATCH"),
+        ]
+        for field, value, code in mutations:
+            mutated = copy.deepcopy(image_info())
+            mutated[0][field] = value
+            with (
+                self.subTest(code=code),
+                self.assertRaises(linux_oci.LinuxOciUnavailable) as raised,
+            ):
+                linux_oci.validate_image_info(mutated, identity)
+            self.assertEqual(raised.exception.code, code)
+
+        volumes = copy.deepcopy(image_info())
+        volumes[0]["Config"]["Volumes"] = {"/data": {}}  # type: ignore[index]
+        with self.assertRaises(linux_oci.LinuxOciUnavailable) as raised:
+            linux_oci.validate_image_info(volumes, identity)
+        self.assertEqual(raised.exception.code, "LINUX_OCI_IMAGE_VOLUMES_FORBIDDEN")
+
+        missing = []
+        with self.assertRaises(linux_oci.LinuxOciUnavailable) as raised:
+            linux_oci.validate_image_info(missing, identity)
+        self.assertEqual(raised.exception.code, "LINUX_OCI_IMAGE_UNAVAILABLE")
+
+        reference = copy.deepcopy(image_info())
+        reference[0]["RepoDigests"] = []
+        with self.assertRaises(linux_oci.LinuxOciUnavailable) as raised:
+            linux_oci.validate_image_info(reference, identity)
+        self.assertEqual(raised.exception.code, "LINUX_OCI_IMAGE_REFERENCE_MISMATCH")
+
+    def test_runtime_response_rejects_duplicate_security_keys(self) -> None:
+        response = linux_oci.CommandResult(
+            returncode=0,
+            stdout=b'{"host":{"security":{"rootless":true,"rootless":false}}}',
+            stderr=b"",
+        )
+        with self.assertRaises(linux_oci.LinuxOciUnavailable) as raised:
+            linux_oci._runtime_json(response)
+        self.assertEqual(
+            raised.exception.code,
+            "LINUX_OCI_RUNTIME_RESPONSE_INVALID",
+        )
+
+        for result, code in (
+            (
+                linux_oci.CommandResult(returncode=1, stdout=b"", stderr=b"private"),
+                "LINUX_OCI_RUNTIME_UNAVAILABLE",
+            ),
+            (
+                linux_oci.CommandResult(returncode=0, stdout=b"{", stderr=b""),
+                "LINUX_OCI_RUNTIME_RESPONSE_INVALID",
+            ),
+            (
+                linux_oci.CommandResult(
+                    returncode=0,
+                    stdout=b"x" * (linux_oci.MAX_RUNTIME_OUTPUT_BYTES + 1),
+                    stderr=b"",
+                ),
+                "LINUX_OCI_RUNTIME_OUTPUT_LIMIT",
+            ),
+        ):
+            with (
+                self.subTest(code=code),
+                self.assertRaises(linux_oci.LinuxOciUnavailable) as raised,
+            ):
+                linux_oci._runtime_json(result)
+            self.assertEqual(raised.exception.code, code)
+
+    def test_direct_runtime_wrapper_bounds_output_and_redacts_failures(self) -> None:
+        completed = SimpleNamespace(returncode=0, stdout=b"{}", stderr=b"")
+        with mock.patch.object(linux_oci.subprocess, "run", return_value=completed) as run:
+            result = linux_oci._run_command(
+                ["/usr/bin/podman", "info"],
+                {"HOME": "/private"},
+                1.0,
+            )
+        self.assertEqual(result.stdout, b"{}")
+        self.assertFalse(run.call_args.kwargs["shell"])
+        self.assertEqual(run.call_args.args[0], ["/usr/bin/podman", "info"])
+
+        oversized = SimpleNamespace(
+            returncode=0,
+            stdout=b"x" * (linux_oci.MAX_RUNTIME_OUTPUT_BYTES + 1),
+            stderr=b"",
+        )
+        with (
+            mock.patch.object(linux_oci.subprocess, "run", return_value=oversized),
+            self.assertRaises(linux_oci.LinuxOciUnavailable) as raised,
+        ):
+            linux_oci._run_command(
+                ["/usr/bin/podman", "info"],
+                {"HOME": "/private"},
+                1.0,
+            )
+        self.assertEqual(raised.exception.code, "LINUX_OCI_RUNTIME_OUTPUT_LIMIT")
+
+        with (
+            mock.patch.object(
+                linux_oci.subprocess,
+                "run",
+                side_effect=OSError("secret host detail"),
+            ),
+            self.assertRaises(linux_oci.LinuxOciUnavailable) as raised,
+        ):
+            linux_oci._run_command(
+                ["/usr/bin/podman", "info"],
+                {"HOME": "/private"},
+                1.0,
+            )
+        self.assertEqual(raised.exception.code, "LINUX_OCI_RUNTIME_UNAVAILABLE")
+        self.assertNotIn("secret", raised.exception.message)
+
+    def test_probe_command_is_fixed_direct_argv_with_one_bounded_tmpfs(self) -> None:
+        identity = backend_identity()
+        limits = {
+            "wall_time_ms": 1000,
+            "output_bytes": 4096,
+            "workspace_bytes": 8192,
+            "process_count": 3,
+            "memory_mib": 64,
+            "cpu_time_ms": 1000,
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            state_root = Path(directory)
+            command = linux_oci.build_probe_create_argv(
+                identity,
+                limits=limits,
+                state_root=state_root,
+                cidfile=state_root / "container.cid",
+                seccomp_profile=state_root / "seccomp.json",
+            )
+
+        expected_image = f"sha256:{'4' * 64}"
+        self.assertEqual(command[0], "/usr/bin/podman")
+        self.assertIn("--pull=never", command)
+        self.assertIn("--userns=nomap", command)
+        self.assertIn("--network=none", command)
+        self.assertIn("--pid=private", command)
+        self.assertIn("--ipc=none", command)
+        self.assertIn("--uts=private", command)
+        self.assertIn("--cgroupns=private", command)
+        self.assertIn("--read-only=true", command)
+        self.assertIn("--read-only-tmpfs=false", command)
+        self.assertIn("--image-volume=ignore", command)
+        self.assertIn("--cap-drop=ALL", command)
+        self.assertIn("--security-opt=no-new-privileges=true", command)
+        self.assertIn("--cgroup-conf=memory.swap.max=0", command)
+        self.assertIn("--tmpfs=/sandbox:rw,nosuid,nodev,noexec,size=8192,mode=0700", command)
+        self.assertIn("--log-driver=none", command)
+        self.assertIn("--unsetenv-all", command)
+        self.assertEqual(command[-1], expected_image)
+        self.assertNotIn(identity["image"]["reference"], command)  # type: ignore[index]
+        self.assertFalse(any(value == "--mount" for value in command))
+        self.assertNotIn("--passwd=false", command)
+        self.assertFalse(any("fixture" in value for value in command))
+
+    def test_zero_workspace_or_output_fails_closed(self) -> None:
+        identity = backend_identity()
+        base_limits = {
+            "wall_time_ms": 1000,
+            "output_bytes": 1,
+            "workspace_bytes": 1,
+            "process_count": 1,
+            "memory_mib": 64,
+            "cpu_time_ms": 1000,
+        }
+        for field, code in (
+            ("workspace_bytes", "LINUX_OCI_ZERO_WORKSPACE_UNSUPPORTED"),
+            ("output_bytes", "LINUX_OCI_ZERO_OUTPUT_UNSUPPORTED"),
+        ):
+            limits = dict(base_limits)
+            limits[field] = 0
+            with (
+                self.subTest(field=field),
+                tempfile.TemporaryDirectory() as directory,
+                self.assertRaises(linux_oci.LinuxOciUnavailable) as raised,
+            ):
+                root = Path(directory)
+                linux_oci.build_probe_create_argv(
+                    identity,
+                    limits=limits,
+                    state_root=root,
+                    cidfile=root / "container.cid",
+                    seccomp_profile=root / "seccomp.json",
+                )
+            self.assertEqual(raised.exception.code, code)
+
+        for field in ("process_count", "memory_mib"):
+            limits = dict(base_limits)
+            limits[field] = 0
+            with (
+                self.subTest(field=field),
+                tempfile.TemporaryDirectory() as directory,
+                self.assertRaises(linux_oci.LinuxOciUnavailable) as raised,
+            ):
+                root = Path(directory)
+                linux_oci.build_probe_create_argv(
+                    identity,
+                    limits=limits,
+                    state_root=root,
+                    cidfile=root / "container.cid",
+                    seccomp_profile=root / "seccomp.json",
+                )
+            self.assertEqual(raised.exception.code, "LINUX_OCI_LIMIT_INVALID")
+
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            self.assertRaises(linux_oci.LinuxOciUnavailable) as raised,
+        ):
+            root = Path(directory)
+            linux_oci.build_probe_create_argv(
+                identity,
+                limits=base_limits,
+                state_root=root,
+                cidfile=root / "container.cid",
+                seccomp_profile=root.parent / "outside-seccomp.json",
+            )
+        self.assertEqual(raised.exception.code, "LINUX_OCI_RUNNER_PATH_INVALID")
+
+    def test_preflight_uses_only_info_and_exact_image_inspect(self) -> None:
+        identity = backend_identity()
+        calls: list[tuple[list[str], dict[str, str], float]] = []
+
+        def fake_runner(
+            argv: list[str],
+            environment: dict[str, str],
+            timeout_seconds: float,
+        ) -> linux_oci.CommandResult:
+            calls.append((argv, environment, timeout_seconds))
+            payload: object
+            if "info" in argv:
+                payload = host_info()
+            else:
+                payload = image_info()
+            return linux_oci.CommandResult(
+                returncode=0,
+                stdout=json.dumps(payload).encode("utf-8"),
+                stderr=b"",
+            )
+
+        digests = {
+            Path("/usr/bin/podman"): "1" * 64,
+            Path("/usr/bin/crun"): "2" * 64,
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            summary = linux_oci.preflight(
+                identity,
+                state_root=Path(directory),
+                command_runner=fake_runner,
+                binary_digest=lambda path: digests[path],
+                platform_name="linux",
+                effective_uid=1000,
+            )
+
+        self.assertEqual(summary["status"], "available")
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0][0][-3:], ["info", "--format", "json"])
+        self.assertEqual(
+            calls[1][0][-5:],
+            ["image", "inspect", "--format", "json", f"sha256:{'4' * 64}"],
+        )
+        self.assertTrue(all("--pull" not in argument for call in calls for argument in call[0]))
+        self.assertTrue(all("create" not in call[0] for call in calls))
+
+    def test_preflight_rejects_platform_root_and_binary_mismatch_before_spawn(
+        self,
+    ) -> None:
+        identity = backend_identity()
+        for platform_name, uid, digest, code in (
+            ("win32", 1000, "1" * 64, "LINUX_OCI_PLATFORM_UNSUPPORTED"),
+            ("linux", 0, "1" * 64, "LINUX_OCI_ROOT_USER_FORBIDDEN"),
+            ("linux", 1000, "9" * 64, "LINUX_OCI_RUNTIME_IDENTITY_MISMATCH"),
+        ):
+            calls = 0
+
+            def forbidden_runner(
+                argv: list[str],
+                environment: dict[str, str],
+                timeout_seconds: float,
+            ) -> linux_oci.CommandResult:
+                del argv, environment, timeout_seconds
+                nonlocal calls
+                calls += 1
+                raise AssertionError("runtime must not be invoked")
+
+            with (
+                self.subTest(code=code),
+                tempfile.TemporaryDirectory() as directory,
+                self.assertRaises(linux_oci.LinuxOciUnavailable) as raised,
+            ):
+                linux_oci.preflight(
+                    identity,
+                    state_root=Path(directory),
+                    command_runner=forbidden_runner,
+                    binary_digest=lambda _path, selected=digest: selected,
+                    platform_name=platform_name,
+                    effective_uid=uid,
+                )
+            self.assertEqual(raised.exception.code, code)
+            self.assertEqual(calls, 0)
+
+        digests = {
+            Path("/usr/bin/podman"): "1" * 64,
+            Path("/usr/bin/crun"): "9" * 64,
+        }
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            self.assertRaises(linux_oci.LinuxOciUnavailable) as raised,
+        ):
+            linux_oci.preflight(
+                identity,
+                state_root=Path(directory),
+                command_runner=forbidden_runner,
+                binary_digest=lambda path: digests[path],
+                platform_name="linux",
+                effective_uid=1000,
+            )
+        self.assertEqual(raised.exception.code, "LINUX_OCI_CRUN_IDENTITY_MISMATCH")
+
+    def test_cli_reports_stable_available_and_unavailable_results(self) -> None:
+        identity = backend_identity()
+        available = {
+            "schema_version": 1,
+            "backend_kind": "linux_oci",
+            "status": "available",
+            "conformance_status": "not-run",
+        }
+        stdout = io.StringIO()
+        with (
+            mock.patch.object(
+                linux_oci,
+                "load_identity",
+                return_value=(identity, "a" * 64),
+            ),
+            mock.patch.object(linux_oci, "preflight", return_value=available),
+            redirect_stdout(stdout),
+        ):
+            exit_code = linux_oci.main(["--identity", "identity.json"])
+        self.assertEqual(exit_code, 0)
+        output = json.loads(stdout.getvalue())
+        self.assertEqual(output["identity_sha256"], "a" * 64)
+
+        stdout = io.StringIO()
+        unavailable = linux_oci.LinuxOciUnavailable(
+            "LINUX_OCI_PLATFORM_UNSUPPORTED",
+            "Linux OCI backend preflight requires Linux",
+        )
+        with (
+            mock.patch.object(
+                linux_oci,
+                "load_identity",
+                side_effect=unavailable,
+            ),
+            redirect_stdout(stdout),
+        ):
+            exit_code = linux_oci.main(["--identity", "identity.json"])
+        self.assertEqual(exit_code, 1)
+        output = json.loads(stdout.getvalue())
+        self.assertEqual(
+            output["diagnostics"][0]["code"],
+            "LINUX_OCI_PLATFORM_UNSUPPORTED",
+        )
+
+    def test_identity_digest_is_raw_byte_stable(self) -> None:
+        raw = json.dumps(
+            backend_identity(),
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        self.assertEqual(
+            linux_oci.identity_sha256(raw),
+            hashlib.sha256(raw).hexdigest(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -658,6 +658,11 @@ schema layer MUST NOT be treated as an execution sandbox:
    capabilities; no host devices; a non-root identity; only explicit
    read-only inputs; a size-bounded writable tmpfs; cgroup-backed aggregate
    limits; streaming output accounting; and whole-container termination.
+   The supported v1 runtime is local, rootless Podman at the fixed absolute
+   path `/usr/bin/podman`, using local `crun`, cgroup v2, delegated `cpu`,
+   `memory`, and `pids` controllers, and seccomp. Remote Podman, rootful
+   Podman, Docker, mutable image references, PATH lookup, and best-effort
+   fallback are not conforming backends.
 3. The Windows layer requires a capability-less AppContainer or LPAC and
    private filesystem ACLs. The child is created suspended, assigned to a Job
    Object with kill-on-close, no-breakaway, process, CPU, and memory limits,
@@ -681,6 +686,46 @@ hard ceilings, backend identities, and adapter executable digests. A backend
 or adapter marked ready requires an immutable SHA-256 identity. The policy does
 not contain operator authorization: `run-case` additionally requires an
 explicit `--allow-trusted-execution` invocation flag.
+
+For `linux_oci`, `identity_sha256` is the SHA-256 of the exact raw bytes of a
+closed Linux OCI backend identity document validated by
+`linux-oci-backend.schema.json`. That document binds the Podman and `crun`
+binaries, their fixed absolute paths, the exact OCI manifest and local config
+image identities, the reviewed seccomp profile, and the in-image shim and
+runner-owned invariant probe. The image `reference` contains the manifest
+digest and MUST agree with `manifest_sha256`; a run addresses only the already
+present `sha256:<config_sha256>` image with pull disabled. The runner verifies
+both image identities, operating system, architecture, and absence of
+image-declared volumes before it creates a container.
+
+Linux capability preflight runs in a separate process-owning module. It uses
+only fixed direct argument vectors and a runner-owned sanitized environment.
+It MUST prove local non-remote rootless operation, `crun`, cgroup v2 with
+delegated `cpu`, `memory`, and `pids` controllers, seccomp, exact runtime
+binary hashes, and the exact local image. Missing or mismatched capabilities
+produce a stable non-passing result before any fixture is decoded or
+materialized.
+
+The first Linux delivery tranche contains only this identity validation,
+capability preflight, and construction of the runner-owned invariant-probe
+container. It MUST NOT decode or execute fixture commands. Its container is
+created with an exact config image identity and `--pull=never`, a private
+unmapped rootless user namespace, private PID/IPC/UTS/cgroup namespaces,
+network disabled, a read-only root with implicit writable tmpfs mounts
+disabled, all capabilities dropped, `no_new_privileges`, no devices or bind
+mounts, a fixed non-root identity and environment, and one bounded
+runner-owned tmpfs. A zero-byte workspace is rejected rather than expressed
+as `tmpfs size=0`, which can mean unlimited. Swap is disabled with the cgroup
+v2 `memory.swap.max=0` control; `--memory-swap=<memory>` is not used. CPU
+quota limits rate only, so later execution MUST also meter aggregate
+`cpu.stat usage_usec` and kill the entire container cgroup at the effective
+CPU-time ceiling.
+
+The checked-in execution policy remains disabled and Linux remains
+`unavailable` until the exact identity document and image have passed every
+runner-owned filesystem, network, environment, namespace, resource, output,
+cancellation, and descendant-termination probe in a protected Linux
+workflow. Preflight success alone never marks the backend ready.
 
 The execution-corpus digest is SHA-256 over all `*.json` cases sorted by their
 portable path relative to `execution-cases/`. For each case, append the

--- a/code/specs/fixtures/build-tool-v1/CHANGELOG.md
+++ b/code/specs/fixtures/build-tool-v1/CHANGELOG.md
@@ -30,3 +30,7 @@
 - Split Linux OCI, Windows AppContainer, macOS isolation, and the later
   execution-semantics/security-probe corpus into explicit dependent backlog
   items. The bootstrap runner remains execution-disabled.
+- Added the closed Linux OCI backend identity schema and specified the
+  fail-closed rootless-Podman capability/preflight tranche. It binds exact
+  runtime, image, seccomp, shim, and invariant-probe identities while keeping
+  the checked-in policy disabled and the execution corpus empty.

--- a/code/specs/fixtures/build-tool-v1/README.md
+++ b/code/specs/fixtures/build-tool-v1/README.md
@@ -13,6 +13,7 @@ build-tool-v1/
   execution.schema.json
   execution-policy.schema.json
   execution-policy.json
+  linux-oci-backend.schema.json
   implementations.schema.json
   implementations.json
   CHANGELOG.md
@@ -64,12 +65,27 @@ unavailable. The empty `execution-cases/*.json` set therefore has the standard
 empty SHA-256 digest. Execution cases are added only after an enforcing backend
 is reviewed.
 
+`linux-oci-backend.schema.json` closes the separate immutable identity document
+for the first Linux backend tranche. It binds exact rootless Podman, `crun`,
+OCI manifest/config, seccomp, shim, and invariant-probe identities. The
+process-owning `build_tool_conformance_linux_oci.py` preflight validates those
+identities and host capabilities without decoding a fixture or creating a
+container. No identity document is checked in while Linux remains unavailable.
+
 ## Runner
 
 Validate the complete corpus and inventory:
 
 ```text
 python code/scripts/build_tool_conformance.py validate-corpus
+```
+
+Validate a reviewed Linux OCI identity and the local non-executing capability
+preflight:
+
+```text
+python code/scripts/build_tool_conformance_linux_oci.py \
+  --identity path/to/reviewed-linux-oci-identity.json
 ```
 
 Compare one externally produced adapter result with its fixture:

--- a/code/specs/fixtures/build-tool-v1/execution-cases/README.md
+++ b/code/specs/fixtures/build-tool-v1/execution-cases/README.md
@@ -7,3 +7,7 @@ directory only after an enforcing platform backend is reviewed.
 
 The bootstrap `cases/` directory remains process-free. Never move an execution
 case there or add an execution-enabling flag to the bootstrap validator.
+
+The Linux OCI backend identity schema and process-owning capability preflight
+do not change this gate. They validate and probe runner-owned containment
+inputs only; they never decode or execute a case from this directory.

--- a/code/specs/fixtures/build-tool-v1/linux-oci-backend.schema.json
+++ b/code/specs/fixtures/build-tool-v1/linux-oci-backend.schema.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/build-tool-conformance-linux-oci-backend-v1.json",
+  "title": "Build-tool Linux OCI backend identity v1",
+  "description": "Immutable identities for the reviewed rootless-Podman backend. This record is policy data, not operator authorization.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "backend_kind",
+    "platform",
+    "architecture",
+    "runtime",
+    "oci_runtime",
+    "image",
+    "seccomp_profile_sha256",
+    "shim",
+    "probe"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "backend_kind": {
+      "const": "linux_oci"
+    },
+    "platform": {
+      "const": "linux"
+    },
+    "architecture": {
+      "const": "amd64"
+    },
+    "runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "implementation",
+        "path",
+        "version",
+        "sha256"
+      ],
+      "properties": {
+        "implementation": {
+          "const": "podman"
+        },
+        "path": {
+          "const": "/usr/bin/podman"
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+          "maxLength": 32
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "oci_runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "implementation",
+        "path",
+        "sha256"
+      ],
+      "properties": {
+        "implementation": {
+          "const": "crun"
+        },
+        "path": {
+          "const": "/usr/bin/crun"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reference",
+        "manifest_sha256",
+        "config_sha256",
+        "os",
+        "architecture"
+      ],
+      "properties": {
+        "reference": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9._/-]*@sha256:[0-9a-f]{64}$",
+          "maxLength": 512
+        },
+        "manifest_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "config_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "os": {
+          "const": "linux"
+        },
+        "architecture": {
+          "const": "amd64"
+        }
+      }
+    },
+    "seccomp_profile_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "shim": {
+      "$ref": "#/$defs/image_artifact"
+    },
+    "probe": {
+      "$ref": "#/$defs/image_artifact"
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "image_path": {
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 256,
+      "pattern": "^/(?:[A-Za-z0-9._-]+/)*[A-Za-z0-9._-]+$"
+    },
+    "image_artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "sha256"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/image_path"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    }
+  }
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -105,18 +105,18 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-inventory was regenerated on July 29, 2026 after the Haskell `barcode-1d` and
-`http-core` ports, the Go/Rust `multi-directed-graph` slice, and a new wave of
-Rust-only package families:
+inventory was regenerated on July 30, 2026 at `bee64b477` after the Haskell
+`barcode-1d` and `http-core` ports, the Go/Rust `multi-directed-graph` slice,
+and a new wave of Rust-only package families:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
 | Present in 10-15 languages | 172 | 278 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 733 | 10,262 |
+| Present in one language | 737 | 10,318 |
 
-The loop must not start by attempting 10,262 singleton ports. It should finish
+The loop must not start by attempting 10,318 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The July 29 lane audit is:
@@ -135,7 +135,7 @@ The July 29 lane audit is:
 | Perl | 251 | 0 | 63.3% |
 | Python | 496 | 1 | 100% |
 | Ruby | 294 | 0 | 70.3% |
-| Rust | 948 | 0 | 100% |
+| Rust | 952 | 0 | 100% |
 | Swift | 160 | 51 | 37.8% |
 | TypeScript | 439 | 0 | 82.2% |
 
@@ -804,8 +804,14 @@ language ports stay eligible for later dependency-shaped waves.
 
 ## Priority 4: Classify Sparse And Singleton Families
 
-The singleton inventory is led by 538 Rust, 86 Python, and 84 TypeScript
+The singleton inventory is led by 542 Rust, 86 Python, and 84 TypeScript
 packages. Classify families before opening implementation PRs.
+
+The July 30 inventory added three Rust singleton identities that now have
+explicit classification work in the loop state: `axiom-to-semantic-ir` is a
+likely portable deterministic lowering; `http1-client` needs its portable
+protocol core separated from native transport behavior; and
+`smart-home-discovery-service` is a likely native/service applicability case.
 
 ### Likely portable Rust-led families
 
@@ -922,33 +928,43 @@ Delivery order:
    input/result records, reviewed corpus and adapter digests, explicit operator
    authorization, stable backend-unavailable results, and a backend interface
    with no host-execution fallback. This tranche validates authority but never
-   executes fixture code.
-5. Implement the Linux OCI backend first. Require a pinned pre-existing image
-   identity, private mount/user/PID/network namespaces, a read-only root,
-   dropped capabilities, `no_new_privileges`, non-root execution, bounded
-   writable tmpfs, streaming output accounting, cgroup limits, and
-   whole-container termination.
-6. Implement the native Windows boundary with AppContainer or LPAC plus Job
+   executes fixture code. Completed by PR #9178.
+5. Implement the Linux OCI backend first. The selected first tranche defines a
+   closed identity for exact rootless Podman, `crun`, OCI manifest/config,
+   seccomp, shim, and invariant-probe artifacts; proves local non-remote
+   rootless operation, cgroup v2 delegation, seccomp, exact binaries, and the
+   already-present image; and constructs the exact no-pull, private-namespace,
+   read-only, capability-free probe container. It does not decode or launch a
+   fixture, and Linux remains unavailable.
+6. Before trusted Linux execution, bind operator approval to the complete
+   reviewed authority bundle, bind case selection to the exact hashed
+   root-handle/no-follow snapshot, and normalize dependency-skip/result-state
+   semantics. Then execute the runner-owned Linux invariant probe with
+   aggregate cgroup CPU metering, combined streaming output/result accounting,
+   hard writable-workspace semantics, cancellation, and verified
+   whole-container kill/reap/removal. Only protected evidence can mark Linux
+   ready.
+7. Implement the native Windows boundary with AppContainer or LPAC plus Job
    Objects and root-handle reparse-safe filesystem operations. Keep macOS
    non-passing until a signed helper or isolated VM can prove the same
    filesystem, network, resource, and tree-termination guarantees;
    `sandbox-exec` alone is not sufficient evidence.
-7. Add closed execution-semantics cases for command ordering, failure
+8. Add closed execution-semantics cases for command ordering, failure
    propagation, dependency skips, dry-run, jobs, resource locks, legacy shell
    behavior, and direct argv. Keep escape, network, environment, link-race,
    cancellation, and resource-exhaustion checks as runner-owned non-oracular
    probes.
-8. Make the Go reference pass the contract, including structured Starlark
+9. Make the Go reference pass the contract, including structured Starlark
    context/commands and the B05 Windows executor contract.
-9. Remediate existing ports in fixture-failure order: C#/F#, Python, Ruby,
+10. Remediate existing ports in fixture-failure order: C#/F#, Python, Ruby,
    Swift, TypeScript, Elixir, Rust, Perl, Haskell, and Lua. Each independent
    engine is its own PR; a reviewed shared-engine exception must be explicit.
-10. Add language-native Java and Kotlin implementations using shared JVM fixture
+11. Add language-native Java and Kotlin implementations using shared JVM fixture
    infrastructure but separate engines, then add Dart.
-11. Add the OCaml implementation after the lane foundation is stable.
-12. Decide and document whether C and C++ require native build tools before
+12. Add the OCaml implementation after the lane foundation is stable.
+13. Decide and document whether C and C++ require native build tools before
    either emerging lane graduates.
-13. Gate completion in CI: every supported implementation runs the same
+14. Gate completion in CI: every supported implementation runs the same
    conformance corpus on its applicable operating systems.
 
 Pull-request CI may validate the policy, schemas, digests, and fake-backend
@@ -970,6 +986,19 @@ land before final adapter parity:
 - model deterministic inline inputs and semantic oracles for dependency,
   standalone-prerequisite, Starlark-declaration, identity, toolchain, and path
   validation checks before admitting them to the closed v1 schema.
+
+The Linux OCI review discovered four additional dependency gates:
+
+- replace corpus-only approval with a domain-separated authority digest over
+  the exact source, policy, schemas, runner, launcher, seccomp, image, shim,
+  and adapter identities;
+- execute only the exact direct corpus member bytes from the approved
+  root-handle/no-follow snapshot, never a reopened caller path;
+- normalize `dep-skipped` terminology and enforce result-state/return-code
+  invariants before execution fixtures land;
+- separate identity/preflight and exact command construction from actual
+  containment enforcement, aggregate resource accounting, lifecycle cleanup,
+  and protected runner-owned probe evidence.
 
 ## Cross-Cutting Stream B: Introduce OCaml Safely
 


### PR DESCRIPTION
## Summary

- define a closed, hash-bound Linux OCI backend identity covering Podman, crun, the immutable image, seccomp policy, shim, and invariant probe
- add a fail-closed Linux capability preflight for rootless local Podman, crun, cgroup v2 delegation, required controllers, seccomp, and the exact local image identity
- construct the fixed no-pull, no-network, read-only, capability-dropped invariant-probe container request without decoding or executing fixture commands
- keep execution policy disabled until the separately tracked authority-bundle, case-snapshot, status-normalization, enforcement, and protected-probe work is complete
- record the dependency-shaped follow-up work in the package-parity loop state and roadmap

## Security boundary

This tranche intentionally owns only backend identity, capability discovery, and the runner-owned invariant-probe request. It does not execute fixture commands and does not add a Docker or host-process fallback. Unsupported, mismatched, remote, mutable, or partially configured environments fail closed.

The portable Podman 5.8.3 Windows client was installed locally and its published SHA-256 checksum was verified. Its live `podman create --help` output was used to verify every emitted option. The real namespace/cgroup/seccomp probe remains a protected Linux evidence gate and was not treated as validated on Windows.

## Validation

- 100 focused Python tests across parity reporting and build-tool schemas/runners, including 14 Linux OCI fake-driver tests
- `build_tool_conformance.py validate-corpus`: 30 process-free cases valid
- `build_tool_conformance_execution.py validate-contract`: empty execution digest valid; 0 adapters and 0 ready backends
- branch-aware coverage for the new Linux OCI module: 83%
- Ruff: clean
- Bandit: clean
- Python bytecode compilation: clean
- JSON state/schema validation: clean
- workflow YAML parse: clean
- `git diff --check`: clean
- package parity inventory: 0 collisions and 0 unknown buckets
- Go build-tool: `go test ./...` and `go build` pass
- build-file audit: only the 73 pre-existing `BUILD_windows` gaps already tracked by `build-file-standalone-integrity` (12 Python, 3 Swift, 58 TypeScript)

## Follow-up gates

- trusted authority bundle
- immutable execution-case snapshot
- execution-status normalization
- Linux OCI enforcement and protected invariant-probe evidence
- execution semantics after those prerequisites
