### PR TITLE
feat(spice): validate MOS transconductance

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-positive or non-finite Level-1 MOS model-card `KP` values with a
+  stable diagnostic before temperature scaling and current evaluation.
 - Reject negative or non-finite Level-1 MOS model-card `U0` / `UO` values with
   a stable diagnostic before mobility preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `TOX` values with a

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -578,6 +578,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET TOX must be finite and positive")
         elif canonical == "U0" and (not math.isfinite(value) or value < 0.0):
             raise ValueError(f"{name}: MOSFET U0 must be finite and non-negative")
+        elif canonical == "KP" and (not math.isfinite(value) or value <= 0.0):
+            raise ValueError(f"{name}: MOSFET KP must be finite and positive")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1045,6 +1045,19 @@ def test_mos_model_card_rejects_invalid_surface_mobility() -> None:
             normalize_model_card("Minvalid", "nmos", {"U0": invalid_mobility})
 
 
+def test_mos_model_card_rejects_invalid_transconductance() -> None:
+    valid = normalize_model_card("Mvalid", "nmos", {"KP": 200.0e-6})
+    assert valid.parameters["KP"] == pytest.approx(200.0e-6)
+
+    for invalid_transconductance in (0.0, -1.0, math.inf, math.nan):
+        with pytest.raises(
+            ValueError, match="MOSFET KP must be finite and positive"
+        ):
+            normalize_model_card(
+                "Minvalid", "nmos", {"KP": invalid_transconductance}
+            )
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-positive or non-finite Level-1 MOS model-card `KP` values with a
+  stable diagnostic before temperature scaling and current evaluation.
 - Reject negative or non-finite Level-1 MOS model-card `U0` / `UO` values with
   a stable diagnostic before mobility preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `TOX` values with a

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4375,6 +4375,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET U0 must be finite and non-negative".to_string(),
                 });
+            } else if canonical == "KP" && (!raw_value.is_finite() || *raw_value <= 0.0) {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET KP must be finite and positive".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -849,6 +849,20 @@ fn mos_model_card_rejects_invalid_surface_mobility() {
 }
 
 #[test]
+fn mos_model_card_rejects_invalid_transconductance() {
+    let valid = normalize_model_card("Mvalid", "nmos", &[("KP", 200.0e-6)]).unwrap();
+    assert_close(*valid.parameters.get("KP").unwrap(), 200.0e-6);
+
+    for invalid_transconductance in [0.0, -1.0, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("KP", invalid_transconductance)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET KP must be finite and positive"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-positive or non-finite Level-1 MOS model-card `KP` values with a
+  stable diagnostic before temperature scaling and current evaluation.
 - Reject negative or non-finite Level-1 MOS model-card `U0` / `UO` values with
   a stable diagnostic before mobility preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `TOX` values with a

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8440,6 +8440,8 @@ export function normalizeModelCard(
       throw invalidElement(name, "MOSFET TOX must be finite and positive");
     } else if (canonical === "U0" && (!Number.isFinite(value) || value < 0.0)) {
       throw invalidElement(name, "MOSFET U0 must be finite and non-negative");
+    } else if (canonical === "KP" && (!Number.isFinite(value) || value <= 0.0)) {
+      throw invalidElement(name, "MOSFET KP must be finite and positive");
     } else {
       normalized[canonical] = value;
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -714,6 +714,22 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects invalid MOS transconductance", () => {
+    const valid = normalizeModelCard("Mvalid", "nmos", { KP: 200.0e-6 });
+    expect(valid.parameters.KP).toBe(200.0e-6);
+
+    for (const invalidTransconductance of [
+      0.0,
+      -1.0,
+      Number.POSITIVE_INFINITY,
+      Number.NaN,
+    ]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { KP: invalidTransconductance }),
+      ).toThrow("MOSFET KP must be finite and positive");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS surface-mobility validation.
+1. Cross-language Level-1 MOS transconductance validation.
    - Status: current PR completion candidate.
-   - Reject negative or non-finite model-card `U0` / `UO` values before
-     mobility preprocessing and process-derived `KP`.
-   - Preserve zero and positive surface mobility with stable diagnostics across
-     Rust, Python, and TypeScript.
+   - Reject non-positive or non-finite model-card `KP` values before
+     temperature scaling and current evaluation.
+   - Preserve positive explicit transconductance and its precedence over
+     process-derived `KP` across Rust, Python, and TypeScript.
 
 ## Completed Slices
 
@@ -3664,6 +3664,13 @@ the Rust, Python, and TypeScript surfaces together.
      mobility and electrostatic process-parameter preprocessing.
    - Positive oxide thickness and stable diagnostics remain aligned across
      Rust, Python, and TypeScript.
+
+298. Cross-language Level-1 MOS surface-mobility validation.
+   - Status: completed in PR 9197.
+   - Negative and non-finite model-card `U0` / `UO` values are rejected before
+     mobility preprocessing and process-derived `KP`.
+   - Zero and positive surface mobility plus stable diagnostics remain aligned
+     across Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject non-positive and non-finite Level-1 MOS model-card `KP` values during normalization
- preserve valid explicit `KP` and its precedence over process-derived transconductance
- record PR #9197 in the SPICE completion plan and select transconductance validation as the current slice

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python Ruff plus full pytest: 680 passed, 88.94% coverage
- TypeScript tests: 423 passed
- `npm run build`