### PR TITLE
feat(adj-formula-stdlib): specific-energy — NIST SP 811 B.9 specific-energy→J/kg factors (RS-5 table)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs
@@ -1662,6 +1662,56 @@ fn shipped_density_of_heat_conversions_table_resolves_and_abstains() {
 }
 
 // ---------------------------------------------------------------------------
+// Shipped specific-energy table — two EXACT NIST SP 811 B.9 factors resolve, and a wrong-dimension
+// unit (a mass unit) abstains. Guards the SLICE of a NEW dimension (specific energy / available
+// energy, the joule per kilogram) and the honest cross-dimension abstention: `pound` is a mass unit,
+// so a specific-energy lookup for it must abstain, catching the specific-energy/mass confusion
+// directly, not mere absence of a value. (Specific energy is energy per mass — distinct from plain
+// energy, J, and from specific heat capacity, J/(kg·K).)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shipped_specific_energy_conversions_table_resolves_and_abstains() {
+    let dir = scratch("shipped_specificenergy");
+    let src = stdlib().join("reference/specific-energy-conversions.adj");
+    std::fs::copy(&src, dir.join("specific-energy-conversions.adj"))
+        .expect("copy shipped specific-energy-conversions.adj");
+    write(
+        dir.as_path(),
+        "case.adj",
+        "import \"specific-energy-conversions.adj\"\n\
+         ? specific_energy_to_joule_per_kilogram(calorie_it_per_gram, $v)\n\
+         ? specific_energy_to_joule_per_kilogram(calorie_th_per_gram, $v)\n\
+         ? specific_energy_to_joule_per_kilogram(pound, $v)\n",
+    );
+    let (ok, out, err) = run_full(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}{err}");
+    // The NIST SP 811 B.9 exact factors resolve, character-for-character from the table (boldface =
+    // exact; the International-Table calorie is exactly 4.1868 J and the thermochemical calorie is
+    // exactly 4.184 J, so calIT/g = 4186.8 and calth/g = 4184 J/kg, exactly).
+    assert!(
+        out.contains("\"v\":\"4186.8\""),
+        "calorieIT per gram = 4.1868 E+03 J/kg: {out}"
+    );
+    assert!(
+        out.contains("\"v\":\"4184\""),
+        "calorieth per gram = 4.184 E+03 J/kg: {out}"
+    );
+    // The table's citation rides along on the answer.
+    assert!(
+        out.contains("nist-guide-si-appendix-b9"),
+        "carries the NIST SP 811 B.9 locator: {out}"
+    );
+    // `pound` is a MASS unit (it converts to the kilogram, a DIFFERENT quantity), so this
+    // specific-energy table has no row for it — the engine abstains rather than mis-converting a mass
+    // unit as if it were an energy-per-mass unit.
+    assert!(
+        out.contains("\"abstained\":true"),
+        "a wrong-dimension unit abstains, never a cross-dimension fabricated factor: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // (c) Arity guard — a row of the wrong length is a clean compile error.
 // ---------------------------------------------------------------------------
 

--- a/code/specs/data/adj-formula-stdlib/reference/specific-energy-conversions.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/specific-energy-conversions.adj
@@ -1,0 +1,68 @@
+% ============================================================================
+% specific-energy-conversions — specific-energy / available-energy unit → joule-per-kilogram factors
+% (ADJ-TABLES RS-5).
+% ============================================================================
+% A `table` sibling of the NIST-cited conversion tables (length, mass, area, volume, energy, force,
+% power, pressure, the electric-EMU family, the two viscosities, wave number, linear mass density,
+% temperature interval, mass density, moment of force, specific heat capacity, density of heat, and the
+% rest): a native tabular relation ingested VERBATIM from a published NIST conversion table. Each row
+% states the factor converting a common non-SI unit of SPECIFIC ENERGY (energy CONTENT PER UNIT MASS —
+% the energy released or stored per kilogram, as in a fuel's energy density or a food's caloric
+% content) to the SI coherent derived unit, the joule per kilogram, J/kg:
+%
+%     ? specific_energy_to_joule_per_kilogram(calorie_it_per_gram, $v)   % 4186.8
+%     ? specific_energy_to_joule_per_kilogram(calorie_th_per_gram, $v)   % 4184
+%
+% This opens a NEW dimension — SPECIFIC ENERGY (energy per mass, J/kg; NIST SP 811 B.9 labels it
+% "available energy") — alongside the already-tabulated length/mass/area/volume/time/speed/energy/
+% pressure/force/power/acceleration/dynamic-viscosity/kinematic-viscosity/magnetic-flux-density/
+% magnetic-flux/illuminance/luminance/radioactivity/absorbed-dose/dose-equivalent/exposure/wave-number/
+% linear-mass-density/temperature-interval/mass-density/moment-of-force/specific-heat-capacity/
+% density-of-heat tables and the electric charge/potential/resistance/capacitance/inductance/
+% conductance/current tables. Specific energy is energy PER MASS [energy / mass] — distinct from plain
+% ENERGY, the joule (no mass), and from SPECIFIC HEAT CAPACITY, J/(kg·K) (energy per mass PER
+% TEMPERATURE): do NOT confuse them. (An absorbed radiation dose, the gray, is ALSO joules per
+% kilogram, but is a distinct quantity kept in the separate absorbed-dose table.) A value given in
+% cal/g must be put into SI first, then reasoned over (write-once-use-many). Why a `table` and not
+% hand-written `relate` clauses: this is exactly the shape reference data comes in — a published table,
+% not prose. The citable artifact IS the NIST conversion-factors table at the `locator` below; each
+% factor here is a CELL of NIST Special Publication 811, Appendix B.9, defended by one provenance
+% envelope. Each `row` lowers to a ground relation `specific_energy_to_joule_per_kilogram(unit, v)`, so
+% the exact lookups above are the ordinary SLD binding query — the engine returns the factor WITH this
+% table's citation as its proof, on the CPU, with zero model calls.
+%
+% HONESTY NOTE (like every other NIST table, only the EXACT defined factors get rows): NIST SP 811 B.9
+% prints both specific-energy factors below in BOLDFACE, its convention for factors that are EXACT by
+% definition, transcribed here as the plain decimal number of joules per kilogram each names:
+%
+%     calorieIT per gram (calIT/g)   4.1868 E+03  →  4186.8
+%     calorieth per gram (calth/g)   4.184  E+03  →  4184
+%
+% Both are EXACT and terminate; nothing here is a rounded measurement. They are exact because each
+% underlying thermal unit is DEFINED exactly — the International-Table calorie is exactly 4.1868 J and
+% the thermochemical calorie is exactly 4.184 J — and gram→kilogram is an exact ×1000, so calIT/g =
+% 4.1868 × 1000 = 4186.8 J/kg and calth/g = 4.184 × 1000 = 4184 J/kg, exactly. (These are the SAME two
+% numbers the specific-heat-capacity table carries, because a per-gram calorie and a per-gram-per-degree
+% calorie share the same calorie factor and the ×1000 gram scaling; they are nonetheless a DIFFERENT
+% quantity — energy per mass, not energy per mass per temperature — and get their own table.) This
+% table is SPECIFIC to specific energy: a unit of a DIFFERENT quantity — e.g. the "pound", which NIST
+% SP 811 B.9 lists separately as a MASS unit converting to the kilogram, NOT to J/kg — therefore gets no
+% row here, and a `? specific_energy_to_joule_per_kilogram(pound, $v)` ABSTAINS rather than
+% mis-converting a mass unit as if it were a specific-energy unit. The only claim this table makes is
+% "these are the exact factors NIST SP 811 B.9 prints for the calorieIT-per-gram's and
+% calorieth-per-gram's conversions to the joule per kilogram" — which is exactly what a byte-check
+% against the cited table verifies. `trust authoritative` — a primary, re-fetchable standards
+% reference. (See ADJ-TABLES.md; and feedback_nothing_human_authored — each factor is a verbatim cell
+% of the cited table, nothing asserted from memory.)
+% ============================================================================
+
+table specific_energy_to_joule_per_kilogram {
+    columns unit, joule_per_kilogram
+
+    row (calorie_it_per_gram, 4186.8)
+    row (calorie_th_per_gram, 4184)
+
+    source "Factors for units listed alphabetically"
+    locator "https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9"
+    trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/reference/specific-energy-conversions.query.adj
+++ b/code/specs/data/adj-formula-stdlib/reference/specific-energy-conversions.query.adj
@@ -1,0 +1,27 @@
+% ============================================================================
+% specific-energy-conversions.query.adj — worked lookups over the NIST specific-energy →
+% joule-per-kilogram table.
+% ============================================================================
+% The shape a consumer produces to convert a specific energy (an energy-per-mass content, e.g. a fuel
+% or food energy density in cal/g) into SI: it `import`s the grounded table and asks the engine to bind
+% the factor. No arithmetic and no factor is stated by the consumer; the engine returns the cell WITH
+% the table's NIST citation as its proof, on the CPU.
+%
+%   ? specific_energy_to_joule_per_kilogram(calorie_it_per_gram, $v)   % 4186.8
+%   ? specific_energy_to_joule_per_kilogram(calorie_th_per_gram, $v)   % 4184
+%
+% And the dimension guard: a unit of a DIFFERENT quantity has no row, so the lookup ABSTAINS rather
+% than mis-converting across dimensions. The "pound" is a MASS unit (it converts to the kilogram), NOT
+% a specific-energy unit — so it is caught rather than silently mis-converted:
+%
+%   ? specific_energy_to_joule_per_kilogram(pound, $v)   % abstains (pound is mass → kilogram)
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli specific-energy-conversions.query.adj
+% ============================================================================
+
+import "specific-energy-conversions.adj"
+
+? specific_energy_to_joule_per_kilogram(calorie_it_per_gram, $v)   % expect 4186.8  (exact NIST SP 811 B.9 factor)
+? specific_energy_to_joule_per_kilogram(calorie_th_per_gram, $v)   % expect 4184    (exact NIST SP 811 B.9 factor)
+? specific_energy_to_joule_per_kilogram(pound, $v)                 % expect abstain (mass unit, wrong dimension)


### PR DESCRIPTION
## What

Adds a new NIST-cited RS-5 reference conversion `table` opening a **new dimension** — **specific energy** / available energy (energy per mass, the joule per kilogram `J/kg`) — alongside the length/mass/energy/power/pressure/force/moment-of-force/viscosity/electric/specific-heat-capacity/density-of-heat/… tables already shipped.

Two **exact** (NIST-boldface) factors, transcribed verbatim from [SP 811 Appendix B.9](https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b9):

| from | to | factor |
|---|---|---|
| calorie_IT per gram (calIT/g) | J/kg | **4186.8** |
| calorie_th per gram (calth/g) | J/kg | **4184** |

Both are exact and terminate: the International-Table calorie is exactly `4.1868 J` and the thermochemical calorie exactly `4.184 J`, and gram→kilogram is an exact `×1000`, so `calIT/g = 4186.8` and `calth/g = 4184` J/kg exactly. (These are the same two numbers the specific-heat-capacity table carries — same calorie factor and `×1000` gram scaling — but specific energy is a **different quantity**, energy per mass rather than energy per mass per temperature, and gets its own table.) Only NIST's exact/boldface factors get rows.

## Files

- `code/specs/data/adj-formula-stdlib/reference/specific-energy-conversions.adj` — the table (2 rows + one provenance envelope).
- `code/specs/data/adj-formula-stdlib/reference/specific-energy-conversions.query.adj` — worked lookups + a wrong-dimension abstain probe.
- `code/packages/rust/adj-lang-cli/tests/rs5_table_e2e.rs` — appends `shipped_specific_energy_conversions_table_resolves_and_abstains` to the shared RS-5 anchor.

## Behaviour (asserted by the e2e test)

- `? …(calorie_it_per_gram, $v)` → `4186.8`, carrying the B.9 locator + `trust:authoritative`
- `? …(calorie_th_per_gram, $v)` → `4184`
- `? …(pound, $v)` → **abstains** (`pound` is a MASS unit → kilogram; the table refuses to mis-convert across dimensions rather than fabricating a factor)

## Checks

- `cargo test -p adj-lang-cli --test rs5_table_e2e specific_energy` — 1 passed (42 total in the anchor).
- `cargo clippy -p adj-lang-cli --tests -- -D warnings` — clean.
- Render-probe against the built CLI confirms `4186.8` / `4184` resolve and `pound` abstains, all with the NIST locator.
- NUL-scan clean on all three files.
- `/security-review` — SECURITY REVIEW PASSED.

Data + test only; no engine change, **no version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)