### PR TITLE
Add Venture browser scroll state

### DIFF
--- a/code/packages/rust/venture-browser-core/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.0
+
+- Add finite, clamped `ScrollState` geometry with resize re-clamping.
+- Add scroll-aware link hit-testing.
+- Add `scrolled_viewport_scene`, which wraps document instructions in a
+  negative-Y translated group on a viewport-sized scene.
+
 ## 0.1.0
 
 - Add `NavigationHistory` with Back, Forward, Home, Reload, and redirect

--- a/code/packages/rust/venture-browser-core/Cargo.toml
+++ b/code/packages/rust/venture-browser-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "venture-browser-core"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Host-neutral navigation and page-loading orchestration for the Venture browser."
 
@@ -10,9 +10,9 @@ html-to-layout = { path = "../html-to-layout" }
 html-to-paint = { path = "../html-to-paint" }
 http1-client = { path = "../http1-client" }
 layout-ir = { path = "../layout-ir" }
+paint-instructions = { path = "../paint-instructions" }
 text-interfaces = { path = "../text-interfaces" }
 
 [dev-dependencies]
 image-codec-gif = { path = "../image-codec-gif" }
-paint-instructions = { path = "../paint-instructions" }
 paint-vm-cairo = { path = "../paint-vm-cairo" }

--- a/code/packages/rust/venture-browser-core/README.md
+++ b/code/packages/rust/venture-browser-core/README.md
@@ -24,6 +24,11 @@ and the final paint backend also remain caller-owned.
 `NavigationHistory` implements the BR01 in-memory navigation model: navigate,
 Back, Forward, Home, Reload, and redirect replacement.
 
