### PR TITLE
feat(adj-formula-stdlib): corrected-sodium — StatPearls hyperglycemia-corrected serum sodium formulabook (clinical track)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_corrected_sodium_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_corrected_sodium_e2e.rs
@@ -1,0 +1,142 @@
+//! End-to-end tests for the `clinical/corrected-sodium.adj` library — the hyperglycemia-corrected
+//! serum sodium (corrected sodium = measured sodium + 1.6 × (glucose − 100) / 100) and its two exact
+//! rearrangements — driven through the built CLI binary against the SHIPPED stdlib. The same invariant
+//! as every other formula library: a consumer states NO arithmetic; it imports the grounded library,
+//! binds the measured sodium and glucose with `observe`, and the engine applies the cited correction
+//! on the CPU, computing the EXACT value (over exact rationals — 1.6 = 8/5) and rendering the citation
+//! and trust tier in the `derived` section (the auditable answer). The three formulas INVERT around
+//! the worked case measured sodium = 126, glucose = 600: 126 + 1.6 × (600 − 100) / 100 = 134
+//! (corrected), 134 − 1.6 × (600 − 100) / 100 = 126 (measured), 100 + (134 − 126) × 100 / 1.6 = 600
+//! (glucose). The three asserted values (134, 126, 600) are distinct, none a colon-anchored prefix of
+//! another rendered value.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped corrected-sodium library, resolved from this crate's manifest dir so
+/// the test is location-independent.
+fn shipped_cs_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/corrected-sodium.adj")
+        .canonicalize()
+        .expect("shipped corrected-sodium.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_cs_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_cs_lib()).unwrap();
+    std::fs::write(dir.join("corrected-sodium.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// corrected_sodium — the correction: measured sodium + 1.6 × (glucose − 100) / 100.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_corrected_sodium_library_and_computes_it_with_citation() {
+    let dir = scratch("cs");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"corrected-sodium.adj\"\n\
+         observe measured_sodium(126)\n\
+         observe glucose(600)\n\
+         ? corrected_sodium(measured_sodium, glucose)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied correction's result: 126 + 1.6 × (600 − 100) / 100
+    // = 134, computed EXACTLY over rationals (1.6 = 8/5), not as a rounded float.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"corrected_sodium\"") && s.contains("\"value\":134"),
+        "corrected_sodium(126, 600) = 134: {s}"
+    );
+    // … AND the article citation and trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "applied correction carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// measured_sodium — the same correction solved for the measured sodium: corrected − 1.6 × (glucose − 100) / 100.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_measured_sodium_from_corrected_with_citation() {
+    let dir = scratch("meas");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"corrected-sodium.adj\"\n\
+         observe corrected_sodium(134)\n\
+         observe glucose(600)\n\
+         ? measured_sodium(corrected_sodium, glucose)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 134 − 1.6 × (600 − 100) / 100 = 126, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"measured_sodium\"") && s.contains("\"value\":126"),
+        "measured_sodium(134, 600) = 126: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "measured_sodium carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// glucose — the same correction solved for the glucose: 100 + (corrected − measured) × 100 / 1.6, the
+// third reading of the one correction.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_glucose_from_corrected_and_measured_with_citation() {
+    let dir = scratch("gluc");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"corrected-sodium.adj\"\n\
+         observe corrected_sodium(134)\n\
+         observe measured_sodium(126)\n\
+         ? glucose(corrected_sodium, measured_sodium)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 100 + (134 − 126) × 100 / 1.6 = 100 + 800 / 1.6 = 100 + 500 = 600, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"glucose\"") && s.contains("\"value\":600"),
+        "glucose(134, 126) = 600: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("ncbi.nlm.nih.gov"),
+        "glucose carries its cited provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/corrected-sodium.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/corrected-sodium.adj
@@ -1,0 +1,97 @@
+% ============================================================================
+% corrected-sodium.adj — the hyperglycemia-corrected serum sodium
+% (corrected sodium = measured sodium + 1.6 × (glucose − 100) / 100) in the ADJ standard library.
+% ============================================================================
+% The corrected-sodium entry of the *clinical* track — the correction that undoes the FALSELY LOW
+% serum sodium caused by hyperglycemia. A high plasma glucose draws water into the vascular space and
+% dilutes the measured sodium (a translocational / dilutional pseudohyponatremia); the correction adds
+% the sodium back so the value reflects the true sodium the patient would show at a normal glucose.
+% THE LABORATORY SODIUM IS CORRECTED BY ADDING 1.6 mEq FOR EACH 100 mg/dL OF GLUCOSE ABOVE 100 mg/dL —
+% i.e. measured sodium + 1.6 × (glucose − 100) / 100. It ships as an importable, byte-provenanced,
+% PARAMETERIZED `formula`, together with its two exact rearrangements (the measured sodium a corrected
+% value implies at a given glucose, and the glucose a corrected/measured pair implies). As with every
+% compute library, a consumer states NO arithmetic: it `import`s this file, binds the measured sodium
+% and glucose from its own byte-provenance decomposition, and asks the engine to APPLY the cited
+% correction on the CPU. Zero math is performed by the model; the engine computes each value EXACTLY
+% (over exact rationals — 1.6 = 8/5), carrying the correction's citation.
+%
+%     import "corrected-sodium.adj"
+%     observe measured_sodium(126)   % "…serum sodium 126 mEq/L…"    (span cited by the model)
+%     observe glucose(600)            % "…glucose 600 mg/dL…"         (span cited by the model)
+%     ? corrected_sodium(measured_sodium, glucose)
+%                                      % engine → 134, the corrected sodium (mEq/L)
+%
+% The 1.6 mEq-per-100 mg/dL coefficient and the 100 mg/dL glucose reference are the EXACT constants of
+% the cited correction (not measurements); the formulas are otherwise exact linear expressions over the
+% parameters, so every value the engine returns is exact. They COMPOSE and invert cleanly around the
+% worked case measured sodium = 126 mEq/L, glucose = 600 mg/dL (corrected = 126 + 1.6 × (600 − 100) /
+% 100 = 126 + 1.6 × 5 = 126 + 8 = 134 mEq/L): the `corrected_sodium` a consumer computes is exactly the
+% value the `measured_sodium` formula subtracts the same 1.6 × (glucose − 100) / 100 offset from to
+% recover 126, and exactly the value the `glucose` formula back-solves to recover 600.
+%
+%   corrected_sodium(measured_sodium, glucose) = measured_sodium + 1.6 * (glucose - 100) / 100  % (correction)
+%   measured_sodium(corrected_sodium, glucose) = corrected_sodium - 1.6 * (glucose - 100) / 100  % (solved for measured)
+%   glucose(corrected_sodium, measured_sodium) = 100 + (corrected_sodium - measured_sodium) * 100 / 1.6  % (solved for glucose)
+%
+% NOTE ON UNITS AND MODELLING: this is the conventional correction used in hyperglycemic crises (DKA /
+% hyperosmolar state) — sodium in mEq/L, glucose in mg/dL, reference glucose 100 mg/dL, coefficient
+% 1.6 mEq/L per 100 mg/dL. The correction only ADJUSTS the interpretation of a measured sodium for the
+% dilutional effect of hyperglycemia; it does not itself diagnose the sodium disorder, and (as the
+% cited article and later work note) the 1.6 factor is the standard approximation, best below very high
+% glucose. The cited article states the correction as prose — "The laboratory serum sodium finding is
+% often falsely low in DKA cases and can be corrected by adding 1.6 mEq to the measured serum sodium
+% for each 100 mg/dL of glucose above 100 mg/dL." — which is exactly the correction read forward; the
+% two rearrangements are the same relation solved for each input.
+%
+% All three formulas are defended by the SAME clause — the quoted correction sentence — because that
+% one statement (the corrected sodium IS the measured value plus 1.6 per 100 mg/dL of glucose above
+% 100) sanctions the relation read every way. The quote is transcribed verbatim from the StatPearls
+% "Adult Diabetic Ketoacidosis" article on the NCBI Bookshelf (a current, non-archived article), so
+% each `formula` carries the provenance envelope every shipped grounded clause carries; the linter
+% rejects an unsourced one. (See feedback_nothing_human_authored — the correction, including its 1.6
+% and 100 constants, is a verbatim span of the cited page, not asserted from memory.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `measured_sodium`, `glucose` and `corrected_sodium` each appear BOTH as a derived result
+% and as an input (of the other formulas), so each is a single dictionary term used in both roles. The
+% `surface` lists are the everyday names a decomposer maps onto the canonical term; the trailing
+% comment records the intended unit.
+% ----------------------------------------------------------------------------
+dictionary corrected_sodium_vocab {
+    define measured_sodium  : finding  surface "measured sodium", "serum sodium", "sodium"   % mEq/L
+    define glucose          : finding  surface "glucose", "serum glucose", "blood glucose"    % mg/dL
+    define corrected_sodium : finding  surface "corrected sodium", "hyperglycemia-corrected sodium"  % mEq/L
+}
+
+% ----------------------------------------------------------------------------
+% The correction, all three ways. Each is a named, importable, reusable formula over its formal
+% parameters, bound at apply time, and each carries the correction sentence from the StatPearls "Adult
+% Diabetic Ketoacidosis" article on the NCBI Bookshelf (a quote is required on a shipped formula). Each
+% is an exact linear expression in the measured quantities and the cited 1.6/100 constants, so the
+% engine returns each value EXACTLY.
+% ----------------------------------------------------------------------------
+formulabook corrected_sodium_laws {
+    use corrected_sodium_vocab
+
+    % Corrected sodium — the measured sodium plus 1.6 mEq/L per 100 mg/dL of glucose above the 100 mg/dL
+    % reference.
+    formula corrected_sodium(measured_sodium, glucose) = measured_sodium + 1.6 * (glucose - 100) / 100
+        source "The laboratory serum sodium finding is often falsely low in DKA cases and can be corrected by adding 1.6 mEq to the measured serum sodium for each 100 mg/dL of glucose above 100 mg/dL."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560723/"
+        trust authoritative
+
+    % Measured sodium — the same correction solved for the measured sodium (subtract the offset).
+    % Defended by the SAME sentence.
+    formula measured_sodium(corrected_sodium, glucose) = corrected_sodium - 1.6 * (glucose - 100) / 100
+        source "The laboratory serum sodium finding is often falsely low in DKA cases and can be corrected by adding 1.6 mEq to the measured serum sodium for each 100 mg/dL of glucose above 100 mg/dL."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560723/"
+        trust authoritative
+
+    % Glucose — the same correction solved for the glucose (back out the offset). The SAME sentence,
+    % read the third way.
+    formula glucose(corrected_sodium, measured_sodium) = 100 + (corrected_sodium - measured_sodium) * 100 / 1.6
+        source "The laboratory serum sodium finding is often falsely low in DKA cases and can be corrected by adding 1.6 mEq to the measured serum sodium for each 100 mg/dL of glucose above 100 mg/dL."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK560723/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/clinical/corrected-sodium.query.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/corrected-sodium.query.adj
@@ -1,0 +1,27 @@
+% ============================================================================
+% corrected-sodium.query.adj — worked applications of the hyperglycemia-corrected-sodium correction.
+% ============================================================================
+% The shape a consumer produces once it has decomposed a hyperglycemic-crisis vignette into a measured
+% serum sodium and a glucose: it `import`s the grounded formulabook, `observe`s the two values, and
+% asks the engine to APPLY the cited correction. No arithmetic is stated by the consumer; the engine
+% computes each value EXACTLY (over exact rationals) and carries the article's citation as its proof,
+% on the CPU, with zero model calls.
+%
+% Worked case (measured sodium = 126 mEq/L, glucose = 600 mg/dL): corrected = 126 + 1.6 × (600 − 100) /
+% 100 = 134 mEq/L. Each query fixes two of the three quantities and asks the engine to recover the
+% third; every answer is exact and the three COMPOSE (each inversion recovers exactly the worked value).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli corrected-sodium.query.adj
+% ============================================================================
+
+import "corrected-sodium.adj"
+
+% --- Correction: the corrected sodium the measured value and glucose imply (expect 134). ------------
+observe measured_sodium(126)
+observe glucose(600)
+? corrected_sodium(measured_sodium, glucose)   % expect 134
+
+% --- Inverse: the measured sodium a corrected 134 implies at glucose 600 (expect 126). --------------
+observe corrected_sodium(134)
+? measured_sodium(corrected_sodium, glucose)   % expect 126


### PR DESCRIPTION
## What

Adds the **hyperglycemia-corrected serum sodium** (the correction that undoes the falsely-low measured sodium in hyperglycemic crises) to the ADJ formula standard library (clinical track), as a byte-provenanced, importable `formulabook` together with its two exact rearrangements:

```
corrected_sodium(measured_sodium, glucose) = measured_sodium + 1.6 * (glucose - 100) / 100
measured_sodium(corrected_sodium, glucose) = corrected_sodium - 1.6 * (glucose - 100) / 100
glucose(corrected_sodium, measured_sodium)  = 100 + (corrected_sodium - measured_sodium) * 100 / 1.6
```

All three formulas are defended by the **same verbatim clause** from the current (non-archived) StatPearls *Adult Diabetic Ketoacidosis* article on the NCBI Bookshelf ([NBK560723](https://www.ncbi.nlm.nih.gov/books/NBK560723/)):

> The laboratory serum sodium finding is often falsely low in DKA cases and can be corrected by adding 1.6 mEq to the measured serum sodium for each 100 mg/dL of glucose above 100 mg/dL.

The `1.6` mEq-per-100-mg/dL coefficient and the `100` mg/dL glucose reference are the exact constants of the cited correction. The engine computes every value **exactly over rationals** (`1.6 = 8/5`). As with every compute library, a consumer states **no arithmetic** — it imports the library, `observe`s the measured sodium and glucose, and the engine applies the cited correction on the CPU. Distinct from the already-shipped anion-gap and osmolar-gap formulas.

## Files

- `code/specs/data/adj-formula-stdlib/clinical/corrected-sodium.adj` — dictionary + 3-formula formulabook (each carrying source/locator/trust).
- `code/specs/data/adj-formula-stdlib/clinical/corrected-sodium.query.adj` — worked forward + inverse applications.
- `code/packages/rust/adj-lang-cli/tests/formula_corrected_sodium_e2e.rs` — dedicated e2e test.

## Worked case & inversion (asserted by the e2e test)

- forward: measured_sodium=126, glucose=600 → `corrected_sodium = 126 + 1.6·(600−100)/100 = 134`
- inverse: corrected_sodium=134, glucose=600 → `measured_sodium = 126`
- inverse: corrected_sodium=134, measured_sodium=126 → `glucose = 100 + (134−126)·100/1.6 = 600`

Each answer carries the NBK560723 citation and `trust:authoritative`.

## Checks

- `cargo test -p adj-lang-cli --test formula_corrected_sodium_e2e` — 3 passed.
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean.
- Render-probe against the built CLI confirms `corrected_sodium=134` / `measured_sodium=126`, both with the NBK560723 locator + authoritative trust.
- NUL-scan clean on all three new files.
- `/security-review` — SECURITY REVIEW PASSED.

Data + test only; no engine change, **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)