### PR TITLE
feat(smart-home): persist runtime state

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -905,6 +905,7 @@ members = [
     "zwave-serial-api",
     "thread-mle",
     "smart-home-runtime",
+    "smart-home-runtime-store",
     "zigbee-zcl",
     "hue-client",
     "hue-integration",

--- a/code/packages/rust/smart-home-core/CHANGELOG.md
+++ b/code/packages/rust/smart-home-core/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this package will be documented in this file.
 
 ### Added
 
+- Serde support for the normalized smart-home model so versioned durable stores
+  can persist protocol-neutral topology, state, events, and command records.
 - `smart_home.get_recovery_readiness_brief` tool descriptor for read-only Chief
   return-to-normal readiness packets over existing D23 recovery,
   service-execution safety, activation rollback, observability, guardrail,

--- a/code/packages/rust/smart-home-core/Cargo.toml
+++ b/code/packages/rust/smart-home-core/Cargo.toml
@@ -6,3 +6,4 @@ description = "Repository-owned normalized smart-home model shared by integratio
 license = "MIT"
 
 [dependencies]
+serde = { version = "1", features = ["derive"] }

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -7,6 +7,7 @@
 
 #![forbid(unsafe_code)]
 
+use serde::{Deserialize, Serialize};
 use std::{collections::BTreeSet, fmt};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -53,7 +54,7 @@ impl std::error::Error for SmartHomeError {}
 
 macro_rules! id_type {
     ($name:ident, $kind:literal) => {
-        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
         pub struct $name(String);
 
         impl $name {
@@ -95,13 +96,13 @@ id_type!(VaultRef, "vault reference");
 id_type!(AgentId, "agent id");
 id_type!(CapabilityGrantId, "capability grant id");
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RuntimeKind {
     InProcessRust,
     RustWorkerProcess,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BridgeTransport {
     LanHttp,
     Mdns,
@@ -111,7 +112,7 @@ pub enum BridgeTransport {
     LocalProcess,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Health {
     Unknown,
     Discoverable,
@@ -141,7 +142,7 @@ impl Health {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EntityKind {
     Light,
     LightGroup,
@@ -156,14 +157,14 @@ pub enum EntityKind {
     Unknown,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CapabilityMode {
     Observe,
     Command,
     ObserveAndCommand,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ValueKind {
     Null,
     Boolean,
@@ -175,7 +176,7 @@ pub enum ValueKind {
     Array,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Value {
     Null,
     Bool(bool),
@@ -196,7 +197,7 @@ impl Value {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Capability {
     pub capability_id: CapabilityId,
     pub mode: CapabilityMode,
@@ -371,7 +372,7 @@ pub fn canonical_capability_catalog() -> Vec<Capability> {
     ]
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CapabilitySurfaceSummary {
     pub total_capabilities: usize,
     pub observe_only_capabilities: usize,
@@ -445,7 +446,7 @@ impl CapabilitySurfaceSummary {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ProtocolFamily {
     Hue,
     Zigbee,
@@ -470,7 +471,7 @@ impl ProtocolFamily {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProtocolIdentifier {
     pub family: ProtocolFamily,
     pub kind: String,
@@ -503,7 +504,7 @@ impl ProtocolIdentifier {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct MqttTopicName(String);
 
 impl MqttTopicName {
@@ -536,7 +537,7 @@ impl fmt::Display for MqttTopicName {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct MqttTopicFilter(String);
 
 impl MqttTopicFilter {
@@ -565,7 +566,7 @@ impl fmt::Display for MqttTopicFilter {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MqttQualityOfService {
     AtMostOnce,
     AtLeastOnce,
@@ -582,7 +583,7 @@ impl MqttQualityOfService {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MqttTopicRole {
     Discovery,
     Availability,
@@ -603,7 +604,7 @@ impl MqttTopicRole {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MqttTopicBinding {
     pub role: MqttTopicRole,
     pub topic: MqttTopicName,
@@ -632,7 +633,7 @@ impl MqttTopicBinding {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Metadata {
     pub key: String,
     pub value: String,
@@ -647,7 +648,7 @@ impl Metadata {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IntegrationDescriptor {
     pub integration_id: IntegrationId,
     pub display_name: String,
@@ -744,7 +745,7 @@ impl IntegrationDescriptor {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IntegrationSurfaceSummary {
     pub integration_id: IntegrationId,
     pub display_name: String,
@@ -758,7 +759,7 @@ pub struct IntegrationSurfaceSummary {
     pub supports_pairing: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IntegrationCatalogSummary {
     pub total_integrations: usize,
     pub in_process_rust_integrations: usize,
@@ -973,7 +974,7 @@ pub fn canonical_integration_catalog_summary() -> IntegrationCatalogSummary {
     IntegrationCatalogSummary::from_descriptors(catalog.iter())
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Bridge {
     pub bridge_id: BridgeId,
     pub integration_id: IntegrationId,
@@ -1010,7 +1011,7 @@ impl Bridge {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Device {
     pub device_id: DeviceId,
     pub bridge_id: BridgeId,
@@ -1026,7 +1027,7 @@ pub struct Device {
     pub metadata: Vec<Metadata>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Entity {
     pub entity_id: EntityId,
     pub device_id: DeviceId,
@@ -1043,7 +1044,7 @@ impl Entity {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StateSource {
     EventStream,
     Poll,
@@ -1051,7 +1052,7 @@ pub enum StateSource {
     Manual,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StateConfidence {
     Confirmed,
     Optimistic,
@@ -1059,7 +1060,7 @@ pub enum StateConfidence {
     Unknown,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StateSnapshot {
     pub entity_id: EntityId,
     pub value: Value,
@@ -1077,7 +1078,7 @@ impl StateSnapshot {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SmartHomeInventorySummary {
     pub total_bridges: usize,
     pub online_bridges: usize,
@@ -1170,7 +1171,7 @@ impl SmartHomeInventorySummary {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DeviceEventType {
     Discovered,
     Updated,
@@ -1180,13 +1181,13 @@ pub enum DeviceEventType {
     Health,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StateDelta {
     pub capability_id: CapabilityId,
     pub value: Value,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DeviceEvent {
     pub event_id: EventId,
     pub bridge_id: BridgeId,
@@ -1201,7 +1202,7 @@ pub struct DeviceEvent {
     pub metadata: Vec<Metadata>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CommandType {
     TurnOn,
     TurnOff,
@@ -1227,7 +1228,7 @@ impl CommandType {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum PrivilegeTier {
     ReadOnly,
     LowRisk,
@@ -1235,7 +1236,7 @@ pub enum PrivilegeTier {
     HighRisk,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DeviceCommand {
     pub command_id: CommandId,
     pub entity_id: EntityId,
@@ -1289,7 +1290,7 @@ pub fn tier_for_command(command_type: CommandType) -> PrivilegeTier {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CommandStatus {
     Accepted,
     Rejected,
@@ -1297,7 +1298,7 @@ pub enum CommandStatus {
     Failed,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommandResult {
     pub command_id: CommandId,
     pub status: CommandStatus,
@@ -1342,7 +1343,7 @@ impl CommandResult {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SceneScope {
     Room,
     Zone,
@@ -1351,13 +1352,13 @@ pub enum SceneScope {
     Custom,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SceneAction {
     pub entity_id: EntityId,
     pub desired_state: Value,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Scene {
     pub scene_id: SceneId,
     pub scope: SceneScope,
@@ -1366,7 +1367,7 @@ pub struct Scene {
     pub metadata: Vec<Metadata>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ToolSideEffects {
     None,
     Read,
@@ -1382,7 +1383,7 @@ pub struct ToolDescriptor {
     pub required_tier: PrivilegeTier,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SmartHomeToolCatalogSummary {
     pub total_tools: usize,
     pub read_tools: usize,
@@ -1443,7 +1444,7 @@ impl SmartHomeToolCatalogSummary {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SmartHomeTool {
     ListIntegrations,
     DescribeIntegration,
@@ -2645,7 +2646,7 @@ impl SmartHomeTool {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CapabilityGrantStatus {
     Pending,
     Active,
@@ -2653,7 +2654,7 @@ pub enum CapabilityGrantStatus {
     Expired,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CapabilityGrantScope {
     Tool(SmartHomeTool),
     Capability(CapabilityId),
@@ -2664,7 +2665,7 @@ pub enum CapabilityGrantScope {
     AllSmartHome,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CapabilityGrant {
     pub grant_id: CapabilityGrantId,
     pub principal_id: AgentId,
@@ -2844,7 +2845,7 @@ impl ToolDescriptor {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CapabilityGrantInventorySummary {
     pub generated_at_ms: u64,
     pub total_grants: usize,
@@ -2924,13 +2925,13 @@ impl CapabilityGrantInventorySummary {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AuthorizationOutcome {
     Allowed,
     Denied,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AuthorizationSubject {
     Tool(SmartHomeTool),
     Command {
@@ -2940,7 +2941,7 @@ pub enum AuthorizationSubject {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuthorizationDecision {
     pub principal_id: AgentId,
     pub subject: AuthorizationSubject,
@@ -3025,13 +3026,13 @@ impl AuthorizationDecision {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AuthorizationSubjectKind {
     Tool,
     Command,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuthorizationDecisionSummary {
     pub subject_kind: AuthorizationSubjectKind,
     pub outcome: AuthorizationOutcome,
@@ -3070,7 +3071,7 @@ impl AuthorizationDecisionSummary {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuthorizationDecisionLogSummary {
     pub total_decisions: usize,
     pub allowed_decisions: usize,

--- a/code/packages/rust/smart-home-runtime-store/BUILD
+++ b/code/packages/rust/smart-home-runtime-store/BUILD
@@ -1,0 +1,1 @@
+cargo test -p smart-home-runtime-store -- --nocapture

--- a/code/packages/rust/smart-home-runtime-store/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime-store/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Add versioned, compare-and-swap smart-home runtime snapshots.
+- Restore registry, state, history, pairing, desired state, and automation
+  definitions from durable storage.
+- Prove restart recovery with the local-folder storage backend.

--- a/code/packages/rust/smart-home-runtime-store/Cargo.toml
+++ b/code/packages/rust/smart-home-runtime-store/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "smart-home-runtime-store"
+version = "0.1.0"
+edition = "2021"
+description = "Restart-safe persistence for normalized smart-home runtime state"
+license = "MIT"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+smart-home-runtime = { path = "../smart-home-runtime" }
+storage-core = { path = "../storage-core" }
+
+[dev-dependencies]
+smart-home-core = { path = "../smart-home-core" }
+storage-local-folder = { path = "../storage-local-folder" }

--- a/code/packages/rust/smart-home-runtime-store/README.md
+++ b/code/packages/rust/smart-home-runtime-store/README.md
@@ -1,0 +1,9 @@
+# smart-home-runtime-store
+
+`smart-home-runtime-store` persists a versioned `SmartHomeRuntime` snapshot
+through the repository-owned `StorageBackend` contract. It restores normalized
+topology, state, event and command history, pairing sessions, desired state,
+and opaque automation definitions after a process restart.
+
+Live discovery workers and event subscriptions are deliberately process-local
+and are rebuilt by their owners.

--- a/code/packages/rust/smart-home-runtime-store/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime-store/src/lib.rs
@@ -1,0 +1,414 @@
+//! Restart-safe persistence for the normalized smart-home runtime.
+
+#![forbid(unsafe_code)]
+
+use serde::{Deserialize, Serialize};
+use smart_home_runtime::{RuntimeDurableSnapshot, RuntimeError, SmartHomeRuntime};
+use std::fmt;
+use storage_core::{Revision, StorageBackend, StorageError, StorageMetadata, StoragePutInput};
+
+const SCHEMA_VERSION: u32 = 1;
+const DEFAULT_NAMESPACE: &str = "smart-home-runtime";
+const DEFAULT_KEY: &str = "runtime-state";
+const CONTENT_TYPE: &str = "application/vnd.coding-adventures.smart-home-runtime+json";
+
+/// A durable automation document kept alongside runtime state.
+///
+/// The rules engine owns the document schema. This store only requires a stable
+/// identifier and JSON object so definitions survive restarts before and after
+/// an engine implementation changes.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DurableAutomationDefinition {
+    pub automation_id: String,
+    pub enabled: bool,
+    pub definition: serde_json::Value,
+}
+
+impl DurableAutomationDefinition {
+    pub fn new(
+        automation_id: impl Into<String>,
+        enabled: bool,
+        definition: serde_json::Value,
+    ) -> Result<Self, RuntimeStoreError> {
+        let automation_id = automation_id.into();
+        if automation_id.trim().is_empty() {
+            return Err(RuntimeStoreError::Validation {
+                field: "automation_id",
+                message: "must not be empty".to_string(),
+            });
+        }
+        if !definition.is_object() {
+            return Err(RuntimeStoreError::Validation {
+                field: "definition",
+                message: "must be a JSON object".to_string(),
+            });
+        }
+        Ok(Self {
+            automation_id,
+            enabled,
+            definition,
+        })
+    }
+}
+
+/// State returned after loading one durable runtime snapshot.
+#[derive(Debug)]
+pub struct RestoredSmartHomeRuntime {
+    pub runtime: SmartHomeRuntime,
+    pub automation_definitions: Vec<DurableAutomationDefinition>,
+    pub saved_at_ms: u64,
+    pub revision: Revision,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct RuntimeStoreEnvelope {
+    schema_version: u32,
+    saved_at_ms: u64,
+    runtime: RuntimeDurableSnapshot,
+    automation_definitions: Vec<DurableAutomationDefinition>,
+}
+
+/// Errors surfaced by durable runtime persistence.
+#[derive(Debug)]
+pub enum RuntimeStoreError {
+    Storage(StorageError),
+    Runtime(RuntimeError),
+    Encode(String),
+    Decode(String),
+    UnsupportedSchema(u32),
+    Validation {
+        field: &'static str,
+        message: String,
+    },
+}
+
+impl fmt::Display for RuntimeStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Storage(error) => write!(f, "{error}"),
+            Self::Runtime(error) => write!(f, "{error}"),
+            Self::Encode(message) => write!(f, "could not encode smart-home runtime: {message}"),
+            Self::Decode(message) => write!(f, "could not decode smart-home runtime: {message}"),
+            Self::UnsupportedSchema(version) => {
+                write!(f, "unsupported smart-home runtime schema version {version}")
+            }
+            Self::Validation { field, message } => {
+                write!(f, "invalid smart-home runtime {field}: {message}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RuntimeStoreError {}
+
+impl From<StorageError> for RuntimeStoreError {
+    fn from(error: StorageError) -> Self {
+        Self::Storage(error)
+    }
+}
+
+impl From<RuntimeError> for RuntimeStoreError {
+    fn from(error: RuntimeError) -> Self {
+        Self::Runtime(error)
+    }
+}
+
+/// Versioned durable runtime store over any repository-owned backend.
+pub struct SmartHomeRuntimeStore<B> {
+    backend: B,
+    namespace: String,
+    key: String,
+}
+
+impl<B: StorageBackend> SmartHomeRuntimeStore<B> {
+    pub fn new(backend: B) -> Self {
+        Self {
+            backend,
+            namespace: DEFAULT_NAMESPACE.to_string(),
+            key: DEFAULT_KEY.to_string(),
+        }
+    }
+
+    pub fn with_location(backend: B, namespace: impl Into<String>, key: impl Into<String>) -> Self {
+        Self {
+            backend,
+            namespace: namespace.into(),
+            key: key.into(),
+        }
+    }
+
+    pub fn save(
+        &self,
+        runtime: &SmartHomeRuntime,
+        automation_definitions: &[DurableAutomationDefinition],
+        saved_at_ms: u64,
+    ) -> Result<Revision, RuntimeStoreError> {
+        validate_automation_definitions(automation_definitions)?;
+        self.backend.initialize()?;
+        let previous = self.backend.get(&self.namespace, &self.key)?;
+        let envelope = RuntimeStoreEnvelope {
+            schema_version: SCHEMA_VERSION,
+            saved_at_ms,
+            runtime: runtime.durable_snapshot(),
+            automation_definitions: automation_definitions.to_vec(),
+        };
+        let body = serde_json::to_vec(&envelope)
+            .map_err(|error| RuntimeStoreError::Encode(error.to_string()))?;
+        let input = StoragePutInput::new(
+            self.namespace.clone(),
+            self.key.clone(),
+            CONTENT_TYPE,
+            StorageMetadata::Object(Default::default()),
+            body,
+        )?
+        .with_if_revision(previous.map(|record| record.revision));
+        Ok(self.backend.put(input)?.revision)
+    }
+
+    pub fn load(&self) -> Result<Option<RestoredSmartHomeRuntime>, RuntimeStoreError> {
+        self.backend.initialize()?;
+        let Some(record) = self.backend.get(&self.namespace, &self.key)? else {
+            return Ok(None);
+        };
+        let envelope: RuntimeStoreEnvelope = serde_json::from_slice(&record.body)
+            .map_err(|error| RuntimeStoreError::Decode(error.to_string()))?;
+        if envelope.schema_version != SCHEMA_VERSION {
+            return Err(RuntimeStoreError::UnsupportedSchema(
+                envelope.schema_version,
+            ));
+        }
+        validate_automation_definitions(&envelope.automation_definitions)?;
+        Ok(Some(RestoredSmartHomeRuntime {
+            runtime: SmartHomeRuntime::restore_durable_snapshot(envelope.runtime)?,
+            automation_definitions: envelope.automation_definitions,
+            saved_at_ms: envelope.saved_at_ms,
+            revision: record.revision,
+        }))
+    }
+
+    pub fn into_backend(self) -> B {
+        self.backend
+    }
+}
+
+fn validate_automation_definitions(
+    definitions: &[DurableAutomationDefinition],
+) -> Result<(), RuntimeStoreError> {
+    let mut ids = std::collections::BTreeSet::new();
+    for definition in definitions {
+        DurableAutomationDefinition::new(
+            definition.automation_id.clone(),
+            definition.enabled,
+            definition.definition.clone(),
+        )?;
+        if !ids.insert(definition.automation_id.as_str()) {
+            return Err(RuntimeStoreError::Validation {
+                field: "automation_id",
+                message: format!("duplicate id {}", definition.automation_id),
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use smart_home_core::{
+        AgentId, Bridge, BridgeId, BridgeTransport, Capability, CapabilityId, CommandId,
+        CommandResult, CommandStatus, CorrelationId, Device, DeviceEvent, DeviceEventType,
+        DeviceId, Entity, EntityId, EntityKind, EventId, Health, IntegrationId, StateDelta, Value,
+    };
+    use smart_home_runtime::{
+        DesiredEntityState, DesiredStateQuery, RuntimeCommandResultQuery, RuntimeEvent,
+        RuntimePairingSession, RuntimePairingSessionId, RuntimePairingSessionQuery,
+    };
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use storage_local_folder::LocalFolderStorageBackend;
+
+    fn temp_root(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("test clock should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "smart-home-runtime-store-{}-{name}-{nanos}",
+            std::process::id()
+        ))
+    }
+
+    fn runtime_fixture() -> SmartHomeRuntime {
+        let mut runtime = SmartHomeRuntime::new();
+        runtime
+            .upsert_bridge(Bridge::new(
+                BridgeId::trusted("bridge-1"),
+                IntegrationId::trusted("hue"),
+                BridgeTransport::LanHttp,
+            ))
+            .unwrap();
+        runtime
+            .upsert_device(Device {
+                device_id: DeviceId::trusted("device-1"),
+                bridge_id: BridgeId::trusted("bridge-1"),
+                manufacturer: "Signify".to_string(),
+                model: "Hue bulb".to_string(),
+                name: "Kitchen".to_string(),
+                serial: None,
+                firmware_version: None,
+                room_id: Some("kitchen".to_string()),
+                entity_ids: Vec::new(),
+                identifiers: Vec::new(),
+                health: Health::Online,
+                metadata: Vec::new(),
+            })
+            .unwrap();
+        runtime
+            .upsert_entity(Entity {
+                entity_id: EntityId::trusted("entity-1"),
+                device_id: DeviceId::trusted("device-1"),
+                kind: EntityKind::Light,
+                name: "Kitchen Light".to_string(),
+                capabilities: vec![Capability::light_on_off()],
+                state: None,
+                metadata: Vec::new(),
+            })
+            .unwrap();
+        runtime
+            .apply_device_event(DeviceEvent {
+                event_id: EventId::trusted("event-1"),
+                bridge_id: BridgeId::trusted("bridge-1"),
+                device_id: Some(DeviceId::trusted("device-1")),
+                entity_id: Some(EntityId::trusted("entity-1")),
+                observed_at_ms: 100,
+                received_at_ms: 101,
+                event_type: DeviceEventType::Updated,
+                state_delta: Some(StateDelta {
+                    capability_id: CapabilityId::trusted("light.on_off"),
+                    value: Value::Bool(true),
+                }),
+                raw_ref: None,
+                correlation_id: None,
+                metadata: Vec::new(),
+            })
+            .unwrap();
+        runtime
+            .event_bus_mut()
+            .publish(RuntimeEvent::CommandResult(CommandResult {
+                command_id: CommandId::trusted("command-1"),
+                status: CommandStatus::Accepted,
+                bridge_id: BridgeId::trusted("bridge-1"),
+                correlation_id: CorrelationId::trusted("correlation-1"),
+                message: None,
+            }));
+        let bridge = runtime
+            .registry()
+            .bridge(&BridgeId::trusted("bridge-1"))
+            .unwrap()
+            .clone();
+        runtime
+            .start_pairing_session(RuntimePairingSession::pending(
+                RuntimePairingSessionId::trusted("pairing-1"),
+                &bridge,
+                AgentId::trusted("agent:test"),
+                200,
+                1_200,
+                Vec::new(),
+            ))
+            .unwrap();
+        runtime
+            .upsert_desired_state(DesiredEntityState::new(
+                EntityId::trusted("entity-1"),
+                vec![StateDelta {
+                    capability_id: CapabilityId::trusted("light.on_off"),
+                    value: Value::Bool(false),
+                }],
+            ))
+            .unwrap();
+        runtime
+    }
+
+    #[test]
+    fn local_folder_restart_restores_runtime_and_automation_definitions() {
+        let root = temp_root("restart");
+        let automation = DurableAutomationDefinition::new(
+            "automation-kitchen-off",
+            true,
+            serde_json::json!({
+                "trigger": {"kind": "schedule", "at": "23:00"},
+                "actions": [{"entity_id": "entity-1", "on": false}]
+            }),
+        )
+        .unwrap();
+        let runtime = runtime_fixture();
+        let store = SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(root.clone()));
+        let saved_revision = store
+            .save(&runtime, std::slice::from_ref(&automation), 500)
+            .unwrap();
+        drop(store);
+
+        let reopened = SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(root.clone()));
+        let restored = reopened
+            .load()
+            .unwrap()
+            .expect("saved runtime should exist");
+
+        assert_eq!(restored.saved_at_ms, 500);
+        assert_eq!(restored.revision, saved_revision);
+        assert_eq!(restored.automation_definitions, vec![automation]);
+        assert_eq!(restored.runtime.registry().counts().bridges, 1);
+        assert_eq!(restored.runtime.registry().counts().devices, 1);
+        assert_eq!(restored.runtime.registry().counts().entities, 1);
+        assert_eq!(restored.runtime.registry().counts().states, 1);
+        assert_eq!(restored.runtime.registry().counts().events, 1);
+        assert_eq!(
+            restored
+                .runtime
+                .query_command_results(&RuntimeCommandResultQuery::new())
+                .len(),
+            1
+        );
+        assert_eq!(
+            restored
+                .runtime
+                .query_pairing_sessions(&RuntimePairingSessionQuery::new())
+                .len(),
+            1
+        );
+        assert_eq!(
+            restored
+                .runtime
+                .query_desired_states(&DesiredStateQuery::new())
+                .len(),
+            1
+        );
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn rejects_duplicate_automation_ids_before_writing() {
+        let root = temp_root("duplicate-automation");
+        let automation =
+            DurableAutomationDefinition::new("duplicate", true, serde_json::json!({})).unwrap();
+        let store = SmartHomeRuntimeStore::new(LocalFolderStorageBackend::new(root.clone()));
+
+        let error = store
+            .save(
+                &SmartHomeRuntime::new(),
+                &[automation.clone(), automation],
+                1,
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            RuntimeStoreError::Validation {
+                field: "automation_id",
+                ..
+            }
+        ));
+        assert!(!root.exists());
+    }
+}

--- a/code/packages/rust/smart-home-runtime/CHANGELOG.md
+++ b/code/packages/rust/smart-home-runtime/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this package will be documented in this file.
 
 ### Added
 
+- `RuntimeDurableSnapshot` plus snapshot and restore helpers for normalized
+  registry, state, history, pairing, optimistic, and desired-state data.
 - `RuntimeEventDeliverySummary` plus delivery-batch `summary()` helpers for
   compact delivered-event and remaining-backlog counts after subscription polls.
 - `RuntimePollEventsToolRequest` / `RuntimePollEventsToolOutput` and

--- a/code/packages/rust/smart-home-runtime/Cargo.toml
+++ b/code/packages/rust/smart-home-runtime/Cargo.toml
@@ -6,6 +6,7 @@ description = "Smart-home runtime coordinator for event routing, command validat
 license = "MIT"
 
 [dependencies]
+serde = { version = "1", features = ["derive"] }
 smart-home-core = { path = "../smart-home-core" }
 smart-home-discovery = { path = "../smart-home-discovery" }
 smart-home-integration-catalog = { path = "../smart-home-integration-catalog" }

--- a/code/packages/rust/smart-home-runtime/src/lib.rs
+++ b/code/packages/rust/smart-home-runtime/src/lib.rs
@@ -7,6 +7,7 @@
 
 #![forbid(unsafe_code)]
 
+use serde::{Deserialize, Serialize};
 use smart_home_core::{
     tier_for_command, AgentId, AuthorizationDecision, AuthorizationDecisionLogSummary,
     AuthorizationOutcome, Bridge, BridgeId, Capability, CapabilityGrant,
@@ -219,7 +220,7 @@ impl fmt::Display for RuntimeSubscriptionId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct RuntimePairingSessionId(String);
 
 impl RuntimePairingSessionId {
@@ -267,7 +268,7 @@ pub enum RuntimeEventFilter {
     Supervision,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum RuntimeEvent {
     Device(DeviceEvent),
     CommandResult(CommandResult),
@@ -2612,14 +2613,14 @@ impl RuntimeDiscoveryScheduler {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ReconciliationReason {
     MissingState,
     StaleState,
     Drifted,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DesiredEntityState {
     pub entity_id: EntityId,
     pub desired: Vec<StateDelta>,
@@ -2789,7 +2790,7 @@ pub struct BridgeHealthReport {
     pub metadata: Vec<Metadata>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PairingSessionStatus {
     PendingUserPresence,
     Completed,
@@ -2808,7 +2809,7 @@ impl PairingSessionStatus {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RuntimePairingSession {
     pub session_id: RuntimePairingSessionId,
     pub bridge_id: BridgeId,
@@ -4277,6 +4278,28 @@ pub struct SmartHomeRuntime {
     desired_states: BTreeMap<EntityId, DesiredEntityState>,
 }
 
+/// Durable, transport-neutral runtime state.
+///
+/// Discovery scheduling and live subscriptions are intentionally omitted:
+/// they are process-local workers and consumers. Everything needed to rebuild
+/// normalized topology, state, history, pending pairing work, and desired
+/// state is retained.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RuntimeDurableSnapshot {
+    pub bridges: Vec<Bridge>,
+    pub devices: Vec<Device>,
+    pub entities: Vec<Entity>,
+    pub scenes: Vec<Scene>,
+    pub states: Vec<StateSnapshot>,
+    pub registry_events: Vec<DeviceEvent>,
+    pub capability_grants: Vec<CapabilityGrant>,
+    pub authorization_decisions: Vec<AuthorizationDecision>,
+    pub runtime_events: Vec<RuntimeEvent>,
+    pub pairing_sessions: Vec<RuntimePairingSession>,
+    pub optimistic_states: Vec<StateSnapshot>,
+    pub desired_states: Vec<DesiredEntityState>,
+}
+
 impl SmartHomeRuntime {
     pub fn new() -> Self {
         Self {
@@ -4297,6 +4320,86 @@ impl SmartHomeRuntime {
 
     pub fn registry_mut(&mut self) -> &mut InMemorySmartHomeRegistry {
         &mut self.registry
+    }
+
+    pub fn durable_snapshot(&self) -> RuntimeDurableSnapshot {
+        RuntimeDurableSnapshot {
+            bridges: self.registry.bridges().cloned().collect(),
+            devices: self.registry.devices().cloned().collect(),
+            entities: self.registry.entities().cloned().collect(),
+            scenes: self.registry.scenes().cloned().collect(),
+            states: self.registry.states().cloned().collect(),
+            registry_events: self.registry.events().cloned().collect(),
+            capability_grants: self.registry.capability_grants().cloned().collect(),
+            authorization_decisions: self.registry.authorization_decisions().cloned().collect(),
+            runtime_events: self.event_bus.published().to_vec(),
+            pairing_sessions: self.pairing_sessions.values().cloned().collect(),
+            optimistic_states: self.optimistic_states.values().cloned().collect(),
+            desired_states: self.desired_states.values().cloned().collect(),
+        }
+    }
+
+    pub fn restore_durable_snapshot(
+        snapshot: RuntimeDurableSnapshot,
+    ) -> Result<Self, RuntimeError> {
+        let RuntimeDurableSnapshot {
+            bridges,
+            devices,
+            entities,
+            scenes,
+            states,
+            registry_events,
+            capability_grants,
+            authorization_decisions,
+            runtime_events,
+            pairing_sessions,
+            optimistic_states,
+            desired_states,
+        } = snapshot;
+        let mut runtime = Self::new();
+
+        for bridge in bridges {
+            runtime.upsert_bridge(bridge)?;
+        }
+        for device in devices {
+            runtime.upsert_device(device)?;
+        }
+        for entity in entities {
+            runtime.upsert_entity(entity)?;
+        }
+        for scene in scenes {
+            runtime.upsert_scene(scene)?;
+        }
+        for event in registry_events {
+            runtime.registry.record_event(event)?;
+        }
+        for state in states {
+            runtime.registry.apply_state_snapshot(state)?;
+        }
+        for grant in capability_grants {
+            runtime.registry.upsert_capability_grant(grant);
+        }
+        for decision in authorization_decisions {
+            runtime.registry.record_authorization_decision(decision);
+        }
+        for event in runtime_events {
+            runtime.event_bus.publish(event);
+        }
+        for session in pairing_sessions {
+            runtime
+                .pairing_sessions
+                .insert(session.session_id.clone(), session);
+        }
+        for state in optimistic_states {
+            runtime
+                .optimistic_states
+                .insert(state.entity_id.clone(), state);
+        }
+        for desired_state in desired_states {
+            runtime.upsert_desired_state(desired_state)?;
+        }
+
+        Ok(runtime)
     }
 
     pub fn discovery(&self) -> &DiscoveryCatalog {

--- a/code/specs/D18-D23-chief-smart-home-completion-inventory.md
+++ b/code/specs/D18-D23-chief-smart-home-completion-inventory.md
@@ -367,12 +367,30 @@ These items are Chief of Staff architecture, not smart-home platform work:
 
 - No remaining items within the D18 Chief architecture completion boundary.
 
+## Current Durable Runtime Persistence Slice
+
+This slice makes normalized D23 runtime data restart-safe without moving
+process-local worker or subscription ownership into storage:
+
+- `smart-home-core` exposes serde support for the normalized protocol-neutral
+  model, and `smart-home-runtime` can produce and restore a versioned durable
+  snapshot through its existing validated registry and desired-state paths.
+- The snapshot retains bridge, device, entity, scene, state, device-event,
+  authorization, capability-grant, runtime-event, command-result, pairing,
+  optimistic-state, and desired-state data.
+- `smart-home-runtime-store` persists that snapshot through any D18A
+  `StorageBackend`, uses compare-and-swap revisions, and keeps validated opaque
+  automation definitions beside runtime data for the future rules engine.
+- A local-folder restart test closes and reopens the durable backend before
+  proving topology, state, event and command history, pairing, desired state,
+  and automation definitions are queryable again.
+- Live discovery workers and event subscriptions remain process-local and are
+  rebuilt by their owners instead of restoring stale network work or consumers.
+
 ## Smart Home Remaining Work
 
 These items move toward retiring an existing Home Assistant install:
 
-- Persist registry, state cache, event history, command history, pairing
-  sessions, desired state, and automation definitions.
 - Add a local API surface for dashboard, mobile, CLI, and Chief of Staff jobs.
 - Add an automation/rules engine with schedules, triggers, conditions, scenes,
   idempotency, dry-run planning, and audit.


### PR DESCRIPTION
## Summary
- add serde-backed durable snapshots for the normalized smart-home model and runtime
- add `smart-home-runtime-store` over the shared `StorageBackend` contract with versioning and CAS revisions
- restore registry, state/event and command history, pairing sessions, desired state, authorization data, and opaque automation definitions after restart
- update the D18-D23 completion inventory to close the broad runtime persistence item

## Verification
- `cargo test -p smart-home-core -p smart-home-runtime -p smart-home-runtime-store -- --nocapture`
- `cargo clippy -p smart-home-core -p smart-home-runtime -p smart-home-runtime-store --all-targets -- -D warnings`
- `sh BUILD` in `smart-home-core`, `smart-home-runtime`, and `smart-home-runtime-store`
- `cargo fmt -p smart-home-runtime-store -- --check`
- `git diff --check`

The restart proof uses `storage-local-folder`, drops the first backend, reopens the same directory, and verifies the restored runtime through normal query APIs.