+`ScrollState` clamps vertical offsets against content and viewport geometry,
+performs scroll-aware link hit-testing, and feeds `scrolled_viewport_scene`.
+That function preserves the document scene beneath a group translated by the
+negative scroll offset and sizes the returned scene to the visible viewport.
+
 ## Development
 
 ```bash

--- a/code/packages/rust/venture-browser-core/src/lib.rs
+++ b/code/packages/rust/venture-browser-core/src/lib.rs
@@ -7,15 +7,16 @@
 use coding_adventures_html_parser::{parse_html, BrowserDocument, BrowserRenderTree};
 use html_to_layout::HtmlTheme;
 use html_to_paint::{
-    html_render_tree_to_paint, resolve_scene_image_resources_with_mosaic_fallback, FetchedImage,
-    HtmlImageResourceError, HtmlPaintOutput, HtmlPaintViewport,
+    hit_test_link, html_render_tree_to_paint, resolve_scene_image_resources_with_mosaic_fallback,
+    FetchedImage, HtmlImageResourceError, HtmlPaintOutput, HtmlPaintViewport, LinkRegion,
 };
 use http1_client::HttpClient;
 use layout_ir::TextMeasurer;
+use paint_instructions::{PaintBase, PaintGroup, PaintInstruction, PaintScene};
 use std::fmt;
 use text_interfaces::{FontMetrics, FontResolver, TextShaper};
 
-pub const VERSION: &str = "0.1.0";
+pub const VERSION: &str = "0.2.0";
 
 /// In-memory browser navigation state.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -106,6 +107,86 @@ impl NavigationHistory {
         self.current_url.as_ref()?;
         self.current_url = Some(final_url.into());
         self.current_url()
+    }
+}
+
+/// Vertical document scroll state in logical content coordinates.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ScrollState {
+    offset_y: f64,
+    viewport_height: f64,
+    content_height: f64,
+}
+
+impl ScrollState {
+    pub fn new(viewport_height: f64, content_height: f64) -> Self {
+        Self {
+            offset_y: 0.0,
+            viewport_height: finite_non_negative(viewport_height),
+            content_height: finite_non_negative(content_height),
+        }
+    }
+
+    pub fn offset_y(&self) -> f64 {
+        self.offset_y
+    }
+
+    pub fn viewport_height(&self) -> f64 {
+        self.viewport_height
+    }
+
+    pub fn content_height(&self) -> f64 {
+        self.content_height
+    }
+
+    pub fn max_offset_y(&self) -> f64 {
+        (self.content_height - self.viewport_height).max(0.0)
+    }
+
+    pub fn set_offset_y(&mut self, offset_y: f64) -> f64 {
+        self.offset_y = finite_non_negative(offset_y).min(self.max_offset_y());
+        self.offset_y
+    }
+
+    pub fn scroll_by(&mut self, delta_y: f64) -> f64 {
+        let delta_y = if delta_y.is_finite() { delta_y } else { 0.0 };
+        self.set_offset_y(self.offset_y + delta_y)
+    }
+
+    /// Update page or viewport geometry and re-clamp the current offset.
+    pub fn set_dimensions(&mut self, viewport_height: f64, content_height: f64) -> f64 {
+        self.viewport_height = finite_non_negative(viewport_height);
+        self.content_height = finite_non_negative(content_height);
+        self.set_offset_y(self.offset_y)
+    }
+
+    pub fn hit_test<'a>(
+        &self,
+        links: &'a [LinkRegion],
+        viewport_x: f64,
+        viewport_y: f64,
+    ) -> Option<&'a LinkRegion> {
+        hit_test_link(links, viewport_x, viewport_y, self.offset_y)
+    }
+}
+
+/// Build the viewport scene a paint backend should render at the current scroll.
+///
+/// The document instructions remain unchanged beneath a translated group. The
+/// viewport-sized output surface provides the clip boundary at the backend.
+pub fn scrolled_viewport_scene(scene: &PaintScene, scroll: &ScrollState) -> PaintScene {
+    PaintScene {
+        width: scene.width,
+        height: scroll.viewport_height,
+        background: scene.background.clone(),
+        instructions: vec![PaintInstruction::Group(PaintGroup {
+            base: PaintBase::default(),
+            children: scene.instructions.clone(),
+            transform: Some([1.0, 0.0, 0.0, 1.0, 0.0, -scroll.offset_y]),
+            opacity: None,
+        })],
+        id: scene.id.clone(),
+        metadata: scene.metadata.clone(),
     }
 }
 
@@ -319,6 +400,14 @@ fn is_success(status: u16) -> bool {
     (200..300).contains(&status)
 }
 
+fn finite_non_negative(value: f64) -> f64 {
+    if value.is_finite() {
+        value.max(0.0)
+    } else {
+        0.0
+    }
+}
+
 fn ensure_html_media_type(response: &BrowserFetchResponse) -> Result<(), BrowserLoadError> {
     let Some(media_type) = response.media_type.as_deref() else {
         return Ok(());
@@ -370,6 +459,55 @@ mod tests {
             history.replace_current("http://home.test/index.html"),
             Some("http://home.test/index.html")
         );
+    }
+
+    #[test]
+    fn scroll_state_clamps_offsets_and_reacts_to_geometry_changes() {
+        let mut scroll = ScrollState::new(100.0, 260.0);
+        assert_eq!(scroll.max_offset_y(), 160.0);
+        assert_eq!(scroll.scroll_by(-20.0), 0.0);
+        assert_eq!(scroll.set_offset_y(75.0), 75.0);
+        assert_eq!(scroll.scroll_by(200.0), 160.0);
+        assert_eq!(scroll.scroll_by(f64::NAN), 160.0);
+
+        assert_eq!(scroll.set_dimensions(120.0, 80.0), 0.0);
+        assert_eq!(scroll.max_offset_y(), 0.0);
+        assert_eq!(scroll.set_dimensions(f64::NAN, f64::INFINITY), 0.0);
+        assert_eq!(scroll.viewport_height(), 0.0);
+        assert_eq!(scroll.content_height(), 0.0);
+    }
+
+    #[test]
+    fn scroll_state_hit_tests_content_and_wraps_a_translated_viewport_scene() {
+        let link = LinkRegion {
+            x: 10.0,
+            y: 80.0,
+            width: 30.0,
+            height: 12.0,
+            url: "http://example.test/next".into(),
+        };
+        let mut scroll = ScrollState::new(60.0, 140.0);
+        scroll.set_offset_y(60.0);
+        assert_eq!(
+            scroll.hit_test(std::slice::from_ref(&link), 10.0, 20.0),
+            Some(&link)
+        );
+
+        let mut document = PaintScene::new(100.0, 140.0);
+        document.background = "rgb(192, 192, 192)".into();
+        document.instructions.push(PaintInstruction::Rect(
+            paint_instructions::PaintRect::filled(0.0, 70.0, 20.0, 20.0, "#000000"),
+        ));
+        let viewport = scrolled_viewport_scene(&document, &scroll);
+
+        assert_eq!(viewport.width, 100.0);
+        assert_eq!(viewport.height, 60.0);
+        assert_eq!(viewport.background, document.background);
+        let [PaintInstruction::Group(group)] = viewport.instructions.as_slice() else {
+            panic!("viewport should contain one translated group");
+        };
+        assert_eq!(group.transform, Some([1.0, 0.0, 0.0, 1.0, 0.0, -60.0]));
+        assert_eq!(group.children, document.instructions);
     }
 
     #[test]

--- a/code/specs/BR01-venture-browser.md
+++ b/code/specs/BR01-venture-browser.md
@@ -64,9 +64,11 @@ the page omits `<base>`. `venture-browser-core` now owns the in-memory
 Back/Forward/Home/Reload model and composes an injectable page fetch through
 document-URL-aware parsing, layout, paint, and synchronous image resolution.
 Its acceptance path carries a redirected canned page and GIF resource through
-Cairo to RGBA pixels. The remaining browser gate is the concrete platform shell
-that binds those core results to native window events, controls, scrolling, and
-the selected production paint backend.
+Cairo to RGBA pixels. The core also owns clamped vertical scroll geometry,
+scroll-aware link hit-testing, and viewport scene translation. The remaining
+browser gate is the concrete platform shell that binds those core results to
+native window events, controls, scrollbars, and the selected production paint
+backend.
 
 ## Where It Fits
 


### PR DESCRIPTION
## Summary

- add finite, clamped vertical `ScrollState` to `venture-browser-core`
- re-clamp offsets when page or viewport geometry changes
- connect scroll state to existing link hit-testing
- add `scrolled_viewport_scene`, preserving document instructions beneath a negative-Y translated group on a viewport-sized scene
- update the browser core version, package docs, changelog, and BR01 status

## Why

BR01 specifies scroll geometry and scene translation, but the platform host previously had to recreate that policy. This keeps mouse-wheel, scrollbar, hit-testing, and paint coordinates on one shared logical offset while leaving native event wiring and backend selection in the platform shell.

## Validation

- `cargo test -p venture-browser-core -- --nocapture`
- `cargo test -p paint-instructions -p html-to-paint -p venture-browser-core -- --nocapture`
- `cargo clippy -p venture-browser-core --all-targets -- -D warnings`
- `cargo fmt --manifest-path venture-browser-core/Cargo.toml -- --check`
- exact upstream conformance audit: tree construction 1,934 upstream / 2,637 local / 0 missing; tokenizer 6,806 upstream / 7,015 local raw / 0 missing / 7,242 normalized / 0 skipped
- `cargo metadata --no-deps --format-version 1`
- `git diff --check`
