### PR TITLE
feat(spice): validate MOS threshold voltage

### DIFF
--- a/code/packages/python/spice-engine/CHANGELOG.md
+++ b/code/packages/python/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-finite Level-1 MOS model-card `VT0` / `VTO` / `VTH` values with a
+  stable diagnostic before threshold preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `KP` values with a
   stable diagnostic before temperature scaling and current evaluation.
 - Reject negative or non-finite Level-1 MOS model-card `U0` / `UO` values with

--- a/code/packages/python/spice-engine/src/spice_engine/model_cards.py
+++ b/code/packages/python/spice-engine/src/spice_engine/model_cards.py
@@ -580,6 +580,8 @@ def normalize_model_card(
             raise ValueError(f"{name}: MOSFET U0 must be finite and non-negative")
         elif canonical == "KP" and (not math.isfinite(value) or value <= 0.0):
             raise ValueError(f"{name}: MOSFET KP must be finite and positive")
+        elif canonical == "VT0" and not math.isfinite(value):
+            raise ValueError(f"{name}: MOSFET VT0 must be finite")
         else:
             normalized[canonical] = value
     return NormalizedModelCard(

--- a/code/packages/python/spice-engine/tests/test_engine.py
+++ b/code/packages/python/spice-engine/tests/test_engine.py
@@ -1058,6 +1058,16 @@ def test_mos_model_card_rejects_invalid_transconductance() -> None:
             )
 
 
+def test_mos_model_card_rejects_non_finite_threshold_voltage() -> None:
+    for name, value in (("VT0", -0.7), ("VTO", 0.0), ("VTH", 0.7)):
+        valid = normalize_model_card("Mvalid", "nmos", {name: value})
+        assert valid.parameters["VT0"] == pytest.approx(value)
+
+    for invalid_threshold in (-math.inf, math.inf, math.nan):
+        with pytest.raises(ValueError, match="MOSFET VT0 must be finite"):
+            normalize_model_card("Minvalid", "nmos", {"VTO": invalid_threshold})
+
+
 def test_dc_rejects_invalid_jfet_flicker_noise_coefficient() -> None:
     circuit = Circuit()
     circuit.add(JFET("J1", "drain", "gate", "0", Kf=-1.0))

--- a/code/packages/rust/spice-engine/CHANGELOG.md
+++ b/code/packages/rust/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-finite Level-1 MOS model-card `VT0` / `VTO` / `VTH` values with a
+  stable diagnostic before threshold preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `KP` values with a
   stable diagnostic before temperature scaling and current evaluation.
 - Reject negative or non-finite Level-1 MOS model-card `U0` / `UO` values with

--- a/code/packages/rust/spice-engine/src/lib.rs
+++ b/code/packages/rust/spice-engine/src/lib.rs
@@ -4380,6 +4380,11 @@ pub fn normalize_model_card(
                     name: name.clone(),
                     reason: "MOSFET KP must be finite and positive".to_string(),
                 });
+            } else if canonical == "VT0" && !raw_value.is_finite() {
+                return Err(SpiceError::InvalidElement {
+                    name: name.clone(),
+                    reason: "MOSFET VT0 must be finite".to_string(),
+                });
             } else {
                 normalized.insert(canonical.to_string(), *raw_value);
             }

--- a/code/packages/rust/spice-engine/tests/dc_tests.rs
+++ b/code/packages/rust/spice-engine/tests/dc_tests.rs
@@ -863,6 +863,22 @@ fn mos_model_card_rejects_invalid_transconductance() {
 }
 
 #[test]
