### PR TITLE
feat(spice): validate MOS surface mobility

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject negative or non-finite Level-1 MOS model-card `U0` / `UO` values with
+  a stable diagnostic before mobility preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `TOX` values with a
   stable diagnostic before mobility and electrostatic preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `NSUB` values with a

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -576,6 +576,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET NSUB must be finite and positive")
         elif canonical == "TOX" and (not math.isfinite(value) or value <= 0.0):
             raise ValueError(f"{name}: MOSFET TOX must be finite and positive")
+        elif canonical == "U0" and (not math.isfinite(value) or value < 0.0):
+            raise ValueError(f"{name}: MOSFET U0 must be finite and non-negative")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1033,6 +1033,18 @@ def test_mos_model_card_rejects_invalid_oxide_thickness() -> None:
             normalize_model_card("Minvalid", "nmos", {"TOX": invalid_thickness})
 
 
+def test_mos_model_card_rejects_invalid_surface_mobility() -> None:
+    for name, value in (("U0", 0.0), ("UO", 600.0)):
+        valid = normalize_model_card("Mvalid", "nmos", {name: value})
+        assert valid.parameters["U0"] == pytest.approx(value)
+
+    for invalid_mobility in (-1.0, math.inf, math.nan):
+        with pytest.raises(
+            ValueError, match="MOSFET U0 must be finite and non-negative"
+        ):
+            normalize_model_card("Minvalid", "nmos", {"U0": invalid_mobility})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject negative or non-finite Level-1 MOS model-card `U0` / `UO` values with
+  a stable diagnostic before mobility preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `TOX` values with a
   stable diagnostic before mobility and electrostatic preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `NSUB` values with a

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4370,6 +4370,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET TOX must be finite and positive".to_string(),
                 });
+            } else if canonical == "U0" && (!raw_value.is_finite() || *raw_value < 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET U0 must be finite and non-negative".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -833,6 +833,22 @@ fn mos_model_card_rejects_invalid_oxide_thickness() {
 }
 
 #[test]
+fn mos_model_card_rejects_invalid_surface_mobility() {
+    for (name, value) in [("U0", 0.0), ("UO", 600.0)] {
+        let valid = normalize_model_card("Mvalid", "nmos", &[(name, value)]).unwrap();
+        assert_close(*valid.parameters.get("U0").unwrap(), value);
+    }
+
+    for invalid_mobility in [-1.0, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("U0", invalid_mobility)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET U0 must be finite and non-negative"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject negative or non-finite Level-1 MOS model-card `U0` / `UO` values with
+  a stable diagnostic before mobility preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `TOX` values with a
   stable diagnostic before mobility and electrostatic preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `NSUB` values with a

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8438,6 +8438,8 @@ export function normalizeModelCard(
       throw invalidElement(name, "MOSFET NSUB must be finite and positive");
     } else if (canonical === "TOX" && (!Number.isFinite(value) || value <= 0.0)) {
       throw invalidElement(name, "MOSFET TOX must be finite and positive");
+    } else if (canonical === "U0" && (!Number.isFinite(value) || value < 0.0)) {
+      throw invalidElement(name, "MOSFET U0 must be finite and non-negative");
     } else {
       normalized[canonical] = value;
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -701,6 +701,19 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects invalid MOS surface mobility", () => {
+    for (const [name, value] of [["U0", 0.0], ["UO", 600.0]] as const) {
+      const valid = normalizeModelCard("Mvalid", "nmos", { [name]: value });
+      expect(valid.parameters.U0).toBe(value);
+    }
+
+    for (const invalidMobility of [-1.0, Number.POSITIVE_INFINITY, Number.NaN]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { U0: invalidMobility }),
+      ).toThrow("MOSFET U0 must be finite and non-negative");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS oxide-thickness validation.
+1. Cross-language Level-1 MOS surface-mobility validation.
    - Status: current PR completion candidate.
-   - Reject non-positive or non-finite model-card `TOX` values before mobility
-     and electrostatic process-parameter preprocessing.
-   - Preserve positive oxide thickness and stable diagnostics across Rust,
-     Python, and TypeScript.
+   - Reject negative or non-finite model-card `U0` / `UO` values before
+     mobility preprocessing and process-derived `KP`.
+   - Preserve zero and positive surface mobility with stable diagnostics across
+     Rust, Python, and TypeScript.
 
 ## Completed Slices
 
@@ -3657,6 +3657,13 @@ the Rust, Python, and TypeScript surfaces together.
      process-parameter preprocessing, including when `TOX` is absent.
    - Positive substrate doping and the stricter intrinsic-density requirement
      for `NSUB` plus `TOX` remain aligned across Rust, Python, and TypeScript.
+
+297. Cross-language Level-1 MOS oxide-thickness validation.
+   - Status: completed in PR 9190.
+   - Non-positive and non-finite model-card `TOX` values are rejected before
+     mobility and electrostatic process-parameter preprocessing.
+   - Positive oxide thickness and stable diagnostics remain aligned across
+     Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject negative and non-finite Level-1 MOS model-card `U0` and `UO` values during normalization
- preserve zero and positive surface mobility with one stable cross-language diagnostic
- record PR #9190 in the SPICE completion plan and select surface-mobility validation as the current slice

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python Ruff plus full pytest: 679 passed, 88.94% coverage
- TypeScript tests: 422 passed
- `npm run build`