### PR TITLE
feat(adj-formula-stdlib): corrected-calcium — StatPearls albumin-corrected serum calcium formulabook (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_corrected_calcium_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_corrected_calcium_e2e.rs
@@ -1,0 +1,142 @@
+//! End-to-end tests for the `clinical/corrected-calcium.adj` library — the albumin-corrected-calcium
+//! correction (corrected calcium = measured calcium + 0.8 × (4 − albumin)) and its two exact
+//! rearrangements — driven through the built CLI binary against the SHIPPED stdlib. The same invariant
+//! as every other formula library: a consumer states NO arithmetic; it imports the grounded library,
+//! binds the measured calcium and albumin with `observe`, and the engine applies the cited correction
+//! on the CPU, computing the EXACT value (over exact rationals — 0.8 = 4/5, so 9.6 is exact, not a
+//! rounded float) and rendering the citation and trust tier in the `derived` section (the auditable
+//! answer). The three formulas INVERT around the worked case measured calcium = 8, albumin = 2:
+//! 8 + 0.8 × (4 − 2) = 9.6 (corrected), 9.6 − 0.8 × (4 − 2) = 8 (measured), 4 − (9.6 − 8) / 0.8 = 2
+//! (albumin). The three asserted values (9.6, 8, 2) are distinct, none a colon-anchored prefix of
+//! another rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped corrected-calcium library, resolved from this crate's manifest dir so
+/// the test is location-independent.
+fn shipped_cc_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/corrected-calcium.adj")
+        .canonicalize()
+        .expect("shipped corrected-calcium.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_cc_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_cc_lib()).unwrap();
+    std::fs::write(dir.join("corrected-calcium.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// corrected_calcium — the correction: measured calcium + 0.8 × (4 − albumin).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_corrected_calcium_library_and_computes_it_with_citation() {
+    let dir = scratch("cc");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"corrected-calcium.adj\"\n\
+         observe measured_calcium(8)\n\
+         observe albumin(2)\n\
+         ? corrected_calcium(measured_calcium, albumin)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied correction's result: 8 + 0.8 × (4 − 2) = 9.6,
+    // computed EXACTLY over rationals (0.8 = 4/5), not as a rounded float.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"corrected_calcium\"") && s.contains("\"value\":9.6"),
+        "corrected_calcium(8, 2) = 9.6: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied relation carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// measured_calcium — the same correction solved for the measured calcium: corrected − 0.8 × (4 − albumin).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_measured_calcium_from_corrected_with_citation() {
+    let dir = scratch("meas");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"corrected-calcium.adj\"\n\
+         observe corrected_calcium(9.6)\n\
+         observe albumin(2)\n\
+         ? measured_calcium(corrected_calcium, albumin)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 9.6 − 0.8 × (4 − 2) = 8, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"measured_calcium\"") && s.contains("\"value\":8"),
+        "measured_calcium(9.6, 2) = 8: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "measured_calcium carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// albumin — the same correction solved for the albumin: 4 − (corrected − measured) / 0.8, the third
+// reading of the one correction.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_albumin_from_corrected_and_measured_with_citation() {
+    let dir = scratch("alb");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"corrected-calcium.adj\"\n\
+         observe corrected_calcium(9.6)\n\
+         observe measured_calcium(8)\n\
+         ? albumin(corrected_calcium, measured_calcium)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 4 − (9.6 − 8) / 0.8 = 2, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"albumin\"") && s.contains("\"value\":2"),
+        "albumin(9.6, 8) = 2: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "albumin carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/corrected-calcium.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/corrected-calcium.adj
@@ -1,0 +1,96 @@
+% ============================================================================
+% corrected-calcium.adj — the albumin-corrected serum calcium
+% (corrected calcium = measured calcium + 0.8 × (4 − serum albumin)) in the ADJ standard library.
+% ============================================================================
+% The corrected-calcium entry of the *clinical* track — the hypoalbuminaemia correction applied to a
+% measured TOTAL serum calcium. Because roughly half of serum calcium is bound to albumin, a low
+% albumin lowers the measured TOTAL calcium without changing the physiologically active IONISED
+% calcium; the correction adds back the calcium "hidden" by the albumin deficit so the total is
+% interpreted as if albumin were normal. THE CORRECTED CALCIUM IS THE MEASURED CALCIUM PLUS 0.8 mg/dL
+% FOR EACH 1 g/dL THE SERUM ALBUMIN FALLS BELOW THE 4 g/dL REFERENCE — i.e. measured calcium + 0.8 ×
+% (4 − albumin). It ships as an importable, byte-provenanced, PARAMETERIZED `formula`, together with
+% its two exact rearrangements (the measured calcium a corrected value implies at a given albumin, and
+% the albumin a corrected/measured pair implies). As with every compute library, a consumer states NO
+% arithmetic: it `import`s this file, binds the measured calcium and albumin from its own
+% byte-provenance decomposition, and asks the engine to APPLY the cited correction on the CPU. Zero
+% math is performed by the model; the engine computes each value EXACTLY (over exact rationals),
+% carrying the correction's citation.
+%
+%     import "corrected-calcium.adj"
+%     observe measured_calcium(8)   % "…serum calcium 8 mg/dL…"      (span cited by the model)
+%     observe albumin(2)             % "…albumin 2 g/dL…"             (span cited by the model)
+%     ? corrected_calcium(measured_calcium, albumin)
+%                                     % engine → 9.6, carrying the corrected calcium
+%
+% The 0.8 mg/dL-per-g/dL coefficient and the 4 g/dL reference albumin are the EXACT constants of the
+% cited correction (not measurements); the formulas are otherwise exact linear expressions over the
+% parameters, so every value the engine returns is exact. They COMPOSE and invert cleanly around the
+% worked case measured calcium = 8 mg/dL, albumin = 2 g/dL (corrected = 8 + 0.8 × (4 − 2) = 8 + 1.6 =
+% 9.6 mg/dL): the `corrected_calcium` a consumer computes is exactly the value the `measured_calcium`
+% formula subtracts the same 0.8 × (4 − albumin) offset from to recover 8, and exactly the value the
+% `albumin` formula back-solves to recover 2.
+%
+%   corrected_calcium(measured_calcium, albumin) = measured_calcium + 0.8 * (4 - albumin)   % (correction)
+%   measured_calcium(corrected_calcium, albumin) = corrected_calcium - 0.8 * (4 - albumin)   % (solved for measured)
+%   albumin(corrected_calcium, measured_calcium) = 4 - (corrected_calcium - measured_calcium) / 0.8  % (solved for albumin)
+%
+% NOTE ON UNITS AND MODELLING: this is the conventional US-unit correction — calcium in mg/dL, albumin
+% in g/dL, reference albumin 4 g/dL, coefficient 0.8 mg/dL per g/dL. The correction only ADJUSTS the
+% interpretation of a TOTAL calcium for a low albumin; it does NOT replace a directly measured IONISED
+% calcium, which is preferred when available. The cited article states the correction as prose — "total
+% serum calcium should be corrected by adding approximately 0.8 mg/dL for each 1 g/dL decrease in serum
+% albumin below 4 gm/dL" — which is exactly the correction read forward; the two rearrangements are the
+% same relation solved for each input.
+%
+% All three formulas are defended by the SAME clause — the quoted correction sentence — because that
+% one statement (the corrected calcium IS the measured value plus 0.8 per g/dL of albumin deficit below
+% 4) sanctions the relation read every way. The quote is transcribed verbatim from the StatPearls
+% "Hypocalcemia" article on the NCBI Bookshelf (a current, non-archived article), so each `formula`
+% carries the provenance envelope every shipped grounded clause carries; the linter rejects an
+% unsourced one. (See feedback_nothing_human_authored — the correction, including its 0.8 and 4
+% constants, is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `measured_calcium`, `albumin` and `corrected_calcium` each appear BOTH as a derived
+% result and as an input (of the other formulas), so each is a single dictionary term used in both
+% roles. The `surface` lists are the everyday names a decomposer maps onto the canonical term; the
+% trailing comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary corrected_calcium_vocab {
+    define measured_calcium  : finding  surface "measured calcium", "serum calcium", "total calcium"   % mass per volume (mg/dL)
+    define albumin           : finding  surface "albumin", "serum albumin"                              % mass per volume (g/dL)
+    define corrected_calcium : finding  surface "corrected calcium", "albumin-corrected calcium"        % mass per volume (mg/dL)
+}
+
+% ----------------------------------------------------------------------------
+% The correction, all three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the correction sentence from the StatPearls
+% "Hypocalcemia" article on the NCBI Bookshelf (a quote is required on a shipped formula). Each is an
+% exact linear expression in the measured quantities and the cited 0.8/4 constants, so the engine
+% returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook corrected_calcium_laws {
+    use corrected_calcium_vocab
+
+    % Corrected calcium — the measured calcium plus 0.8 mg/dL per g/dL of albumin below the 4 g/dL
+    % reference.
+    formula corrected_calcium(measured_calcium, albumin) = measured_calcium + 0.8 * (4 - albumin)
+        source "total serum calcium should be corrected by adding approximately 0.8 mg/dL for each 1 g/dL decrease in serum albumin below 4 gm/dL"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK430912/"
+        trust authoritative
+
+    % Measured calcium — the same correction solved for the measured calcium (subtract the offset).
+    % Defended by the SAME sentence.
+    formula measured_calcium(corrected_calcium, albumin) = corrected_calcium - 0.8 * (4 - albumin)
+        source "total serum calcium should be corrected by adding approximately 0.8 mg/dL for each 1 g/dL decrease in serum albumin below 4 gm/dL"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK430912/"
+        trust authoritative
+
+    % Albumin — the same correction solved for the albumin (back out the deficit from the offset). The
+    % SAME sentence, read the third way.
+    formula albumin(corrected_calcium, measured_calcium) = 4 - (corrected_calcium - measured_calcium) / 0.8
+        source "total serum calcium should be corrected by adding approximately 0.8 mg/dL for each 1 g/dL decrease in serum albumin below 4 gm/dL"
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK430912/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/corrected-calcium.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/corrected-calcium.query.adj
@@ -1,0 +1,27 @@
+% ============================================================================
+% corrected-calcium.query.adj — worked applications of the albumin-corrected-calcium correction.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a chemistry vignette into a measured total
+% calcium and a serum albumin: it `import`s the grounded formulabook, `observe`s the two values, and
+% asks the engine to APPLY the cited correction. No arithmetic is stated by the consumer; the engine
+% computes each value EXACTLY (over exact rationals) and carries the article's citation as its proof,
+% on the CPU, with zero model calls.
+%
+% Worked case (measured calcium = 8 mg/dL, albumin = 2 g/dL): corrected = 8 + 0.8 × (4 − 2) = 9.6 mg/dL.
+% Each query fixes two of the three quantities and asks the engine to recover the third; every answer
+% is exact and the three COMPOSE (each inversion recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli corrected-calcium.query.adj
+% ============================================================================
+
+import "corrected-calcium.adj"
+
+% --- Correction: the corrected calcium the measured value and albumin imply (expect 9.6). ----------
+observe measured_calcium(8)
+observe albumin(2)
+? corrected_calcium(measured_calcium, albumin)   % expect 9.6
+
+% --- Inverse: the measured calcium a corrected 9.6 implies at albumin 2 (expect 8). ----------------
+observe corrected_calcium(9.6)
+? measured_calcium(corrected_calcium, albumin)   % expect 8


### PR DESCRIPTION
## What

Adds the **albumin-corrected serum calcium** correction to the ADJ formula standard library (clinical track), as a byte-provenanced, importable `formulabook` together with its two exact rearrangements:

```
corrected_calcium(measured_calcium, albumin) = measured_calcium + 0.8 * (4 - albumin)
measured_calcium(corrected_calcium, albumin) = corrected_calcium - 0.8 * (4 - albumin)
albumin(corrected_calcium, measured_calcium)  = 4 - (corrected_calcium - measured_calcium) / 0.8
```

All three formulas are defended by the **same verbatim clause** from the current (non-archived) StatPearls *Hypocalcemia* article on the NCBI Bookshelf ([NBK430912](https://www.ncbi.nlm.nih.gov/books/NBK430912/)):

> total serum calcium should be corrected by adding approximately 0.8 mg/dL for each 1 g/dL decrease in serum albumin below 4 gm/dL

The `0.8` mg/dL-per-g/dL coefficient and the `4` g/dL reference albumin are the exact constants of the cited correction (not measurements). The engine computes every value **exactly over rationals** (`0.8 = 4/5`, so `9.6` is exact, not a rounded float). As with every compute library, a consumer states **no arithmetic** — it imports the library, `observe`s the measured calcium and albumin from its own byte-provenance decomposition, and asks the engine to apply the cited correction on the CPU.

## Files

- `code/specs/data/adj-formula-stdlib/clinical/corrected-calcium.adj` — dictionary + 3-formula formulabook (each carrying source/locator/trust).
- `code/specs/data/adj-formula-stdlib/clinical/corrected-calcium.query.adj` — worked forward + inverse applications.
- `code/packages/rust/adj-lang-cli/tests/formula_corrected_calcium_e2e.rs` — dedicated e2e test.

## Worked case & inversion (asserted by the e2e test)

- forward: measured_calcium=8, albumin=2 → `corrected_calcium = 9.6`
- inverse: corrected_calcium=9.6, albumin=2 → `measured_calcium = 8`
- inverse: corrected_calcium=9.6, measured_calcium=8 → `albumin = 2`

Each answer carries the NBK430912 citation and `trust:authoritative`.

## Checks

- `cargo test -p adj-lang-cli --test formula_corrected_calcium_e2e` — 3 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean.
- Render-probe against the built CLI confirms `corrected_calcium=9.6` / `measured_calcium=8`, both with the locator + authoritative trust.
- NUL-scan clean on all three new files.
- `/security-review` — SECURITY REVIEW PASSED.

Data + test only; no engine change, **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)