+fn mos_model_card_rejects_non_finite_threshold_voltage() {
+    for (name, value) in [("VT0", -0.7), ("VTO", 0.0), ("VTH", 0.7)] {
+        let valid = normalize_model_card("Mvalid", "nmos", &[(name, value)]).unwrap();
+        assert_close(*valid.parameters.get("VT0").unwrap(), value);
+    }
+
+    for invalid_threshold in [f64::NEG_INFINITY, f64::INFINITY, f64::NAN] {
+        assert!(matches!(
+            normalize_model_card("Minvalid", "nmos", &[("VTO", invalid_threshold)]),
+            Err(SpiceError::InvalidElement { reason, .. })
+                if reason == "MOSFET VT0 must be finite"
+        ));
+    }
+}
+
+#[test]
 fn bjt_legacy_leakage_ratios_derive_currents_with_explicit_precedence() {
     let legacy_card = normalize_model_card(
         "Qlegacy",

--- a/code/packages/typescript/spice-engine/CHANGELOG.md
+++ b/code/packages/typescript/spice-engine/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Reject non-finite Level-1 MOS model-card `VT0` / `VTO` / `VTH` values with a
+  stable diagnostic before threshold preprocessing.
 - Reject non-positive or non-finite Level-1 MOS model-card `KP` values with a
   stable diagnostic before temperature scaling and current evaluation.
 - Reject negative or non-finite Level-1 MOS model-card `U0` / `UO` values with

--- a/code/packages/typescript/spice-engine/src/index.ts
+++ b/code/packages/typescript/spice-engine/src/index.ts
@@ -8442,6 +8442,8 @@ export function normalizeModelCard(
       throw invalidElement(name, "MOSFET U0 must be finite and non-negative");
     } else if (canonical === "KP" && (!Number.isFinite(value) || value <= 0.0)) {
       throw invalidElement(name, "MOSFET KP must be finite and positive");
+    } else if (canonical === "VT0" && !Number.isFinite(value)) {
+      throw invalidElement(name, "MOSFET VT0 must be finite");
     } else {
       normalized[canonical] = value;
     }

--- a/code/packages/typescript/spice-engine/tests/dc.test.ts
+++ b/code/packages/typescript/spice-engine/tests/dc.test.ts
@@ -730,6 +730,23 @@ describe("dcOp", () => {
     }
   });
 
+  it("rejects non-finite MOS threshold voltage", () => {
+    for (const [name, value] of [["VT0", -0.7], ["VTO", 0.0], ["VTH", 0.7]] as const) {
+      const valid = normalizeModelCard("Mvalid", "nmos", { [name]: value });
+      expect(valid.parameters.VT0).toBe(value);
+    }
+
+    for (const invalidThreshold of [
+      Number.NEGATIVE_INFINITY,
+      Number.POSITIVE_INFINITY,
+      Number.NaN,
+    ]) {
+      expect(() =>
+        normalizeModelCard("Minvalid", "nmos", { VTO: invalidThreshold }),
+      ).toThrow("MOSFET VT0 must be finite");
+    }
+  });
+
   it("derives BJT legacy leakage ratios with explicit-current precedence", () => {
     const legacyCard = normalizeModelCard("Qlegacy", "npn", {
       IS: 2.0e-14,

--- a/code/specs/spice-full-implementation-plan.md
+++ b/code/specs/spice-full-implementation-plan.md
@@ -33,12 +33,12 @@ the Rust, Python, and TypeScript surfaces together.
 
 ## Current PR Slice
 
-1. Cross-language Level-1 MOS transconductance validation.
+1. Cross-language Level-1 MOS threshold-voltage validation.
    - Status: current PR completion candidate.
-   - Reject non-positive or non-finite model-card `KP` values before
-     temperature scaling and current evaluation.
-   - Preserve positive explicit transconductance and its precedence over
-     process-derived `KP` across Rust, Python, and TypeScript.
+   - Reject non-finite model-card `VT0` / `VTO` / `VTH` values before threshold
+     preprocessing and explicit-value precedence.
+   - Preserve arbitrary finite NMOS and PMOS threshold voltages across Rust,
+     Python, and TypeScript.
 
 ## Completed Slices
 
@@ -3671,6 +3671,13 @@ the Rust, Python, and TypeScript surfaces together.
      mobility preprocessing and process-derived `KP`.
    - Zero and positive surface mobility plus stable diagnostics remain aligned
      across Rust, Python, and TypeScript.
+
+299. Cross-language Level-1 MOS transconductance validation.
+   - Status: completed in PR 9202.
+   - Non-positive and non-finite model-card `KP` values are rejected before
+     temperature scaling and current evaluation.
+   - Positive explicit transconductance and its precedence over process-derived
+     `KP` remain aligned across Rust, Python, and TypeScript.
 
 ## Backlog
 


### PR DESCRIPTION
## Summary
- reject non-finite Level-1 MOS model-card `VT0`, `VTO`, and `VTH` values during normalization
- preserve arbitrary finite threshold values and explicit-threshold precedence
- record PR #9202 in the SPICE completion plan and select threshold-voltage validation as the current slice

## Verification
- `cargo fmt --package spice-engine -- --check`
- `cargo clippy -p spice-engine --all-targets -- -D warnings`
- `cargo test -p spice-engine`
- Python Ruff plus full pytest: 681 passed, 88.94% coverage
- TypeScript tests: 424 passed
- `npm run build`
- focused post-rebase tests passed in all three ports