### PR TITLE
Add Venture browser viewport state

### DIFF
--- a/code/packages/rust/venture-browser-core/CHANGELOG.md
+++ b/code/packages/rust/venture-browser-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.0
+
+- Add `BrowserViewport`, binding the current page to clamped scrolling,
+  viewport-space link hit-testing, and translated render-scene projection.
+- Preserve viewport height and reset scroll when replacing the loaded page.
+
 ## 0.2.0
 
 - Add finite, clamped `ScrollState` geometry with resize re-clamping.

--- a/code/packages/rust/venture-browser-core/Cargo.toml
+++ b/code/packages/rust/venture-browser-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "venture-browser-core"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Host-neutral navigation and page-loading orchestration for the Venture browser."
 

--- a/code/packages/rust/venture-browser-core/README.md
+++ b/code/packages/rust/venture-browser-core/README.md
@@ -29,6 +29,11 @@ performs scroll-aware link hit-testing, and feeds `scrolled_viewport_scene`.
 That function preserves the document scene beneath a group translated by the
 negative scroll offset and sizes the returned scene to the visible viewport.
 
+`BrowserViewport` binds a loaded `BrowserPage` to that scroll policy. Native
+content-area hosts can resize or scroll it, hit-test links in viewport
+coordinates, and request the exact viewport scene for each paint event. Page
+replacement resets scroll while preserving the current viewport height.
+
 ## Development
 
 ```bash

--- a/code/packages/rust/venture-browser-core/src/lib.rs
+++ b/code/packages/rust/venture-browser-core/src/lib.rs
@@ -16,7 +16,7 @@ use paint_instructions::{PaintBase, PaintGroup, PaintInstruction, PaintScene};
 use std::fmt;
 use text_interfaces::{FontMetrics, FontResolver, TextShaper};
 
-pub const VERSION: &str = "0.2.0";
+pub const VERSION: &str = "0.3.0";
 
 /// In-memory browser navigation state.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -265,6 +265,63 @@ pub struct BrowserPage {
     pub render_tree: BrowserRenderTree,
     pub paint: HtmlPaintOutput,
     pub image_failures: Vec<HtmlImageResourceError>,
+}
+
+/// The current loaded page and its viewport interaction state.
+///
+/// This is the value a native content-area host keeps between input and paint
+/// events. Replacing the page preserves viewport height while resetting scroll
+/// to the top of the new document.
+#[derive(Clone, Debug, PartialEq)]
+pub struct BrowserViewport {
+    page: BrowserPage,
+    scroll: ScrollState,
+}
+
+impl BrowserViewport {
+    pub fn new(page: BrowserPage, viewport_height: f64) -> Self {
+        let scroll = ScrollState::new(viewport_height, page.paint.scene.height);
+        Self { page, scroll }
+    }
+
+    pub fn page(&self) -> &BrowserPage {
+        &self.page
+    }
+
+    pub fn scroll_state(&self) -> &ScrollState {
+        &self.scroll
+    }
+
+    pub fn set_scroll_offset_y(&mut self, offset_y: f64) -> f64 {
+        self.scroll.set_offset_y(offset_y)
+    }
+
+    pub fn scroll_by(&mut self, delta_y: f64) -> f64 {
+        self.scroll.scroll_by(delta_y)
+    }
+
+    pub fn resize(&mut self, viewport_height: f64) -> f64 {
+        self.scroll
+            .set_dimensions(viewport_height, self.page.paint.scene.height)
+    }
+
+    pub fn replace_page(&mut self, page: BrowserPage) {
+        self.scroll = ScrollState::new(self.scroll.viewport_height, page.paint.scene.height);
+        self.page = page;
+    }
+
+    pub fn hit_test_link(&self, viewport_x: f64, viewport_y: f64) -> Option<&LinkRegion> {
+        self.scroll
+            .hit_test(&self.page.paint.links, viewport_x, viewport_y)
+    }
+
+    pub fn viewport_scene(&self) -> PaintScene {
+        scrolled_viewport_scene(&self.page.paint.scene, &self.scroll)
+    }
+
+    pub fn into_page(self) -> BrowserPage {
+        self.page
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -589,6 +646,31 @@ mod tests {
             .data
             .chunks_exact(4)
             .any(|pixel| pixel != [192, 192, 192, 255]));
+
+        let link = page.paint.links[0].clone();
+        let mut viewport = BrowserViewport::new(page, 40.0);
+        let offset = viewport.set_scroll_offset_y(link.y);
+        let viewport_y = link.y - offset + link.height / 2.0;
+        assert_eq!(
+            viewport.hit_test_link(link.x + link.width / 2.0, viewport_y),
+            Some(&link)
+        );
+        let scene = viewport.viewport_scene();
+        assert_eq!(scene.height, 40.0);
+        let [PaintInstruction::Group(group)] = scene.instructions.as_slice() else {
+            panic!("browser viewport should project one translated group");
+        };
+        assert_eq!(group.transform, Some([1.0, 0.0, 0.0, 1.0, 0.0, -offset]));
+
+        viewport.scroll_by(100.0);
+        let mut replacement = viewport.page().clone();
+        replacement.final_url = "http://example.test/replacement".into();
+        replacement.paint.scene.height = 20.0;
+        viewport.replace_page(replacement);
+        assert_eq!(viewport.page().final_url, "http://example.test/replacement");
+        assert_eq!(viewport.scroll_state().offset_y(), 0.0);
+        assert_eq!(viewport.scroll_state().content_height(), 20.0);
+        assert_eq!(viewport.scroll_state().viewport_height(), 40.0);
     }
 
     #[test]

--- a/code/specs/BR01-venture-browser.md
+++ b/code/specs/BR01-venture-browser.md
@@ -65,10 +65,11 @@ Back/Forward/Home/Reload model and composes an injectable page fetch through
 document-URL-aware parsing, layout, paint, and synchronous image resolution.
 Its acceptance path carries a redirected canned page and GIF resource through
 Cairo to RGBA pixels. The core also owns clamped vertical scroll geometry,
-scroll-aware link hit-testing, and viewport scene translation. The remaining
-browser gate is the concrete platform shell that binds those core results to
-native window events, controls, scrollbars, and the selected production paint
-backend.
+scroll-aware link hit-testing, and viewport scene translation.
+`BrowserViewport` binds those policies to the current loaded page and resets
+scroll coherently when the page changes. The remaining browser gate is the
+concrete platform shell that binds those core results to native window events,
+controls, scrollbars, and the selected production paint backend.
 
 ## Where It Fits
 


### PR DESCRIPTION
## Summary

- add `BrowserViewport` as the host-neutral owner of the loaded page and its scroll state
- expose viewport-coordinate link hit-testing and translated scene projection for native content-area events
- preserve viewport height while resetting scroll when navigation replaces the page
- document the remaining native-shell acceptance gate and bump `venture-browser-core` to 0.3.0

## Why

The parser, layout, paint, resource loading, and scroll primitives were individually available, but a browser host still had to coordinate page replacement, scrolling, hit-testing, and paint projection itself. This slice gives the eventual Mosaic/Venture platform shell one coherent state object to keep between input and paint events.

## Validation

- `cargo fmt --manifest-path venture-browser-core/Cargo.toml -- --check`
- `cargo clippy -q -p venture-browser-core --all-targets -- -D warnings`
- `cargo test -q -p venture-browser-core`
- `cargo test -q -p paint-instructions -p html-to-paint -p venture-browser-core`
- `cargo metadata --no-deps --format-version 1`
- `git diff --check`
- exact conformance audit: WPT tree construction 1,934 upstream / 2,637 local / 0 missing; html5lib tokenizer 6,806 upstream / 7,015 local raw / 0 missing; 7,242 normalized / 0 skipped