### PR TITLE
feat(adj-formula-stdlib): density-of-heat — NIST SP 811 B.9 density-of-heat→J/m² factors (RS-5 table)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -1615,6 +1615,53 @@ fn shipped_specific_heat_capacity_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// Shipped density-of-heat table — two EXACT NIST SP 811 B.9 factors (two names for one unit) resolve,
+// and a wrong-dimension unit (a mass unit) abstains. Guards the SLICE of a NEW dimension (density of
+// heat, energy per area, the joule per square metre) and the honest cross-dimension abstention:
+// `pound` is a mass unit, so a density-of-heat lookup for it must abstain, catching the
+// density-of-heat/mass confusion directly, not mere absence of a value. (Density of heat is energy per
+// area — distinct from plain energy, J; from density of heat flow rate / irradiance, W/m²; and from
+// pressure, a force per area.)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_density_of_heat_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_densityofheat");
+    let src = stdlib().join("reference/density-of-heat-conversions.adj");
+    std::fs::copy(&src, dir.join("density-of-heat-conversions.adj"))
+        .expect("copy shipped density-of-heat-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"density-of-heat-conversions.adj\"\n\
+         ? density_of_heat_to_joule_per_square_metre(calorie_th_per_square_centimetre, $v)\n\
+         ? density_of_heat_to_joule_per_square_metre(langley, $v)\n\
+         ? density_of_heat_to_joule_per_square_metre(pound, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 exact factor resolves, character-for-character from the table (boldface =
+    // exact; one thermochemical calorie per square centimetre — equivalently one langley — is exactly
+    // 4.184 E+04 J/m²). Both keys map to the same exact value because the langley IS one calth/cm².
+    assert!(
+        out.contains("\"v\":\"41840\""),
+        "calorieth per square centimetre / langley = 4.184 E+04 J/m^2: {out}"
+    );
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `pound` is a MASS unit (it converts to the kilogram, a DIFFERENT quantity), so this
+    // density-of-heat table has no row for it — the engine abstains rather than mis-converting a mass
+    // unit as if it were an energy-per-area unit.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a wrong-dimension unit abstains, never a cross-dimension fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/density-of-heat-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/density-of-heat-conversions.adj
@@ -1,0 +1,68 @@
+% ============================================================================
+% density-of-heat-conversions — density-of-heat (energy per area) unit → joule-per-square-metre
+% factors (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of the NIST-cited conversion tables (length, mass, area, volume, energy, force,
+% power, pressure, the electric-EMU family, the two viscosities, wave number, linear mass density,
+% temperature interval, mass density, moment of force, specific heat capacity, and the rest): a native
+% tabular relation ingested VERBATIM from a published NIST conversion table. Each row states the factor
+% converting a common non-SI unit of DENSITY OF HEAT (a quantity of heat energy DELIVERED PER UNIT
+% AREA — the time-integrated energy dose a surface receives, as in a radiant-exposure or insolation
+% measurement) to the SI coherent derived unit, the joule per square metre, J/m²:
+%
+%     ? density_of_heat_to_joule_per_square_metre(calorie_th_per_square_centimetre, $v)   % 41840
+%     ? density_of_heat_to_joule_per_square_metre(langley, $v)                            % 41840
+%
+% This opens a NEW dimension — DENSITY OF HEAT (energy per area, J/m²) — alongside the already-tabulated
+% length/mass/area/volume/time/speed/energy/pressure/force/power/acceleration/dynamic-viscosity/
+% kinematic-viscosity/magnetic-flux-density/magnetic-flux/illuminance/luminance/radioactivity/
+% absorbed-dose/dose-equivalent/exposure/wave-number/linear-mass-density/temperature-interval/
+% mass-density/moment-of-force/specific-heat-capacity tables and the electric charge/potential/
+% resistance/capacitance/inductance/conductance/current tables. Density of heat is energy PER AREA
+% [energy / area] — distinct from plain ENERGY, the joule (no area), from DENSITY OF HEAT FLOW RATE /
+% irradiance, W/m² (energy per area PER TIME), and from PRESSURE, also N/m² = J/m³ dimensionally-close
+% but a force per area, NOT an energy per area: do NOT confuse them. A value given in cal/cm² or
+% langleys must be put into SI first, then reasoned over (write-once-use-many). Why a `table` and not
+% hand-written `relate` clauses: this is exactly the shape reference data comes in — a published table,
+% not prose. The citable artifact IS the NIST conversion-factors table at the `locator` below; each
+% factor here is a CELL of NIST Special Publication 811, Appendix B.9, defended by one provenance
+% envelope. Each `row` lowers to a ground relation
+% `density_of_heat_to_joule_per_square_metre(unit, v)`, so the exact lookups above are the ordinary SLD
+% binding query — the engine returns the factor WITH this table's citation as its proof, on the CPU,
+% with zero model calls.
+%
+% HONESTY NOTE (like every other NIST table, only the EXACT defined factors get rows): NIST SP 811 B.9
+% prints both density-of-heat factors below in BOLDFACE, its convention for factors that are EXACT by
+% definition, transcribed here as the plain decimal number of joules per square metre each names:
+%
+%     calorieth per square centimeter (calth/cm2)   4.184 E+04  →  41840
+%     langley (calth/cm2)                           4.184 E+04  →  41840
+%
+% Both are EXACT and terminate; nothing here is a rounded measurement. They land on the SAME value
+% because the LANGLEY is DEFINED as one thermochemical calorie per square centimetre — the two names
+% denote the identical unit — and that unit is exact because the thermochemical calorie is exactly
+% 4.184 J and cm²→m² is an exact power of ten: 1 calth/cm² = 4.184 J / (10⁻² m)² = 4.184 / 10⁻⁴ =
+% 4.184 × 10⁴ = 41840 J/m², exactly. (Two names for one exact unit — langley and calth/cm² — is a real
+% feature of the definitions, the langley being the customary name in solar-radiation / insolation
+% work, not a coincidence to hide.) This table is SPECIFIC to density of heat: a unit of a DIFFERENT
+% quantity — e.g. the "pound", which NIST SP 811 B.9 lists separately as a MASS unit converting to the
+% kilogram, NOT to J/m² — therefore gets no row here, and a
+% `? density_of_heat_to_joule_per_square_metre(pound, $v)` ABSTAINS rather than mis-converting a mass
+% unit as if it were an energy-per-area unit. The only claim this table makes is "these are the exact
+% factors NIST SP 811 B.9 prints for the calorieth per square centimetre's and langley's conversions to
+% the joule per square metre" — which is exactly what a byte-check against the cited table verifies.
+% `trust authoritative` — a primary, re-fetchable standards reference. (See ADJ-TABLES.md; and
+% feedback_nothing_human_authored — each factor is a verbatim cell of the cited table, nothing asserted
+% from memory.)
+% ============================================================================
+
+table density_of_heat_to_joule_per_square_metre {
+    columns unit, joule_per_square_metre
+
+    row (calorie_th_per_square_centimetre, 41840)
+    row (langley, 41840)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/density-of-heat-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/density-of-heat-conversions.query.adj
@@ -1,0 +1,27 @@
+% ============================================================================
+% density-of-heat-conversions.query.adj — worked lookups over the NIST density-of-heat →
+% joule-per-square-metre table.
+% ============================================================================
+% The shape a consumer produces to convert a density of heat (an energy-per-area dose, e.g. an
+% insolation reading in langleys) into SI: it `import`s the grounded table and asks the engine to bind
+% the factor. No arithmetic and no factor is stated by the consumer; the engine returns the cell WITH
+% the table's NIST citation as its proof, on the CPU.
+%
+%   ? density_of_heat_to_joule_per_square_metre(calorie_th_per_square_centimetre, $v)   % 41840
+%   ? density_of_heat_to_joule_per_square_metre(langley, $v)                            % 41840
+%
+% And the dimension guard: a unit of a DIFFERENT quantity has no row, so the lookup ABSTAINS rather
+% than mis-converting across dimensions. The "pound" is a MASS unit (it converts to the kilogram), NOT
+% a density-of-heat unit — so it is caught rather than silently mis-converted:
+%
+%   ? density_of_heat_to_joule_per_square_metre(pound, $v)   % abstains (pound is mass → kilogram)
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli density-of-heat-conversions.query.adj
+% ============================================================================
+
+import "density-of-heat-conversions.adj"
+
+? density_of_heat_to_joule_per_square_metre(calorie_th_per_square_centimetre, $v)   % expect 41840  (exact NIST SP 811 B.9 factor)
+? density_of_heat_to_joule_per_square_metre(langley, $v)                            % expect 41840  (exact NIST SP 811 B.9 factor; langley = 1 calth/cm2)
+? density_of_heat_to_joule_per_square_metre(pound, $v)                              % expect abstain (mass unit, wrong dimension)


### PR DESCRIPTION
## What

Adds a new NIST-cited RS-5 reference conversion `table` opening a **new dimension** — **density of heat** (energy per area, the joule per square metre `J/m²`) — alongside the length/mass/energy/power/pressure/force/moment-of-force/viscosity/electric/specific-heat-capacity/… tables already shipped.

Two **exact** (NIST-boldface) factors, transcribed verbatim from [SP 811 Appendix B.9](https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9):

| from | to | factor |
|---|---|---|
| calorie_th per square centimeter (cal_th/cm²) | J/m² | **41840** |
| langley (cal_th/cm²) | J/m² | **41840** |

Both are exact and terminate, and land on the **same value** because the **langley** is *defined* as one thermochemical calorie per square centimetre (the two names denote the identical unit): the thermochemical calorie is exactly `4.184 J` and cm²→m² is an exact power of ten, so `1 cal_th/cm² = 4.184 / 1e-4 = 4.184 E+04 = 41840 J/m²`, exactly. The langley is the customary unit in solar-radiation / insolation work. Only NIST's exact/boldface factors get rows.

## Files

- `code/specs/data/adj-formula-stdlib/reference/density-of-heat-conversions.adj` — the table (2 rows + one provenance envelope).
- `code/specs/data/adj-formula-stdlib/reference/density-of-heat-conversions.query.adj` — worked lookups + a wrong-dimension abstain probe.
- `code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs` — appends `shipped_density_of_heat_conversions_table_resolves_and_abstains` to the shared RS-5 anchor.

## Behaviour (asserted by the e2e test)

- `? …(calorie_th_per_square_centimetre, $v)` → `41840`, carrying the B.9 locator + `trust:authoritative`
- `? …(langley, $v)` → `41840` (same exact unit)
- `? …(pound, $v)` → **abstains** (`pound` is a MASS unit → kilogram; the table refuses to mis-convert across dimensions rather than fabricating a factor)

## Checks

- `cargo test -p adj-lang-cli --test rs5_table_e2e density_of_heat` — 1 passed (41 total in the anchor).
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean.
- Render-probe against the built CLI confirms both keys → `41840` and `pound` abstains, all with the NIST locator.
- NUL-scan clean on all three files.
- `/security-review` — SECURITY REVIEW PASSED.

Data + test only; no engine change, **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)