### PR TITLE
feat(adj-formula-stdlib): winters-formula — StatPearls expected-PaCO₂ metabolic-acidosis compensation formulabook (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_winters_formula_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_winters_formula_e2e.rs
@@ -1,0 +1,106 @@
+//! End-to-end tests for the `clinical/winters-formula.adj` library — Winter's formula (expected PaCO₂
+//! = 1.5 × HCO₃ + 8) and its exact rearrangement — driven through the built CLI binary against the
+//! SHIPPED stdlib. The same invariant as every other formula library: a consumer states NO arithmetic;
+//! it imports the grounded library, binds the measured bicarbonate with `observe`, and the engine
+//! applies the cited formula on the CPU, computing the EXACT value (over exact rationals — 1.5 = 3/2)
+//! and rendering the citation and trust tier in the `derived` section (the auditable answer). The two
+//! formulas INVERT around the worked case HCO₃ = 10: 1.5 × 10 + 8 = 23 (expected PaCO₂), (23 − 8) / 1.5
+//! = 10 (bicarbonate). The two asserted values (23, 10) are distinct, neither a colon-anchored prefix
+//! of the other.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped winters-formula library, resolved from this crate's manifest dir so
+/// the test is location-independent.
+fn shipped_wf_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/winters-formula.adj")
+        .canonicalize()
+        .expect("shipped winters-formula.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_wf_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_wf_lib()).unwrap();
+    std::fs::write(dir.join("winters-formula.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// expected_paco2 — Winter's formula: 1.5 × HCO₃ + 8.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_winters_formula_library_and_computes_expected_paco2_with_citation() {
+    let dir = scratch("wf");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"winters-formula.adj\"\n\
+         observe hco3(10)\n\
+         ? expected_paco2(hco3)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 1.5 × 10 + 8 = 23, computed
+    // EXACTLY over rationals (1.5 = 3/2), not as a rounded float.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"expected_paco2\"") && s.contains("\"value\":23"),
+        "expected_paco2(10) = 23: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// hco3 — the same formula solved for the bicarbonate: (expected PaCO₂ − 8) / 1.5.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_hco3_from_expected_paco2_with_citation() {
+    let dir = scratch("hco3");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"winters-formula.adj\"\n\
+         observe expected_paco2(23)\n\
+         ? hco3(expected_paco2)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (23 − 8) / 1.5 = 15 / 1.5 = 10, computed exactly on the CPU.
+    assert!(
+        s.contains("\"name\":\"hco3\"") && s.contains("\"value\":10"),
+        "hco3(23) = 10: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "hco3 carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/winters-formula.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/winters-formula.adj
@@ -1,0 +1,83 @@
+% ============================================================================
+% winters-formula.adj — Winter's formula: the expected (compensatory) PaCO₂ in metabolic acidosis
+% (expected PaCO₂ = 1.5 × HCO₃ + 8) in the ADJ standard library.
+% ============================================================================
+% The Winter's-formula entry of the *clinical* track — the RESPIRATORY COMPENSATION a simple metabolic
+% acidosis should produce. In metabolic acidosis the lungs blow off CO₂ to buffer the fall in
+% bicarbonate; Winter's formula predicts the arterial CO₂ tension (PaCO₂) that ADEQUATE compensation
+% should reach for a given serum bicarbonate. THE EXPECTED PaCO₂ IS 1.5 TIMES THE BICARBONATE PLUS 8
+% (mm Hg), within ±2 — i.e. expected PaCO₂ = 1.5 × HCO₃ + 8. A measured PaCO₂ higher than this window
+% signals a superimposed respiratory ACIDOSIS (inadequate compensation); lower signals a superimposed
+% respiratory ALKALOSIS (over-compensation). It ships as an importable, byte-provenanced, PARAMETERIZED
+% `formula`, together with its exact rearrangement (the bicarbonate a given expected PaCO₂ implies). As
+% with every compute library, a consumer states NO arithmetic: it `import`s this file, binds the
+% measured bicarbonate from its own byte-provenance decomposition, and asks the engine to APPLY the
+% cited formula on the CPU. Zero math is performed by the model; the engine computes each value EXACTLY
+% (over exact rationals — 1.5 = 3/2), carrying the formula's citation.
+%
+%     import "winters-formula.adj"
+%     observe hco3(10)   % "…serum bicarbonate 10 mEq/L…"     (span cited by the model)
+%     ? expected_paco2(hco3)
+%                         % engine → 23, the expected PaCO₂ (mm Hg)
+%
+% The 1.5 multiplier and the +8 mm Hg intercept are the EXACT constants of the cited formula (not
+% measurements); the ±2 is a TOLERANCE BAND around the point estimate, not part of the central value,
+% so this library computes the central expected PaCO₂ (1.5 × HCO₃ + 8) and leaves the ±2 acceptance
+% window to the consumer. The two formulas COMPOSE and invert cleanly around the worked case
+% HCO₃ = 10 mEq/L (expected PaCO₂ = 1.5 × 10 + 8 = 15 + 8 = 23 mm Hg): the `expected_paco2` a consumer
+% computes is exactly the value the `hco3` formula back-solves to recover 10.
+%
+%   expected_paco2(hco3)           = 1.5 * hco3 + 8              % (Winter's formula, read forward)
+%   hco3(expected_paco2)           = (expected_paco2 - 8) / 1.5  % (solved for the bicarbonate)
+%
+% NOTE ON UNITS AND MODELLING: PaCO₂ in mm Hg, bicarbonate in mEq/L; the 1.5 and 8 are the conventional
+% Winter's-formula constants. The formula applies to a SIMPLE metabolic acidosis with expected
+% respiratory compensation; it does not itself diagnose the acid–base disturbance, and (per the cited
+% article) the bicarbonate is conventionally a venous value. The cited article states the formula as a
+% single explicit equation — "PaCO2 = (1.5 x HCO3 +8 ) ±2" — which is exactly the relation read
+% forward; the rearrangement is the same relation solved for the bicarbonate.
+%
+% Both formulas are defended by the SAME clause — the quoted Winter's-formula sentence — because that
+% one statement (the expected PaCO₂ IS 1.5 times the bicarbonate plus 8) sanctions the relation read
+% either way. The quote is transcribed verbatim from the StatPearls "Anion Gap and Non-Anion Gap
+% Metabolic Acidosis" article on the NCBI Bookshelf (a current, non-archived article), so each `formula`
+% carries the provenance envelope every shipped grounded clause carries; the linter rejects an
+% unsourced one. (See feedback_nothing_human_authored — the formula, including its 1.5 and 8 constants,
+% is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `hco3` and `expected_paco2` each appear BOTH as a derived result and as an input (of the
+% other formula), so each is a single dictionary term used in both roles. The `surface` lists are the
+% everyday names a decomposer maps onto the canonical term; the trailing comment records the intended
+% unit.
+% ----------------------------------------------------------------------------
+dictionary winters_formula_vocab {
+    define hco3           : finding  surface "bicarbonate", "serum bicarbonate", "HCO3"   % mEq/L
+    define expected_paco2 : finding  surface "expected PaCO2", "expected pCO2", "predicted PaCO2"  % mm Hg
+}
+
+% ----------------------------------------------------------------------------
+% Winter's formula, both ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the formula sentence from the StatPearls "Anion Gap
+% and Non-Anion Gap Metabolic Acidosis" article on the NCBI Bookshelf (a quote is required on a shipped
+% formula). Each is an exact linear expression in the measured quantity and the cited 1.5/8 constants,
+% so the engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook winters_formula_laws {
+    use winters_formula_vocab
+
+    % Expected PaCO₂ — 1.5 times the bicarbonate plus the 8 mm Hg intercept (the central value of the
+    % ±2 window).
+    formula expected_paco2(hco3) = 1.5 * hco3 + 8
+        source "Metabolic acidosis causes a compensatory hyperventilation response within 12 to 24 hours, which can be calculated through Winter's formula: PaCO2 = (1.5 x HCO3 +8 ) ±2."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK448090/"
+        trust authoritative
+
+    % Bicarbonate — the same formula solved for the bicarbonate (subtract the 8, divide by 1.5).
+    % Defended by the SAME sentence.
+    formula hco3(expected_paco2) = (expected_paco2 - 8) / 1.5
+        source "Metabolic acidosis causes a compensatory hyperventilation response within 12 to 24 hours, which can be calculated through Winter's formula: PaCO2 = (1.5 x HCO3 +8 ) ±2."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK448090/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/winters-formula.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/winters-formula.query.adj
@@ -1,0 +1,26 @@
+% ============================================================================
+% winters-formula.query.adj — worked applications of Winter's formula.
+% ============================================================================
+% The shape a consumer produces once it has decomposed an acid–base vignette into a measured serum
+% bicarbonate: it `import`s the grounded formulabook, `observe`s the value, and asks the engine to
+% APPLY Winter's formula. No arithmetic is stated by the consumer; the engine computes each value
+% EXACTLY (over exact rationals) and carries the article's citation as its proof, on the CPU, with zero
+% model calls.
+%
+% Worked case (HCO₃ = 10 mEq/L): expected PaCO₂ = 1.5 × 10 + 8 = 23 mm Hg. Each query fixes one of the
+% two quantities and asks the engine to recover the other; both answers are exact and COMPOSE (the
+% inversion recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli winters-formula.query.adj
+% ============================================================================
+
+import "winters-formula.adj"
+
+% --- Winter's formula: the expected PaCO₂ a bicarbonate of 10 implies (expect 23). ------------------
+observe hco3(10)
+? expected_paco2(hco3)            % expect 23
+
+% --- Inverse: the bicarbonate an expected PaCO₂ of 23 implies (expect 10). --------------------------
+observe expected_paco2(23)
+? hco3(expected_paco2)            % expect 10


### PR DESCRIPTION
## What

Adds **Winter's formula** — the expected (compensatory) PaCO₂ in a simple metabolic acidosis — to the ADJ formula standard library (clinical track), as a byte-provenanced, importable `formulabook` together with its exact rearrangement:

```
expected_paco2(hco3)  = 1.5 * hco3 + 8
hco3(expected_paco2)  = (expected_paco2 - 8) / 1.5
```

Both formulas are defended by the **same verbatim clause** from the current (non-archived) StatPearls *Anion Gap and Non-Anion Gap Metabolic Acidosis* article on the NCBI Bookshelf ([NBK448090](https://www.ncbi.nlm.nih.gov/books/NBK448090/)):

> Metabolic acidosis causes a compensatory hyperventilation response within 12 to 24 hours, which can be calculated through Winter's formula: PaCO2 = (1.5 x HCO3 +8 ) ±2.

The `1.5` multiplier and `8` mm Hg intercept are the exact constants of the cited formula. The `±2` is a **tolerance band** around the point estimate (left to the consumer), so this library computes the central expected PaCO₂. The engine computes every value **exactly over rationals** (`1.5 = 3/2`). As with every compute library, a consumer states **no arithmetic** — it imports the library, `observe`s the bicarbonate, and the engine applies the cited formula on the CPU. Distinct from the already-shipped anion-gap formula.

## Files

- `code/specs/data/adj-formula-stdlib/clinical/winters-formula.adj` — dictionary + 2-formula formulabook (each carrying source/locator/trust).
- `code/specs/data/adj-formula-stdlib/clinical/winters-formula.query.adj` — worked forward + inverse applications.
- `code/packages/rust/adj-lang-cli/tests/formula_winters_formula_e2e.rs` — dedicated e2e test.

## Worked case & inversion (asserted by the e2e test)

- forward: hco3=10 → `expected_paco2 = 1.5 × 10 + 8 = 23`
- inverse: expected_paco2=23 → `hco3 = (23 − 8) / 1.5 = 10`

Each answer carries the NBK448090 citation and `trust:authoritative`.

## Checks

- `cargo test -p adj-lang-cli --test formula_winters_formula_e2e` — 2 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean.
- Render-probe against the built CLI confirms `expected_paco2=23` / `hco3=10`, both with the NBK448090 locator + authoritative trust.
- NUL-scan clean on all three new files.
- `/security-review` — SECURITY REVIEW PASSED.

Data + test only; no engine change, **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)