### PR TITLE
content(dravidian): please across Tamil/Kannada/Telugu/Malayalam

### DIFF
--- a/code/learning/human-languages/concepts/taxonomy.json
+++ b/code/learning/human-languages/concepts/taxonomy.json
@@ -93,6 +93,12 @@
       "core": false,
       "notes": "Requesting-a-favour formula: Russian пожалуйста, French s'il vous plaît, Spanish por favor, German bitte. Several languages (Russian, German) use the same word to reply to thanks."
     },
+    "COURTESY-SORRY": {
+      "family": "COURTESY",
+      "gloss": "sorry / excuse me (apology or attention-getting formula)",
+      "core": false,
+      "notes": "Apology/attention formula: Spanish lo siento (regret) vs. perdón (fault/attention), German Entschuldigung vs. es tut mir leid, Arabic āsif, Hindi māf kījiye. Many languages split this into two words — one for regret/sympathy, one for fault/forgiveness or getting someone's attention — track both where a language has the split."
+    },
 
     "RESPONSE-YES": {
       "family": "RESPONSE",

--- a/code/learning/human-languages/german/lessons/GE-C19-entschuldigung.md
+++ b/code/learning/human-languages/german/lessons/GE-C19-entschuldigung.md
@@ -1,0 +1,69 @@
+---
+id: GE-C19-entschuldigung
+chapter: 19
+type: word
+headword: Entschuldigung
+gloss: sorry / excuse me (literally "un-guilting," from Schuld "guilt/fault")
+concept_tag: COURTESY-SORRY
+prerequisites: [GE-C03-bitte]
+sounds: [ch-ach, u-umlaut-adjacent]
+roots: [schuld-german]
+etymology_hook: "Entschuldigung ← ent- 'away/un-' + Schuld 'guilt, fault' — Schuld shares its ancient root with English shall/should ('to owe')"
+est_minutes: 4
+reviews_of: [GE-C03-bitte, GE-C03-danke]
+---
+
+# Entschuldigung — "sorry" / "excuse me" (un-guilting)
+
+## Warm-up
+
+[PAUSE 2s] You already know **bitte** does triple duty for "please," "you're
+welcome," and "here you go." German's word for **sorry** is just as
+hard-working: **Entschuldigung** covers both "**excuse me**" and "**I'm
+sorry**."
+
+## The word, taken apart
+
+- **ent-** = a "removal / undoing" prefix — the same shape as in
+  **ent**decken ("un-cover" → discover) or **ent**fernen ("un-distance" →
+  remove).
+- **Schuld** = "**guilt, fault, blame**" (also, separately, "debt" — a *Schuld*
+  can be money owed or wrong done).
+- **-igung** = a noun-forming suffix, roughly "-ing/-ation."
+
+So **Entschuldigung** is literally "**an un-guilting**" — the act of removing
+blame. Saying it hands the guilt back: *I release you from any fault* (when
+getting someone's attention or brushing past) or *I ask you to release me from
+mine* (when apologizing).
+
+**Schuld** has a striking cousin: it traces to the same ancient Germanic root
+as English **shall** and **should** — a verb that originally meant **"to
+owe."** *Schuld* (what is owed, guilt) and *shall* (what one is obliged to do)
+are, at root, the same idea of an obligation outstanding.
+
+## Be honest about the other phrase: es tut mir leid
+
+For **deeper regret** — real sorrow, not a bump in the hallway — German often
+reaches for **es tut mir leid**, literally "**it does to-me sorrow**":
+
+- **es** = "it," **tut** = "does" (from **tun**, "to do"), **mir** = "to me,"
+  **Leid** = "sorrow, suffering" (a cousin of English **loath**, both from a
+  root meaning "hateful, painful").
+
+Use **Entschuldigung** for the everyday sorry/excuse-me (stepping on a foot,
+interrupting), and **es tut mir leid** when you mean it more — condolences, a
+real regret. The two overlap; native speakers move between them by feel.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "Schuld" — guilt/fault — then "Entschuldigung," sorry / excuse me]
+- [YOU SAY: the deeper phrase — "es tut mir leid," it pains me / I'm so sorry]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **Entschuldigung** literally mean, piece by piece?
+(**"Un-guilting"** — *ent-* "away" + *Schuld* "guilt/fault.") What English word
+shares Schuld's ancient root? (**Shall/should** — both from a root meaning "to
+owe.") What's the deeper phrase for real regret? (**Es tut mir leid**, "it
+does to me sorrow.")

--- a/code/learning/human-languages/kannada/lessons/KA-C08-dayavittu.md
+++ b/code/learning/human-languages/kannada/lessons/KA-C08-dayavittu.md
@@ -1,0 +1,78 @@
+---
+id: KA-C08-dayavittu
+chapter: 8
+type: word
+headword: ದಯವಿಟ್ಟು
+gloss: please (dayaviṭṭu — "having placed compassion," from ದಯ daya "compassion")
+concept_tag: COURTESY-PLEASE
+prerequisites: [KA-C01-dhanyavada]
+sounds: [kannada-vowel-sign-i, kannada-virama-ottu, kannada-geminate-tta]
+roots: [daya-compassion]
+etymology_hook: "ದಯವಿಟ್ಟು = 'having placed compassion' — Kannada asks please with daya, like Tamil, Arabic faḍl and Hindi kṛpā"
+est_minutes: 5
+reviews_of: [KA-C01-dhanyavada]
+---
+
+# ದಯವಿಟ್ಟು (dayaviṭṭu) — please (having placed compassion)
+
+## Warm-up
+
+[PAUSE 2s] Kannada's everyday "please" is, once you open it up, a small act of
+generosity: "having **placed** compassion" between us.
+
+## The word
+
+**ದಯವಿಟ್ಟು** = **please**, literally "**having placed compassion / kindness**." Two
+pieces:
+
+- **ದಯ** (*daya*) = **compassion, kindness, grace** — from Sanskrit **daya**.
+- **ಇಟ್ಟು** (*iṭṭu*) = "**having placed / set down**," from the verb **ಇಡು**
+  (*iḍu*) "to place, to put."
+
+So *dayaviṭṭu* means, at heart, *setting kindness down (before you)* — asking the
+listener to act from compassion.
+
+That is exactly how **Tamil** builds it (*tayavu seytu*, "**do** the kindness"),
+and the same instinct as **Arabic** *min faḍlik* ("from your **grace**") and
+**Hindi** *kṛpayā* (from *kṛpā*, "**compassion**"). A wide arc of Asia says
+*please* by naming the kindness it hopes for.
+
+## The Dravidian family, side by side
+
+**daya** + a light verb, four times over:
+
+- Kannada **ದಯವಿಟ್ಟು** *daya**viṭṭu*** — compassion **+ having placed**
+- Tamil **தயவுசெய்து** *tayavu **sey**tu* — kindness **+ do**
+- Telugu **దయచేసి** *daya**cēsi*** — compassion **+ having done**
+- Malayalam **ദയവായി** *daya**vāyi*** — compassion **+ as / having become**
+
+## Be honest about how it's used
+
+The honest note: a standalone please-word is a little **formal / emphatic**.
+Everyday Kannada politeness leans on the **respectful command** — the verb ending
+**‑ಿ** (*-i*): **ಕುಳಿತುಕೊಳ್ಳಿ** (*kuḷitukoḷḷi*) "please sit,"  **ಹೇಳಿ** (*hēḷi*)
+"please tell me." That ending already means "please" do this. Add **ದಯವಿಟ್ಟು** in
+front when you want to underline the courtesy.
+
+## Sound & structure point
+
+Look at **ಟ್ಟು** — a **doubled** *ṭ*. The first **ಟ್** is *ṭa* silenced by the
+**virama** (its vowel cut), and it tucks **under** the next letter as an *ottu*
+(a subscript form) before **ಟು** *ṭu*. Kannada writes a double consonant by
+stacking, not repeating side by side — a neat contrast with how the Roman
+alphabet just writes "tt."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "daya" — compassion — then "iṭṭu," having placed]
+- [YOU SAY: the whole word — "dayaviṭṭu" = please]
+- [YOU SAY: the everyday way — the verb ending: "kuḷitukoḷḷi" = please sit]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is the Kannada word for please? (**ದಯವಿಟ್ಟು** *dayaviṭṭu*.) What
+do its pieces mean? ("**Compassion**" *daya* + "**having placed**" *iṭṭu*.) Which
+cousins ask the same way? (**Tamil, Telugu, Malayalam** with *daya* — plus
+**Arabic** *faḍl*, **Hindi** *kṛpā*.) What carries "please" in ordinary speech?
+(**The respectful verb ending ‑ಿ** *-i*.)

--- a/code/learning/human-languages/malayalam/lessons/ML-C08-dayavayi.md
+++ b/code/learning/human-languages/malayalam/lessons/ML-C08-dayavayi.md
@@ -1,0 +1,79 @@
+---
+id: ML-C08-dayavayi
+chapter: 8
+type: word
+headword: ദയവായി
+gloss: please (dayavāyi — "as a compassion," from ദയ daya "compassion")
+concept_tag: COURTESY-PLEASE
+prerequisites: [ML-C01-athe]
+sounds: [malayalam-vowel-sign-aa, malayalam-vowel-sign-i, malayalam-va]
+roots: [daya-compassion]
+etymology_hook: "ദയവായി = 'as a compassion' — Malayalam asks please with daya, like Tamil, Kannada, Telugu, Arabic faḍl and Hindi kṛpā"
+est_minutes: 5
+reviews_of: [ML-C01-athe]
+---
+
+# ദയവായി (dayavāyi) — please (as a compassion)
+
+## Warm-up
+
+[PAUSE 2s] Malayalam's "please" turns compassion into an adverb: do this thing
+**as a kindness**.
+
+## The word
+
+**ദയവായി** = **please**, literally "**kindly / as a compassion**." Two pieces:
+
+- **ദയ** (*daya*) = **compassion, kindness, grace** — from Sanskrit **daya**.
+- **‑വായി** (*-vāyi*) = "**having become / as**," turning the noun into "*in the
+  manner of* compassion" — i.e. **kindly**. (The true historical seam is
+  *dayavu* "kindness" + **‑ആയി** *-āyi*, the adverb of **ആകുക** *ākuka* "to
+  become"; we split it *-vāyi* here just to keep the *daya* root visible.)
+
+So *dayavāyi* asks you to act *kindly*, *as a kindness*. Where Tamil and Telugu
+say "**do** the kindness" and Kannada "having **placed** it," Malayalam makes
+kindness the **manner** of the whole request.
+
+The family resemblance is unmistakable, and it reaches beyond Dravidian:
+**Arabic** *min faḍlik* ("from your **grace**") and **Hindi** *kṛpayā* (from
+*kṛpā*, "**compassion**") ask by the same grace-naming instinct.
+
+## The Dravidian family, side by side
+
+**daya** + a light verb, four ways:
+
+- Malayalam **ദയവായി** *daya**vāyi*** — compassion **+ as / having become**
+- Tamil **தயவுசெய்து** *tayavu **sey**tu* — kindness **+ do**
+- Kannada **ದಯವಿಟ್ಟು** *daya**viṭṭu*** — compassion **+ having placed**
+- Telugu **దయచేసి** *daya**cēsi*** — compassion **+ having done**
+
+## Be honest about how it's used
+
+Honestly: as elsewhere in the family, the standalone word is a touch **formal /
+emphatic**. Everyday Malayalam politeness leans on the **respectful request**
+form of the verb — endings like **‑ൂ** (*-ū*) or **‑ണം** (*-aṇaṁ*): **ഇരിക്കൂ**
+(*irikkū*) "please sit," **പറയൂ** (*paṟayū*) "please tell me." Add **ദയവായി** in
+front when you want the courtesy spoken aloud.
+
+## Sound & structure point
+
+The heart of the word is **വാ** — *va* stretched by the **long‑ā** sign **ാ**
+(*-ā*) — then **യി**, *ya* + the *i* sign (**ി**). Malayalam's rounded letters
+hang their vowel-signs to the right; the long **ാ** is simply a tall stroke after
+the consonant, the same *ā* you would meet across the Dravidian scripts.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "daya" — compassion — then "-vāyi," as / kindly]
+- [YOU SAY: the whole word — "dayavāyi" = please]
+- [YOU SAY: the everyday way — the verb ending: "irikkū" = please sit]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is the Malayalam word for please? (**ദയവായി** *dayavāyi*.) What do
+its pieces mean? ("**Compassion**" *daya* + "**as / having become**" *-vāyi* —
+*kindly*.) Which cousins ask the same way? (**Tamil, Kannada, Telugu** with
+*daya* — plus **Arabic** *faḍl*, **Hindi** *kṛpā*.) What carries "please" in
+ordinary speech? (**The respectful verb form**, endings like **‑ൂ** *-ū* / **‑ണം**
+*-aṇaṁ*.)

