### PR TITLE
feat(spice): validate MOS oxide thickness

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-positive or non-finite Level-1 MOS model-card `TOX` values with a
+  stable diagnostic before mobility and electrostatic preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `NSUB` values with a
   stable diagnostic before process-parameter preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `TNOM` values with a

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -574,6 +574,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET TNOM must be finite and positive")
         elif canonical == "N_SUB" and (not math.isfinite(value) or value <= 0.0):
             raise ValueError(f"{name}: MOSFET NSUB must be finite and positive")
+        elif canonical == "TOX" and (not math.isfinite(value) or value <= 0.0):
+            raise ValueError(f"{name}: MOSFET TOX must be finite and positive")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1022,6 +1022,17 @@ def test_mos_model_card_rejects_invalid_substrate_doping() -> None:
             normalize_model_card("Minvalid", "nmos", {"NSUB": invalid_doping})
 
 
+def test_mos_model_card_rejects_invalid_oxide_thickness() -> None:
+    valid = normalize_model_card("Mvalid", "nmos", {"TOX": 100.0e-9})
+    assert valid.parameters["TOX"] == pytest.approx(100.0e-9)
+
+    for invalid_thickness in (0.0, -1.0, math.inf, math.nan):
+        with pytest.raises(
+            ValueError, match="MOSFET TOX must be finite and positive"
+        ):
+            normalize_model_card("Minvalid", "nmos", {"TOX": invalid_thickness})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-positive or non-finite Level-1 MOS model-card `TOX` values with a
+  stable diagnostic before mobility and electrostatic preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `NSUB` values with a
   stable diagnostic before process-parameter preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `TNOM` values with a

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4365,6 +4365,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET NSUB must be finite and positive".to_string(),
                 });
+            } else if canonical == "TOX" && (!raw_value.is_finite() || *raw_value <= 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET TOX must be finite and positive".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -819,6 +819,20 @@ fn mos_model_card_rejects_invalid_substrate_doping() {
 }
 
 #[test]
+fn mos_model_card_rejects_invalid_oxide_thickness() {
+    let valid = normalize_model_card("Mvalid", "nmos", &[("TOX", 100.0e-9)]).unwrap();
+    assert_close(*valid.parameters.get("TOX").unwrap(), 100.0e-9);
+
+    for invalid_thickness in [0.0, -1.0, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("TOX", invalid_thickness)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET TOX must be finite and positive"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-positive or non-finite Level-1 MOS model-card `TOX` values with a
+  stable diagnostic before mobility and electrostatic preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `NSUB` values with a
   stable diagnostic before process-parameter preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `TNOM` values with a

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8436,6 +8436,8 @@ export function normalizeModelCard(
       throw invalidElement(name, "MOSFET TNOM must be finite and positive");
     } else if (canonical === "N_SUB" && (!Number.isFinite(value) || value <= 0.0)) {
       throw invalidElement(name, "MOSFET NSUB must be finite and positive");
+    } else if (canonical === "TOX" && (!Number.isFinite(value) || value <= 0.0)) {
+      throw invalidElement(name, "MOSFET TOX must be finite and positive");
     } else {
       normalized[canonical] = value;
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -690,6 +690,17 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects invalid MOS oxide thickness", () => {
+    const valid = normalizeModelCard("Mvalid", "nmos", { TOX: 100.0e-9 });
+    expect(valid.parameters.TOX).toBe(100.0e-9);
+
+    for (const invalidThickness of [0.0, -1.0, Number.POSITIVE_INFINITY, Number.NaN]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { TOX: invalidThickness }),
+      ).toThrow("MOSFET TOX must be finite and positive");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS substrate-doping validation.
+1. Cross-language Level-1 MOS oxide-thickness validation.
    - Status: current PR completion candidate.
-   - Reject non-positive or non-finite model-card `NSUB` values before
-     process-parameter preprocessing, including when `TOX` is absent.
-   - Preserve positive substrate doping and the stricter intrinsic-density
-     requirement when `NSUB` plus `TOX` derives process parameters.
+   - Reject non-positive or non-finite model-card `TOX` values before mobility
+     and electrostatic process-parameter preprocessing.
+   - Preserve positive oxide thickness and stable diagnostics across Rust,
+     Python, and TypeScript.
 
 ## Completed Slices
 
@@ -3650,6 +3650,13 @@ the Rust, Python, and TypeScript surfaces together.
      temperature and electrostatic preprocessing.
    - Positive nominal temperatures, parameter coverage, and stable diagnostics
      remain aligned across Rust, Python, and TypeScript.
+
+296. Cross-language Level-1 MOS substrate-doping validation.
+   - Status: completed in PR 9183.
+   - Non-positive and non-finite model-card `NSUB` values are rejected before
+     process-parameter preprocessing, including when `TOX` is absent.
+   - Positive substrate doping and the stricter intrinsic-density requirement
+     for `NSUB` plus `TOX` remain aligned across Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject non-positive and non-finite Level-1 MOS model-card `TOX` values during normalization
- keep the stable diagnostic and positive-value behavior aligned across Rust, Python, and TypeScript
- reconcile the SPICE completion plan by recording PR #9183 and selecting oxide-thickness validation as the current slice

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python Ruff plus full pytest: 678 passed, 88.94% coverage
- TypeScript tests: 421 passed
- `npm run build`