### PR TITLE
feat(build-tool): add exact backend loader

### DIFF
--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,7 +8,12 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": null,
+  "active_pr": {
+    "item_id": "build-tool-authority-exact-backend-loader",
+    "number": 9208,
+    "branch": "codex/build-tool-authority-exact-backend-loader",
+    "url": "https://github.com/adhithyan15/coding-adventures/pull/9208"
+  },
   "last_inventory": {
     "revision": "a06ed28b7096c178d84a36a1c1929bf69f056c92",
     "schema_version": 2,
@@ -81,14 +86,14 @@
     {
       "id": "build-tool-authority-exact-backend-loader",
       "title": "Load the exact approved preflight backend through an atomic runner boundary",
-      "status": "in-progress",
+      "status": "pr-open",
       "depends_on": [
         "build-tool-trusted-authority-bundle",
         "build-tool-linux-oci-sandbox"
       ],
       "branch": "codex/build-tool-authority-exact-backend-loader",
-      "pr_number": null,
-      "notes": "Selected after PR #9196 merged because it is the smallest dependency-shaped gate for every later Linux enforcement tranche. Add a separately domain-bound profile, atomic beneath-root component snapshot, sealed exact bytes, stdlib-only backend closure, and one-shot isolated loadability worker. This tranche runs no Podman capability command, container, case, adapter, or invariant probe."
+      "pr_number": 9208,
+      "notes": "Ready-for-review PR #9208. The domain-separated ten-role loader authority binds exact approved verifier, loader, backend, manifest, identity, policy, and schema bytes; retained no-follow directory handles and sealed memfds close component races. The isolated worker validates an exact stdlib import closure and closed interfaces by AST plus compilation without importing the backend or running Podman. Validation covered 125 conformance tests, 67% combined branch-aware coverage, Ruff, Bandit, corpus/contract validators, Go tests/build, parity collision checks, and the unchanged 73-gap build-file audit. Linux-only filesystem, sealed-worker, process-group, and streaming-cap paths run in Ubuntu CI."
     },
     {
       "id": "build-tool-linux-capability-preflight-broker",

--- a/.claude/package-parity-loop-state.json
+++ b/.claude/package-parity-loop-state.json
@@ -8,18 +8,13 @@
     "reprioritize_after_every_merge": true,
     "ocaml_denominator_status": "emerging-until-promotion-gates-pass"
   },
-  "active_pr": {
-    "item_id": "build-tool-trusted-authority-bundle",
-    "pr_number": 9196,
-    "branch": "codex/build-tool-trusted-authority-bundle",
-    "url": "https://github.com/adhithyan15/coding-adventures/pull/9196"
-  },
+  "active_pr": null,
   "last_inventory": {
-    "revision": "d0b9c442f03520fdff75c12b4f236c50de7f152c",
+    "revision": "a06ed28b7096c178d84a36a1c1929bf69f056c92",
     "schema_version": 2,
     "established_languages": 15,
-    "implementation_identities": 1187,
-    "implementation_package_slots": 4328,
+    "implementation_identities": 1190,
+    "implementation_package_slots": 4331,
     "high_consensus_packages": 172,
     "high_consensus_missing_slots": 278,
     "canonical_collisions": 0,
@@ -74,26 +69,37 @@
     {
       "id": "build-tool-trusted-authority-bundle",
       "title": "Define the external authority bundle and Linux preflight profile",
-      "status": "pr-open",
+      "status": "merged",
       "depends_on": [
         "build-tool-execution-sandbox",
         "build-tool-linux-oci-sandbox"
       ],
       "branch": "codex/build-tool-trusted-authority-bundle",
       "pr_number": 9196,
-      "notes": "Ready-for-review PR #9196. Security review split out a safe first profile: a post-merge external bundle whose raw-byte approval binds the exact source commit/tree, policy, schemas, authority verifier, Linux preflight backend, and external backend identity. Schema v1 approves exact bytes for capability inspection only, with no corpus, adapter, container, executable payload, or process handoff. Local validation covers 108 focused tests, 86% branch-aware authority-module coverage, Ruff, Bandit, corpus/contract validators, Go tests/build, parity collision checks, and the unchanged 73-gap build-file audit."
+      "notes": "Merged PR #9196. Security review split out a safe first profile: a post-merge external bundle whose raw-byte approval binds the exact source commit/tree, policy, schemas, authority verifier, Linux preflight backend, and external backend identity. Schema v1 approves exact bytes for capability inspection only, with no corpus, adapter, container, executable payload, or process handoff. Validation covered 108 focused tests, 86% branch-aware authority-module coverage, Ruff, Bandit, corpus/contract validators, Go tests/build, parity collision checks, and the unchanged 73-gap build-file audit."
     },
     {
       "id": "build-tool-authority-exact-backend-loader",
       "title": "Load the exact approved preflight backend through an atomic runner boundary",
-      "status": "pending",
+      "status": "in-progress",
       "depends_on": [
         "build-tool-trusted-authority-bundle",
         "build-tool-linux-oci-sandbox"
       ],
+      "branch": "codex/build-tool-authority-exact-backend-loader",
+      "pr_number": null,
+      "notes": "Selected after PR #9196 merged because it is the smallest dependency-shaped gate for every later Linux enforcement tranche. Add a separately domain-bound profile, atomic beneath-root component snapshot, sealed exact bytes, stdlib-only backend closure, and one-shot isolated loadability worker. This tranche runs no Podman capability command, container, case, adapter, or invariant probe."
+    },
+    {
+      "id": "build-tool-linux-capability-preflight-broker",
+      "title": "Broker the two approved Linux OCI capability commands",
+      "status": "pending",
+      "depends_on": [
+        "build-tool-authority-exact-backend-loader"
+      ],
       "branch": null,
       "pr_number": null,
-      "notes": "Discovered during final authority security review. Replace name-based Python import and check-then-open traversal with an atomic beneath-root loader over the exact retained backend bytes and a closed approved import closure. Until this lands, the authority verifier remains process-free and the bare Linux preflight CLI stays disabled."
+      "notes": "Discovered during exact-loader security review. Add a separately authorized protected broker over already-open verified Podman/crun and a retained private state root; permit only info and exact-config image inspect, stream combined output limits, scrub the environment and descriptors, enforce timeout and full descendant cleanup, and eliminate binary hash-to-exec and state-root path races. No container is created."
     },
     {
       "id": "build-tool-execution-case-snapshot",
@@ -119,7 +125,8 @@
       "status": "pending",
       "depends_on": [
         "build-tool-trusted-authority-bundle",
-        "build-tool-authority-exact-backend-loader"
+        "build-tool-authority-exact-backend-loader",
+        "build-tool-linux-capability-preflight-broker"
       ],
       "branch": null,
       "pr_number": null,
@@ -401,7 +408,7 @@
       "depends_on": [],
       "branch": null,
       "pr_number": null,
-      "notes": "The bee64b477 inventory added axiom-to-semantic-ir, http1-client, and smart-home-discovery-service. Review axiom-to-semantic-ir as a likely portable deterministic lowering, http1-client for portable-core versus native transport boundaries, and smart-home-discovery-service as a likely native/service applicability case before opening any port PR."
+      "notes": "The July 30 inventories added axiom-to-semantic-ir, http1-client, smart-home-discovery-service, hue-integration, and venture-browser-core. Review axiom-to-semantic-ir as a likely portable deterministic lowering; http1-client and venture-browser-core for portable-core versus native transport boundaries; and both smart-home packages as likely native/service applicability cases before opening any port PR."
     },
     {
       "id": "c-cpp-graduation",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_execution_schema.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_execution_runner.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_authority.py'
+          python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_backend_loader.py'
           python3 -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_linux_oci.py'
           python3 code/scripts/build_tool_conformance.py validate-corpus
           python3 code/scripts/build_tool_conformance_execution.py validate-contract

--- a/code/scripts/build_tool_conformance_authority.py
+++ b/code/scripts/build_tool_conformance_authority.py
@@ -27,8 +27,10 @@ from typing import Any
 import build_tool_conformance as bootstrap
 
 AUTHORITY_DOMAIN = (
-    b"coding-adventures/build-tool-authority/"
-    b"linux-capability-preflight/v1\0"
+    b"coding-adventures/build-tool-authority/linux-capability-preflight/v1\0"
+)
+LOADER_AUTHORITY_DOMAIN = (
+    b"coding-adventures/build-tool-authority/linux-capability-preflight-loader/v1\0"
 )
 MAX_AUTHORITY_BUNDLE_BYTES = bootstrap.MAX_DOCUMENT_BYTES
 MAX_AUTHORITY_COMPONENT_BYTES = 16_777_216
@@ -46,25 +48,45 @@ REPOSITORY_COMPONENT_PATHS = MappingProxyType(
         "execution_policy_schema": (
             "code/specs/fixtures/build-tool-v1/execution-policy.schema.json"
         ),
-        "execution_policy": (
-            "code/specs/fixtures/build-tool-v1/execution-policy.json"
-        ),
+        "execution_policy": ("code/specs/fixtures/build-tool-v1/execution-policy.json"),
         "linux_backend_identity_schema": (
             "code/specs/fixtures/build-tool-v1/linux-oci-backend.schema.json"
         ),
         "bootstrap_runner": "code/scripts/build_tool_conformance.py",
-        "authority_verifier": (
-            "code/scripts/build_tool_conformance_authority.py"
-        ),
-        "linux_preflight_backend": (
-            "code/scripts/build_tool_conformance_linux_oci.py"
-        ),
+        "authority_verifier": ("code/scripts/build_tool_conformance_authority.py"),
+        "linux_preflight_backend": ("code/scripts/build_tool_conformance_linux_oci.py"),
     }
 )
 BUNDLE_COMPONENT_PATHS = MappingProxyType(
     {"linux_backend_identity": "linux-oci-backend.json"}
 )
 COMPONENT_ROLES = (*REPOSITORY_COMPONENT_PATHS, *BUNDLE_COMPONENT_PATHS)
+LOADER_REPOSITORY_COMPONENT_PATHS = MappingProxyType(
+    {
+        "authority_bundle_schema": (
+            "code/specs/fixtures/build-tool-v1/"
+            "execution-preflight-loader-authority.schema.json"
+        ),
+        "execution_policy_schema": (
+            "code/specs/fixtures/build-tool-v1/execution-policy.schema.json"
+        ),
+        "execution_policy": ("code/specs/fixtures/build-tool-v1/execution-policy.json"),
+        "linux_backend_identity_schema": (
+            "code/specs/fixtures/build-tool-v1/linux-oci-backend.schema.json"
+        ),
+        "bootstrap_runner": "code/scripts/build_tool_conformance.py",
+        "authority_verifier": ("code/scripts/build_tool_conformance_authority.py"),
+        "preflight_loader": ("code/scripts/build_tool_conformance_backend_loader.py"),
+        "linux_preflight_backend": ("code/scripts/build_tool_conformance_linux_oci.py"),
+        "preflight_import_manifest": (
+            "code/specs/fixtures/build-tool-v1/preflight-imports.json"
+        ),
+    }
+)
+LOADER_COMPONENT_ROLES = (
+    *LOADER_REPOSITORY_COMPONENT_PATHS,
+    *BUNDLE_COMPONENT_PATHS,
+)
 GIT_OID_LENGTH = 40
 
 
@@ -80,11 +102,32 @@ class PreflightAuthority:
     identity_schema: dict[str, Any]
 
 
+@dataclass(frozen=True)
+class LoaderAuthority:
+    """Retained exact bytes approved only for isolated loadability."""
+
+    bundle_digest: str
+    bundle: dict[str, Any]
+    components: Mapping[str, bytes]
+    policy: dict[str, Any]
+    identity: dict[str, Any]
+
+
 def authority_bundle_sha256(raw: bytes) -> str:
     """Digest exact bundle bytes with scope and length separation."""
 
     digest = hashlib.sha256()
     digest.update(AUTHORITY_DOMAIN)
+    digest.update(struct.pack(">Q", len(raw)))
+    digest.update(raw)
+    return digest.hexdigest()
+
+
+def loader_authority_bundle_sha256(raw: bytes) -> str:
+    """Digest exact loader-authority bytes in their separate scope."""
+
+    digest = hashlib.sha256()
+    digest.update(LOADER_AUTHORITY_DOMAIN)
     digest.update(struct.pack(">Q", len(raw)))
     digest.update(raw)
     return digest.hexdigest()
@@ -147,11 +190,7 @@ def _read_bound_regular(
                 getattr(before, "st_file_attributes", 0)
                 & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
             )
-            if (
-                not stat.S_ISREG(before.st_mode)
-                or is_reparse
-                or before.st_nlink != 1
-            ):
+            if not stat.S_ISREG(before.st_mode) or is_reparse or before.st_nlink != 1:
                 raise bootstrap.ConformanceError(
                     f"{prefix}_FILE_INVALID",
                     f"{label} must be one regular, non-reparse, singly linked file",
@@ -181,6 +220,121 @@ def _read_bound_regular(
             f"{label} changed during its authority read",
         )
     return raw
+
+
+def _open_absolute_directory(path: Path) -> int:
+    """Open an absolute directory chain without following any component."""
+
+    if (
+        os.name != "posix"
+        or not path.is_absolute()
+        or any(part in {".", ".."} for part in path.parts[1:])
+    ):
+        raise bootstrap.ConformanceError(
+            "LOADER_AUTHORITY_PLATFORM_UNSUPPORTED",
+            "atomic loader authority traversal requires Linux",
+        )
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    descriptor: int | None = None
+    try:
+        descriptor = os.open("/", flags)
+        for part in path.parts[1:]:
+            child = os.open(part, flags, dir_fd=descriptor)
+            os.close(descriptor)
+            descriptor = child
+            status = os.fstat(descriptor)
+            if not stat.S_ISDIR(status.st_mode):
+                raise OSError("authority directory component is not a directory")
+        return descriptor
+    except (OSError, ValueError) as error:
+        if descriptor is not None:
+            os.close(descriptor)
+        raise bootstrap.ConformanceError(
+            "LOADER_AUTHORITY_ROOT_INVALID",
+            "loader authority root could not be retained without following links",
+        ) from error
+    except BaseException:
+        if descriptor is not None:
+            os.close(descriptor)
+        raise
+
+
+def _read_bound_regular_at(
+    directory: int,
+    relative_path: str,
+    *,
+    label: str,
+    max_bytes: int,
+) -> bytes:
+    """Read a retained-root-relative file without path re-resolution."""
+
+    parts = relative_path.split("/")
+    if (
+        not parts
+        or any(not part or part in {".", ".."} for part in parts)
+        or "\\" in relative_path
+    ):
+        raise bootstrap.ConformanceError(
+            "LOADER_AUTHORITY_COMPONENT_ROLE_INVALID",
+            f"{label} has an invalid fixed path",
+        )
+    directory_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    current = os.dup(directory)
+    file_descriptor: int | None = None
+    try:
+        for part in parts[:-1]:
+            child = os.open(part, directory_flags, dir_fd=current)
+            os.close(current)
+            current = child
+        file_descriptor = os.open(
+            parts[-1],
+            os.O_RDONLY
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_NONBLOCK", 0),
+            dir_fd=current,
+        )
+        before = os.fstat(file_descriptor)
+        if not stat.S_ISREG(before.st_mode) or before.st_nlink != 1:
+            raise OSError("authority component is not singly linked and regular")
+        chunks: list[bytes] = []
+        total = 0
+        while chunk := os.read(file_descriptor, min(1_048_576, max_bytes + 1 - total)):
+            chunks.append(chunk)
+            total += len(chunk)
+            if total > max_bytes:
+                raise bootstrap.ConformanceError(
+                    "LOADER_AUTHORITY_COMPONENT_TOO_LARGE",
+                    f"{label} exceeds its byte ceiling",
+                )
+        after = os.fstat(file_descriptor)
+        if _file_identity(before) != _file_identity(after) or before.st_size != total:
+            raise bootstrap.ConformanceError(
+                "LOADER_AUTHORITY_COMPONENT_CHANGED",
+                f"{label} changed during its authority read",
+            )
+        return b"".join(chunks)
+    except bootstrap.ConformanceError:
+        raise
+    except (OSError, ValueError) as error:
+        raise bootstrap.ConformanceError(
+            "LOADER_AUTHORITY_COMPONENT_READ_FAILED",
+            f"{label} could not be read from its retained root",
+        ) from error
+    finally:
+        if file_descriptor is not None:
+            os.close(file_descriptor)
+        os.close(current)
 
 
 def _read_component_bytes(
@@ -258,10 +412,7 @@ def _validate_bundle_profile(bundle: Mapping[str, Any]) -> None:
             "authority bundle is not the closed Linux capability-preflight profile",
         )
     components = bundle.get("components")
-    if (
-        not isinstance(components, Mapping)
-        or set(components) != set(COMPONENT_ROLES)
-    ):
+    if not isinstance(components, Mapping) or set(components) != set(COMPONENT_ROLES):
         raise bootstrap.ConformanceError(
             "AUTHORITY_COMPONENT_ROLE_INVALID",
             "authority bundle must contain exactly the fixed preflight roles",
@@ -333,9 +484,8 @@ def _validate_identity_semantics(identity: dict[str, Any]) -> None:
             "AUTHORITY_IDENTITY_SCHEMA_INVALID",
             "Linux backend image artifact identity is invalid",
         )
-    if (
-        shim.get("path") == probe.get("path")
-        or shim.get("sha256") == probe.get("sha256")
+    if shim.get("path") == probe.get("path") or shim.get("sha256") == probe.get(
+        "sha256"
     ):
         raise bootstrap.ConformanceError(
             "AUTHORITY_IMAGE_ARTIFACT_COLLISION",
@@ -407,8 +557,7 @@ def authorize_preflight(
     _validate_bundle_profile(bundle)
 
     authority_schema_path = (
-        selected_repository
-        / REPOSITORY_COMPONENT_PATHS["authority_bundle_schema"]
+        selected_repository / REPOSITORY_COMPONENT_PATHS["authority_bundle_schema"]
     )
     authority_schema_raw = _read_bound_regular(
         authority_schema_path,
@@ -472,12 +621,9 @@ def authorize_preflight(
                 f"authority component {role} has the wrong byte length",
             )
         expected_sha256 = record.get("sha256")
-        if (
-            not isinstance(expected_sha256, str)
-            or not hmac.compare_digest(
-                hashlib.sha256(raw).hexdigest(),
-                expected_sha256,
-            )
+        if not isinstance(expected_sha256, str) or not hmac.compare_digest(
+            hashlib.sha256(raw).hexdigest(),
+            expected_sha256,
         ):
             raise bootstrap.ConformanceError(
                 "AUTHORITY_COMPONENT_DIGEST_MISMATCH",
@@ -525,6 +671,200 @@ def authorize_preflight(
         identity=identity,
         identity_schema=identity_schema,
     )
+
+
+def authorize_backend_loader(
+    bundle_path: Path,
+    *,
+    approved_digest: str,
+    expected_commit_oid: str,
+    expected_tree_oid: str,
+    repository_root: Path = bootstrap.REPO_ROOT,
+) -> LoaderAuthority:
+    """Authorize exact bytes for isolated backend loadability only."""
+
+    if not _is_sha256(approved_digest):
+        raise bootstrap.ConformanceError(
+            "LOADER_AUTHORITY_DIGEST_INVALID",
+            "approved loader-authority SHA-256 must be lowercase hexadecimal",
+        )
+    if not _is_git_oid(expected_commit_oid) or not _is_git_oid(expected_tree_oid):
+        raise bootstrap.ConformanceError(
+            "LOADER_AUTHORITY_SOURCE_ID_INVALID",
+            "expected source commit and tree must be full lowercase SHA-1 identities",
+        )
+    selected_bundle = bundle_path.absolute()
+    selected_repository = repository_root.absolute()
+    repository_descriptor: int | None = None
+    bundle_descriptor: int | None = None
+    try:
+        repository_descriptor = _open_absolute_directory(selected_repository)
+        bundle_descriptor = _open_absolute_directory(selected_bundle.parent)
+        raw_bundle = _read_bound_regular_at(
+            bundle_descriptor,
+            selected_bundle.name,
+            label="loader authority bundle",
+            max_bytes=MAX_AUTHORITY_BUNDLE_BYTES,
+        )
+        actual_digest = loader_authority_bundle_sha256(raw_bundle)
+        if not hmac.compare_digest(actual_digest, approved_digest):
+            raise bootstrap.ConformanceError(
+                "LOADER_AUTHORITY_DIGEST_MISMATCH",
+                "loader authority does not match the out-of-band approval",
+            )
+        bundle = bootstrap.strict_load_bytes(
+            raw_bundle,
+            max_bytes=MAX_AUTHORITY_BUNDLE_BYTES,
+        )
+        if not _source_matches(bundle, expected_commit_oid, expected_tree_oid):
+            raise bootstrap.ConformanceError(
+                "LOADER_AUTHORITY_SOURCE_MISMATCH",
+                "loader authority source does not match protected identities",
+            )
+        expected_profile = {
+            "schema_version": 1,
+            "purpose": "build-tool-trusted-authority",
+            "authorization_scope": "linux_capability_preflight_loader_v1",
+            "repository": "github.com/adhithyan15/coding-adventures",
+            "conformance_revision": "v1",
+            "platform": "linux",
+            "architecture": "amd64",
+        }
+        components_value = bundle.get("components")
+        if (
+            any(bundle.get(key) != value for key, value in expected_profile.items())
+            or not isinstance(components_value, Mapping)
+            or set(components_value) != set(LOADER_COMPONENT_ROLES)
+        ):
+            raise bootstrap.ConformanceError(
+                "LOADER_AUTHORITY_PROFILE_INVALID",
+                "authority is not the closed exact-loader profile",
+            )
+
+        retained: dict[str, bytes] = {}
+        total_bytes = 0
+        for role in LOADER_COMPONENT_ROLES:
+            record = components_value.get(role)
+            if not isinstance(record, Mapping):
+                raise bootstrap.ConformanceError(
+                    "LOADER_AUTHORITY_COMPONENT_ROLE_INVALID",
+                    f"loader authority component {role} is missing",
+                )
+            if role in LOADER_REPOSITORY_COMPONENT_PATHS:
+                expected_provenance = "repository"
+                expected_path = LOADER_REPOSITORY_COMPONENT_PATHS[role]
+                root_descriptor = repository_descriptor
+            else:
+                expected_provenance = "bundle"
+                expected_path = BUNDLE_COMPONENT_PATHS[role]
+                root_descriptor = bundle_descriptor
+            if (
+                record.get("provenance") != expected_provenance
+                or record.get("path") != expected_path
+                or bootstrap.portable_path_error(expected_path)
+            ):
+                raise bootstrap.ConformanceError(
+                    "LOADER_AUTHORITY_COMPONENT_ROLE_INVALID",
+                    f"loader authority component {role} does not match its role",
+                )
+            raw = _read_bound_regular_at(
+                root_descriptor,
+                expected_path,
+                label=f"loader authority component {role}",
+                max_bytes=MAX_AUTHORITY_COMPONENT_BYTES,
+            )
+            total_bytes += len(raw)
+            if total_bytes > MAX_AUTHORITY_TOTAL_BYTES:
+                raise bootstrap.ConformanceError(
+                    "LOADER_AUTHORITY_COMPONENT_TOTAL_TOO_LARGE",
+                    "loader authority components exceed their aggregate ceiling",
+                )
+            if record.get("byte_length") != len(raw):
+                raise bootstrap.ConformanceError(
+                    "LOADER_AUTHORITY_COMPONENT_LENGTH_MISMATCH",
+                    f"loader authority component {role} has the wrong length",
+                )
+            digest = record.get("sha256")
+            if not isinstance(digest, str) or not hmac.compare_digest(
+                hashlib.sha256(raw).hexdigest(), digest
+            ):
+                raise bootstrap.ConformanceError(
+                    "LOADER_AUTHORITY_COMPONENT_DIGEST_MISMATCH",
+                    f"loader authority component {role} has the wrong digest",
+                )
+            retained[role] = raw
+
+        authority_schema = _strict_component_document(
+            retained["authority_bundle_schema"],
+            code="LOADER_AUTHORITY_BUNDLE_SCHEMA_INVALID",
+        )
+        bootstrap._validate_schema(
+            bundle,
+            authority_schema,
+            "LOADER_AUTHORITY_BUNDLE_SCHEMA_INVALID",
+        )
+        policy_schema = _strict_component_document(
+            retained["execution_policy_schema"],
+            code="LOADER_AUTHORITY_POLICY_SCHEMA_INVALID",
+        )
+        policy = _strict_component_document(
+            retained["execution_policy"],
+            code="LOADER_AUTHORITY_POLICY_INVALID",
+        )
+        bootstrap._validate_schema(
+            policy,
+            policy_schema,
+            "LOADER_AUTHORITY_POLICY_SCHEMA_INVALID",
+        )
+        _validate_preflight_policy(
+            policy,
+            conformance_revision=bundle["conformance_revision"],
+        )
+        identity_schema = _strict_component_document(
+            retained["linux_backend_identity_schema"],
+            code="LOADER_AUTHORITY_IDENTITY_SCHEMA_INVALID",
+        )
+        identity = _strict_component_document(
+            retained["linux_backend_identity"],
+            code="LOADER_AUTHORITY_IDENTITY_INVALID",
+        )
+        bootstrap._validate_schema(
+            identity,
+            identity_schema,
+            "LOADER_AUTHORITY_IDENTITY_SCHEMA_INVALID",
+        )
+        _validate_identity_semantics(identity)
+        manifest = _strict_component_document(
+            retained["preflight_import_manifest"],
+            code="LOADER_AUTHORITY_IMPORT_MANIFEST_INVALID",
+        )
+        if (
+            set(manifest) != {"schema_version", "module", "imports", "required_exports"}
+            or manifest.get("schema_version") != 1
+            or manifest.get("module") != "build_tool_conformance_linux_oci"
+            or manifest.get("required_exports")
+            != [
+                "CommandResult",
+                "LinuxOciUnavailable",
+                "preflight_prevalidated",
+            ]
+        ):
+            raise bootstrap.ConformanceError(
+                "LOADER_AUTHORITY_IMPORT_MANIFEST_INVALID",
+                "loader authority import manifest is outside the v1 profile",
+            )
+        return LoaderAuthority(
+            bundle_digest=actual_digest,
+            bundle=bundle,
+            components=MappingProxyType(retained),
+            policy=policy,
+            identity=identity,
+        )
+    finally:
+        if repository_descriptor is not None:
+            os.close(repository_descriptor)
+        if bundle_descriptor is not None:
+            os.close(bundle_descriptor)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/code/scripts/build_tool_conformance_backend_loader.py
+++ b/code/scripts/build_tool_conformance_backend_loader.py
@@ -1,0 +1,882 @@
+#!/usr/bin/env python3
+"""Load an approved Linux OCI backend without ambient Python authority.
+
+The parent process receives already-authorized exact bytes.  It seals those
+bytes in anonymous Linux files and starts the sealed copy of this loader in a
+fresh isolated Python worker.  The worker verifies the closed stdlib import
+manifest and required interfaces, but never invokes preflight or Podman.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+import os
+import selectors
+import signal
+import subprocess  # nosec B404
+import sys
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - exercised by the platform guard
+    fcntl = None  # type: ignore[assignment]
+
+MAX_COMPONENT_BYTES = 16_777_216
+MAX_WORKER_OUTPUT_BYTES = 65_536
+WORKER_TIMEOUT_SECONDS = 10.0
+MODULE_NAME = "build_tool_conformance_linux_oci"
+REQUIRED_EXPORTS = (
+    "CommandResult",
+    "LinuxOciUnavailable",
+    "preflight_prevalidated",
+)
+FORBIDDEN_DYNAMIC_IMPORTS = {"__import__", "import_module"}
+RESERVED_SAFE_BINDINGS = {"Path", "dataclass", "frozenset", "__name__"}
+
+
+class LoaderUnavailable(RuntimeError):
+    """A stable fail-closed exact-loader error."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True)
+class ImportManifest:
+    """Closed import and interface contract for the approved backend."""
+
+    module: str
+    imports: tuple[str, ...]
+    required_exports: tuple[str, ...]
+
+
+def _strict_json(raw: bytes, *, code: str) -> dict[str, Any]:
+    if not raw or len(raw) > MAX_COMPONENT_BYTES:
+        raise LoaderUnavailable(code, "loader document exceeds its byte ceiling")
+    try:
+        text = raw.decode("utf-8", errors="strict")
+
+        def reject_duplicates(
+            pairs: list[tuple[str, object]],
+        ) -> dict[str, object]:
+            value: dict[str, object] = {}
+            for key, item in pairs:
+                if key in value:
+                    raise ValueError("duplicate key")
+                value[key] = item
+            return value
+
+        value = json.loads(text, object_pairs_hook=reject_duplicates)
+    except (UnicodeDecodeError, ValueError) as error:
+        raise LoaderUnavailable(code, "loader document is not strict JSON") from error
+    if not isinstance(value, dict):
+        raise LoaderUnavailable(code, "loader document must be an object")
+    return value
+
+
+def parse_import_manifest(raw: bytes) -> ImportManifest:
+    """Parse the exact closed import manifest."""
+
+    value = _strict_json(raw, code="LOADER_IMPORT_MANIFEST_INVALID")
+    if set(value) != {
+        "schema_version",
+        "module",
+        "imports",
+        "required_exports",
+    }:
+        raise LoaderUnavailable(
+            "LOADER_IMPORT_MANIFEST_INVALID",
+            "import manifest fields are not the closed v1 profile",
+        )
+    imports = value.get("imports")
+    exports = value.get("required_exports")
+    valid_imports = (
+        isinstance(imports, list)
+        and all(
+            isinstance(item, str)
+            and item
+            and item == item.strip()
+            and all(part.isidentifier() for part in item.split("."))
+            for item in imports
+        )
+        and len(imports) == len(set(imports))
+        and imports == sorted(imports)
+        and all(
+            item.split(".", 1)[0] in sys.stdlib_module_names or item == "__future__"
+            for item in imports
+        )
+    )
+    if (
+        value.get("schema_version") != 1
+        or value.get("module") != MODULE_NAME
+        or not valid_imports
+        or exports != list(REQUIRED_EXPORTS)
+    ):
+        raise LoaderUnavailable(
+            "LOADER_IMPORT_MANIFEST_INVALID",
+            "import manifest does not match the closed backend profile",
+        )
+    return ImportManifest(
+        module=MODULE_NAME,
+        imports=tuple(item for item in imports if isinstance(item, str)),
+        required_exports=REQUIRED_EXPORTS,
+    )
+
+
+def _parsed_source(raw: bytes) -> ast.Module:
+    if not raw or len(raw) > MAX_COMPONENT_BYTES:
+        raise LoaderUnavailable(
+            "LOADER_BACKEND_SOURCE_INVALID",
+            "backend source exceeds its byte ceiling",
+        )
+    try:
+        text = raw.decode("utf-8", errors="strict")
+        return ast.parse(text, filename="<approved-linux-oci-backend>")
+    except (SyntaxError, UnicodeDecodeError) as error:
+        raise LoaderUnavailable(
+            "LOADER_BACKEND_SOURCE_INVALID",
+            "backend source is not valid strict UTF-8 Python",
+        ) from error
+
+
+def source_imports(raw: bytes) -> frozenset[str]:
+    """Return every statically declared import in exact backend source."""
+
+    imports: set[str] = set()
+    for node in ast.walk(_parsed_source(raw)):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level != 0 or node.module is None:
+                raise LoaderUnavailable(
+                    "LOADER_RELATIVE_IMPORT_FORBIDDEN",
+                    "relative backend imports are forbidden",
+                )
+            if any(alias.name == "*" for alias in node.names):
+                raise LoaderUnavailable(
+                    "LOADER_WILDCARD_IMPORT_FORBIDDEN",
+                    "wildcard backend imports are forbidden",
+                )
+            imports.add(node.module)
+    return frozenset(imports)
+
+
+def _call_is_safe_assignment(node: ast.Call) -> bool:
+    if not isinstance(node.func, ast.Name) or node.keywords:
+        return False
+    if node.func.id == "Path":
+        return (
+            len(node.args) == 1
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        )
+    if node.func.id == "frozenset" and len(node.args) == 1:
+        value = node.args[0]
+        return isinstance(value, (ast.Set, ast.Tuple, ast.List)) and all(
+            isinstance(item, ast.Constant) for item in value.elts
+        )
+    return False
+
+
+def _validate_static_expression(node: ast.expr) -> None:
+    forbidden = (
+        ast.Await,
+        ast.DictComp,
+        ast.GeneratorExp,
+        ast.Lambda,
+        ast.ListComp,
+        ast.NamedExpr,
+        ast.SetComp,
+        ast.Yield,
+        ast.YieldFrom,
+    )
+    for child in ast.walk(node):
+        if isinstance(child, forbidden) or (
+            isinstance(child, ast.Call) and not _call_is_safe_assignment(child)
+        ):
+            raise LoaderUnavailable(
+                "LOADER_IMPORT_TIME_CODE_FORBIDDEN",
+                "backend import-time executable code is forbidden",
+            )
+
+
+def _validate_function_header(node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+    if node.decorator_list:
+        raise LoaderUnavailable(
+            "LOADER_IMPORT_TIME_CODE_FORBIDDEN",
+            "backend function decorators are forbidden",
+        )
+    defaults = [*node.args.defaults, *node.args.kw_defaults]
+    for default in defaults:
+        if default is not None:
+            _validate_static_expression(default)
+
+
+def _is_frozen_dataclass_decorator(node: ast.expr) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "dataclass"
+        and not node.args
+        and len(node.keywords) == 1
+        and node.keywords[0].arg == "frozen"
+        and isinstance(node.keywords[0].value, ast.Constant)
+        and node.keywords[0].value.value is True
+    )
+
+
+def _validate_class_shape(node: ast.ClassDef) -> None:
+    if node.keywords or any(
+        not isinstance(base, ast.Name) or base.id != "RuntimeError"
+        for base in node.bases
+    ):
+        raise LoaderUnavailable(
+            "LOADER_IMPORT_TIME_CODE_FORBIDDEN",
+            "backend class construction is outside the closed profile",
+        )
+    if node.decorator_list:
+        valid_dataclass = len(
+            node.decorator_list
+        ) == 1 and _is_frozen_dataclass_decorator(node.decorator_list[0])
+        if not valid_dataclass:
+            raise LoaderUnavailable(
+                "LOADER_IMPORT_TIME_CODE_FORBIDDEN",
+                "backend class decorators are outside the closed profile",
+            )
+    for statement in node.body:
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            _validate_function_header(statement)
+        elif isinstance(statement, ast.Expr) and isinstance(
+            statement.value,
+            ast.Constant,
+        ):
+            continue
+        elif isinstance(statement, ast.AnnAssign):
+            if statement.value is not None:
+                _validate_static_expression(statement.value)
+        elif isinstance(statement, ast.Pass):
+            continue
+        else:
+            raise LoaderUnavailable(
+                "LOADER_IMPORT_TIME_CODE_FORBIDDEN",
+                "backend class body contains executable import-time code",
+            )
+
+
+def _is_main_guard(node: ast.If) -> bool:
+    return (
+        isinstance(node.test, ast.Compare)
+        and isinstance(node.test.left, ast.Name)
+        and node.test.left.id == "__name__"
+        and len(node.test.ops) == 1
+        and isinstance(node.test.ops[0], ast.Eq)
+        and len(node.test.comparators) == 1
+        and isinstance(node.test.comparators[0], ast.Constant)
+        and node.test.comparators[0].value == "__main__"
+        and not node.orelse
+    )
+
+
+def _validate_import_time_shape(tree: ast.Module) -> None:
+    imported_bindings: dict[str, tuple[str, str | None]] = {}
+    for statement in tree.body:
+        if isinstance(statement, ast.Import):
+            for alias in statement.names:
+                imported_bindings[alias.asname or alias.name.split(".")[0]] = (
+                    alias.name,
+                    None,
+                )
+        elif isinstance(statement, ast.ImportFrom) and statement.module is not None:
+            for alias in statement.names:
+                imported_bindings[alias.asname or alias.name] = (
+                    statement.module,
+                    alias.name,
+                )
+    calls = [
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    ]
+    if ("Path" in calls and imported_bindings.get("Path") != ("pathlib", "Path")) or (
+        "dataclass" in calls
+        and imported_bindings.get("dataclass") != ("dataclasses", "dataclass")
+    ):
+        raise LoaderUnavailable(
+            "LOADER_IMPORT_TIME_CODE_FORBIDDEN",
+            "backend safe constructors do not have their fixed bindings",
+        )
+    if "frozenset" in imported_bindings:
+        raise LoaderUnavailable(
+            "LOADER_IMPORT_TIME_CODE_FORBIDDEN",
+            "backend may not shadow its safe builtin constructor",
+        )
+
+    for statement in tree.body:
+        if isinstance(statement, (ast.Import, ast.ImportFrom)):
+            continue
+        if isinstance(statement, ast.Expr) and isinstance(
+            statement.value,
+            ast.Constant,
+        ):
+            continue
+        if isinstance(statement, ast.Assign):
+            if not all(
+                isinstance(target, ast.Name) and target.id not in RESERVED_SAFE_BINDINGS
+                for target in statement.targets
+            ):
+                raise LoaderUnavailable(
+                    "LOADER_IMPORT_TIME_CODE_FORBIDDEN",
+                    "backend assignment target is outside the closed profile",
+                )
+            _validate_static_expression(statement.value)
+            continue
+        if isinstance(statement, ast.AnnAssign):
+            if (
+                not isinstance(statement.target, ast.Name)
+                or statement.target.id in RESERVED_SAFE_BINDINGS
+            ):
+                raise LoaderUnavailable(
+                    "LOADER_IMPORT_TIME_CODE_FORBIDDEN",
+                    "backend assignment target is outside the closed profile",
+                )
+            if statement.value is not None:
+                _validate_static_expression(statement.value)
+            continue
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            _validate_function_header(statement)
+            continue
+        if isinstance(statement, ast.ClassDef):
+            _validate_class_shape(statement)
+            continue
+        if isinstance(statement, ast.If) and _is_main_guard(statement):
+            continue
+        raise LoaderUnavailable(
+            "LOADER_IMPORT_TIME_CODE_FORBIDDEN",
+            "backend contains executable import-time statements",
+        )
+
+
+def validate_source_closure(raw: bytes, manifest: ImportManifest) -> None:
+    """Require exact static imports and reject dynamic import entry points."""
+
+    tree = _parsed_source(raw)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            function = node.func
+            name = function.id if isinstance(function, ast.Name) else None
+            attribute = function.attr if isinstance(function, ast.Attribute) else None
+            if name in FORBIDDEN_DYNAMIC_IMPORTS or attribute in (
+                FORBIDDEN_DYNAMIC_IMPORTS
+            ):
+                raise LoaderUnavailable(
+                    "LOADER_DYNAMIC_IMPORT_FORBIDDEN",
+                    "dynamic backend imports are forbidden",
+                )
+    _validate_import_time_shape(tree)
+    if source_imports(raw) != frozenset(manifest.imports):
+        raise LoaderUnavailable(
+            "LOADER_IMPORT_CLOSURE_MISMATCH",
+            "backend imports do not match the exact approved manifest",
+        )
+
+
+def _sha256(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _sealed_memfd(name: str, raw: bytes) -> int:
+    """Copy exact bytes into one write-sealed anonymous Linux file."""
+
+    if (
+        not sys.platform.startswith("linux")
+        or not hasattr(os, "memfd_create")
+        or fcntl is None
+    ):
+        raise LoaderUnavailable(
+            "LOADER_PLATFORM_UNSUPPORTED",
+            "sealed exact loading requires Linux memfd support",
+        )
+    if not raw or len(raw) > MAX_COMPONENT_BYTES:
+        raise LoaderUnavailable(
+            "LOADER_COMPONENT_SIZE_INVALID",
+            "loader component exceeds its byte ceiling",
+        )
+    descriptor = os.memfd_create(
+        name,
+        flags=os.MFD_CLOEXEC | os.MFD_ALLOW_SEALING,
+    )
+    try:
+        offset = 0
+        while offset < len(raw):
+            offset += os.write(descriptor, raw[offset:])
+        os.fsync(descriptor)
+        seals = (
+            fcntl.F_SEAL_SEAL
+            | fcntl.F_SEAL_SHRINK
+            | fcntl.F_SEAL_GROW
+            | fcntl.F_SEAL_WRITE
+        )
+        fcntl.fcntl(descriptor, fcntl.F_ADD_SEALS, seals)
+        actual = fcntl.fcntl(descriptor, fcntl.F_GET_SEALS)
+        if actual & seals != seals:
+            raise LoaderUnavailable(
+                "LOADER_SEAL_FAILED",
+                "loader component could not be fully sealed",
+            )
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        return descriptor
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def _read_fd(descriptor: int) -> bytes:
+    status = os.fstat(descriptor)
+    if status.st_size <= 0 or status.st_size > MAX_COMPONENT_BYTES:
+        raise LoaderUnavailable(
+            "LOADER_COMPONENT_SIZE_INVALID",
+            "sealed loader component has an invalid size",
+        )
+    raw = os.pread(descriptor, status.st_size + 1, 0)
+    if len(raw) != status.st_size:
+        raise LoaderUnavailable(
+            "LOADER_COMPONENT_CHANGED",
+            "sealed loader component did not retain its exact size",
+        )
+    return raw
+
+
+def _validate_backend_structure(
+    source: bytes,
+    manifest: ImportManifest,
+) -> None:
+    """Compile and inspect exact source without executing backend code."""
+
+    validate_source_closure(source, manifest)
+    tree = _parsed_source(source)
+    try:
+        compile(
+            source.decode("utf-8"),
+            "<sealed-linux-oci-backend>",
+            "exec",
+            dont_inherit=True,
+        )
+    except (SyntaxError, UnicodeDecodeError) as error:
+        raise LoaderUnavailable(
+            "LOADER_BACKEND_COMPILE_FAILED",
+            "approved backend failed isolated compilation",
+        ) from error
+
+    class_nodes = [node for node in tree.body if isinstance(node, ast.ClassDef)]
+    function_nodes = [node for node in tree.body if isinstance(node, ast.FunctionDef)]
+    classes = {node.name: node for node in class_nodes}
+    functions = {node.name: node for node in function_nodes}
+    preflight = functions.get("preflight_prevalidated")
+    valid_preflight = (
+        preflight is not None
+        and [argument.arg for argument in preflight.args.posonlyargs] == []
+        and [argument.arg for argument in preflight.args.args] == ["identity"]
+        and preflight.args.vararg is None
+        and [argument.arg for argument in preflight.args.kwonlyargs]
+        == [
+            "state_root",
+            "command_runner",
+            "binary_digest",
+            "platform_name",
+            "effective_uid",
+        ]
+        and preflight.args.kw_defaults[0] is None
+        and isinstance(preflight.args.kw_defaults[1], ast.Name)
+        and preflight.args.kw_defaults[1].id == "_run_command"
+        and isinstance(preflight.args.kw_defaults[2], ast.Name)
+        and preflight.args.kw_defaults[2].id == "_binary_digest"
+        and isinstance(preflight.args.kw_defaults[3], ast.Constant)
+        and preflight.args.kw_defaults[3].value is None
+        and isinstance(preflight.args.kw_defaults[4], ast.Constant)
+        and preflight.args.kw_defaults[4].value is None
+        and preflight.args.kwarg is None
+    )
+    unavailable = classes.get("LinuxOciUnavailable")
+    unavailable_init = (
+        next(
+            (
+                statement
+                for statement in unavailable.body
+                if isinstance(statement, ast.FunctionDef)
+                and statement.name == "__init__"
+            ),
+            None,
+        )
+        if unavailable is not None
+        else None
+    )
+    assigned_error_fields = (
+        {
+            target.attr
+            for statement in unavailable_init.body
+            if isinstance(statement, ast.Assign)
+            for target in statement.targets
+            if isinstance(target, ast.Attribute)
+            and isinstance(target.value, ast.Name)
+            and target.value.id == "self"
+        }
+        if unavailable_init is not None
+        else set()
+    )
+    valid_unavailable = (
+        unavailable is not None
+        and len(unavailable.bases) == 1
+        and isinstance(unavailable.bases[0], ast.Name)
+        and unavailable.bases[0].id == "RuntimeError"
+        and unavailable_init is not None
+        and [argument.arg for argument in unavailable_init.args.args]
+        == ["self", "code", "message"]
+        and not unavailable_init.args.posonlyargs
+        and not unavailable_init.args.defaults
+        and unavailable_init.args.vararg is None
+        and not unavailable_init.args.kwonlyargs
+        and unavailable_init.args.kwarg is None
+        and assigned_error_fields == {"code", "message"}
+    )
+    command_result = classes.get("CommandResult")
+    command_field_statements = (
+        [
+            statement
+            for statement in command_result.body
+            if isinstance(statement, ast.AnnAssign)
+        ]
+        if command_result is not None
+        else []
+    )
+    command_fields = {
+        statement.target.id: statement.annotation.id
+        for statement in command_field_statements
+        if isinstance(statement.target, ast.Name)
+        and isinstance(statement.annotation, ast.Name)
+    }
+    valid_command_result = (
+        command_result is not None
+        and len(command_result.decorator_list) == 1
+        and _is_frozen_dataclass_decorator(command_result.decorator_list[0])
+        and len(command_field_statements) == 3
+        and command_fields
+        == {"returncode": "int", "stdout": "bytes", "stderr": "bytes"}
+    )
+    required_names = {
+        "CommandResult",
+        "LinuxOciUnavailable",
+        "preflight_prevalidated",
+    }
+    duplicate_required = any(
+        sum(node.name == name for node in [*class_nodes, *function_nodes]) != 1
+        for name in required_names
+    )
+    if (
+        not valid_preflight
+        or not valid_unavailable
+        or not valid_command_result
+        or duplicate_required
+    ):
+        raise LoaderUnavailable(
+            "LOADER_BACKEND_INTERFACE_INVALID",
+            "approved backend is missing a required structural interface",
+        )
+
+
+def _worker_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--isolated-worker", action="store_true", required=True)
+    for name in ("loader", "backend", "manifest", "identity"):
+        parser.add_argument(f"--{name}-fd", type=int, required=True)
+        parser.add_argument(f"--{name}-sha256", required=True)
+    return parser
+
+
+def _isolated_worker(argv: Sequence[str]) -> int:
+    arguments = _worker_parser().parse_args(argv)
+    values: dict[str, bytes] = {}
+    for name in ("loader", "backend", "manifest", "identity"):
+        raw = _read_fd(getattr(arguments, f"{name}_fd"))
+        if _sha256(raw) != getattr(arguments, f"{name}_sha256"):
+            raise LoaderUnavailable(
+                "LOADER_COMPONENT_DIGEST_MISMATCH",
+                "sealed loader component has the wrong digest",
+            )
+        values[name] = raw
+    manifest = parse_import_manifest(values["manifest"])
+    identity = _strict_json(
+        values["identity"],
+        code="LOADER_IDENTITY_INVALID",
+    )
+    if (
+        identity.get("backend_kind") != "linux_oci"
+        or identity.get("platform") != "linux"
+        or identity.get("architecture") != "amd64"
+    ):
+        raise LoaderUnavailable(
+            "LOADER_IDENTITY_INVALID",
+            "backend identity is outside the closed Linux amd64 profile",
+        )
+    _validate_backend_structure(values["backend"], manifest)
+    print(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "authorization_scope": "loadability-only",
+                "backend_sha256": _sha256(values["backend"]),
+                "identity_sha256": _sha256(values["identity"]),
+                "loader_sha256": _sha256(values["loader"]),
+                "manifest_sha256": _sha256(values["manifest"]),
+                "status": "loadable",
+                "conformance_status": "not-run",
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
+    return 0
+
+
+def _terminate_worker(process: subprocess.Popen[bytes]) -> None:
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    process.wait()
+
+
+def _read_worker_output(
+    process: subprocess.Popen[bytes],
+) -> tuple[bytes, bytes]:
+    """Stream both worker pipes with one aggregate hard byte ceiling."""
+
+    if process.stdout is None or process.stderr is None:
+        raise LoaderUnavailable(
+            "LOADER_WORKER_PROTOCOL_INVALID",
+            "isolated loader worker pipes are unavailable",
+        )
+    selector = selectors.DefaultSelector()
+    selector.register(process.stdout, selectors.EVENT_READ, "stdout")
+    selector.register(process.stderr, selectors.EVENT_READ, "stderr")
+    buffers = {"stdout": bytearray(), "stderr": bytearray()}
+    total = 0
+    deadline = time.monotonic() + WORKER_TIMEOUT_SECONDS
+    try:
+        while selector.get_map():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                _terminate_worker(process)
+                raise LoaderUnavailable(
+                    "LOADER_WORKER_TIMEOUT",
+                    "isolated loader worker exceeded its time ceiling",
+                )
+            events = selector.select(min(remaining, 0.1))
+            for key, _mask in events:
+                chunk = os.read(
+                    key.fileobj.fileno(),
+                    min(16_384, MAX_WORKER_OUTPUT_BYTES + 1 - total),
+                )
+                if not chunk:
+                    selector.unregister(key.fileobj)
+                    continue
+                buffers[key.data].extend(chunk)
+                total += len(chunk)
+                if total > MAX_WORKER_OUTPUT_BYTES:
+                    _terminate_worker(process)
+                    raise LoaderUnavailable(
+                        "LOADER_WORKER_OUTPUT_LIMIT",
+                        "isolated loader worker exceeded its output ceiling",
+                    )
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            _terminate_worker(process)
+            raise LoaderUnavailable(
+                "LOADER_WORKER_TIMEOUT",
+                "isolated loader worker exceeded its time ceiling",
+            )
+        process.wait(timeout=remaining)
+        return bytes(buffers["stdout"]), bytes(buffers["stderr"])
+    except subprocess.TimeoutExpired as error:
+        _terminate_worker(process)
+        raise LoaderUnavailable(
+            "LOADER_WORKER_TIMEOUT",
+            "isolated loader worker exceeded its time ceiling",
+        ) from error
+    finally:
+        selector.close()
+
+
+def validate_exact_backend(
+    *,
+    loader_source: bytes,
+    backend_source: bytes,
+    import_manifest: bytes,
+    identity: bytes,
+) -> dict[str, Any]:
+    """Validate exact retained bytes in a fresh isolated one-shot worker."""
+
+    if not sys.platform.startswith("linux"):
+        raise LoaderUnavailable(
+            "LOADER_PLATFORM_UNSUPPORTED",
+            "exact backend loadability validation requires Linux",
+        )
+    manifest = parse_import_manifest(import_manifest)
+    validate_source_closure(backend_source, manifest)
+    components = {
+        "loader": loader_source,
+        "backend": backend_source,
+        "manifest": import_manifest,
+        "identity": identity,
+    }
+    descriptors: dict[str, int] = {}
+    try:
+        for name, raw in components.items():
+            descriptors[name] = _sealed_memfd(f"build-tool-{name}", raw)
+        command = [
+            sys.executable,
+            "-I",
+            "-S",
+            "-B",
+            f"/proc/self/fd/{descriptors['loader']}",
+            "--isolated-worker",
+        ]
+        for name, raw in components.items():
+            command.extend(
+                [
+                    f"--{name}-fd",
+                    str(descriptors[name]),
+                    f"--{name}-sha256",
+                    _sha256(raw),
+                ]
+            )
+        environment = {
+            "LANG": "C.UTF-8",
+            "LC_ALL": "C.UTF-8",
+            "PATH": "/usr/bin:/bin",
+            "PYTHONHASHSEED": "0",
+            "TZ": "UTC",
+        }
+        process = subprocess.Popen(  # nosec B603
+            command,
+            cwd="/",
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            close_fds=True,
+            pass_fds=tuple(descriptors.values()),
+            start_new_session=True,
+        )
+        stdout, stderr = _read_worker_output(process)
+        if process.returncode != 0:
+            code = "LOADER_BACKEND_IMPORT_FAILED"
+            try:
+                error_value = json.loads(stderr.decode("utf-8"))
+                if isinstance(error_value, dict) and isinstance(
+                    error_value.get("code"),
+                    str,
+                ):
+                    code = error_value["code"]
+            except (UnicodeDecodeError, ValueError):
+                pass
+            raise LoaderUnavailable(
+                code,
+                "isolated loader worker rejected the approved backend",
+            )
+        receipt = _strict_json(stdout, code="LOADER_WORKER_RESPONSE_INVALID")
+        if (
+            receipt.get("status") != "loadable"
+            or receipt.get("conformance_status") != "not-run"
+            or receipt.get("authorization_scope") != "loadability-only"
+        ):
+            raise LoaderUnavailable(
+                "LOADER_WORKER_RESPONSE_INVALID",
+                "isolated loader worker returned an invalid receipt",
+            )
+        return receipt
+    finally:
+        for descriptor in descriptors.values():
+            os.close(descriptor)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate one externally approved exact Linux backend loader."
+    )
+    parser.add_argument("--authority-bundle", type=Path, required=True)
+    parser.add_argument("--approved-authority-sha256", required=True)
+    parser.add_argument("--source-commit", required=True)
+    parser.add_argument("--source-tree", required=True)
+    parser.add_argument("--repository-root", type=Path, required=True)
+    return parser
+
+
+def _parent_main(argv: Sequence[str]) -> int:
+    arguments = _build_parser().parse_args(argv)
+    import build_tool_conformance_authority as authority
+
+    approved = authority.authorize_backend_loader(
+        arguments.authority_bundle,
+        approved_digest=arguments.approved_authority_sha256,
+        expected_commit_oid=arguments.source_commit,
+        expected_tree_oid=arguments.source_tree,
+        repository_root=arguments.repository_root,
+    )
+    receipt = validate_exact_backend(
+        loader_source=approved.components["preflight_loader"],
+        backend_source=approved.components["linux_preflight_backend"],
+        import_manifest=approved.components["preflight_import_manifest"],
+        identity=approved.components["linux_backend_identity"],
+    )
+    receipt["authorization_scope"] = approved.bundle["authorization_scope"]
+    receipt["authority_sha256"] = approved.bundle_digest
+    receipt["source_commit"] = arguments.source_commit
+    receipt["source_tree"] = arguments.source_tree
+    print(json.dumps(receipt, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    try:
+        if "--isolated-worker" in arguments:
+            return _isolated_worker(arguments)
+        return _parent_main(arguments)
+    except LoaderUnavailable as error:
+        print(
+            json.dumps(
+                {"code": error.code, "message": error.message, "status": "error"},
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as error:
+        code = getattr(error, "code", None)
+        message = getattr(error, "message", None)
+        if not isinstance(code, str) or not isinstance(message, str):
+            raise
+        print(
+            json.dumps(
+                {"code": code, "message": message, "status": "error"},
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/scripts/build_tool_conformance_linux_oci.py
+++ b/code/scripts/build_tool_conformance_linux_oci.py
@@ -25,10 +25,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-import build_tool_conformance as bootstrap
-
-DEFAULT_FIXTURE_ROOT = bootstrap.DEFAULT_FIXTURE_ROOT
-DEFAULT_IDENTITY_SCHEMA = DEFAULT_FIXTURE_ROOT / "linux-oci-backend.schema.json"
+DEFAULT_IDENTITY_SCHEMA = Path("linux-oci-backend.schema.json")
+MAX_DOCUMENT_BYTES = 2_000_000
 PODMAN_PATH = Path("/usr/bin/podman")
 CRUN_PATH = Path("/usr/bin/crun")
 PODMAN_COMMAND = "/usr/bin/podman"
@@ -72,15 +70,111 @@ def _mapping(value: object, *, code: str) -> Mapping[str, Any]:
     return value
 
 
+def _is_sha256(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _is_version(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) <= 32
+        and len(value.split(".")) == 3
+        and all(part and part.isascii() and part.isdigit() for part in value.split("."))
+    )
+
+
+def _is_image_path(value: object) -> bool:
+    allowed = frozenset(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-"
+    )
+    return (
+        isinstance(value, str)
+        and 2 <= len(value) <= 256
+        and value.startswith("/")
+        and all(segment and set(segment) <= allowed for segment in value[1:].split("/"))
+    )
+
+
+def _is_image_reference(value: object) -> bool:
+    if not isinstance(value, str) or len(value) > 512:
+        return False
+    prefix, separator, digest = value.rpartition("@sha256:")
+    allowed = frozenset("abcdefghijklmnopqrstuvwxyz0123456789._/-")
+    return (
+        separator == "@sha256:"
+        and bool(prefix)
+        and prefix[0] in frozenset("abcdefghijklmnopqrstuvwxyz0123456789")
+        and set(prefix) <= allowed
+        and _is_sha256(digest)
+    )
+
+
 def validate_identity(
     identity: dict[str, Any],
     schema: dict[str, Any] | None = None,
 ) -> None:
     """Validate the closed identity and cross-field digest bindings."""
 
-    selected_schema = schema or bootstrap.load_document(DEFAULT_IDENTITY_SCHEMA)
-    errors = bootstrap._schema_errors(identity, selected_schema)
-    if errors:
+    del schema
+    exact_keys = {
+        "schema_version",
+        "backend_kind",
+        "platform",
+        "architecture",
+        "runtime",
+        "oci_runtime",
+        "image",
+        "seccomp_profile_sha256",
+        "shim",
+        "probe",
+    }
+    valid = (
+        set(identity) == exact_keys
+        and type(identity.get("schema_version")) is int
+        and identity.get("schema_version") == 1
+        and identity.get("backend_kind") == "linux_oci"
+        and identity.get("platform") == "linux"
+        and identity.get("architecture") == "amd64"
+        and isinstance(identity.get("runtime"), dict)
+        and set(identity["runtime"]) == {"implementation", "path", "version", "sha256"}
+        and identity["runtime"].get("implementation") == "podman"
+        and identity["runtime"].get("path") == "/usr/bin/podman"
+        and _is_version(identity["runtime"].get("version"))
+        and _is_sha256(identity["runtime"].get("sha256"))
+        and isinstance(identity.get("oci_runtime"), dict)
+        and set(identity["oci_runtime"]) == {"implementation", "path", "sha256"}
+        and identity["oci_runtime"].get("implementation") == "crun"
+        and identity["oci_runtime"].get("path") == "/usr/bin/crun"
+        and _is_sha256(identity["oci_runtime"].get("sha256"))
+        and isinstance(identity.get("image"), dict)
+        and set(identity["image"])
+        == {
+            "reference",
+            "manifest_sha256",
+            "config_sha256",
+            "os",
+            "architecture",
+        }
+        and identity["image"].get("os") == "linux"
+        and identity["image"].get("architecture") == "amd64"
+        and _is_image_reference(identity["image"].get("reference"))
+        and _is_sha256(identity["image"].get("manifest_sha256"))
+        and _is_sha256(identity["image"].get("config_sha256"))
+        and isinstance(identity.get("shim"), dict)
+        and set(identity["shim"]) == {"path", "sha256"}
+        and _is_image_path(identity["shim"].get("path"))
+        and _is_sha256(identity["shim"].get("sha256"))
+        and isinstance(identity.get("probe"), dict)
+        and set(identity["probe"]) == {"path", "sha256"}
+        and _is_image_path(identity["probe"].get("path"))
+        and _is_sha256(identity["probe"].get("sha256"))
+        and _is_sha256(identity.get("seccomp_profile_sha256"))
+    )
+    if not valid:
         raise LinuxOciUnavailable(
             "LINUX_OCI_IDENTITY_SCHEMA_INVALID",
             "Linux OCI backend identity does not match its closed schema",
@@ -88,14 +182,19 @@ def validate_identity(
     image = _mapping(identity.get("image"), code="LINUX_OCI_IDENTITY_SCHEMA_INVALID")
     manifest = image.get("manifest_sha256")
     reference = image.get("reference")
-    if not isinstance(reference, str) or reference.rsplit("@sha256:", 1)[-1] != manifest:
+    if (
+        not isinstance(reference, str)
+        or reference.rsplit("@sha256:", 1)[-1] != manifest
+    ):
         raise LinuxOciUnavailable(
             "LINUX_OCI_IMAGE_IDENTITY_MISMATCH",
             "image reference and manifest identity must match exactly",
         )
     shim = _mapping(identity.get("shim"), code="LINUX_OCI_IDENTITY_SCHEMA_INVALID")
     probe = _mapping(identity.get("probe"), code="LINUX_OCI_IDENTITY_SCHEMA_INVALID")
-    if shim.get("path") == probe.get("path"):
+    if shim.get("path") == probe.get("path") or shim.get("sha256") == probe.get(
+        "sha256"
+    ):
         raise LinuxOciUnavailable(
             "LINUX_OCI_IMAGE_ARTIFACT_COLLISION",
             "shim and invariant probe must be distinct image artifacts",
@@ -109,33 +208,89 @@ def load_identity(
 ) -> tuple[dict[str, Any], str]:
     """Load a bounded strict identity and return it with its raw digest."""
 
+    del schema_path
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(
+            os,
+            "O_NOFOLLOW",
+            0,
+        )
+    )
     try:
-        with bootstrap._open_regular_no_follow(path) as source:
-            raw = source.read(bootstrap.MAX_DOCUMENT_BYTES + 1)
+        descriptor = os.open(path, flags)
+        try:
+            status = os.fstat(descriptor)
+            if not stat.S_ISREG(status.st_mode):
+                raise OSError("identity is not regular")
+            chunks: list[bytes] = []
+            total = 0
+            while chunk := os.read(
+                descriptor,
+                min(1_048_576, MAX_DOCUMENT_BYTES + 1 - total),
+            ):
+                chunks.append(chunk)
+                total += len(chunk)
+                if total > MAX_DOCUMENT_BYTES:
+                    break
+            after = os.fstat(descriptor)
+            before_identity = (
+                status.st_dev,
+                status.st_ino,
+                status.st_size,
+                status.st_mtime_ns,
+            )
+            after_identity = (
+                after.st_dev,
+                after.st_ino,
+                after.st_size,
+                after.st_mtime_ns,
+            )
+            if before_identity != after_identity:
+                raise OSError("identity changed while it was read")
+            raw = b"".join(chunks)
+            if total <= MAX_DOCUMENT_BYTES and before_identity[2] != len(raw):
+                raise OSError("identity length changed while it was read")
+        finally:
+            os.close(descriptor)
     except (OSError, ValueError) as error:
         raise LinuxOciUnavailable(
             "LINUX_OCI_IDENTITY_READ_FAILED",
             "Linux OCI backend identity could not be read",
         ) from error
-    if len(raw) > bootstrap.MAX_DOCUMENT_BYTES:
+    if len(raw) > MAX_DOCUMENT_BYTES:
         raise LinuxOciUnavailable(
             "LINUX_OCI_IDENTITY_TOO_LARGE",
             "Linux OCI backend identity exceeds the document ceiling",
         )
     try:
-        value = bootstrap.strict_load_bytes(raw)
-    except bootstrap.ConformanceError as error:
+
+        def reject_duplicates(
+            pairs: list[tuple[str, object]],
+        ) -> dict[str, object]:
+            value: dict[str, object] = {}
+            for key, item in pairs:
+                if key in value:
+                    raise ValueError("duplicate identity key")
+                value[key] = item
+            return value
+
+        value = json.loads(
+            raw.decode("utf-8", errors="strict"),
+            object_pairs_hook=reject_duplicates,
+        )
+    except (UnicodeDecodeError, ValueError) as error:
         raise LinuxOciUnavailable(
             "LINUX_OCI_IDENTITY_PARSE_FAILED",
             "Linux OCI backend identity is not strict JSON",
         ) from error
     if not isinstance(value, dict):
         raise LinuxOciUnavailable(
-            "LINUX_OCI_IDENTITY_SCHEMA_INVALID",
-            "Linux OCI backend identity must be an object",
+            "LINUX_OCI_IDENTITY_PARSE_FAILED",
+            "Linux OCI backend identity is not a strict JSON object",
         )
-    schema = bootstrap.load_document(schema_path)
-    validate_identity(value, schema)
+    validate_identity(value)
     return value, identity_sha256(raw)
 
 
@@ -359,7 +514,9 @@ def validate_host_info(info_value: object, identity: Mapping[str, Any]) -> None:
     info = _mapping(info_value, code="LINUX_OCI_RUNTIME_RESPONSE_INVALID")
     host = _mapping(info.get("host"), code="LINUX_OCI_RUNTIME_RESPONSE_INVALID")
     version = _mapping(info.get("version"), code="LINUX_OCI_RUNTIME_RESPONSE_INVALID")
-    runtime = _mapping(identity.get("runtime"), code="LINUX_OCI_IDENTITY_SCHEMA_INVALID")
+    runtime = _mapping(
+        identity.get("runtime"), code="LINUX_OCI_IDENTITY_SCHEMA_INVALID"
+    )
     oci_runtime = _mapping(
         identity.get("oci_runtime"),
         code="LINUX_OCI_IDENTITY_SCHEMA_INVALID",
@@ -390,11 +547,8 @@ def validate_host_info(info_value: object, identity: Mapping[str, Any]) -> None:
             "cgroup v2 is required for the Linux OCI backend",
         )
     controllers = host.get("cgroupControllers")
-    if (
-        not isinstance(controllers, list)
-        or not REQUIRED_CGROUP_CONTROLLERS.issubset(
-            item for item in controllers if isinstance(item, str)
-        )
+    if not isinstance(controllers, list) or not REQUIRED_CGROUP_CONTROLLERS.issubset(
+        item for item in controllers if isinstance(item, str)
     ):
         raise LinuxOciUnavailable(
             "LINUX_OCI_CGROUP_CONTROLLERS_MISSING",
@@ -409,10 +563,9 @@ def validate_host_info(info_value: object, identity: Mapping[str, Any]) -> None:
         host.get("ociRuntime"),
         code="LINUX_OCI_RUNTIME_RESPONSE_INVALID",
     )
-    if (
-        detected_oci_runtime.get("name") != oci_runtime.get("implementation")
-        or detected_oci_runtime.get("path") != oci_runtime.get("path")
-    ):
+    if detected_oci_runtime.get("name") != oci_runtime.get(
+        "implementation"
+    ) or detected_oci_runtime.get("path") != oci_runtime.get("path"):
         raise LinuxOciUnavailable(
             "LINUX_OCI_CRUN_REQUIRED",
             "the reviewed local crun runtime is required",
@@ -471,10 +624,9 @@ def validate_image_info(
             "LINUX_OCI_IMAGE_REFERENCE_MISMATCH",
             "local OCI image does not retain the reviewed manifest reference",
         )
-    if (
-        image_info.get("Os") != image_identity.get("os")
-        or image_info.get("Architecture") != image_identity.get("architecture")
-    ):
+    if image_info.get("Os") != image_identity.get("os") or image_info.get(
+        "Architecture"
+    ) != image_identity.get("architecture"):
         raise LinuxOciUnavailable(
             "LINUX_OCI_IMAGE_PLATFORM_MISMATCH",
             "local OCI image platform does not match policy",
@@ -602,19 +754,21 @@ def build_probe_create_argv(
     ]
 
 
-def preflight(
+def preflight_prevalidated(
     identity: dict[str, Any],
     *,
     state_root: Path,
-    identity_schema: dict[str, Any] | None = None,
     command_runner: CommandRunner = _run_command,
     binary_digest: DigestReader = _binary_digest,
     platform_name: str | None = None,
     effective_uid: int | None = None,
 ) -> dict[str, Any]:
-    """Prove host and image capabilities without creating a container."""
+    """Inspect host capabilities for an already formally validated identity.
 
-    validate_identity(identity, identity_schema)
+    This process-owning interface is intentionally not called by the exact
+    loadability worker. A later protected broker must own its two commands.
+    """
+
     selected_platform = platform_name or sys.platform
     if not selected_platform.startswith("linux"):
         raise LinuxOciUnavailable(
@@ -674,6 +828,29 @@ def preflight(
         "status": "available",
         "conformance_status": "not-run",
     }
+
+
+def preflight(
+    identity: dict[str, Any],
+    *,
+    state_root: Path,
+    identity_schema: dict[str, Any] | None = None,
+    command_runner: CommandRunner = _run_command,
+    binary_digest: DigestReader = _binary_digest,
+    platform_name: str | None = None,
+    effective_uid: int | None = None,
+) -> dict[str, Any]:
+    """Validate an identity, then use the legacy unbrokered preflight path."""
+
+    validate_identity(identity, identity_schema)
+    return preflight_prevalidated(
+        identity,
+        state_root=state_root,
+        command_runner=command_runner,
+        binary_digest=binary_digest,
+        platform_name=platform_name,
+        effective_uid=effective_uid,
+    )
 
 
 def _unavailable_result(error: LinuxOciUnavailable) -> dict[str, Any]:

--- a/code/scripts/tests/test_build_tool_conformance_backend_loader.py
+++ b/code/scripts/tests/test_build_tool_conformance_backend_loader.py
@@ -1,0 +1,615 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import struct
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import build_tool_conformance as bootstrap
+import build_tool_conformance_authority as authority
+import build_tool_conformance_backend_loader as loader
+
+REPO_ROOT = SCRIPTS_DIR.parents[1]
+FIXTURE_ROOT = REPO_ROOT / "code" / "specs" / "fixtures" / "build-tool-v1"
+BACKEND_PATH = SCRIPTS_DIR / "build_tool_conformance_linux_oci.py"
+LOADER_PATH = SCRIPTS_DIR / "build_tool_conformance_backend_loader.py"
+
+
+def identity_bytes() -> bytes:
+    manifest = "4" * 64
+    value = {
+        "schema_version": 1,
+        "backend_kind": "linux_oci",
+        "platform": "linux",
+        "architecture": "amd64",
+        "runtime": {
+            "implementation": "podman",
+            "path": "/usr/bin/podman",
+            "version": "5.8.3",
+            "sha256": "1" * 64,
+        },
+        "oci_runtime": {
+            "implementation": "crun",
+            "path": "/usr/bin/crun",
+            "sha256": "2" * 64,
+        },
+        "image": {
+            "reference": f"localhost/build-tool@sha256:{manifest}",
+            "manifest_sha256": manifest,
+            "config_sha256": "5" * 64,
+            "os": "linux",
+            "architecture": "amd64",
+        },
+        "seccomp_profile_sha256": "6" * 64,
+        "shim": {"path": "/opt/conformance/shim", "sha256": "7" * 64},
+        "probe": {"path": "/opt/conformance/probe", "sha256": "8" * 64},
+    }
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode() + b"\n"
+
+
+def source_bytes(body: str = "") -> bytes:
+    return (
+        "from __future__ import annotations\n"
+        "from dataclasses import dataclass\n"
+        "\n"
+        "class LinuxOciUnavailable(RuntimeError):\n"
+        "    def __init__(self, code: str, message: str) -> None:\n"
+        "        super().__init__(message)\n"
+        "        self.code = code\n"
+        "        self.message = message\n"
+        "\n"
+        "@dataclass(frozen=True)\n"
+        "class CommandResult:\n"
+        "    returncode: int\n"
+        "    stdout: bytes\n"
+        "    stderr: bytes\n"
+        "\n"
+        "def preflight_prevalidated(\n"
+        "    identity,\n"
+        "    *,\n"
+        "    state_root,\n"
+        "    command_runner=_run_command,\n"
+        "    binary_digest=_binary_digest,\n"
+        "    platform_name=None,\n"
+        "    effective_uid=None,\n"
+        "):\n"
+        "    raise AssertionError('loadability validation must not call preflight')\n"
+        f"{body}"
+    ).encode()
+
+
+def manifest_bytes(imports: list[str]) -> bytes:
+    value = {
+        "schema_version": 1,
+        "module": "build_tool_conformance_linux_oci",
+        "imports": imports,
+        "required_exports": [
+            "CommandResult",
+            "LinuxOciUnavailable",
+            "preflight_prevalidated",
+        ],
+    }
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode() + b"\n"
+
+
+def write_loader_authority_fixture(root: Path) -> dict[str, object]:
+    repository = root / "repository"
+    bundle_root = root / "authority"
+    bundle_root.mkdir(parents=True)
+    components: dict[str, dict[str, object]] = {}
+    for role, relative in authority.LOADER_REPOSITORY_COMPONENT_PATHS.items():
+        raw = (REPO_ROOT / relative).read_bytes()
+        target = repository / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(raw)
+        components[role] = {
+            "provenance": "repository",
+            "path": relative,
+            "byte_length": len(raw),
+            "sha256": hashlib.sha256(raw).hexdigest(),
+        }
+    raw_identity = identity_bytes()
+    (bundle_root / "linux-oci-backend.json").write_bytes(raw_identity)
+    components["linux_backend_identity"] = {
+        "provenance": "bundle",
+        "path": "linux-oci-backend.json",
+        "byte_length": len(raw_identity),
+        "sha256": hashlib.sha256(raw_identity).hexdigest(),
+    }
+    bundle = {
+        "schema_version": 1,
+        "purpose": "build-tool-trusted-authority",
+        "authorization_scope": "linux_capability_preflight_loader_v1",
+        "repository": "github.com/adhithyan15/coding-adventures",
+        "conformance_revision": "v1",
+        "platform": "linux",
+        "architecture": "amd64",
+        "source": {
+            "git_object_format": "sha1",
+            "commit_oid": "a" * 40,
+            "tree_oid": "b" * 40,
+        },
+        "components": components,
+    }
+    raw_bundle = (
+        json.dumps(bundle, sort_keys=True, separators=(",", ":")).encode() + b"\n"
+    )
+    bundle_path = bundle_root / "authority.json"
+    bundle_path.write_bytes(raw_bundle)
+    return {
+        "repository": repository,
+        "bundle": bundle,
+        "bundle_path": bundle_path,
+        "digest": authority.loader_authority_bundle_sha256(raw_bundle),
+    }
+
+
+class ImportManifestTests(unittest.TestCase):
+    def test_loader_authority_schema_is_closed_and_domain_separated(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = write_loader_authority_fixture(Path(directory))
+            schema = bootstrap.load_document(
+                FIXTURE_ROOT / "execution-preflight-loader-authority.schema.json"
+            )
+            self.assertEqual(
+                bootstrap._schema_errors(fixture["bundle"], schema),
+                [],
+            )
+            raw = fixture["bundle_path"].read_bytes()  # type: ignore[union-attr]
+        manual = hashlib.sha256(
+            authority.LOADER_AUTHORITY_DOMAIN + struct.pack(">Q", len(raw)) + raw
+        ).hexdigest()
+        self.assertEqual(fixture["digest"], manual)
+        self.assertNotEqual(
+            authority.authority_bundle_sha256(raw),
+            manual,
+        )
+
+    def test_repository_backend_matches_closed_manifest(self) -> None:
+        manifest = loader.parse_import_manifest(
+            (FIXTURE_ROOT / "preflight-imports.json").read_bytes()
+        )
+        self.assertEqual(
+            loader.source_imports(BACKEND_PATH.read_bytes()),
+            frozenset(manifest.imports),
+        )
+        self.assertIsNone(
+            loader._validate_backend_structure(BACKEND_PATH.read_bytes(), manifest)
+        )
+
+    def test_manifest_rejects_duplicates_unknown_fields_and_bad_exports(self) -> None:
+        valid = json.loads(manifest_bytes(["__future__", "dataclasses"]))
+        mutations = []
+        duplicate = dict(valid)
+        duplicate["imports"] = ["dataclasses", "dataclasses"]
+        mutations.append(duplicate)
+        extra = dict(valid)
+        extra["ambient"] = True
+        mutations.append(extra)
+        exports = dict(valid)
+        exports["required_exports"] = ["preflight"]
+        mutations.append(exports)
+        third_party = dict(valid)
+        third_party["imports"] = ["jsonschema"]
+        mutations.append(third_party)
+        for value in mutations:
+            with (
+                self.subTest(value=value),
+                self.assertRaises(loader.LoaderUnavailable),
+            ):
+                loader.parse_import_manifest(json.dumps(value).encode())
+
+    def test_undeclared_and_dynamic_imports_fail_before_execution(self) -> None:
+        with self.assertRaises(loader.LoaderUnavailable) as raised:
+            loader.validate_source_closure(
+                b"import os\nimport subprocess\n",
+                loader.parse_import_manifest(manifest_bytes(["os"])),
+            )
+        self.assertEqual(raised.exception.code, "LOADER_IMPORT_CLOSURE_MISMATCH")
+
+        with self.assertRaises(loader.LoaderUnavailable) as raised:
+            loader.validate_source_closure(
+                b"__import__('os')\n",
+                loader.parse_import_manifest(manifest_bytes([])),
+            )
+        self.assertEqual(raised.exception.code, "LOADER_DYNAMIC_IMPORT_FORBIDDEN")
+
+        with self.assertRaises(loader.LoaderUnavailable) as raised:
+            loader.validate_source_closure(
+                b"from os import *\n",
+                loader.parse_import_manifest(manifest_bytes(["os"])),
+            )
+        self.assertEqual(raised.exception.code, "LOADER_WILDCARD_IMPORT_FORBIDDEN")
+
+    def test_backend_definitions_load_without_invoking_preflight(self) -> None:
+        manifest = loader.parse_import_manifest(
+            manifest_bytes(["__future__", "dataclasses"])
+        )
+        self.assertIsNone(loader._validate_backend_structure(source_bytes(), manifest))
+
+        dangerous = (
+            b"import subprocess\n"
+            b"subprocess.run(['/usr/bin/podman', 'info'])\n"
+            b"class LinuxOciUnavailable(RuntimeError):\n"
+            b"    pass\n"
+            b"class CommandResult:\n"
+            b"    pass\n"
+            b"def preflight_prevalidated(identity, *, state_root):\n"
+            b"    return None\n"
+        )
+        with self.assertRaises(loader.LoaderUnavailable) as raised:
+            loader._validate_backend_structure(
+                dangerous,
+                loader.parse_import_manifest(manifest_bytes(["subprocess"])),
+            )
+        self.assertEqual(
+            raised.exception.code,
+            "LOADER_IMPORT_TIME_CODE_FORBIDDEN",
+        )
+
+        for imports, dangerous_source in (
+            (
+                ["sys"],
+                b"import sys\nsys.modules['subprocess'].run(['podman'])\n",
+            ),
+            (
+                ["pathlib"],
+                b"import pathlib\npathlib.os.system('podman info')\n",
+            ),
+        ):
+            with (
+                self.subTest(imports=imports),
+                self.assertRaises(loader.LoaderUnavailable) as raised,
+            ):
+                loader.validate_source_closure(
+                    dangerous_source,
+                    loader.parse_import_manifest(manifest_bytes(imports)),
+                )
+            self.assertEqual(
+                raised.exception.code,
+                "LOADER_IMPORT_TIME_CODE_FORBIDDEN",
+            )
+
+    def test_required_backend_interface_is_closed(self) -> None:
+        invalid = (
+            b"class LinuxOciUnavailable(RuntimeError):\n"
+            b"    pass\n"
+            b"class CommandResult:\n"
+            b"    pass\n"
+        )
+        with self.assertRaises(loader.LoaderUnavailable) as raised:
+            loader._validate_backend_structure(
+                invalid,
+                loader.parse_import_manifest(manifest_bytes([])),
+            )
+        self.assertEqual(raised.exception.code, "LOADER_BACKEND_INTERFACE_INVALID")
+
+        stable_source = source_bytes()
+        for name, malformed in (
+            (
+                "error-fields",
+                stable_source.replace(
+                    b"    def __init__(self, code: str, message: str) -> None:\n"
+                    b"        super().__init__(message)\n"
+                    b"        self.code = code\n"
+                    b"        self.message = message\n",
+                    b"    pass\n",
+                ),
+            ),
+            (
+                "command-field-type",
+                stable_source.replace(b"    stdout: bytes\n", b"    stdout: str\n"),
+            ),
+        ):
+            with (
+                self.subTest(name=name),
+                self.assertRaises(loader.LoaderUnavailable) as raised,
+            ):
+                loader._validate_backend_structure(
+                    malformed,
+                    loader.parse_import_manifest(
+                        manifest_bytes(["__future__", "dataclasses"])
+                    ),
+                )
+            self.assertEqual(
+                raised.exception.code,
+                "LOADER_BACKEND_INTERFACE_INVALID",
+            )
+
+        required_keywords = (
+            b"from dataclasses import dataclass\n"
+            b"class LinuxOciUnavailable(RuntimeError):\n"
+            b"    def __init__(self, code, message):\n"
+            b"        self.code = code\n"
+            b"        self.message = message\n"
+            b"@dataclass(frozen=True)\n"
+            b"class CommandResult:\n"
+            b"    returncode: int\n"
+            b"    stdout: bytes\n"
+            b"    stderr: bytes\n"
+            b"def preflight_prevalidated(\n"
+            b"    identity, *, state_root, command_runner, binary_digest,\n"
+            b"    platform_name, effective_uid\n"
+            b"):\n"
+            b"    pass\n"
+        )
+        with self.assertRaises(loader.LoaderUnavailable) as raised:
+            loader._validate_backend_structure(
+                required_keywords,
+                loader.parse_import_manifest(manifest_bytes(["dataclasses"])),
+            )
+        self.assertEqual(raised.exception.code, "LOADER_BACKEND_INTERFACE_INVALID")
+
+        extra_subscript_field = source_bytes().replace(
+            b"    stderr: bytes\n",
+            b"    stderr: bytes\n    extra: list[int]\n",
+        )
+        with self.assertRaises(loader.LoaderUnavailable) as raised:
+            loader._validate_backend_structure(
+                extra_subscript_field,
+                loader.parse_import_manifest(
+                    manifest_bytes(["__future__", "dataclasses"])
+                ),
+            )
+        self.assertEqual(raised.exception.code, "LOADER_BACKEND_INTERFACE_INVALID")
+
+        ambiguous = (
+            b"class LinuxOciUnavailable(RuntimeError):\n"
+            b"    pass\n"
+            b"class CommandResult:\n"
+            b"    pass\n"
+            b"def preflight_prevalidated(identity, required_extra, *, state_root):\n"
+            b"    pass\n"
+        )
+        with self.assertRaises(loader.LoaderUnavailable) as raised:
+            loader._validate_backend_structure(
+                ambiguous,
+                loader.parse_import_manifest(manifest_bytes([])),
+            )
+        self.assertEqual(raised.exception.code, "LOADER_BACKEND_INTERFACE_INVALID")
+
+
+class LoaderAuthorityLogicTests(unittest.TestCase):
+    def _authorize_with_retained_bytes(
+        self,
+        fixture: dict[str, object],
+    ) -> authority.LoaderAuthority:
+        repository = fixture["repository"]
+        bundle_path = fixture["bundle_path"]
+        assert isinstance(repository, Path)
+        assert isinstance(bundle_path, Path)
+
+        def retained_read(
+            descriptor: int,
+            relative: str,
+            *,
+            label: str,
+            max_bytes: int,
+        ) -> bytes:
+            del label, max_bytes
+            if descriptor == 101:
+                return (repository / relative).read_bytes()
+            return (bundle_path.parent / relative).read_bytes()
+
+        with (
+            mock.patch.object(
+                authority,
+                "_open_absolute_directory",
+                side_effect=[101, 202],
+            ),
+            mock.patch.object(
+                authority,
+                "_read_bound_regular_at",
+                side_effect=retained_read,
+            ),
+            mock.patch.object(authority.os, "close"),
+        ):
+            return authority.authorize_backend_loader(
+                bundle_path,
+                approved_digest=fixture["digest"],  # type: ignore[arg-type]
+                expected_commit_oid="a" * 40,
+                expected_tree_oid="b" * 40,
+                repository_root=repository,
+            )
+
+    def test_loader_profile_authorizes_exact_roles_only(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = write_loader_authority_fixture(Path(directory))
+            approved = self._authorize_with_retained_bytes(fixture)
+        self.assertEqual(
+            set(approved.components),
+            set(authority.LOADER_COMPONENT_ROLES),
+        )
+        self.assertEqual(
+            approved.bundle["authorization_scope"],
+            "linux_capability_preflight_loader_v1",
+        )
+        self.assertFalse(approved.policy["enabled"])
+
+    def test_old_scope_cannot_authorize_loader(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = write_loader_authority_fixture(Path(directory))
+            bundle = fixture["bundle"]
+            bundle_path = fixture["bundle_path"]
+            assert isinstance(bundle, dict)
+            assert isinstance(bundle_path, Path)
+            bundle["authorization_scope"] = "linux_capability_preflight_v1"
+            raw = (
+                json.dumps(bundle, sort_keys=True, separators=(",", ":")).encode()
+                + b"\n"
+            )
+            bundle_path.write_bytes(raw)
+            fixture["digest"] = authority.loader_authority_bundle_sha256(raw)
+            with self.assertRaises(bootstrap.ConformanceError) as raised:
+                self._authorize_with_retained_bytes(fixture)
+        self.assertEqual(
+            raised.exception.code,
+            "LOADER_AUTHORITY_PROFILE_INVALID",
+        )
+
+
+@unittest.skipUnless(sys.platform.startswith("linux"), "Linux sealed memfd contract")
+class IsolatedLoaderTests(unittest.TestCase):
+    def test_loader_authority_retains_exact_closed_components(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = write_loader_authority_fixture(Path(directory))
+            approved = authority.authorize_backend_loader(
+                fixture["bundle_path"],  # type: ignore[arg-type]
+                approved_digest=fixture["digest"],  # type: ignore[arg-type]
+                expected_commit_oid="a" * 40,
+                expected_tree_oid="b" * 40,
+                repository_root=fixture["repository"],  # type: ignore[arg-type]
+            )
+        self.assertEqual(
+            set(approved.components),
+            set(authority.LOADER_COMPONENT_ROLES),
+        )
+        self.assertEqual(
+            approved.bundle["authorization_scope"],
+            "linux_capability_preflight_loader_v1",
+        )
+
+    def test_intermediate_symlink_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = write_loader_authority_fixture(Path(directory))
+            repository = fixture["repository"]
+            assert isinstance(repository, Path)
+            scripts = repository / "code" / "scripts"
+            retained = repository / "code" / "scripts-retained"
+            scripts.rename(retained)
+            scripts.symlink_to(retained, target_is_directory=True)
+            with self.assertRaises(bootstrap.ConformanceError) as raised:
+                authority.authorize_backend_loader(
+                    fixture["bundle_path"],  # type: ignore[arg-type]
+                    approved_digest=fixture["digest"],  # type: ignore[arg-type]
+                    expected_commit_oid="a" * 40,
+                    expected_tree_oid="b" * 40,
+                    repository_root=repository,
+                )
+        self.assertEqual(
+            raised.exception.code,
+            "LOADER_AUTHORITY_COMPONENT_READ_FAILED",
+        )
+
+    def test_final_fifo_is_rejected_without_blocking(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = write_loader_authority_fixture(Path(directory))
+            repository = fixture["repository"]
+            assert isinstance(repository, Path)
+            loader_path = (
+                repository
+                / authority.LOADER_REPOSITORY_COMPONENT_PATHS["preflight_loader"]
+            )
+            loader_path.unlink()
+            os.mkfifo(loader_path)
+            with self.assertRaises(bootstrap.ConformanceError) as raised:
+                authority.authorize_backend_loader(
+                    fixture["bundle_path"],  # type: ignore[arg-type]
+                    approved_digest=fixture["digest"],  # type: ignore[arg-type]
+                    expected_commit_oid="a" * 40,
+                    expected_tree_oid="b" * 40,
+                    repository_root=repository,
+                )
+        self.assertEqual(
+            raised.exception.code,
+            "LOADER_AUTHORITY_COMPONENT_READ_FAILED",
+        )
+
+    def test_missing_root_has_stable_error(self) -> None:
+        with self.assertRaises(bootstrap.ConformanceError) as raised:
+            authority._open_absolute_directory(
+                Path("/definitely-missing-loader-authority-root")
+            )
+        self.assertEqual(
+            raised.exception.code,
+            "LOADER_AUTHORITY_ROOT_INVALID",
+        )
+
+    def test_exact_backend_loads_without_calling_preflight(self) -> None:
+        receipt = loader.validate_exact_backend(
+            loader_source=LOADER_PATH.read_bytes(),
+            backend_source=source_bytes(),
+            import_manifest=manifest_bytes(["__future__", "dataclasses"]),
+            identity=identity_bytes(),
+        )
+        self.assertEqual(receipt["status"], "loadable")
+        self.assertEqual(receipt["conformance_status"], "not-run")
+        self.assertEqual(receipt["authorization_scope"], "loadability-only")
+
+    def test_poisoned_python_environment_is_not_authority(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            poison = Path(directory)
+            (poison / "sitecustomize.py").write_text(
+                "raise RuntimeError('ambient sitecustomize ran')\n",
+                encoding="utf-8",
+            )
+            old_pythonpath = os.environ.get("PYTHONPATH")
+            os.environ["PYTHONPATH"] = str(poison)
+            try:
+                receipt = loader.validate_exact_backend(
+                    loader_source=LOADER_PATH.read_bytes(),
+                    backend_source=source_bytes(),
+                    import_manifest=manifest_bytes(["__future__", "dataclasses"]),
+                    identity=identity_bytes(),
+                )
+            finally:
+                if old_pythonpath is None:
+                    os.environ.pop("PYTHONPATH", None)
+                else:
+                    os.environ["PYTHONPATH"] = old_pythonpath
+        self.assertEqual(receipt["status"], "loadable")
+
+    def test_import_time_process_attempt_is_blocked(self) -> None:
+        dangerous = (
+            b"import subprocess\n"
+            b"subprocess.run(['/usr/bin/podman', 'info'])\n"
+            b"class LinuxOciUnavailable(RuntimeError):\n"
+            b"    pass\n"
+            b"class CommandResult:\n"
+            b"    pass\n"
+            b"def preflight_prevalidated(identity, *, state_root):\n"
+            b"    return None\n"
+        )
+        with self.assertRaises(loader.LoaderUnavailable) as raised:
+            loader.validate_exact_backend(
+                loader_source=LOADER_PATH.read_bytes(),
+                backend_source=dangerous,
+                import_manifest=manifest_bytes(["subprocess"]),
+                identity=identity_bytes(),
+            )
+        self.assertEqual(
+            raised.exception.code,
+            "LOADER_IMPORT_TIME_CODE_FORBIDDEN",
+        )
+
+    def test_sealed_input_cannot_be_mutated_after_worker_start(self) -> None:
+        descriptor = loader._sealed_memfd("test-input", b"approved")
+        try:
+            with self.assertRaises(OSError):
+                os.pwrite(descriptor, b"changed", 0)
+            self.assertEqual(os.pread(descriptor, 8, 0), b"approved")
+        finally:
+            os.close(descriptor)
+
+    def test_worker_output_is_streamed_to_a_hard_combined_cap(self) -> None:
+        flood_loader = b"import os\nos.write(1, b'x' * 70000)\n"
+        with self.assertRaises(loader.LoaderUnavailable) as raised:
+            loader.validate_exact_backend(
+                loader_source=flood_loader,
+                backend_source=source_bytes(),
+                import_manifest=manifest_bytes(["__future__", "dataclasses"]),
+                identity=identity_bytes(),
+            )
+        self.assertEqual(raised.exception.code, "LOADER_WORKER_OUTPUT_LIMIT")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/scripts/tests/test_build_tool_conformance_linux_oci.py
+++ b/code/scripts/tests/test_build_tool_conformance_linux_oci.py
@@ -114,6 +114,45 @@ class LinuxOciBackendTests(unittest.TestCase):
         unknown = copy.deepcopy(identity)
         unknown["runtime"]["arguments"] = ["--fixture-controlled"]  # type: ignore[index]
         self.assertTrue(bootstrap._schema_errors(unknown, self.schema))
+        with self.assertRaises(linux_oci.LinuxOciUnavailable) as raised:
+            linux_oci.validate_identity(unknown, self.schema)
+        self.assertEqual(
+            raised.exception.code,
+            "LINUX_OCI_IDENTITY_SCHEMA_INVALID",
+        )
+
+        for field, mutate in (
+            (
+                "boolean-schema-version",
+                lambda value: value.__setitem__("schema_version", True),
+            ),
+            (
+                "version",
+                lambda value: value["runtime"].__setitem__("version", "latest"),
+            ),
+            (
+                "reference",
+                lambda value: value["image"].__setitem__(
+                    "reference",
+                    f"UPPER/build@sha256:{'3' * 64}",
+                ),
+            ),
+            (
+                "artifact-path",
+                lambda value: value["probe"].__setitem__("path", "/bad//probe"),
+            ),
+        ):
+            invalid = copy.deepcopy(identity)
+            mutate(invalid)  # type: ignore[arg-type]
+            with (
+                self.subTest(field=field),
+                self.assertRaises(linux_oci.LinuxOciUnavailable) as raised,
+            ):
+                linux_oci.validate_identity(invalid, self.schema)
+            self.assertEqual(
+                raised.exception.code,
+                "LINUX_OCI_IDENTITY_SCHEMA_INVALID",
+            )
 
         mismatch = copy.deepcopy(identity)
         mismatch["image"]["manifest_sha256"] = "8" * 64  # type: ignore[index]
@@ -330,7 +369,9 @@ class LinuxOciBackendTests(unittest.TestCase):
 
     def test_direct_runtime_wrapper_bounds_output_and_redacts_failures(self) -> None:
         completed = SimpleNamespace(returncode=0, stdout=b"{}", stderr=b"")
-        with mock.patch.object(linux_oci.subprocess, "run", return_value=completed) as run:
+        with mock.patch.object(
+            linux_oci.subprocess, "run", return_value=completed
+        ) as run:
             result = linux_oci._run_command(
                 ["/usr/bin/podman", "info"],
                 {"HOME": "/private"},
@@ -407,7 +448,9 @@ class LinuxOciBackendTests(unittest.TestCase):
         self.assertIn("--cap-drop=ALL", command)
         self.assertIn("--security-opt=no-new-privileges=true", command)
         self.assertIn("--cgroup-conf=memory.swap.max=0", command)
-        self.assertIn("--tmpfs=/sandbox:rw,nosuid,nodev,noexec,size=8192,mode=0700", command)
+        self.assertIn(
+            "--tmpfs=/sandbox:rw,nosuid,nodev,noexec,size=8192,mode=0700", command
+        )
         self.assertIn("--log-driver=none", command)
         self.assertIn("--unsetenv-all", command)
         self.assertEqual(command[-1], expected_image)
@@ -521,7 +564,9 @@ class LinuxOciBackendTests(unittest.TestCase):
             calls[1][0][-5:],
             ["image", "inspect", "--format", "json", f"sha256:{'4' * 64}"],
         )
-        self.assertTrue(all("--pull" not in argument for call in calls for argument in call[0]))
+        self.assertTrue(
+            all("--pull" not in argument for call in calls for argument in call[0])
+        )
         self.assertTrue(all("create" not in call[0] for call in calls))
 
     def test_preflight_rejects_platform_root_and_binary_mismatch_before_spawn(

--- a/code/specs/build-tool-conformance.md
+++ b/code/specs/build-tool-conformance.md
@@ -729,13 +729,13 @@ remain process-free and never enumerate or decode an execution case.
 
 Authorization scopes are cryptographically and semantically distinct. Schema
 v1 admits only `linux_capability_preflight_v1`: it approves the exact
-components intended for a future host/image capability inspection, binds an
-empty execution corpus and no adapters, and cannot import a process backend,
-create a container, or decode a case. The future exact-byte preflight loader,
-invariant-probe profile, and trusted-execution profile require additional
-closed contracts after their corresponding components exist and before those
-enforcement paths may run; a preflight digest is therefore structurally
-unusable for either future execution scope.
+components intended for a future host/image capability inspection and binds an
+empty execution corpus and no adapters. Its process-free verifier cannot
+import a process backend, create a container, or decode a case. The exact-byte
+loader, invariant-probe profile, and trusted-execution profile use distinct
+domain-separated scopes and closed contracts after their corresponding
+components exist; a digest for one scope is therefore structurally unusable
+for another.
 
 The authority SHA-256 uses this exact framing:
 
@@ -780,6 +780,66 @@ operation, `crun`, cgroup v2 with delegated `cpu`, `memory`, and `pids`
 controllers, seccomp, exact runtime binary hashes, and the exact local image.
 Missing or mismatched capabilities produce a stable non-passing result before
 any fixture is decoded or materialized.
+
+The exact loader is a separate loadability-only prerequisite, not yet the
+capability-command handoff. Its authority record is described by
+`execution-preflight-loader-authority.schema.json`, uses authorization scope
+`linux_capability_preflight_loader_v1`, and is approved with this distinct
+framing:
+
+1. append the ASCII domain separator
+   `coding-adventures/build-tool-authority/linux-capability-preflight-loader/v1`
+   followed by one NUL;
+2. append the unsigned 64-bit big-endian exact raw-bundle byte length; and
+3. append the exact bounded raw UTF-8 JSON bytes.
+
+The loader profile binds exactly ten roles: its own authority schema, the
+execution policy and schema, the Linux identity schema, the process-free
+bootstrap and authority verifier, the exact loader, the stdlib-only Linux
+preflight backend, the closed backend import manifest, and the external Linux
+identity. The protected source commit/tree remains mandatory. The older
+eight-role `linux_capability_preflight_v1` bundle cannot be upgraded or reused.
+
+The loader profile and implementation have these requirements:
+
+1. Authority validation opens repository and bundle roots once, traverses
+   every fixed component path one segment at a time relative to retained
+   directory handles, and applies no-follow, directory, close-on-exec,
+   bounded-read, stable-file, and singly-linked regular-file checks. Absolute,
+   empty, dot, linked, and separator-containing path segments fail closed.
+2. The stage copies the exact retained loader, backend, import-manifest, and
+   identity bytes into anonymous Linux memory files and applies write, grow,
+   shrink, and seal seals before a worker sees them. If handle-relative
+   traversal, anonymous files, or sealing are unavailable, it fails closed.
+3. One fresh worker starts with the protected interpreter using `-I -S -B`, a
+   fixed scrubbed environment, no checkout directory on `sys.path`, no bytecode
+   cache, no caller modules, and only the sealed component descriptors. The
+   interpreter, standard library, native extensions, libc, and dynamic loader
+   are explicitly part of the protected runner-image TCB.
+4. The worker strictly parses the closed import manifest, rejects invalid
+   UTF-8, a BOM, NUL, relative or wildcard imports, and any import not listed
+   exactly. It rejects executable module/class statements, decorators,
+   defaults, comprehensions, or dynamic imports outside the closed static
+   profile, then compiles the sealed backend bytes without executing them.
+   Every declared import root must be reviewed standard library. The backend
+   has no repository or third-party dependency.
+5. The worker verifies the exact loader/backend/manifest/identity digests and
+   the backend's structural `preflight_prevalidated`, unavailable-error, and
+   command-result declarations. It does not execute backend module code, invoke
+   preflight, inspect Podman, open an execution case, construct a container
+   argv, or retain a reusable worker.
+6. The parent bounds the worker protocol, timeout, output, descriptor set, and
+   exit status. Success is only a loadability receipt binding the authority
+   digest, protected source IDs, and exact component digests. It is not
+   capability, containment, or readiness evidence.
+
+A later protected capability-command broker must retain an atomic private state
+root, execute already-open verified runtime binaries or rely on an attested
+immutable runner image, allow only Podman `info` and exact-config `image
+inspect`, stream a combined output cap, enforce time and complete-descendant
+cleanup, and return stable non-passing capability diagnostics. Until that
+broker and its own authority profile land, the bare Linux CLI remains disabled
+and no real preflight runs. This loader cannot mark Linux ready.
 
 The first Linux delivery tranche contains identity validation, capability
 preflight logic, and construction of the runner-owned invariant-probe

--- a/code/specs/fixtures/build-tool-v1/CHANGELOG.md
+++ b/code/specs/fixtures/build-tool-v1/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## 2026-07-30
 
+- Added a separately domain-bound exact-loader authority schema with ten fixed
+  component roles and a closed standard-library import manifest.
+- Added retained-directory-handle component reads, sealed anonymous component
+  copies, and a fresh `python -I -S -B` loadability worker that runs the exact
+  approved loader bytes with a scrubbed environment while compiling but never
+  executing the approved backend module.
+- Made the Linux backend import closure standard-library-only and split out the
+  formally prevalidated interface. Loader validation checks the interface but
+  never calls it, Podman, a fixture, an adapter, or a container.
+- Kept capability inspection disabled and recorded its protected command broker
+  as a required dependency before invariant-probe authority.
 - Added the closed external authority-bundle schema and exact
   domain/length/raw-byte approval digest for Linux capability preflight.
 - Added a process-free authority verifier that binds the protected source

--- a/code/specs/fixtures/build-tool-v1/README.md
+++ b/code/specs/fixtures/build-tool-v1/README.md
@@ -12,9 +12,11 @@ build-tool-v1/
   pure-domains.schema.json
   execution.schema.json
   execution-authority.schema.json
+  execution-preflight-loader-authority.schema.json
   execution-policy.schema.json
   execution-policy.json
   linux-oci-backend.schema.json
+  preflight-imports.json
   implementations.schema.json
   implementations.json
   CHANGELOG.md
@@ -82,6 +84,17 @@ identity document. Scope `linux_capability_preflight_v1` binds no corpus,
 adapter, launcher, or executable case and cannot authorize container creation
 or trusted execution.
 
+`execution-preflight-loader-authority.schema.json` is a separately
+domain-bound ten-role profile. It adds the exact loader and closed stdlib
+import manifest without broadening the earlier scope. On Linux, the verifier
+traverses every component from retained directory handles, and the loader
+copies its own source, the backend, manifest, and identity into sealed memfds.
+A fresh `python -I -S -B` worker executes the sealed loader, rejects undeclared
+or dynamic imports and executable import-time statements, compiles but never
+executes the backend, and verifies its three required structural interfaces.
+Its receipt reports loadability only: it does not call preflight, Podman, a
+fixture, an adapter, or a container.
+
 ## Runner
 
 Validate the complete corpus and inventory:
@@ -100,11 +113,22 @@ python code/scripts/build_tool_conformance_authority.py validate-authority \
   --source-tree <full-reviewed-tree>
 ```
 
-This tranche exposes no process-owning `preflight` subcommand. The bare
+Validate a separately approved exact-loader bundle on Linux:
+
+```text
+python code/scripts/build_tool_conformance_backend_loader.py \
+  --authority-bundle path/to/external-loader-authority.json \
+  --approved-authority-sha256 <out-of-band-loader-sha256> \
+  --source-commit <full-reviewed-commit> \
+  --source-tree <full-reviewed-tree> \
+  --repository-root <absolute-reviewed-checkout>
+```
+
+This command starts only one isolated Python loadability worker. The bare
 `build_tool_conformance_linux_oci.py --identity ...` entry point fails closed
-with `LINUX_OCI_AUTHORITY_REQUIRED`. A follow-on exact-byte loader must execute
-the retained approved backend and its bound import closure without a
-name-based Python import before protected capability inspection can run.
+with `LINUX_OCI_AUTHORITY_REQUIRED`. Protected capability inspection remains
+disabled until a later broker eliminates the runtime-binary and state-root
+path races, streams bounded combined output, and owns full descendant cleanup.
 
 Compare one externally produced adapter result with its fixture:
 
@@ -140,7 +164,7 @@ decisions.
 
 ## Security boundary
 
-Authority validation and pull-request CI are intentionally process-free:
+The bootstrap and authority verifiers remain process-free:
 
 - it never launches an adapter or shell;
 - it never applies fixture environment data;
@@ -149,11 +173,11 @@ Authority validation and pull-request CI are intentionally process-free:
   changing permissions, or using a process API; and
 - the preflight authority profile has no flag that can enable execution.
 
-There is intentionally no process handoff in this tranche. Ordinary
-name-based importing after validation would not prove that the approved
-backend bytes are the code being executed. A later loader must consume the
-exact retained artifact and its bound import closure through an atomic
-runner-owned boundary before capability inspection can run.
+The exact-loader tranche has one narrow process handoff: a fresh isolated
+Python worker started from the sealed approved loader bytes. It receives only
+sealed descriptors, fixed digests, a scrubbed environment, and standard-library
+search paths. The worker validates source closure and interfaces and exits; it
+cannot make the unavailable Linux backend available.
 
 The bootstrap runner performs no workspace materialization. Adapter
 orchestration and execution fixtures remain blocked until the separate
@@ -217,6 +241,9 @@ python -m unittest discover \
 python -m unittest discover \
   -s code/scripts/tests \
   -p "test_build_tool_conformance_authority.py"
+python -m unittest discover \
+  -s code/scripts/tests \
+  -p "test_build_tool_conformance_backend_loader.py"
 python -m unittest discover \
   -s code/scripts/tests \
   -p "test_build_tool_conformance_linux_oci.py"

--- a/code/specs/fixtures/build-tool-v1/execution-preflight-loader-authority.schema.json
+++ b/code/specs/fixtures/build-tool-v1/execution-preflight-loader-authority.schema.json
@@ -1,0 +1,329 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coding-adventures.dev/schemas/build-tool-conformance-preflight-loader-authority-v1.json",
+  "title": "Build-tool exact Linux preflight-loader authority bundle v1",
+  "description": "External post-review authority for atomic exact-byte loader validation. This scope runs no capability command, container, fixture, or adapter.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "purpose",
+    "authorization_scope",
+    "repository",
+    "conformance_revision",
+    "platform",
+    "architecture",
+    "source",
+    "components"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "purpose": {
+      "const": "build-tool-trusted-authority"
+    },
+    "authorization_scope": {
+      "const": "linux_capability_preflight_loader_v1"
+    },
+    "repository": {
+      "const": "github.com/adhithyan15/coding-adventures"
+    },
+    "conformance_revision": {
+      "const": "v1"
+    },
+    "platform": {
+      "const": "linux"
+    },
+    "architecture": {
+      "const": "amd64"
+    },
+    "source": {
+      "$ref": "#/$defs/source"
+    },
+    "components": {
+      "$ref": "#/$defs/components"
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "git_oid": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "safe_path": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "^(?!/)(?![A-Za-z]:)(?!.*\\\\)(?!.*(?:^|/)\\.\\.?(?:/|$))(?!.*//)[^<>:\"|?*\\u0000-\\u001F/]+(?:/[^<>:\"|?*\\u0000-\\u001F/]+)*$"
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "git_object_format",
+        "commit_oid",
+        "tree_oid"
+      ],
+      "properties": {
+        "git_object_format": {
+          "const": "sha1"
+        },
+        "commit_oid": {
+          "$ref": "#/$defs/git_oid"
+        },
+        "tree_oid": {
+          "$ref": "#/$defs/git_oid"
+        }
+      }
+    },
+    "component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provenance",
+        "path",
+        "byte_length",
+        "sha256"
+      ],
+      "properties": {
+        "provenance": {
+          "enum": [
+            "repository",
+            "bundle"
+          ]
+        },
+        "path": {
+          "$ref": "#/$defs/safe_path"
+        },
+        "byte_length": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 16777216
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "repository_component": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/component"
+        },
+        {
+          "properties": {
+            "provenance": {
+              "const": "repository"
+            }
+          }
+        }
+      ]
+    },
+    "bundle_component": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/component"
+        },
+        {
+          "properties": {
+            "provenance": {
+              "const": "bundle"
+            }
+          }
+        }
+      ]
+    },
+    "components": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authority_bundle_schema",
+        "execution_policy_schema",
+        "execution_policy",
+        "linux_backend_identity_schema",
+        "bootstrap_runner",
+        "authority_verifier",
+        "preflight_loader",
+        "linux_preflight_backend",
+        "preflight_import_manifest",
+        "linux_backend_identity"
+      ],
+      "properties": {
+        "authority_bundle_schema": {
+          "$ref": "#/$defs/authority_bundle_schema_component"
+        },
+        "execution_policy_schema": {
+          "$ref": "#/$defs/execution_policy_schema_component"
+        },
+        "execution_policy": {
+          "$ref": "#/$defs/execution_policy_component"
+        },
+        "linux_backend_identity_schema": {
+          "$ref": "#/$defs/linux_backend_identity_schema_component"
+        },
+        "bootstrap_runner": {
+          "$ref": "#/$defs/bootstrap_runner_component"
+        },
+        "authority_verifier": {
+          "$ref": "#/$defs/authority_verifier_component"
+        },
+        "preflight_loader": {
+          "$ref": "#/$defs/preflight_loader_component"
+        },
+        "linux_preflight_backend": {
+          "$ref": "#/$defs/linux_preflight_backend_component"
+        },
+        "preflight_import_manifest": {
+          "$ref": "#/$defs/preflight_import_manifest_component"
+        },
+        "linux_backend_identity": {
+          "$ref": "#/$defs/linux_backend_identity_component"
+        }
+      }
+    },
+    "authority_bundle_schema_component": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/repository_component"
+        },
+        {
+          "properties": {
+            "path": {
+              "const": "code/specs/fixtures/build-tool-v1/execution-preflight-loader-authority.schema.json"
+            }
+          }
+        }
+      ]
+    },
+    "execution_policy_schema_component": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/repository_component"
+        },
+        {
+          "properties": {
+            "path": {
+              "const": "code/specs/fixtures/build-tool-v1/execution-policy.schema.json"
+            }
+          }
+        }
+      ]
+    },
+    "execution_policy_component": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/repository_component"
+        },
+        {
+          "properties": {
+            "path": {
+              "const": "code/specs/fixtures/build-tool-v1/execution-policy.json"
+            }
+          }
+        }
+      ]
+    },
+    "linux_backend_identity_schema_component": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/repository_component"
+        },
+        {
+          "properties": {
+            "path": {
+              "const": "code/specs/fixtures/build-tool-v1/linux-oci-backend.schema.json"
+            }
+          }
+        }
+      ]
+    },
+    "authority_verifier_component": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/repository_component"
+        },
+        {
+          "properties": {
+            "path": {
+              "const": "code/scripts/build_tool_conformance_authority.py"
+            }
+          }
+        }
+      ]
+    },
+    "bootstrap_runner_component": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/repository_component"
+        },
+        {
+          "properties": {
+            "path": {
+              "const": "code/scripts/build_tool_conformance.py"
+            }
+          }
+        }
+      ]
+    },
+    "preflight_loader_component": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/repository_component"
+        },
+        {
+          "properties": {
+            "path": {
+              "const": "code/scripts/build_tool_conformance_backend_loader.py"
+            }
+          }
+        }
+      ]
+    },
+    "linux_preflight_backend_component": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/repository_component"
+        },
+        {
+          "properties": {
+            "path": {
+              "const": "code/scripts/build_tool_conformance_linux_oci.py"
+            }
+          }
+        }
+      ]
+    },
+    "preflight_import_manifest_component": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/repository_component"
+        },
+        {
+          "properties": {
+            "path": {
+              "const": "code/specs/fixtures/build-tool-v1/preflight-imports.json"
+            }
+          }
+        }
+      ]
+    },
+    "linux_backend_identity_component": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/bundle_component"
+        },
+        {
+          "properties": {
+            "path": {
+              "const": "linux-oci-backend.json"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/code/specs/fixtures/build-tool-v1/preflight-imports.json
+++ b/code/specs/fixtures/build-tool-v1/preflight-imports.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "module": "build_tool_conformance_linux_oci",
+  "imports": [
+    "__future__",
+    "argparse",
+    "collections.abc",
+    "dataclasses",
+    "hashlib",
+    "json",
+    "os",
+    "pathlib",
+    "stat",
+    "subprocess",
+    "sys",
+    "typing"
+  ],
+  "required_exports": [
+    "CommandResult",
+    "LinuxOciUnavailable",
+    "preflight_prevalidated"
+  ]
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -105,19 +105,21 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. The current
-inventory was regenerated on July 30, 2026 at `d0b9c442f` after the Haskell
+inventory was regenerated on July 30, 2026 at `a06ed28b7` after the Haskell
 `barcode-1d` and `http-core` ports, the Go/Rust `multi-directed-graph` slice,
-the Linux OCI preflight contract, and a new wave of Rust-only package
-families. The OCI tranche did not change package counts:
+the Linux OCI preflight and external-authority contracts, and a new wave of
+Rust-only package families. The latest refresh added the Rust-only
+`hue-integration` and `venture-browser-core` identities and found zero
+canonical collisions or unknown language buckets:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
 | Present in 10-15 languages | 172 | 278 |
 | Present in 5-9 languages | 121 | 911 |
 | Present in 2-4 languages | 157 | 1,970 |
-| Present in one language | 737 | 10,318 |
+| Present in one language | 740 | 10,360 |
 
-The loop must not start by attempting 10,318 singleton ports. It should finish
+The loop must not start by attempting 10,360 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 The July 29 lane audit is:
@@ -805,14 +807,16 @@ language ports stay eligible for later dependency-shaped waves.
 
 ## Priority 4: Classify Sparse And Singleton Families
 
-The singleton inventory is led by 542 Rust, 86 Python, and 84 TypeScript
+The singleton inventory is led by 545 Rust, 86 Python, and 84 TypeScript
 packages. Classify families before opening implementation PRs.
 
-The July 30 inventory added three Rust singleton identities that now have
+The July 30 inventories added five Rust singleton identities that now have
 explicit classification work in the loop state: `axiom-to-semantic-ir` is a
 likely portable deterministic lowering; `http1-client` needs its portable
 protocol core separated from native transport behavior; and
-`smart-home-discovery-service` is a likely native/service applicability case.
+`venture-browser-core` needs a portable-core versus native-boundary review.
+`smart-home-discovery-service` and `hue-integration` are likely native/service
+applicability cases.
 
 ### Likely portable Rust-led families
 
@@ -943,17 +947,20 @@ Delivery order:
    semantics. Then execute the runner-owned Linux invariant probe with
    aggregate cgroup CPU metering, combined streaming output/result accounting,
    hard writable-workspace semantics, cancellation, and verified
-   whole-container kill/reap/removal. The current selected tranche is the
-   first prerequisite: replace corpus-only approval with a process-free,
-   domain-separated external bundle over the reviewed source revision, policy,
-   schemas, authority verifier, Linux preflight backend, and external backend
-   identity. This first closed profile binds no corpus or adapter and
-   approves bytes for capability inspection only; it exposes no process
-   handoff. Next add an atomic exact-byte backend/import-closure loader and a
-   separate invariant-probe authority profile. Run protected probe enforcement
-   to produce containment evidence, then add a distinct trusted-execution
-   profile binding that evidence, the exact case snapshot, and one adapter
-   before trusted-case enforcement. Only protected evidence can mark Linux
+   whole-container kill/reap/removal. The completed first prerequisite
+   replaced corpus-only approval with a
+   process-free, domain-separated external bundle over the reviewed source
+   revision, policy, schemas, authority verifier, Linux preflight backend, and
+   external backend identity. This first closed profile binds no corpus or
+   adapter and approves bytes for capability inspection only; it exposes no
+   process handoff. The current selected tranche adds a separately domain-bound
+   atomic exact-byte backend/import-closure loader and a one-shot isolated
+   loadability worker; it runs no capability command. A protected command
+   broker follows, then a separate invariant-probe authority profile. Run
+   protected probe enforcement to produce containment evidence, then add a
+   distinct trusted-execution profile binding that evidence, the exact case
+   snapshot, and one adapter before trusted-case enforcement. Only protected
+   evidence can mark Linux
    ready.
 7. Implement the native Windows boundary with AppContainer or LPAC plus Job
    Objects and root-handle reparse-safe filesystem operations. Keep macOS


### PR DESCRIPTION
## Summary

- add a domain-separated, ten-role loader authority whose raw-byte approvals bind the exact verifier, loader, backend, import manifest, identity, policy, and schemas
- retain no-follow directory handles, seal approved bytes in Linux memfds, and execute only the exact loader in a scrubbed isolated Python worker
- validate the backend by strict AST plus compilation without importing or executing it, with an exact standard-library import closure and closed interface shape
- stream worker output under an aggregate 65,536-byte cap, fail closed on filesystem races/FIFOs/timeouts, and keep capability execution behind the next broker dependency

## Validation

- `python -m unittest discover -s code/scripts/tests -p 'test_build_tool_conformance_*.py'` — 125 passed, 10 Linux-only skips on Windows
- branch coverage — authority 69%, exact loader 52%, Linux OCI backend 83%, combined 67%
- Ruff format/check, Bandit, compileall, JSON Schema/fixture parsing, workflow YAML parsing, state-DAG validation, and `git diff --check`
- pure corpus validator — 30 cases across 11 domains, valid
- execution contract validator — disabled contract valid with 0 execution cases/adapters/ready backends
- parity reporter — 1,190 implementation identities, 4,331 slots, 0 collisions, 0 unknown language buckets
- Go build-tool `go test ./...` and clean binary build
- forced full build-file dry-run — unchanged 73 pre-existing `BUILD_windows` validation gaps (12 Python, 3 Swift, 58 TypeScript)

Linux memfd, no-follow/FIFO, sealed-worker, process-group, and output-cap paths run directly in the Ubuntu CI lane; this Windows host has no WSL or Docker runtime.