--- a/code/learning/human-languages/spanish/lessons/ES-C20-lo-siento.md
+++ b/code/learning/human-languages/spanish/lessons/ES-C20-lo-siento.md
@@ -1,0 +1,66 @@
+---
+id: ES-C20-lo-siento
+chapter: 20
+type: phrase
+headword: lo siento
+gloss: I'm sorry (literally "I feel it")
+concept_tag: COURTESY-SORRY
+prerequisites: [ES-C06-por-favor]
+sounds: [r-tap, s-clear]
+roots: [sentire-latin]
+etymology_hook: "siento ← Latin sentīre 'to feel' → English sentiment, sense, consent, resent"
+est_minutes: 4
+reviews_of: [ES-C06-por-favor]
+---
+
+# lo siento — "I'm sorry," i.e. "I feel it"
+
+## Warm-up
+
+[PAUSE 2s] You already know **por favor**, "please" — the fourth courtesy word
+is **lo siento**, "I'm sorry." Spanish doesn't say "I am sorry" as an
+adjective; it says something closer to **"I feel this."**
+
+## The phrase, taken apart
+
+- **lo** = "it" — a neuter pronoun pointing at the situation itself, not a
+  specific noun.
+- **siento** = "I feel," from the verb **sentir**, "to feel," from Latin
+  **sentīre**. That root gave English a whole family: **sentiment**, **sense**,
+  **consent** ("feel together"), and **resent** ("feel again/against").
+
+So **lo siento** is literally *"I feel it"* — you're naming the feeling
+(regret, sympathy) rather than declaring a state. It's the Spanish you reach
+for both to apologize ("*lo siento*, I stepped on your foot") and to console
+("*lo siento mucho*," I'm so sorry, on hearing sad news).
+
+## Be honest about the other word: perdón
+
+Spanish keeps a **second** word for a different job. **Perdón** ("pardon"),
+from **perdonar** — Latin **per-** ("thoroughly") + **dōnāre** ("to give," the
+same root as English **donate** and **condone**) — literally "**to give
+completely**," i.e. to forgive. **Perdón** is what you say to:
+
+- get someone's **attention** or squeeze past them (like English "excuse me"),
+- ask forgiveness for something **you did wrong** (a real apology, often
+  stronger than *lo siento*).
+
+**Lo siento** leans toward **regret/sympathy** ("I'm sorry that happened"),
+while **perdón** leans toward **fault and forgiveness** ("excuse me / forgive
+me"). Native speakers reach for whichever fits — the boundary is soft, and
+mixing them up is not a real mistake, just a shade off.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "siento" — I feel — then "lo siento," I feel it / I'm sorry]
+- [YOU SAY: the cousin word — "perdón," pardon / excuse me]
+- [YOU SAY: both together in your head: regret vs. forgiveness]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What does **lo siento** literally mean? (**"I feel it"** — *siento*
+"I feel," from Latin *sentīre*, like English *sentiment*.) What's the other
+Spanish word for sorry/excuse-me, and how is it different? (**Perdón**,
+"pardon" — leans toward fault and forgiveness, or getting someone's attention,
+while *lo siento* leans toward regret and sympathy.)

--- a/code/learning/human-languages/tamil/lessons/TA-C08-tayavuseytu.md
+++ b/code/learning/human-languages/tamil/lessons/TA-C08-tayavuseytu.md
@@ -1,0 +1,86 @@
+---
+id: TA-C08-tayavuseytu
+chapter: 8
+type: phrase
+headword: தயவுசெய்து
+gloss: please (tayavu seytu — "do the kindness," from தயவு tayavu "compassion/grace")
+concept_tag: COURTESY-PLEASE
+prerequisites: [TA-C01-aam]
+sounds: [tamil-vowel-sign-u, pulli-virama, tamil-vowel-sign-e]
+roots: [daya-compassion]
+etymology_hook: "தயவுசெய்து = 'do the kindness' — Tamil asks please by naming daya 'compassion', like Arabic faḍl and Hindi kṛpā"
+est_minutes: 5
+reviews_of: [TA-C01-aam]
+---
+
+# தயவுசெய்து (tayavu seytu) — please (do the kindness)
+
+## Warm-up
+
+[PAUSE 2s] Across a whole band of Asia, the word for *please* is really the word
+**compassion**, dressed as a small request. Tamil says it most literally of all:
+"**do** the kindness."
+
+## The phrase
+
+**தயவுசெய்து** = **please**, literally "**do the kindness / grace**." It is two
+pieces snapped together:
+
+- **தயவு** (*tayavu*) = **kindness, compassion, grace** — from Sanskrit **daya**
+  "compassion."
+- **செய்து** (*seytu*) = "**having done**," from the verb **செய்** (*sey*) "to do."
+
+So *tayavu seytu* is an invitation: *do me the kindness (of…)*. You place it in
+front of a request the way English puts "please" in front of one.
+
+This is the same instinct as **Arabic** *min faḍlik* ("from your **grace**") and
+**Hindi** *kṛpayā* (from *kṛpā*, "**compassion**"). Naming the kindness you hope
+for is one of the great strategies of politeness — different from French's "if
+it **pleases** you," and from Latin/German's "I **ask**."
+
+## The Dravidian family, side by side
+
+All four Dravidian cousins build *please* the very same way — **daya** plus a
+light verb "do / place / become":
+
+- Tamil **தயவுசெய்து** *tayavu **sey**tu* — kindness **+ do**
+- Kannada **ದಯವಿಟ್ಟು** *daya**viṭṭu*** — compassion **+ having placed**
+- Telugu **దయచేసి** *daya**cēsi*** — compassion **+ having done**
+- Malayalam **ദയവായി** *daya**vāyi*** — compassion **+ as / having become**
+
+One idea, four scripts. Learn one and you can almost read the others.
+
+## Be honest about how it's used
+
+Here is the honest part. A standalone "please" word is more **emphatic and
+formal** in Tamil than in English. In ordinary speech, politeness usually lives
+**in the verb** — the respectful command ending **‑உங்கள்** (*-uṅgaḷ*):
+**உட்காருங்கள்** (*uṭkāruṅgaḷ*) "please sit," **சொல்லுங்கள்** (*sollungaḷ*) "please
+tell me." That *-uṅgaḷ* already carries the "please."
+
+So reach for **தயவுசெய்து** when you want to be markedly, warmly polite —
+"*please*, do me the kindness" — and lean on the **‑உங்கள்** verb ending for
+everyday courtesy.
+
+## Sound & structure point
+
+Notice the join in **செய்து**: **செ** is *ca* wearing the **‑ெ** sign for *e*,
+then **ய்** is *ya* shut off by the **புள்ளி** (*puḷḷi*, the virama dot) — a bare
+consonant *y* — before **து** *tu*. That dot, silencing a vowel, is the same tool
+you met building the numbers.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "tayavu" — the kindness — then "seytu," having done]
+- [YOU SAY: the whole phrase — "tayavu seytu" = please, do the kindness]
+- [YOU SAY: the everyday way — the verb ending: "uṭkāruṅgaḷ" = please sit]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is the Tamil phrase for please? (**தயவுசெய்து** *tayavu seytu*.)
+What do its two pieces mean? ("**Kindness**" *tayavu* + "**having done**" *seytu*
+— *do the kindness*.) Which languages ask the same way? (**Kannada, Telugu,
+Malayalam** with *daya*, and further off **Arabic** *faḍl* and **Hindi** *kṛpā*.)
+And what carries "please" in ordinary speech? (**The verb ending ‑உங்கள்**
+*-uṅgaḷ*.)

--- a/code/learning/human-languages/telugu/lessons/TE-C08-dayachesi.md
+++ b/code/learning/human-languages/telugu/lessons/TE-C08-dayachesi.md
@@ -1,0 +1,76 @@
+---
+id: TE-C08-dayachesi
+chapter: 8
+type: word
+headword: దయచేసి
+gloss: please (dayacēsi — "having done compassion," from దయ daya "compassion")
+concept_tag: COURTESY-PLEASE
+prerequisites: [TE-C01-avunu]
+sounds: [telugu-vowel-sign-ee, telugu-vowel-sign-i, telugu-ca]
+roots: [daya-compassion]
+etymology_hook: "దయచేసి = 'having done compassion' — Telugu asks please with daya, like Tamil, Kannada, Arabic faḍl and Hindi kṛpā"
+est_minutes: 5
+reviews_of: [TE-C01-avunu]
+---
+
+# దయచేసి (dayacēsi) — please (having done compassion)
+
+## Warm-up
+
+[PAUSE 2s] Telugu's "please" carries a whole small sentence inside it: "having
+**done** (me) a compassion."
+
+## The word
+
+**దయచేసి** = **please**, literally "**having done kindness / compassion**." Two
+pieces:
+
+- **దయ** (*daya*) = **compassion, kindness, grace** — from Sanskrit **daya**.
+- **చేసి** (*cēsi*) = "**having done**," from the verb **చేయు** (*cēyu*) "to do."
+
+So *dayacēsi* is *having done (a) kindness* — you ask by crediting the listener
+with the grace you hope they'll show.
+
+It is the twin of **Tamil** *tayavu seytu* ("**do** the kindness") — both use a
+"do" verb — and cousins with **Kannada** *dayaviṭṭu* ("having **placed**
+compassion"). Further off, **Arabic** *min faḍlik* ("from your **grace**") and
+**Hindi** *kṛpayā* (from *kṛpā*, "**compassion**") ask in the very same spirit.
+
+## The Dravidian family, side by side
+
+**daya** + a light verb, four ways:
+
+- Telugu **దయచేసి** *daya**cēsi*** — compassion **+ having done**
+- Tamil **தயவுசெய்து** *tayavu **sey**tu* — kindness **+ do**
+- Kannada **ದಯವಿಟ್ಟು** *daya**viṭṭu*** — compassion **+ having placed**
+- Malayalam **ദയവായി** *daya**vāyi*** — compassion **+ as / having become**
+
+## Be honest about how it's used
+
+Honestly: the standalone word is somewhat **formal / emphatic**. Day-to-day,
+Telugu politeness rides on the **respectful command** ending **‑ండి** (*-aṇḍi*):
+**కూర్చోండి** (*kūrcōṇḍi*) "please sit," **చెప్పండి** (*ceppaṇḍi*) "please tell me."
+That *-aṇḍi* is already "please." Put **దయచేసి** in front to warm it further.
+
+## Sound & structure point
+
+The middle syllable **చే** is *ca* wearing the **long‑ē** sign **‑ే** (the
+counterpart of the short‑e sign **‑ె**), giving *cē*; then **సి** is *sa* + the
+*i* sign (**‑ి**). Telugu marks a
+vowel's length and quality by the little sign riding on the consonant — the
+consonant stays put, the vowel-sign changes the tune.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: "daya" — compassion — then "cēsi," having done]
+- [YOU SAY: the whole word — "dayacēsi" = please]
+- [YOU SAY: the everyday way — the verb ending: "kūrcōṇḍi" = please sit]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is the Telugu word for please? (**దయచేసి** *dayacēsi*.) What do
+its pieces mean? ("**Compassion**" *daya* + "**having done**" *cēsi*.) Which
+cousins ask the same way? (**Tamil, Kannada, Malayalam** with *daya* — plus
+**Arabic** *faḍl*, **Hindi** *kṛpā*.) What carries "please" in ordinary speech?
+(**The respectful verb ending ‑ండి** *-aṇḍi*.)

--- a/lessons.md
+++ b/lessons.md
@@ -1833,3 +1833,24 @@ went 82 → 86 instead of 85, which is the tell). Only `clippy -D warnings` fail
 restating as a hard habit: **anchor an insertion on the previous item's closing brace,
 never on the next item's signature** — attributes and doc comments both live above the
 signature, and anchoring there always cuts through them.
