### PR TITLE
feat(adj-formula-stdlib): specific-heat-capacity — NIST SP 811 B.9 specific-heat-capacity→J/(kg·K) factors (RS-5 table)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -1564,6 +1564,57 @@ fn shipped_moment_of_force_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// Shipped specific-heat-capacity table — two EXACT NIST SP 811 B.9 factors resolve, and a
+// wrong-dimension unit (a mass unit) abstains. Guards the SLICE of a NEW dimension (specific heat
+// capacity / specific entropy, the joule per kilogram kelvin) and the honest cross-dimension
+// abstention: `pound` is a mass unit, so a specific-heat lookup for it must abstain, catching the
+// specific-heat/mass confusion directly, not mere absence of a value. (Specific heat capacity is an
+// intensive per-unit-mass quantity — energy/(mass·temperature) — distinct from plain heat capacity,
+// J/K, and from specific energy, J/kg.)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_specific_heat_capacity_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_specificheatcapacity");
+    let src = stdlib().join("reference/specific-heat-capacity-conversions.adj");
+    std::fs::copy(&src, dir.join("specific-heat-capacity-conversions.adj"))
+        .expect("copy shipped specific-heat-capacity-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"specific-heat-capacity-conversions.adj\"\n\
+         ? specific_heat_capacity_to_joule_per_kilogram_kelvin(calorie_it_per_gram_celsius, $v)\n\
+         ? specific_heat_capacity_to_joule_per_kilogram_kelvin(calorie_th_per_gram_celsius, $v)\n\
+         ? specific_heat_capacity_to_joule_per_kilogram_kelvin(pound, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 exact factors resolve, character-for-character from the table (boldface =
+    // exact; the International-Table calorie is exactly 4.1868 J and the thermochemical calorie is
+    // exactly 4.184 J, so calIT/(g*degC) = 4186.8 and calth/(g*degC) = 4184 J/(kg*K), exactly).
+    assert!(
+        out.contains("\"v\":\"4186.8\""),
+        "calorieIT per gram degree Celsius = 4.1868 E+03 J/(kg*K): {out}"
+    );
+    assert!(
+        out.contains("\"v\":\"4184\""),
+        "calorieth per gram degree Celsius = 4.184 E+03 J/(kg*K): {out}"
+    );
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `pound` is a MASS unit (it converts to the kilogram, a DIFFERENT quantity), so this
+    // specific-heat-capacity table has no row for it — the engine abstains rather than mis-converting a
+    // mass unit as if it were a specific-heat unit.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a wrong-dimension unit abstains, never a cross-dimension fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/specific-heat-capacity-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/specific-heat-capacity-conversions.adj
@@ -1,0 +1,78 @@
+% ============================================================================
+% specific-heat-capacity-conversions — specific-heat-capacity / specific-entropy unit →
+% joule-per-kilogram-kelvin factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of the NIST-cited conversion tables (length, mass, area, volume, energy, force,
+% power, pressure, the electric-EMU family, the two viscosities, wave number, linear mass density,
+% temperature interval, mass density, moment of force, and the rest): a native tabular relation
+% ingested VERBATIM from a published NIST conversion table. Each row states the factor converting a
+% common non-SI unit of SPECIFIC HEAT CAPACITY (the heat needed to raise a UNIT MASS of a substance by
+% a unit of temperature — heat capacity PER KILOGRAM) to the SI coherent derived unit, the joule per
+% kilogram kelvin, J/(kg·K):
+%
+%     ? specific_heat_capacity_to_joule_per_kilogram_kelvin(calorie_it_per_gram_celsius, $v)   % 4186.8
+%     ? specific_heat_capacity_to_joule_per_kilogram_kelvin(calorie_th_per_gram_celsius, $v)   % 4184
+%
+% This opens a NEW dimension — SPECIFIC HEAT CAPACITY (equivalently SPECIFIC ENTROPY: NIST SP 811 B.9
+% tabulates the two together, since J/(kg·K) is their shared SI unit) — alongside the already-tabulated
+% length/mass/area/volume/time/speed/energy/pressure/force/power/acceleration/dynamic-viscosity/
+% kinematic-viscosity/magnetic-flux-density/magnetic-flux/illuminance/luminance/radioactivity/
+% absorbed-dose/dose-equivalent/exposure/wave-number/linear-mass-density/temperature-interval/
+% mass-density/moment-of-force tables and the electric charge/potential/resistance/capacitance/
+% inductance/conductance/current tables. Specific heat capacity is an INTENSIVE, per-unit-mass quantity
+% [energy / (mass × temperature)] — distinct from plain HEAT CAPACITY, J/K (no mass in the denominator),
+% and from SPECIFIC ENERGY, J/kg (no temperature): do NOT confuse them. A value given in
+% cal/(g·°C) or Btu/(lb·°F) must be put into SI first, then reasoned over (write-once-use-many).
+% Why a `table` and not hand-written `relate` clauses: this is exactly the shape reference data comes in
+% — a published table, not prose. The citable artifact IS the NIST conversion-factors table at the
+% `locator` below; each factor here is a CELL of NIST Special Publication 811, Appendix B.9, defended by
+% one provenance envelope. Each `row` lowers to a ground relation
+% `specific_heat_capacity_to_joule_per_kilogram_kelvin(unit, v)`, so the exact lookups above are the
+% ordinary SLD binding query — the engine returns the factor WITH this table's citation as its proof,
+% on the CPU, with zero model calls.
+%
+% HONESTY NOTE (like every other NIST table, only the EXACT defined factors get rows): NIST SP 811 B.9
+% prints all four specific-heat-capacity factors below in BOLDFACE, its convention for factors that are
+% EXACT by definition, transcribed here as the plain decimal number of joules per kilogram kelvin each
+% names:
+%
+%     calorieIT per gram degree Celsius [calIT/(g·°C)]      4.1868 E+03  →  4186.8
+%     calorieth per gram degree Celsius [calth/(g·°C)]      4.184  E+03  →  4184
+%     British thermal unitIT per pound degree Fahrenheit    4.1868 E+03  →  4186.8
+%     British thermal unitth per pound degree Fahrenheit    4.184  E+03  →  4184
+%
+% All four are EXACT and terminate; nothing here is a rounded measurement. They are exact because each
+% underlying thermal unit is DEFINED exactly — the International-Table calorie is exactly 4.1868 J and
+% the thermochemical calorie is exactly 4.184 J — and the per-mass, per-temperature scaling is by exact
+% factors: gram→kilogram is ×1000, and a Celsius-degree interval EQUALS a kelvin interval, so
+% calIT/(g·°C) = 4.1868 × 1000 = 4186.8 J/(kg·K) and calth/(g·°C) = 4.184 × 1000 = 4184 J/(kg·K),
+% exactly. The two British-thermal-unit rows land on the SAME two values because the BtuIT and Btuth are
+% defined FROM the corresponding calories, and the pound (0.453 592 37 kg, exact) and Fahrenheit-degree
+% (exactly 5/9 of a kelvin interval) combine to leave an exactly terminating result that NIST likewise
+% prints boldface — so, unlike the pure temperature-interval °F→K factor (5/9, non-terminating) or the
+% pound-force torque units (a factor of 127 in the denominator), these compound specific-heat factors
+% ARE exact and DO get rows. (Two distinct units sharing one exact value — calIT and BtuIT both giving
+% 4186.8 — is a real feature of the definitions, not a coincidence to hide.) This table is SPECIFIC to
+% specific heat capacity: a unit of a DIFFERENT quantity — e.g. the "pound", which NIST SP 811 B.9 lists
+% separately as a MASS unit converting to the kilogram, NOT to J/(kg·K) — therefore gets no row here,
+% and a `? specific_heat_capacity_to_joule_per_kilogram_kelvin(pound, $v)` ABSTAINS rather than
+% mis-converting a mass unit as if it were a specific-heat unit. The only claim this table makes is
+% "these are the exact factors NIST SP 811 B.9 prints for these four specific-heat-capacity units'
+% conversions to the joule per kilogram kelvin" — which is exactly what a byte-check against the cited
+% table verifies. `trust authoritative` — a primary, re-fetchable standards reference. (See
+% ADJ-TABLES.md; and feedback_nothing_human_authored — each factor is a verbatim cell of the cited
+% table, nothing asserted from memory.)
+% ============================================================================
+
+table specific_heat_capacity_to_joule_per_kilogram_kelvin {
+    columns unit, joule_per_kilogram_kelvin
+
+    row (calorie_it_per_gram_celsius, 4186.8)
+    row (calorie_th_per_gram_celsius, 4184)
+    row (btu_it_per_pound_fahrenheit, 4186.8)
+    row (btu_th_per_pound_fahrenheit, 4184)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/specific-heat-capacity-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/specific-heat-capacity-conversions.query.adj
@@ -1,0 +1,27 @@
+% ============================================================================
+% specific-heat-capacity-conversions.query.adj — worked lookups over the NIST specific-heat-capacity →
+% joule-per-kilogram-kelvin table.
+% ============================================================================
+% The shape a consumer produces to convert a specific heat capacity given in a non-SI unit into SI: it
+% `import`s the grounded table and asks the engine to bind the factor. No arithmetic and no factor is
+% stated by the consumer; the engine returns the cell WITH the table's NIST citation as its proof, on
+% the CPU.
+%
+%   ? specific_heat_capacity_to_joule_per_kilogram_kelvin(calorie_it_per_gram_celsius, $v)   % 4186.8
+%   ? specific_heat_capacity_to_joule_per_kilogram_kelvin(calorie_th_per_gram_celsius, $v)   % 4184
+%
+% And the dimension guard: a unit of a DIFFERENT quantity has no row, so the lookup ABSTAINS rather
+% than mis-converting across dimensions. The "pound" is a MASS unit (it converts to the kilogram), NOT
+% a specific-heat-capacity unit — so it is caught rather than silently mis-converted:
+%
+%   ? specific_heat_capacity_to_joule_per_kilogram_kelvin(pound, $v)   % abstains (pound is mass → kilogram)
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli specific-heat-capacity-conversions.query.adj
+% ============================================================================
+
+import "specific-heat-capacity-conversions.adj"
+
+? specific_heat_capacity_to_joule_per_kilogram_kelvin(calorie_it_per_gram_celsius, $v)   % expect 4186.8  (exact NIST SP 811 B.9 factor)
+? specific_heat_capacity_to_joule_per_kilogram_kelvin(calorie_th_per_gram_celsius, $v)   % expect 4184    (exact NIST SP 811 B.9 factor)
+? specific_heat_capacity_to_joule_per_kilogram_kelvin(pound, $v)                         % expect abstain (mass unit, wrong dimension)


### PR DESCRIPTION
## What

Adds a new NIST-cited RS-5 reference conversion `table` opening a **new dimension** — **specific heat capacity / specific entropy**, the joule per kilogram kelvin `J/(kg·K)` — alongside the length/mass/energy/power/pressure/force/moment-of-force/viscosity/electric/… tables already shipped.

Four **exact** (NIST-boldface) factors, transcribed verbatim from [SP 811 Appendix B.9](https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9):

| from | to | factor |
|---|---|---|
| calorie_IT per gram degree Celsius | J/(kg·K) | **4186.8** |
| calorie_th per gram degree Celsius | J/(kg·K) | **4184** |
| Btu_IT per pound degree Fahrenheit | J/(kg·K) | **4186.8** |
| Btu_th per pound degree Fahrenheit | J/(kg·K) | **4184** |

All four are exact and terminate: the International-Table calorie is exactly `4.1868 J` and the thermochemical calorie exactly `4.184 J`; gram→kilogram is `×1000` and a Celsius interval equals a kelvin interval, so `calIT/(g·°C) = 4186.8` and `calth/(g·°C) = 4184` J/(kg·K) exactly. The two Btu rows land on the same two values because the Btu is defined from the corresponding calorie, and the pound (`0.45359237 kg`) and Fahrenheit-degree (`5/9 K`) combine to an exactly terminating result NIST likewise prints boldface. Only NIST's exact/boldface factors get rows (non-terminating factors are excluded, per the exact-only rule).

## Files

- `code/specs/data/adj-formula-stdlib/reference/specific-heat-capacity-conversions.adj` — the table (4 rows + one provenance envelope).
- `code/specs/data/adj-formula-stdlib/reference/specific-heat-capacity-conversions.query.adj` — worked lookups + a wrong-dimension abstain probe.
- `code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs` — appends `shipped_specific_heat_capacity_conversions_table_resolves_and_abstains` to the shared RS-5 anchor.

## Behaviour (asserted by the e2e test)

- `? …(calorie_it_per_gram_celsius, $v)` → `4186.8`, carrying the B.9 locator + `trust:authoritative`
- `? …(calorie_th_per_gram_celsius, $v)` → `4184`
- `? …(pound, $v)` → **abstains** (`pound` is a MASS unit → kilogram; the table refuses to mis-convert across dimensions rather than fabricating a factor)

## Checks

- `cargo test -p adj-lang-cli --test rs5_table_e2e specific_heat` — 1 passed (40 total in the anchor).
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean.
- Render-probe against the built CLI confirms `4186.8` / `4184` resolve and `pound` abstains, all with the NIST locator.
- NUL-scan clean on all three files.
- `/security-review` — SECURITY REVIEW PASSED.

Data + test only; no engine change, **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)