### PR TITLE
feat(build-tool): define external preflight authority

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,7 +8,12 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": null,
+  "active_pr": {
+    "item_id": "build-tool-trusted-authority-bundle",
+    "pr_number": 9196,
+    "branch": "codex/build-tool-trusted-authority-bundle",
+    "url": "https://github.com/adhithyan15/coding-adventures/pull/9196"
+  },
   "last_inventory": {
     "revision": "d0b9c442f03520fdff75c12b4f236c50de7f152c",
     "schema_version": 2,
@@ -69,14 +74,14 @@
     {
       "id": "build-tool-trusted-authority-bundle",
       "title": "Define the external authority bundle and Linux preflight profile",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": [
         "build-tool-execution-sandbox",
         "build-tool-linux-oci-sandbox"
       ],
       "branch": "codex/build-tool-trusted-authority-bundle",
-      "pr_number": null,
-      "notes": "Selected after PR #9189 merged because it is the highest-leverage ready security prerequisite. Security review split out a safe first profile: a post-merge external bundle whose raw-byte approval binds the exact source commit/tree, policy, schemas, authority verifier, Linux preflight backend, and external backend identity. Schema v1 approves exact bytes for capability inspection only, with no corpus, adapter, container, executable payload, or process handoff."
+      "pr_number": 9196,
+      "notes": "Ready-for-review PR #9196. Security review split out a safe first profile: a post-merge external bundle whose raw-byte approval binds the exact source commit/tree, policy, schemas, authority verifier, Linux preflight backend, and external backend identity. Schema v1 approves exact bytes for capability inspection only, with no corpus, adapter, container, executable payload, or process handoff. Local validation covers 108 focused tests, 86% branch-aware authority-module coverage, Ruff, Bandit, corpus/contract validators, Go tests/build, parity collision checks, and the unchanged 73-gap build-file audit."
     },
     {
       "id": "build-tool-authority-exact-backend-loader",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,14 +8,9 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": {
-    "item_id": "build-tool-linux-oci-sandbox",
-    "pr_number": 9189,
-    "branch": "codex/build-tool-linux-oci-sandbox",
-    "url": "https://github.com/adhithyan15/coding-adventures/pull/9189"
-  },
+  "active_pr": null,
   "last_inventory": {
-    "revision": "bee64b4774b87cd43bea6c9e413e647742334f96",
+    "revision": "d0b9c442f03520fdff75c12b4f236c50de7f152c",
     "schema_version": 2,
     "established_languages": 15,
     "implementation_identities": 1187,
@@ -65,20 +60,35 @@
     {
       "id": "build-tool-linux-oci-sandbox",
       "title": "Define the Linux OCI identity, capability preflight, and invariant-probe container",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": ["build-tool-execution-sandbox"],
       "branch": "codex/build-tool-linux-oci-sandbox",
       "pr_number": 9189,
-      "notes": "Ready-for-review PR #9189. Security review split the backend into a safe first tranche: a closed identity binding rootless Podman, crun, exact OCI manifest/config, seccomp, shim, and probe; fail-closed host/image preflight; and exact probe-container argv with no fixture decode or launch. Local validation covers 100 focused tests, 83% branch-aware module coverage, Ruff, Bandit, Go build-tool tests/build, parity collision checks, and build-file auditing. The checked-in policy remains disabled and Linux unavailable until protected enforcement evidence exists."
+      "notes": "Merged PR #9189. The closed identity binds rootless Podman, crun, exact OCI manifest/config, seccomp, shim, and probe; the process-owning module adds fail-closed host/image preflight and exact probe-container argv without fixture decode or launch. The checked-in policy remains disabled and Linux unavailable until protected enforcement evidence exists."
     },
     {
       "id": "build-tool-trusted-authority-bundle",
-      "title": "Bind trusted execution to the complete reviewed authority bundle",
+      "title": "Define the external authority bundle and Linux preflight profile",
+      "status": "in-progress",
+      "depends_on": [
+        "build-tool-execution-sandbox",
+        "build-tool-linux-oci-sandbox"
+      ],
+      "branch": "codex/build-tool-trusted-authority-bundle",
+      "pr_number": null,
+      "notes": "Selected after PR #9189 merged because it is the highest-leverage ready security prerequisite. Security review split out a safe first profile: a post-merge external bundle whose raw-byte approval binds the exact source commit/tree, policy, schemas, authority verifier, Linux preflight backend, and external backend identity. Schema v1 approves exact bytes for capability inspection only, with no corpus, adapter, container, executable payload, or process handoff."
+    },
+    {
+      "id": "build-tool-authority-exact-backend-loader",
+      "title": "Load the exact approved preflight backend through an atomic runner boundary",
       "status": "pending",
-      "depends_on": ["build-tool-execution-sandbox"],
+      "depends_on": [
+        "build-tool-trusted-authority-bundle",
+        "build-tool-linux-oci-sandbox"
+      ],
       "branch": null,
       "pr_number": null,
-      "notes": "Discovered during the Linux OCI security review. Replace corpus-only operator approval with one domain-separated digest binding exact source revision, policy, schemas, runner, launcher, seccomp, shim, OCI manifest/config, and adapter identity before any executable payload decode."
+      "notes": "Discovered during final authority security review. Replace name-based Python import and check-then-open traversal with an atomic beneath-root loader over the exact retained backend bytes and a closed approved import closure. Until this lands, the authority verifier remains process-free and the bare Linux preflight CLI stays disabled."
     },
     {
       "id": "build-tool-execution-case-snapshot",
@@ -99,18 +109,60 @@
       "notes": "Discovered during the fixture audit. Replace the duplicated schema term dependency-skipped with normative dep-skipped and enforce built, failed, dep-skipped, would-build, return-code, command-state, and outcome consistency before execution cases enter the corpus."
     },
     {
+      "id": "build-tool-invariant-probe-authority-profile",
+      "title": "Promote preflight approval to an invariant-probe authority profile",
+      "status": "pending",
+      "depends_on": [
+        "build-tool-trusted-authority-bundle",
+        "build-tool-authority-exact-backend-loader"
+      ],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered during final dependency reconciliation. Add a distinct domain-separated profile that binds the verified seccomp artifact, enforcement launcher, exact invariant-probe identity, and lifecycle/accounting implementation before the runner may create the probe container. It binds no execution case or adapter."
+    },
+    {
       "id": "build-tool-linux-oci-enforcement",
-      "title": "Run and police the Linux OCI invariant probe and trusted cases",
+      "title": "Run and police the Linux OCI invariant probe",
       "status": "pending",
       "depends_on": [
         "build-tool-linux-oci-sandbox",
         "build-tool-trusted-authority-bundle",
+        "build-tool-authority-exact-backend-loader",
+        "build-tool-invariant-probe-authority-profile"
+      ],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Execute only after exact-byte loading and invariant-probe authority. Add aggregate cgroup CPU metering, combined streaming output/result accounting, hard workspace semantics, cancellation, whole-container kill/reap/removal, adversarial runner-owned probes, and protected Linux workflow evidence before marking Linux ready. This item runs no fixture case."
+    },
+    {
+      "id": "build-tool-trusted-execution-authority-profile",
+      "title": "Promote verified Linux containment to a trusted-execution authority profile",
+      "status": "pending",
+      "depends_on": [
+        "build-tool-trusted-authority-bundle",
+        "build-tool-authority-exact-backend-loader",
+        "build-tool-invariant-probe-authority-profile",
+        "build-tool-linux-oci-enforcement",
         "build-tool-execution-case-snapshot",
         "build-tool-execution-status-normalization"
       ],
       "branch": null,
       "pr_number": null,
-      "notes": "Execute only after the first preflight tranche. Add aggregate cgroup CPU metering, combined streaming output/result accounting, hard workspace semantics, cancellation, whole-container kill/reap/removal, image-contained adapters, adversarial runner-owned probes, and protected Linux workflow evidence before marking Linux ready."
+      "notes": "Discovered during final dependency reconciliation. After protected invariant-probe evidence exists, add a distinct domain-separated profile that binds that evidence, the exact held corpus snapshot, one selected in-image adapter, and the trusted-case enforcement implementation. Preflight and invariant-probe approvals remain structurally unusable for a fixture case."
+    },
+    {
+      "id": "build-tool-linux-trusted-execution-enforcement",
+      "title": "Execute and police trusted build-tool cases on Linux",
+      "status": "pending",
+      "depends_on": [
+        "build-tool-linux-oci-enforcement",
+        "build-tool-trusted-execution-authority-profile",
+        "build-tool-execution-case-snapshot",
+        "build-tool-execution-status-normalization"
+      ],
+      "branch": null,
+      "pr_number": null,
+      "notes": "Discovered during final dependency reconciliation. Execute only the exact retained case snapshot with one authority-bound in-image adapter under the already-proved Linux containment boundary; preserve aggregate resource accounting, streaming output limits, cancellation, and whole-container cleanup."
     },
     {
       "id": "build-tool-windows-appcontainer-sandbox",
@@ -135,7 +187,8 @@
       "title": "Add execution semantics cases and adversarial sandbox probes",
       "status": "pending",
       "depends_on": [
-        "build-tool-linux-oci-enforcement",
+        "build-tool-trusted-execution-authority-profile",
+        "build-tool-linux-trusted-execution-enforcement",
         "build-tool-windows-appcontainer-sandbox",
         "build-tool-macos-isolated-sandbox"
       ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_runner.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_execution_schema.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_execution_runner.py'
+          python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_authority.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_linux_oci.py'
           python3 code/scripts/build_tool_conformance.py validate-corpus
           python3 code/scripts/build_tool_conformance_execution.py validate-contract

--- a/code/scripts/build_tool_conformance_authority.py
+++ b/code/scripts/build_tool_conformance_authority.py
@@ -1,0 +1,595 @@
+#!/usr/bin/env python3
+"""Verify external build-tool authority for a future Linux preflight.
+
+Authority validation is deliberately process-free. This tranche does not
+import or invoke the process-owning backend: a later exact-byte loader must
+prove that the code used for capability inspection is the retained approved
+artifact and its approved import closure. The v1 scope cannot authorize an
+invariant probe, fixture decode, container, adapter, or execution case.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+import stat
+import struct
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any
+
+import build_tool_conformance as bootstrap
+
+AUTHORITY_DOMAIN = (
+    b"coding-adventures/build-tool-authority/"
+    b"linux-capability-preflight/v1\0"
+)
+MAX_AUTHORITY_BUNDLE_BYTES = bootstrap.MAX_DOCUMENT_BYTES
+MAX_AUTHORITY_COMPONENT_BYTES = 16_777_216
+MAX_AUTHORITY_TOTAL_BYTES = 67_108_864
+EMPTY_SHA256 = hashlib.sha256(b"").hexdigest()
+DEFAULT_AUTHORITY_SCHEMA = (
+    bootstrap.DEFAULT_FIXTURE_ROOT / "execution-authority.schema.json"
+)
+
+REPOSITORY_COMPONENT_PATHS = MappingProxyType(
+    {
+        "authority_bundle_schema": (
+            "code/specs/fixtures/build-tool-v1/execution-authority.schema.json"
+        ),
+        "execution_policy_schema": (
+            "code/specs/fixtures/build-tool-v1/execution-policy.schema.json"
+        ),
+        "execution_policy": (
+            "code/specs/fixtures/build-tool-v1/execution-policy.json"
+        ),
+        "linux_backend_identity_schema": (
+            "code/specs/fixtures/build-tool-v1/linux-oci-backend.schema.json"
+        ),
+        "bootstrap_runner": "code/scripts/build_tool_conformance.py",
+        "authority_verifier": (
+            "code/scripts/build_tool_conformance_authority.py"
+        ),
+        "linux_preflight_backend": (
+            "code/scripts/build_tool_conformance_linux_oci.py"
+        ),
+    }
+)
+BUNDLE_COMPONENT_PATHS = MappingProxyType(
+    {"linux_backend_identity": "linux-oci-backend.json"}
+)
+COMPONENT_ROLES = (*REPOSITORY_COMPONENT_PATHS, *BUNDLE_COMPONENT_PATHS)
+GIT_OID_LENGTH = 40
+
+
+@dataclass(frozen=True)
+class PreflightAuthority:
+    """Retained exact bytes and typed values approved for one preflight."""
+
+    bundle_digest: str
+    bundle: dict[str, Any]
+    components: Mapping[str, bytes]
+    policy: dict[str, Any]
+    identity: dict[str, Any]
+    identity_schema: dict[str, Any]
+
+
+def authority_bundle_sha256(raw: bytes) -> str:
+    """Digest exact bundle bytes with scope and length separation."""
+
+    digest = hashlib.sha256()
+    digest.update(AUTHORITY_DOMAIN)
+    digest.update(struct.pack(">Q", len(raw)))
+    digest.update(raw)
+    return digest.hexdigest()
+
+
+def _is_sha256(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _is_git_oid(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == GIT_OID_LENGTH
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _file_identity(value: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (
+        value.st_dev,
+        value.st_ino,
+        value.st_size,
+        value.st_mtime_ns,
+        value.st_nlink,
+    )
+
+
+def _read_bound_regular(
+    path: Path,
+    *,
+    prefix: str,
+    label: str,
+    max_bytes: int,
+) -> bytes:
+    """Read one stable, singly linked, bounded regular file without follow."""
+
+    try:
+        initial = path.lstat()
+        initial_reparse = bool(
+            getattr(initial, "st_file_attributes", 0)
+            & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+        )
+        if (
+            not stat.S_ISREG(initial.st_mode)
+            or stat.S_ISLNK(initial.st_mode)
+            or initial_reparse
+            or initial.st_nlink != 1
+        ):
+            raise bootstrap.ConformanceError(
+                f"{prefix}_FILE_INVALID",
+                f"{label} must be one regular, non-reparse, singly linked file",
+            )
+        with bootstrap._open_regular_no_follow(path) as source:
+            before = os.fstat(source.fileno())
+            is_reparse = bool(
+                getattr(before, "st_file_attributes", 0)
+                & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+            )
+            if (
+                not stat.S_ISREG(before.st_mode)
+                or is_reparse
+                or before.st_nlink != 1
+            ):
+                raise bootstrap.ConformanceError(
+                    f"{prefix}_FILE_INVALID",
+                    f"{label} must be one regular, non-reparse, singly linked file",
+                )
+            raw = source.read(max_bytes + 1)
+            after = os.fstat(source.fileno())
+    except bootstrap.ConformanceError:
+        raise
+    except (OSError, ValueError) as error:
+        raise bootstrap.ConformanceError(
+            f"{prefix}_READ_FAILED",
+            f"{label} could not be read without following a link",
+        ) from error
+
+    if len(raw) > max_bytes:
+        raise bootstrap.ConformanceError(
+            f"{prefix}_TOO_LARGE",
+            f"{label} exceeds its byte ceiling",
+        )
+    if (
+        _file_identity(initial) != _file_identity(before)
+        or _file_identity(before) != _file_identity(after)
+        or before.st_size != len(raw)
+    ):
+        raise bootstrap.ConformanceError(
+            f"{prefix}_CHANGED",
+            f"{label} changed during its authority read",
+        )
+    return raw
+
+
+def _read_component_bytes(
+    *,
+    repository_root: Path,
+    bundle_path: Path,
+    role: str,
+    record: Mapping[str, Any],
+) -> bytes:
+    """Resolve one closed role and retain its exact approved bytes."""
+
+    if role in REPOSITORY_COMPONENT_PATHS:
+        expected_provenance = "repository"
+        expected_path = REPOSITORY_COMPONENT_PATHS[role]
+        base = repository_root
+    elif role in BUNDLE_COMPONENT_PATHS:
+        expected_provenance = "bundle"
+        expected_path = BUNDLE_COMPONENT_PATHS[role]
+        base = bundle_path.parent
+    else:
+        raise bootstrap.ConformanceError(
+            "AUTHORITY_COMPONENT_ROLE_INVALID",
+            "authority bundle contains an unknown component role",
+        )
+    if (
+        record.get("provenance") != expected_provenance
+        or record.get("path") != expected_path
+        or bootstrap.portable_path_error(expected_path)
+    ):
+        raise bootstrap.ConformanceError(
+            "AUTHORITY_COMPONENT_ROLE_INVALID",
+            f"authority component {role} does not match its fixed role",
+        )
+    return _read_bound_regular(
+        base / expected_path,
+        prefix="AUTHORITY_COMPONENT",
+        label=f"authority component {role}",
+        max_bytes=MAX_AUTHORITY_COMPONENT_BYTES,
+    )
+
+
+def _source_matches(
+    bundle: Mapping[str, Any],
+    expected_commit_oid: str,
+    expected_tree_oid: str,
+) -> bool:
+    source = bundle.get("source")
+    return (
+        isinstance(source, Mapping)
+        and source.get("git_object_format") == "sha1"
+        and hmac.compare_digest(
+            str(source.get("commit_oid", "")),
+            expected_commit_oid,
+        )
+        and hmac.compare_digest(
+            str(source.get("tree_oid", "")),
+            expected_tree_oid,
+        )
+    )
+
+
+def _validate_bundle_profile(bundle: Mapping[str, Any]) -> None:
+    expected = {
+        "schema_version": 1,
+        "purpose": "build-tool-trusted-authority",
+        "authorization_scope": "linux_capability_preflight_v1",
+        "repository": "github.com/adhithyan15/coding-adventures",
+        "conformance_revision": "v1",
+        "platform": "linux",
+        "architecture": "amd64",
+    }
+    if any(bundle.get(key) != value for key, value in expected.items()):
+        raise bootstrap.ConformanceError(
+            "AUTHORITY_PROFILE_INVALID",
+            "authority bundle is not the closed Linux capability-preflight profile",
+        )
+    components = bundle.get("components")
+    if (
+        not isinstance(components, Mapping)
+        or set(components) != set(COMPONENT_ROLES)
+    ):
+        raise bootstrap.ConformanceError(
+            "AUTHORITY_COMPONENT_ROLE_INVALID",
+            "authority bundle must contain exactly the fixed preflight roles",
+        )
+
+
+def _validate_preflight_policy(
+    policy: dict[str, Any],
+    *,
+    conformance_revision: str,
+) -> None:
+    expected_backends = (
+        ("darwin", "macos_isolated"),
+        ("linux", "linux_oci"),
+        ("windows", "windows_appcontainer"),
+    )
+    actual_backends = policy.get("backends")
+    valid_backends = (
+        isinstance(actual_backends, list)
+        and len(actual_backends) == len(expected_backends)
+        and all(
+            isinstance(item, Mapping)
+            and item.get("platform") == platform
+            and item.get("kind") == kind
+            and item.get("status") == "unavailable"
+            and item.get("identity_sha256") is None
+            for item, (platform, kind) in zip(
+                actual_backends,
+                expected_backends,
+                strict=True,
+            )
+        )
+    )
+    if (
+        policy.get("conformance_revision") != conformance_revision
+        or policy.get("enabled") is not False
+        or policy.get("execution_corpus_sha256") != EMPTY_SHA256
+        or policy.get("adapters") != []
+        or not valid_backends
+    ):
+        raise bootstrap.ConformanceError(
+            "AUTHORITY_POLICY_PROFILE_INVALID",
+            "capability preflight requires the disabled empty execution profile",
+        )
+
+
+def _validate_identity_semantics(identity: dict[str, Any]) -> None:
+    image = identity.get("image")
+    shim = identity.get("shim")
+    probe = identity.get("probe")
+    if not isinstance(image, Mapping):
+        raise bootstrap.ConformanceError(
+            "AUTHORITY_IDENTITY_SCHEMA_INVALID",
+            "Linux backend image identity is invalid",
+        )
+    reference = image.get("reference")
+    manifest = image.get("manifest_sha256")
+    if (
+        not isinstance(reference, str)
+        or not isinstance(manifest, str)
+        or reference.rsplit("@sha256:", 1)[-1] != manifest
+    ):
+        raise bootstrap.ConformanceError(
+            "AUTHORITY_IMAGE_IDENTITY_MISMATCH",
+            "image reference and manifest identity must match exactly",
+        )
+    if not isinstance(shim, Mapping) or not isinstance(probe, Mapping):
+        raise bootstrap.ConformanceError(
+            "AUTHORITY_IDENTITY_SCHEMA_INVALID",
+            "Linux backend image artifact identity is invalid",
+        )
+    if (
+        shim.get("path") == probe.get("path")
+        or shim.get("sha256") == probe.get("sha256")
+    ):
+        raise bootstrap.ConformanceError(
+            "AUTHORITY_IMAGE_ARTIFACT_COLLISION",
+            "shim and invariant probe must have distinct identities",
+        )
+
+
+def _strict_component_document(
+    raw: bytes,
+    *,
+    code: str,
+) -> dict[str, Any]:
+    try:
+        return bootstrap.strict_load_bytes(
+            raw,
+            max_bytes=MAX_AUTHORITY_COMPONENT_BYTES,
+        )
+    except bootstrap.ConformanceError as error:
+        raise bootstrap.ConformanceError(
+            code,
+            "authority component is not a strict bounded JSON object",
+        ) from error
+
+
+def authorize_preflight(
+    bundle_path: Path,
+    *,
+    approved_digest: str,
+    expected_commit_oid: str,
+    expected_tree_oid: str,
+    repository_root: Path = bootstrap.REPO_ROOT,
+) -> PreflightAuthority:
+    """Prove one external bundle for capability inspection only."""
+
+    if not _is_sha256(approved_digest):
+        raise bootstrap.ConformanceError(
+            "AUTHORITY_DIGEST_INVALID",
+            "approved authority SHA-256 must be 64 lowercase hexadecimal digits",
+        )
+    if not _is_git_oid(expected_commit_oid) or not _is_git_oid(expected_tree_oid):
+        raise bootstrap.ConformanceError(
+            "AUTHORITY_SOURCE_ID_INVALID",
+            "expected source commit and tree must be full lowercase SHA-1 identities",
+        )
+
+    selected_bundle = bundle_path.absolute()
+    selected_repository = repository_root.absolute()
+    raw_bundle = _read_bound_regular(
+        selected_bundle,
+        prefix="AUTHORITY_BUNDLE",
+        label="authority bundle",
+        max_bytes=MAX_AUTHORITY_BUNDLE_BYTES,
+    )
+    actual_digest = authority_bundle_sha256(raw_bundle)
+    if not hmac.compare_digest(actual_digest, approved_digest):
+        raise bootstrap.ConformanceError(
+            "AUTHORITY_DIGEST_MISMATCH",
+            "authority bundle does not match the out-of-band approval",
+        )
+    bundle = bootstrap.strict_load_bytes(
+        raw_bundle,
+        max_bytes=MAX_AUTHORITY_BUNDLE_BYTES,
+    )
+    if not _source_matches(bundle, expected_commit_oid, expected_tree_oid):
+        raise bootstrap.ConformanceError(
+            "AUTHORITY_SOURCE_MISMATCH",
+            "authority source does not match protected commit and tree identities",
+        )
+    _validate_bundle_profile(bundle)
+
+    authority_schema_path = (
+        selected_repository
+        / REPOSITORY_COMPONENT_PATHS["authority_bundle_schema"]
+    )
+    authority_schema_raw = _read_bound_regular(
+        authority_schema_path,
+        prefix="AUTHORITY_COMPONENT",
+        label="authority component authority_bundle_schema",
+        max_bytes=MAX_AUTHORITY_COMPONENT_BYTES,
+    )
+    authority_schema = _strict_component_document(
+        authority_schema_raw,
+        code="AUTHORITY_BUNDLE_SCHEMA_INVALID",
+    )
+    bootstrap._validate_schema(
+        bundle,
+        authority_schema,
+        "AUTHORITY_BUNDLE_SCHEMA_INVALID",
+    )
+
+    components_value = bundle.get("components")
+    if not isinstance(components_value, Mapping):
+        raise bootstrap.ConformanceError(
+            "AUTHORITY_BUNDLE_SCHEMA_INVALID",
+            "authority components must be a closed object",
+        )
+    retained: dict[str, bytes] = {}
+    total_bytes = 0
+    for role in COMPONENT_ROLES:
+        record = components_value.get(role)
+        if not isinstance(record, Mapping):
+            raise bootstrap.ConformanceError(
+                "AUTHORITY_COMPONENT_ROLE_INVALID",
+                f"authority component {role} is missing",
+            )
+        if role == "authority_bundle_schema" and (
+            record.get("provenance") != "repository"
+            or record.get("path")
+            != REPOSITORY_COMPONENT_PATHS["authority_bundle_schema"]
+        ):
+            raise bootstrap.ConformanceError(
+                "AUTHORITY_COMPONENT_ROLE_INVALID",
+                "authority schema component does not match its fixed role",
+            )
+        raw = (
+            authority_schema_raw
+            if role == "authority_bundle_schema"
+            else _read_component_bytes(
+                repository_root=selected_repository,
+                bundle_path=selected_bundle,
+                role=role,
+                record=record,
+            )
+        )
+        total_bytes += len(raw)
+        if total_bytes > MAX_AUTHORITY_TOTAL_BYTES:
+            raise bootstrap.ConformanceError(
+                "AUTHORITY_COMPONENT_TOTAL_TOO_LARGE",
+                "authority components exceed their aggregate byte ceiling",
+            )
+        if record.get("byte_length") != len(raw):
+            raise bootstrap.ConformanceError(
+                "AUTHORITY_COMPONENT_LENGTH_MISMATCH",
+                f"authority component {role} has the wrong byte length",
+            )
+        expected_sha256 = record.get("sha256")
+        if (
+            not isinstance(expected_sha256, str)
+            or not hmac.compare_digest(
+                hashlib.sha256(raw).hexdigest(),
+                expected_sha256,
+            )
+        ):
+            raise bootstrap.ConformanceError(
+                "AUTHORITY_COMPONENT_DIGEST_MISMATCH",
+                f"authority component {role} has the wrong SHA-256",
+            )
+        retained[role] = raw
+
+    policy_schema = _strict_component_document(
+        retained["execution_policy_schema"],
+        code="AUTHORITY_POLICY_SCHEMA_INVALID",
+    )
+    policy = _strict_component_document(
+        retained["execution_policy"],
+        code="AUTHORITY_POLICY_INVALID",
+    )
+    bootstrap._validate_schema(
+        policy,
+        policy_schema,
+        "AUTHORITY_POLICY_SCHEMA_INVALID",
+    )
+    _validate_preflight_policy(
+        policy,
+        conformance_revision=bundle["conformance_revision"],
+    )
+
+    identity_schema = _strict_component_document(
+        retained["linux_backend_identity_schema"],
+        code="AUTHORITY_IDENTITY_SCHEMA_INVALID",
+    )
+    identity = _strict_component_document(
+        retained["linux_backend_identity"],
+        code="AUTHORITY_IDENTITY_INVALID",
+    )
+    bootstrap._validate_schema(
+        identity,
+        identity_schema,
+        "AUTHORITY_IDENTITY_SCHEMA_INVALID",
+    )
+    _validate_identity_semantics(identity)
+    return PreflightAuthority(
+        bundle_digest=actual_digest,
+        bundle=bundle,
+        components=MappingProxyType(retained),
+        policy=policy,
+        identity=identity,
+        identity_schema=identity_schema,
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Verify external build-tool capability-preflight authority."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    selected = subparsers.add_parser(
+        "validate-authority",
+        help="Validate exact authority without importing a process backend.",
+    )
+    selected.add_argument("--authority-bundle", type=Path, required=True)
+    selected.add_argument("--approved-authority-sha256", required=True)
+    selected.add_argument("--source-commit", required=True)
+    selected.add_argument("--source-tree", required=True)
+    selected.add_argument(
+        "--repository-root",
+        type=Path,
+        default=bootstrap.REPO_ROOT,
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    try:
+        arguments = parser.parse_args(argv)
+    except SystemExit as error:
+        return int(error.code)
+    try:
+        keywords = {
+            "approved_digest": arguments.approved_authority_sha256,
+            "expected_commit_oid": arguments.source_commit,
+            "expected_tree_oid": arguments.source_tree,
+            "repository_root": arguments.repository_root,
+        }
+        approved = authorize_preflight(
+            arguments.authority_bundle,
+            **keywords,
+        )
+        output = {
+            "schema_version": 1,
+            "authorization_scope": approved.bundle["authorization_scope"],
+            "authority_sha256": approved.bundle_digest,
+            "status": "valid",
+            "conformance_status": "not-run",
+        }
+        exit_code = 0
+    except bootstrap.ConformanceError as error:
+        print(
+            json.dumps(
+                {
+                    "code": error.code,
+                    "message": error.message,
+                    "status": "error",
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+            file=sys.stderr,
+        )
+        return 2
+    print(json.dumps(output, sort_keys=True, separators=(",", ":")))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/build_tool_conformance_execution.py
+++ b/code/scripts/build_tool_conformance_execution.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any
 
 import build_tool_conformance as bootstrap
+import build_tool_conformance_authority as authority
 
 DEFAULT_FIXTURE_ROOT = bootstrap.DEFAULT_FIXTURE_ROOT
 DEFAULT_EXECUTION_CASE_ROOT = DEFAULT_FIXTURE_ROOT / "execution-cases"
@@ -353,6 +354,7 @@ def _load_contract_documents(
     dict[str, Any],
     dict[str, Any],
     dict[str, Any],
+    dict[str, Any],
 ]:
     return (
         bootstrap.load_document(fixture_root / "schema.json"),
@@ -360,6 +362,7 @@ def _load_contract_documents(
         bootstrap.load_document(fixture_root / "execution.schema.json"),
         bootstrap.load_document(fixture_root / "execution-policy.schema.json"),
         bootstrap.load_document(fixture_root / "execution-policy.json"),
+        bootstrap.load_document(fixture_root / "execution-authority.schema.json"),
     )
 
 
@@ -375,6 +378,7 @@ def validate_contract(
         execution_schema,
         policy_schema,
         policy,
+        authority_schema,
     ) = _load_contract_documents(fixture_root)
     linux_oci_schema = bootstrap.load_document(
         fixture_root / "linux-oci-backend.schema.json"
@@ -385,6 +389,7 @@ def validate_contract(
         execution_schema,
         policy_schema,
         linux_oci_schema,
+        authority_schema,
     ):
         bootstrap._schema_errors({}, schema)
     bootstrap._validate_schema(
@@ -481,72 +486,36 @@ def run_case(
     case_path: Path,
     *,
     language: str,
-    approved_digest: str,
+    authority_bundle: Path,
+    approved_authority_digest: str,
+    expected_commit_oid: str,
+    expected_tree_oid: str,
     allow_trusted_execution: bool,
-    fixture_root: Path = DEFAULT_FIXTURE_ROOT,
-    platform_name: str | None = None,
+    repository_root: Path = bootstrap.REPO_ROOT,
 ) -> dict[str, Any]:
-    """Check execution authority and fail closed before any process operation."""
+    """Reject preflight-only authority before decoding an execution case."""
 
-    del case_path  # The policy-only tranche never decodes executable case data.
+    del case_path, language  # This tranche never decodes executable case data.
     if not allow_trusted_execution:
         raise bootstrap.ConformanceError(
             "EXECUTION_AUTHORIZATION_REQUIRED",
             "trusted execution requires --allow-trusted-execution",
         )
-
-    fixture_root = fixture_root.resolve()
-    _, _, _, policy_schema, policy = _load_contract_documents(fixture_root)
-    bootstrap._validate_schema(
-        policy,
-        policy_schema,
-        "EXECUTION_POLICY_SCHEMA_INVALID",
-    )
-    validate_policy_semantics(policy)
-    actual_digest = execution_corpus_digest(fixture_root / "execution-cases")
-    if (
-        not _is_sha256(approved_digest)
-        or approved_digest != actual_digest
-        or approved_digest != policy["execution_corpus_sha256"]
-    ):
+    if not _is_sha256(approved_authority_digest):
         raise bootstrap.ConformanceError(
-            "EXECUTION_DIGEST_MISMATCH",
-            "approved digest, policy digest, and corpus digest must match exactly",
+            "AUTHORITY_DIGEST_INVALID",
+            "approved authority SHA-256 must be 64 lowercase hexadecimal digits",
         )
-
-    if not policy["enabled"]:
-        return _nonpassing_skip(
-            "EXECUTION_POLICY_DISABLED",
-            "trusted execution policy is disabled",
-        )
-
-    selected_platform = platform_name or _platform_name()
-    backend = next(
-        (item for item in policy["backends"] if item["platform"] == selected_platform),
-        None,
+    authority.authorize_preflight(
+        authority_bundle,
+        approved_digest=approved_authority_digest,
+        expected_commit_oid=expected_commit_oid,
+        expected_tree_oid=expected_tree_oid,
+        repository_root=repository_root,
     )
-    if backend is None or backend["status"] != "ready":
-        return _nonpassing_skip(
-            "EXECUTION_BACKEND_UNAVAILABLE",
-            f"no enforcing trusted-execution backend for {selected_platform}",
-        )
-
-    adapter = next(
-        (
-            item
-            for item in policy["adapters"]
-            if item["language"] == language and item["platform"] == selected_platform
-        ),
-        None,
-    )
-    if adapter is None:
-        return _nonpassing_skip(
-            "EXECUTION_ADAPTER_UNAVAILABLE",
-            f"no reviewed adapter for {language}/{selected_platform}",
-        )
     return _nonpassing_skip(
-        "EXECUTION_BACKEND_UNIMPLEMENTED",
-        "policy authority is valid, but this tranche contains no process backend",
+        "EXECUTION_AUTHORITY_SCOPE_UNAVAILABLE",
+        "capability-preflight authority cannot authorize an execution case",
     )
 
 
@@ -572,12 +541,15 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     run_parser.add_argument("--case", type=Path, required=True)
     run_parser.add_argument("--language", required=True)
-    run_parser.add_argument("--approved-corpus-sha256", required=True)
+    run_parser.add_argument("--authority-bundle", type=Path, required=True)
+    run_parser.add_argument("--approved-authority-sha256", required=True)
+    run_parser.add_argument("--source-commit", required=True)
+    run_parser.add_argument("--source-tree", required=True)
     run_parser.add_argument("--allow-trusted-execution", action="store_true")
     run_parser.add_argument(
-        "--fixture-root",
+        "--repository-root",
         type=Path,
-        default=DEFAULT_FIXTURE_ROOT,
+        default=bootstrap.REPO_ROOT,
     )
     return parser
 
@@ -596,9 +568,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             output = run_case(
                 arguments.case,
                 language=arguments.language,
-                approved_digest=arguments.approved_corpus_sha256,
+                authority_bundle=arguments.authority_bundle,
+                approved_authority_digest=arguments.approved_authority_sha256,
+                expected_commit_oid=arguments.source_commit,
+                expected_tree_oid=arguments.source_tree,
                 allow_trusted_execution=arguments.allow_trusted_execution,
-                fixture_root=arguments.fixture_root,
+                repository_root=arguments.repository_root,
             )
             exit_code = 1
     except bootstrap.ConformanceError as error:

--- a/code/scripts/build_tool_conformance_linux_oci.py
+++ b/code/scripts/build_tool_conformance_linux_oci.py
@@ -20,7 +20,6 @@ import stat
 # This is the deliberately isolated process-owning backend.
 import subprocess  # nosec B404
 import sys
-import tempfile
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -607,6 +606,7 @@ def preflight(
     identity: dict[str, Any],
     *,
     state_root: Path,
+    identity_schema: dict[str, Any] | None = None,
     command_runner: CommandRunner = _run_command,
     binary_digest: DigestReader = _binary_digest,
     platform_name: str | None = None,
@@ -614,7 +614,7 @@ def preflight(
 ) -> dict[str, Any]:
     """Prove host and image capabilities without creating a container."""
 
-    validate_identity(identity)
+    validate_identity(identity, identity_schema)
     selected_platform = platform_name or sys.platform
     if not selected_platform.startswith("linux"):
         raise LinuxOciUnavailable(
@@ -703,14 +703,11 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     parser = _build_parser()
     try:
-        arguments = parser.parse_args(argv)
-        identity, digest = load_identity(arguments.identity)
-        with tempfile.TemporaryDirectory(prefix="btconf-linux-oci-") as directory:
-            result = preflight(identity, state_root=Path(directory))
-        result["identity_sha256"] = digest
-        print(json.dumps(result, sort_keys=True, separators=(",", ":")))
-        return 0
-    except LinuxOciUnavailable as error:
+        parser.parse_args(argv)
+        error = LinuxOciUnavailable(
+            "LINUX_OCI_AUTHORITY_REQUIRED",
+            "use build_tool_conformance_authority.py with out-of-band approval",
+        )
         print(
             json.dumps(
                 _unavailable_result(error),

--- a/code/scripts/tests/test_build_tool_conformance_authority.py
+++ b/code/scripts/tests/test_build_tool_conformance_authority.py
@@ -1,0 +1,589 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import io
+import json
+import os
+import struct
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import build_tool_conformance as bootstrap
+import build_tool_conformance_authority as authority
+
+FIXTURE_ROOT = bootstrap.DEFAULT_FIXTURE_ROOT
+COMMIT_OID = "a" * 40
+TREE_OID = "b" * 40
+EMPTY_DIGEST = hashlib.sha256(b"").hexdigest()
+
+REPOSITORY_COMPONENTS = {
+    "authority_bundle_schema": (
+        "code/specs/fixtures/build-tool-v1/execution-authority.schema.json"
+    ),
+    "execution_policy_schema": (
+        "code/specs/fixtures/build-tool-v1/execution-policy.schema.json"
+    ),
+    "execution_policy": "code/specs/fixtures/build-tool-v1/execution-policy.json",
+    "linux_backend_identity_schema": (
+        "code/specs/fixtures/build-tool-v1/linux-oci-backend.schema.json"
+    ),
+    "bootstrap_runner": "code/scripts/build_tool_conformance.py",
+    "authority_verifier": "code/scripts/build_tool_conformance_authority.py",
+    "linux_preflight_backend": "code/scripts/build_tool_conformance_linux_oci.py",
+}
+
+
+def backend_identity() -> dict[str, object]:
+    manifest = "4" * 64
+    return {
+        "schema_version": 1,
+        "backend_kind": "linux_oci",
+        "platform": "linux",
+        "architecture": "amd64",
+        "runtime": {
+            "implementation": "podman",
+            "path": "/usr/bin/podman",
+            "version": "5.8.3",
+            "sha256": "1" * 64,
+        },
+        "oci_runtime": {
+            "implementation": "crun",
+            "path": "/usr/bin/crun",
+            "sha256": "2" * 64,
+        },
+        "image": {
+            "reference": f"localhost/build-tool@sha256:{manifest}",
+            "manifest_sha256": manifest,
+            "config_sha256": "5" * 64,
+            "os": "linux",
+            "architecture": "amd64",
+        },
+        "seccomp_profile_sha256": "6" * 64,
+        "shim": {
+            "path": "/opt/conformance/shim",
+            "sha256": "7" * 64,
+        },
+        "probe": {
+            "path": "/opt/conformance/probe",
+            "sha256": "8" * 64,
+        },
+    }
+
+
+def component_path(
+    repository_root: Path,
+    bundle_path: Path,
+    role: str,
+    record: dict[str, object],
+) -> Path:
+    if record["provenance"] == "repository":
+        return repository_root / str(record["path"])
+    return bundle_path.parent / str(record["path"])
+
+
+def write_authority_fixture(root: Path) -> dict[str, object]:
+    repository_root = root / "repository"
+    bundle_root = root / "authority"
+    bundle_root.mkdir(parents=True)
+
+    fixture_sources = {
+        "authority_bundle_schema": FIXTURE_ROOT / "execution-authority.schema.json",
+        "execution_policy_schema": FIXTURE_ROOT / "execution-policy.schema.json",
+        "execution_policy": FIXTURE_ROOT / "execution-policy.json",
+        "linux_backend_identity_schema": FIXTURE_ROOT / "linux-oci-backend.schema.json",
+    }
+    raw_components: dict[str, bytes] = {
+        role: source.read_bytes() for role, source in fixture_sources.items()
+    }
+    raw_components.update(
+        {
+            "bootstrap_runner": b"# process-free bootstrap\n",
+            "authority_verifier": b"# process-free authority verifier\n",
+            "linux_preflight_backend": b"# process-owning Linux preflight\n",
+        }
+    )
+    for role, relative_path in REPOSITORY_COMPONENTS.items():
+        target = repository_root / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(raw_components[role])
+
+    identity_path = bundle_root / "linux-oci-backend.json"
+    identity_path.write_bytes(
+        json.dumps(
+            backend_identity(),
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        + b"\n"
+    )
+    bundle_path = bundle_root / "authority.json"
+    bundle: dict[str, object] = {
+        "schema_version": 1,
+        "purpose": "build-tool-trusted-authority",
+        "authorization_scope": "linux_capability_preflight_v1",
+        "repository": "github.com/adhithyan15/coding-adventures",
+        "conformance_revision": "v1",
+        "platform": "linux",
+        "architecture": "amd64",
+        "source": {
+            "git_object_format": "sha1",
+            "commit_oid": COMMIT_OID,
+            "tree_oid": TREE_OID,
+        },
+        "components": {
+            **{
+                role: {
+                    "provenance": "repository",
+                    "path": relative_path,
+                    "byte_length": len(raw_components[role]),
+                    "sha256": hashlib.sha256(raw_components[role]).hexdigest(),
+                }
+                for role, relative_path in REPOSITORY_COMPONENTS.items()
+            },
+            "linux_backend_identity": {
+                "provenance": "bundle",
+                "path": "linux-oci-backend.json",
+                "byte_length": len(identity_path.read_bytes()),
+                "sha256": hashlib.sha256(identity_path.read_bytes()).hexdigest(),
+            },
+        },
+    }
+    environment: dict[str, object] = {
+        "repository_root": repository_root,
+        "bundle_path": bundle_path,
+        "bundle": bundle,
+    }
+    rewrite_bundle(environment)
+    return environment
+
+
+def rewrite_bundle(environment: dict[str, object]) -> str:
+    bundle_path = environment["bundle_path"]
+    bundle = environment["bundle"]
+    assert isinstance(bundle_path, Path)
+    assert isinstance(bundle, dict)
+    raw = (
+        json.dumps(bundle, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        + b"\n"
+    )
+    bundle_path.write_bytes(raw)
+    digest = authority.authority_bundle_sha256(raw)
+    environment["approved_digest"] = digest
+    return digest
+
+
+def refresh_component(
+    environment: dict[str, object],
+    role: str,
+    raw: bytes,
+) -> str:
+    repository_root = environment["repository_root"]
+    bundle_path = environment["bundle_path"]
+    bundle = environment["bundle"]
+    assert isinstance(repository_root, Path)
+    assert isinstance(bundle_path, Path)
+    assert isinstance(bundle, dict)
+    components = bundle["components"]
+    assert isinstance(components, dict)
+    record = components[role]
+    assert isinstance(record, dict)
+    component_path(repository_root, bundle_path, role, record).write_bytes(raw)
+    record["byte_length"] = len(raw)
+    record["sha256"] = hashlib.sha256(raw).hexdigest()
+    return rewrite_bundle(environment)
+
+
+def authorize(environment: dict[str, object]) -> authority.PreflightAuthority:
+    return authority.authorize_preflight(
+        environment["bundle_path"],  # type: ignore[arg-type]
+        approved_digest=environment["approved_digest"],  # type: ignore[arg-type]
+        expected_commit_oid=COMMIT_OID,
+        expected_tree_oid=TREE_OID,
+        repository_root=environment["repository_root"],  # type: ignore[arg-type]
+    )
+
+
+class AuthoritySchemaTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.schema = bootstrap.load_document(
+            FIXTURE_ROOT / "execution-authority.schema.json"
+        )
+
+    def test_closed_preflight_bundle_validates(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            environment = write_authority_fixture(Path(directory))
+            self.assertEqual(
+                bootstrap._schema_errors(environment["bundle"], self.schema),
+                [],
+            )
+
+    def test_self_digest_future_scope_revision_and_role_swap_are_rejected(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            environment = write_authority_fixture(Path(directory))
+            bundle = environment["bundle"]
+            assert isinstance(bundle, dict)
+
+            self_digest = copy.deepcopy(bundle)
+            self_digest["authority_sha256"] = "0" * 64
+            self.assertTrue(bootstrap._schema_errors(self_digest, self.schema))
+
+            future_scope = copy.deepcopy(bundle)
+            future_scope["authorization_scope"] = "trusted_execution_v1"
+            self.assertTrue(bootstrap._schema_errors(future_scope, self.schema))
+
+            future_revision = copy.deepcopy(bundle)
+            future_revision["conformance_revision"] = "v2"
+            self.assertTrue(bootstrap._schema_errors(future_revision, self.schema))
+
+            swapped = copy.deepcopy(bundle)
+            components = swapped["components"]
+            assert isinstance(components, dict)
+            first = components["bootstrap_runner"]
+            second = components["authority_verifier"]
+            assert isinstance(first, dict)
+            assert isinstance(second, dict)
+            first["path"], second["path"] = second["path"], first["path"]
+            self.assertTrue(bootstrap._schema_errors(swapped, self.schema))
+
+
+class AuthorityVerifierTests(unittest.TestCase):
+    def test_digest_has_exact_domain_length_and_raw_byte_framing(self) -> None:
+        raw = b'{"schema_version":1}\n'
+        manual = hashlib.sha256(
+            authority.AUTHORITY_DOMAIN + struct.pack(">Q", len(raw)) + raw
+        ).hexdigest()
+        self.assertEqual(authority.authority_bundle_sha256(raw), manual)
+        for changed in (
+            b'{ "schema_version": 1 }\n',
+            b'{"schema_version":1}',
+            b'{"schema_version":1}\r\n',
+        ):
+            self.assertNotEqual(authority.authority_bundle_sha256(changed), manual)
+
+    def test_invalid_approval_fails_before_any_read(self) -> None:
+        with (
+            mock.patch.object(authority, "_read_bound_regular") as reader,
+            self.assertRaises(bootstrap.ConformanceError) as raised,
+        ):
+            authority.authorize_preflight(
+                Path("missing.json"),
+                approved_digest="not-a-digest",
+                expected_commit_oid=COMMIT_OID,
+                expected_tree_oid=TREE_OID,
+                repository_root=Path("missing"),
+            )
+        self.assertEqual(raised.exception.code, "AUTHORITY_DIGEST_INVALID")
+        reader.assert_not_called()
+
+    def test_invalid_source_identities_fail_before_any_read(self) -> None:
+        for commit, tree in (
+            ("A" * 40, TREE_OID),
+            ("a" * 39, TREE_OID),
+            (COMMIT_OID, "not-a-tree"),
+        ):
+            with (
+                self.subTest(commit=commit, tree=tree),
+                mock.patch.object(authority, "_read_bound_regular") as reader,
+                self.assertRaises(bootstrap.ConformanceError) as raised,
+            ):
+                authority.authorize_preflight(
+                    Path("missing.json"),
+                    approved_digest="0" * 64,
+                    expected_commit_oid=commit,
+                    expected_tree_oid=tree,
+                    repository_root=Path("missing"),
+                )
+            self.assertEqual(raised.exception.code, "AUTHORITY_SOURCE_ID_INVALID")
+            reader.assert_not_called()
+
+    def test_digest_mismatch_fails_before_parse_or_component_read(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            environment = write_authority_fixture(Path(directory))
+            with (
+                mock.patch.object(bootstrap, "strict_load_bytes") as parser,
+                mock.patch.object(authority, "_read_component_bytes") as components,
+                self.assertRaises(bootstrap.ConformanceError) as raised,
+            ):
+                authority.authorize_preflight(
+                    environment["bundle_path"],  # type: ignore[arg-type]
+                    approved_digest="0" * 64,
+                    expected_commit_oid=COMMIT_OID,
+                    expected_tree_oid=TREE_OID,
+                    repository_root=environment["repository_root"],  # type: ignore[arg-type]
+                )
+            self.assertEqual(raised.exception.code, "AUTHORITY_DIGEST_MISMATCH")
+            parser.assert_not_called()
+            components.assert_not_called()
+
+    def test_source_mismatch_fails_before_component_read(self) -> None:
+        for commit, tree in (("c" * 40, TREE_OID), (COMMIT_OID, "d" * 40)):
+            with self.subTest(commit=commit, tree=tree), tempfile.TemporaryDirectory() as directory:
+                environment = write_authority_fixture(Path(directory))
+                with (
+                    mock.patch.object(
+                        authority,
+                        "_read_component_bytes",
+                    ) as components,
+                    self.assertRaises(bootstrap.ConformanceError) as raised,
+                ):
+                    authority.authorize_preflight(
+                        environment["bundle_path"],  # type: ignore[arg-type]
+                        approved_digest=environment["approved_digest"],  # type: ignore[arg-type]
+                        expected_commit_oid=commit,
+                        expected_tree_oid=tree,
+                        repository_root=environment["repository_root"],  # type: ignore[arg-type]
+                    )
+                self.assertEqual(
+                    raised.exception.code,
+                    "AUTHORITY_SOURCE_MISMATCH",
+                )
+                components.assert_not_called()
+
+    def test_valid_bundle_authorizes_only_disabled_preflight_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            environment = write_authority_fixture(Path(directory))
+            approved = authorize(environment)
+        self.assertEqual(approved.bundle_digest, environment["approved_digest"])
+        self.assertEqual(approved.bundle["authorization_scope"], "linux_capability_preflight_v1")
+        self.assertFalse(approved.policy["enabled"])
+        self.assertEqual(approved.policy["execution_corpus_sha256"], EMPTY_DIGEST)
+        self.assertEqual(approved.policy["adapters"], [])
+        linux = next(
+            item for item in approved.policy["backends"] if item["platform"] == "linux"
+        )
+        self.assertEqual(linux["status"], "unavailable")
+        self.assertIsNone(linux["identity_sha256"])
+        self.assertEqual(approved.identity["backend_kind"], "linux_oci")
+        self.assertFalse(hasattr(authority, "subprocess"))
+
+    def test_every_component_is_bound_by_exact_length_and_digest(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            environment = write_authority_fixture(Path(directory))
+            bundle = environment["bundle"]
+            repository_root = environment["repository_root"]
+            bundle_path = environment["bundle_path"]
+            assert isinstance(bundle, dict)
+            assert isinstance(repository_root, Path)
+            assert isinstance(bundle_path, Path)
+            components = bundle["components"]
+            assert isinstance(components, dict)
+            for role, record in components.items():
+                assert isinstance(record, dict)
+                path = component_path(repository_root, bundle_path, role, record)
+                original = path.read_bytes()
+                with self.subTest(role=role, mutation="digest"):
+                    path.write_bytes(original + b"\n")
+                    with self.assertRaises(bootstrap.ConformanceError) as raised:
+                        authorize(environment)
+                    self.assertEqual(
+                        raised.exception.code,
+                        "AUTHORITY_COMPONENT_LENGTH_MISMATCH",
+                    )
+                    path.write_bytes(original)
+                with self.subTest(role=role, mutation="declared-length"):
+                    record["byte_length"] = len(original) + 1
+                    rewrite_bundle(environment)
+                    with self.assertRaises(bootstrap.ConformanceError) as raised:
+                        authorize(environment)
+                    self.assertEqual(
+                        raised.exception.code,
+                        "AUTHORITY_COMPONENT_LENGTH_MISMATCH",
+                    )
+                    record["byte_length"] = len(original)
+                    rewrite_bundle(environment)
+                with self.subTest(role=role, mutation="declared-digest"):
+                    record["sha256"] = "0" * 64
+                    rewrite_bundle(environment)
+                    with self.assertRaises(bootstrap.ConformanceError) as raised:
+                        authorize(environment)
+                    self.assertEqual(
+                        raised.exception.code,
+                        "AUTHORITY_COMPONENT_DIGEST_MISMATCH",
+                    )
+                    record["sha256"] = hashlib.sha256(original).hexdigest()
+                    rewrite_bundle(environment)
+
+    def test_policy_must_remain_disabled_empty_and_unavailable(self) -> None:
+        mutations = [
+            ("enabled", lambda policy: policy.__setitem__("enabled", True)),
+            (
+                "corpus",
+                lambda policy: policy.__setitem__("execution_corpus_sha256", "9" * 64),
+            ),
+            (
+                "adapter",
+                lambda policy: policy["adapters"].append(
+                    {
+                        "language": "go",
+                        "platform": "linux",
+                        "executable": "code/programs/go/build-tool",
+                        "executable_sha256": "1" * 64,
+                    }
+                ),
+            ),
+            (
+                "backend",
+                lambda policy: policy["backends"][1].update(
+                    {"status": "ready", "identity_sha256": "2" * 64}
+                ),
+            ),
+        ]
+        for name, mutate in mutations:
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as directory:
+                environment = write_authority_fixture(Path(directory))
+                policy = bootstrap.load_document(FIXTURE_ROOT / "execution-policy.json")
+                mutate(policy)
+                digest = refresh_component(
+                    environment,
+                    "execution_policy",
+                    json.dumps(policy, sort_keys=True).encode("utf-8"),
+                )
+                environment["approved_digest"] = digest
+                with self.assertRaises(bootstrap.ConformanceError) as raised:
+                    authorize(environment)
+                self.assertEqual(
+                    raised.exception.code,
+                    "AUTHORITY_POLICY_PROFILE_INVALID",
+                )
+
+    def test_identity_cross_field_mismatches_fail_closed(self) -> None:
+        mutations = [
+            (
+                "reference",
+                lambda identity: identity["image"].__setitem__(  # type: ignore[union-attr]
+                    "reference",
+                    f"localhost/build-tool@sha256:{'9' * 64}",
+                ),
+                "AUTHORITY_IMAGE_IDENTITY_MISMATCH",
+            ),
+            (
+                "artifact-collision",
+                lambda identity: identity["probe"].__setitem__(  # type: ignore[union-attr]
+                    "path",
+                    identity["shim"]["path"],  # type: ignore[index]
+                ),
+                "AUTHORITY_IMAGE_ARTIFACT_COLLISION",
+            ),
+        ]
+        for name, mutate, code in mutations:
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as directory:
+                environment = write_authority_fixture(Path(directory))
+                identity = backend_identity()
+                mutate(identity)
+                digest = refresh_component(
+                    environment,
+                    "linux_backend_identity",
+                    json.dumps(identity, sort_keys=True).encode("utf-8"),
+                )
+                environment["approved_digest"] = digest
+                with self.assertRaises(bootstrap.ConformanceError) as raised:
+                    authorize(environment)
+                self.assertEqual(raised.exception.code, code)
+
+    def test_hardlinked_component_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            environment = write_authority_fixture(Path(directory))
+            repository_root = environment["repository_root"]
+            assert isinstance(repository_root, Path)
+            target = repository_root / REPOSITORY_COMPONENTS["bootstrap_runner"]
+            sibling = target.with_name("bootstrap-hardlink.py")
+            try:
+                os.link(target, sibling)
+            except (NotImplementedError, OSError):
+                self.skipTest("hard links are unavailable")
+            with self.assertRaises(bootstrap.ConformanceError) as raised:
+                authorize(environment)
+            self.assertEqual(
+                raised.exception.code,
+                "AUTHORITY_COMPONENT_FILE_INVALID",
+            )
+
+    def test_symlinked_component_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            environment = write_authority_fixture(Path(directory))
+            bundle_path = environment["bundle_path"]
+            assert isinstance(bundle_path, Path)
+            identity_path = bundle_path.parent / "linux-oci-backend.json"
+            target = bundle_path.parent / "identity-target.json"
+            target.write_bytes(identity_path.read_bytes())
+            identity_path.unlink()
+            try:
+                identity_path.symlink_to(target)
+            except (NotImplementedError, OSError):
+                self.skipTest("symbolic links are unavailable")
+            with self.assertRaises(bootstrap.ConformanceError) as raised:
+                authorize(environment)
+            self.assertEqual(
+                raised.exception.code,
+                "AUTHORITY_COMPONENT_FILE_INVALID",
+            )
+
+    def test_directory_component_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            environment = write_authority_fixture(Path(directory))
+            repository_root = environment["repository_root"]
+            assert isinstance(repository_root, Path)
+            target = repository_root / REPOSITORY_COMPONENTS["bootstrap_runner"]
+            target.unlink()
+            target.mkdir()
+            with self.assertRaises(bootstrap.ConformanceError) as raised:
+                authorize(environment)
+            self.assertEqual(
+                raised.exception.code,
+                "AUTHORITY_COMPONENT_FILE_INVALID",
+            )
+
+    def test_validate_cli_reports_stable_process_free_result(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            environment = write_authority_fixture(Path(directory))
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                exit_code = authority.main(
+                    [
+                        "validate-authority",
+                        "--authority-bundle",
+                        str(environment["bundle_path"]),
+                        "--approved-authority-sha256",
+                        str(environment["approved_digest"]),
+                        "--source-commit",
+                        COMMIT_OID,
+                        "--source-tree",
+                        TREE_OID,
+                        "--repository-root",
+                        str(environment["repository_root"]),
+                    ]
+                )
+        self.assertEqual(exit_code, 0)
+        output = json.loads(stdout.getvalue())
+        self.assertEqual(output["status"], "valid")
+        self.assertEqual(output["authorization_scope"], "linux_capability_preflight_v1")
+        self.assertNotIn(str(environment["repository_root"]), stdout.getvalue())
+        self.assertEqual(stderr.getvalue(), "")
+
+        with redirect_stderr(io.StringIO()):
+            self.assertEqual(authority.main([]), 2)
+
+    def test_process_backend_handoff_is_not_exposed_by_this_tranche(self) -> None:
+        self.assertFalse(hasattr(authority, "run_authorized_preflight"))
+        self.assertFalse(hasattr(authority, "subprocess"))
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            exit_code = authority.main(["preflight"])
+        self.assertEqual(exit_code, 2)
+        self.assertIn("invalid choice", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/scripts/tests/test_build_tool_conformance_execution_runner.py
+++ b/code/scripts/tests/test_build_tool_conformance_execution_runner.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 import copy
 import io
 import json
-import shutil
 import sys
-import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
@@ -20,26 +18,6 @@ import build_tool_conformance_execution as execution
 FIXTURE_ROOT = bootstrap.DEFAULT_FIXTURE_ROOT
 EMPTY_DIGEST = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
-
-def write_policy_fixture(root: Path, policy: dict[str, object]) -> Path:
-    fixture_root = root / "fixtures"
-    fixture_root.mkdir()
-    for name in (
-        "schema.json",
-        "result.schema.json",
-        "execution.schema.json",
-        "execution-policy.schema.json",
-        "linux-oci-backend.schema.json",
-    ):
-        shutil.copyfile(FIXTURE_ROOT / name, fixture_root / name)
-    (fixture_root / "execution-cases").mkdir()
-    (fixture_root / "execution-policy.json").write_text(
-        json.dumps(policy),
-        encoding="utf-8",
-    )
-    return fixture_root
-
-
 class ExecutionPolicyRunnerTests(unittest.TestCase):
     def test_checked_in_contract_validates_without_execution(self) -> None:
         summary = execution.validate_contract(FIXTURE_ROOT)
@@ -53,124 +31,62 @@ class ExecutionPolicyRunnerTests(unittest.TestCase):
     def test_operator_authorization_is_checked_before_case_read(self) -> None:
         missing = Path("definitely-not-present.json")
         with (
-            mock.patch.object(execution, "_read_raw_regular") as reader,
+            mock.patch.object(execution.authority, "authorize_preflight") as verifier,
             self.assertRaises(bootstrap.ConformanceError) as raised,
         ):
             execution.run_case(
                 missing,
                 language="go",
-                approved_digest=EMPTY_DIGEST,
+                authority_bundle=Path("missing-authority.json"),
+                approved_authority_digest="0" * 64,
+                expected_commit_oid="a" * 40,
+                expected_tree_oid="b" * 40,
                 allow_trusted_execution=False,
-                fixture_root=FIXTURE_ROOT,
             )
         self.assertEqual(raised.exception.code, "EXECUTION_AUTHORIZATION_REQUIRED")
-        reader.assert_not_called()
+        verifier.assert_not_called()
 
-    def test_approved_digest_is_checked_before_case_decode(self) -> None:
+    def test_approved_authority_syntax_is_checked_before_bundle_or_case(self) -> None:
         missing = Path("definitely-not-present.json")
         with (
-            mock.patch.object(execution, "_read_raw_regular") as reader,
+            mock.patch.object(execution.authority, "authorize_preflight") as verifier,
             self.assertRaises(bootstrap.ConformanceError) as raised,
         ):
             execution.run_case(
                 missing,
                 language="go",
-                approved_digest="0" * 64,
+                authority_bundle=Path("missing-authority.json"),
+                approved_authority_digest="not-a-digest",
+                expected_commit_oid="a" * 40,
+                expected_tree_oid="b" * 40,
                 allow_trusted_execution=True,
-                fixture_root=FIXTURE_ROOT,
             )
-        self.assertEqual(raised.exception.code, "EXECUTION_DIGEST_MISMATCH")
-        reader.assert_not_called()
+        self.assertEqual(raised.exception.code, "AUTHORITY_DIGEST_INVALID")
+        verifier.assert_not_called()
 
-    def test_disabled_policy_returns_nonpassing_skip_without_process_api(self) -> None:
-        with tempfile.TemporaryDirectory() as directory:
-            case = Path(directory) / "case.json"
-            case.write_text("{}", encoding="utf-8")
+    def test_preflight_scope_cannot_authorize_case_or_import_process_api(self) -> None:
+        with mock.patch.object(
+            execution.authority,
+            "authorize_preflight",
+            return_value=mock.sentinel.preflight_authority,
+        ) as verifier:
             result = execution.run_case(
-                case,
+                Path("never-read-case.json"),
                 language="go",
-                approved_digest=EMPTY_DIGEST,
+                authority_bundle=Path("authority.json"),
+                approved_authority_digest="0" * 64,
+                expected_commit_oid="a" * 40,
+                expected_tree_oid="b" * 40,
                 allow_trusted_execution=True,
-                fixture_root=FIXTURE_ROOT,
             )
         self.assertEqual(result["outcome"], "skipped")
         self.assertEqual(result["conformance_status"], "non-passing")
         self.assertEqual(
             result["diagnostics"][0]["code"],
-            "EXECUTION_POLICY_DISABLED",
+            "EXECUTION_AUTHORITY_SCOPE_UNAVAILABLE",
         )
+        verifier.assert_called_once()
         self.assertFalse(hasattr(execution, "subprocess"))
-
-    def test_ready_backend_is_still_fail_closed_in_policy_only_tranche(self) -> None:
-        policy = bootstrap.load_document(FIXTURE_ROOT / "execution-policy.json")
-        policy["enabled"] = True
-        linux = next(item for item in policy["backends"] if item["platform"] == "linux")
-        linux["status"] = "ready"
-        linux["identity_sha256"] = "1" * 64
-        policy["adapters"] = [
-            {
-                "language": "go",
-                "platform": "linux",
-                "executable": "code/programs/go/build-tool",
-                "executable_sha256": "2" * 64,
-            }
-        ]
-        with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
-            fixture_root = write_policy_fixture(root, policy)
-            case = root / "case.json"
-            case.write_text("{}", encoding="utf-8")
-            result = execution.run_case(
-                case,
-                language="go",
-                approved_digest=EMPTY_DIGEST,
-                allow_trusted_execution=True,
-                fixture_root=fixture_root,
-                platform_name="linux",
-            )
-        self.assertEqual(result["outcome"], "skipped")
-        self.assertEqual(
-            result["diagnostics"][0]["code"],
-            "EXECUTION_BACKEND_UNIMPLEMENTED",
-        )
-
-    def test_enabled_policy_skips_unavailable_backend_and_missing_adapter(self) -> None:
-        policy = bootstrap.load_document(FIXTURE_ROOT / "execution-policy.json")
-        policy["enabled"] = True
-        with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
-            fixture_root = write_policy_fixture(root, policy)
-            result = execution.run_case(
-                root / "unused.json",
-                language="go",
-                approved_digest=EMPTY_DIGEST,
-                allow_trusted_execution=True,
-                fixture_root=fixture_root,
-                platform_name="windows",
-            )
-        self.assertEqual(
-            result["diagnostics"][0]["code"],
-            "EXECUTION_BACKEND_UNAVAILABLE",
-        )
-
-        linux = next(item for item in policy["backends"] if item["platform"] == "linux")
-        linux["status"] = "ready"
-        linux["identity_sha256"] = "1" * 64
-        with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
-            fixture_root = write_policy_fixture(root, policy)
-            result = execution.run_case(
-                root / "unused.json",
-                language="go",
-                approved_digest=EMPTY_DIGEST,
-                allow_trusted_execution=True,
-                fixture_root=fixture_root,
-                platform_name="linux",
-            )
-        self.assertEqual(
-            result["diagnostics"][0]["code"],
-            "EXECUTION_ADAPTER_UNAVAILABLE",
-        )
 
     def test_platform_mapping_is_explicit_and_fail_closed(self) -> None:
         with mock.patch.object(execution.sys, "platform", "linux-x"):
@@ -188,7 +104,7 @@ class ExecutionPolicyRunnerTests(unittest.TestCase):
         ):
             self.assertEqual(execution._platform_name(), "unsupported")
 
-    def test_cli_validate_contract_and_disabled_run_case_have_stable_exit_codes(
+    def test_cli_validate_contract_and_preflight_only_run_case_have_stable_codes(
         self,
     ) -> None:
         stdout = io.StringIO()
@@ -197,24 +113,35 @@ class ExecutionPolicyRunnerTests(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertEqual(json.loads(stdout.getvalue())["status"], "valid")
 
-        with tempfile.TemporaryDirectory() as directory:
-            case = Path(directory) / "case.json"
-            case.write_text("{}", encoding="utf-8")
-            stdout = io.StringIO()
-            stderr = io.StringIO()
-            with redirect_stdout(stdout), redirect_stderr(stderr):
-                exit_code = execution.main(
-                    [
-                        "run-case",
-                        "--case",
-                        str(case),
-                        "--language",
-                        "go",
-                        "--approved-corpus-sha256",
-                        EMPTY_DIGEST,
-                        "--allow-trusted-execution",
-                    ]
-                )
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with (
+            mock.patch.object(
+                execution.authority,
+                "authorize_preflight",
+                return_value=mock.sentinel.preflight_authority,
+            ),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            exit_code = execution.main(
+                [
+                    "run-case",
+                    "--case",
+                    "never-read.json",
+                    "--language",
+                    "go",
+                    "--authority-bundle",
+                    "authority.json",
+                    "--approved-authority-sha256",
+                    "0" * 64,
+                    "--source-commit",
+                    "a" * 40,
+                    "--source-tree",
+                    "b" * 40,
+                    "--allow-trusted-execution",
+                ]
+            )
         self.assertEqual(exit_code, 1)
         self.assertEqual(json.loads(stdout.getvalue())["outcome"], "skipped")
         self.assertEqual(stderr.getvalue(), "")
@@ -225,11 +152,17 @@ class ExecutionPolicyRunnerTests(unittest.TestCase):
                 [
                     "run-case",
                     "--case",
-                    str(case),
+                    "never-read.json",
                     "--language",
                     "go",
-                    "--approved-corpus-sha256",
-                    EMPTY_DIGEST,
+                    "--authority-bundle",
+                    "authority.json",
+                    "--approved-authority-sha256",
+                    "0" * 64,
+                    "--source-commit",
+                    "a" * 40,
+                    "--source-tree",
+                    "b" * 40,
                 ]
             )
         self.assertEqual(exit_code, 2)
@@ -237,6 +170,31 @@ class ExecutionPolicyRunnerTests(unittest.TestCase):
             json.loads(stderr.getvalue())["code"],
             "EXECUTION_AUTHORIZATION_REQUIRED",
         )
+
+        legacy_stderr = io.StringIO()
+        with redirect_stderr(legacy_stderr):
+            exit_code = execution.main(
+                [
+                    "run-case",
+                    "--case",
+                    "never-read.json",
+                    "--language",
+                    "go",
+                    "--authority-bundle",
+                    "authority.json",
+                    "--approved-authority-sha256",
+                    "0" * 64,
+                    "--source-commit",
+                    "a" * 40,
+                    "--source-tree",
+                    "b" * 40,
+                    "--approved-corpus-sha256",
+                    EMPTY_DIGEST,
+                    "--allow-trusted-execution",
+                ]
+            )
+        self.assertEqual(exit_code, 2)
+        self.assertIn("unrecognized arguments", legacy_stderr.getvalue())
 
         with redirect_stderr(io.StringIO()):
             self.assertEqual(execution.main([]), 2)

--- a/code/scripts/tests/test_build_tool_conformance_execution_schema.py
+++ b/code/scripts/tests/test_build_tool_conformance_execution_schema.py
@@ -433,6 +433,7 @@ class ExecutionSchemaTests(unittest.TestCase):
                 "result.schema.json",
                 "execution.schema.json",
                 "execution-policy.schema.json",
+                "execution-authority.schema.json",
                 "linux-oci-backend.schema.json",
             ):
                 shutil.copyfile(FIXTURE_ROOT / name, root / name)

--- a/code/scripts/tests/test_build_tool_conformance_linux_oci.py
+++ b/code/scripts/tests/test_build_tool_conformance_linux_oci.py
@@ -579,40 +579,11 @@ class LinuxOciBackendTests(unittest.TestCase):
             )
         self.assertEqual(raised.exception.code, "LINUX_OCI_CRUN_IDENTITY_MISMATCH")
 
-    def test_cli_reports_stable_available_and_unavailable_results(self) -> None:
-        identity = backend_identity()
-        available = {
-            "schema_version": 1,
-            "backend_kind": "linux_oci",
-            "status": "available",
-            "conformance_status": "not-run",
-        }
+    def test_direct_cli_requires_external_authority_before_identity_read(self) -> None:
         stdout = io.StringIO()
         with (
-            mock.patch.object(
-                linux_oci,
-                "load_identity",
-                return_value=(identity, "a" * 64),
-            ),
-            mock.patch.object(linux_oci, "preflight", return_value=available),
-            redirect_stdout(stdout),
-        ):
-            exit_code = linux_oci.main(["--identity", "identity.json"])
-        self.assertEqual(exit_code, 0)
-        output = json.loads(stdout.getvalue())
-        self.assertEqual(output["identity_sha256"], "a" * 64)
-
-        stdout = io.StringIO()
-        unavailable = linux_oci.LinuxOciUnavailable(
-            "LINUX_OCI_PLATFORM_UNSUPPORTED",
-            "Linux OCI backend preflight requires Linux",
-        )
-        with (
-            mock.patch.object(
-                linux_oci,
-                "load_identity",
-                side_effect=unavailable,
-            ),
+            mock.patch.object(linux_oci, "load_identity") as identity_reader,
+            mock.patch.object(linux_oci, "preflight") as preflight,
             redirect_stdout(stdout),
         ):
             exit_code = linux_oci.main(["--identity", "identity.json"])
@@ -620,8 +591,10 @@ class LinuxOciBackendTests(unittest.TestCase):
         output = json.loads(stdout.getvalue())
         self.assertEqual(
             output["diagnostics"][0]["code"],
-            "LINUX_OCI_PLATFORM_UNSUPPORTED",
+            "LINUX_OCI_AUTHORITY_REQUIRED",
         )
+        identity_reader.assert_not_called()
+        preflight.assert_not_called()
 
     def test_identity_digest_is_raw_byte_stable(self) -> None:
         raw = json.dumps(

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -577,9 +577,12 @@ A fixture is data supplied to a program that can execute commands. Therefore:
 1. The runner MUST treat every fixture and adapter binary as untrusted by
    default. A fixture cannot
    grant itself trust with `trusted_execution`. Execution trust comes only from
-   out-of-band runner policy: an explicit operator/CI flag plus a reviewed,
-   immutable corpus digest. Pull-request changes are untrusted until reviewed
-   and merged into that policy.
+   out-of-band runner policy: an explicit operator/CI flag plus one reviewed,
+   domain-separated authority-bundle digest. Each closed authorization profile
+   binds only the exact source revision and components it actually consumes.
+   The initial capability-preflight profile binds no corpus, adapter, launcher,
+   or executable case. A corpus digest alone is not authorization.
+   Pull-request changes are untrusted until reviewed and approved out of band.
 2. Every adapter run, including a pure domain, MUST be enclosed by the outer
    runner sandbox. Pure domains MUST NOT execute fixture commands, spawn child
    processes, use the network, or consult the host checkout.
@@ -685,7 +688,76 @@ exact conformance revision, exact execution-corpus SHA-256, runner-controlled
 hard ceilings, backend identities, and adapter executable digests. A backend
 or adapter marked ready requires an immutable SHA-256 identity. The policy does
 not contain operator authorization: `run-case` additionally requires an
-explicit `--allow-trusted-execution` invocation flag.
+explicit `--allow-trusted-execution` invocation flag, an exact reviewed source
+revision, and the corresponding out-of-band approved authority-bundle SHA-256.
+The old corpus-only approval is deliberately insufficient.
+
+The process-free authority bundle is an external, post-review artifact
+described by `execution-authority.schema.json`. It is generated only after the
+reviewed commit and required backend artifacts exist; a production bundle is
+not checked into the commit whose identity it carries. The v1 preflight
+profile's closed record binds:
+
+- one exact authorization scope, repository, Linux platform/architecture, and
+  full Git commit and tree object identities;
+- the policy, authority, and Linux OCI identity schemas;
+- the checked-in execution policy;
+- the process-free bootstrap runner;
+- the process-free authority verifier;
+- the process-owning Linux OCI backend implementation;
+- the exact raw Linux backend identity document stored beside the external
+  bundle.
+
+The Linux backend identity document transitively binds the reviewed Podman and
+`crun` binaries, exact OCI manifest/config identities, seccomp profile,
+in-image shim, and invariant probe. The bundle binds the exact raw identity
+document; the verifier validates its typed fields and cross-field identities.
+A future seccomp artifact or host execution launcher becomes authority only
+after its exact raw bytes are a separate role. The current preflight
+implementation MUST NOT be mislabeled as an enforcing execution launcher.
+
+Bundle components are a closed object with eight fixed roles. Seven paths are
+fixed repository-relative constants; the Linux identity is the sole
+bundle-relative artifact and has a fixed filename. Missing, unknown, extra, or
+role-swapped components fail schema validation. The verifier rejects a linked,
+reparse, non-regular, or multiply linked final file, unsafe paths, exact
+byte-length/digest mismatches, and source-identity mismatches. Component
+identity is the retained approved bytes, not pathname topology. The protected
+orchestrator proves the checkout tree; the later process handoff additionally
+requires atomic beneath-root traversal and an exact-byte loader. These reads
+remain process-free and never enumerate or decode an execution case.
+
+Authorization scopes are cryptographically and semantically distinct. Schema
+v1 admits only `linux_capability_preflight_v1`: it approves the exact
+components intended for a future host/image capability inspection, binds an
+empty execution corpus and no adapters, and cannot import a process backend,
+create a container, or decode a case. The future exact-byte preflight loader,
+invariant-probe profile, and trusted-execution profile require additional
+closed contracts after their corresponding components exist and before those
+enforcement paths may run; a preflight digest is therefore structurally
+unusable for either future execution scope.
+
+The authority SHA-256 uses this exact framing:
+
+1. append the ASCII domain separator
+   `coding-adventures/build-tool-authority/linux-capability-preflight/v1`
+   followed by one NUL;
+2. append the unsigned 64-bit big-endian exact raw-bundle byte length; and
+3. append the exact bounded raw UTF-8 JSON bytes.
+
+The bundle MUST NOT contain its own digest. Exact-byte identity is deliberate:
+whitespace, key order, or a trailing newline changes the approval. The runner
+checks the syntactically valid out-of-band digest with a constant-time
+comparison before following any component path named by the bundle. It then
+strictly parses the already-approved bytes, rejects duplicate keys and invalid
+Unicode, validates the closed schema, and proves every component and semantic
+cross-equality.
+
+The protected orchestrator supplies the expected full commit and tree
+identities from immutable runner metadata and proves the checkout is exactly
+that revision before invoking repository code. The approved authority digest
+is the sole out-of-band content approval. Recomputing a candidate digest inside
+an untrusted pull request does not approve it.
 
 For `linux_oci`, `identity_sha256` is the SHA-256 of the exact raw bytes of a
 closed Linux OCI backend identity document validated by
@@ -698,28 +770,31 @@ present `sha256:<config_sha256>` image with pull disabled. The runner verifies
 both image identities, operating system, architecture, and absence of
 image-declared volumes before it creates a container.
 
-Linux capability preflight runs in a separate process-owning module. It uses
-only fixed direct argument vectors and a runner-owned sanitized environment.
-It MUST prove local non-remote rootless operation, `crun`, cgroup v2 with
-delegated `cpu`, `memory`, and `pids` controllers, seccomp, exact runtime
-binary hashes, and the exact local image. Missing or mismatched capabilities
-produce a stable non-passing result before any fixture is decoded or
-materialized.
+Linux capability preflight is implemented in a separate process-owning module.
+Its direct CLI is authority-disabled, and the process-free authority verifier
+MUST NOT import it. A later loader must establish that the exact retained
+backend bytes and approved import closure are the code being invoked before it
+may use the module's fixed direct argument vectors and runner-owned sanitized
+environment. Capability inspection then MUST prove local non-remote rootless
+operation, `crun`, cgroup v2 with delegated `cpu`, `memory`, and `pids`
+controllers, seccomp, exact runtime binary hashes, and the exact local image.
+Missing or mismatched capabilities produce a stable non-passing result before
+any fixture is decoded or materialized.
 
-The first Linux delivery tranche contains only this identity validation,
-capability preflight, and construction of the runner-owned invariant-probe
-container. It MUST NOT decode or execute fixture commands. Its container is
-created with an exact config image identity and `--pull=never`, a private
-unmapped rootless user namespace, private PID/IPC/UTS/cgroup namespaces,
-network disabled, a read-only root with implicit writable tmpfs mounts
-disabled, all capabilities dropped, `no_new_privileges`, no devices or bind
-mounts, a fixed non-root identity and environment, and one bounded
-runner-owned tmpfs. A zero-byte workspace is rejected rather than expressed
-as `tmpfs size=0`, which can mean unlimited. Swap is disabled with the cgroup
-v2 `memory.swap.max=0` control; `--memory-swap=<memory>` is not used. CPU
-quota limits rate only, so later execution MUST also meter aggregate
-`cpu.stat usage_usec` and kill the entire container cgroup at the effective
-CPU-time ceiling.
+The first Linux delivery tranche contains identity validation, capability
+preflight logic, and construction of the runner-owned invariant-probe
+container argv. It does not invoke that argv and MUST NOT decode or execute
+fixture commands. The candidate argv specifies an exact config image identity
+and `--pull=never`, a private unmapped rootless user namespace, private
+PID/IPC/UTS/cgroup namespaces, network disabled, a read-only root with
+implicit writable tmpfs mounts disabled, all capabilities dropped,
+`no_new_privileges`, no devices or bind mounts, a fixed non-root identity and
+environment, and one bounded runner-owned tmpfs. A zero-byte workspace is
+rejected rather than expressed as `tmpfs size=0`, which can mean unlimited.
+Swap is disabled with the cgroup v2 `memory.swap.max=0` control;
+`--memory-swap=<memory>` is not used. CPU quota limits rate only, so later
+execution MUST also meter aggregate `cpu.stat usage_usec` and kill the entire
+container cgroup at the effective CPU-time ceiling.
 
 The checked-in execution policy remains disabled and Linux remains
 `unavailable` until the exact identity document and image have passed every
@@ -732,7 +807,7 @@ portable path relative to `execution-cases/`. For each case, append the
 unsigned 64-bit big-endian path-byte length, UTF-8 path bytes, unsigned 64-bit
 big-endian raw-content length, and exact raw bytes. The empty corpus therefore
 has the standard SHA-256 empty digest. Any byte, filename, addition, or removal
-changes the authority.
+changes the internal corpus identity; it does not grant authority.
 
 The process-free `validate-corpus` and `validate-result` bootstrap commands
 remain unchanged and MUST reject execution intent. A separate execution
@@ -742,8 +817,9 @@ creating a workspace, probing a toolchain, importing a process API, or
 launching anything.
 
 Pull-request workflows may run only these process-free checks and fake-backend
-unit tests. Real execution requires a protected reviewed revision, read-only
-repository permissions, no repository secrets, and the approved digest
+unit tests. They MAY print an unapproved candidate bundle for review. Real
+execution requires a protected reviewed revision, read-only repository
+permissions, no repository secrets, and the approved authority-bundle digest
 supplied out of band. `pull_request_target` MUST NOT execute changed fixtures
 or runner code.
 

--- a/code/specs/fixtures/build-tool-v1/CHANGELOG.md
+++ b/code/specs/fixtures/build-tool-v1/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2026-07-30
+
+- Added the closed external authority-bundle schema and exact
+  domain/length/raw-byte approval digest for Linux capability preflight.
+- Added a process-free authority verifier that binds the protected source
+  commit/tree, eight fixed component roles, disabled empty execution policy,
+  and external Linux backend identity before any capability command.
+- Replaced corpus-only `run-case` approval with fail-closed external-authority
+  inputs. The preflight-only scope remains structurally unable to authorize a
+  case, adapter, invariant-probe container, or trusted execution.
+- Disabled the bare identity-only Linux CLI entry point. This tranche exposes
+  no process handoff; an exact-byte backend loader remains a required
+  dependency before protected capability inspection.
+
 ## 2026-07-29
 
 - Added the process-free bootstrap conformance runner.

--- a/code/specs/fixtures/build-tool-v1/README.md
+++ b/code/specs/fixtures/build-tool-v1/README.md
@@ -11,6 +11,7 @@ build-tool-v1/
   result.schema.json
   pure-domains.schema.json
   execution.schema.json
+  execution-authority.schema.json
   execution-policy.schema.json
   execution-policy.json
   linux-oci-backend.schema.json
@@ -72,6 +73,15 @@ process-owning `build_tool_conformance_linux_oci.py` preflight validates those
 identities and host capabilities without decoding a fixture or creating a
 container. No identity document is checked in while Linux remains unavailable.
 
+`execution-authority.schema.json` closes the external, post-review authority
+bundle for the first safe authorization profile. Its exact raw bytes are
+approved out of band with a domain- and length-separated SHA-256. The bundle
+binds the reviewed source commit/tree, policy and schemas, process-free
+bootstrap and verifier, Linux preflight backend, and one external Linux
+identity document. Scope `linux_capability_preflight_v1` binds no corpus,
+adapter, launcher, or executable case and cannot authorize container creation
+or trusted execution.
+
 ## Runner
 
 Validate the complete corpus and inventory:
@@ -80,13 +90,21 @@ Validate the complete corpus and inventory:
 python code/scripts/build_tool_conformance.py validate-corpus
 ```
 
-Validate a reviewed Linux OCI identity and the local non-executing capability
-preflight:
+Validate an approved external bundle without importing a process API:
 
 ```text
-python code/scripts/build_tool_conformance_linux_oci.py \
-  --identity path/to/reviewed-linux-oci-identity.json
+python code/scripts/build_tool_conformance_authority.py validate-authority \
+  --authority-bundle path/to/external-authority.json \
+  --approved-authority-sha256 <out-of-band-sha256> \
+  --source-commit <full-reviewed-commit> \
+  --source-tree <full-reviewed-tree>
 ```
+
+This tranche exposes no process-owning `preflight` subcommand. The bare
+`build_tool_conformance_linux_oci.py --identity ...` entry point fails closed
+with `LINUX_OCI_AUTHORITY_REQUIRED`. A follow-on exact-byte loader must execute
+the retained approved backend and its bound import closure without a
+name-based Python import before protected capability inspection can run.
 
 Compare one externally produced adapter result with its fixture:
 
@@ -102,11 +120,13 @@ Validate the process-free trusted-execution contract:
 python code/scripts/build_tool_conformance_execution.py validate-contract
 ```
 
-The separate `run-case` command requires both
-`--allow-trusted-execution` and an exact
-`--approved-corpus-sha256`. In this policy-only tranche it can only return a
-stable non-passing skip. It never imports a process API, decodes executable
-workspace payloads, materializes files, or launches an adapter.
+The separate `run-case` command requires `--allow-trusted-execution`, the
+external bundle and approved authority SHA-256, and the protected full source
+commit/tree identities. Corpus-only approval is no longer accepted. Because
+schema v1 is preflight-only, `run-case` returns the stable non-passing
+`EXECUTION_AUTHORITY_SCOPE_UNAVAILABLE` result after validation. It never
+imports a process API, decodes executable workspace payloads, materializes
+files, or launches an adapter.
 
 Both commands use bounded strict JSON parsing, formal Draft 2020-12 validation,
 semantic path and identity checks, domain-aware result canonicalization, and
@@ -120,14 +140,20 @@ decisions.
 
 ## Security boundary
 
-This tranche is intentionally process-free:
+Authority validation and pull-request CI are intentionally process-free:
 
 - it never launches an adapter or shell;
 - it never applies fixture environment data;
 - it never interprets manifest content as a command;
 - it rejects `execution` or `trusted_execution` intent before decoding files,
   changing permissions, or using a process API; and
-- it has no flag that can enable execution.
+- the preflight authority profile has no flag that can enable execution.
+
+There is intentionally no process handoff in this tranche. Ordinary
+name-based importing after validation would not prove that the approved
+backend bytes are the code being executed. A later loader must consume the
+exact retained artifact and its bound import closure through an atomic
+runner-owned boundary before capability inspection can run.
 
 The bootstrap runner performs no workspace materialization. Adapter
 orchestration and execution fixtures remain blocked until the separate
@@ -167,10 +193,11 @@ The platform delivery order is explicit:
 4. Closed execution-semantics fixtures and runner-owned adversarial boundary
    probes after all required platform boundaries exist.
 
-Pull-request CI validates only the process-free schemas, policy, digest, and
-unit tests. Real execution belongs to a protected reviewed revision with
-read-only repository permissions, no repository secrets, and the approved
-digest supplied out of band.
+Pull-request CI validates only the process-free schemas, policy, candidate
+digest algorithm, and fake unit tests. Real capability inspection and future
+execution belong to a protected reviewed revision with read-only repository
+permissions, no repository secrets, and the approved authority-bundle digest
+supplied out of band.
 
 ## Validation
 
@@ -187,6 +214,12 @@ python -m unittest discover \
 python -m unittest discover \
   -s code/scripts/tests \
   -p "test_build_tool_conformance_execution_runner.py"
+python -m unittest discover \
+  -s code/scripts/tests \
+  -p "test_build_tool_conformance_authority.py"
+python -m unittest discover \
+  -s code/scripts/tests \
+  -p "test_build_tool_conformance_linux_oci.py"
 python code/scripts/build_tool_conformance_execution.py validate-contract
 ```
 

--- a/code/specs/fixtures/build-tool-v1/execution-authority.schema.json
+++ b/code/specs/fixtures/build-tool-v1/execution-authority.schema.json
@@ -1,0 +1,293 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/build-tool-conformance-execution-authority-v1.json",
+  "title": "Build-tool Linux capability-preflight authority bundle v1",
+  "description": "External post-review authority record for process-free validation followed only by Linux capability preflight. The out-of-band approval is the domain-separated digest of the exact raw bundle bytes, never a field in this record.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "purpose",
+    "authorization_scope",
+    "repository",
+    "conformance_revision",
+    "platform",
+    "architecture",
+    "source",
+    "components"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "purpose": {
+      "const": "build-tool-trusted-authority"
+    },
+    "authorization_scope": {
+      "const": "linux_capability_preflight_v1"
+    },
+    "repository": {
+      "const": "github.com/adhithyan15/coding-adventures"
+    },
+    "conformance_revision": {
+      "const": "v1"
+    },
+    "platform": {
+      "const": "linux"
+    },
+    "architecture": {
+      "const": "amd64"
+    },
+    "source": {
+      "$ref": "#/$defs/source"
+    },
+    "components": {
+      "$ref": "#/$defs/components"
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "git_oid": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "safe_path": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^(?!/)(?![A-Za-z]:)(?!.*\\\\)(?!.*(?:^|/)\\.\\.?(?:/|$))(?!.*//)[^<>:\"|?*\\u0000-\\u001F/]+(?:/[^<>:\"|?*\\u0000-\\u001F/]+)*$"
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "git_object_format",
+        "commit_oid",
+        "tree_oid"
+      ],
+      "properties": {
+        "git_object_format": {
+          "const": "sha1"
+        },
+        "commit_oid": {
+          "$ref": "#/$defs/git_oid"
+        },
+        "tree_oid": {
+          "$ref": "#/$defs/git_oid"
+        }
+      }
+    },
+    "component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provenance",
+        "path",
+        "byte_length",
+        "sha256"
+      ],
+      "properties": {
+        "provenance": {
+          "enum": [
+            "repository",
+            "bundle"
+          ]
+        },
+        "path": {
+          "$ref": "#/$defs/safe_path"
+        },
+        "byte_length": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 16777216
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "components": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authority_bundle_schema",
+        "execution_policy_schema",
+        "execution_policy",
+        "linux_backend_identity_schema",
+        "bootstrap_runner",
+        "authority_verifier",
+        "linux_preflight_backend",
+        "linux_backend_identity"
+      ],
+      "properties": {
+        "authority_bundle_schema": {
+          "$ref": "#/$defs/authority_bundle_schema_component"
+        },
+        "execution_policy_schema": {
+          "$ref": "#/$defs/execution_policy_schema_component"
+        },
+        "execution_policy": {
+          "$ref": "#/$defs/execution_policy_component"
+        },
+        "linux_backend_identity_schema": {
+          "$ref": "#/$defs/linux_backend_identity_schema_component"
+        },
+        "bootstrap_runner": {
+          "$ref": "#/$defs/bootstrap_runner_component"
+        },
+        "authority_verifier": {
+          "$ref": "#/$defs/authority_verifier_component"
+        },
+        "linux_preflight_backend": {
+          "$ref": "#/$defs/linux_preflight_backend_component"
+        },
+        "linux_backend_identity": {
+          "$ref": "#/$defs/linux_backend_identity_component"
+        }
+      }
+    },
+    "repository_component": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/component"
+        },
+        {
+          "properties": {
+            "provenance": {
+              "const": "repository"
+            }
+          }
+        }
+      ]
+    },
+    "bundle_component": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/component"
+        },
+        {
+          "properties": {
+            "provenance": {
+              "const": "bundle"
+            }
+          }
+        }
+      ]
+    },
+    "authority_bundle_schema_component": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/repository_component"
+        },
+        {
+          "properties": {
+            "path": {
+              "const": "code/specs/fixtures/build-tool-v1/execution-authority.schema.json"
+            }
+          }
+        }
+      ]
+    },
+    "execution_policy_schema_component": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/repository_component"
+        },
+        {
+          "properties": {
+            "path": {
+              "const": "code/specs/fixtures/build-tool-v1/execution-policy.schema.json"
+            }
+          }
+        }
+      ]
+    },
+    "execution_policy_component": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/repository_component"
+        },
+        {
+          "properties": {
+            "path": {
+              "const": "code/specs/fixtures/build-tool-v1/execution-policy.json"
+            }
+          }
+        }
+      ]
+    },
+    "linux_backend_identity_schema_component": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/repository_component"
+        },
+        {
+          "properties": {
+            "path": {
+              "const": "code/specs/fixtures/build-tool-v1/linux-oci-backend.schema.json"
+            }
+          }
+        }
+      ]
+    },
+    "bootstrap_runner_component": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/repository_component"
+        },
+        {
+          "properties": {
+            "path": {
+              "const": "code/scripts/build_tool_conformance.py"
+            }
+          }
+        }
+      ]
+    },
+    "authority_verifier_component": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/repository_component"
+        },
+        {
+          "properties": {
+            "path": {
+              "const": "code/scripts/build_tool_conformance_authority.py"
+            }
+          }
+        }
+      ]
+    },
+    "linux_preflight_backend_component": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/repository_component"
+        },
+        {
+          "properties": {
+            "path": {
+              "const": "code/scripts/build_tool_conformance_linux_oci.py"
+            }
+          }
+        }
+      ]
+    },
+    "linux_backend_identity_component": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/bundle_component"
+        },
+        {
+          "properties": {
+            "path": {
+              "const": "linux-oci-backend.json"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -105,9 +105,10 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-inventory was regenerated on July 30, 2026 at `bee64b477` after the Haskell
+inventory was regenerated on July 30, 2026 at `d0b9c442f` after the Haskell
 `barcode-1d` and `http-core` ports, the Go/Rust `multi-directed-graph` slice,
-and a new wave of Rust-only package families:
+the Linux OCI preflight contract, and a new wave of Rust-only package
+families. The OCI tranche did not change package counts:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
@@ -929,20 +930,30 @@ Delivery order:
    authorization, stable backend-unavailable results, and a backend interface
    with no host-execution fallback. This tranche validates authority but never
    executes fixture code. Completed by PR #9178.
-5. Implement the Linux OCI backend first. The selected first tranche defines a
+5. Implement the Linux OCI backend first. The completed first tranche defines a
    closed identity for exact rootless Podman, `crun`, OCI manifest/config,
    seccomp, shim, and invariant-probe artifacts; proves local non-remote
    rootless operation, cgroup v2 delegation, seccomp, exact binaries, and the
    already-present image; and constructs the exact no-pull, private-namespace,
-   read-only, capability-free probe container. It does not decode or launch a
-   fixture, and Linux remains unavailable.
+   read-only, capability-free probe-container argv. It invokes neither that
+   argv nor a fixture, and Linux remains unavailable. Completed by PR #9189.
 6. Before trusted Linux execution, bind operator approval to the complete
    reviewed authority bundle, bind case selection to the exact hashed
    root-handle/no-follow snapshot, and normalize dependency-skip/result-state
    semantics. Then execute the runner-owned Linux invariant probe with
    aggregate cgroup CPU metering, combined streaming output/result accounting,
    hard writable-workspace semantics, cancellation, and verified
-   whole-container kill/reap/removal. Only protected evidence can mark Linux
+   whole-container kill/reap/removal. The current selected tranche is the
+   first prerequisite: replace corpus-only approval with a process-free,
+   domain-separated external bundle over the reviewed source revision, policy,
+   schemas, authority verifier, Linux preflight backend, and external backend
+   identity. This first closed profile binds no corpus or adapter and
+   approves bytes for capability inspection only; it exposes no process
+   handoff. Next add an atomic exact-byte backend/import-closure loader and a
+   separate invariant-probe authority profile. Run protected probe enforcement
+   to produce containment evidence, then add a distinct trusted-execution
+   profile binding that evidence, the exact case snapshot, and one adapter
+   before trusted-case enforcement. Only protected evidence can mark Linux
    ready.
 7. Implement the native Windows boundary with AppContainer or LPAC plus Job
    Objects and root-handle reparse-safe filesystem operations. Keep macOS
@@ -971,9 +982,10 @@ Pull-request CI may validate the policy, schemas, digests, and fake-backend
 tests, but it must not authorize execution from branch-modifiable code or
 fixtures. Real sandbox probes run only from reviewed immutable revisions in a
 protected `push`/manual workflow with read-only repository permissions, no
-repository secrets, and an out-of-band approved corpus digest. The trusted
-runner never pulls a container image and never falls back to unsandboxed host
-execution.
+repository secrets, and an out-of-band approved authority-bundle digest. The
+corpus digest remains an internal consistency identity and cannot authorize
+execution. The trusted runner never pulls a container image and never falls
+back to unsandboxed host execution.
 
 The pure-domain security review also discovered three follow-on gates that must
 land before final adapter parity:
@@ -989,9 +1001,14 @@ land before final adapter parity:
 
 The Linux OCI review discovered four additional dependency gates:
 
-- replace corpus-only approval with a domain-separated authority digest over
-  the exact source, policy, schemas, runner, launcher, seccomp, image, shim,
-  and adapter identities;
+- replace corpus-only approval with a domain-separated external authority
+  profile. The first profile binds the exact source, policy, schemas, verifier,
+  Linux preflight backend, and external identity for capability inspection
+  only; later profiles add launcher, seccomp, image, shim, corpus, and adapter
+  bytes only after those components are enforced;
+- load process-owning code only from the exact retained approved backend and
+  its bound import closure, using atomic beneath-root handles rather than a
+  name-based Python import or check-then-open path traversal;
 - execute only the exact direct corpus member bytes from the approved
   root-handle/no-follow snapshot, never a reopened caller path;
 - normalize `dep-skipped` terminology and enforce result-state/return-code


### PR DESCRIPTION
## Summary

- add a closed external `linux_capability_preflight_v1` authority-bundle schema with eight fixed roles, exact source commit/tree identities, and a domain/length/raw-byte SHA-256 approved out of band
- add a process-free authority validator that verifies the bundle digest before parsing, retains exact component bytes, and requires the disabled empty policy plus a valid external Linux identity
- remove corpus-only `run-case` authorization, make preflight authority structurally unusable for execution cases, and keep the bare Linux identity CLI fail-closed
- record the exact-byte backend/import-closure loader, invariant-probe authority/evidence, trusted-execution authority, and trusted-case enforcement as separate dependency-shaped backlog gates

No production authority bundle or backend identity is checked in. This tranche deliberately exposes no process-backend import or preflight handoff.

## Validation

- `python -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_*.py'` — 108 passed, 1 Windows symlink test skipped (covered on symlink-capable CI)
- authority module branch coverage — 86% (92% including its tests)
- `python code/scripts/build_tool_conformance.py validate-corpus` — 30 cases / 11 process-free domains valid
- `python code/scripts/build_tool_conformance_execution.py validate-contract` — disabled policy, 0 execution cases/adapters/ready backends valid
- Ruff, Bandit, `compileall`, JSON Schema Draft 2020-12 checks, workflow YAML parse, state DAG/invariants, and `git diff --check` — passed
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` — 0 collisions, 0 unknown language buckets
- Go reference build tool: `go test ./...` and clean temporary-output `go build` — passed
- full forced build-file dry-run — unchanged 73 pre-existing standalone `BUILD_windows` gaps already tracked by `build-file-standalone-integrity`
- final independent security, schema, and contract reconciliation reviews — no release-blocking findings