+
+## A brand-new `concept_tag` fails CI even with perfect content — register it in `concepts/taxonomy.json` first
+
+Adding lessons with a fresh `concept_tag` (e.g. `COURTESY-SORRY`, introducing a new
+courtesy concept alongside existing `COURTESY-PLEASE`/`COURTESY-THANKS`) failed both
+`human-language-data` integration tests — "every concept id is canonical or
+namespaced" and "has zero validation errors" — with `concept_tag 'COURTESY-SORRY' is
+neither canonical nor namespaced`. `COURTESY-PLEASE` needed no such step because it
+was already a registered concept from an earlier PR; a genuinely new concept has no
+such precedent.
+
+`code/learning/human-languages/concepts/taxonomy.json` is the canonical concept
+registry (`code/packages/typescript/human-language-data/src/loader.ts` loads it;
+`validate.ts` rejects any `concept_tag` that is neither `in taxonomy.concepts` nor
+matching the language-local `NAMESPACED_TAG` pattern like `TA-NUMBERS-1-5`). Before
+writing the first lesson for a brand-new cross-language concept, add its entry to
+`taxonomy.json` (`family`, `gloss`, `core`, optional `retires`/`notes` — copy the
+shape of a neighboring entry, e.g. `COURTESY-PLEASE`) and validate it's still parseable
+JSON, THEN write the lessons. Re-run both suites
+(`code/packages/typescript/human-language-data` + the app suite) after any new
+concept_tag lands — a green run before is not evidence the new tag is registered.


### PR DESCRIPTION
## What
Completes the **please** (`COURTESY-PLEASE`) concept across the whole language chain. Adds Tamil, Kannada, Telugu, and Malayalam - the last four languages needing it.

## The pattern
All four Dravidian languages build please the same way: Sanskrit **daya** ("compassion") + a light verb.

- Tamil **தயவுசெய்து** *tayavu seytu* - "do the kindness" (செய் *sey* "do")
- Kannada **ದಯವಿಟ್ಟು** *dayaviṭṭu* - "having placed compassion" (ಇಡು *iḍu* "place")
- Telugu **దయచేసి** *dayacēsi* - "having done compassion" (చేయు *cēyu* "do")
- Malayalam **ദయവായി** *dayavāyi* - "as a compassion / kindly" (adverbial *-āyi*)

This closes the loop on the concept's cross-language hook: Dravidian *daya*, Arabic *faḍl*, and Hindi *kṛpā* all name **grace/compassion**, versus Romance "if it pleases you" and Latin/German "I ask."

**Honest throughout:** each lesson notes the standalone word is formal/emphatic, and everyday politeness actually rides on the respectful verb ending (Tamil *-uṅgaḷ*, Kannada *-i*, Telugu *-aṇḍi*, Malayalam *-ū*/*-aṇaṁ*).

## Review
Glyphs codepoint-verified against Unicode. Linguistics subagent review caught a real error (a Telugu script-claim mislabeled the long-ē vowel sign as the long-ī sign) - fixed. Malayalam's morpheme split was softened to note the true historical seam (*dayavu* + *-āyi*). 38 + 268 tests green.

## Note
This is intended as **the accumulator PR** for ongoing content work - expect more commits landing here as the next concept (`COURTESY-SORRY`) and others are built, per your request to keep one PR going rather than opening a new one each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)